### PR TITLE
[common][platform][openthread] Fix race condition during Thread stack initialization (observed on NXP Zephyr platform)

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -748,7 +748,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::ConfigureThreadS
 #endif
 
 exit:
-    
+
     Impl()->UnlockThreadStack();
     ChipLogProgress(DeviceLayer, "OpenThread started: %s", otThreadErrorToString(otErr));
     return err;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -712,6 +712,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::ConfigureThreadS
     otError otErr  = OT_ERROR_NONE;
 
     mOTInst = otInst;
+
+    // Lock the OpenThread stack to prevent race conditions with OpenThread's internal operations.
+    // On some platforms (e.g., Zephyr), OpenThread may already be running before Matter initialization completes.
     Impl()->LockThreadStack();
 
     // Arrange for OpenThread to call the OnOpenThreadStateChange method whenever a

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -712,6 +712,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::ConfigureThreadS
     otError otErr  = OT_ERROR_NONE;
 
     mOTInst = otInst;
+    Impl()->LockThreadStack();
 
     // Arrange for OpenThread to call the OnOpenThreadStateChange method whenever a
     // state change occurs.  Note that we reference the OnOpenThreadStateChange method
@@ -747,7 +748,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::ConfigureThreadS
 #endif
 
 exit:
-
+    
+    Impl()->UnlockThreadStack();
     ChipLogProgress(DeviceLayer, "OpenThread started: %s", otThreadErrorToString(otErr));
     return err;
 }


### PR DESCRIPTION

#### Summary

This PR fixes a race condition in the common OpenThread platform integration for Matter.
When running on Zephyr, the OS initializes the networking subsystems during the kernel initialization phase. This causes OpenThread to start running before Matter completes its initialization. As a result, ConfigureThreadStack() calls into the OpenThread API without synchronization, which can overlap with OpenThread’s own internal thread/radio operations.
This unsynchronized access can cause concurrent access to the OpenThread resources and is observable on NXP Zephyr platform during Matter startup.

#### Root cause
- Zephyr starts OpenThread early during kernel boot.
- Matter init then calls GenericThreadStackManagerImpl_OpenThread::ConfigureThreadStack().
- This function uses OT APIs without holding the OT mutex.
- Concurrent access occurs between: OT internal thread, and Matter initialization thread calling OT APIs.

#### Fix
Wrap all OpenThread API calls inside ConfigureThreadStack() with "LockThreadStack" to lock the OT mutex. This guarantees serialized access to OT when configuring the Thread stack, preventing other threads from accessing the shared OT resources.

#### Testing

Tested by building and running Matter-over-Thread on NXP Zephyr platform RW612, to confirm successful initialization. A full commissioning was also run successfully.
Build command: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr/ -DEXTRA_CONF_FILE=prj_thread_ftd.conf -p always"
