### PR TITLE
[Crypto] Fix the wrong handling PSA pending keypair.

### DIFF
--- a/src/crypto/PSAOperationalKeystore.cpp
+++ b/src/crypto/PSAOperationalKeystore.cpp
@@ -60,17 +60,28 @@ CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Generate()
     psa_status_t status             = PSA_SUCCESS;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_id_t keyId              = 0;
-    size_t publicKeyLength;
+    size_t publicKeyLength          = 0;
 
-    TEMPORARY_RETURN_IGNORED Destroy();
+    // Only destroy a prior pending key if it is volatile; do not destroy the persistent operational key.
+    if (GetKeyId() != PSA_KEY_ID_NULL)
+    {
+        status = psa_get_key_attributes(GetKeyId(), &attributes);
+
+        if (status == PSA_SUCCESS && PSA_KEY_LIFETIME_IS_VOLATILE(psa_get_key_lifetime(&attributes)))
+        {
+            TEMPORARY_RETURN_IGNORED Destroy();
+        }
+
+        psa_reset_key_attributes(&attributes);
+    }
 
     // Type based on ECC with the elliptic curve SECP256r1 -> PSA_ECC_FAMILY_SECP_R1
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
     psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
-    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
-    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
-    psa_set_key_id(&attributes, GetKeyId());
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE | PSA_KEY_USAGE_COPY);
+
+    // Update the key attributes if needed
     GetPSAKeyAllocator().UpdateKeyAttributes(attributes);
 
     status = psa_generate_key(&attributes, &keyId);
@@ -81,6 +92,17 @@ CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Generate()
     VerifyOrExit(publicKeyLength == kP256_PublicKey_Length, error = CHIP_ERROR_INTERNAL);
 
 exit:
+
+    if (error != CHIP_NO_ERROR)
+    {
+        psa_destroy_key(keyId);
+    }
+    else
+    {
+        // Save the volatile key id to the context
+        ToPsaContext(mKeypair).key_id = keyId;
+    }
+
     psa_reset_key_attributes(&attributes);
 
     return error;
@@ -88,7 +110,9 @@ exit:
 
 CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Destroy()
 {
-    psa_status_t status = psa_destroy_key(GetKeyId());
+    psa_status_t status = PSA_SUCCESS;
+
+    status = psa_destroy_key(GetKeyId());
 
     VerifyOrReturnError(status != PSA_ERROR_INVALID_HANDLE, CHIP_ERROR_INVALID_FABRIC_INDEX);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
@@ -183,9 +207,45 @@ CHIP_ERROR PSAOperationalKeystore::CommitOpKeypairForFabric(FabricIndex fabricIn
     VerifyOrReturnError(IsValidFabricIndex(fabricIndex) && mPendingFabricIndex == fabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
     VerifyOrReturnError(mIsPendingKeypairActive, CHIP_ERROR_INCORRECT_STATE);
 
-    ReleasePendingKeypair();
+    psa_status_t status             = PSA_SUCCESS;
+    CHIP_ERROR error                = CHIP_NO_ERROR;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_id_t keyId              = 0;
 
-    return CHIP_NO_ERROR;
+    PersistentP256Keypair keyPairToCommit(fabricIndex);
+
+    status = psa_get_key_attributes(mPendingKeypair->GetKeyId(), &attributes);
+    VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+
+    status = psa_destroy_key(keyPairToCommit.GetKeyId());
+    VerifyOrExit(status == PSA_SUCCESS || status == PSA_ERROR_INVALID_HANDLE, error = CHIP_ERROR_INTERNAL);
+
+    // Switch to the persistent key
+    psa_set_key_id(&attributes, keyPairToCommit.GetKeyId());
+    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
+
+    {
+        // The committed persistent key should be not copyable.
+        psa_key_usage_t usage = psa_get_key_usage_flags(&attributes);
+        usage &= ~PSA_KEY_USAGE_COPY;
+        psa_set_key_usage_flags(&attributes, usage);
+    }
+
+    // Update the key attributes if needed
+    GetPSAKeyAllocator().UpdateKeyAttributes(attributes);
+
+    status = psa_copy_key(mPendingKeypair->GetKeyId(), &attributes, &keyId);
+    VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(keyId == keyPairToCommit.GetKeyId(), error = CHIP_ERROR_INTERNAL);
+
+    // Copied was done, so we can revert the pending keypair
+    RevertPendingKeypair();
+
+exit:
+    LogPsaError(status);
+    psa_reset_key_attributes(&attributes);
+
+    return error;
 }
 
 CHIP_ERROR PSAOperationalKeystore::ExportOpKeypairForFabric(FabricIndex fabricIndex, Crypto::P256SerializedKeypair & outKeypair)

--- a/src/crypto/tests/TestPSAOpKeyStore.cpp
+++ b/src/crypto/tests/TestPSAOpKeyStore.cpp
@@ -193,6 +193,70 @@ TEST_F(TestPSAOpKeyStore, TestEphemeralKeys)
     opKeyStore.ReleaseEphemeralKeypair(ephemeralKeypair);
 }
 
+TEST_F(TestPSAOpKeyStore, TestPendingKeypairRevertPreservesActiveKeyWithCustomAllocator)
+{
+    constexpr FabricIndex kFabricIndex = 111;
+    constexpr psa_key_id_t kBaseKeyId  = 4096;
+
+    class CustomAllocator : public PSAKeyAllocator
+    {
+    public:
+        psa_key_id_t GetDacKeyId() override { return kBaseKeyId; }
+        psa_key_id_t GetOpKeyId(FabricIndex fabricIndex) override { return kBaseKeyId + fabricIndex; }
+        psa_key_id_t AllocateICDKeyId() override { return PSA_KEY_ID_NULL; }
+        void UpdateKeyAttributes(psa_key_attributes_t & attrs) override
+        {
+            // Keep default behavior for algorithm/usage, only enforce deterministic key ID mapping for persistent keys.
+            if (psa_get_key_lifetime(&attrs) == PSA_KEY_LIFETIME_PERSISTENT && psa_get_key_id(&attrs) == 0)
+            {
+                psa_set_key_id(&attrs, GetOpKeyId(kFabricIndex));
+            }
+        }
+    };
+
+    static CustomAllocator customAllocator;
+    SetPSAKeyAllocator(&customAllocator);
+
+    PSAOperationalKeystore opKeystore;
+    uint8_t csrBuf[kMIN_CSR_Buffer_Size];
+    MutableByteSpan csrSpan{ csrBuf };
+    P256PublicKey activePublicKey;
+    P256PublicKey pendingPublicKey;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Commit the first keypair as active.
+    err = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), activePublicKey), CHIP_NO_ERROR);
+    EXPECT_EQ(opKeystore.ActivateOpKeypairForFabric(kFabricIndex, activePublicKey), CHIP_NO_ERROR);
+    EXPECT_EQ(opKeystore.CommitOpKeypairForFabric(kFabricIndex), CHIP_NO_ERROR);
+    EXPECT_FALSE(opKeystore.HasPendingOpKeypair());
+    EXPECT_TRUE(opKeystore.HasOpKeypairForFabric(kFabricIndex));
+
+    // Start a second keypair generation for the same fabric; this one stays pending.
+    csrSpan = MutableByteSpan{ csrBuf };
+    err     = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), pendingPublicKey), CHIP_NO_ERROR);
+    EXPECT_FALSE(activePublicKey.Matches(pendingPublicKey));
+    EXPECT_EQ(opKeystore.ActivateOpKeypairForFabric(kFabricIndex, pendingPublicKey), CHIP_NO_ERROR);
+    EXPECT_TRUE(opKeystore.HasPendingOpKeypair());
+
+    // Reverting a pending keypair must not remove the already committed key.
+    EXPECT_EQ(opKeystore.RemoveOpKeypairForFabric(kFabricIndex), CHIP_NO_ERROR);
+    EXPECT_FALSE(opKeystore.HasPendingOpKeypair());
+    EXPECT_TRUE(opKeystore.HasOpKeypairForFabric(kFabricIndex));
+
+    uint8_t msg[] = { 0x01, 0x02, 0x03 };
+    P256ECDSASignature signature;
+    EXPECT_EQ(opKeystore.SignWithOpKeypair(kFabricIndex, ByteSpan{ msg }, signature), CHIP_NO_ERROR);
+    EXPECT_EQ(activePublicKey.ECDSA_validate_msg_signature(msg, sizeof(msg), signature), CHIP_NO_ERROR);
+    EXPECT_EQ(pendingPublicKey.ECDSA_validate_msg_signature(msg, sizeof(msg), signature), CHIP_ERROR_INVALID_SIGNATURE);
+
+    EXPECT_EQ(opKeystore.RemoveOpKeypairForFabric(kFabricIndex), CHIP_NO_ERROR);
+    SetPSAKeyAllocator(nullptr);
+}
+
 TEST_F(TestPSAOpKeyStore, TestMigrationKeys)
 {
     chip::TestPersistentStorageDelegate storage;


### PR DESCRIPTION
#### Summary

The pending keypair was handled in a wrong way in the PSA PAL.

This keypair should be saved to ITS as volatile persistence, then all operations should be done using this instance, and it must be saved to persistent storage in the CommitOpKeypairForFabric function.

Previously, the same KeyId was used both to active and pending keypairs, and when a failsafe occurs, then this key has been removed and there is no key for the fabric anymore.

Main changes:
- PersistentP256Keypair::Generate generates a pending keypair as volatile with additional usage flag PSA_KEY_USAGE_COPY.
- In the CommitOpKeypairForFabric function the pending keypair is copied to persistent location, and the keyId for fabric is replaced.

#### Testing

- nRFConnect testing on desk.
- Existing unit tests are still passing, they cover generating and committing the key.
- `test_TC_OPCREDS_3_8` passes thanks to this change, because to meet its requirements and do not remove the key so quickly, we need to generate a key as volatile, then perform some operations, and if everything finishes successfully, store the key in the persistent storage.
- Added a new unit test to cover the new scenario.
