### PR TITLE
Display execution time for crypto unit tests

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -394,6 +394,10 @@ set(GN_ROOT_TARGET ${CHIP_ROOT}/config/esp32)
 
 set(chip_libraries "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a")
 
+if (CONFIG_BUILD_CHIP_TESTS)
+    list(APPEND chip_libraries "${CMAKE_CURRENT_BINARY_DIR}/lib/libPWTestsWrapper.a")
+endif()
+
 if(CONFIG_ENABLE_PW_RPC)
   list(APPEND chip_libraries "${CMAKE_CURRENT_BINARY_DIR}/lib/libPwRpc.a")
 endif()

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -426,6 +426,7 @@ pw_static_library("pw_tests_wrapper") {
     "$dir_pw_unit_test",
     "$dir_pw_unit_test:logging",
     "${chip_root}/src/lib/core:string-builder-adapters",
+    "${chip_root}/src/system",
   ]
   sources = [
     "UnitTest.cpp",

--- a/src/lib/support/UnitTest.cpp
+++ b/src/lib/support/UnitTest.cpp
@@ -1,15 +1,52 @@
 #include "UnitTest.h"
 
 #include "pw_unit_test/framework.h"
+#include "pw_unit_test/googletest_style_event_handler.h"
 #include "pw_unit_test/logging_event_handler.h"
+#include <pw_log/log.h>
+
+#include <system/SystemClock.h>
 
 namespace chip {
 namespace test {
 
+class SuccessTimingLoggingEventHandler : public pw::unit_test::LoggingEventHandler
+{
+public:
+    SuccessTimingLoggingEventHandler() : LoggingEventHandler(false), mTestStartTime(0) {}
+
+    void TestCaseStart(const pw::unit_test::TestCase & test_case) override
+    {
+        // Store the start time
+        mTestStartTime = System::Clock::Milliseconds32(System::SystemClock().GetMonotonicTimestamp()).count();
+
+        // Call the parent implementation to keep default behavior
+        LoggingEventHandler::TestCaseStart(test_case);
+    }
+
+    void TestCaseEnd(const pw::unit_test::TestCase & test_case, pw::unit_test::TestResult result) override
+    {
+        // Calculate elapsed time
+        uint32_t endTime   = System::Clock::Milliseconds32(System::SystemClock().GetMonotonicTimestamp()).count();
+        uint32_t elapsedMs = endTime - mTestStartTime;
+
+        if (result == pw::unit_test::TestResult::kSuccess)
+        {
+            PW_LOG_INFO("[       OK ] %s.%s (%" PRIu32 " ms)", test_case.suite_name, test_case.test_name, elapsedMs);
+            return;
+        }
+
+        LoggingEventHandler::TestCaseEnd(test_case, result);
+    }
+
+private:
+    uint32_t mTestStartTime;
+};
+
 int RunAllTests()
 {
     testing::InitGoogleTest(nullptr, static_cast<char **>(nullptr));
-    pw::unit_test::LoggingEventHandler handler;
+    SuccessTimingLoggingEventHandler handler;
     pw::unit_test::RegisterEventHandler(&handler);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
#### Summary

Print execution time if a unit test is executed successful.

#### Testing

Ran crypto unit tests on NXP MCXW72 platform and the logging looks like:

```
INF  [ RUN      ] TestChipCryptoPAL.TestECDSA_SigningMsgInvalidParams
INF  [       OK ] TestChipCryptoPAL.TestECDSA_SigningMsgInvalidParams (1120 ms)
INF  [ RUN      ] TestChipCryptoPAL.TestECDSA_ValidationMsgInvalidParam
INF  [       OK ] TestChipCryptoPAL.TestECDSA_ValidationMsgInvalidParam (1140 ms)
INF  [ RUN      ] TestChipCryptoPAL.TestECDSA_ValidationHashInvalidParam
INF  [       OK ] TestChipCryptoPAL.TestECDSA_ValidationHashInvalidParam (1130 ms)
```

