### PR TITLE
[Darwin] add parsing of multiple payload QR codes to framework tool

### DIFF
--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -69,6 +69,20 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
 
 CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
 {
+    // If the top-level payload is concatenated, we recurse with the subpayloads
+    //  which will have `isConcatenated` as `false`. 
+    if (payload.isConcatenated) {
+        bool firstPayload = true;
+        for (MTRSetupPayload * subPayload in payload.subPayloads) {
+            if (!firstPayload) {
+                NSLog(@"----------");
+            }
+            ReturnErrorOnFailure(Print(subPayload));
+            firstPayload = false;
+        }
+        return CHIP_NO_ERROR;
+    }
+
     NSLog(@"Version:       %@", payload.version);
     NSLog(@"VendorID:      %@", payload.vendorID);
     NSLog(@"ProductID:     %@", payload.productID);

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -70,7 +70,7 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
 CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
 {
     // If the top-level payload is concatenated, we recurse with the subpayloads
-    //  which will have `isConcatenated` as `false`. 
+    //  which will have `isConcatenated` as `false`.
     if (payload.isConcatenated) {
         bool firstPayload = true;
         for (MTRSetupPayload * subPayload in payload.subPayloads) {


### PR DESCRIPTION


#### Summary

support was already in Darwin framework, use it in `darwin-framework-tool`

use same output format as `chip-tool` for multiple payloads

#### Related issues

Fixes #43510.

#### Testing

Use test case from #43510: 
```
./darwin-framework-tool payload parse-setup-payload "MT:-24J0CEK01KA0648G00*-24J0KQS020O0648G00"
```
Expect two parsed payloads to be output like with `chip-tool`.

Use non-concatenated QR code to check for regression:
```
./darwin-framework-tool payload parse-setup-payload "MT:-24J0CEK01KA0648G00"
```
Expect one parsed payload to be output like with `chip-tool`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase
