### PR TITLE
ESP32:  Fixed advertising address change when switching between fast and slow broadcast intervals.

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1199,10 +1199,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
             return err;
         }
 
-        if (mFlags.Has(Flags::kFastAdvertisingEnabled)) 
+        if (mFlags.Has(Flags::kFastAdvertisingEnabled))
         {
             ble_addr_t addr;
-        
             /* generate static random address */
             err = MapBLEError(ble_hs_id_gen_rnd(0, &addr));
             if (err != CHIP_NO_ERROR)

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1199,22 +1199,25 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
             return err;
         }
 
-        ble_addr_t addr;
-
-        /* generate new non-resolvable private address */
-        err = MapBLEError(ble_hs_id_gen_rnd(1, &addr));
-        if (err != CHIP_NO_ERROR)
+        if (mFlags.Has(Flags::kFastAdvertisingEnabled)) 
         {
-            ChipLogError(DeviceLayer, "ble_hs_id_gen_rnd failed: %" CHIP_ERROR_FORMAT, err.Format());
-            return err;
-        }
+            ble_addr_t addr;
+        
+            /* generate static random address */
+            err = MapBLEError(ble_hs_id_gen_rnd(0, &addr));
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "ble_hs_id_gen_rnd failed: %" CHIP_ERROR_FORMAT, err.Format());
+                return err;
+            }
 
-        /* Set generated address */
-        err = MapBLEError(ble_gap_ext_adv_set_addr(kMatterAdvInstance, &addr));
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(DeviceLayer, "ble_gap_ext_adv_set_addr failed: %" CHIP_ERROR_FORMAT, err.Format());
-            return err;
+            /* Set generated address */
+            err = MapBLEError(ble_gap_ext_adv_set_addr(kMatterAdvInstance, &addr));
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "ble_gap_ext_adv_set_addr failed: %" CHIP_ERROR_FORMAT, err.Format());
+                return err;
+            }
         }
 
         struct os_mbuf * data = os_msys_get_pkthdr(mMatterAdvDataLen, 0);


### PR DESCRIPTION
#### Summary
-  Fixed advertising address change when switching between fast and slow broadcast intervals.

#### Related issues
- When using the ESP32 extended broadcast interface for Amazon MSS authentication, the BLE broadcast address will cause authentication failure.

#### Testing
- The test showed that the BLE broadcast address did not change when switching to slow broadcast.

