### PR TITLE
Fix(rework): Null mContext crash when commissioning after background/foreground

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -1102,11 +1102,10 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     Server::GetInstance().Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    // Commissioner shutdown call shuts down entire stack, including the platform manager.
     ShutdownCommissioner();
-#else
-    DeviceLayer::PlatformMgr().Shutdown();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+
+    DeviceLayer::PlatformMgr().Shutdown();
 
 #if ENABLE_TRACING
     tracing_setup.StopTracing();

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -154,16 +154,22 @@
         completion([MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
     }));
 
-    dispatch_async(_workQueue, ^{
-        __block CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->Start();
+    // Resume the work queue FIRST so it can process the Start() dispatch below.
+    __block CHIP_ERROR err = chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(AppServer, "MCCastingApp.start StartEventLoopTask failed: %s", err.AsString());
         dispatch_async(self->_clientQueue, ^{
             completion([MCErrorUtils NSErrorFromChipError:err]);
         });
+        return;
+    }
+
+    dispatch_async(_workQueue, ^{
+        CHIP_ERROR startErr = matter::casting::core::CastingApp::GetInstance()->Start();
+        dispatch_async(self->_clientQueue, ^{
+            completion([MCErrorUtils NSErrorFromChipError:startErr]);
+        });
     });
-    __block CHIP_ERROR err = chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
-    VerifyOrReturn(err == CHIP_NO_ERROR, dispatch_async(self->_clientQueue, ^{
-        completion([MCErrorUtils NSErrorFromChipError:err]);
-    }));
 }
 
 - (void)stopWithCompletionBlock:(void (^)(NSError *))completion
@@ -175,6 +181,16 @@
 
     dispatch_async(_workQueue, ^{
         __block CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->Stop();
+
+        // Stop the event loop task so StartEventLoopTask() can succeed on the next Start().
+        // The work queue transitions from kRunning → kSuspended.
+        CHIP_ERROR stopEventLoopErr = chip::DeviceLayer::PlatformMgrImpl().StopEventLoopTask();
+        if (stopEventLoopErr != CHIP_NO_ERROR) {
+            ChipLogError(AppServer, "MCCastingApp.stop StopEventLoopTask failed: %s", stopEventLoopErr.AsString());
+            if (err == CHIP_NO_ERROR) {
+                err = stopEventLoopErr;
+            }
+        }
 
         dispatch_async(self->_clientQueue, ^{
             completion([MCErrorUtils NSErrorFromChipError:err]);

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -80,6 +80,7 @@ buildconfig_header("app_buildconfig") {
     "CHIP_DEVICE_CONFIG_DYNAMIC_SERVER=${chip_build_controller_dynamic_server}",
     "CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP=${chip_enable_busy_handling_for_operational_session_setup}",
     "CHIP_CONFIG_DATA_MODEL_EXTRA_LOGGING=${chip_data_model_extra_logging}",
+    "CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT=${chip_enable_server_restart_support}",
     "CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED=${chip_terms_and_conditions_required}",
     "CHIP_CONFIG_ENABLE_GROUPCAST=${chip_config_enable_groupcast}",
   ]

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -300,6 +300,17 @@ void InteractionModelEngine::Shutdown()
     // mpFabricTable    = nullptr;
     // mpExchangeMgr    = nullptr;
 
+    // Shutdown the data model provider and mark it as needing re-startup so that
+    // SetDataModelProvider() with the same pointer re-calls Startup() on the next
+    // Server::Init() cycle. We keep the pointer (rather than nulling it) so the
+    // provider remains accessible between Shutdown() and the next Init().
+    if (mDataModelProvider != nullptr)
+    {
+        ChipLogProgress(InteractionModel, "Shutting down data model provider %p", mDataModelProvider);
+        LogErrorOnFailure(mDataModelProvider->Shutdown());
+        mDataModelProviderNeedsStartup = true;
+    }
+
     mState = State::kUninitialized;
 }
 
@@ -1941,20 +1952,31 @@ DataModel::Provider * InteractionModelEngine::SetDataModelProvider(DataModel::Pr
     // Altering data model should not be done while IM is actively handling requests.
     VerifyOrDie(mReadHandlers.begin() == mReadHandlers.end());
 
+    DataModel::Provider * oldModel = mDataModelProvider;
+
     if (model == mDataModelProvider)
     {
-        // no-op, just return
-        return model;
-    }
-
-    DataModel::Provider * oldModel = mDataModelProvider;
-    if (oldModel != nullptr)
-    {
-        oldModel->UnregisterAttributeChangeListener(mReportingEngine);
-        CHIP_ERROR err = oldModel->Shutdown();
-        if (err != CHIP_NO_ERROR)
+        if (!mDataModelProviderNeedsStartup)
         {
-            ChipLogError(InteractionModel, "Failure on interaction model shutdown: %" CHIP_ERROR_FORMAT, err.Format());
+            // Same provider, already running — no-op.
+            return model;
+        }
+        // Same provider but it was shut down (e.g. Server restart cycle).
+        // Don't call Shutdown() again — just proceed to re-call Startup() below.
+        ChipLogProgress(InteractionModel, "Re-starting data model provider %p (server restart cycle)", model);
+    }
+    else if (oldModel != nullptr)
+    {
+        // Different provider replacing the current one — shut down the old one first.
+        oldModel->UnregisterAttributeChangeListener(mReportingEngine);
+        if (!mDataModelProviderNeedsStartup)
+        {
+            // Only shut down if not already shut down by InteractionModelEngine::Shutdown().
+            CHIP_ERROR err = oldModel->Shutdown();
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(InteractionModel, "Failure on interaction model shutdown: %" CHIP_ERROR_FORMAT, err.Format());
+            }
         }
     }
 
@@ -1970,8 +1992,12 @@ DataModel::Provider * InteractionModelEngine::SetDataModelProvider(DataModel::Pr
         {
             ChipLogError(InteractionModel, "Failure on interaction model startup: %" CHIP_ERROR_FORMAT, err.Format());
         }
-        // Register to the new model
-        mDataModelProvider->RegisterAttributeChangeListener(mReportingEngine);
+        mDataModelProviderNeedsStartup = false;
+        // Register to the new model (skip if same provider — already registered)
+        if (model != oldModel)
+        {
+            mDataModelProvider->RegisterAttributeChangeListener(mReportingEngine);
+        }
     }
 
     return oldModel;

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -739,7 +739,11 @@ private:
 
     SubscriptionResumptionStorage * mpSubscriptionResumptionStorage = nullptr;
 
-    DataModel::Provider * mDataModelProvider      = nullptr;
+    DataModel::Provider * mDataModelProvider = nullptr;
+    // Tracks whether the provider was shut down and needs Startup() called again.
+    // We can't null mDataModelProvider on shutdown because tests and other code
+    // may still reference it between Shutdown() and the next Init().
+    bool mDataModelProviderNeedsStartup           = false;
     Messaging::ExchangeContext * mCurrentExchange = nullptr;
 
     enum class State : uint8_t

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -39,6 +39,14 @@ declare_args() {
       current_os == "linux" || current_os == "ios" || current_os == "mac" ||
       current_os == "android"
 
+  # Enable shutdown callbacks in CodegenDataModelProvider::Shutdown() so that
+  # Server::Shutdown() → Server::Init() cycles re-initialize clusters correctly.
+  # Disabled by default on embedded platforms to avoid pulling in per-cluster
+  # shutdown callbacks (~7-8K flash on some lighting apps).
+  chip_enable_server_restart_support =
+      current_os == "linux" || current_os == "ios" || current_os == "mac" ||
+      current_os == "android"
+
   # Flag that controls whether the camera server is enabled
   matter_enable_camera_server = false
 

--- a/src/app/dynamic_server/DynamicDispatcher.cpp
+++ b/src/app/dynamic_server/DynamicDispatcher.cpp
@@ -35,6 +35,7 @@
 #include <app/WriteHandler.h>
 #include <app/clusters/ota-provider/OTAProviderCluster.h>
 #include <app/data-model/Decode.h>
+#include <app/util/attribute-storage-detail.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
 #include <app/util/endpoint-config-api.h>
@@ -351,4 +352,9 @@ const EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpo
 {
     // no known attributes even for OTA
     return nullptr;
+}
+
+void emAfCallShutdowns(MatterClusterShutdownType shutdownType)
+{
+    // No-op for dynamic server: no ember-style cluster init/shutdown.
 }

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.h
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.h
@@ -16,10 +16,12 @@
  */
 #pragma once
 
+#include <app/AppConfig.h>
 #include <app/ConcreteClusterPath.h>
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include <cstdint>
 #include <new>
@@ -86,7 +88,16 @@ public:
 
     void Destroy()
     {
-        VerifyOrDie(IsConstructed());
+        if (!IsConstructed())
+        {
+            // Should not happen — Init/Shutdown are paired at the CodegenDataModelProvider level.
+#if CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT
+            ChipLogError(AppServer, "Destroy() called on already-destroyed cluster — this should not happen");
+#else
+            chipDie();
+#endif
+            return;
+        }
         Registration().~ServerClusterRegistration();
         memset(mRegistration, 0, sizeof(mRegistration));
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -916,6 +916,12 @@ void Server::Shutdown()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     app::InteractionModelEngine::GetInstance()->SetICDManager(nullptr);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+    // EventManagement::Init() guards against double-init with a state check.
+    // Reset it here (after IME shutdown, which may trigger cluster shutdowns
+    // that access EventManagement) so a subsequent Server::Init() can re-initialize it.
+    app::EventManagement::DestroyEventManagement();
+
     // Shut down any remaining sessions (and hence exchanges) before we do any
     // futher teardown.  CASE handshakes have been shut down already via
     // shutting down mCASESessionManager and mCASEServer above; shutting

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -945,11 +945,8 @@ void Server::Shutdown()
     mICDManager.Shutdown();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
-    // NOTE: chip::Platform::MemoryShutdown() intentionally NOT called here.
-    // It belongs to outer code (AppMain/PlatformMgr) which controls the full
-    // platform lifecycle. Calling it here destroys objects (e.g. EndPointManager)
-    // before PlatformMgr().Shutdown() has a chance to shut them down properly.
-    // See TODO(16969).
+    // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
+    chip::Platform::MemoryShutdown();
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -945,8 +945,11 @@ void Server::Shutdown()
     mICDManager.Shutdown();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
-    // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
-    chip::Platform::MemoryShutdown();
+    // NOTE: chip::Platform::MemoryShutdown() intentionally NOT called here.
+    // It belongs to outer code (AppMain/PlatformMgr) which controls the full
+    // platform lifecycle. Calling it here destroys objects (e.g. EndPointManager)
+    // before PlatformMgr().Shutdown() has a chance to shut them down properly.
+    // See TODO(16969).
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/src/app/tests/test-interaction-model-api.h
+++ b/src/app/tests/test-interaction-model-api.h
@@ -106,6 +106,9 @@ class TestImCustomDataModel : public CodegenDataModelProvider
 public:
     static TestImCustomDataModel & Instance();
 
+    // No-op: mock provider has no persistent storage delegate, so skip the real
+    // CodegenDataModelProvider::Startup() which requires one.
+    CHIP_ERROR Startup(DataModel::InteractionModelContext context) override { return CHIP_NO_ERROR; }
     CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; }
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/util/attribute-storage-detail.h
+++ b/src/app/util/attribute-storage-detail.h
@@ -23,6 +23,7 @@
 #include <app/util/endpoint-config-api.h>
 #include <lib/support/CodeUtils.h>
 
+#include <app/util/af-types.h>
 #include <app/util/attribute-metadata.h>
 #include <zap-generated/endpoint_config.h>
 
@@ -30,7 +31,20 @@
 
 extern uint8_t attributeData[]; // main storage bucket for all attributes
 
+/// Calls cluster init callbacks for all enabled endpoints.
+/// For each enabled endpoint, calls initializeEndpoint() which:
+///   - MatterClusterServerInitCallback (code-driven cluster init)
+///   - emberAfClusterInitCallback (weak no-op by default, must be reentrant)
+///   - Cluster-specific init function if MATTER_CLUSTER_FLAG_INIT_FUNCTION is set
 void emAfCallInits();
+
+/// Calls cluster shutdown callbacks for all enabled endpoints.
+/// Symmetric to emAfCallInits(). For each enabled endpoint, calls shutdownEndpoint() which:
+///   - MatterClusterServerShutdownCallback (code-driven cluster shutdown)
+///   - Cluster-specific shutdown function if MATTER_CLUSTER_FLAG_SHUTDOWN_FUNCTION is set
+///   - Unregisters all AAI and CHI for the endpoint
+/// Note: AAI/CHI registered outside of cluster init callbacks will not be restored on re-init.
+void emAfCallShutdowns(MatterClusterShutdownType shutdownType);
 
 chip::Protocols::InteractionModel::Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord,
                                                                    const EmberAfAttributeMetadata ** metadata, uint8_t * buffer,

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -530,6 +530,19 @@ void emAfCallInits()
     }
 }
 
+// Symmetric to emAfCallInits() — calls shutdown callbacks for all enabled endpoints.
+void emAfCallShutdowns(MatterClusterShutdownType shutdownType)
+{
+    uint16_t index;
+    for (index = 0; index < emberAfEndpointCount(); index++)
+    {
+        if (emberAfEndpointIndexIsEnabled(index))
+        {
+            shutdownEndpoint(&(emAfEndpoints[index]), shutdownType);
+        }
+    }
+}
+
 // Returns the pointer to metadata, or null if it is not found
 const EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId)
 {

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -51,6 +51,7 @@
 
 #include <app/util/af-types.h>
 #include <app/util/attribute-metadata.h>
+#include <app/util/attribute-storage-detail.h>
 
 typedef uint8_t EmberAfClusterMask;
 
@@ -582,3 +583,8 @@ void ResetMockNodeConfig()
 
 } // namespace Testing
 } // namespace chip
+
+void emAfCallShutdowns(MatterClusterShutdownType shutdownType)
+{
+    // No-op in mock: no real clusters to shut down.
+}

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -38,6 +38,7 @@
 #include <app/util/IMClusterCommandHandler.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-metadata.h>
+#include <app/util/attribute-storage-detail.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <lib/core/CHIPError.h>
@@ -126,6 +127,13 @@ DefaultAttributePersistenceProvider gDefaultAttributePersistence;
 
 CHIP_ERROR CodegenDataModelProvider::Shutdown()
 {
+#if CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT
+    // Shutdown ember cluster implementations (symmetric to InitDataModelForTesting()
+    // in Startup which creates them). This calls the per-cluster shutdown callbacks
+    // and unregisters AAI/CHI so clusters can be re-created on the next Startup().
+    emAfCallShutdowns(MatterClusterShutdownType::kClusterShutdown);
+    ChipLogProgress(DataManagement, "CodegenDataModelProvider::Shutdown() complete");
+#endif // CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT
     Reset();
     mContext.reset();
     mRegistry.ClearContext();


### PR DESCRIPTION
Fix: Null mContext crash when commissioning after background/foreground

#### Summary

After backgrounding and foregrounding the iOS casting app, commissioning crashes
with a null `mContext` in `HandleCommissioningComplete`.

Root cause: `Server::Shutdown()` doesn't tear down the data model provider.
On the next `Server::Init()`, `SetDataModelProvider()` sees the same pointer
and no-ops — `Startup()` is never called, so clusters aren't re-initialized.

Fix: make `Shutdown()` symmetric with `Init()` at three layers:

1. **`InteractionModelEngine::Shutdown()`** — shut down the provider and set
   `mDataModelProviderNeedsStartup` so `SetDataModelProvider()` re-calls
   `Startup()` on the next `Init()`.
2. **`Server::Shutdown()`** — call `DestroyEventManagement()` so
   `EventManagement::Init()` succeeds on re-init.
3. **`CodegenDataModelProvider::Shutdown()`** — call `emAfCallShutdowns()`
   (symmetric to `emAfCallInits()`) gated behind
   `CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT` (linux/ios/mac/android only).

Also fixed `MCCastingApp.mm` event loop task ordering for stop/start cycles.

#### Related issues

Fixes iOS Matter Casting app crash after backgrounding/foregrounding.
Rework of reverted #43127 per review feedback in #43416.

#### Changes in revision 4

Addresses Andrei's May 20 comments:

- **Flag placement:** Moved `mDataModelProviderNeedsStartup = false` to right after
  `Startup()` is called (was previously cleared early in the if-block).
- **Double-shutdown via `CHIPDeviceControllerFactory`:** `SetDataModelProvider(nullptr)`
  after `Shutdown()` was calling `oldModel->Shutdown()` again. Fixed by checking
  `mDataModelProviderNeedsStartup` — if true, the provider was already shut down,
  skip the redundant shutdown.
- **`Destroy()` guard:** Replaced speculative comment with:
  - Without `CHIP_CONFIG_ENABLE_SERVER_RESTART_SUPPORT`: `VerifyOrDie` (crash on bug)
  - With restart support: error log + return (shouldn't happen, allows investigation)

#### Changes in revision 3

- Fixed listener double-registration causing infinite loop in
  `NotifyAttributeChanged` after restart (same provider path was re-registering
  the reporting engine listener).
- Removed `LazyRegisteredServerCluster` from ember-layer comments.
- Added detailed doc comments on `emAfCallInits`/`emAfCallShutdowns`.
- Moved `ChipLogProgress` inside `#ifdef`.

#### Testing

iOS Simulator (tv-casting-app + tv-app):
- Cold start → commission → success
- Background (lock 60s) → foreground → commission → success
- Multiple lock/unlock cycles → commission → success


Commissioning after a background foreground cycle:
[1_log back-fore.log](https://github.com/user-attachments/files/27978701/1_log.back-fore.log)

Commissioning on fresh app start:
[2_log fresh.log](https://github.com/user-attachments/files/27978708/2_log.fresh.log)

Commissioning after a background, phone lock, phone unlock, foreground cycle :
[3_log long lock.log](https://github.com/user-attachments/files/27978716/3_log.long.lock.log)

