### PR TITLE
[Silabs] Change a log message level to Progress

### DIFF
--- a/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
+++ b/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
@@ -189,7 +189,7 @@ CHIP_ERROR OTAMultiImageProcessorImpl::SelectProcessor(ByteSpan & block)
         return CHIP_OTA_PROCESSOR_NOT_REGISTERED;
     }
 
-    ChipLogDetail(SoftwareUpdate, "Selected processor with tag: %lu", static_cast<uint32_t>(pair->first));
+    ChipLogProgress(SoftwareUpdate, "Selected processor with tag: %lu", static_cast<uint32_t>(pair->first));
     mCurrentProcessor = pair->second;
     mCurrentProcessor->SetLength(header.length);
     mCurrentProcessor->SetWasSelected(true);
@@ -383,7 +383,7 @@ void OTAMultiImageProcessorImpl::HandleApply(intptr_t context)
 
     ChipLogProgress(SoftwareUpdate, "HandleApply: started");
 
-    // Force KVS to store pending keys such as data from StoreCurrentUpdateInfo()
+    // Force KVS to store pending keys such as the data from StoreCurrentUpdateInfo()
     DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().ForceKeyMapSave();
 
     if (imageProcessor == nullptr)


### PR DESCRIPTION
#### Summary

Change the logging level to Progress in a key multi-ota log message that is expected by the QA automation scripts. In a recent change the default logging level had been set to Progress and so messages with the level Detail no longer show up.

#### Related issues

None

#### Testing

Verified in the OTA Software Update tests. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
