### PR TITLE
Improvements and less surprises during libdatachannel build

### DIFF
--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -24,14 +24,6 @@ assert(chip_build_tools)
 config("config") {
   cflags = [ "-Wno-shadow" ]
 
-  if (is_clang) {
-    # libdatachannel has a lot of these like:
-    #   ...... libdatachannel/repo/include/rtc/h265nalunit.hpp:40:60: error: implicit conversion loses integer precision: 'int'
-    #   to 'uint8_t' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
-    #   40 |         uint8_t nuhLayerId() const { return ((_first & 0x1) << 5) | ((_second & 0b1111'1000) >> 3); }
-    cflags += [ "-Wno-implicit-int-conversion" ]
-  }
-
   include_dirs = [
     "include",
     "include/clusters/chime",

--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -26,14 +26,6 @@ assert(chip_build_tools)
 config("config") {
   cflags = [ "-Wno-shadow" ]
 
-  if (is_clang) {
-    # libdatachannel has a lot of these like:
-    #   ...... libdatachannel/repo/include/rtc/h265nalunit.hpp:40:60: error: implicit conversion loses integer precision: 'int'
-    #   to 'uint8_t' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
-    #   40 |         uint8_t nuhLayerId() const { return ((_first & 0x1) << 5) | ((_second & 0b1111'1000) >> 3); }
-    cflags += [ "-Wno-implicit-int-conversion" ]
-  }
-
   include_dirs = [
     ".",
     "${chip_root}/examples/common",

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -49,12 +49,4 @@ static_library("chip_webrtc") {
     "${chip_root}/src/platform",
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
-
-  libs = [
-    "ssl",
-    "crypto",
-  ]
-
-  # suppress known `libdatachannel` int conversion issues
-  cflags = [ "-Wno-implicit-int-conversion" ]
 }

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -32,7 +32,7 @@ action("build_libdatachannel") {
 
   args = [
     "--build-dir",
-    rebase_path(_output_dir),
+    rebase_path(_output_dir, root_build_dir),
   ]
 
   if (is_clang) {
@@ -71,10 +71,10 @@ config("datachannel_config") {
   cflags = [ "-Wno-implicit-int-conversion" ]
 
   lib_dirs = [
-    rebase_path("${_output_dir}"),
-    rebase_path("${_output_dir}/deps/usrsctp/usrsctplib"),
-    rebase_path("${_output_dir}/deps/libsrtp"),
-    rebase_path("${_output_dir}/deps/libjuice"),
+    rebase_path("${_output_dir}", root_build_dir),
+    rebase_path("${_output_dir}/deps/usrsctp/usrsctplib", root_build_dir),
+    rebase_path("${_output_dir}/deps/libsrtp", root_build_dir),
+    rebase_path("${_output_dir}/deps/libjuice", root_build_dir),
   ]
 }
 

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -58,21 +58,17 @@ config("datachannel_config") {
     "usrsctp",
     "srtp2",
     "juice-static",
+
+    # We build static libraries and srtp2 depends on openssl
+    # TODO: can we somehow query this dynamically?
+    "ssl",
+    "crypto",
   ]
 
   cflags_cc = [ "-Wno-shadow" ]
 
   # suppress known `libdatachannel` int conversion issues
   cflags = [ "-Wno-implicit-int-conversion" ]
-
-  if (is_clang) {
-    # We build static libraries and srtp2 depends on openssl
-    # TODO: can we somehow query this dynamically?
-    libs += [
-      "ssl",
-      "crypto",
-    ]
-  }
 
   lib_dirs = [
     rebase_path("${_output_dir}"),

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -19,12 +19,21 @@ _compiler_subdir = "gcc"
 if (is_clang) {
   _compiler_subdir = "clang"
 }
-_output_dir = "build/$current_cpu-$_compiler_subdir"
+_output_dir = "${target_out_dir}/$current_cpu-$_compiler_subdir"
 
 action("build_libdatachannel") {
   script = "scripts/build_libdatachannel.py"
-  outputs = [ "$target_gen_dir/repo/${_output_dir}/libdatachannel.so" ]
-  args = [ "--output-dir=${_output_dir}" ]
+  outputs = [
+    "${_output_dir}/libdatachannel.a",
+    "${_output_dir}/deps/usrsctp/usrsctplib/libusrsctp.a",
+    "${_output_dir}/deps/libsrtp/libsrtp2.a",
+    "${_output_dir}/deps/libjuice/libjuice.a",
+  ]
+
+  args = [
+    "--build-dir",
+    rebase_path(_output_dir),
+  ]
 
   if (is_clang) {
     args += [ "--clang" ]
@@ -66,10 +75,10 @@ config("datachannel_config") {
   }
 
   lib_dirs = [
-    rebase_path("repo/${_output_dir}"),
-    rebase_path("repo/${_output_dir}/deps/usrsctp/usrsctplib"),
-    rebase_path("repo/${_output_dir}/deps/libsrtp"),
-    rebase_path("repo/${_output_dir}/deps/libjuice"),
+    rebase_path("${_output_dir}"),
+    rebase_path("${_output_dir}/deps/usrsctp/usrsctplib"),
+    rebase_path("${_output_dir}/deps/libsrtp"),
+    rebase_path("${_output_dir}/deps/libjuice"),
   ]
 }
 

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -24,10 +24,10 @@ _output_dir = "${target_out_dir}/$current_cpu-$_compiler_subdir"
 action("build_libdatachannel") {
   script = "scripts/build_libdatachannel.py"
   outputs = [
-    "${_output_dir}/libdatachannel.a",
+    "${_output_dir}/libdatachannel-static.a",
     "${_output_dir}/deps/usrsctp/usrsctplib/libusrsctp.a",
     "${_output_dir}/deps/libsrtp/libsrtp2.a",
-    "${_output_dir}/deps/libjuice/libjuice.a",
+    "${_output_dir}/deps/libjuice/libjuice-static.a",
   ]
 
   args = [
@@ -54,10 +54,10 @@ action("build_libdatachannel") {
 
 config("datachannel_config") {
   libs = [
-    "datachannel",
+    "datachannel-static",
     "usrsctp",
     "srtp2",
-    "juice",
+    "juice-static",
   ]
 
   cflags_cc = [ "-Wno-shadow" ]

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -32,7 +32,7 @@ action("build_libdatachannel") {
 
   args = [
     "--build-dir",
-    rebase_path(_output_dir, root_build_dir),
+    rebase_path(_output_dir, root_out_dir),
   ]
 
   if (is_clang) {
@@ -66,15 +66,16 @@ config("datachannel_config") {
   ]
 
   cflags_cc = [ "-Wno-shadow" ]
-
-  # suppress known `libdatachannel` int conversion issues
-  cflags = [ "-Wno-implicit-int-conversion" ]
+  if (is_clang) {
+    # suppress known `libdatachannel` int conversion issues
+    cflags = [ "-Wno-implicit-int-conversion" ]
+  }
 
   lib_dirs = [
-    rebase_path("${_output_dir}", root_build_dir),
-    rebase_path("${_output_dir}/deps/usrsctp/usrsctplib", root_build_dir),
-    rebase_path("${_output_dir}/deps/libsrtp", root_build_dir),
-    rebase_path("${_output_dir}/deps/libjuice", root_build_dir),
+    "${_output_dir}",
+    "${_output_dir}/deps/usrsctp/usrsctplib",
+    "${_output_dir}/deps/libsrtp",
+    "${_output_dir}/deps/libjuice",
   ]
 }
 

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -6,21 +6,22 @@ import subprocess
 
 import click
 
+# figure out paths for building
+script_dir = os.path.dirname(os.path.abspath(__file__))
+repo_dir = os.path.join(script_dir, "..", "repo")
 
 @click.command()
 @click.option("--clang", is_flag=True, default=False, help="If specified, use clang instead of gcc")
-@click.option("--output-dir", default="build", help="Output directory for libdatachannel build")
+@click.option("--build-dir", default=os.path.join(repo_dir, "build"), show_default=True,
+              help="Build directory for libdatachannel build")
 @click.option("--cross-compile-cpu-type", default=None, help="CPU type for cross compilation if needed")
 @click.option("--target-cc", default=None, help="C compiler for cross compilation (from args.gn)")
 @click.option("--target-cxx", default=None, help="C++ compiler for cross compilation (from args.gn)")
-def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
+def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
          target_cc: str | None, target_cxx: str | None):
-    # figure out paths for building
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    repo_dir = os.path.join(script_dir, "..", "repo")
-    build_dir = os.path.join(repo_dir, output_dir)
 
-    # Generate build files in ./build
+
+    # Generate build files in build_dir
     cmake_cmd = [
         "cmake",
         "-B",

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -97,7 +97,6 @@ def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
     print(f"Running: {shlex.join(cmake_cmd)}")
     subprocess.run(cmake_cmd, check=True)
 
-    # Build with Make
     make_cmd = ["cmake", "--build", str(build_dir), "--target", "datachannel-static", f"-j{os.cpu_count()}"]
     print(f"Running: {shlex.join(make_cmd)}")
     subprocess.run(make_cmd, check=True)

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -3,16 +3,16 @@
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 import click
 
 # figure out paths for building
-script_dir = os.path.dirname(os.path.abspath(__file__))
-repo_dir = os.path.join(script_dir, "..", "repo")
+repo_dir = Path(__file__).resolve().parents[1] / "repo"
 
 @click.command()
 @click.option("--clang", is_flag=True, default=False, help="If specified, use clang instead of gcc")
-@click.option("--build-dir", default=os.path.join(repo_dir, "build"), show_default=True,
+@click.option("--build-dir", default=repo_dir / "build", show_default=True,
               help="Build directory for libdatachannel build")
 @click.option("--cross-compile-cpu-type", default=None, help="CPU type for cross compilation if needed")
 @click.option("--target-cc", default=None, help="C compiler for cross compilation (from args.gn)")

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -32,7 +32,6 @@ def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
         "-DUSE_NICE=0",
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_CXX_FLAGS=-Wno-shadow",
-        "-DBUILD_SHARED_LIBS=OFF",
     ]
 
     # Default compilers
@@ -99,7 +98,7 @@ def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
     subprocess.run(cmake_cmd, check=True)
 
     # Build with Make
-    make_cmd = ["cmake", "--build", str(build_dir), f"-j{os.cpu_count()}"]
+    make_cmd = ["cmake", "--build", str(build_dir), "--target", "datachannel-static", f"-j{os.cpu_count()}"]
     print(f"Running: {shlex.join(make_cmd)}")
     subprocess.run(make_cmd, check=True)
 

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -24,8 +24,10 @@ def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
     # Generate build files in build_dir
     cmake_cmd = [
         "cmake",
+        "-S",
+        str(repo_dir),
         "-B",
-        build_dir,
+        str(build_dir),
         "-DUSE_GNUTLS=0",
         "-DUSE_NICE=0",
         "-DCMAKE_BUILD_TYPE=Release",
@@ -94,12 +96,12 @@ def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
     )
 
     print(f"Running: {shlex.join(cmake_cmd)}")
-    subprocess.run(cmake_cmd, cwd=repo_dir, check=True)
+    subprocess.run(cmake_cmd, check=True)
 
     # Build with Make
-    make_cmd = ["make", "-j%d" % os.cpu_count()]
+    make_cmd = ["cmake", "--build", str(build_dir), f"-j{os.cpu_count()}"]
     print(f"Running: {shlex.join(make_cmd)}")
-    subprocess.run(make_cmd, cwd=build_dir, check=True)
+    subprocess.run(make_cmd, check=True)
 
     print("libdatachannel build complete.")
     print(f"Artifacts are located in: {build_dir}")

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -10,6 +10,7 @@ import click
 # figure out paths for building
 repo_dir = Path(__file__).resolve().parents[1] / "repo"
 
+
 @click.command()
 @click.option("--clang", is_flag=True, default=False, help="If specified, use clang instead of gcc")
 @click.option("--build-dir", default=repo_dir / "build", show_default=True,
@@ -19,7 +20,6 @@ repo_dir = Path(__file__).resolve().parents[1] / "repo"
 @click.option("--target-cxx", default=None, help="C++ compiler for cross compilation (from args.gn)")
 def main(clang: bool, build_dir: str, cross_compile_cpu_type: str | None,
          target_cc: str | None, target_cxx: str | None):
-
 
     # Generate build files in build_dir
     cmake_cmd = [


### PR DESCRIPTION
#### Summary

Multiple improvements to the way `libdatachannel` is built:

- build in the output directory not in source tree resulting in less surprises when one forgets to remove `repo/build`
- build process aligned with `BUILDING.md` from upstream, use dedicated `datachannel-static` target instead of overriding BUILD_SHARED_LIBS
- moved stray `cflags` and `libs` from downstream to the libdatachannel target
- abstract away `make` calls with `cmake --build`, pass directories explicitly to `cmake`
- drop `os.path` usage

#### Testing

Run `local.py build` and `build_examples.py` on affected apps to check if build is still ok.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X]  CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
