### PR TITLE
[Realtek] Add Level and Color Control support to light-switch app

### DIFF
--- a/examples/all-clusters-app/realtek/common/main/AppTask.cpp
+++ b/examples/all-clusters-app/realtek/common/main/AppTask.cpp
@@ -235,10 +235,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -248,6 +244,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/light-switch-app/realtek/common/main/AppTask.cpp
+++ b/examples/light-switch-app/realtek/common/main/AppTask.cpp
@@ -287,10 +287,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -300,6 +296,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
+++ b/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
@@ -219,7 +219,7 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Bind
 
     if (CHIP_NO_ERROR != ret)
     {
-        ChipLogError(NotSpecified, "Invoke Group Command Request ERROR: %s", ErrorStr(ret));
+        ChipLogError(NotSpecified, "Invoke LevelControl Command Request ERROR: %s", ErrorStr(ret));
     }
 }
 

--- a/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
+++ b/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
@@ -196,22 +196,21 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Bind
 
     switch (aCommandId)
     {
-    case Clusters::LevelControl::Commands::MoveToLevel::Id:
+    case Clusters::LevelControl::Commands::MoveToLevel::Id: {
+        Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
+        moveToLevelCommand.level = data->Value;
+        if (aDevice)
         {
-            Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
-            moveToLevelCommand.level = data->Value;
-            if (aDevice)
-            {
-                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
-                                                    aBinding.remote, moveToLevelCommand, onSuccess, onFailure);
-            }
-            else
-            {
-                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToLevelCommand);
-            }
+            ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                   aBinding.remote, moveToLevelCommand, onSuccess, onFailure);
         }
-        break;
+        else
+        {
+            Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToLevelCommand);
+        }
+    }
+    break;
 
     default:
         ChipLogProgress(NotSpecified, "Invalid binding command data - commandId is not supported");
@@ -225,7 +224,7 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Bind
 }
 
 void BindingHandler::ColorControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
-                                                 OperationalDeviceProxy * aDevice, void * aContext)
+                                                OperationalDeviceProxy * aDevice, void * aContext)
 {
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
 
@@ -248,42 +247,40 @@ void BindingHandler::ColorControlProcessCommand(CommandId aCommandId, const Bind
 
     switch (aCommandId)
     {
-    case Clusters::ColorControl::Commands::MoveToColor::Id:
+    case Clusters::ColorControl::Commands::MoveToColor::Id: {
+        Clusters::ColorControl::Commands::MoveToColor::Type moveToColorCommand;
+        moveToColorCommand.colorX = data->ColorXY.x;
+        moveToColorCommand.colorY = data->ColorXY.y;
+        if (aDevice)
         {
-            Clusters::ColorControl::Commands::MoveToColor::Type moveToColorCommand;
-            moveToColorCommand.colorX = data->ColorXY.x;
-            moveToColorCommand.colorY = data->ColorXY.y;
-            if (aDevice)
-            {
-                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
-                                                       aBinding.remote, moveToColorCommand, onSuccess, onFailure);
-            }
-            else
-            {
-                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToColorCommand);
-            }
+            ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                   aBinding.remote, moveToColorCommand, onSuccess, onFailure);
         }
-        break;
+        else
+        {
+            Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToColorCommand);
+        }
+    }
+    break;
 
-    case Clusters::ColorControl::Commands::MoveToColorTemperature::Id:
+    case Clusters::ColorControl::Commands::MoveToColorTemperature::Id: {
+        Clusters::ColorControl::Commands::MoveToColorTemperature::Type moveToColorTemperatureCommand;
+        moveToColorTemperatureCommand.colorTemperatureMireds = data->ColorTemperatureMireds;
+        moveToColorTemperatureCommand.transitionTime         = 0;
+        if (aDevice)
         {
-            Clusters::ColorControl::Commands::MoveToColorTemperature::Type moveToColorTemperatureCommand;
-            moveToColorTemperatureCommand.colorTemperatureMireds = data->ColorTemperatureMireds;
-            moveToColorTemperatureCommand.transitionTime         = 0;
-            if (aDevice)
-            {
-                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
-                                                       aBinding.remote, moveToColorTemperatureCommand, onSuccess, onFailure);
-            }
-            else
-            {
-                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId,
-                                                           moveToColorTemperatureCommand);
-            }
+            ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                   aBinding.remote, moveToColorTemperatureCommand, onSuccess, onFailure);
         }
-        break;
+        else
+        {
+            Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId,
+                                                        moveToColorTemperatureCommand);
+        }
+    }
+    break;
 
     default:
         ChipLogProgress(NotSpecified, "Invalid binding command data - commandId is not supported");

--- a/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
+++ b/examples/light-switch-app/realtek/common/main/BindingHandler.cpp
@@ -171,6 +171,131 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const Binding::Ta
     }
 }
 
+void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
+                                                OperationalDeviceProxy * aDevice, void * aContext)
+{
+    BindingData * data = reinterpret_cast<BindingData *>(aContext);
+
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(NotSpecified, "Binding command applied successfully!");
+
+        // If session was recovered and communication works, reset flag to the initial state.
+        if (BindingHandler::GetInstance().mCaseSessionRecovered)
+            BindingHandler::GetInstance().mCaseSessionRecovered = false;
+    };
+
+    auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable { BindingHandler::OnInvokeCommandFailure(dataRef, aError); };
+
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+
+    if (aDevice)
+    {
+        // We are validating connection is ready once here instead of multiple times in each case statement below.
+        VerifyOrDie(aDevice->ConnectionReady());
+    }
+
+    switch (aCommandId)
+    {
+    case Clusters::LevelControl::Commands::MoveToLevel::Id:
+        {
+            Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
+            moveToLevelCommand.level = data->Value;
+            if (aDevice)
+            {
+                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                    aBinding.remote, moveToLevelCommand, onSuccess, onFailure);
+            }
+            else
+            {
+                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToLevelCommand);
+            }
+        }
+        break;
+
+    default:
+        ChipLogProgress(NotSpecified, "Invalid binding command data - commandId is not supported");
+        break;
+    }
+
+    if (CHIP_NO_ERROR != ret)
+    {
+        ChipLogError(NotSpecified, "Invoke Group Command Request ERROR: %s", ErrorStr(ret));
+    }
+}
+
+void BindingHandler::ColorControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
+                                                 OperationalDeviceProxy * aDevice, void * aContext)
+{
+    BindingData * data = reinterpret_cast<BindingData *>(aContext);
+
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(NotSpecified, "Binding command applied successfully!");
+
+        // If session was recovered and communication works, reset flag to the initial state.
+        if (BindingHandler::GetInstance().mCaseSessionRecovered)
+            BindingHandler::GetInstance().mCaseSessionRecovered = false;
+    };
+
+    auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable { BindingHandler::OnInvokeCommandFailure(dataRef, aError); };
+
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+
+    if (aDevice)
+    {
+        VerifyOrDie(aDevice->ConnectionReady());
+    }
+
+    switch (aCommandId)
+    {
+    case Clusters::ColorControl::Commands::MoveToColor::Id:
+        {
+            Clusters::ColorControl::Commands::MoveToColor::Type moveToColorCommand;
+            moveToColorCommand.colorX = data->ColorXY.x;
+            moveToColorCommand.colorY = data->ColorXY.y;
+            if (aDevice)
+            {
+                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                       aBinding.remote, moveToColorCommand, onSuccess, onFailure);
+            }
+            else
+            {
+                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToColorCommand);
+            }
+        }
+        break;
+
+    case Clusters::ColorControl::Commands::MoveToColorTemperature::Id:
+        {
+            Clusters::ColorControl::Commands::MoveToColorTemperature::Type moveToColorTemperatureCommand;
+            moveToColorTemperatureCommand.colorTemperatureMireds = data->ColorTemperatureMireds;
+            moveToColorTemperatureCommand.transitionTime         = 0;
+            if (aDevice)
+            {
+                ret = Controller::InvokeCommandRequest(aDevice->GetExchangeManager(), aDevice->GetSecureSession().Value(),
+                                                       aBinding.remote, moveToColorTemperatureCommand, onSuccess, onFailure);
+            }
+            else
+            {
+                Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+                ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId,
+                                                           moveToColorTemperatureCommand);
+            }
+        }
+        break;
+
+    default:
+        ChipLogProgress(NotSpecified, "Invalid binding command data - commandId is not supported");
+        break;
+    }
+
+    if (CHIP_NO_ERROR != ret)
+    {
+        ChipLogError(NotSpecified, "Invoke ColorControl Command Request ERROR: %s", ErrorStr(ret));
+    }
+}
+
 void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & aBinding, OperationalDeviceProxy * deviceProxy,
                                                void * context)
 {
@@ -224,6 +349,12 @@ void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & aBind
         case Clusters::OnOff::Id:
             OnOffProcessCommand(data->CommandId, aBinding, nullptr, context);
             break;
+        case Clusters::LevelControl::Id:
+            LevelControlProcessCommand(data->CommandId, aBinding, nullptr, context);
+            break;
+        case Clusters::ColorControl::Id:
+            ColorControlProcessCommand(data->CommandId, aBinding, nullptr, context);
+            break;
         default:
             ChipLogError(NotSpecified, "Invalid binding group command data");
             break;
@@ -235,6 +366,12 @@ void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & aBind
         {
         case Clusters::OnOff::Id:
             OnOffProcessCommand(data->CommandId, aBinding, deviceProxy, context);
+            break;
+        case Clusters::LevelControl::Id:
+            LevelControlProcessCommand(data->CommandId, aBinding, deviceProxy, context);
+            break;
+        case Clusters::ColorControl::Id:
+            ColorControlProcessCommand(data->CommandId, aBinding, deviceProxy, context);
             break;
         default:
             ChipLogError(NotSpecified, "Invalid binding unicast command data");

--- a/examples/light-switch-app/realtek/common/main/LightSwitch.cpp
+++ b/examples/light-switch-app/realtek/common/main/LightSwitch.cpp
@@ -23,6 +23,8 @@
 #include <app/server/Server.h>
 #include <controller/InvokeInteraction.h>
 
+#define CHIP_DEVICE_CONFIG_BRIGHTNESS_MAXIMUM 254
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -72,6 +74,101 @@ void LightSwitch::InitiateActionSwitch(chip::EndpointId endpointId, uint8_t acti
             Platform::Delete(data);
             return;
         }
+        DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    }
+}
+
+void LightSwitch::DimmerChangeBrightness(chip::EndpointId endpointId, uint8_t brightness)
+{
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
+    if (!bindingTable.Size())
+    {
+        ChipLogError(DeviceLayer, "bindingTable empty");
+        return;
+    }
+
+    BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
+
+    if (data)
+    {
+        data->EndpointId = endpointId;
+        data->CommandId  = Clusters::LevelControl::Commands::MoveToLevel::Id;
+        data->ClusterId  = Clusters::LevelControl::Id;
+        data->Value   = (brightness > CHIP_DEVICE_CONFIG_BRIGHTNESS_MAXIMUM ? CHIP_DEVICE_CONFIG_BRIGHTNESS_MAXIMUM : brightness);
+        data->IsGroup = false;
+
+        for (auto & entry : bindingTable)
+        {
+            if (endpointId == entry.local && Binding::MATTER_MULTICAST_BINDING == entry.type)
+            {
+                data->IsGroup = true;
+                break;
+            }
+        }
+
+        DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    }
+}
+
+void LightSwitch::ColorChange(chip::EndpointId endpointId, uint16_t colorX, uint16_t colorY)
+{
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
+    if (!bindingTable.Size())
+    {
+        ChipLogError(DeviceLayer, "bindingTable empty");
+        return;
+    }
+
+    BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
+    if (data)
+    {
+        data->EndpointId = endpointId;
+        data->CommandId  = Clusters::ColorControl::Commands::MoveToColor::Id;
+        data->ClusterId  = Clusters::ColorControl::Id;
+        data->ColorXY.x  = colorX;
+        data->ColorXY.y  = colorY;
+        data->IsGroup    = false;
+
+        for (auto & entry : bindingTable)
+        {
+            if (endpointId == entry.local && Binding::MATTER_MULTICAST_BINDING == entry.type)
+            {
+                data->IsGroup = true;
+                break;
+            }
+        }
+
+        DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    }
+}
+
+void LightSwitch::ColorTemperatureChange(chip::EndpointId endpointId, uint16_t colorTemperatureMireds)
+{
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
+    if (!bindingTable.Size())
+    {
+        ChipLogError(DeviceLayer, "bindingTable empty");
+        return;
+    }
+
+    BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
+    if (data)
+    {
+        data->EndpointId             = endpointId;
+        data->CommandId              = Clusters::ColorControl::Commands::MoveToColorTemperature::Id;
+        data->ClusterId              = Clusters::ColorControl::Id;
+        data->ColorTemperatureMireds = colorTemperatureMireds;
+        data->IsGroup                = false;
+
+        for (auto & entry : bindingTable)
+        {
+            if (endpointId == entry.local && Binding::MATTER_MULTICAST_BINDING == entry.type)
+            {
+                data->IsGroup = true;
+                break;
+            }
+        }
+
         DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     }
 }

--- a/examples/light-switch-app/realtek/common/main/include/BindingHandler.h
+++ b/examples/light-switch-app/realtek/common/main/include/BindingHandler.h
@@ -29,12 +29,21 @@
 class BindingHandler
 {
 public:
+    struct ColorXYData
+    {
+        uint16_t x;
+        uint16_t y;
+    };
+
     struct BindingData
     {
         chip::EndpointId EndpointId;
         chip::CommandId CommandId;
         chip::ClusterId ClusterId;
+        uint8_t Value;
         bool IsGroup{ false };
+        ColorXYData ColorXY;
+        uint16_t ColorTemperatureMireds;
     };
 
     struct SubscribeCommandData
@@ -60,6 +69,10 @@ public:
 private:
     static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
                                     chip::OperationalDeviceProxy *, void *);
+    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                           chip::OperationalDeviceProxy *, void *);
+    static void ColorControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                           chip::OperationalDeviceProxy *, void *);
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);

--- a/examples/light-switch-app/realtek/common/main/include/LightSwitch.h
+++ b/examples/light-switch-app/realtek/common/main/include/LightSwitch.h
@@ -57,6 +57,9 @@ class LightSwitch
 public:
     void Init();
     void InitiateActionSwitch(chip::EndpointId endpointId, uint8_t action);
+    void DimmerChangeBrightness(chip::EndpointId endpointId, uint8_t brightness);
+    void ColorChange(chip::EndpointId endpointId, uint16_t colorX, uint16_t colorY);
+    void ColorTemperatureChange(chip::EndpointId endpointId, uint16_t colorTemperatureMireds);
     void GenericSwitchInitialPress();
     void GenericSwitchReleasePress();
 

--- a/examples/lighting-app/realtek/common/main/AppTask.cpp
+++ b/examples/lighting-app/realtek/common/main/AppTask.cpp
@@ -230,10 +230,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -243,6 +239,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/lock-app/realtek/common/main/AppTask.cpp
+++ b/examples/lock-app/realtek/common/main/AppTask.cpp
@@ -233,10 +233,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -253,6 +249,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/ota-requestor-app/realtek/common/main/AppTask.cpp
+++ b/examples/ota-requestor-app/realtek/common/main/AppTask.cpp
@@ -195,10 +195,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -208,6 +204,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/thermostat/realtek/common/main/AppTask.cpp
+++ b/examples/thermostat/realtek/common/main/AppTask.cpp
@@ -223,10 +223,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -236,6 +232,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }

--- a/examples/window-app/realtek/common/main/AppTask.cpp
+++ b/examples/window-app/realtek/common/main/AppTask.cpp
@@ -195,10 +195,6 @@ void AppTask::AppTaskMain(void * pvParameter)
                 {
                     switch (io_msg.type)
                     {
-                    case IO_MSG_TYPE_QDECODE:
-                        matter_ble_handle_io_msg(&io_msg);
-                        break;
-
                     case IO_MSG_TYPE_GPIO:
                         ButtonHandler(&io_msg);
                         break;
@@ -208,6 +204,7 @@ void AppTask::AppTaskMain(void * pvParameter)
                         break;
 
                     default:
+                        matter_ble_handle_io_msg(&io_msg);
                         break;
                     }
                 }


### PR DESCRIPTION
#### Summary

1. Add support for dimming, color (XY), and color temperature control  to the light-switch sample.
2. Use matter_ble_handle_io_msg() to handle all other io msg.

#### Related issues

NA

#### Testing

Tested manually by building light-switch with latest docker container.