### PR TITLE
[v1.4] Fix CIPD ZAP package path for bootstrap

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/google/keep-sorted
+    rev: v0.7.1
+    hooks:
+      - id: keep-sorted

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -1,20 +1,20 @@
 {
     "packages": [
         {
-            "path": "fuchsia/third_party/zap/${platform}",
+            "path": "experimental/matter/zap/${platform}",
             "platforms": [
                 "linux-amd64",
                 "linux-arm64",
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2024.08.14-nightly.1"]
+            "tags": ["version:v2024.08.14-nightly.2"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
-            "path": "fuchsia/third_party/zap/mac-amd64",
+            "path": "experimental/matter/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2024.08.14-nightly.1"]
+            "tags": ["version:v2024.08.14-nightly.2"]
         }
     ]
 }


### PR DESCRIPTION
#### Summary

The ZAP packages were moved from fuchsia/third_party/zap/ to fuchsia/third_party/3pp/zap/ on CIPD, causing bootstrap to fail with anonymous access errors and triggering unnecessary login prompts.

Updated path and bumped ZAP version to match v1.4.2-branch since the old version was never published to the new path.

#### Related issues

Fixes #43692

#### Testing

- Able to successfully run the bootstrap on with the fix.