### PR TITLE
Fix dangling pointer in CastingPlayer copy constructor in examples/tv-casting-app 

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -601,10 +601,33 @@ void CastingPlayer::LogDetail() const
 }
 
 CastingPlayer::CastingPlayer(const CastingPlayer & other) :
-    std::enable_shared_from_this<CastingPlayer>(other), mEndpoints(other.mEndpoints), mConnectionState(other.mConnectionState),
-    mAttributes(other.mAttributes), mIdOptions(other.mIdOptions),
-    mCommissioningWindowTimeoutSec(other.mCommissioningWindowTimeoutSec), mOnCompleted(other.mOnCompleted)
-{}
+    std::enable_shared_from_this<CastingPlayer>(other), mConnectionState(other.mConnectionState), mAttributes(other.mAttributes),
+    mIdOptions(other.mIdOptions), mCommissioningWindowTimeoutSec(other.mCommissioningWindowTimeoutSec),
+    mOnCompleted(other.mOnCompleted)
+{
+    ChipLogProgress(AppServer, "CastingPlayer::CastingPlayer(copy) deep-copying %u endpoint(s) from other=%p to this=%p",
+                    static_cast<unsigned int>(other.mEndpoints.size()), static_cast<const void *>(&other),
+                    static_cast<void *>(this));
+
+    // Create new Endpoint objects instead of sharing them, so that each Endpoint's
+    // mCastingPlayer raw pointer points to *this* CastingPlayer (not `other`).
+    // Sharing Endpoint shared_ptrs would leave their mCastingPlayer pointing to `other`,
+    // which becomes a dangling pointer when `other` is destroyed (e.g. when
+    // CastingStore::ReadAll() returns a std::list<CastingPlayer> by value).
+    mEndpoints.reserve(other.mEndpoints.size());
+    for (const auto & endpoint : other.mEndpoints)
+    {
+        EndpointAttributes attrs;
+        attrs.mId             = endpoint->GetId();
+        attrs.mVendorId       = endpoint->GetVendorId();
+        attrs.mProductId      = endpoint->GetProductId();
+        attrs.mDeviceTypeList = endpoint->GetDeviceTypeList();
+
+        auto newEndpoint = std::make_shared<Endpoint>(this, attrs);
+        newEndpoint->RegisterClusters(endpoint->GetServerList());
+        mEndpoints.push_back(newEndpoint);
+    }
+}
 
 CastingPlayer & CastingPlayer::operator=(const CastingPlayer & other)
 {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -129,7 +129,8 @@ public:
     }
 
     /**
-     * @brief Define the copy constructor
+     * @brief Copy constructor. Deep-copies Endpoint objects so that each Endpoint's
+     * mCastingPlayer raw pointer points to this new CastingPlayer instance.
      */
     CastingPlayer(const CastingPlayer & other);
 


### PR DESCRIPTION
…-casting-app

#### Summary

Fix dangling pointer in CastingPlayer copy constructor in examples/tv-casting-app 

Fixed a memory safety bug in the `CastingPlayer` copy constructor that could cause a SIGSEGV crash on Android.

The copy constructor was performing a shallow copy of the `mEndpoints` vector (`shared_ptr<Endpoint>` references). Each `Endpoint` holds a raw `CastingPlayer *` back-pointer (`mCastingPlayer`). After a copy, the shared `Endpoint` objects still pointed to the original `CastingPlayer`. When the original was destroyed, `Endpoint::mCastingPlayer` became a dangling pointer, and any subsequent access to `endpoint->GetCastingPlayer()` would dereference freed memory.

This was reported as a SIGSEGV crash on Android during commissioning re-attempts after the target device (Fire TV) was restarted, clearing its Matter cache. The crash occurred in or immediately after `CastingStore::ReadAll()`, which returns a `std::list<CastingPlayer>` by value — triggering the copy constructor.

The fix updates the copy constructor to deep-copy endpoints, creating new `Endpoint` objects with `mCastingPlayer` pointing to the newly constructed `CastingPlayer` (`this`). This matches the pattern already used by `CastingPlayer::operator=`.

#### Related issues

Fixes: #18

#### Testing

- Built and ran the Linux tv-casting-app (`chip_casting_simplified=true`)
- Reproduced the commissioning failure scenario: commission → clear tv-app cache → re-commission
- Verified via debug logging that all `Endpoint::mCastingPlayer` pointers correctly reference their owning `CastingPlayer` after `CastingStore::ReadAll()` returns
- Android testing with the example tv-casting-app is pending (Raspberry-Pi dev environment)
- Requested partner (Vizbee) to validate on Android with their crash scenario (commission → restart Fire TV → commission again)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
