### PR TITLE
[ESP32] support chip-shell for ESP-IDF v6.0

### DIFF
--- a/examples/shell/esp32/main/main.cpp
+++ b/examples/shell/esp32/main/main.cpp
@@ -34,8 +34,8 @@ extern "C" void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
     chip::Platform::MemoryInit();
-    chip::DeviceLayer::PlatformMgr().InitChipStack();
-    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
+    SuccessOrDie(chip::DeviceLayer::PlatformMgr().InitChipStack());
+    SuccessOrDie(chip::DeviceLayer::PlatformMgr().StartEventLoopTask());
 
     int ret = Engine::Root().Init();
     VerifyOrDie(ret == 0);

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -30,6 +30,9 @@
 
 #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
 #include "driver/uart.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "driver/uart_vfs.h"
+#endif
 #endif
 
 #ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
@@ -60,8 +63,15 @@ int streamer_esp32_init(streamer_t * streamer)
     fsync(fileno(stdout));
     setvbuf(stdin, NULL, _IONBF, 0);
 #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     esp_vfs_dev_uart_port_set_rx_line_endings((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
     esp_vfs_dev_uart_port_set_tx_line_endings((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
+#else
+    uart_vfs_dev_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
+    uart_vfs_dev_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
+#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+
     if (!uart_is_driver_installed((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM))
     {
         ESP_ERROR_CHECK(uart_driver_install((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, 256, 0, 0, NULL, 0));
@@ -80,7 +90,13 @@ int streamer_esp32_init(streamer_t * streamer)
 #endif
     };
     ESP_ERROR_CHECK(uart_param_config((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, &uart_config));
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     esp_vfs_dev_uart_use_driver(0);
+#else
+    uart_vfs_dev_use_driver(CONFIG_ESP_CONSOLE_UART_NUM);
+#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+
 #endif // CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
 
 #ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG


### PR DESCRIPTION
#### Summary

This is the Second PR for adding esp-idf v6.0 support.

`cd examples/shell/esp32 && idf.py build` would fail with error

<details> <summary> Click to view errors </summary>

```
../../../../../../config/esp32/third_party/connectedhomeip/src/lib/shell/streamer_esp32.cpp: In function 'int chip::Shell::streamer_esp32_init(streamer_t*)':
../../../../../../config/esp32/third_party/connectedhomeip/src/lib/shell/streamer_esp32.cpp:63:5: error: 'esp_vfs_dev_uart_port_set_rx_line_endings' was not declared in this scope
   63 |     esp_vfs_dev_uart_port_set_rx_line_endings((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../config/esp32/third_party/connectedhomeip/src/lib/shell/streamer_esp32.cpp:64:5: error: 'esp_vfs_dev_uart_port_set_tx_line_endings' was not declared in this scope
   64 |     esp_vfs_dev_uart_port_set_tx_line_endings((uart_port_t) CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../config/esp32/third_party/connectedhomeip/src/lib/shell/streamer_esp32.cpp:83:5: error: 'esp_vfs_dev_uart_use_driver' was not declared in this scope
   83 |     esp_vfs_dev_uart_use_driver(0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics


/Users/shubhampatil/esp/connectedhomeip/examples/shell/esp32/main/main.cpp:37:51: error: ignoring returned value of type 'CHIP_ERROR' {aka 'chip::ChipError'}, declar
ed with attribute 'nodiscard' [-Werror=unused-result]
   37 |     chip::DeviceLayer::PlatformMgr().InitChipStack();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /Users/shubhampatil/esp/connectedhomeip/src/include/platform/CHIPDeviceLayer.h:31,
                 from /Users/shubhampatil/esp/connectedhomeip/examples/shell/esp32/main/main.cpp:24:
/Users/shubhampatil/esp/connectedhomeip/src/include/platform/PlatformManager.h:362:19: note: in call to 'CHIP_ERROR chip::DeviceLayer::PlatformManager::InitChipStack
()', declared here
  362 | inline CHIP_ERROR PlatformManager::InitChipStack()
      |                   ^~~~~~~~~~~~~~~
In file included from /Users/shubhampatil/esp/connectedhomeip/src/lib/shell/Engine.h:28,
                 from /Users/shubhampatil/esp/connectedhomeip/examples/shell/esp32/main/main.cpp:21:
/Users/shubhampatil/esp/connectedhomeip/src/lib/core/CHIPError.h:503:7: note: 'CHIP_ERROR' {aka 'chip::ChipError'} declared here
  503 | using CHIP_ERROR = ::chip::ChipError;
      |       ^~~~~~~~~~
/Users/shubhampatil/esp/connectedhomeip/examples/shell/esp32/main/main.cpp:38:56: error: ignoring returned value of type 'CHIP_ERROR' {aka 'chip::ChipError'}, declar
ed with attribute 'nodiscard' [-Werror=unused-result]
   38 |     chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/Users/shubhampatil/esp/connectedhomeip/src/include/platform/PlatformManager.h:419:19: note: in call to 'CHIP_ERROR chip::DeviceLayer::PlatformManager::StartEventLoo
pTask()', declared here
  419 | inline CHIP_ERROR PlatformManager::StartEventLoopTask()
      |                   ^~~~~~~~~~~~~~~
/Users/shubhampatil/esp/connectedhomeip/src/lib/core/CHIPError.h:503:7: note: 'CHIP_ERROR' {aka 'chip::ChipError'} declared here
  503 | using CHIP_ERROR = ::chip::ChipError;
      |       ^~~~~~~~~~
cc1plus: all warnings being treated as errors
```

</details>

- ESP-IDF v6.0 renamed UART VFS APIs (esp_vfs_dev_uart_* → uart_vfs_dev_*) and moved the header to driver/uart_vfs.h. Added version guards to support both IDF v6.0 and < v6.0
- Handle CHIP_ERROR return values from InitChipStack() and StartEventLoopTask() in the shell example using SuccessOrDie() instead of silently discarding them.

#### Related issues
- PR-1: #43668

#### Testing
- Re-build the `examples/shell/esp32` with the changes and build succeeded.

