### PR TITLE
[MinMdns][Bugfix] early ignore of non-Matter service names in `IncrementalResolver::InitializeParsing`

### DIFF
--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -141,6 +141,14 @@ SerializedQNameIterator StoredServerName::Get() const
 CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
                                                   const mdns::Minimal::SrvRecord & srv)
 {
+    // Reject non-matter service names before storing anything. Non-matter devices may use instance names larger than
+    // kMaxStoredNameLength, leading to errors such as CHIP_ERROR_NO_MEMORY.
+    mServiceNameType = ComputeServiceNameType(name);
+    if (mServiceNameType == ServiceNameType::kInvalid)
+    {
+        return CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME;
+    }
+
     AutoInactiveResetter inactiveReset(*this);
 
     ReturnErrorOnFailure(mRecordName.Set(name));
@@ -164,8 +172,6 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
         // only save the first part: the MAC or 802.15.4 Extended Address in hex
         Platform::CopyString(mCommonResolutionData.hostName, serverName.Value());
     }
-
-    mServiceNameType = ComputeServiceNameType(name);
 
     switch (mServiceNameType)
     {

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -141,6 +141,8 @@ SerializedQNameIterator StoredServerName::Get() const
 CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
                                                   const mdns::Minimal::SrvRecord & srv)
 {
+    AutoInactiveResetter inactiveReset(*this);
+
     // Reject non-matter service names before storing anything. Non-matter devices may use instance names larger than
     // kMaxStoredNameLength, leading to errors such as CHIP_ERROR_NO_MEMORY.
     mServiceNameType = ComputeServiceNameType(name);
@@ -148,8 +150,6 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
     {
         return CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME;
     }
-
-    AutoInactiveResetter inactiveReset(*this);
 
     ReturnErrorOnFailure(mRecordName.Set(name));
     ReturnErrorOnFailure(mTargetHostName.Set(srv.GetName()));

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -114,6 +114,8 @@ public:
     /// Start parsing a new record. SRV records are the records we are mainly
     /// interested on, after which TXT and A/AAAA are looked for.
     ///
+    /// Returns CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME for non-matter service names.
+    ///
     /// If this function returns with error, the object will be in an inactive state.
     CHIP_ERROR InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
                                  const mdns::Minimal::SrvRecord & srv);

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -52,6 +52,11 @@ const auto kTestHostName = testing::TestQName<2>({ "abcd", "local" });
 
 const auto kIrrelevantHostName = testing::TestQName<2>({ "different", "local" });
 
+// Non-Matter name that is longer than `kMaxStoredNameLength`, meaning it will not fit in the server name storage of
+// IncrementalResolver
+const auto kLongNonMatterNode =
+    testing::TestQName<4>({ "455UT80006LA.DFPGLWE-fac0e7b473ee4a44966ab1487258d398", "not_a_matter_device", "_tcp", "local" });
+
 void PreloadSrvRecord(SrvRecord & record)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes] = {};
@@ -180,6 +185,29 @@ TEST(TestIncrementalResolve, TestInactiveResetOnInitError)
 
     // test host name is not a 'matter' name
     EXPECT_NE(resolver.InitializeParsing(kTestHostName.Serialized(), 0, srvRecord), CHIP_NO_ERROR);
+
+    EXPECT_FALSE(resolver.IsActive());
+    EXPECT_FALSE(resolver.IsActiveCommissionParse());
+    EXPECT_FALSE(resolver.IsActiveOperationalParse());
+}
+
+TEST(TestIncrementalResolve, TestLongNonMatterNameReturnsUnsupportedServiceName)
+{
+    IncrementalResolver resolver;
+
+    EXPECT_FALSE(resolver.IsActive());
+
+    SrvRecord srvRecord;
+    PreloadSrvRecord(srvRecord);
+
+    // Ensure that kLongNonMatterNode is a name that does NOT fit in the server name storage of IncrementalResolver; This verifies
+    // that InitializeParsing rejects overly long non-Matter names with a clear error, instead of returning CHIP_ERROR_NO_MEMORY.
+    StoredServerName name;
+    EXPECT_EQ(name.Set(kLongNonMatterNode.Serialized()), CHIP_ERROR_NO_MEMORY);
+
+    // InitializeParsing should return CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME for non-matter service names, even if they are too
+    // long to fit in the server name storage of IncrementalResolver.
+    EXPECT_EQ(resolver.InitializeParsing(kLongNonMatterNode.Serialized(), 0, srvRecord), CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME);
 
     EXPECT_FALSE(resolver.IsActive());
     EXPECT_FALSE(resolver.IsActiveCommissionParse());


### PR DESCRIPTION
#### Summary

 - fix for: https://github.com/project-chip/connectedhomeip/issues/42763

- Basically, verbose Error logs are displayed when non-matter devices advertised mDNS services with Instance Names larger than 64 Bytes are detected by a Matter App
- Fix: when non-Matter mdns Packets are detected, return from `IncrementalResolver::InitializeParsing` before we start storing the ServiceName to avoid triggering `CHIP_ERROR_NO_MEMORY` and also because it is not needed.  

#### Testing
- Added Unit Test case
- Tested locally, by advertising a non-matter mDNS packet with larger instance name than supported (>64 bytes).