### PR TITLE
JF datastore: defensive change to improve AddAdmin code clarity

### DIFF
--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -1012,14 +1012,18 @@ JointFabricDatastore::UpdateGroupKeySetEntry(
 
 CHIP_ERROR
 JointFabricDatastore::AddAdmin(
-    Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type & adminId)
+    const Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type & adminId)
 {
     VerifyOrReturnError(IsAdminEntryPresent(adminId.nodeID) == false, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     VerifyOrReturnError(mAdminEntries.size() < kMaxAdminNodes, CHIP_ERROR_NO_MEMORY);
 
-    ReturnErrorOnFailure(SetAdminEntryWithOwnedStorage(adminId.nodeID, adminId.friendlyName, adminId.icac, adminId));
+    Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type entryToStore;
+    entryToStore.nodeID   = adminId.nodeID;
+    entryToStore.vendorID = adminId.vendorID;
 
-    mAdminEntries.push_back(adminId);
+    ReturnErrorOnFailure(SetAdminEntryWithOwnedStorage(adminId.nodeID, adminId.friendlyName, adminId.icac, entryToStore));
+
+    mAdminEntries.push_back(entryToStore);
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -329,7 +329,8 @@ public:
     CHIP_ERROR RemoveGroupKeySetEntry(uint16_t groupKeySetId);
     CHIP_ERROR UpdateGroupKeySetEntry(Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet);
 
-    CHIP_ERROR AddAdmin(Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type & adminId);
+    CHIP_ERROR
+    AddAdmin(const Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type & adminId);
     bool IsAdminEntryPresent(NodeId nodeId);
     CHIP_ERROR UpdateAdmin(NodeId nodeId, CharSpan friendlyName, ByteSpan icac);
     CHIP_ERROR RemoveAdmin(NodeId nodeId);


### PR DESCRIPTION
#### Summary
Code clarity/defensive change: Ensure `JointFabricDatastore::AddAdmin` does not modify caller input and working with a local copy instead.

#### Related issues
N/A

#### Testing
Test Instructions to execute Python Tests

Build and Activate the Python Environment
```
./scripts/build_python.sh -i out/python_env

source out/python_env/bin/activate
```

Run the Test
Execute the JFDS 2.4 Python test script with the required application paths:

```
python3 src/python_testing/TC_JFDS_2_4.py \
  --string-arg "jfa_server_app:/home/vijay/apps/jfa-app" \
  --string-arg "jfc_server_app:/home/vijay/apps/jfc-app"
```