### PR TITLE
[ESP32]: Wi-Fi and netif changes for ESP-IDF v6.0

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -11,7 +11,7 @@ dependencies:
             - if: "idf_version >=4.3"
 
     espressif/esp_encrypted_img:
-        version: "2.3.0"
+        version: "2.7.0"
         require: public
         rules:
             - if: "idf_version >=4.4"

--- a/src/platform/ESP32/CHIPDevicePlatformEvent.h
+++ b/src/platform/ESP32/CHIPDevicePlatformEvent.h
@@ -28,6 +28,7 @@
 #include <platform/CHIPDeviceEvent.h>
 
 #include <esp_event.h>
+#include <esp_idf_version.h>
 #include <esp_netif_types.h>
 #include <esp_wifi_types.h>
 
@@ -77,7 +78,11 @@ struct ChipDevicePlatformEvent final
                 ip_event_t EthGotIp;
                 ip_event_got_ip_t IpGotIp;
                 ip_event_got_ip6_t IpGotIp6;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+                ip_event_assigned_ip_to_client_t IpApStaIpAssigned;
+#else
                 ip_event_ap_staipassigned_t IpApStaIpAssigned;
+#endif
                 wifi_event_sta_scan_done_t WiFiStaScanDone;
                 wifi_event_sta_connected_t WiFiStaConnected;
                 wifi_event_sta_disconnected_t WiFiStaDisconnected;

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -680,9 +680,9 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     case WIFI_REASON_AUTH_EXPIRE:
     case WIFI_REASON_AUTH_LEAVE:
     case WIFI_REASON_ASSOC_LEAVE:
-  #if !(ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+#if !(ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
     case WIFI_REASON_ASSOC_EXPIRE:
-  #endif
+#endif
         break;
 
     default:

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -633,7 +633,11 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     switch (reason)
     {
     case WIFI_REASON_ASSOC_TOOMANY:
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    case WIFI_REASON_CLASS3_FRAME_FROM_NONASSOC_STA:
+#else
     case WIFI_REASON_NOT_ASSOCED:
+#endif
     case WIFI_REASON_ASSOC_NOT_AUTHED:
     case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
     case WIFI_REASON_GROUP_CIPHER_INVALID:
@@ -648,7 +652,11 @@ void ConnectivityManagerImpl::OnStationDisconnected()
             delegate->OnAssociationFailureDetected(associationFailureCause, reason);
         }
         break;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    case WIFI_REASON_CLASS2_FRAME_FROM_NONAUTH_STA:
+#else
     case WIFI_REASON_NOT_AUTHED:
+#endif
     case WIFI_REASON_MIC_FAILURE:
     case WIFI_REASON_IE_IN_4WAY_DIFFERS:
     case WIFI_REASON_INVALID_RSN_IE_CAP:
@@ -672,7 +680,9 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     case WIFI_REASON_AUTH_EXPIRE:
     case WIFI_REASON_AUTH_LEAVE:
     case WIFI_REASON_ASSOC_LEAVE:
+  #if !(ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
     case WIFI_REASON_ASSOC_EXPIRE:
+  #endif
         break;
 
     default:

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -190,7 +190,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** netifpp)
 {
-    esp_netif_t * netif     = esp_netif_next(NULL);
+    // TODO: safely iterate over netifs
+    esp_netif_t * netif     = esp_netif_next_unsafe(NULL);
     NetworkInterface * head = NULL;
     uint8_t ipv6_addr_count = 0;
     esp_ip6_addr_t ip6_addr[LWIP_IPV6_NUM_ADDRESSES];
@@ -200,7 +201,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     }
     else
     {
-        for (esp_netif_t * ifa = netif; ifa != NULL; ifa = esp_netif_next(ifa))
+        for (esp_netif_t * ifa = netif; ifa != NULL; ifa = esp_netif_next_unsafe(ifa))
         {
             NetworkInterface * ifp = new NetworkInterface();
             uint8_t addressSize    = 0;

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -28,6 +28,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <esp_timer.h>
+#include <sys/time.h>
 
 namespace chip {
 namespace System {


### PR DESCRIPTION
#### Summary

This is the Third PR for adding esp-idf v6.0 support.

- bump esp_encrypted_img to pull in idf v6 changes
- remove deprecated ip_event_ap_staipassigned_t and use ip_event_assigned_ip_to_client_t
- remove deprecated wifi disconnect reason enum usages
- changed esp_netif_next to esp_netif_next_unsafe
- include sys/time.h used by settimeofday

#### Related issues

- PR-1: #43668
- PR-2: #43709

#### Testing
- Build the `examples/shell/esp32` app on both v6.0 and v5.5.2 and ensured both build correctly with these changes.