### PR TITLE
[Localization Configuration] Support subscriber notification on attribute write

### DIFF
--- a/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
@@ -124,7 +124,12 @@ DataModel::ActionReturnStatus LocalizationConfigurationCluster::ReadAttribute(co
 DataModel::ActionReturnStatus LocalizationConfigurationCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                                AttributeValueDecoder & aDecoder)
 {
-    AttributePersistence persistence(mContext->attributeStorage);
+    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, WriteImpl(request, aDecoder));
+}
+
+DataModel::ActionReturnStatus LocalizationConfigurationCluster::WriteImpl(const DataModel::WriteAttributeRequest & request,
+                                                                          AttributeValueDecoder & aDecoder)
+{
     switch (request.path.mAttributeId)
     {
     case ActiveLocale::Id: {

--- a/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
@@ -155,6 +155,9 @@ DataModel::ActionReturnStatus LocalizationConfigurationCluster::SetActiveLocale(
         return Status::ConstraintError;
     }
 
+    VerifyOrReturnValue(!mActiveLocale.Content().data_equal(activeLocale),
+                        DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
+
     VerifyOrReturnError(mActiveLocale.SetContent(activeLocale), Status::ConstraintError);
     if (mContext != nullptr)
     {

--- a/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.h
+++ b/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.h
@@ -56,6 +56,8 @@ public:
     CharSpan GetActiveLocale();
 
 private:
+    DataModel::ActionReturnStatus WriteImpl(const DataModel::WriteAttributeRequest & request, AttributeValueDecoder & aDecoder);
+
     /*
      * Read the supported locales.
      *

--- a/src/app/clusters/localization-configuration-server/tests/BUILD.gn
+++ b/src/app/clusters/localization-configuration-server/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app/clusters/localization-configuration-server",
+    "${chip_root}/src/app/data-model-provider/tests:encode-decode",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -233,6 +233,8 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
     EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("fr-FR")));
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
+    EXPECT_TRUE(
+        context.ChangeListener().IsDirty(ConcreteAttributePath(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id)));
     EXPECT_NE(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionAfterFirstWrite);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -255,6 +257,33 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
     AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("de-DE"));
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, Status::ConstraintError);
+
+    CharSpan actualLocale = cluster.GetActiveLocale();
+    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("en-US")));
+
+    EXPECT_TRUE(context.ChangeListener().DirtyList().empty());
+    EXPECT_EQ(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionBefore);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestLocalizationConfigurationCluster, WriteSameLocaleIsNoOp)
+{
+    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
+
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+
+    chip::Testing::TestServerClusterContext context;
+    ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    DataVersion versionBefore = cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id });
+
+    chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
+    writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
+    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("en-US"));
+    DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
+    EXPECT_EQ(status, DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
 
     CharSpan actualLocale = cluster.GetActiveLocale();
     EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("en-US")));

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -18,8 +18,11 @@
 
 #include <app/clusters/localization-configuration-server/LocalizationConfigurationCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/data-model-provider/tests/TestConstants.h>
+#include <app/data-model-provider/tests/WriteTesting.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/LocalizationConfiguration/Enums.h>
 #include <clusters/LocalizationConfiguration/Ids.h>
@@ -190,5 +193,74 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAttributes)
                                             LocalizationConfiguration::Attributes::ActiveLocale::kMetadataEntry,
                                             LocalizationConfiguration::Attributes::SupportedLocales::kMetadataEntry,
                                         }));
+}
+
+TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
+{
+    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES"),
+                                               CharSpan::fromCharString("fr-FR") };
+    mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
+
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+
+    chip::Testing::TestServerClusterContext context;
+    ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
+    writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
+
+    AttributeValueDecoder decoder = writeOp.DecoderFor(CharSpan::fromCharString("es-ES"));
+    DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
+    EXPECT_EQ(status, Status::Success);
+
+    CharSpan actualLocale = cluster.GetActiveLocale();
+    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("es-ES")));
+
+    ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
+    EXPECT_TRUE(context.ChangeListener().IsDirty(ConcreteAttributePath(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id)));
+
+    context.ChangeListener().DirtyList().clear();
+    DataVersion versionAfterFirstWrite = cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id });
+
+    chip::Testing::WriteOperation writeOp2(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
+    writeOp2.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
+    AttributeValueDecoder decoder2 = writeOp2.DecoderFor(CharSpan::fromCharString("fr-FR"));
+    status = cluster.WriteAttribute(writeOp2.GetRequest(), decoder2);
+    EXPECT_EQ(status, Status::Success);
+
+    actualLocale = cluster.GetActiveLocale();
+    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("fr-FR")));
+
+    ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
+    EXPECT_NE(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionAfterFirstWrite);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
+{
+    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
+
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+
+    chip::Testing::TestServerClusterContext context;
+    ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    DataVersion versionBefore = cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id });
+
+    chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
+    writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
+    AttributeValueDecoder decoder = writeOp.DecoderFor(CharSpan::fromCharString("de-DE"));
+    DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
+    EXPECT_EQ(status, Status::ConstraintError);
+
+    CharSpan actualLocale = cluster.GetActiveLocale();
+    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("en-US")));
+
+    EXPECT_TRUE(context.ChangeListener().DirtyList().empty());
+    EXPECT_EQ(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionBefore);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 } // namespace

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -209,7 +209,7 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
     chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
 
-    AttributeValueDecoder decoder = writeOp.DecoderFor(CharSpan::fromCharString("es-ES"));
+    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("es-ES"));
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, Status::Success);
 
@@ -217,7 +217,8 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
     EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("es-ES")));
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
-    EXPECT_TRUE(context.ChangeListener().IsDirty(ConcreteAttributePath(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id)));
+    EXPECT_TRUE(
+        context.ChangeListener().IsDirty(ConcreteAttributePath(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id)));
 
     context.ChangeListener().DirtyList().clear();
     DataVersion versionAfterFirstWrite = cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id });
@@ -225,7 +226,7 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
     chip::Testing::WriteOperation writeOp2(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp2.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
     AttributeValueDecoder decoder2 = writeOp2.DecoderFor(CharSpan::fromCharString("fr-FR"));
-    status = cluster.WriteAttribute(writeOp2.GetRequest(), decoder2);
+    status                         = cluster.WriteAttribute(writeOp2.GetRequest(), decoder2);
     EXPECT_EQ(status, Status::Success);
 
     actualLocale = cluster.GetActiveLocale();
@@ -251,7 +252,7 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
 
     chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
-    AttributeValueDecoder decoder = writeOp.DecoderFor(CharSpan::fromCharString("de-DE"));
+    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("de-DE"));
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, Status::ConstraintError);
 


### PR DESCRIPTION
#### Summary

- On attribute write, cluster should mart the attribute dirty so that subscribers know attribute is changed.
- Added `NotifyAttributeChangedIfSuccess` on write attribute.

#### Related issues

Fixes: https://github.com/project-chip/connectedhomeip/issues/43701


#### Testing

Added unit tests to verify the workflow.