### PR TITLE
[Telink] Add Aliro (Apple Home) delegate for door lock

### DIFF
--- a/examples/lock-app/telink/CMakeLists.txt
+++ b/examples/lock-app/telink/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(app PRIVATE
 
 target_sources(app PRIVATE
                src/AppTask.cpp
+               src/AliroDelegate.cpp
                src/ZclCallbacks.cpp
                src/LockManager.cpp
                src/LockSettingsStorage.cpp

--- a/examples/lock-app/telink/include/AliroDelegate.h
+++ b/examples/lock-app/telink/include/AliroDelegate.h
@@ -69,10 +69,10 @@ private:
 
     struct CredentialSlot
     {
-        DlCredentialStatus status        = DlCredentialStatus::kAvailable;
-        chip::FabricIndex createdBy      = 0;
-        chip::FabricIndex lastModifiedBy = 0;
-        size_t dataSize                  = 0;
+        DlCredentialStatus status             = DlCredentialStatus::kAvailable;
+        chip::FabricIndex createdBy           = 0;
+        chip::FabricIndex lastModifiedBy      = 0;
+        size_t dataSize                       = 0;
         uint8_t data[kAliroCredentialMaxSize] = { 0 };
     };
 

--- a/examples/lock-app/telink/include/AliroDelegate.h
+++ b/examples/lock-app/telink/include/AliroDelegate.h
@@ -1,0 +1,86 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <AppConfig.h>
+#include <app/clusters/door-lock-server/door-lock-delegate.h>
+#include <app/clusters/door-lock-server/door-lock-server.h>
+
+class AliroDelegate : public chip::app::Clusters::DoorLock::Delegate
+{
+public:
+    static AliroDelegate & GetInstance() { return sInstance; }
+
+    AliroDelegate(const AliroDelegate &)             = delete;
+    AliroDelegate & operator=(const AliroDelegate &) = delete;
+
+    // DoorLock::Delegate interface
+    CHIP_ERROR GetAliroReaderVerificationKey(chip::MutableByteSpan & verificationKey) override;
+    CHIP_ERROR GetAliroReaderGroupIdentifier(chip::MutableByteSpan & groupIdentifier) override;
+    CHIP_ERROR GetAliroReaderGroupSubIdentifier(chip::MutableByteSpan & groupSubIdentifier) override;
+    CHIP_ERROR GetAliroExpeditedTransactionSupportedProtocolVersionAtIndex(size_t index,
+                                                                           chip::MutableByteSpan & protocolVersion) override;
+    CHIP_ERROR GetAliroGroupResolvingKey(chip::MutableByteSpan & groupResolvingKey) override;
+    CHIP_ERROR GetAliroSupportedBLEUWBProtocolVersionAtIndex(size_t index, chip::MutableByteSpan & protocolVersion) override;
+    uint8_t GetAliroBLEAdvertisingVersion() override;
+    uint16_t GetNumberOfAliroCredentialIssuerKeysSupported() override;
+    uint16_t GetNumberOfAliroEndpointKeysSupported() override;
+    CHIP_ERROR SetAliroReaderConfig(const chip::ByteSpan & signingKey, const chip::ByteSpan & verificationKey,
+                                    const chip::ByteSpan & groupIdentifier,
+                                    const chip::Optional<chip::ByteSpan> & groupResolvingKey) override;
+    CHIP_ERROR ClearAliroReaderConfig() override;
+
+    // Aliro credential storage — called from LockManager
+    static bool IsAliroCredentialType(CredentialTypeEnum type);
+    bool GetCredential(uint16_t index, CredentialTypeEnum type, EmberAfPluginDoorLockCredentialInfo & out);
+    bool SetCredential(uint16_t index, chip::FabricIndex creator, chip::FabricIndex modifier, DlCredentialStatus status,
+                       CredentialTypeEnum type, const chip::ByteSpan & data);
+
+private:
+    AliroDelegate();
+
+    CHIP_ERROR CopyProtocolVersionIntoSpan(uint16_t protocolVersionValue, chip::MutableByteSpan & protocolVersion);
+
+    // Aliro provisioning state
+    uint8_t mAliroReaderVerificationKey[chip::app::Clusters::DoorLock::kAliroReaderVerificationKeySize];
+    uint8_t mAliroReaderGroupIdentifier[chip::app::Clusters::DoorLock::kAliroReaderGroupIdentifierSize];
+    uint8_t mAliroReaderGroupSubIdentifier[chip::app::Clusters::DoorLock::kAliroReaderGroupSubIdentifierSize];
+    uint8_t mAliroGroupResolvingKey[chip::app::Clusters::DoorLock::kAliroGroupResolvingKeySize];
+    bool mAliroStateInitialized = false;
+
+    // Aliro credential storage (in-memory; Aliro keys are not persisted to NVM)
+    static constexpr size_t kAliroCredentialMaxSize = 65;
+
+    struct CredentialSlot
+    {
+        DlCredentialStatus status        = DlCredentialStatus::kAvailable;
+        chip::FabricIndex createdBy      = 0;
+        chip::FabricIndex lastModifiedBy = 0;
+        size_t dataSize                  = 0;
+        uint8_t data[kAliroCredentialMaxSize] = { 0 };
+    };
+
+    CredentialSlot * SlotArrayForType(CredentialTypeEnum type);
+
+    CredentialSlot mIssuerKeys[APP_MAX_CREDENTIAL];
+    CredentialSlot mEvictableEndpointKeys[APP_MAX_CREDENTIAL];
+    CredentialSlot mNonEvictableEndpointKeys[APP_MAX_CREDENTIAL];
+
+    static AliroDelegate sInstance;
+};

--- a/examples/lock-app/telink/src/AliroDelegate.cpp
+++ b/examples/lock-app/telink/src/AliroDelegate.cpp
@@ -135,8 +135,7 @@ uint16_t AliroDelegate::GetNumberOfAliroEndpointKeysSupported()
 }
 
 CHIP_ERROR AliroDelegate::SetAliroReaderConfig(const ByteSpan & signingKey, const ByteSpan & verificationKey,
-                                               const ByteSpan & groupIdentifier,
-                                               const Optional<ByteSpan> & groupResolvingKey)
+                                               const ByteSpan & groupIdentifier, const Optional<ByteSpan> & groupResolvingKey)
 {
     // We ignore the signing key, since we never do anything with it.
     (void) signingKey;
@@ -217,8 +216,8 @@ bool AliroDelegate::GetCredential(uint16_t index, CredentialTypeEnum type, Ember
     return true;
 }
 
-bool AliroDelegate::SetCredential(uint16_t index, chip::FabricIndex creator, chip::FabricIndex modifier,
-                                  DlCredentialStatus status, CredentialTypeEnum type, const chip::ByteSpan & data)
+bool AliroDelegate::SetCredential(uint16_t index, chip::FabricIndex creator, chip::FabricIndex modifier, DlCredentialStatus status,
+                                  CredentialTypeEnum type, const chip::ByteSpan & data)
 {
     CredentialSlot * slots = SlotArrayForType(type);
     VerifyOrReturnValue(slots != nullptr, false);
@@ -227,10 +226,10 @@ bool AliroDelegate::SetCredential(uint16_t index, chip::FabricIndex creator, chi
 
     if (status == DlCredentialStatus::kAvailable)
     {
-        slot.status          = DlCredentialStatus::kAvailable;
-        slot.dataSize        = 0;
-        slot.createdBy       = creator;
-        slot.lastModifiedBy  = modifier;
+        slot.status         = DlCredentialStatus::kAvailable;
+        slot.dataSize       = 0;
+        slot.createdBy      = creator;
+        slot.lastModifiedBy = modifier;
         return true;
     }
 

--- a/examples/lock-app/telink/src/AliroDelegate.cpp
+++ b/examples/lock-app/telink/src/AliroDelegate.cpp
@@ -30,8 +30,14 @@ AliroDelegate AliroDelegate::sInstance;
 
 AliroDelegate::AliroDelegate()
 {
-    // The group sub-identifier is non-nullable; initialize once with random bytes.
-    TEMPORARY_RETURN_IGNORED Crypto::DRBG_get_bytes(mAliroReaderGroupSubIdentifier, sizeof(mAliroReaderGroupSubIdentifier));
+    CHIP_ERROR err = Crypto::DRBG_get_bytes(
+        mAliroReaderGroupSubIdentifier,
+        sizeof(mAliroReaderGroupSubIdentifier));
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "Failed to init Aliro sub-identifier: %" CHIP_ERROR_FORMAT, err.Format());
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/lock-app/telink/src/AliroDelegate.cpp
+++ b/examples/lock-app/telink/src/AliroDelegate.cpp
@@ -1,0 +1,249 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AliroDelegate.h"
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip;
+using namespace chip::app::Clusters::DoorLock;
+
+AliroDelegate AliroDelegate::sInstance;
+
+AliroDelegate::AliroDelegate()
+{
+    // The group sub-identifier is non-nullable; initialize once with random bytes.
+    TEMPORARY_RETURN_IGNORED Crypto::DRBG_get_bytes(mAliroReaderGroupSubIdentifier, sizeof(mAliroReaderGroupSubIdentifier));
+}
+
+// ---------------------------------------------------------------------------
+// DoorLock::Delegate — Aliro provisioning attributes
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR AliroDelegate::GetAliroReaderVerificationKey(MutableByteSpan & verificationKey)
+{
+    if (!mAliroStateInitialized)
+    {
+        verificationKey.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    return CopySpanToMutableSpan(ByteSpan(mAliroReaderVerificationKey), verificationKey);
+}
+
+CHIP_ERROR AliroDelegate::GetAliroReaderGroupIdentifier(MutableByteSpan & groupIdentifier)
+{
+    if (!mAliroStateInitialized)
+    {
+        groupIdentifier.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    return CopySpanToMutableSpan(ByteSpan(mAliroReaderGroupIdentifier), groupIdentifier);
+}
+
+CHIP_ERROR AliroDelegate::GetAliroReaderGroupSubIdentifier(MutableByteSpan & groupSubIdentifier)
+{
+    return CopySpanToMutableSpan(ByteSpan(mAliroReaderGroupSubIdentifier), groupSubIdentifier);
+}
+
+CHIP_ERROR AliroDelegate::CopyProtocolVersionIntoSpan(uint16_t protocolVersionValue, MutableByteSpan & protocolVersion)
+{
+    static_assert(sizeof(protocolVersionValue) == kAliroProtocolVersionSize);
+
+    if (protocolVersion.size() < kAliroProtocolVersionSize)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Per Aliro spec, protocol version encoding is big-endian.
+    Encoding::BigEndian::Put16(protocolVersion.data(), protocolVersionValue);
+    protocolVersion.reduce_size(kAliroProtocolVersionSize);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AliroDelegate::GetAliroExpeditedTransactionSupportedProtocolVersionAtIndex(size_t index,
+                                                                                      MutableByteSpan & protocolVersion)
+{
+    // Only claim support for the one known protocol version for now: 0x0100.
+    constexpr uint16_t knownProtocolVersion = 0x0100;
+
+    if (index > 0)
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+
+    return CopyProtocolVersionIntoSpan(knownProtocolVersion, protocolVersion);
+}
+
+CHIP_ERROR AliroDelegate::GetAliroGroupResolvingKey(MutableByteSpan & groupResolvingKey)
+{
+    if (!mAliroStateInitialized)
+    {
+        groupResolvingKey.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    return CopySpanToMutableSpan(ByteSpan(mAliroGroupResolvingKey), groupResolvingKey);
+}
+
+CHIP_ERROR AliroDelegate::GetAliroSupportedBLEUWBProtocolVersionAtIndex(size_t index, MutableByteSpan & protocolVersion)
+{
+    // Only claim support for the one known protocol version for now: 0x0100.
+    constexpr uint16_t knownProtocolVersion = 0x0100;
+
+    if (index > 0)
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+
+    return CopyProtocolVersionIntoSpan(knownProtocolVersion, protocolVersion);
+}
+
+uint8_t AliroDelegate::GetAliroBLEAdvertisingVersion()
+{
+    // For now the only defined value of the BLE advertising version for Aliro is 0.
+    return 0;
+}
+
+uint16_t AliroDelegate::GetNumberOfAliroCredentialIssuerKeysSupported()
+{
+    return APP_MAX_CREDENTIAL;
+}
+
+uint16_t AliroDelegate::GetNumberOfAliroEndpointKeysSupported()
+{
+    return APP_MAX_CREDENTIAL;
+}
+
+CHIP_ERROR AliroDelegate::SetAliroReaderConfig(const ByteSpan & signingKey, const ByteSpan & verificationKey,
+                                               const ByteSpan & groupIdentifier,
+                                               const Optional<ByteSpan> & groupResolvingKey)
+{
+    // We ignore the signing key, since we never do anything with it.
+    (void) signingKey;
+
+    VerifyOrReturnError(verificationKey.size() == sizeof(mAliroReaderVerificationKey), CHIP_ERROR_INVALID_ARGUMENT);
+    memcpy(mAliroReaderVerificationKey, verificationKey.data(), sizeof(mAliroReaderVerificationKey));
+
+    VerifyOrReturnError(groupIdentifier.size() == sizeof(mAliroReaderGroupIdentifier), CHIP_ERROR_INVALID_ARGUMENT);
+    memcpy(mAliroReaderGroupIdentifier, groupIdentifier.data(), sizeof(mAliroReaderGroupIdentifier));
+
+    if (groupResolvingKey.HasValue())
+    {
+        VerifyOrReturnError(groupResolvingKey.Value().size() == sizeof(mAliroGroupResolvingKey), CHIP_ERROR_INVALID_ARGUMENT);
+        memcpy(mAliroGroupResolvingKey, groupResolvingKey.Value().data(), sizeof(mAliroGroupResolvingKey));
+    }
+
+    mAliroStateInitialized = true;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AliroDelegate::ClearAliroReaderConfig()
+{
+    // A real implementation would clear out key data from persistent storage.
+    mAliroStateInitialized = false;
+    return CHIP_NO_ERROR;
+}
+
+// ---------------------------------------------------------------------------
+// Aliro credential storage
+// ---------------------------------------------------------------------------
+
+/* static */ bool AliroDelegate::IsAliroCredentialType(CredentialTypeEnum type)
+{
+    switch (type)
+    {
+    case CredentialTypeEnum::kAliroCredentialIssuerKey:
+    case CredentialTypeEnum::kAliroEvictableEndpointKey:
+    case CredentialTypeEnum::kAliroNonEvictableEndpointKey:
+        return true;
+    default:
+        return false;
+    }
+}
+
+AliroDelegate::CredentialSlot * AliroDelegate::SlotArrayForType(CredentialTypeEnum type)
+{
+    switch (type)
+    {
+    case CredentialTypeEnum::kAliroCredentialIssuerKey:
+        return mIssuerKeys;
+    case CredentialTypeEnum::kAliroEvictableEndpointKey:
+        return mEvictableEndpointKeys;
+    case CredentialTypeEnum::kAliroNonEvictableEndpointKey:
+        return mNonEvictableEndpointKeys;
+    default:
+        return nullptr;
+    }
+}
+
+bool AliroDelegate::GetCredential(uint16_t index, CredentialTypeEnum type, EmberAfPluginDoorLockCredentialInfo & out)
+{
+    CredentialSlot * slots = SlotArrayForType(type);
+    VerifyOrReturnValue(slots != nullptr, false);
+
+    auto & slot = slots[index];
+
+    out.status             = slot.status;
+    out.credentialType     = type;
+    out.createdBy          = slot.createdBy;
+    out.lastModifiedBy     = slot.lastModifiedBy;
+    out.creationSource     = DlAssetSource::kMatterIM;
+    out.modificationSource = DlAssetSource::kMatterIM;
+    out.credentialData     = chip::ByteSpan{ slot.data, slot.dataSize };
+
+    ChipLogProgress(Zcl, "AliroDelegate::GetCredential [type=%u,index=%u,status=%d]", to_underlying(type), index,
+                    (int) slot.status);
+
+    return true;
+}
+
+bool AliroDelegate::SetCredential(uint16_t index, chip::FabricIndex creator, chip::FabricIndex modifier,
+                                  DlCredentialStatus status, CredentialTypeEnum type, const chip::ByteSpan & data)
+{
+    CredentialSlot * slots = SlotArrayForType(type);
+    VerifyOrReturnValue(slots != nullptr, false);
+
+    auto & slot = slots[index];
+
+    if (status == DlCredentialStatus::kAvailable)
+    {
+        slot.status          = DlCredentialStatus::kAvailable;
+        slot.dataSize        = 0;
+        slot.createdBy       = creator;
+        slot.lastModifiedBy  = modifier;
+        return true;
+    }
+
+    VerifyOrReturnValue(data.size() <= kAliroCredentialMaxSize, false);
+
+    memcpy(slot.data, data.data(), data.size());
+    slot.dataSize       = data.size();
+    slot.status         = status;
+    slot.createdBy      = creator;
+    slot.lastModifiedBy = modifier;
+
+    ChipLogProgress(Zcl, "AliroDelegate::SetCredential [type=%u,index=%u,dataSize=%u]", to_underlying(type), index,
+                    static_cast<unsigned int>(data.size()));
+
+    return true;
+}

--- a/examples/lock-app/telink/src/AliroDelegate.cpp
+++ b/examples/lock-app/telink/src/AliroDelegate.cpp
@@ -30,9 +30,7 @@ AliroDelegate AliroDelegate::sInstance;
 
 AliroDelegate::AliroDelegate()
 {
-    CHIP_ERROR err = Crypto::DRBG_get_bytes(
-        mAliroReaderGroupSubIdentifier,
-        sizeof(mAliroReaderGroupSubIdentifier));
+    CHIP_ERROR err = Crypto::DRBG_get_bytes(mAliroReaderGroupSubIdentifier, sizeof(mAliroReaderGroupSubIdentifier));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/lock-app/telink/src/AppTask.cpp
+++ b/examples/lock-app/telink/src/AppTask.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "AppTask.h"
+#include "AliroDelegate.h"
 #include "ButtonManager.h"
 #include "LEDManager.h"
 #include <LockManager.h>
@@ -119,6 +120,9 @@ CHIP_ERROR AppTask::Init(void)
 
     // Disable auto-relock time feature.
     DoorLockServer::Instance().SetAutoRelockTime(kExampleEndpointId, 0);
+
+    // Register a Door Lock delegate to handle Aliro provisioning attributes/commands.
+    DoorLockServer::Instance().SetDelegate(kExampleEndpointId, &AliroDelegate::GetInstance());
 
     return CHIP_NO_ERROR;
 }

--- a/examples/lock-app/telink/src/LockManager.cpp
+++ b/examples/lock-app/telink/src/LockManager.cpp
@@ -33,7 +33,6 @@ LockManager LockManager::sLock;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace TelinkDoorLock::LockInitParams;
 
-
 #if LOCK_MANAGER_CONFIG_USE_NVM_CREDENTIAL_STORAGE
 __attribute__((section(".data"))) EmberAfPluginDoorLockUserInfo mCurrentLockUsers;
 

--- a/examples/lock-app/telink/src/LockManager.cpp
+++ b/examples/lock-app/telink/src/LockManager.cpp
@@ -18,6 +18,7 @@
 
 #include <LockManager.h>
 
+#include <AliroDelegate.h>
 #include <AppConfig.h>
 #include <AppTask.h>
 #include <LockSettingsStorage.h>
@@ -31,6 +32,7 @@ LockManager LockManager::sLock;
 
 using namespace ::chip::DeviceLayer::Internal;
 using namespace TelinkDoorLock::LockInitParams;
+
 
 #if LOCK_MANAGER_CONFIG_USE_NVM_CREDENTIAL_STORAGE
 __attribute__((section(".data"))) EmberAfPluginDoorLockUserInfo mCurrentLockUsers;
@@ -414,7 +416,7 @@ bool LockManager::IsValidCredentialIndex(uint16_t credentialIndex, CredentialTyp
 
 bool LockManager::IsValidCredentialType(CredentialTypeEnum type)
 {
-    return (to_underlying(type) < kNumCredentialTypes);
+    return AliroDelegate::IsAliroCredentialType(type) || (to_underlying(type) < kNumCredentialTypes);
 }
 
 bool LockManager::IsValidWeekdayScheduleIndex(uint8_t scheduleIndex)
@@ -628,6 +630,11 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
                     to_underlying(credentialType), credentialIndex);
 
 #if LOCK_MANAGER_CONFIG_USE_NVM_CREDENTIAL_STORAGE
+    if (AliroDelegate::IsAliroCredentialType(credentialType))
+    {
+        return AliroDelegate::GetInstance().GetCredential(credentialIndex, credentialType, credential);
+    }
+
     size_t outLen;
     EmberAfPluginDoorLockCredentialInfo lockCredentials;
     uint8_t lockCredentialsData[kMaxCredentialSize] = { 0 };
@@ -743,6 +750,12 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
                     to_underlying(credentialStatus), to_underlying(credentialType), credentialData.size(), creator, modifier);
 
 #if LOCK_MANAGER_CONFIG_USE_NVM_CREDENTIAL_STORAGE
+    if (AliroDelegate::IsAliroCredentialType(credentialType))
+    {
+        return AliroDelegate::GetInstance().SetCredential(credentialIndex, creator, modifier, credentialStatus, credentialType,
+                                                          credentialData);
+    }
+
     size_t outLen;
     EmberAfPluginDoorLockCredentialInfo lockCredentials;
     uint8_t lockCredentialsData[kMaxCredentialSize] = { 0 };


### PR DESCRIPTION
#### Summary

Introduce AliroDelegate to handle Aliro provisioning attributes and
credential storage required for Apple Home compatibility.
**Reproduced only on iOS 26.x** where Aliro is already in Apple Home. Versions 17,18 could work without this patch. 

- Add AliroDelegate class inheriting DoorLock::Delegate, implementing
  all Aliro provisioning interface methods (reader config, group keys,
  protocol versions, BLE/UWB advertising)
- Move Aliro credential storage (issuer keys, evictable/non-evictable
  endpoint keys) into AliroDelegate as private state, replacing the
  anonymous-namespace arrays that were previously scattered in
  LockManager.cpp
- Expose AliroDelegate as a singleton (GetInstance()) consistent with
  LockManager pattern; remove local static from AppTask
- Add AliroDelegate::IsAliroCredentialType() / GetCredential() /
  SetCredential() so LockManager delegates Aliro credential I/O without
  owning Aliro state
- Register delegate with DoorLockServer at init time in AppTask::Init()
- Extend LockManager::IsValidCredentialType() to accept Aliro credential
  types (kAliroCredentialIssuerKey, kAliroEvictableEndpointKey,
  kAliroNonEvictableEndpointKey)

#### Testing

- tested lock-app manually with Apple Home Pod mini (v 26.3), iPhone 16 Pro Max (iOS 26.3.1)
