### PR TITLE
Move CHIP_CONFIG_ENABLE_GROUPCAST definition

### DIFF
--- a/examples/all-clusters-app/linux/args.gni
+++ b/examples/all-clusters-app/linux/args.gni
@@ -51,3 +51,4 @@ openthread_project_core_config_file = rebase_path(
         get_path_info(
             "${chip_root}/third_party/openthread/repo/examples/platforms/simulation/openthread-core-simulation-config.h",
             "abspath"))
+chip_config_enable_groupcast = true

--- a/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
@@ -67,6 +67,3 @@
 
 // Max Binding entries per fabric for CI tests
 #define CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC 1
-
-// Enable groupcast
-#define CHIP_CONFIG_ENABLE_GROUPCAST 1

--- a/examples/all-devices-app/posix/args.gni
+++ b/examples/all-devices-app/posix/args.gni
@@ -23,3 +23,5 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/all-devices-app/posix/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
+chip_config_enable_groupcast = true

--- a/examples/all-devices-app/posix/include/CHIPProjectAppConfig.h
+++ b/examples/all-devices-app/posix/include/CHIPProjectAppConfig.h
@@ -29,6 +29,3 @@
 
 // include the CHIPProjectConfig from config/standalone
 #include <CHIPProjectConfig.h>
-
-// Enable groupcast
-#define CHIP_CONFIG_ENABLE_GROUPCAST 1

--- a/examples/build_overrides/freertos.gni
+++ b/examples/build_overrides/freertos.gni
@@ -16,3 +16,5 @@ declare_args() {
   # Root directory for FreeRTOS
   freertos_root = "//third_party/connectedhomeip/third_party/freertos"
 }
+
+chip_config_enable_groupcast = true

--- a/examples/build_overrides/freertos.gni
+++ b/examples/build_overrides/freertos.gni
@@ -16,5 +16,3 @@ declare_args() {
   # Root directory for FreeRTOS
   freertos_root = "//third_party/connectedhomeip/third_party/freertos"
 }
-
-chip_config_enable_groupcast = true

--- a/examples/lighting-app-data-mode-no-unique-id/linux/args.gni
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/args.gni
@@ -33,3 +33,5 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_enable_read_client = false
+
+chip_config_enable_groupcast = true

--- a/examples/lighting-app-data-mode-no-unique-id/linux/include/CHIPProjectAppConfig.h
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/include/CHIPProjectAppConfig.h
@@ -46,6 +46,3 @@
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1
 
 #define CHIP_DEVICE_CONFIG_DEVICE_NAME "Test Bulb"
-
-// Enable groupcast
-#define CHIP_CONFIG_ENABLE_GROUPCAST 1

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -32,3 +32,5 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_enable_read_client = false
+
+chip_config_enable_groupcast = true

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License..
 
 # CHIPProjectConfig.h
 

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License..
+# limitations under the License.
 
 # CHIPProjectConfig.h
 

--- a/examples/lighting-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/lighting-app/linux/include/CHIPProjectAppConfig.h
@@ -46,6 +46,3 @@
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1
 
 #define CHIP_DEVICE_CONFIG_DEVICE_NAME "Test Bulb"
-
-// Enable groupcast
-#define CHIP_CONFIG_ENABLE_GROUPCAST 1

--- a/examples/lighting-app/silabs/build_for_wifi_args.gni
+++ b/examples/lighting-app/silabs/build_for_wifi_args.gni
@@ -24,3 +24,5 @@ chip_enable_read_client = false
 chip_enable_ota_requestor = true
 app_data_model =
     "${chip_root}/examples/lighting-app/silabs/data_model:silabs-lighting"
+
+chip_config_enable_groupcast = true

--- a/examples/lighting-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/silabs/include/CHIPProjectConfig.h
@@ -106,6 +106,3 @@
  *
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
-
-// Enable groupcast
-#define CHIP_CONFIG_ENABLE_GROUPCAST 1

--- a/examples/lighting-app/silabs/openthread.gni
+++ b/examples/lighting-app/silabs/openthread.gni
@@ -28,3 +28,5 @@ chip_enable_read_client = false
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
+
+chip_config_enable_groupcast = true

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -81,6 +81,7 @@ buildconfig_header("app_buildconfig") {
     "CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP=${chip_enable_busy_handling_for_operational_session_setup}",
     "CHIP_CONFIG_DATA_MODEL_EXTRA_LOGGING=${chip_data_model_extra_logging}",
     "CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED=${chip_terms_and_conditions_required}",
+    "CHIP_CONFIG_ENABLE_GROUPCAST=${chip_config_enable_groupcast}",
   ]
 
   visibility = [ ":app_config" ]

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -41,4 +41,8 @@ declare_args() {
 
   # Flag that controls whether the camera server is enabled
   matter_enable_camera_server = false
+
+  # Disable matter groupcast by default, this should be enabled on an 
+  # application/platform specific layer
+  chip_config_enable_groupcast = false
 }

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -42,7 +42,7 @@ declare_args() {
   # Flag that controls whether the camera server is enabled
   matter_enable_camera_server = false
 
-  # Disable matter groupcast by default, this should be enabled on an 
+  # Disable matter groupcast by default, this should be enabled on an
   # application/platform specific layer
   chip_config_enable_groupcast = false
 }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1132,15 +1132,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif // CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT
 
 /**
- * @def CHIP_CONFIG_ENABLE_GROUPCAST
- *
- * @brief Enable (1) or disable (0) the Groupcast cluster.
- */
-#ifndef CHIP_CONFIG_ENABLE_GROUPCAST
-#define CHIP_CONFIG_ENABLE_GROUPCAST 0
-#endif // CHIP_CONFIG_ENABLE_GROUPCAST
-
-/**
  * @def CHIP_CONFIG_MAX_GROUPS_PER_FABRIC
  *
  * @brief Defines the number of groups supported per fabric, see Group Key Management Cluster in specification.


### PR DESCRIPTION
#### Summary

This PR is a follow-up to #43677 based on the [following comment](https://github.com/project-chip/connectedhomeip/pull/43677#discussion_r3001289654). This PR moved the definition of the macro used to enable/disable groupcast to a build config header in `src/app/BUILD.gn`. It's default value (of false) and the examples/platforms it is enabled on remain the same.

#### Testing

- CI should still pass
