### PR TITLE
Removing TC_SU_2_2 form nightly tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -170,7 +170,7 @@ jobs:
                 # Regex filter by TC SU we think 45 minutes is more than engough for this task
                 # Each on one run to avoid all the jobs fail if one fails
                 # Add slow tests here as needed using the filter, individually or by group.
-                filter: ["", "TC_SU_2_2", "TC_SU_2_5", "TC_SU_2_7"]
+                filter: ["", "TC_SU_2_5", "TC_SU_2_7"]
         env:
             BUILD_VARIANT: ipv6only-no-ble-no-wifi
             DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}


### PR DESCRIPTION
#### Summary

The test `TC_SU_2_2.py` is not working properly in the nightly CI jobs. In oder to avoid this failing constantly is better to disabled while the solution for the issue is completed.

Test removed from the yaml file.

#### Related issues

N/A

#### Testing

Verify `TC_SU_2_2.py` does not run in the CI.


