### PR TITLE
Enable backwards compatibility test run/compilation on linux/darwin

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -148,6 +148,22 @@ if (chip_build_tests) {
       # "${chip_root}/src/app/clusters/commodity-tariff-server/tests",
     ]
 
+    # Backwards compatibility uses ember mocks, so they cannot run in a "unified"
+    # test build. Restrict them to specific platforms only
+    if ((chip_device_platform == "darwin") || (chip_device_platform == "linux")) {
+      tests += [
+      # keep-sorted: start
+      "${chip_root}/src/app/clusters/chime-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/device-energy-management-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/electrical-energy-measurement-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/electrical-power-measurement-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/energy-evse-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/identify-server/tests:tests-backwards-compatibility",
+      "${chip_root}/src/app/clusters/power-topology-server/tests:tests-backwards-compatibility",
+      # keep-sorted: end
+      ]
+    }
+
     if (current_os != "zephyr") {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
     }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -150,17 +150,18 @@ if (chip_build_tests) {
 
     # Backwards compatibility uses ember mocks, so they cannot run in a "unified"
     # test build. Restrict them to specific platforms only
-    if ((chip_device_platform == "darwin") || (chip_device_platform == "linux")) {
+    if (chip_device_platform == "darwin" || chip_device_platform == "linux") {
       tests += [
-      # keep-sorted: start
-      "${chip_root}/src/app/clusters/chime-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/device-energy-management-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/electrical-energy-measurement-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/electrical-power-measurement-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/energy-evse-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/identify-server/tests:tests-backwards-compatibility",
-      "${chip_root}/src/app/clusters/power-topology-server/tests:tests-backwards-compatibility",
-      # keep-sorted: end
+        # keep-sorted: start
+        "${chip_root}/src/app/clusters/chime-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/device-energy-management-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/electrical-energy-measurement-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/electrical-power-measurement-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/energy-evse-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/identify-server/tests:tests-backwards-compatibility",
+        "${chip_root}/src/app/clusters/power-topology-server/tests:tests-backwards-compatibility",
+
+        # keep-sorted: end
       ]
     }
 

--- a/src/app/clusters/chime-server/tests/TestChimeClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeClusterBackwardsCompatibility.cpp
@@ -19,7 +19,7 @@
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/chime-server/chime-server.h>
-#include <app/server-cluster/testingClusterTester.h>
+#include <app/server-cluster/testing/ClusterTester.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <gtest/gtest.h>
 
@@ -59,7 +59,7 @@ public:
         }
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
     }
-    Protocols::InteractionModel::Status PlayChimeSound() override
+    Protocols::InteractionModel::Status PlayChimeSound(uint8_t) override
     {
         playChimeSoundCalled = true;
         return Protocols::InteractionModel::Status::Success;

--- a/src/app/clusters/device-energy-management-server/tests/TestDeviceEnergyManagementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/device-energy-management-server/tests/TestDeviceEnergyManagementClusterBackwardsCompatibility.cpp
@@ -74,7 +74,7 @@ TEST_F(TestDeviceEnergyManagementClusterBackwardsCompatibility, TestInstanceLife
         EXPECT_TRUE(instance.HasFeature(Feature::kConstraintBasedAdjustment));
 
         // Test shutdown (unregistration)
-        instance.Shutdown(ClusterShutdownType::kClusterShutdown);
+        instance.Shutdown();
 
         // Verify cluster is unregistered from the registry
         auto * unregisteredCluster =
@@ -97,7 +97,7 @@ TEST_F(TestDeviceEnergyManagementClusterBackwardsCompatibility, TestInstanceLife
         EXPECT_FALSE(instance.HasFeature(Feature::kPausable));
 
         // Test shutdown
-        instance.Shutdown(ClusterShutdownType::kClusterShutdown);
+        instance.Shutdown();
     }
 }
 

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -195,7 +195,6 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         EXPECT_EQ(SetMeasurementAccuracy(kTestEndpointId, accuracy), CHIP_NO_ERROR);
 
         // Verify the value was set
-        Structs::MeasurementAccuracyStruct::Type readAccuracy;
         cluster->GetMeasurementAccuracy(readAccuracy);
         // Verify that the MeasurementAccuracyStruct is not erased by the empty accuracyRanges
         EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -249,10 +249,13 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         ASSERT_TRUE(event.has_value());
 
         using CumulativeEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::Type;
+
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         EXPECT_EQ(event->eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, CumulativeEventType::GetClusterId(), CumulativeEventType::GetEventId()));
 
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::DecodableType decodedEvent;
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         ASSERT_EQ(event->GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());
@@ -290,10 +293,12 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         ASSERT_TRUE(event.has_value());
 
         using PeriodicEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::Type;
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         EXPECT_EQ(event->eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, PeriodicEventType::GetClusterId(), PeriodicEventType::GetEventId()));
 
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::DecodableType decodedEvent;
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         ASSERT_EQ(event->GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());

--- a/src/app/clusters/power-topology-server/tests/TestPowerTopologyClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/power-topology-server/tests/TestPowerTopologyClusterBackwardsCompatibility.cpp
@@ -58,7 +58,7 @@ TEST_F(TestPowerTopologyClusterBackwardsCompatibility, TestInstanceLifecycle)
     EXPECT_EQ(instance.Init(), CHIP_NO_ERROR);
 
     // Test shutdown
-    instance.Shutdown(ClusterShutdownType::kClusterShutdown);
+    instance.Shutdown();
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

We wrote these tests but do not run them by default ... and they already bitrotted :(

This fixes the tests and enables them to run by default. Since they use codegen mocks, I enabled them for linux and darwin only by default, since I expect they conflict if we try to use the monolith test infra for on-device. Probably that is fixable (we only have one mock for testing) however for now this seems to be the minimal fix.

#### Testing

Ran tests on linux and they passed.