### PR TITLE
[Camera App] Fix 3 shutdown bugs: Heap-use-after-free and leak

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -104,6 +104,7 @@ public:
     CameraDeviceInterface::CameraHALInterface & GetCameraHALInterface() override { return *this; }
 
     void Init();
+    void Shutdown();
 
     // HAL interface impl
     CameraError InitializeCameraDevice() override;

--- a/examples/camera-app/linux/main.cpp
+++ b/examples/camera-app/linux/main.cpp
@@ -70,6 +70,10 @@ void ApplicationInit()
 
 void ApplicationShutdown()
 {
+    // Close WebRTC connections before CameraAppShutdown and PlatformMgr().Shutdown() to ensure webRTC callbacks (such as
+    // WebRTCProviderManager::OnConnectionStateChanged) can still use the SystemLayer.
+    gCameraDevice.Shutdown();
+
     CameraAppShutdown();
 
     TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();

--- a/examples/camera-app/linux/main.cpp
+++ b/examples/camera-app/linux/main.cpp
@@ -70,7 +70,7 @@ void ApplicationInit()
 
 void ApplicationShutdown()
 {
-    // Close WebRTC connections before CameraAppShutdown and PlatformMgr().Shutdown() to ensure webRTC callbacks (such as
+    // Close WebRTC connections before CameraAppShutdown and PlatformMgr().Shutdown() to ensure WebRTC callbacks (such as
     // WebRTCProviderManager::OnConnectionStateChanged) can still use the SystemLayer.
     gCameraDevice.Shutdown();
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -444,17 +444,6 @@ CameraDevice::CameraDevice()
 
 CameraDevice::~CameraDevice()
 {
-    // Stop Video and Audio Streams so their threads don't access CameraDevice members (like mAudioStreamPtsOffsetMs) after
-    // destruction.
-    for (auto & stream : mVideoStreams)
-    {
-        StopVideoStream(stream.videoStreamParams.videoStreamID);
-    }
-    for (auto & stream : mAudioStreams)
-    {
-        StopAudioStream(stream.audioStreamParams.audioStreamID);
-    }
-
     if (videoDeviceFd != -1)
     {
         close(videoDeviceFd);
@@ -473,6 +462,17 @@ void CameraDevice::Shutdown()
 {
     // Close WebRTC connections while the SystemLayer is still alive, so that WebRTC callbacks can safely use ScheduleLambda.
     mWebRTCProviderManager.CloseConnection();
+
+    // Stop Video and Audio Streams so their threads don't access CameraDevice members (like mAudioStreamPtsOffsetMs) after
+    // destruction.
+    for (auto & stream : mVideoStreams)
+    {
+        StopVideoStream(stream.videoStreamParams.videoStreamID);
+    }
+    for (auto & stream : mAudioStreams)
+    {
+        StopAudioStream(stream.audioStreamParams.audioStreamID);
+    }
 }
 
 CameraError CameraDevice::InitializeCameraDevice()

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -444,6 +444,17 @@ CameraDevice::CameraDevice()
 
 CameraDevice::~CameraDevice()
 {
+    // Stop Video and Audio Streams so their threads don't access CameraDevice members (like mAudioStreamPtsOffsetMs) after
+    // destruction.
+    for (auto & stream : mVideoStreams)
+    {
+        StopVideoStream(stream.videoStreamParams.videoStreamID);
+    }
+    for (auto & stream : mAudioStreams)
+    {
+        StopAudioStream(stream.audioStreamParams.audioStreamID);
+    }
+
     if (videoDeviceFd != -1)
     {
         close(videoDeviceFd);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -458,6 +458,12 @@ void CameraDevice::Init()
     mPushAVTransportManager.Init();
 }
 
+void CameraDevice::Shutdown()
+{
+    // Close WebRTC connections while the SystemLayer is still alive, so that WebRTC callbacks can safely use ScheduleLambda.
+    mWebRTCProviderManager.CloseConnection();
+}
+
 CameraError CameraDevice::InitializeCameraDevice()
 {
     static bool gstreamerInitialized = false;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -153,7 +153,7 @@ void WebRTCProviderManager::Init()
 void WebRTCProviderManager::CloseConnection()
 {
     // Cancel all pending connection timers and freeing their contexts to avoid leaks
-    while (!mConnectionTimerContexts.empty())
+    while (!mConnectionTimerContexts.empty() && DeviceLayer::SystemLayer().IsInitialized())
     {
         CancelConnectionTimer(mConnectionTimerContexts.begin()->first);
     }

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -152,6 +152,12 @@ void WebRTCProviderManager::Init()
 
 void WebRTCProviderManager::CloseConnection()
 {
+    // Cancel all pending connection timers and freeing their contexts to avoid leaks
+    while (!mConnectionTimerContexts.empty())
+    {
+        CancelConnectionTimer(mConnectionTimerContexts.begin()->first);
+    }
+
     // Clean up all the Webrtc Transports
     mWebrtcTransportMap.clear();
     mSessionIdMap.clear();


### PR DESCRIPTION
#### Summary

- Fixes https://github.com/project-chip/connectedhomeip/issues/43681


- Basically there are three issues:

1. During Shutdown, ScheduleLambda was being called as part of a callback, but the SystemLayer was destroyed:
   - Fix: Add a Shutdown method in `CameraDevice` to close WebRTC connections BEFORE the SystemLayer is destroyed, so that callbacks like `WebRTCProviderManager::OnConnectionStateChanged` can still safely use ScheduleLambda

2. Leak of ConnectionTimerContext:  
   -  Fix: Cancel the pending connection timers in WebRTCProviderManager::CloseConnection

3. Audio and Video stream were accessing  CameraDevice members (like mAudioStreamPtsOffsetMs) AFTER CameraDevice was destructed
   - Fix: Stop the Audio and Video Stream in `CameraDevice::Shutdown()`


#### Testing

- Tested by Building and running Camera App using `asan-clang` and `asan-gcc` and valgrind and making sure not errors are triggered (except those the false positives related to libdatachannel)
- The changes were also tested in the PR https://github.com/project-chip/connectedhomeip/pull/43152

