### PR TITLE
[Silabs] : Use latest SLT and non-interactive

### DIFF
--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -43,7 +43,7 @@ def get_platform_vars():
         logger.error("Platform %s is not supported (Linux and macOS only)", platform)
         sys.exit(1)
 
-    slt_cli_url = f"https://www.silabs.com/documents/public/software/slt-cli-1.0.1-{platform_name}-x64.zip"
+    slt_cli_url = f"https://www.silabs.com/documents/public/software/slt-cli-1.1.1-{platform_name}-x64.zip"
     return platform_name, slt_cli_url
 
 
@@ -221,7 +221,7 @@ def download_slt_cli():
 
 def update_slt_cli(slt_cli_path):
     """Update SLT CLI to latest version."""
-    update_cmd = [slt_cli_path, "update", "--self"]
+    update_cmd = [slt_cli_path, "update", "--self", "--non-interactive"]
     try:
         logger.info("Updating SLT CLI to latest version...")
         subprocess.run(update_cmd, stdin=subprocess.DEVNULL, check=True)
@@ -252,7 +252,7 @@ def install_sdk_packages(slt_cli_path):
             sys.exit(1)
 
     for pkg_path in get_pkg_manifest_paths():
-        install_cmd = [slt_cli_path, "install", "-f", pkg_path]
+        install_cmd = [slt_cli_path, "install", "-f", pkg_path, "--non-interactive"]
         try:
             logger.info("Installing packages from %s...", os.path.basename(pkg_path))
             subprocess.run(install_cmd, stdin=subprocess.DEVNULL, check=True)
@@ -266,7 +266,7 @@ def slt_where(slt_cli_path, package):
     """Run 'slt where <package>' and return the path, or None if not found."""
     try:
         result = subprocess.run(
-            [slt_cli_path, "where", package],
+            [slt_cli_path, "where", "--non-interactive", package],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -224,7 +224,7 @@ def update_slt_cli(slt_cli_path):
     update_cmd = [slt_cli_path, "update", "--self", "--non-interactive"]
     try:
         logger.info("Updating SLT CLI to latest version...")
-        subprocess.run(update_cmd, stdin=subprocess.DEVNULL, check=True)
+        subprocess.run(update_cmd, check=True)
         logger.info("SLT CLI updated successfully")
     except subprocess.CalledProcessError as e:
         logger.warning("Failed to update slt-cli: %s", e)
@@ -255,7 +255,7 @@ def install_sdk_packages(slt_cli_path):
         install_cmd = [slt_cli_path, "install", "-f", pkg_path, "--non-interactive"]
         try:
             logger.info("Installing packages from %s...", os.path.basename(pkg_path))
-            subprocess.run(install_cmd, stdin=subprocess.DEVNULL, check=True)
+            subprocess.run(install_cmd, check=True)
             logger.info("Packages from %s installed successfully", os.path.basename(pkg_path))
         except subprocess.CalledProcessError as e:
             logger.error("Failed to install packages from %s: %s", pkg_path, e)
@@ -267,7 +267,6 @@ def slt_where(slt_cli_path, package):
     try:
         result = subprocess.run(
             [slt_cli_path, "where", "--non-interactive", package],
-            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
#### Summary

If there's multiple SLT's on device SLT shows 
```
************ Preferred SLT ************
SLT is designed to only run one instance on each host.
There is already a preferred slt placed at ..
Do you want to replace it and run this one instead
[y/n]?
```

The new version of SLT fixes that, also using non-interactive flag whil will help CI use cases, and also will stop asking this for local use cases

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/43760

#### Testing
Tested locally with multiple SLTs, do not see the above question anymore

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
