### PR TITLE
[Silabs] : fix build script and remove wf200 stale references

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -36,6 +36,7 @@ else
     PW_PATH="$PW_ENVIRONMENT_ROOT/cipd/packages/pigweed"
 fi
 
+env
 USE_WIFI=false
 USE_DOCKER=false
 USE_GIT_SHA_FOR_VERSION=true
@@ -292,7 +293,7 @@ else
                 shift
                 ;;
             *)
-                if [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                if [[ "$1" == *use_SiWx917=true* ]]; then
                     USE_WIFI=true
                     # NCP Mode so base MCU is an EFR32
                     optArgs+="chip_device_platform =\"efr32\" "

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -104,8 +104,6 @@ if [ "$#" == "0" ]; then
             --icd can be used to configure both arguments
         use_SiWx917
             Build wifi example with extension board SiWx917. (Default false)
-        use_wf200
-            Build wifi example with extension board wf200. (Default false)
         use_pw_rpc
             Use to build the example with pigweed RPC
         ota_periodic_query_timeout_sec
@@ -140,7 +138,7 @@ if [ "$#" == "0" ]; then
         --low-power
             disables all power consuming features for the most power efficient build
             This flag is to be used with --icd
-        --wifi <wf200 | SiWx917>
+        --wifi <SiWx917>
             build wifi example variant for given expansion board
         --additional_data_advertising
             enable Addition data advertissing and rotating device ID
@@ -188,16 +186,14 @@ else
                 ;;
             --wifi)
                 if [ -z "$2" ]; then
-                    echo "--wifi requires SiWx917 or wf200"
+                    echo "--wifi requires SiWx917"
                     exit 1
                 fi
 
                 if [ "$2" = "SiWx917" ]; then
                     optArgs+="use_SiWx917=true "
-                elif [ "$2" = "wf200" ]; then
-                    optArgs+="use_wf200=true "
                 else
-                    echo "Wifi usage: --wifi SiWx917|wf200"
+                    echo "Wifi usage: --wifi SiWx917"
                     exit 1
                 fi
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -36,7 +36,6 @@ else
     PW_PATH="$PW_ENVIRONMENT_ROOT/cipd/packages/pigweed"
 fi
 
-env
 USE_WIFI=false
 USE_DOCKER=false
 USE_GIT_SHA_FOR_VERSION=true


### PR DESCRIPTION
#### Summary
Fix syntax, use`==` instead of "=~" to resolve the build issue
Removed all stale references of wf200, as we do not support it anymore

#### Related issues

Fixes: https://github.com/project-chip/connectedhomeip/issues/43760

#### Testing
Ran the `./scripts/examples/gn_silabs_example.sh \
  examples/lighting-app/silabs \
  ./out/lighting-app/ \
  BRD4187C \
  chip_build_libshell=true` 
locally do not see the error message anymore

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
