### PR TITLE
[OccupancySensing] notify attribute changed for attribute aliases as well

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
@@ -205,13 +205,27 @@ DataModel::ActionReturnStatus OccupancySensingCluster::SetHoldTime(uint16_t hold
     VerifyOrReturnError(holdTime >= mHoldTimeLimits.holdTimeMin, Protocols::InteractionModel::Status::ConstraintError);
     VerifyOrReturnError(holdTime <= mHoldTimeLimits.holdTimeMax, Protocols::InteractionModel::Status::ConstraintError);
 
-    if (mHoldTime == holdTime)
+    if (!SetAttributeValue(mHoldTime, holdTime, Attributes::HoldTime::Id))
     {
         return DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp;
     }
 
-    mHoldTime = holdTime;
-    NotifyAttributeChanged(Attributes::HoldTime::Id);
+    /// HoldTime is reported as aliases in several attributes, so notify all of them.
+    if (mShowDeprecatedAttributes)
+    {
+        if (mFeatureMap.Has(Feature::kPassiveInfrared))
+        {
+            NotifyAttributeChanged(Attributes::PIROccupiedToUnoccupiedDelay::Id);
+        }
+        if (mFeatureMap.Has(Feature::kUltrasonic))
+        {
+            NotifyAttributeChanged(Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id);
+        }
+        if (mFeatureMap.Has(Feature::kPhysicalContact))
+        {
+            NotifyAttributeChanged(Attributes::PhysicalContactOccupiedToUnoccupiedDelay::Id);
+        }
+    }
 
     // If a timer is currently active, we need to adjust its duration to reflect the new hold time.
     if (mHoldTimeDelegate->IsTimerActive(this))

--- a/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
@@ -214,8 +214,8 @@ TEST_F(TestOccupancySensingCluster, TestAliasAttributeNotifications)
     chip::Testing::TestServerClusterContext context;
     constexpr uint16_t kHoldTime                                               = 100;
     OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
-                                                                                    .holdTimeMax     = 200,
-                                                                                    .holdTimeDefault = kHoldTime };
+                                                                                   .holdTimeMax     = 200,
+                                                                                   .holdTimeDefault = kHoldTime };
     OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
                                          .WithHoldTime(kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate)
                                          .WithFeatures(Feature::kPassiveInfrared)
@@ -224,13 +224,15 @@ TEST_F(TestOccupancySensingCluster, TestAliasAttributeNotifications)
     chip::Testing::ClusterTester tester(cluster);
 
     // 1. Verify that PIROccupiedToUnoccupiedDelay is NOT dirty initially
-    EXPECT_FALSE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
+    EXPECT_FALSE(
+        context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
 
     // 2. Write to PIROccupiedToUnoccupiedDelay via tester (which calls WriteAttribute)
     EXPECT_EQ(tester.WriteAttribute(Attributes::PIROccupiedToUnoccupiedDelay::Id, static_cast<uint16_t>(150)), CHIP_NO_ERROR);
 
     // 3. Verify that PIROccupiedToUnoccupiedDelay IS dirty now
-    EXPECT_TRUE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
+    EXPECT_TRUE(
+        context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
 
     // 4. Verify that HoldTime IS also dirty (since it is the primary attribute updated)
     EXPECT_TRUE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::HoldTime::Id }));

--- a/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
@@ -209,6 +209,33 @@ TEST_F(TestOccupancySensingCluster, TestHoldTimeAttribute)
     EXPECT_EQ(clusterNoHoldTime.SetHoldTime(10), Protocols::InteractionModel::Status::UnsupportedAttribute);
 }
 
+TEST_F(TestOccupancySensingCluster, TestAliasAttributeNotifications)
+{
+    chip::Testing::TestServerClusterContext context;
+    constexpr uint16_t kHoldTime                                               = 100;
+    OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
+                                                                                    .holdTimeMax     = 200,
+                                                                                    .holdTimeDefault = kHoldTime };
+    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
+                                         .WithHoldTime(kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate)
+                                         .WithFeatures(Feature::kPassiveInfrared)
+                                         .WithDeprecatedAttributes(true) };
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    chip::Testing::ClusterTester tester(cluster);
+
+    // 1. Verify that PIROccupiedToUnoccupiedDelay is NOT dirty initially
+    EXPECT_FALSE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
+
+    // 2. Write to PIROccupiedToUnoccupiedDelay via tester (which calls WriteAttribute)
+    EXPECT_EQ(tester.WriteAttribute(Attributes::PIROccupiedToUnoccupiedDelay::Id, static_cast<uint16_t>(150)), CHIP_NO_ERROR);
+
+    // 3. Verify that PIROccupiedToUnoccupiedDelay IS dirty now
+    EXPECT_TRUE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::PIROccupiedToUnoccupiedDelay::Id }));
+
+    // 4. Verify that HoldTime IS also dirty (since it is the primary attribute updated)
+    EXPECT_TRUE(context.ChangeListener().IsDirty({ kTestEndpointId, OccupancySensing::Id, Attributes::HoldTime::Id }));
+}
+
 TEST_F(TestOccupancySensingCluster, TestHoldTimePersistence)
 {
     chip::Testing::TestServerClusterContext context;


### PR DESCRIPTION
#### Summary

HoldTime is an alias for several attributes in occupancy sensing. Notify all of them on change.

#### Related issues

Fixes #71362

#### Testing

Unit test added.