### PR TITLE
[Groupcast]Update The Yaml tests that are not automated and are disabled from CI

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -306,8 +306,8 @@ tests:
       disabled: true
 
     - label:
-          "Step 11a: DUT is triggered to send Multicast On command to
-          its binding entries"
+          "Step 11a: DUT is triggered to send Multicast On command to its
+          binding entries"
       PICS: OO.C.C01.Tx
       verification: |
           Press button no.2 on [ nRF52840-DK ]thread board

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -76,14 +76,16 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: If the Groupcast cluster is enabled on the RootNode endpoint, skip to step 9a. Otherwise, DUT generates random key, EpochKey0."
+          "Step 5: If the Groupcast cluster is enabled on the RootNode endpoint,
+          skip to step 9a. Otherwise, DUT generates random key, EpochKey0."
       verification: |
           As Admin generates it is not necessary to verify
       disabled: true
 
     - label:
           "Step 6: DUT sends KeySetWrite command to GroupKeyManagement cluster
-          to TH2 on Endpoint 0 with GroupKeySetID 1 and the randomly generated key and EpochKey0."
+          to TH2 on Endpoint 0 with GroupKeySetID 1 and the randomly generated
+          key and EpochKey0."
       PICS: GRPKEY.C.C00.Tx
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
@@ -249,13 +251,17 @@ tests:
       disabled: true
 
     - label:
-          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast featuremap attribute."
+          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode
+          endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast
+          featuremap attribute."
       verification: |
           TH1 receives the featuremap attribute and verify that Sender feature (bit 1) is set.
       disabled: true
 
     - label:
-          "Step 9b: DUT sends Groupcast JoinGroup command with GroupID=1, Endpoints=[EP1], KeySetID=1, Key=randomly generated key to TH2 endpoint 0."
+          "Step 9b: DUT sends Groupcast JoinGroup command with GroupID=1,
+          Endpoints=[EP1], KeySetID=1, Key=randomly generated key to TH2
+          endpoint 0."
       verification: |
           TH2 responds with SUCCESS
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -76,24 +76,21 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: DUT generates fabric-unique GroupID, GroupName, random key,
-          EpochKey0 and GroupKeySetID."
+          "Step 5: If the Groupcast cluster is enabled on the RootNode endpoint, skip to step 9a. Otherwise, DUT generates random key, EpochKey0."
       verification: |
           As Admin generates it is not necessary to verify
       disabled: true
 
     - label:
           "Step 6: DUT sends KeySetWrite command to GroupKeyManagement cluster
-          to TH2 on Endpoint 0."
+          to TH2 on Endpoint 0 with GroupKeySetID 1 and the randomly generated key and EpochKey0."
       PICS: GRPKEY.C.C00.Tx
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42,
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 1,
           "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1":
-          "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001,"epochKey2":
-          "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002,
+          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,
           "groupKeyMulticastPolicy": 0}' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
@@ -131,11 +128,9 @@ tests:
 
           Run this command for lighting app in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42,
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 1,
           "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1":
-          "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001,"epochKey2":
-          "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002,
+          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,
           "groupKeyMulticastPolicy": 0}' 2 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
@@ -174,13 +169,13 @@ tests:
       disabled: true
 
     - label:
-          "Step 7: DUT binds GroupId with GroupKeySetID in the GroupKeyMap
+          "Step 7: DUT binds GroupId 1 with GroupKeySetID 1 in the GroupKeyMap
           attribute list on GroupKeyManagement cluster to TH2 on Endpoint 0"
       PICS: GRPKEY.C.A0000
       verification: |
           Run this cmmd for [ nRF52840-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 74 0
+          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 1, "fabricIndex": 1}]' 74 0
 
           On TH1(Chip-tool), Verify the success response for GroupKeySetID
 
@@ -193,7 +188,7 @@ tests:
 
           Run this cmmd for lighting app in chip-tool:
 
-          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 2 0
+          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 1, "fabricIndex": 1}]' 2 0
 
           On TH1(Chip-tool), Verify the success response for GroupKeySetID
 
@@ -237,9 +232,9 @@ tests:
 
           ./chip-tool groupsettings add-group grp1 0x0001
 
-          ./chip-tool groupsettings add-keysets 0x0042 0 0x000000000021dfe0 hex:d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          ./chip-tool groupsettings add-keysets 0x0001 0 0x000000000021dfe0 hex:d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
 
-          ./chip-tool groupsettings bind-keyset 0x0001 0x0042
+          ./chip-tool groupsettings bind-keyset 0x0001 0x0001
 
           ./chip-tool groupsettings show-groups
 
@@ -249,12 +244,24 @@ tests:
             | Group Id   |  KeySet Id     |   Group Name                                          |
             | 0x101           0x1a1            Group #1                                           |
             | 0x102           0x1a2            Group #2                                           |
-            | 0x1               0x42              grp1                                                   |
+            | 0x1               0x1               grp1                                                   |
             +-------------------------------------------------------------------------------------+"
       disabled: true
 
     - label:
-          "Step 9: TH1 writes Binding entry into DUT with Entry 1: Group = The
+          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast featuremap attribute."
+      verification: |
+          TH1 receives the featuremap attribute and verify that Sender feature (bit 1) is set.
+      disabled: true
+
+    - label:
+          "Step 9b: DUT sends Groupcast JoinGroup command with GroupID=1, Endpoints=[EP1], KeySetID=1, Key=randomly generated key to TH2 endpoint 0."
+      verification: |
+          TH2 responds with SUCCESS
+      disabled: true
+
+    - label:
+          "Step 10: TH1 writes Binding entry into DUT with Entry 1: Group = The
           Group ID in the AddGroup command sent from DUT to TH2"
       verification: |
           Before write the binding entries run the ACL Commands:
@@ -293,14 +300,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 10a: DUT is triggered to send Multicast message On command to
+          "Step 11a: DUT is triggered to send Multicast message On command to
           its binding entries"
       PICS: OO.C.C01.Tx
       verification: |
           Press button no.2 on [ nRF52840-DK ]thread board
       disabled: true
 
-    - label: "Step 10b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
+    - label: "Step 11b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
       PICS: OO.C.C01.Tx
       verification: |
           Run this cmmd for lighting app in chip-tool:
@@ -313,7 +320,7 @@ tests:
           [1657717900.832890][4381:4386] CHIP:TOO:   OnOff: TRUE
       disabled: true
 
-    - label: "Step 11: TH1 removes all the binding entries from DUT"
+    - label: "Step 12: TH1 removes all the binding entries from DUT"
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
@@ -328,14 +335,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 12a: DUT is triggered to send Multicast message off command to
+          "Step 13a: DUT is triggered to send Multicast message off command to
           its binding entries"
       PICS: OO.C.C00.Tx
       verification: |
           Press button no.2 on [ nRF52840-DK ] thread board
       disabled: true
 
-    - label: "Step 12b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
+    - label: "Step 13b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
       PICS: OO.C.C01.Tx
       verification: |
           Run this command for lighting app in chip-tool:

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -83,8 +83,8 @@ tests:
       disabled: true
 
     - label:
-          "Step 6: DUT sends KeySetWrite command to GroupKeyManagement cluster
-          to TH2 on Endpoint 0 with GroupKeySetID 1 and the randomly generated
+          "Step 6: DUT sends KeySetWrite command to GroupKeyManagement cluster,
+          to TH2 on Endpoint 0 with GroupKeySetID 1, and the randomly generated
           key and EpochKey0."
       PICS: GRPKEY.C.C00.Tx
       verification: |
@@ -171,8 +171,8 @@ tests:
       disabled: true
 
     - label:
-          "Step 7: DUT binds GroupId 1 with GroupKeySetID 1 in the GroupKeyMap
-          attribute list on GroupKeyManagement cluster to TH2 on Endpoint 0"
+          "Step 7: DUT binds GroupId 1 with GroupKeySetID 1, in the GroupKeyMap
+          attribute on GroupKeyManagement cluster, to TH2 on Endpoint 0"
       PICS: GRPKEY.C.A0000
       verification: |
           Run this cmmd for [ nRF52840-DK ]Thread device in chip-tool:
@@ -260,7 +260,7 @@ tests:
 
     - label:
           "Step 9b: DUT sends Groupcast JoinGroup command with GroupID=1,
-          Endpoints=[EP1], KeySetID=1, Key=randomly generated key to TH2
+          Endpoints=[EP1], KeySetID=1, Key=(randomly generated) key to TH2
           endpoint 0."
       verification: |
           TH2 responds with SUCCESS
@@ -306,7 +306,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 11a: DUT is triggered to send Multicast message On command to
+          "Step 11a: DUT is triggered to send Multicast On command to
           its binding entries"
       PICS: OO.C.C01.Tx
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
@@ -165,7 +165,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 8: TH1 sends AddGroup with GroupID 1 (Group Name and Group-ID)
+          "Step 8: TH1 sends AddGroup with GroupID 1 (Group Name, Group-ID)
           Command to TH2 on Endpoint 1."
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
@@ -76,23 +76,20 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: TH1 generates fabric-unique GroupID, GroupName, random key,
-          EpochKey0 and GroupKeySetID."
+          "Step 5: If the Groupcast cluster is enabled on the RootNode endpoint, skip to step 9a. Otherwise, TH1 generates a random key (Key1) and EpochKey0 and uses GroupID 1, GroupName \"\", and GroupKeySetID 0x01a1."
       verification: |
           As Admin generates it is not required to verify
       disabled: true
 
     - label:
           "Step 6: TH1 sends KeySetWrite command to GroupKeyManagement cluster
-          to TH2 on Endpoint 0."
+          to TH2 on Endpoint 0 with GroupKeySetID 0x01a1, Key1, and EpochKey0."
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42,
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 417,
           "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1":
-          "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001,"epochKey2":
-          "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002,
+          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,
           "groupKeyMulticastPolicy": 0}' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
@@ -129,7 +126,7 @@ tests:
 
           Run this command for lighting app in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42, "groupKeySecurityPolicy": 0, "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001,"epochKey2": "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002, "groupKeyMulticastPolicy": 0 }' 2 0
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 417, "groupKeySecurityPolicy": 0, "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001, "groupKeyMulticastPolicy": 0 }' 2 0
 
           On TH1, Verify the success response for KeySetWrite
 
@@ -137,12 +134,12 @@ tests:
       disabled: true
 
     - label:
-          "Step 7: TH1 binds GroupId with GroupKeySetID in the GroupKeyMap
+          "Step 7: TH1 binds GroupId 1 with GroupKeySetID 0x01a1 in the GroupKeyMap
           attribute list on GroupKeyManagement cluster to TH2 on Endpoint 0"
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 74 0
+          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 417, "fabricIndex": 1}]' 74 0
 
           On TH1(Chip-tool), Verify the success response for GroupKeySetID
 
@@ -153,7 +150,7 @@ tests:
           [1657719130.464342][4557:4562] CHIP:DMG:
 
           Run this command for lighting app in chip-tool:
-          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 2 0
+          ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 417, "fabricIndex": 1}]' 2 0
 
           On TH1(Chip-tool), Verify the success response for GroupKeySetID
 
@@ -165,7 +162,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 8: TH1 sends AddGroup( Group Name and Group-ID) Command to TH2
+          "Step 8: TH1 sends AddGroup with GroupID 1 (Group Name and Group-ID) Command to TH2
           on Endpoint 1."
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
@@ -198,9 +195,9 @@ tests:
 
           ./chip-tool groupsettings add-group grp1 0x0001
 
-          ./chip-tool groupsettings add-keysets 0x0042 0 0x000000000021dfe0 hex:d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          ./chip-tool groupsettings add-keysets 0x01a1 0 0x000000000021dfe0 hex:d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
 
-          ./chip-tool groupsettings bind-keyset 0x0001 0x0042
+          ./chip-tool groupsettings bind-keyset 0x0001 0x01a1
 
           ./chip-tool groupsettings show-groups
 
@@ -208,14 +205,24 @@ tests:
             | Available Groups :                                                                  |
             +-------------------------------------------------------------------------------------+
             | Group Id   |  KeySet Id     |   Group Name                                          |
-            | 0x101           0x1a1            Group #1                                           |
-            | 0x102           0x1a2            Group #2                                           |
-            | 0x1               0x42              grp1                                                   |
+            | 0x1             0x1a1            Group #1                                           |
             +-------------------------------------------------------------------------------------+"
       disabled: true
 
     - label:
-          "Step 9: TH1 writes Binding entry into DUT with Entry 1: Group = The
+          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast featuremap attribute."
+      verification: |
+
+      disabled: true
+
+    - label:
+          "Step 9b: TH1 sends Groupcast JoinGroup command with GroupID=1, Endpoints=[EP1], KeySetID=0x01a1, Key=Key1 to TH2 endpoint 0."
+      verification: |
+
+      disabled: true
+
+    - label:
+          "Step 10: TH1 writes Binding entry into DUT with Entry 1: Group = The
           Group ID in the AddGroup command sent from TH1 to TH2"
       verification: |
           Before write the binding entries run the ACL Commands:
@@ -253,20 +260,43 @@ tests:
           [1657719251.763440][4597:4602] CHIP:DMG:                         },
       disabled: true
 
-    - label: "Step 10: TH1 sets up group settings on DUT"
+    - label:
+          "Step 11: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH1 sets up group settings on DUT"
       verification: |
 
       disabled: true
 
     - label:
-          "Step 11a: DUT is triggered to send Multicast message On command to
+          "Step 12: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip this step. Otherwise, TH1 sends Groupcast JoinGroup command with GroupID=1, Endpoints=[], KeySetID=0x01a1, Key=Key1 to DUT endpoint 0."
+      verification: |
+
+      disabled: true
+
+    - label: "Step 13a: TH1 sends a unicast Off command to TH2 (Endpoint 1)"
+      verification: |
+          Example:
+
+          ./chip-tool onoff off 2 1
+      disabled: true
+
+    - label: "Step 13b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
+      verification: |
+          Run this command for lighting app in chip-tool:
+
+          ./chip-tool onoff read on-off 2 1
+
+          On TH1(Chip-tool), verify that OnOff value is OFF (FALSE).
+      disabled: true
+
+    - label:
+          "Step 14a: DUT is triggered to send Multicast message On command to
           its binding entries"
       PICS: OO.C.C01.Tx
       verification: |
           Press button no.2 on nrf52840 DK thread board
       disabled: true
 
-    - label: "Step 11b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
+    - label: "Step 14b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
       PICS: OO.C.C01.Tx
       verification: |
           Run this command for lighting app in chip-tool:
@@ -279,7 +309,7 @@ tests:
           [1657719363.799380][4615:4620] CHIP:TOO:   OnOff: TRUE
       disabled: true
 
-    - label: "Step 12: TH1 removes all the binding entries from DUT"
+    - label: "Step 15: TH1 removes all the binding entries from DUT"
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
@@ -294,14 +324,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 13a: DUT is triggered to send Multicast message off command to
+          "Step 16a: DUT is triggered to send Multicast message off command to
           its binding entries"
       PICS: OO.C.C00.Tx
       verification: |
           Press button no.2 on nrf52840 DK thread board
       disabled: true
 
-    - label: "Step 13b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
+    - label: "Step 16b: TH1 reads OnOff attribute from TH2 (Endpoint 1)"
       PICS: OO.C.C01.Tx
       verification: |
           Run this command for lighting app in chip-tool:

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
@@ -76,7 +76,9 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: If the Groupcast cluster is enabled on the RootNode endpoint, skip to step 9a. Otherwise, TH1 generates a random key (Key1) and EpochKey0 and uses GroupID 1, GroupName \"\", and GroupKeySetID 0x01a1."
+          'Step 5: If the Groupcast cluster is enabled on the RootNode endpoint,
+          skip to step 9a. Otherwise, TH1 generates a random key (Key1) and
+          EpochKey0 and uses GroupID 1, GroupName "", and GroupKeySetID 0x01a1.'
       verification: |
           As Admin generates it is not required to verify
       disabled: true
@@ -134,8 +136,9 @@ tests:
       disabled: true
 
     - label:
-          "Step 7: TH1 binds GroupId 1 with GroupKeySetID 0x01a1 in the GroupKeyMap
-          attribute list on GroupKeyManagement cluster to TH2 on Endpoint 0"
+          "Step 7: TH1 binds GroupId 1 with GroupKeySetID 0x01a1 in the
+          GroupKeyMap attribute list on GroupKeyManagement cluster to TH2 on
+          Endpoint 0"
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
@@ -162,8 +165,8 @@ tests:
       disabled: true
 
     - label:
-          "Step 8: TH1 sends AddGroup with GroupID 1 (Group Name and Group-ID) Command to TH2
-          on Endpoint 1."
+          "Step 8: TH1 sends AddGroup with GroupID 1 (Group Name and Group-ID)
+          Command to TH2 on Endpoint 1."
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
@@ -210,13 +213,16 @@ tests:
       disabled: true
 
     - label:
-          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast featuremap attribute."
+          "Step 9a: If the Groupcast cluster is NOT enabled on the RootNode
+          endpoint, skip to step 10. Otherwise, TH1 reads the DUT Groupcast
+          featuremap attribute."
       verification: |
 
       disabled: true
 
     - label:
-          "Step 9b: TH1 sends Groupcast JoinGroup command with GroupID=1, Endpoints=[EP1], KeySetID=0x01a1, Key=Key1 to TH2 endpoint 0."
+          "Step 9b: TH1 sends Groupcast JoinGroup command with GroupID=1,
+          Endpoints=[EP1], KeySetID=0x01a1, Key=Key1 to TH2 endpoint 0."
       verification: |
 
       disabled: true
@@ -261,13 +267,17 @@ tests:
       disabled: true
 
     - label:
-          "Step 11: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH1 sets up group settings on DUT"
+          "Step 11: If the Groupcast cluster is enabled on the RootNode
+          endpoint, skip this step. Otherwise, TH1 sets up group settings on DUT"
       verification: |
 
       disabled: true
 
     - label:
-          "Step 12: If the Groupcast cluster is NOT enabled on the RootNode endpoint, skip this step. Otherwise, TH1 sends Groupcast JoinGroup command with GroupID=1, Endpoints=[], KeySetID=0x01a1, Key=Key1 to DUT endpoint 0."
+          "Step 12: If the Groupcast cluster is NOT enabled on the RootNode
+          endpoint, skip this step. Otherwise, TH1 sends Groupcast JoinGroup
+          command with GroupID=1, Endpoints=[], KeySetID=0x01a1, Key=Key1 to DUT
+          endpoint 0."
       verification: |
 
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
@@ -415,8 +415,8 @@ tests:
 
     - label:
           "Step 7: DUT sends a command from a cluster enabled on the Endpoint
-          provided in step 6 to TH. The command is sent as a group command
-          using GroupID 1."
+          provided in step 6 to TH. The command is sent as a group command using
+          GroupID 1."
       verification: |
           Validate the group message received from DUT via message layer
           inspection at the receiver: Verify that the IPv6 Destination

--- a/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
@@ -404,7 +404,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 6: If Groupcast cluster is NOT enabled on the RootNode endpoint
+          "Step 6: If Groupcast cluster is NOT enabled on the RootNode endpoint,
           or its Sender feature is disabled, skip remaining steps. Otherwise,
           DUT sends the Groupcast JoinGroup command on the TH on EP0 with
           GroupID=1, Endpoints=[any endpoint from PartsList], KeySetID=1."
@@ -420,6 +420,6 @@ tests:
       verification: |
           Validate the group message received from DUT via message layer
           inspection at the receiver: Verify that the IPv6 Destination
-          Multicast address follows the Matter IANA address FF05::FA, Verify
+          Multicast address matches the Matter IANA address FF05::FA, Verify
           the UDP port is 5540, Verify the DSIZ flag is set to group
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
@@ -216,8 +216,10 @@ tests:
       disabled: true
 
     - label:
-          "Step 3: DUT binds GroupId with GroupKeySetID in the GroupKeyMap
-          attribute list on GroupKeyManagement cluster"
+          "Step 3: If Groupcast cluster is enabled on the RootNode endpoint of
+          the DUT, skip to step 7. Otherwise, DUT binds GroupId with
+          GroupKeySetID in the GroupKeyMap attribute list on GroupKeyManagement
+          cluster"
       PICS: GRPKEY.C.A0000
       verification: |
           ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 259, "groupKeySetID": 419, "fabricIndex": 1},{"groupId": 257, "groupKeySetID": 419, "fabricIndex": 1}]' 1 0
@@ -328,20 +330,15 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: DUT generates fabric-unique GroupID, GroupName. Save the
-          GroupID as GroupID_2, GroupName as GroupName_2"
+          "Step 5: DUT sends an AddGroup command to the Groups cluster with the
+          GroupID field set to GroupID_2 and the GroupName set to GroupName_2.
+          The command is sent as a group command using GroupID_1"
+      PICS: G.C.C00.Tx
       verification: |
           refer to log in step 3
           GroupID_2 = 257
           GroupName_2 = "grp2"
-      disabled: true
 
-    - label:
-          "Step 6: DUT sends a AddGroup Command to the Groups cluster with the
-          GroupID field set to GroupID_2 and the GroupName set to an
-          GroupName_2. The command is sent as a group command using GroupID_1"
-      PICS: G.C.C00.Tx
-      verification: |
           ./chip-tool groups add-group 257 'grp2' 0xffffffffffff0103 0
 
           Verify that  AddGroup command with GroupID as 257 and group name as "grp2" is generated as groupcast message from GroupID 259 is present on TH(Reference app)log:
@@ -404,4 +401,25 @@ tests:
           [1700720496.175523][40754:40754] CHIP:DMG:     {
           [1700720496.175525][40754:40754] CHIP:DMG:         Initiator = true
           [1700720496.175529][40754:40754] CHIP:DMG:     }
+      disabled: true
+
+    - label:
+          "Step 6: If Groupcast cluster is NOT enabled on the RootNode endpoint
+          or its Sender feature is disabled, skip remaining steps. Otherwise,
+          DUT sends the Groupcast JoinGroup command on the TH on EP0 with
+          GroupID=1, Endpoints=[any endpoint from PartsList], KeySetID=1."
+      verification: |
+          Verify the TH receives the Groupcast JoinGroup command as specified
+          in the step label.
+      disabled: true
+
+    - label:
+          "Step 7: DUT sends a command from a cluster enabled on the Endpoint
+          provided in step 6 to TH. The command is sent as a group command
+          using GroupID 1."
+      verification: |
+          Validate the group message received from DUT via message layer
+          inspection at the receiver: Verify that the IPv6 Destination
+          Multicast address follows the Matter IANA address FF05::FA, Verify
+          the UDP port is 5540, Verify the DSIZ flag is set to group
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_SC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_6_1.yaml
@@ -190,8 +190,10 @@ tests:
       disabled: true
 
     - label:
-          "Step 3: DUT binds GroupID with GroupKeySetID in the GroupKeyMap
-          attribute list on GroupKeyManagement cluster"
+          "Step 3: If Groupcast cluster is enabled on the RootNode endpoint of
+          the TH, skip to step 6. Otherwise, DUT binds GroupID with
+          GroupKeySetID in the GroupKeyMap attribute list on GroupKeyManagement
+          cluster"
       PICS: GRPKEY.C.A0000
       verification: |
           ./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 1 0
@@ -288,7 +290,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: DUT sends ViewGroup command with the GroupID and GroupName to
+          "Step 5: DUT sends ViewGroup command with GroupID 1 and GroupName to
           the Group cluster on the TH on EP0"
       PICS: G.C.C01.Tx
       verification: |
@@ -327,7 +329,24 @@ tests:
           [1651471144.502628][4012:4012] CHIP:DMG: AccessControl: allowed
       disabled: true
 
-    - label: "Step 6: DUT sends KeySetRead Command to TH"
+    - label:
+          "Step 6: If Groupcast cluster is not enabled on the RootNode endpoint
+          of the TH, skip to step 8. Otherwise, DUT sends Groupcast JoinGroup
+          command to the TH on EP0 with GroupID=1, Endpoints=[any endpoint from
+          TH's PartsList], KeySetID=1."
+      verification: |
+          Verify the TH receives the Groupcast JoinGroup command as specified
+          in the step label.
+      disabled: true
+
+    - label:
+          "Step 7: DUT reads the Groupcast 'membership' attribute on the TH on
+          EP0."
+      verification: |
+          Test Harness receives the Membership attribute read from DUT
+      disabled: true
+
+    - label: "Step 8: DUT sends KeySetRead Command to TH"
       PICS: GRPKEY.C.C01.Tx
       verification: |
           ./chip-tool groupkeymanagement key-set-read 42 1 0
@@ -366,7 +385,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 7: DUT reads GroupKeyMap Attribute from the GroupKeyManagement
+          "Step 9: DUT reads GroupKeyMap Attribute from the GroupKeyManagement
           cluster from TH"
       PICS: GRPKEY.C.A0000
       verification: |
@@ -402,7 +421,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 8: DUT reads GroupTable attribute from GroupKeyManagement
+          "Step 10: DUT reads GroupTable attribute from GroupKeyManagement
           cluster on TH"
       PICS: GRPKEY.C.A0001
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_SC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_6_1.yaml
@@ -290,7 +290,7 @@ tests:
       disabled: true
 
     - label:
-          "Step 5: DUT sends ViewGroup command with GroupID 1 and GroupName to
+          "Step 5: DUT sends ViewGroup command with GroupID 1, and GroupName to
           the Group cluster on the TH on EP0"
       PICS: G.C.C01.Tx
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
@@ -53,8 +53,8 @@ tests:
     - label:
           "Step 0b: If the Groupcast cluster is enabled on the RootNode
           endpoint, skip this step. Otherwise, TH binds GroupId 0x0001 with
-          GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on
-          GroupKeyManagement cluster by writing the GroupKeyMap attribute with
+          GroupKeySetID 0x01a1 in the GroupKeyMap attribute of
+          GroupKeyManagement cluster, by writing the GroupKeyMap attribute with
           one entry as follows: List item 1: FabricIndex: 1 GroupId: 0x0001
           GroupKeySetId: 0x01a1"
       verification: |
@@ -132,7 +132,7 @@ tests:
           "Step 2: If the Groupcast cluster is enabled on the RootNode endpoint,
           the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and
           KeySetID. Otherwise, TH sends AddGroup with the GroupID field set to
-          G1."
+          Group 1."
       PICS: G.S.C00.Rsp
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup:

--- a/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
@@ -51,10 +51,12 @@ tests:
       disabled: true
 
     - label:
-          "Step 0b: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH binds GroupId 0x0001 with GroupKeySetID 0x01a1 in the
-          GroupKeyMap attribute list on GroupKeyManagement cluster by writing
-          the GroupKeyMap attribute with one entry as follows: List item 1:
-          FabricIndex: 1 GroupId: 0x0001 GroupKeySetId: 0x01a1"
+          "Step 0b: If the Groupcast cluster is enabled on the RootNode
+          endpoint, skip this step. Otherwise, TH binds GroupId 0x0001 with
+          GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on
+          GroupKeyManagement cluster by writing the GroupKeyMap attribute with
+          one entry as follows: List item 1: FabricIndex: 1 GroupId: 0x0001
+          GroupKeySetId: 0x01a1"
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise:
 
@@ -106,7 +108,9 @@ tests:
       disabled: true
 
     - label:
-          "Step 1: If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups."
+          "Step 1: If the Groupcast cluster is enabled on the RootNode endpoint,
+          the TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise,
+          TH sends RemoveAllGroups."
       PICS: G.S.C04.Rsp
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups:
@@ -125,8 +129,10 @@ tests:
       disabled: true
 
     - label:
-          "Step 2: If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup with the GroupID field set
-          to G1."
+          "Step 2: If the Groupcast cluster is enabled on the RootNode endpoint,
+          the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and
+          KeySetID. Otherwise, TH sends AddGroup with the GroupID field set to
+          G1."
       PICS: G.S.C00.Rsp
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup:

--- a/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_5.yaml
@@ -37,11 +37,10 @@ tests:
           GroupKeySet fields are as follows: GroupKeySetID: 0x01a1
           GroupKeySecurityPolicy: TrustFirst (0) EpochKey0:
           a0a1a2a3a4a5a6a7a8a9aaabacadaeaf EpochStartTime0: 1110000 EpochKey1:
-          b0b1b2b3b4b5b6b7b8b9babbbcbdbebf EpochStartTime1: 1110001 EpochKey2:
-          c0c1c2c3c4c5c6c7c8c9cacbcccdcecf EpochStartTime2: 1110002
+          b0b1b2b3b4b5b6b7b8b9babbbcbdbebf EpochStartTime1: 1110001
           GroupKeyMulticastPolicy: 0"
       verification: |
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": "0x01a1","groupKeySecurityPolicy": 0, "epochKey0":"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf","epochStartTime0": 1110000,"epochKey1":"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf", "epochStartTime1": 1110001,"epochKey2":"c0c1c2c3c4c5c6c7c8c9cacbcccdcecf", "epochStartTime2": 1110002, "groupKeyMulticastPolicy": 0 }' 1 0
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": "0x01a1","groupKeySecurityPolicy": 0, "epochKey0":"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf","epochStartTime0": 1110000,"epochKey1":"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf", "epochStartTime1": 1110001, "groupKeyMulticastPolicy": 0 }' 1 0
 
           Verify the "status is success" on the TH(Chip-tool)  Log  and below is the sample log provided for the raspi platform:
 
@@ -52,11 +51,13 @@ tests:
       disabled: true
 
     - label:
-          "Step 0b: TH binds GroupId 0x0001 with GroupKeySetID 0x01a1 in the
+          "Step 0b: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH binds GroupId 0x0001 with GroupKeySetID 0x01a1 in the
           GroupKeyMap attribute list on GroupKeyManagement cluster by writing
           the GroupKeyMap attribute with one entry as follows: List item 1:
           FabricIndex: 1 GroupId: 0x0001 GroupKeySetId: 0x01a1"
       verification: |
+          If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise:
+
           ./chip-tool groupkeymanagement write group-key-map '[{"groupId": "0x0001", "groupKeySetID": "0x01a1", "fabricIndex": 1} ]' 1 0
 
           Verify DUT responds with SUCCESS status response on the TH(Chip-tool)  Log  and below is the sample log provided for the raspi platform:
@@ -104,9 +105,14 @@ tests:
           [1701076939.783090][16287:16289] CHIP:DMG: }
       disabled: true
 
-    - label: "Step 1: TH sends a RemoveAllGroups command to DUT."
+    - label:
+          "Step 1: If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups."
       PICS: G.S.C04.Rsp
       verification: |
+          If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups:
+
+          ./chip-tool groupcast leave-group 0 0
+          or:
           ./chip-tool groups remove-all-groups 1 1
 
           Verify DUT responds with SUCCESS status response on the TH(Chip-tool)  Log  and below is the sample log provided for the raspi platform:
@@ -119,10 +125,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 2: TH sends a AddGroup command to DUT with the GroupID field set
+          "Step 2: If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup with the GroupID field set
           to G1."
       PICS: G.S.C00.Rsp
       verification: |
+          If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup:
+
+          ./chip-tool groupcast join-group 0x01 [1] 0x01a1 0
+          or:
           ./chip-tool groups add-group 0x0001 grp1 1 1
 
           Verify the AddGroupResponse with following fields:

--- a/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
@@ -40,8 +40,8 @@ tests:
           GroupKeyManagement cluster to DUT using a key that is pre-installed on
           the TH. GroupKeySet fields are as follows: * GroupKeySetID: 0x01a1 *
           GroupKeySecurityPolicy: TrustFirst (0) * EpochKey0:
-          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf * EpochStartTime0: 1110000
-           * GroupKeyMulticastPolicy: 0"
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf * EpochStartTime0: 1110000 *
+          GroupKeyMulticastPolicy: 0"
       verification: |
           Please execute the below commands before starting the test case :
 
@@ -93,11 +93,12 @@ tests:
       disabled: true
 
     - label:
-          "Step 0c: Precondition 3: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH binds GroupIds 0x0001 and 0x0002 with
-          GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on
-          GroupKeyManagement cluster by writing the GroupKeyMap attribute with
-          two entries as follows: * List item 1: - FabricIndex: 1 - GroupId:
-          0x0001 - GroupKeySetId: 0x01a1"
+          "Step 0c: Precondition 3: If the Groupcast cluster is enabled on the
+          RootNode endpoint, skip this step. Otherwise, TH binds GroupIds 0x0001
+          and 0x0002 with GroupKeySetID 0x01a1 in the GroupKeyMap attribute list
+          on GroupKeyManagement cluster by writing the GroupKeyMap attribute
+          with two entries as follows: * List item 1: - FabricIndex: 1 -
+          GroupId: 0x0001 - GroupKeySetId: 0x01a1"
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise:
 
@@ -152,7 +153,9 @@ tests:
       disabled: true
 
     - label:
-          "Step 0d: Precondition 4: If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups to DUT."
+          "Step 0d: Precondition 4: If the Groupcast cluster is enabled on the
+          RootNode endpoint, TH sends Groupcast LeaveGroup command with GroupID
+          0. Otherwise, TH sends RemoveAllGroups to DUT."
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups:
 
@@ -189,7 +192,9 @@ tests:
       disabled: true
 
     - label:
-          "Step 0e: Precondition 5: If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup to DUT with the
+          "Step 0e: Precondition 5: If the Groupcast cluster is enabled on the
+          RootNode endpoint, TH sends Groupcast JoinGroup command with GroupID,
+          Endpoints, and KeySetID. Otherwise, TH sends AddGroup to DUT with the
           GroupID field set to G1."
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup:

--- a/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
@@ -95,8 +95,8 @@ tests:
     - label:
           "Step 0c: Precondition 3: If the Groupcast cluster is enabled on the
           RootNode endpoint, skip this step. Otherwise, TH binds GroupIds 0x0001
-          and 0x0002 with GroupKeySetID 0x01a1 in the GroupKeyMap attribute list
-          on GroupKeyManagement cluster by writing the GroupKeyMap attribute
+          and 0x0002 with GroupKeySetID 0x01a1, in the GroupKeyMap attribute
+          of GroupKeyManagement cluster by writing the GroupKeyMap attribute
           with two entries as follows: * List item 1: - FabricIndex: 1 -
           GroupId: 0x0001 - GroupKeySetId: 0x01a1"
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
@@ -95,10 +95,10 @@ tests:
     - label:
           "Step 0c: Precondition 3: If the Groupcast cluster is enabled on the
           RootNode endpoint, skip this step. Otherwise, TH binds GroupIds 0x0001
-          and 0x0002 with GroupKeySetID 0x01a1, in the GroupKeyMap attribute
-          of GroupKeyManagement cluster by writing the GroupKeyMap attribute
-          with two entries as follows: * List item 1: - FabricIndex: 1 -
-          GroupId: 0x0001 - GroupKeySetId: 0x01a1"
+          and 0x0002 with GroupKeySetID 0x01a1, in the GroupKeyMap attribute of
+          GroupKeyManagement cluster by writing the GroupKeyMap attribute with
+          two entries as follows: * List item 1: - FabricIndex: 1 - GroupId:
+          0x0001 - GroupKeySetId: 0x01a1"
       verification: |
           If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise:
 

--- a/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
@@ -45,7 +45,7 @@ tests:
       verification: |
           Please execute the below commands before starting the test case :
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": "0x01a1","groupKeySecurityPolicy": 0, "epochKey0":"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf","epochStartTime0": 1110000,"epochKey1":"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf", "epochStartTime1": 1110001,"epochKey2":"c0c1c2c3c4c5c6c7c8c9cacbcccdcecf", "epochStartTime2": 1110002, "groupKeyMulticastPolicy": 0 }' 1 0
+          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": "0x01a1","groupKeySecurityPolicy": 0, "epochKey0":"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf","epochStartTime0": 1110000}' 1 0
 
           Verify the KeySetWrite command  On TH (all-Clusters-app) log and below is the sample log provided for the raspi platform:
 

--- a/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_3_1.yaml
@@ -40,10 +40,8 @@ tests:
           GroupKeyManagement cluster to DUT using a key that is pre-installed on
           the TH. GroupKeySet fields are as follows: * GroupKeySetID: 0x01a1 *
           GroupKeySecurityPolicy: TrustFirst (0) * EpochKey0:
-          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf * EpochStartTime0: 1110000 *
-          EpochKey1: b0b1b2b3b4b5b6b7b8b9babbbcbdbebf * EpochStartTime1: 1110001
-          * EpochKey2: c0c1c2c3c4c5c6c7c8c9cacbcccdcecf * EpochStartTime2:
-          1110002 * GroupKeyMulticastPolicy: 0"
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf * EpochStartTime0: 1110000
+           * GroupKeyMulticastPolicy: 0"
       verification: |
           Please execute the below commands before starting the test case :
 
@@ -95,12 +93,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 0c: Precondition 3: TH binds GroupIds 0x0001 and 0x0002 with
+          "Step 0c: Precondition 3: If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise, TH binds GroupIds 0x0001 and 0x0002 with
           GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on
           GroupKeyManagement cluster by writing the GroupKeyMap attribute with
           two entries as follows: * List item 1: - FabricIndex: 1 - GroupId:
           0x0001 - GroupKeySetId: 0x01a1"
       verification: |
+          If the Groupcast cluster is enabled on the RootNode endpoint, skip this step. Otherwise:
+
           Please execute the below commands before starting the test case :
 
           ./chip-tool groupkeymanagement write group-key-map '[{"groupId": "0x0001", "groupKeySetID": "0x01a1", "fabricIndex": 1} ]' 1 0
@@ -152,9 +152,13 @@ tests:
       disabled: true
 
     - label:
-          "Step 0d: Precondition 4: TH sends a RemoveAllGroups command to DUT."
+          "Step 0d: Precondition 4: If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups to DUT."
       verification: |
-          ./chip-tool groups remove-all-groups 1 1
+          If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast LeaveGroup command with GroupID 0. Otherwise, TH sends RemoveAllGroups:
+
+            ./chip-tool groupcast leave-group 0 0
+          or:
+            ./chip-tool groups remove-all-groups 1 1
 
           Verify the RemoveAllGroups attribute On TH (all-Clusters-app) log and below is the sample log provided for the raspi platform:
 
@@ -185,11 +189,14 @@ tests:
       disabled: true
 
     - label:
-          "Step 0e: Precondition 5: TH sends a AddGroup command to DUT with the
+          "Step 0e: Precondition 5: If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup to DUT with the
           GroupID field set to G1."
       verification: |
-          Please execute the below commands before starting the test case :
+          If the Groupcast cluster is enabled on the RootNode endpoint, TH sends Groupcast JoinGroup command with GroupID, Endpoints, and KeySetID. Otherwise, TH sends AddGroup:
 
+          Please execute the below commands before starting the test case :
+          ./chip-tool groupcast join-group 0x01 [1] 0x01a1
+          or:
           ./chip-tool groups add-group 0x01 Gp1 1 1
 
           Verify the AddGroup Command  on TH (all-Clusters-app) log and below is the sample log provided for the raspi platform:


### PR DESCRIPTION
#### Summary
Multiples Test plans were updated to use groupcast cluster, if it is enabled on the root endpoint, instead of the groups cluster.
https://github.com/CHIP-Specifications/chip-test-plans/pull/5936

This PR update some Test Case in YAML files that aren't automated and are not part of the CI.
This PR does not attempt to make them automated. (Ideally they would be implemented with python testing suite)
It keeps the status quo for those tests but updates their steps, descriptions, and verifications in line with the Test plans updates.

#### Related issues


#### Testing
N/A :This is only text updates. nothing is automated.
