### PR TITLE
[ESP32] support for detecting post ota boot reason

### DIFF
--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -97,7 +97,6 @@ static_library("ESP32") {
       "OTAImageProcessorImpl.cpp",
       "OTAImageProcessorImpl.h",
     ]
-    deps += [ "${chip_root}/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor:enums" ]
   }
 
   if (chip_enable_ble) {

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -97,6 +97,7 @@ static_library("ESP32") {
       "OTAImageProcessorImpl.cpp",
       "OTAImageProcessorImpl.h",
     ]
+    deps += [ "${chip_root}/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor:enums" ]
   }
 
   if (chip_enable_ble) {

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -196,17 +196,17 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason
 
     if (err == CHIP_NO_ERROR && bytesRead == sizeof(otaState) && otaState == OTAUpdateStateEnum::kApplying)
     {
-        bytesRead  = 0;
-        uint32_t currentVersion = 0;
-        uint32_t targetVersion  = 0;
+        bytesRead                        = 0;
+        uint32_t currentVersion          = 0;
+        uint32_t targetVersion           = 0;
         auto otaTargetVersionKeyName     = DefaultStorageKeyAllocator::OTATargetVersion();
         const char * otaTargetVersionKey = otaTargetVersionKeyName.KeyName();
 
         CHIP_ERROR currentVersionGetErr = ConfigurationMgr().GetSoftwareVersion(currentVersion);
         CHIP_ERROR targetVersionGetErr  = keyMgr.Get(otaTargetVersionKey, &targetVersion, sizeof(targetVersion), &bytesRead);
 
-        if (currentVersionGetErr == CHIP_NO_ERROR && targetVersionGetErr == CHIP_NO_ERROR
-            && bytesRead == sizeof(targetVersion) && currentVersion == targetVersion)
+        if (currentVersionGetErr == CHIP_NO_ERROR && targetVersionGetErr == CHIP_NO_ERROR && bytesRead == sizeof(targetVersion) &&
+            currentVersion == targetVersion)
         {
             bootReason  = BootReasonType::kSoftwareUpdateCompleted;
             mBootReason = bootReason;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -29,7 +29,6 @@
 #include <platform/ESP32/DiagnosticDataProviderImpl.h>
 #include <platform/ESP32/ESP32Utils.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-#include <clusters/OtaSoftwareUpdateRequestor/Enums.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <platform/KeyValueStoreManager.h>
 #endif

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -28,6 +28,11 @@
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/ESP32/DiagnosticDataProviderImpl.h>
 #include <platform/ESP32/ESP32Utils.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include <clusters/OtaSoftwareUpdateRequestor/Enums.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+#include <platform/KeyValueStoreManager.h>
+#endif
 
 #include "esp_event.h"
 #include "esp_heap_caps_init.h"
@@ -161,7 +166,56 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
+    if (mBootReason.has_value())
+    {
+        ChipLogDetail(DeviceLayer, "Boot Reason (cached):%u", to_underlying(mBootReason.value()));
+        bootReason = mBootReason.value();
+        return CHIP_NO_ERROR;
+    }
+
     bootReason = BootReasonType::kUnspecified;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+    // ESP-IDF provides no dedicated reset reason for OTA-triggered reboots.
+    // Detect a post-OTA boot by reading the OTA requestor's persisted update state from KVS.
+    // The OTA requestor stores kApplying before rebooting and clears it after NotifyUpdateApplied(),
+    // so no manual cleanup is needed here.
+    using OTAUpdateStateEnum = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+
+    // KeyValueStoreMgr() is the underlying store used by the OTA requestor's
+    // PersistentStorageDelegate on ESP32 (via KvsPersistentStorageDelegate), so reading
+    // these keys directly is equivalent to what DefaultOTARequestorStorage does.
+    auto & keyMgr = PersistedStorage::KeyValueStoreMgr();
+
+    size_t bytesRead = 0;
+    OTAUpdateStateEnum otaState;
+    auto otaStateKeyName     = DefaultStorageKeyAllocator::OTACurrentUpdateState();
+    const char * otaStateKey = otaStateKeyName.KeyName();
+
+    CHIP_ERROR err = keyMgr.Get(otaStateKey, &otaState, sizeof(otaState), &bytesRead);
+
+    if (err == CHIP_NO_ERROR && bytesRead == sizeof(otaState) && otaState == OTAUpdateStateEnum::kApplying)
+    {
+        bytesRead  = 0;
+        uint32_t currentVersion = 0;
+        uint32_t targetVersion  = 0;
+        auto otaTargetVersionKeyName     = DefaultStorageKeyAllocator::OTATargetVersion();
+        const char * otaTargetVersionKey = otaTargetVersionKeyName.KeyName();
+
+        CHIP_ERROR currentVersionGetErr = ConfigurationMgr().GetSoftwareVersion(currentVersion);
+        CHIP_ERROR targetVersionGetErr  = keyMgr.Get(otaTargetVersionKey, &targetVersion, sizeof(targetVersion), &bytesRead);
+
+        if (currentVersionGetErr == CHIP_NO_ERROR && targetVersionGetErr == CHIP_NO_ERROR
+            && bytesRead == sizeof(targetVersion) && currentVersion == targetVersion)
+        {
+            bootReason  = BootReasonType::kSoftwareUpdateCompleted;
+            mBootReason = bootReason;
+            ChipLogDetail(DeviceLayer, "After OTA Upgrade Boot Reason:%u", to_underlying(bootReason));
+            return CHIP_NO_ERROR;
+        }
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
     uint8_t reason;
     reason = static_cast<uint8_t>(esp_reset_reason());
     if (reason == ESP_RST_UNKNOWN)
@@ -185,6 +239,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason
         bootReason = BootReasonType::kSoftwareWatchdogReset;
         /* Reboot can be due to hardware or software watchdog*/
     }
+    mBootReason = bootReason;
+    ChipLogDetail(DeviceLayer, "from API Boot Reason:%u", to_underlying(bootReason));
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -68,6 +68,9 @@ public:
     CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
     CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+private:
+    std::optional<BootReasonType> mBootReason = std::nullopt;
 };
 
 /**


### PR DESCRIPTION
#### Summary

esp-idf has no way of figuring out if its a post ota boot, but ota requestor stores the ota-update-state and the target version in the kvs, using them to decide whether device is booting after an ota or not.

Since ota-update-state will be set to idle once ota requestor cluster initializes, GetBootReason() API caches the state on the first boot to ensure that the subsequent calls provides the correct boot reason.

#### Related issues

https://github.com/espressif/esp-matter/issues/1716

#### Testing

- Performed the OTA with the `examples/lighting-app/esp32` and `examples/ota-provider-app/linux`
- verified: `chip-tool generaldiagnostics read boot-reason 1 0`
    - boot-after-ota reads: `BootReason: 5` (`SoftwareUpdateCompleted`)
    - subsequent-boot read: `BootReason: 1` (`PowerOnReboot`)