### PR TITLE
psa: alow attribute override for CASE Ephemeral Keys

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -830,6 +830,8 @@ CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
         ExitNow(error = CHIP_ERROR_UNKNOWN_KEY_TYPE);
     }
 
+    GetPSAKeyAllocator().UpdateKeyAttributes(attributes);
+
     status = psa_generate_key(&attributes, &context.key_id);
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
 


### PR DESCRIPTION
#### Summary

Allow platforms to override the attributes of CASE Ephemeral Keys: e.g.: a platform may want to change the location of these keys to the secure element.

#### Testing

UpdateKeyAttributes() does [nothing](https://github.com/project-chip/connectedhomeip/blob/master/src/crypto/PSAKeyAllocator.h#L181) by default. Run locally PSA unit tests on MCXW72 platform (changes contain an override at platform level for UpdateKeyAttributes() - these changes will be submitted in a follow up PR).