### PR TITLE
Crypto: Key handle API improvements and ICD persistence cleanup

### DIFF
--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -274,17 +274,15 @@ CHIP_ERROR DefaultICDClientStorage::Load(FabricIndex fabricIndex, std::vector<IC
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kAesKeyHandle)));
         ByteSpan aesBuf;
         ReturnErrorOnFailure(reader.Get(aesBuf));
-        VerifyOrReturnError(aesBuf.size() == sizeof(Crypto::Symmetric128BitsKeyByteArray), CHIP_ERROR_INTERNAL);
-        memcpy(clientInfo.aes_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), aesBuf.data(),
-               sizeof(Crypto::Symmetric128BitsKeyByteArray));
+        VerifyOrReturnError(aesBuf.size() == Crypto::Aes128KeyHandle::Size(), CHIP_ERROR_INTERNAL);
+        memcpy(clientInfo.aes_key_handle.OpaqueBytes().data(), aesBuf.data(), Crypto::Aes128KeyHandle::Size());
 
         // Hmac key handle
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kHmacKeyHandle)));
         ByteSpan hmacBuf;
         ReturnErrorOnFailure(reader.Get(hmacBuf));
-        VerifyOrReturnError(hmacBuf.size() == sizeof(Crypto::Symmetric128BitsKeyByteArray), CHIP_ERROR_INTERNAL);
-        memcpy(clientInfo.hmac_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), hmacBuf.data(),
-               sizeof(Crypto::Symmetric128BitsKeyByteArray));
+        VerifyOrReturnError(hmacBuf.size() == Crypto::Hmac128KeyHandle::Size(), CHIP_ERROR_INTERNAL);
+        memcpy(clientInfo.hmac_key_handle.OpaqueBytes().data(), hmacBuf.data(), Crypto::Hmac128KeyHandle::Size());
 
         // ClientType
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kClientType)));
@@ -340,10 +338,8 @@ CHIP_ERROR DefaultICDClientStorage::SerializeToTlv(TLV::TLVWriter & writer, cons
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kStartICDCounter), clientInfo.start_icd_counter));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kOffset), clientInfo.offset));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kMonitoredSubject), clientInfo.monitored_subject));
-        ByteSpan aesBuf(clientInfo.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
-        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kAesKeyHandle), aesBuf));
-        ByteSpan hmacBuf(clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
-        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kHmacKeyHandle), hmacBuf));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kAesKeyHandle), clientInfo.aes_key_handle.OpaqueBytes()));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kHmacKeyHandle), clientInfo.hmac_key_handle.OpaqueBytes()));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kClientType), clientInfo.client_type));
         ReturnErrorOnFailure(writer.EndContainer(ICDClientInfoContainerType));
     }

--- a/src/app/icd/client/ICDClientInfo.h
+++ b/src/app/icd/client/ICDClientInfo.h
@@ -50,12 +50,8 @@ struct ICDClientInfo
         offset            = other.offset;
         client_type       = other.client_type;
         monitored_subject = other.monitored_subject;
-        ByteSpan aes_buf(other.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
-        memcpy(aes_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), aes_buf.data(),
-               sizeof(Crypto::Symmetric128BitsKeyByteArray));
-        ByteSpan hmac_buf(other.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
-        memcpy(hmac_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), hmac_buf.data(),
-               sizeof(Crypto::Symmetric128BitsKeyByteArray));
+        memcpy(aes_key_handle.OpaqueBytes().data(), other.aes_key_handle.OpaqueBytes().data(), Crypto::Aes128KeyHandle::Size());
+        memcpy(hmac_key_handle.OpaqueBytes().data(), other.hmac_key_handle.OpaqueBytes().data(), Crypto::Hmac128KeyHandle::Size());
         return *this;
     }
 };

--- a/src/app/icd/server/ICDCheckInSender.cpp
+++ b/src/app/icd/server/ICDCheckInSender.cpp
@@ -101,11 +101,8 @@ CHIP_ERROR ICDCheckInSender::RequestResolve(ICDMonitoringEntry & entry, FabricTa
 
     AddressResolve::NodeLookupRequest request(peerId);
 
-    memcpy(mAes128KeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           entry.aesKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
-
-    memcpy(mHmac128KeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           entry.hmacKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
+    memcpy(mAes128KeyHandle.OpaqueBytes().data(), entry.aesKeyHandle.OpaqueBytes().data(), Crypto::Aes128KeyHandle::Size());
+    memcpy(mHmac128KeyHandle.OpaqueBytes().data(), entry.hmacKeyHandle.OpaqueBytes().data(), Crypto::Hmac128KeyHandle::Size());
 
     CHIP_ERROR err = AddressResolve::Resolver::Instance().LookupNode(request, mAddressLookupHandle);
 

--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -44,11 +44,8 @@ CHIP_ERROR ICDMonitoringEntry::Serialize(TLV::TLVWriter & writer) const
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kCheckInNodeID), checkInNodeID));
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kMonitoredSubject), monitoredSubject));
 
-    ByteSpan aesKeybuf(aesKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>());
-    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kAesKeyHandle), aesKeybuf));
-
-    ByteSpan hmacKeybuf(hmacKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>());
-    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kHmacKeyHandle), hmacKeybuf));
+    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kAesKeyHandle), ByteSpan(aesKeyHandle.OpaqueBytes())));
+    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kHmacKeyHandle), ByteSpan(hmacKeyHandle.OpaqueBytes())));
 
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kClientType), clientType));
 
@@ -85,8 +82,7 @@ CHIP_ERROR ICDMonitoringEntry::Deserialize(TLV::TLVReader & reader)
                 // simply copy the data as is in the keyHandle.
                 // Calling SetKey here would create another keyHandle in storage and will cause
                 // key leaks in some implementations.
-                memcpy(aesKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), buf.data(),
-                       sizeof(Crypto::Symmetric128BitsKeyByteArray));
+                memcpy(aesKeyHandle.OpaqueBytes().data(), buf.data(), Crypto::Aes128KeyHandle::Size());
                 keyHandleValid = true;
             }
             break;
@@ -106,8 +102,7 @@ CHIP_ERROR ICDMonitoringEntry::Deserialize(TLV::TLVReader & reader)
                 // simply copy the data as is in the keyHandle.
                 // Calling SetKey here would create another keyHandle in storage and will cause
                 // key leaks in some implementations.
-                memcpy(hmacKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), buf.data(),
-                       sizeof(Crypto::Symmetric128BitsKeyByteArray));
+                memcpy(hmacKeyHandle.OpaqueBytes().data(), buf.data(), Crypto::Hmac128KeyHandle::Size());
             }
             break;
             case to_underlying(Fields::kClientType):
@@ -222,12 +217,10 @@ ICDMonitoringEntry & ICDMonitoringEntry::operator=(const ICDMonitoringEntry & ic
     index             = icdMonitoringEntry.index;
     keyHandleValid    = icdMonitoringEntry.keyHandleValid;
     symmetricKeystore = icdMonitoringEntry.symmetricKeystore;
-    memcpy(aesKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           icdMonitoringEntry.aesKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(),
-           sizeof(Crypto::Symmetric128BitsKeyByteArray));
-    memcpy(hmacKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           icdMonitoringEntry.hmacKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(),
-           sizeof(Crypto::Symmetric128BitsKeyByteArray));
+    memcpy(aesKeyHandle.OpaqueBytes().data(), icdMonitoringEntry.aesKeyHandle.OpaqueBytes().data(),
+           Crypto::Aes128KeyHandle::Size());
+    memcpy(hmacKeyHandle.OpaqueBytes().data(), icdMonitoringEntry.hmacKeyHandle.OpaqueBytes().data(),
+           Crypto::Hmac128KeyHandle::Size());
 
     return *this;
 }
@@ -275,10 +268,8 @@ CHIP_ERROR ICDMonitoringTable::Set(uint16_t index, const ICDMonitoringEntry & en
     e.index             = index;
     e.symmetricKeystore = entry.symmetricKeystore;
 
-    memcpy(e.aesKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           entry.aesKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
-    memcpy(e.hmacKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
-           entry.hmacKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
+    memcpy(e.aesKeyHandle.OpaqueBytes().data(), entry.aesKeyHandle.OpaqueBytes().data(), Crypto::Aes128KeyHandle::Size());
+    memcpy(e.hmacKeyHandle.OpaqueBytes().data(), entry.hmacKeyHandle.OpaqueBytes().data(), Crypto::Hmac128KeyHandle::Size());
 
     ReturnErrorOnFailure(e.symmetricKeystore->PersistICDKey(e.aesKeyHandle));
     CHIP_ERROR error = e.symmetricKeystore->PersistICDKey(e.hmacKeyHandle);

--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -78,6 +78,7 @@ CHIP_ERROR ICDMonitoringEntry::Deserialize(TLV::TLVReader & reader)
             case to_underlying(Fields::kAesKeyHandle): {
                 ByteSpan buf;
                 ReturnErrorOnFailure(reader.Get(buf));
+                VerifyOrReturnError(buf.size() == Crypto::Aes128KeyHandle::Size(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
                 // Since we are storing either the raw key or a key ID, we must
                 // simply copy the data as is in the keyHandle.
                 // Calling SetKey here would create another keyHandle in storage and will cause
@@ -89,6 +90,10 @@ CHIP_ERROR ICDMonitoringEntry::Deserialize(TLV::TLVReader & reader)
             case to_underlying(Fields::kHmacKeyHandle): {
                 ByteSpan buf;
                 CHIP_ERROR error = reader.Get(buf);
+                if (error == CHIP_NO_ERROR && buf.size() != Crypto::Hmac128KeyHandle::Size())
+                {
+                    error = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT;
+                }
 
                 if (error != CHIP_NO_ERROR)
                 {

--- a/src/app/icd/server/tests/TestICDMonitoringTable.cpp
+++ b/src/app/icd/server/tests/TestICDMonitoringTable.cpp
@@ -86,9 +86,7 @@ struct TestICDMonitoringTable : public ::testing::Test
         EXPECT_GE(loaded.As<psa_key_id_t>(), to_underlying(Crypto::KeyIdBase::ICDKeyRangeStart));
         EXPECT_LE(loaded.As<psa_key_id_t>(), to_underlying(Crypto::KeyIdBase::Maximum));
 #else
-        EXPECT_EQ(memcmp(saved.As<Crypto::Symmetric128BitsKeyByteArray>(), loaded.As<Crypto::Symmetric128BitsKeyByteArray>(),
-                         sizeof(Crypto::Symmetric128BitsKeyByteArray)),
-                  0);
+        EXPECT_TRUE(saved.OpaqueBytes().data_equal(loaded.OpaqueBytes()));
 #endif
     }
 };

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -541,6 +541,19 @@ struct alignas(size_t) P256KeypairContext
  */
 using P256SerializedKeypair = SensitiveDataBuffer<kP256_PublicKey_Length + kP256_PrivateKey_Length>;
 
+/**
+ * A platform-specific P256 keypair handle that is suitable for persistence.
+ * On platforms that don't use PSA (or a similar API) this is simply a P256SerializedKeypair.
+ *
+ * Note that there are no general APIs in the CHIP Crypto PAL that operate on
+ * P256KeypairHandles; such APIs are the domain of the relevant key store interfaces.
+ */
+#if CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE > 0
+using P256KeypairHandle = SensitiveDataBuffer<CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE>;
+#else
+using P256KeypairHandle = P256SerializedKeypair;
+#endif
+
 // Base class of P256Keypair. Do not use directly.
 class P256KeypairBase : public ECPKeypair<P256PublicKey, P256ECDHDerivedSecret, P256ECDSASignature>
 {

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -354,6 +354,12 @@ public:
      */
     static constexpr size_t Capacity() { return kCapacity; }
 
+    void Clear()
+    {
+        mLength = 0;
+        ClearSecretData(mBytes);
+    }
+
 private:
     uint8_t mBytes[kCapacity];
     size_t mLength = 0;
@@ -390,7 +396,7 @@ public:
     /**
      * @brief Returns fixed length of the buffer
      */
-    constexpr size_t Length() const { return kCapacity; }
+    static constexpr size_t Length() { return kCapacity; }
 
     /**
      * @brief Returns non-const pointer to start of the underlying buffer
@@ -411,6 +417,8 @@ public:
      * @brief Returns capacity of the buffer
      */
     static constexpr size_t Capacity() { return kCapacity; }
+
+    void Clear() { ClearSecretData(mBytes); }
 
 private:
     uint8_t mBytes[kCapacity];

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -737,6 +737,21 @@ public:
         return *SafePointerCast<T *>(&mContext);
     }
 
+    static constexpr size_t Size() { return ContextSize; }
+
+    /**
+     * @brief Access the raw opaque context bytes for persistence.
+     *
+     * The bytes may be either raw key material or a platform-specific key reference,
+     * depending on the crypto backend, and must be treated as opaque.
+     *
+     * @note Do NOT use this to pass key material to crypto primitives.
+     *       Backend-specific code should use As() / AsMutable() to access
+     *       the backend-specific concrete representation instead.
+     */
+    FixedByteSpan<ContextSize> OpaqueBytes() const { return FixedSpan(mContext.mOpaque); }
+    MutableFixedByteSpan<ContextSize> OpaqueBytes() { return FixedSpan(mContext.mOpaque); }
+
 protected:
     SymmetricKeyHandle() = default;
     ~SymmetricKeyHandle() { ClearSecretData(mContext.mOpaque); }
@@ -748,14 +763,14 @@ private:
     } mContext;
 };
 
-using Symmetric128BitsKeyByteArray = uint8_t[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
-
 /**
  * @brief Platform-specific 128-bit symmetric key handle
  */
 class Symmetric128BitsKeyHandle : public SymmetricKeyHandle<CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES>
 {
 };
+
+using Symmetric128BitsKeyByteArray = uint8_t[Symmetric128BitsKeyHandle::Size()];
 
 /**
  * @brief Platform-specific 128-bit AES key handle

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -620,6 +620,34 @@ TEST_F(TestChipCryptoPAL, TestAES_CCM_128DecryptInvalidNonceLen)
     EXPECT_GT(numOfTestsRan, 0);
 }
 
+TEST_F(TestChipCryptoPAL, TestSymmetricKeyHandleOpaqueBytesRoundTrip)
+{
+    HeapChecker heapChecker;
+
+    constexpr Symmetric128BitsKeyByteArray keyBytes = { 0xd0, 0x0f };
+    constexpr uint8_t nonce[NONCE_LENGTH]           = { 0xf0, 0x0d };
+    constexpr uint8_t plaintext[16]                 = { 0xca, 0xfe };
+
+    // Create an arbitrary Aes128KeyHandle
+    DefaultSessionKeystore keystore;
+    Aes128KeyHandle originalHandle;
+    ASSERT_SUCCESS(keystore.CreateKey(keyBytes, originalHandle));
+
+    // Simulate a roundtrip into a new handle via persistent storage using OpaqueBytes.
+    Aes128KeyHandle restoredHandle;
+    memcpy(restoredHandle.OpaqueBytes().data(), originalHandle.OpaqueBytes().data(), Aes128KeyHandle::Size());
+
+    // Verify the two handles reference the same key by round-tripping some data
+    uint8_t ciphertext[16];
+    ASSERT_SUCCESS(AES_CTR_crypt(plaintext, sizeof(plaintext), originalHandle, nonce, NONCE_LENGTH, ciphertext));
+    uint8_t recovered[16];
+    ASSERT_SUCCESS(AES_CTR_crypt(ciphertext, sizeof(ciphertext), restoredHandle, nonce, NONCE_LENGTH, recovered));
+    EXPECT_EQ(memcmp(recovered, plaintext, sizeof(plaintext)), 0);
+
+    // Destroy the key via the restored handle only
+    keystore.DestroyKey(restoredHandle);
+}
+
 TEST_F(TestChipCryptoPAL, TestSensitiveDataBuffer)
 {
     HeapChecker heapChecker;

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -232,6 +232,21 @@
 #endif // CHIP_CONFIG_HKDF_KEY_HANDLE_CONTEXT_SIZE
 
 /**
+ *  @def CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE
+ *
+ *  @brief
+ *    Size of a statically allocated P256 keypair handle in CryptoPAL.
+ *
+ *  If this is 0 (the default), then key handles are not supported and
+ *  serialized keypairs (containing the raw public and private keys) are used instead.
+ *
+ *  Platforms that use PSA can define this to match the size of psa_key_id_t (4).
+ */
+#ifndef CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE
+#define CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE (0)
+#endif // CHIP_CONFIG_P256_KEYPAIR_HANDLE_SIZE
+
+/**
  * @def CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
  *
  * @brief


### PR DESCRIPTION
#### Summary

- Add OpaqueBytes() and Size() to SymmetricKeyHandle
    
    This provides an easier and more intentional API for use in key handle
    persistence compared to the existing As<uint8_t[SOME_SIZE]>().
    
    Also add a test that ensures this works for AES handles.

- Refactor ICD key persistence to use OpaqueBytes

- Add missing length checks in ICDMonitoringEntry::Deserialize
    
    This avoids potential out of bounds reads when copying into aesKeyHandle and
    hmacKeyHandle, since the stored value might be shorter than the size of the
    handle.

- Introduce P256KeypairHandle

    Where supported by the crypto backend, this is a key identifier that can be
    persisted. For backends that don't support external key handles it is simply a
    P256SerializedKeypair.

- SensitiveData[Fixed]Buffer: Add explicit Clear() method
    Also make the Length() method static for the Fixed variant.

#### Testing

New unit test for OpaqueBytes round-tripping, otherwise existing tests.
