### PR TITLE
Add support to input vendor_reserved fields in the NOCSR elements

### DIFF
--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -45,7 +45,8 @@ constexpr auto kDACCertificate                = CertificateChainTypeEnum::kDACCe
 constexpr auto kPAICertificate                = CertificateChainTypeEnum::kPAICertificate;
 constexpr auto kNocResponseMaxDebugTextLength = 128;
 
-ByteSpan gVendorReserved[3];
+constexpr size_t kMaxVendorReservedFields = 3;
+ByteSpan gVendorReserved[kMaxVendorReservedFields];
 
 // Get the attestation challenge for the current session in progress. Only valid when called
 // synchronously from inside a CommandHandler. If not called in CASE/PASE session context,
@@ -1052,7 +1053,7 @@ namespace OperationalCredentials {
 CHIP_ERROR SetCSRVendorReserved(CSRVendorReservedField field, ByteSpan data)
 {
     uint8_t index = static_cast<uint8_t>(field);
-    if (index >= 3)
+    if (index >= kMaxVendorReservedFields)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -45,6 +45,8 @@ constexpr auto kDACCertificate                = CertificateChainTypeEnum::kDACCe
 constexpr auto kPAICertificate                = CertificateChainTypeEnum::kPAICertificate;
 constexpr auto kNocResponseMaxDebugTextLength = 128;
 
+ByteSpan gVendorReserved[3];
+
 // Get the attestation challenge for the current session in progress. Only valid when called
 // synchronously from inside a CommandHandler. If not called in CASE/PASE session context,
 // return an empty span. This will for sure make the procedures that rely on the challenge
@@ -312,9 +314,12 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
     {
         constexpr size_t csrLength = Crypto::kMIN_CSR_Buffer_Size;
         size_t nocsrLengthEstimate = 0;
-        ByteSpan kNoVendorReserved;
         Platform::ScopedMemoryBuffer<uint8_t> csr;
         MutableByteSpan csrSpan;
+
+        ByteSpan vendorReserved1 = gVendorReserved[0];
+        ByteSpan vendorReserved2 = gVendorReserved[1];
+        ByteSpan vendorReserved3 = gVendorReserved[2];
 
         // Generate the actual CSR from the ephemeral key
         if (!csr.Alloc(csrLength))
@@ -346,9 +351,11 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
         ChipLogProgress(Zcl, "OpCreds: AllocatePendingOperationalKey succeeded");
 
         // Encode the NOCSR elements with the CSR and Nonce
-        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),  // CSR buffer
-                                                          CSRNonce.size(), // CSR Nonce
-                                                          0u               // no vendor reserved data
+        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),           // CSR buffer
+                                                          CSRNonce.size(),           // CSR Nonce
+                                                          vendorReserved1.size(),    // vendor_reserved1
+                                                          vendorReserved2.size(),    // vendor_reserved2
+                                                          vendorReserved3.size()     // vendor_reserved3
         );
 
         if (!nocsrElements.Alloc(nocsrLengthEstimate + attestationChallenge.size()))
@@ -361,8 +368,8 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
 
         VerifyOrExit(nocsrElementsSpan.size() >= nocsrLengthEstimate, errorStatus = Status::ConstraintError);
 
-        err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, kNoVendorReserved,
-                                                  kNoVendorReserved, kNoVendorReserved, nocsrElementsSpan);
+        err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, vendorReserved1,
+                                                  vendorReserved2, vendorReserved3, nocsrElementsSpan);
         VerifyOrExit(err == CHIP_NO_ERROR, errorStatus = Status::Failure);
 
         // Append attestation challenge in the back of the reserved space for the signature
@@ -1036,6 +1043,30 @@ void OnPlatformEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, in
     }
 }
 } // anonymous namespace
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace OperationalCredentials {
+
+CHIP_ERROR SetCSRVendorReserved(CSRVendorReservedField field, ByteSpan data)
+{
+    uint8_t index = static_cast<uint8_t>(field);
+    if (index >= 3)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    gVendorReserved[index] = data;
+
+    ChipLogProgress(Zcl, "OpCreds: CSR vendor_reserved%u set (%u bytes)", index + 1, static_cast<unsigned>(data.size()));
+    return CHIP_NO_ERROR;
+}
+
+} // namespace OperationalCredentials
+} // namespace Clusters
+} // namespace app
+} // namespace chip
 
 void OperationalCredentialsCluster::FailSafeCleanup(const DeviceLayer::ChipDeviceEvent * event,
                                                     OperationalCredentialsCluster * cluster)

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -351,11 +351,11 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
         ChipLogProgress(Zcl, "OpCreds: AllocatePendingOperationalKey succeeded");
 
         // Encode the NOCSR elements with the CSR and Nonce
-        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),           // CSR buffer
-                                                          CSRNonce.size(),           // CSR Nonce
-                                                          vendorReserved1.size(),    // vendor_reserved1
-                                                          vendorReserved2.size(),    // vendor_reserved2
-                                                          vendorReserved3.size()     // vendor_reserved3
+        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),         // CSR buffer
+                                                          CSRNonce.size(),        // CSR Nonce
+                                                          vendorReserved1.size(), // vendor_reserved1
+                                                          vendorReserved2.size(), // vendor_reserved2
+                                                          vendorReserved3.size()  // vendor_reserved3
         );
 
         if (!nocsrElements.Alloc(nocsrLengthEstimate + attestationChallenge.size()))

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
@@ -30,6 +30,37 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
+namespace OperationalCredentials {
+
+/**
+ * Identifies which vendor_reserved field to set in the CSRResponse NOCSRElements.
+ * Maps to context tags 3, 4, 5 in the NOCSRElements TLV structure per the Matter spec.
+ */
+enum class CSRVendorReservedField : uint8_t
+{
+    kVendorReserved1 = 0, // context tag 3
+    kVendorReserved2 = 1, // context tag 4
+    kVendorReserved3 = 2, // context tag 5
+};
+
+/**
+ * @brief Set vendor-specific data to be included in CSRResponse NOCSRElements.
+ *
+ * Must be called before the Matter stack is started, or from the Matter
+ * event loop thread via PlatformMgr().ScheduleWork().
+ *
+ * @param field      Which vendor_reserved field to set
+ * @param data       Vendor-specific data as a ByteSpan. The caller retains ownership of
+ *                   the underlying memory, which must remain valid for the lifetime of
+ *                   the device. Pass an empty ByteSpan to clear a previously set field.
+ *
+ * @return CHIP_NO_ERROR on success
+ *         CHIP_ERROR_INVALID_ARGUMENT if field is out of range
+ */
+CHIP_ERROR SetCSRVendorReserved(CSRVendorReservedField field, ByteSpan data);
+
+} // namespace OperationalCredentials
+
 class OperationalCredentialsCluster : public DefaultServerCluster, chip::FabricTable::Delegate
 {
 public:


### PR DESCRIPTION
#### Summary


Adds SetCSRVendorReserved() API to allow applications to include vendor-specific data in the CSRResponse NOCSRElements

#### Related issues


Fixes https://github.com/project-chip/connectedhomeip/issues/43758

#### Testing


Verified vendor_reserved1 data present in CSRResponse NOCSRElements (context tag 3) in chiptool logs

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
