### PR TITLE
[Linux ConnectivityManage] LeakFix: Ensure clean-up of WPA Supplicant's glib objects

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -99,6 +99,15 @@ struct GDBusWpaSupplicant
     GAutoPtr<WpaSupplicant1Interface> iface;
     GAutoPtr<char> interfacePath;
     GAutoPtr<char> networkPath;
+
+    // Must be called synchronously on the GLib thread while the GLib main loop is still running.
+    void Reset()
+    {
+        iface.reset();
+        proxy.reset();
+        interfacePath.reset();
+        networkPath.reset();
+    }
 };
 #endif
 
@@ -163,6 +172,9 @@ public:
     CHIP_ERROR CommitConfig();
 
     void StartWiFiManagement();
+    // Release GLib objects before the GLib main loop is quit.
+    // Must be called from PlatformManagerImpl::_Shutdown() before g_main_loop_quit().
+    void StopWiFiManagement();
     bool IsWiFiManagementStarted();
     void StartNonConcurrentWiFiManagement();
     int32_t GetDisconnectReason();
@@ -254,6 +266,7 @@ private:
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 
     CHIP_ERROR _StartWiFiManagement();
+    CHIP_ERROR _StopWiFiManagement();
 
     bool mAssociationStarted             = false;
     unsigned int mAssociationRetriesLeft = 0;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -599,6 +599,13 @@ void ConnectivityManagerImpl::StartWiFiManagement()
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start WiFi management"));
 }
 
+void ConnectivityManagerImpl::StopWiFiManagement()
+{
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](ConnectivityManagerImpl * self) { return self->_StopWiFiManagement(); }, this);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to stop WiFi management"));
+}
+
 CHIP_ERROR ConnectivityManagerImpl::StartWiFiManagementSync()
 {
     if (IsWiFiManagementStarted())
@@ -1631,6 +1638,14 @@ CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ConnectivityManagerImpl::_StopWiFiManagement()
+{
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+
+    mWpaSupplicant.Reset();
+
+    return CHIP_NO_ERROR;
+}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -282,6 +282,11 @@ void PlatformManagerImpl::_Shutdown()
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
     if (mGLibMainLoop != nullptr)
     {
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+        // The wpa_supplicant GLib objects must be released while the GLib main loop is still running. Release them here, before
+        // quitting the loop, otherwise they leak when ConnectivityManager is destructed.
+        ConnectivityMgrImpl().StopWiFiManagement();
+#endif
         g_main_loop_quit(mGLibMainLoop);
         g_thread_join(mGLibMainLoopThread);
         g_main_loop_unref(mGLibMainLoop);


### PR DESCRIPTION
#### Summary
- Fixes https://github.com/project-chip/connectedhomeip/issues/43754

- Ensure WPA supplicant GLib objects are properly destroyed by doing cleanup synchronously on the GLib main context.

#### Testing

- run Asan `all-clusters-app` with `--wifi` and exit it, then make sure there is no leak
```shell
scripts/build/build_examples.py --target linux-x64-all-clusters-asan-clang build
out/linux-x64-all-clusters-asan-clang/chip-all-clusters-app --wifi
```