### PR TITLE
[PAVST-2.3, 2.11] Fix discrepancy between Test plan and script - InvalidTriggerType to ConstraintError

### DIFF
--- a/src/python_testing/TC_PAVST_2_11.py
+++ b/src/python_testing/TC_PAVST_2_11.py
@@ -112,7 +112,7 @@ class TC_PAVST_2_11(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             TestStep(13, "TH sends the AllocatePushTransport command with Invalid URL.",
                      "DUT responds with Status Code InvalidURL."),
             TestStep(14, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
-                     "DUT responds with Status Code InvalidTriggerType."),
+                     "DUT responds with Status Code ConstraintError."),
             TestStep(15, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with a Null Zone in MotionZones.",
                      "DUT responds with Success."),
             TestStep(16, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate numeric Zone IDs within MotionZones.",

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -108,7 +108,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                      "DUT responds with Status Code InvalidTLSEndpoint."),
             TestStep(12, "TH sends the AllocatePushTransport command with an invalid IngestMethod.",
                      "DUT responds with Status Code ConstraintError."),
-            TestStep(13, "DUT responds with Status Code InvalidURL.",
+            TestStep(13, "TH sends the AllocatePushTransport command with Invalid URL.",
                      "DUT responds with Status Code InvalidURL."),
             TestStep(14, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
                      "DUT responds with Status Code ConstraintError."),

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -111,7 +111,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             TestStep(13, "DUT responds with Status Code InvalidURL.",
                      "DUT responds with Status Code InvalidURL."),
             TestStep(14, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
-                     "DUT responds with Status Code InvalidTriggerType."),
+                     "DUT responds with Status Code ConstraintError."),
             TestStep(15, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an Null Zone within MotionZones.",
                      "DUT responds with Status Code Success."),
             TestStep(16, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate numeric Zone IDs within MotionZones.",


### PR DESCRIPTION
#### Summary

https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12216/changes removed explicit validation in favour of generic constraint checking (ConstraintError).

This has been updated in the Test scripts, but left out in the Test plan description

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/42916

Corresponding Test plan PR - https://github.com/CHIP-Specifications/chip-test-plans/pull/6006

#### Testing

Not needed as this is only a text change. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
