### PR TITLE
Apply Fix: Handle null DeviceInfoProvider in label/localization clusters #43232

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -975,65 +975,6 @@ cluster BasicInformation = 40 {
 }
 
 /** Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing common languages, units of measurements, and numerical formatting
-      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
-      they can be configured to use a user’s preferred language, units, etc */
-cluster LocalizationConfiguration = 43 {
-  revision 1;
-
-  attribute access(write: manage) char_string<35> activeLocale = 0;
-  readonly attribute char_string supportedLocales[] = 1;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-}
-
-/** Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
-      or audibly convey time information need a mechanism by which they can be configured to use a
-      user’s preferred format. */
-cluster TimeFormatLocalization = 44 {
-  revision 1;
-
-  enum CalendarTypeEnum : enum8 {
-    kBuddhist = 0;
-    kChinese = 1;
-    kCoptic = 2;
-    kEthiopian = 3;
-    kGregorian = 4;
-    kHebrew = 5;
-    kIndian = 6;
-    kIslamic = 7;
-    kJapanese = 8;
-    kKorean = 9;
-    kPersian = 10;
-    kTaiwanese = 11;
-    kUseActiveLocale = 255;
-  }
-
-  enum HourFormatEnum : enum8 {
-    k12hr = 0;
-    k24hr = 1;
-    kUseActiveLocale = 255;
-  }
-
-  bitmap Feature : bitmap32 {
-    kCalendarFormat = 0x1;
-  }
-
-  attribute access(write: manage) HourFormatEnum hourFormat = 0;
-  attribute access(write: manage) optional CalendarTypeEnum activeCalendarType = 1;
-  readonly attribute optional CalendarTypeEnum supportedCalendarTypes[] = 2;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-}
-
-/** Nodes should be expected to be deployed to any and all regions of the world. These global regions
       may have differing preferences for the units in which values are conveyed in communication to a
       user. As such, Nodes that visually or audibly convey measurable values to the user need a
       mechanism by which they can be configured to use a user’s preferred unit. */
@@ -3071,21 +3012,6 @@ endpoint 0 {
     callback attribute configurationVersion default = 1;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 5;
-  }
-
-  server cluster LocalizationConfiguration {
-    persist  attribute activeLocale default = "en-US";
-    callback attribute supportedLocales;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
-  }
-
-  server cluster TimeFormatLocalization {
-    persist  attribute hourFormat default = 0;
-    persist  attribute activeCalendarType default = 0;
-    callback attribute supportedCalendarTypes;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
   }
 
   server cluster UnitLocalization {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -804,7 +804,7 @@
           "mfgCode": null,
           "define": "LOCALIZATION_CONFIGURATION_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "attributes": [
             {
               "name": "ActiveLocale",
@@ -878,7 +878,7 @@
           "mfgCode": null,
           "define": "TIME_FORMAT_LOCALIZATION_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "attributes": [
             {
               "name": "HourFormat",


### PR DESCRIPTION
Apply fix: https://github.com/project-chip/connectedhomeip/pull/43232 - Fix: Handle null DeviceInfoProvider in label/localization clusters #43232

#### Summary

Fix Android TV Casting App crash by disabling LocalizationConfiguration and TimeFormatLocalization clusters.

**Problem:**
Android TV Casting app crashes on launch with SIGABRT during cluster initialization. LocalizationConfiguration and TimeFormatLocalization clusters require DeviceInfoProvider (for device metadata like locales), but Android platform lacks this implementation.

**Root Cause:**
PR #42565 (Jan 9, 2026) added `VerifyOrDie(provider != nullptr)` checks assuming all platforms have DeviceInfoProvider. Android doesn't, causing immediate crash.

**Solution:**
Disable LocalizationConfiguration and TimeFormatLocalization clusters in ZAP configuration file. These are optional features that Android doesn't need for core casting functionality.

**Impact:**
- Fixes Android launch crash (primary goal)
- iOS and Linux TV Casting apps also lose these 2 clusters (shared ZAP file)
- All platforms lose locale configuration features (acceptable - not critical for casting)

**Background:**
PR #42565 added SetDeviceInfoProvider for iOS/Linux but didn't account for Android lacking the implementation, causing crashes since January 9, 2026.

#### Reproduction Steps (Before Fix)

1. Build Android TV Casting app from master (after Jan 9, 2026)
2. Install and launch on Android device
3. App crashes with SIGABRT in MatterLocalizationConfigurationClusterInitCallback
4. Stack trace shows VerifyOrDie failure due to null DeviceInfoProvider

#### Testing

**Android Testing:**
- ✅ App launches without crash
- ✅ MainActivity displays
- ✅ Casting functionality works
- ✅ No regression in core features

**Files Modified:**
- examples/tv-casting-app/tv-casting-common/tv-casting-app.zap (disable 2 clusters)
- examples/tv-casting-app/tv-casting-common/tv-casting-app.matter (auto-generated from ZAP `./scripts/tools/zap_regen_all.py`)

#### Readability checklist

-   [x] PR title is descriptive
-   [x] Apply the "When in Rome…" rule (coding style)
-   [x] PR size is minimal (2 files, ~80 lines)
-   [x] Clean commit history
-   [x] CI time didn't increase
-   [x] No unnecessary runtime checks or flash overhead

