### PR TITLE
[nxp] laundry washer compile fix - do not depend on "bridged actions" for a laundry app without an actions cluster.

### DIFF
--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -119,7 +119,6 @@ endif()
 target_sources(app
     PRIVATE
     ${ALL_CLUSTERS_COMMON_DIR}/src/smco-stub.cpp
-    ${ALL_CLUSTERS_COMMON_DIR}/src/bridged-actions-stub.cpp
     ${ALL_CLUSTERS_COMMON_DIR}/src/static-supported-temperature-levels.cpp
     ${LAUNDRY_WASHER_NXP_COMMON_DIR}/main/laundry-washer-mode.cpp
     ${ALL_CLUSTERS_COMMON_DIR}/src/laundry-washer-controls-delegate-impl.cpp


### PR DESCRIPTION
Remove bridged-actions-stub.cpp from the NXP Zephyr laundry-washer CMakeLists.txt. The laundry-washer ZAP does not include the Actions cluster, so CodegenIntegration.cpp (which defines ActionsServer and its destructor) is never compiled for this target. Including bridged-actions-stub.cpp, which uses std::unique_ptr<ActionsServer>, caused an undefined reference to ~ActionsServer() at link time.

#### Summary

#### Related issues


#### Testing


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
