### PR TITLE
Add a step to verify DUT SpecificationVersion before running the new test steps

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -341,39 +341,42 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
                                   problem=f'Root node does not contain required cluster {c}', spec_location="Root node device type")
                 self.fail_current_test()
 
-        groupcast_feature_map = 0
-        if Clusters.Groupcast in root:
-            groupcast_feature_map = root[Clusters.Groupcast][Clusters.Groupcast.Attributes.FeatureMap]
-        has_groupcast_listener = bool(groupcast_feature_map & Clusters.Groupcast.Bitmaps.Feature.kListener)
-        has_groupcast_sender = bool(groupcast_feature_map & Clusters.Groupcast.Bitmaps.Feature.kSender)
+        self.print_step(6, "Verify that the specification version is 1.6 or above for the next steps")
+        specification_version = self.endpoints[0][Clusters.BasicInformation][Clusters.BasicInformation.Attributes.SpecificationVersion]
+        if specification_version >= 0x01060000:
+            groupcast_feature_map = 0
+            if Clusters.Groupcast in root:
+                groupcast_feature_map = root[Clusters.Groupcast][Clusters.Groupcast.Attributes.FeatureMap]
+            has_groupcast_listener = bool(groupcast_feature_map & Clusters.Groupcast.Bitmaps.Feature.kListener)
+            has_groupcast_sender = bool(groupcast_feature_map & Clusters.Groupcast.Bitmaps.Feature.kSender)
 
-        self.print_step(6, "Verify GroupcastListenerCond: if any endpoint has Groups server, "
-                        "Groupcast with Listener feature must be on EP0")
-        has_groups_server = any(
-            Clusters.Groups in self.endpoints[ep_id]
-            for ep_id in self.endpoints if ep_id != 0
-        )
-        log.info(f"has_groups_server: {has_groups_server}, has_groupcast_listener: {has_groupcast_listener}")
-        if has_groups_server and not has_groupcast_listener:
-            self.record_error(self.get_test_name(), location=AttributePathLocation(endpoint_id=0),
-                              problem="Groups server found on an endpoint but Groupcast cluster with Listener "
-                              "feature is not present on the root node (EP0)",
-                              spec_location="Root node device type - GroupcastListenerCond")
-            self.fail_current_test()
+            self.print_step(7, "Verify GroupcastListenerCond: if any endpoint has Groups server, "
+                            "Groupcast with Listener feature must be on EP0")
+            has_groups_server = any(
+                Clusters.Groups in self.endpoints[ep_id]
+                for ep_id in self.endpoints if ep_id != 0
+            )
+            log.info(f"has_groups_server: {has_groups_server}, has_groupcast_listener: {has_groupcast_listener}")
+            if has_groups_server and not has_groupcast_listener:
+                self.record_error(self.get_test_name(), location=AttributePathLocation(endpoint_id=0),
+                                  problem="Groups server found on an endpoint but Groupcast cluster with Listener "
+                                  "feature is not present on the root node (EP0)",
+                                  spec_location="Root node device type - GroupcastListenerCond")
+                self.fail_current_test()
 
-        self.print_step(7, "Verify GroupcastSenderCond: if any endpoint has Binding server, "
-                        "Groupcast with Sender feature must be on EP0")
-        has_binding_server = any(
-            Clusters.Binding in self.endpoints[ep_id]
-            for ep_id in self.endpoints if ep_id != 0
-        )
-        log.info(f"has_binding_server: {has_binding_server}, has_groupcast_sender: {has_groupcast_sender}")
-        if has_binding_server and not has_groupcast_sender:
-            self.record_error(self.get_test_name(), location=AttributePathLocation(endpoint_id=0),
-                              problem="Binding server found on an endpoint but Groupcast cluster with Sender "
-                              "feature is not present on the root node (EP0)",
-                              spec_location="Root node device type - GroupcastSenderCond")
-            self.fail_current_test()
+            self.print_step(8, "Verify GroupcastSenderCond: if any endpoint has Binding server, "
+                            "Groupcast with Sender feature must be on EP0")
+            has_binding_server = any(
+                Clusters.Binding in self.endpoints[ep_id]
+                for ep_id in self.endpoints if ep_id != 0
+            )
+            log.info(f"has_binding_server: {has_binding_server}, has_groupcast_sender: {has_groupcast_sender}")
+            if has_binding_server and not has_groupcast_sender:
+                self.record_error(self.get_test_name(), location=AttributePathLocation(endpoint_id=0),
+                                  problem="Binding server found on an endpoint but Groupcast cluster with Sender "
+                                  "feature is not present on the root node (EP0)",
+                                  spec_location="Root node device type - GroupcastSenderCond")
+                self.fail_current_test()
 
     def test_TC_DT_1_1(self):
         self.print_step(1, "Perform a wildcard read of attributes on all endpoints - already done")

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -342,7 +342,7 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
                 self.fail_current_test()
 
         self.print_step(6, "Verify that the specification version is 1.6 or above for the next steps")
-        specification_version = self.endpoints[0][Clusters.BasicInformation][Clusters.BasicInformation.Attributes.SpecificationVersion]
+        specification_version = root[Clusters.BasicInformation].get(Clusters.BasicInformation.Attributes.SpecificationVersion, 0)
         if specification_version >= 0x01060000:
             groupcast_feature_map = 0
             if Clusters.Groupcast in root:


### PR DESCRIPTION
#### Summary
Since the TH/test are run against device with older versions too, the test script need to pass for all versions.
Add a specification version check before executing steps that apply only to Matter 1.6 and above. 

#### Related issues
fixes #71366

#### Testing
run `src/python_testing/TC_DeviceBasicComposition.py` on all-cluster-app
Validated that the Specification version is verified before running the Groupcast presence/conformance checks.
```
 on EP0
[MatterTest] 04-02 09:17:41.521 INFO ***** Test Step 6 : Verify that the specification version is 1.6 or above for the next steps
[MatterTest] 04-02 09:17:41.521 INFO ***** Test Step 7 : Verify GroupcastListenerCond: if any endpoint has Groups server, Groupcast with Listener feature must be on EP0
[MatterTest] 04-02 09:17:41.521 INFO has_groups_server: True, has_groupcast_listener: True
[MatterTest] 04-02 09:17:41.521 INFO ***** Test Step 8 : Verify GroupcastSenderCond: if any endpoint has Binding server, Groupcast with Sender feature must be on EP0
[MatterTest] 04-02 09:17:41.521 INFO has_binding_server: True, has_groupcast_sender: True
```