### PR TITLE
Fix air-quality-sensor build failures on linux

### DIFF
--- a/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
+++ b/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
@@ -156,6 +156,6 @@ void AirQualitySensorAppAttrUpdateDelegate::OnEventCommandReceived(const char * 
         return;
     }
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(AirQualitySensorAttrUpdateHandler::HandleCommand,
-                                                  reinterpret_cast<intptr_t>(handler));
+    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::PlatformMgr().ScheduleWork(AirQualitySensorAttrUpdateHandler::HandleCommand,
+                                                                           reinterpret_cast<intptr_t>(handler));
 }

--- a/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
+++ b/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
+#include <lib/support/CodeUtils.h>
 #include <platform/PlatformManager.h>
 
 #include <air-quality-sensor-manager.h>
@@ -156,6 +157,7 @@ void AirQualitySensorAppAttrUpdateDelegate::OnEventCommandReceived(const char * 
         return;
     }
 
-    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::PlatformMgr().ScheduleWork(AirQualitySensorAttrUpdateHandler::HandleCommand,
-                                                                           reinterpret_cast<intptr_t>(handler));
+    SuccessOrLog(chip::DeviceLayer::PlatformMgr().ScheduleWork(AirQualitySensorAttrUpdateHandler::HandleCommand,
+                                                               reinterpret_cast<intptr_t>(handler)),
+                 DeviceLayer, "Cannot schedule work for command handler");
 }

--- a/examples/air-quality-sensor-app/linux/main.cpp
+++ b/examples/air-quality-sensor-app/linux/main.cpp
@@ -21,6 +21,7 @@
 #include <air-quality-sensor-manager.h>
 
 #include <platform/CHIPDeviceConfig.h>
+#include <lib/support/CodeUtils.h>
 
 #include <string>
 

--- a/examples/air-quality-sensor-app/linux/main.cpp
+++ b/examples/air-quality-sensor-app/linux/main.cpp
@@ -20,8 +20,8 @@
 #include <AppMain.h>
 #include <air-quality-sensor-manager.h>
 
-#include <platform/CHIPDeviceConfig.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #include <string>
 

--- a/examples/air-quality-sensor-app/linux/main.cpp
+++ b/examples/air-quality-sensor-app/linux/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
     if ((!path.empty()) and (sChipNamedPipeCommands.Start(path, &sAirQualitySensorAppCommandDelegate) != CHIP_NO_ERROR))
     {
         ChipLogError(NotSpecified, "Failed to start CHIP NamedPipeCommands");
-        sChipNamedPipeCommands.Stop();
+        SuccessOrLog(sChipNamedPipeCommands.Stop(), NotSpecified, "Failed to cleanup CHIP NamedPipeCommands");
     }
 
 #if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED


### PR DESCRIPTION
#### Summary

The `air-quality-sensor` example fails to build on linux:

```
2026-03-24 13:44:51.744 INFO    ../../examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp:159:50: error: ignoring returned value of type ‘CHIP_ERROR’ {aka ‘chip::ChipError’}, declared with attribute ‘nodiscard’ [-Werror=unused-result]
…
2026-03-24 13:44:51.775 INFO    ../../examples/air-quality-sensor-app/linux/main.cpp:60:36: error: ignoring returned value of type ‘CHIP_ERROR’ {aka ‘chip::ChipError’}, declared with attribute ‘nodiscard’ [-Werror=unused-result]
2026-03-24 13:44:51.775 INFO       60 |         sChipNamedPipeCommands.Stop();
```

#### Testing

```
$ scripts/build/build_examples.py --target linux-x64-air-quality-sensor build
…
2026-03-24 13:50:29.135 INFO    Command ['ninja', '-C', '/workspaces/connectedhomeip/out/linux-x64-air-quality-sensor'] completed
2026-03-24 13:50:29.135 INFO    Build Time Summary:
2026-03-24 13:50:29.135 INFO      - linux-x64-air-quality-sensor: 50s
2026-03-24 13:50:29.135 INFO    Total build time: 50s
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
