### PR TITLE
[Actions] Fix shutdown timing and wrong cluster ID in error log

### DIFF
--- a/src/app/clusters/actions-server/CodegenIntegration.cpp
+++ b/src/app/clusters/actions-server/CodegenIntegration.cpp
@@ -81,9 +81,13 @@ ActionsServer::ActionsServer(EndpointId endpointId, Delegate & delegate) :
 
 ActionsServer::~ActionsServer()
 {
-    // Ensure Shutdown() was explicitly called prior to destruction to
-    // prevent dangling pointers in the data model provider registry.
-    VerifyOrDie(!mRegistered);
+    if (mRegistered)
+    {
+        // Shutdown() was not called before destruction. Call it now to avoid
+        // leaving a dangling pointer in the data model provider registry.
+        ChipLogError(AppServer, "ActionsServer destroyed without Shutdown() being called; shutting down now.");
+        Shutdown();
+    }
     --sInstanceCount;
 }
 

--- a/src/app/clusters/actions-server/CodegenIntegration.cpp
+++ b/src/app/clusters/actions-server/CodegenIntegration.cpp
@@ -81,6 +81,9 @@ ActionsServer::ActionsServer(EndpointId endpointId, Delegate & delegate) :
 
 ActionsServer::~ActionsServer()
 {
+    // Ensure Shutdown() was explicitly called prior to destruction to
+    // prevent dangling pointers in the data model provider registry.
+    VerifyOrDie(!mRegistered);
     --sInstanceCount;
 }
 
@@ -95,16 +98,15 @@ CHIP_ERROR ActionsServer::Init()
 void ActionsServer::Shutdown()
 {
     VerifyOrReturn(mRegistered);
-    mRegistered                    = false;
-    const ConcreteClusterPath path = mCluster.Cluster().GetPaths()[0];
-    CHIP_ERROR err                 = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
+    mRegistered    = false;
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
     if (err != CHIP_NO_ERROR)
     {
+        const ConcreteClusterPath path = mCluster.Cluster().GetPaths()[0];
         ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT, path.mEndpointId,
                      ChipLogValueMEI(path.mClusterId), err.Format());
     }
 }
-
 void ActionsServer::ActionListModified(EndpointId aEndpoint)
 {
     VerifyOrReturn(aEndpoint == mCluster.Cluster().GetPaths()[0].mEndpointId);

--- a/src/app/clusters/actions-server/CodegenIntegration.cpp
+++ b/src/app/clusters/actions-server/CodegenIntegration.cpp
@@ -102,7 +102,7 @@ void ActionsServer::Shutdown()
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
     if (err != CHIP_NO_ERROR)
     {
-        const ConcreteClusterPath path = mCluster.Cluster().GetPaths()[0];
+        [[maybe_unused]] const ConcreteClusterPath path = mCluster.Cluster().GetPaths()[0];
         ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT, path.mEndpointId,
                      ChipLogValueMEI(path.mClusterId), err.Format());
     }

--- a/src/app/clusters/actions-server/CodegenIntegration.cpp
+++ b/src/app/clusters/actions-server/CodegenIntegration.cpp
@@ -81,7 +81,6 @@ ActionsServer::ActionsServer(EndpointId endpointId, Delegate & delegate) :
 
 ActionsServer::~ActionsServer()
 {
-    Shutdown();
     --sInstanceCount;
 }
 
@@ -96,12 +95,13 @@ CHIP_ERROR ActionsServer::Init()
 void ActionsServer::Shutdown()
 {
     VerifyOrReturn(mRegistered);
-    mRegistered    = false;
-    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
+    mRegistered                    = false;
+    const ConcreteClusterPath path = mCluster.Cluster().GetPaths()[0];
+    CHIP_ERROR err                 = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT,
-                     mCluster.Cluster().GetPaths()[0].mEndpointId, ChipLogValueMEI(DeviceEnergyManagement::Id), err.Format());
+        ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT, path.mEndpointId,
+                     ChipLogValueMEI(path.mClusterId), err.Format());
     }
 }
 


### PR DESCRIPTION
#### Summary
Two bugs in `ActionsServer::Shutdown()` (CodegenIntegration.cpp):                                                                 
                                                                                                                                    
  - **Wrong cluster ID in error log**: `DeviceEnergyManagement::Id` was hardcoded due to a copy-paste mistake. Now using `path.mClusterId`  from the cluster's own path.                                                                                                    
                                                                                                                                    
  - **Shutdown called too late**: `~ActionsServer()` was calling `Shutdown()` during static teardown, after the `CodegenDataModelProvider` registry may already be gone. Removed the call from the destructor — callers are expected to call `Shutdown()` explicitly before destroying the instance.
  
#### Related issues


#### Testing


#### Readability checklist

