### PR TITLE
Test Implementation Updates for Groupcast Auxiliary Entries and Events

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -155,6 +155,8 @@
 #include <openthread/instance.h>
 #endif
 
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
+
 using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Credentials;
@@ -982,6 +984,11 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     {
         initParams.advertiseCommissionableIfNoFabrics = false;
     }
+
+    // TODO: THIS MUST BE PROTECTED BEHIND MACRO, SEE PR #43677
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate groupAuxDelegate(initParams.groupDataProvider,
+                                                                                        &Server::GetInstance().GetFabricTable());
+    initParams.groupAuxiliaryAccessControlDelegate = &groupAuxDelegate;
 
     // Set DAC provider before server init because Operational Credentials may snapshot
     // the provider during cluster construction.

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -206,6 +206,7 @@ source_set("app-main") {
     "${chip_root}/examples/providers:device_info_provider_please_do_not_reuse_as_is",
     "${chip_root}/src/app/server",
     "${chip_root}/src/setup_payload:onboarding-codes-utils",
+    "${chip_root}/src/access",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -204,9 +204,9 @@ source_set("app-main") {
     ":ota-test-event-trigger",
     "${chip_root}/examples/providers:all_clusters_device_info_provider",
     "${chip_root}/examples/providers:device_info_provider_please_do_not_reuse_as_is",
+    "${chip_root}/src/access",
     "${chip_root}/src/app/server",
     "${chip_root}/src/setup_payload:onboarding-codes-utils",
-    "${chip_root}/src/access",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/src/python_testing/TC_GC_2_1.py
+++ b/src/python_testing/TC_GC_2_1.py
@@ -54,7 +54,8 @@ class TC_GC_2_1(MatterBaseTest):
         return [TestStep(1, "Commissioning, already done", is_commissioning=True),
                 TestStep(2, "TH reads from the DUT the Membership attribute"),
                 TestStep(3, "TH reads from the DUT the MaxMembershipCount attribute"),
-                TestStep(4, "TH reads from the DUT the MaxMcastAddrCount attribute"),
+                TestStep("4a", "If PGA feature is not supported, TH reads from the DUT the MaxMcastAddrCount attribute, expecting it to be greater than or equal to 1"),
+                TestStep("4b", "If PGA feature is supported, TH reads from the DUT the MaxMcastAddrCount attribute, expecting it to be greater than or equal to 4 and less than or equal to the value in step 3"),
                 TestStep(5, "TH reads from the DUT the UsedMcastAddrCount attribute"),
                 TestStep(6, "TH reads from the DUT the FabricUnderTest attribute")]
 
@@ -83,9 +84,20 @@ class TC_GC_2_1(MatterBaseTest):
         M_max = await self.read_single_attribute_check_success(groupcast_cluster, max_membership_count_attribute)
         asserts.assert_true(M_max >= 10, "MaxMembershipCount attribute should be >= 10")
 
-        self.step(4)
-        A_max = await self.read_single_attribute_check_success(groupcast_cluster, max_mcast_addr_count_attribute)
-        asserts.assert_true(A_max >= 1, "MaxMcastAddrCount attribute should be >= 1")
+        feature_map = await self.read_single_attribute_check_success(groupcast_cluster, Clusters.Groupcast.Attributes.FeatureMap)
+        pga_supported = (feature_map & Clusters.Groupcast.Bitmaps.Feature.kPerGroup) != 0
+
+        if not pga_supported:
+            self.step("4a")
+            A_max = await self.read_single_attribute_check_success(groupcast_cluster, max_mcast_addr_count_attribute)
+            asserts.assert_true(A_max >= 1, "MaxMcastAddrCount attribute should be >= 1 when PGA is not supported")
+            self.skip_step("4b")
+        else:
+            self.skip_step("4a")
+            self.step("4b")
+            A_max = await self.read_single_attribute_check_success(groupcast_cluster, max_mcast_addr_count_attribute)
+            asserts.assert_true(A_max >= 4, "MaxMcastAddrCount attribute should be >= 4 when PGA is supported")
+            asserts.assert_true(A_max <= M_max, "MaxMcastAddrCount attribute should be <= MaxMembershipCount when PGA is supported")
 
         self.step(5)
         usedMcastAddrCount = await self.read_single_attribute_check_success(groupcast_cluster, used_mcast_addr_count_attribute)

--- a/src/python_testing/TC_GC_2_2.py
+++ b/src/python_testing/TC_GC_2_2.py
@@ -38,12 +38,14 @@ import logging
 import secrets
 
 from mobly import asserts
-from TC_GC_common import generate_membership_entry_matcher, get_feature_map, valid_endpoints_list
+from TC_GC_common import (generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map,
+                          valid_endpoints_list)
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
-from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 from matter.tlv import uint
@@ -58,17 +60,24 @@ class TC_GC_2_2(MatterBaseTest):
     def steps_TC_GC_2_2(self):
         return [TestStep("1a", "Commission DUT to TH (can be skipped if done in a preceding test)", is_commissioning=True),
                 TestStep("1b", "TH removes any existing group and KeySetID on the DUT"),
-                TestStep("1c", "Th subscribes to Membership attribute with min interval 0s and max interval 30s"),
+                TestStep("1c", "TH subscribes to Membership attribute of the Groupcast cluster on Endpoint 0 and to the AuxiliaryAccessUpdated event of the AccessControl cluster with a min interval of 0s and max interval of 30s. Accumulate all reports seen."),
+                TestStep("1d", "TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0"),
                 TestStep(2, "If GC.S.F00(LN) feature is not supported on the cluster, skip to step 14"),
                 TestStep("3a", "Attempt to join Group G1 with a new Key with KeySetID K1 on Endpoint EP1"),
                 TestStep("3b", "TH awaits subscription report of new membership within max interval"),
+                TestStep("3c", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute"),
+                TestStep("3d", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
                 TestStep("4a", "If DUT only support one non-root and non-aggregator endpoint, skip to step 6a"),
                 TestStep("4b", "Attempt to add EP2 to Group G1"),
                 TestStep("4c", "TH awaits subscription report of new membership within max interval"),
+                TestStep("4d", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute"),
+                TestStep("4e", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
                 TestStep("5a", "Attempt to replace endpoints with only EP1 for Group G1 using ReplaceEndpoints"),
                 TestStep("5b", "TH awaits subscription report of new membership within max interval"),
                 TestStep("6a", "Attempt to join Group G2 with existing Key1 and using Auxiliary ACL"),
                 TestStep("6b", "TH awaits subscription report of new membership within max interval"),
+                TestStep("6c", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
+                TestStep("6d", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute"),
                 TestStep(7, "Attempt to join Group G3 using a new Key but providing existing KeySetID (result: already exists)"),
                 TestStep(8, "Attempt to join Group G3 using a new KeySetID, but without providing InputKey (result: not found)"),
                 TestStep(9, "Attempt to join Group G3 with invalid endpoint (result: unsupported endpoint)"),
@@ -108,6 +117,13 @@ class TC_GC_2_2(MatterBaseTest):
             self.mark_all_remaining_steps_skipped("1b")
             return
 
+        # Get the Root Node PartsList to use for potential wildcard expansion in ACL checks.
+        parts_list = await self.read_single_attribute_check_success(
+            cluster=Clusters.Descriptor,
+            attribute=Clusters.Descriptor.Attributes.PartsList,
+            endpoint=0
+        )
+
         self.step("1b")
         # Check if there are any groups on the DUT.
         membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
@@ -123,10 +139,17 @@ class TC_GC_2_2(MatterBaseTest):
             if key_set_id != 0:
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
-        # Th subscribes to Membership attribute with min interval 0s and max interval 30s
+        # TH subscribes to Membership attribute of the Groupcast cluster on Endpoint 0 and to the AuxiliaryAccessUpdated event of the AccessControl cluster with a min interval of 0s and max interval of 30s. Accumulate all reports seen.
         self.step("1c")
         membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
         await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
+
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
+
+        # TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0
+        self.step("1d")
+        fabric_index = await self.read_single_attribute_check_success(Clusters.OperationalCredentials, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex, endpoint=0)
 
         # If GC.S.F00(LN) feature is not supported on the cluster, skip to step 12
         self.step(2)
@@ -154,6 +177,19 @@ class TC_GC_2_2(MatterBaseTest):
                 group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
             membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
+            # TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute
+            self.step("3c")
+            aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+
+            # Validate that value does not contain any entry that logically represents or grants access on EP1 to Group G1 for FabricIndex F1.
+            actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+            asserts.assert_false((fabric_index, groupID1, endpoint1) in actual_set,
+                                 f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint EP1 ({endpoint1}) should not be in AuxiliaryACL")
+
+            # TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster
+            self.step("3d")
+            event_sub.wait_for_event_expect_no_report(timeout_sec=5)
+
             # If DUT only support one non-root and non-aggregator endpoint, skip to step 6a
             self.step("4a")
             if len(endpoints_list) < 2:
@@ -173,6 +209,20 @@ class TC_GC_2_2(MatterBaseTest):
                 membership_matcher = generate_membership_entry_matcher(
                     group_id=groupID1, endpoints=endpoints_list[0:2], key_set_id=keySetID1, has_auxiliary_acl=False)
                 membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+                # TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute
+                self.step("4d")
+                aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+
+                # Validate that value does not contain any entry that logically represents or grants access on EP1 or EP2 to Group G1 for FabricIndex F1.
+                actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+                for endpoint_to_check in [endpoints_list[0], endpoints_list[1]]:
+                    asserts.assert_false((fabric_index, groupID1, endpoint_to_check) in actual_set,
+                                         f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint_to_check} should not be in AuxiliaryACL")
+
+                # TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster
+                self.step("4e")
+                event_sub.wait_for_event_expect_no_report(timeout_sec=5)
 
                 # Attempt to replace endpoints for Group G1 using ReplaceEndpoints:
                 self.step("5a")
@@ -205,6 +255,20 @@ class TC_GC_2_2(MatterBaseTest):
             membership_matcher = generate_membership_entry_matcher(
                 group_id=groupID2, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=True)
             membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            # TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster
+            self.step("6c")
+            event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
+            asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+
+            # TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute
+            self.step("6d")
+            aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+
+            # Validate value contains entry that logically represents and grants Operate (3) privilege on EP1 for Group G2 on FabricIndex F1.
+            actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+            asserts.assert_true((fabric_index, groupID2, endpoint1) in actual_set,
+                                f"Could not find valid AuxiliaryACL entry for FabricIndex {fabric_index}, Group G2 ({groupID2}) and Endpoint EP1 ({endpoint1})")
 
             # Attempt to join Group G3 using a new Key but providing existing KeySetID (result: already exists)
             self.step(7)

--- a/src/python_testing/TC_GC_2_2.py
+++ b/src/python_testing/TC_GC_2_2.py
@@ -143,7 +143,8 @@ class TC_GC_2_2(MatterBaseTest):
         membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
         await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
 
-        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl,
+                                             expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
         await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
         # TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0
@@ -258,7 +259,8 @@ class TC_GC_2_2(MatterBaseTest):
             # TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster
             self.step("6c")
             event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
-            asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+            asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId,
+                                 "Event adminNodeID should match TH Node ID")
 
             # TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute
             self.step("6d")

--- a/src/python_testing/TC_GC_2_2.py
+++ b/src/python_testing/TC_GC_2_2.py
@@ -42,7 +42,6 @@ from TC_GC_common import (generate_membership_entry_matcher, get_auxiliary_acl_e
                           valid_endpoints_list)
 
 import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler

--- a/src/python_testing/TC_GC_2_2.py
+++ b/src/python_testing/TC_GC_2_2.py
@@ -38,8 +38,7 @@ import logging
 import secrets
 
 from mobly import asserts
-from TC_GC_common import (generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map,
-                          valid_endpoints_list)
+from TC_GC_common import generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map, valid_endpoints_list
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status

--- a/src/python_testing/TC_GC_2_4.py
+++ b/src/python_testing/TC_GC_2_4.py
@@ -126,7 +126,8 @@ class TC_GC_2_4(MatterBaseTest):
         membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
         await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
 
-        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl,
+                                             expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
         await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
         self.step("1d")

--- a/src/python_testing/TC_GC_2_4.py
+++ b/src/python_testing/TC_GC_2_4.py
@@ -42,7 +42,6 @@ from TC_GC_common import (generate_membership_empty_matcher, generate_membership
                           get_feature_map, valid_endpoints_list)
 
 import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler

--- a/src/python_testing/TC_GC_2_4.py
+++ b/src/python_testing/TC_GC_2_4.py
@@ -38,12 +38,14 @@ import logging
 import secrets
 
 from mobly import asserts
-from TC_GC_common import generate_membership_empty_matcher, generate_membership_entry_matcher, get_feature_map, valid_endpoints_list
+from TC_GC_common import (generate_membership_empty_matcher, generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set,
+                          get_feature_map, valid_endpoints_list)
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
-from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -58,11 +60,18 @@ class TC_GC_2_4(MatterBaseTest):
         return [
             TestStep("1a", "Commission DUT to TH (can be skipped if done in a preceding test)", is_commissioning=True),
             TestStep("1b", "TH removes any existing group and KeySetID on the DUT"),
-            TestStep("1c", "TH subscribes to Membership attribute with min interval 0s and max interval 30s"),
-            TestStep("1d", "Join Group G1 generating new KeySetID K1 with Key InputKey1 using JoinGroup"),
-            TestStep("1e", "Join Group G2 with existing KeySetID K1 using JoinGroup"),
+            TestStep("1c", "TH subscribes to Membership attribute and to the AuxiliaryAccessUpdated event of the AccessControl cluster with a min interval of 0s and max interval of 30s. Accumulate all reports seen."),
+            TestStep("1d", "TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0"),
+            TestStep("1e", "Join Group G1 generating new KeySetID K1 with Key InputKey1 using JoinGroup"),
+            TestStep("1f", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster (expect no report)"),
+            TestStep("1g", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute and verifies G1 entry is not present"),
+            TestStep("1h", "Join Group G2 with existing KeySetID K1 and UseAuxiliaryACL=True"),
+            TestStep("1i", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
+            TestStep("1j", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute and verifies G2 entry is present"),
             TestStep("2a", "Completely Leave Group G2 by omitting the endpoint list parameters. LeaveGroup (GroupID=G2, Endpoints omitted)"),
             TestStep("2b", "TH awaits subscription report of new Membership within max interval. (G2 entry removed)"),
+            TestStep("2c", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
+            TestStep("2d", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute and verifies G2 entry is removed"),
             TestStep(3, "If LN feature is not supported skip to step 5"),
             TestStep("4a", "Join Group G3 with existing KeySetID K1 using JoinGroup"),
             TestStep("4b", "If DUT only support one non-root and non-aggregator endpoint, skip to step 4e"),
@@ -73,8 +82,9 @@ class TC_GC_2_4(MatterBaseTest):
             TestStep("4f", "TH awaits subscription report of new Membership within max interval. (If SD supported: G3 entry with empty endpoints list, else G3 entry removed)"),
             TestStep(5, "Attempt to Leave a non-existing group. LeaveGroup (GroupID=NonExisting)"),
             TestStep(6, "Leave all groups. LeaveGroup with GroupID=0"),
-            TestStep(7, "TH awaits subscription report of new Membership within max interval. (Empty list)"),
-            TestStep(8, "Leave all groups without being part of any group on this fabric. LeaveGroup with GroupID=0"),
+            TestStep(7, "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster (expect no report)"),
+            TestStep(8, "TH awaits subscription report of new Membership within max interval. (Empty list)"),
+            TestStep(9, "Leave all groups without being part of any group on this fabric. LeaveGroup with GroupID=0"),
         ]
 
     def pics_TC_GC_2_4(self) -> list[str]:
@@ -90,6 +100,13 @@ class TC_GC_2_4(MatterBaseTest):
         endpoints_list = await valid_endpoints_list(self, ln_enabled)
         if len(endpoints_list) > 1:
             endpoints_list = endpoints_list[:2]
+
+        # Get the Root Node PartsList to use for potential wildcard expansion in ACL checks.
+        parts_list = await self.read_single_attribute_check_success(
+            cluster=Clusters.Descriptor,
+            attribute=Clusters.Descriptor.Attributes.PartsList,
+            endpoint=0
+        )
 
         self.step("1b")
         # Check if there are any groups on the DUT.
@@ -107,10 +124,16 @@ class TC_GC_2_4(MatterBaseTest):
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
-        sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
-        await sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
+        membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
+        await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
+
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
         self.step("1d")
+        fabric_index = await self.read_single_attribute_check_success(Clusters.OperationalCredentials, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex, endpoint=0)
+
+        self.step("1e")
         groupID1 = 1
         keySetID1 = 1
         inputKey1 = secrets.token_bytes(16)
@@ -122,23 +145,56 @@ class TC_GC_2_4(MatterBaseTest):
             key=inputKey1)
         )
 
-        self.step("1e")
+        self.step("1f")
+        event_sub.wait_for_event_expect_no_report(timeout_sec=5)
+
+        self.step("1g")
+        aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+        actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+        for endpoint in endpoints_list:
+            asserts.assert_false((fabric_index, groupID1, endpoint) in actual_set,
+                                 f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint} should not be in AuxiliaryACL")
+
+        self.step("1h")
         groupID2 = 2
         await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
             groupID=groupID2,
             endpoints=endpoints_list,
-            keySetID=keySetID1)
+            keySetID=keySetID1,
+            useAuxiliaryACL=True)
         )
+
+        self.step("1i")
+        event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
+        asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+
+        self.step("1j")
+        aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+        actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+        for endpoint in endpoints_list:
+            asserts.assert_true((fabric_index, groupID2, endpoint) in actual_set,
+                                f"Could not find valid AuxiliaryACL entry for FabricIndex {fabric_index}, Group G2 ({groupID2}) and Endpoint {endpoint}")
 
         self.step("2a")
         resp: Clusters.Groupcast.Commands.LeaveGroupResponse = await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=groupID2))
         asserts.assert_is_not_none(resp.endpoints, "LeaveGroupResponse endpoints should not be None")
         asserts.assert_equal(resp.endpoints, endpoints_list,
-                             f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to the endpoints list provided in step 1e {endpoints_list}")
+                             f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to the endpoints list provided in step 1h {endpoints_list}")
 
         self.step("2b")
         membership_matcher = generate_membership_entry_matcher(groupID2, test_for_exists=False)
-        sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+        self.step("2c")
+        event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
+        asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+
+        self.step("2d")
+        aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+        actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+        for endpoint in endpoints_list:
+            asserts.assert_false((fabric_index, groupID2, endpoint) in actual_set,
+                                 f"Entry for FabricIndex {fabric_index}, Group G2 ({groupID2}) and Endpoint {endpoint} should have been removed from AuxiliaryACL")
 
         self.step(3)
         if not ln_enabled:
@@ -167,9 +223,9 @@ class TC_GC_2_4(MatterBaseTest):
                                      f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to {endpoint_2}")
 
                 self.step("4d")
-                sub.reset()
+                membership_sub.reset()
                 membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=[endpoints_list[0]])
-                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
             self.step("4e")
             endpoint_1 = [endpoints_list[0]]
@@ -184,10 +240,10 @@ class TC_GC_2_4(MatterBaseTest):
             self.step("4f")
             if sd_enabled:
                 membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=None)
-                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
             else:
                 membership_matcher = generate_membership_entry_matcher(groupID3, test_for_exists=False)
-                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
         self.step(5)
         groupIDUnknown = 100
@@ -205,11 +261,14 @@ class TC_GC_2_4(MatterBaseTest):
                              f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to an empty list")
 
         self.step(7)
-        sub.reset()
-        membership_matcher = generate_membership_empty_matcher()
-        sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+        membership_sub.reset()
+        event_sub.wait_for_event_expect_no_report(timeout_sec=5)
 
         self.step(8)
+        membership_matcher = generate_membership_empty_matcher()
+        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+        self.step(9)
         try:
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
             asserts.fail("LeaveGroup command should have failed, but it succeeded")

--- a/src/python_testing/TC_GC_2_5.py
+++ b/src/python_testing/TC_GC_2_5.py
@@ -38,12 +38,13 @@ import logging
 import secrets
 
 from mobly import asserts
-from TC_GC_common import generate_membership_entry_matcher, get_feature_map, valid_endpoints_list
+from TC_GC_common import (generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map,
+                          valid_endpoints_list)
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
-from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -57,14 +58,18 @@ class TC_GC_2_5(MatterBaseTest):
     def steps_TC_GC_2_5(self):
         return [
             TestStep("1a", "Commission DUT to TH (can be skipped if done in a preceding test)", is_commissioning=True),
-            TestStep("1b", "TH removes any existing group and KeyID on the DUT."),
-            TestStep("1c", "TH subscribes to Membership attribute with min interval 0s and max interval 30s."),
-            TestStep(
-                "1d", "Join group G1 generating a new KeyID K1 with Key InputKey1: TH sends command JoinGroup (GroupID=G1, Endpoints=[EP1], KeyID=K1, Key=InputKey1)."),
+            TestStep("1b", "TH removes any existing group and KeySetID on the DUT."),
+            TestStep("1c", "TH subscribes to Membership attribute of the Groupcast cluster on Endpoint 0 and to the AuxiliaryAccessUpdated event of the AccessControl cluster with a min interval of 0s and max interval of 30s. Accumulate all reports seen."),
+            TestStep("1d", "TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0"),
+            TestStep("1e", "Join group G1 generating a new KeySetID K1 with Key InputKey1: TH sends command JoinGroup (GroupID=G1, Endpoints=[EP1], KeySetID=K1, Key=InputKey1)."),
             TestStep(2, "Enable Auxiliary ACL on group G1: TH sends command ConfigureAuxiliaryACL (GroupID=G1, UseAuxiliaryACL=true)."),
-            TestStep(3, "TH awaits subscription report of new Membership within max interval."),
+            TestStep("3a", "TH awaits subscription report of new Membership within max interval. (G1 entry with HasAuxiliaryACL=true)"),
+            TestStep("3b", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
+            TestStep("3c", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute and verifies G1 entry is present"),
             TestStep(4, "Disable Auxiliary ACL on group G1: TH sends command ConfigureAuxiliaryACL (GroupID=G1, UseAuxiliaryACL=false)."),
-            TestStep(5, "TH awaits subscription report of new Membership within max interval."),
+            TestStep("5a", "TH awaits subscription report of new Membership within max interval. (G1 entry with HasAuxiliaryACL=false)"),
+            TestStep("5b", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
+            TestStep("5c", "TH reads Endpoint 0 AccessControl cluster AuxiliaryACL attribute and verifies G1 entry is removed"),
             TestStep(6, "Attempt to enable Auxiliary ACL on a unknown GroupId: TH sends command ConfigureAuxiliaryACL (GroupID=G_UNKNOWN, UseAuxiliaryACL=true)."),
             TestStep(7, "If GC.S.F01(SD) feature is supported on the cluster, join group G2 as Sender: TH sends command JoinGroup (GroupID=G2, Endpoints=[],KeyId=K1) to join group as sender only."),
             TestStep(8, "If GC.S.F01(SD) feature is supported on the cluster, attempt to enable Auxiliary ACL on group G2: TH sends command ConfigureAuxiliaryACL (GroupID=G2, UseAuxiliaryACL=true) on Sender-only membership"),
@@ -86,8 +91,14 @@ class TC_GC_2_5(MatterBaseTest):
             return
 
         endpoints_list = await valid_endpoints_list(self, ln_enabled)
-        if len(endpoints_list) > 1:
-            endpoints_list = [endpoints_list[0]]
+        endpoint1 = endpoints_list[0]
+
+        # Get the Root Node PartsList to use for wildcard expansion in ACL checks.
+        parts_list = await self.read_single_attribute_check_success(
+            cluster=Clusters.Descriptor,
+            attribute=Clusters.Descriptor.Attributes.PartsList,
+            endpoint=0
+        )
 
         self.step("1b")
         # Check if there are any groups on the DUT.
@@ -105,10 +116,16 @@ class TC_GC_2_5(MatterBaseTest):
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
-        sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
-        await sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
+        membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
+        await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
+
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
         self.step("1d")
+        fabric_index = await self.read_single_attribute_check_success(Clusters.OperationalCredentials, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex, endpoint=0)
+
+        self.step("1e")
         groupID1 = 1
         keySetID1 = 1
         inputKey1 = secrets.token_bytes(16)
@@ -126,9 +143,19 @@ class TC_GC_2_5(MatterBaseTest):
             useAuxiliaryACL=True)
         )
 
-        self.step(3)
+        self.step("3a")
         membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl=True)
-        sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+        self.step("3b")
+        event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
+        asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+
+        self.step("3c")
+        aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+        actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+        asserts.assert_true((fabric_index, groupID1, endpoint1) in actual_set,
+                            f"Could not find valid AuxiliaryACL entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint1}")
 
         self.step(4)
         await self.send_single_cmd(Clusters.Groupcast.Commands.ConfigureAuxiliaryACL(
@@ -136,10 +163,19 @@ class TC_GC_2_5(MatterBaseTest):
             useAuxiliaryACL=False)
         )
 
-        self.step(5)
-        sub.reset()
+        self.step("5a")
         membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl=False)
-        sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+        self.step("5b")
+        event_data = event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=60)
+        asserts.assert_equal(event_data.adminNodeID, self.default_controller.nodeId, "Event adminNodeID should match TH Node ID")
+
+        self.step("5c")
+        aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
+        actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
+        asserts.assert_false((fabric_index, groupID1, endpoint1) in actual_set,
+                             f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint1} should have been removed from AuxiliaryACL")
 
         self.step(6)
         try:

--- a/src/python_testing/TC_GC_2_5.py
+++ b/src/python_testing/TC_GC_2_5.py
@@ -61,7 +61,8 @@ class TC_GC_2_5(MatterBaseTest):
             TestStep("1b", "TH removes any existing group and KeySetID on the DUT."),
             TestStep("1c", "TH subscribes to Membership attribute of the Groupcast cluster on Endpoint 0 and to the AuxiliaryAccessUpdated event of the AccessControl cluster with a min interval of 0s and max interval of 30s. Accumulate all reports seen."),
             TestStep("1d", "TH reads OperationalCredentials cluster's CurrentFabricIndex attribute on Endpoint 0"),
-            TestStep("1e", "Join group G1 generating a new KeySetID K1 with Key InputKey1: TH sends command JoinGroup (GroupID=G1, Endpoints=[EP1], KeySetID=K1, Key=InputKey1)."),
+            TestStep(
+                "1e", "Join group G1 generating a new KeySetID K1 with Key InputKey1: TH sends command JoinGroup (GroupID=G1, Endpoints=[EP1], KeySetID=K1, Key=InputKey1)."),
             TestStep(2, "Enable Auxiliary ACL on group G1: TH sends command ConfigureAuxiliaryACL (GroupID=G1, UseAuxiliaryACL=true)."),
             TestStep("3a", "TH awaits subscription report of new Membership within max interval. (G1 entry with HasAuxiliaryACL=true)"),
             TestStep("3b", "TH awaits subscription report of AuxiliaryAccessUpdated event from AccessControl cluster"),
@@ -120,7 +121,8 @@ class TC_GC_2_5(MatterBaseTest):
         membership_sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)
         await membership_sub.start(self.default_controller, self.dut_node_id, self.get_endpoint(), min_interval_sec=0, max_interval_sec=30)
 
-        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl, expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
+        event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl,
+                                             expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
         await event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
         self.step("1d")

--- a/src/python_testing/TC_GC_2_5.py
+++ b/src/python_testing/TC_GC_2_5.py
@@ -91,7 +91,8 @@ class TC_GC_2_5(MatterBaseTest):
             return
 
         endpoints_list = await valid_endpoints_list(self, ln_enabled)
-        endpoint1 = endpoints_list[0]
+        if len(endpoints_list) > 1:
+            endpoints_list = [endpoints_list[0]]
 
         # Get the Root Node PartsList to use for wildcard expansion in ACL checks.
         parts_list = await self.read_single_attribute_check_success(
@@ -154,8 +155,8 @@ class TC_GC_2_5(MatterBaseTest):
         self.step("3c")
         aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
         actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
-        asserts.assert_true((fabric_index, groupID1, endpoint1) in actual_set,
-                            f"Could not find valid AuxiliaryACL entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint1}")
+        asserts.assert_true((fabric_index, groupID1, endpoints_list[0]) in actual_set,
+                            f"Could not find valid AuxiliaryACL entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoints_list[0]}")
 
         self.step(4)
         await self.send_single_cmd(Clusters.Groupcast.Commands.ConfigureAuxiliaryACL(
@@ -174,8 +175,8 @@ class TC_GC_2_5(MatterBaseTest):
         self.step("5c")
         aux_acl = await self.read_single_attribute_check_success(Clusters.AccessControl, Clusters.AccessControl.Attributes.AuxiliaryACL, endpoint=0)
         actual_set = get_auxiliary_acl_equivalence_set(aux_acl, parts_list)
-        asserts.assert_false((fabric_index, groupID1, endpoint1) in actual_set,
-                             f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoint1} should have been removed from AuxiliaryACL")
+        asserts.assert_false((fabric_index, groupID1, endpoints_list[0]) in actual_set,
+                             f"Entry for FabricIndex {fabric_index}, Group G1 ({groupID1}) and Endpoint {endpoints_list[0]} should have been removed from AuxiliaryACL")
 
         self.step(6)
         try:

--- a/src/python_testing/TC_GC_2_5.py
+++ b/src/python_testing/TC_GC_2_5.py
@@ -38,8 +38,7 @@ import logging
 import secrets
 
 from mobly import asserts
-from TC_GC_common import (generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map,
-                          valid_endpoints_list)
+from TC_GC_common import generate_membership_entry_matcher, get_auxiliary_acl_equivalence_set, get_feature_map, valid_endpoints_list
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status

--- a/src/python_testing/TC_GC_2_5.py
+++ b/src/python_testing/TC_GC_2_5.py
@@ -166,6 +166,7 @@ class TC_GC_2_5(MatterBaseTest):
         )
 
         self.step("5a")
+        membership_sub.reset()
         membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl=False)
         membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -26,9 +26,11 @@ from matter.testing.matter_testing import AttributeMatcher
 
 logger = logging.getLogger(__name__)
 
+
 def group_id_from_node_id(node_id: int) -> int:
     """Extracts the 16-bit Group ID from a Group-scoped Node ID."""
     return node_id & 0xFFFF
+
 
 def get_auxiliary_acl_equivalence_set(aux_acl, parts_list) -> set[tuple[int, int, int]]:
     """Expands AuxiliaryACL entries into a set of (fabric_index, group_id, endpoint_id) tuples.
@@ -78,6 +80,7 @@ def get_auxiliary_acl_equivalence_set(aux_acl, parts_list) -> set[tuple[int, int
                     else:
                         equivalence_set.add((entry.fabricIndex, group_id, endpoint_id))
     return equivalence_set
+
 
 def is_groupcast_supporting_cluster(cluster_id: int) -> bool:
     """

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -21,10 +21,63 @@ from typing import Optional
 from mobly import asserts
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
 from matter.testing.matter_testing import AttributeMatcher
 
 logger = logging.getLogger(__name__)
 
+def group_id_from_node_id(node_id: int) -> int:
+    """Extracts the 16-bit Group ID from a Group-scoped Node ID."""
+    return node_id & 0xFFFF
+
+def get_auxiliary_acl_equivalence_set(aux_acl, parts_list) -> set[tuple[int, int, int]]:
+    """Expands AuxiliaryACL entries into a set of (fabric_index, group_id, endpoint_id) tuples.
+
+    This implements the equivalence class logic for verifying auxiliary entries, accounting
+    for various encodings and wildcards (empty target lists). It also strictly validates
+    that Groupcast auxiliary entries have the correct privilege and auth mode.
+
+    Args:
+        aux_acl: The list of AuxiliaryACL entries read from the DUT.
+        parts_list: The list of endpoints from the Root Node's Descriptor PartsList attribute.
+
+    Returns:
+        A set of (fabric_index, group_id, endpoint_id) tuples representing the granted access.
+    """
+    equivalence_set = set()
+    for entry in aux_acl:
+        # We only process Groupcast auxiliary entries.
+        if entry.auxiliaryType != Clusters.AccessControl.Enums.AccessControlAuxiliaryTypeEnum.kGroupcast:
+            continue
+
+        # Strictly validate metadata for Groupcast auxiliary entries.
+        asserts.assert_equal(entry.privilege, Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kOperate,
+                             f"Groupcast auxiliary entry MUST have Operate privilege, but has {entry.privilege}")
+        asserts.assert_equal(entry.authMode, Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kGroup,
+                             f"Groupcast auxiliary entry MUST have Group auth mode, but has {entry.authMode}")
+
+        subjects = entry.subjects if (entry.subjects is not None and entry.subjects is not NullValue) else []
+        targets = entry.targets if (entry.targets is not None and entry.targets is not NullValue) else []
+
+        for subject in subjects:
+            group_id = group_id_from_node_id(subject)
+
+            if not targets:
+                # Wildcard: empty target list represents all endpoints in the parts list (excluding root).
+                for endpoint_id in parts_list:
+                    if endpoint_id != 0:
+                        equivalence_set.add((entry.fabricIndex, group_id, endpoint_id))
+            else:
+                for target in targets:
+                    endpoint_id = target.endpoint
+                    if endpoint_id is None or endpoint_id is NullValue:
+                        # Wildcard target: applies to all endpoints in the parts list (excluding root).
+                        for ep in parts_list:
+                            if ep != 0:
+                                equivalence_set.add((entry.fabricIndex, group_id, ep))
+                    else:
+                        equivalence_set.add((entry.fabricIndex, group_id, endpoint_id))
+    return equivalence_set
 
 def is_groupcast_supporting_cluster(cluster_id: int) -> bool:
     """


### PR DESCRIPTION
#### Summary
This PR updates groupcast tests to account for auxiliary ACL entries and events. The test updates ensure changes to group data provider information through joining and leaving groups from the groupast cluster properly reflect the appropriate changes in the auxiliary entries reported by the cluster, from the `AuxiliaryACL` attribute in the access control cluster. These entries are only present when `HasAuxiliaryACL` is set to true. It also checks that entries are updated when `ConfigureAuxiliaryACL` is used to update the `HasAuxiliaryACL` boolean. Events (`AuxiliaryAccessUpdated`) are supposed to be emitted when auxiliary entry information is changed, and these test changes also check that. Finally, there is also an update to `TC_GC_2_1` to ensure `MaxMcastAddrCount` attribute values are in the expected ranges as per spec.

#### Testing

- CI shuold still pass
