### PR TITLE
Bad passcode handling (#43141)

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -1177,7 +1177,7 @@ subsequent connections to that TV.
    will attempt to establish a secure connection with the TV by calling
    `FindOrEstablishSession`.
 
-3) **DNS-SD Information Changes**: If the credential matching fails for a TV
+3. **DNS-SD Information Changes**: If the credential matching fails for a TV
    with a cached credential (for example, if fields in the DNS-SD information
    change, such as the IP address or device name), the pin code flow and
    commissioning will be triggered. During this commissioning process, the TV
@@ -1193,7 +1193,7 @@ subsequent connections to that TV.
     In this scenario, the phone app will receive a failure callback for the
     first attempt, but the subsequent commissioning attempt should succeed.
 
-4) **TV Factory Reset Recovery**: If the phone app believes it has a cached
+4. **TV Factory Reset Recovery**: If the phone app believes it has a cached
    credential for a given TV (the DNS-SD information match succeeds), but the TV
    does not recognize the phone app (this could happen if the TV has been
    factory reset but then setup again with the same customer account - and
@@ -1205,13 +1205,181 @@ subsequent connections to that TV.
    call `removeFabric()` to recover. Then it will need to perform the pin code
    flow for this TV again.
 
-5) **Shared Credentials Across TVs**: When there are 2 TVs that use the same
+5. **Shared Credentials Across TVs**: When there are 2 TVs that use the same
    middleware (e.g., FireTV) and are associated with the same customer account,
    they will often use the same cached credential (they use the same Matter
    fabric), however, the DNS-SD information is different. The resulting behavior
    is similar to item (3) - the pin code flow will be attempted and fail, the
    cached credential will be deleted which allows the next attempt to succeed.
    Some middleware providers may handle this scenario differently.
+
+### Handling Passcode Failures and Passcode Length
+
+#### Detecting Passcode Failure
+
+When commissioning fails due to an incorrect passcode, the Casting Client can
+detect this condition in the `onFailure` `ConnectionCallback`. The failure will
+be indicated by a `MatterError` with `errorCode = 0x38`, which corresponds to
+`CHIP_ERROR_INVALID_PASE_PARAMETER`.
+
+When this error occurs, the Casting Client should:
+
+1. Inform the user that the passcode was incorrect
+2. Prompt the user to re-enter the passcode
+3. Retry the connection with the new passcode
+
+On Linux, you can detect passcode failures in the connection failure callback:
+
+```c
+void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer)
+{
+    if(err == CHIP_ERROR_INVALID_PASE_PARAMETER)  // 0x38
+    {
+        ChipLogError(AppServer, "ConnectionHandler: Invalid passcode provided");
+        // Prompt user to re-enter the passcode and retry connection
+        ...
+    }
+    else if(err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "ConnectionHandler: Connection failed with err %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+```
+
+On Android, you can detect passcode failures in the
+`MatterCallback<MatterError>`:
+
+```java
+new MatterCallback<MatterError>() {
+    @Override
+    public void handle(MatterError err) {
+        if (err.getErrorCode() == 0x38) {  // CHIP_ERROR_INVALID_PASE_PARAMETER
+            Log.e(TAG, "Invalid passcode provided");
+            // Prompt user to re-enter the passcode and retry connection
+            getActivity().runOnUiThread(() -> {
+                // Show dialog to re-enter passcode
+                displayPasscodeInputDialog(getActivity());
+            });
+        } else {
+            Log.e(TAG, "CastingPlayer connection failed: " + err);
+        }
+    }
+}
+```
+
+On iOS, you can detect passcode failures in the connection completion callback:
+
+```swift
+let connectionCompleteCallback: (Swift.Error?) -> Void = { err in
+    if let error = err as? MatterError, error.code == 0x38 {  // CHIP_ERROR_INVALID_PASE_PARAMETER
+        self.Log.error("Invalid passcode provided")
+        DispatchQueue.main.async {
+            // Prompt user to re-enter the passcode and retry connection
+            self.connectionStatus = "Invalid passcode. Please try again."
+            self.displayPasscodeInputDialog(on: topViewController, continueConnecting: { newPasscode in
+                // Retry connection with new passcode
+                ...
+            })
+        }
+    } else if err != nil {
+        self.Log.error("Connection failed with error: \(String(describing: err))")
+        DispatchQueue.main.async {
+            self.connectionSuccess = false
+            self.connectionStatus = "Connection failed: \(String(describing: err))"
+        }
+    }
+}
+```
+
+#### Determining Passcode Length for Entry Dialog
+
+The `passcodeLength` field is provided in the `CommissionerDeclaration` sent by
+the TV during the commissioning process. This field indicates the expected
+length of the passcode that should be entered by the user.
+
+When implementing the passcode entry dialog:
+
+-   If `passcodeLength` is `0` or not provided, the Casting Client should
+    provide a variable-length input field for passcode entry
+-   If `passcodeLength` has a specific value (e.g., 8), the Casting Client
+    should configure the input field to accept exactly that many digits
+
+On Linux, you can access the passcode length from the `CommissionerDeclaration`:
+
+```c
+void CommissionerDeclarationCallback(const chip::Transport::PeerAddress & source,
+                                     chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
+{
+    uint8_t passcodeLength = cd.GetPasscodeLength();
+
+    if (passcodeLength == 0) {
+        ChipLogProgress(AppServer, "Variable-length passcode expected");
+        // Display variable-length input field
+    } else {
+        ChipLogProgress(AppServer, "Fixed-length passcode expected: %d digits", passcodeLength);
+        // Display fixed-length input field with passcodeLength digits
+    }
+
+    if (cd.GetCommissionerPasscode()) {
+        // Prompt user to enter the passcode displayed on the CastingPlayer
+        ...
+    }
+}
+```
+
+On Android, you can access the passcode length from the
+`CommissionerDeclaration`:
+
+```java
+new MatterCallback<CommissionerDeclaration>() {
+    @Override
+    public void handle(CommissionerDeclaration cd) {
+        int passcodeLength = cd.getPasscodeLength();
+
+        if (cd.getCommissionerPasscode()) {
+            getActivity().runOnUiThread(() -> {
+                if (passcodeLength == 0) {
+                    Log.d(TAG, "Variable-length passcode expected");
+                    // Display variable-length input field
+                    displayPasscodeInputDialog(getActivity(), /* variableLength= */ true);
+                } else {
+                    Log.d(TAG, "Fixed-length passcode expected: " + passcodeLength + " digits");
+                    // Display fixed-length input field
+                    displayPasscodeInputDialog(getActivity(), passcodeLength);
+                }
+            });
+        }
+    }
+}
+```
+
+On iOS, you can access the passcode length from the `MCCommissionerDeclaration`:
+
+```swift
+let commissionerDeclarationCallback: (MCCommissionerDeclaration) -> Void = { commissionerDeclarationMessage in
+    DispatchQueue.main.async {
+        let passcodeLength = commissionerDeclarationMessage.passcodeLength
+
+        if commissionerDeclarationMessage.commissionerPasscode {
+            if let topViewController = self.getTopMostViewController() {
+                if passcodeLength == 0 {
+                    self.Log.info("Variable-length passcode expected")
+                    // Display variable-length input field
+                    self.displayPasscodeInputDialog(on: topViewController, variableLength: true, continueConnecting: { userEnteredPasscode in
+                        ...
+                    })
+                } else {
+                    self.Log.info("Fixed-length passcode expected: \(passcodeLength) digits")
+                    // Display fixed-length input field
+                    self.displayPasscodeInputDialog(on: topViewController, fixedLength: Int(passcodeLength), continueConnecting: { userEnteredPasscode in
+                        ...
+                    })
+                }
+            }
+        }
+    }
+}
+```
 
 ### Detecting App Presence on Casting Player (Optional)
 
@@ -1275,7 +1443,7 @@ connectionCallbacks.mCommissionerDeclarationCallback = [&instanceName, &targetCa
     // Step 4: Cancel the UDC session by sending CancelPasscode
     matter::casting::core::IdentificationDeclarationOptions cancelOptions;
     cancelOptions.mCancelPasscode = true;
-chip::Platform::CopyString(cancelOptions.mCommissioneeInstanceName, instanceName.c_str());
+    chip::Platform::CopyString(cancelOptions.mCommissioneeInstanceName, instanceName.c_str());
 
     matter::casting::core::ConnectionCallbacks cancelCallbacks;
     // Send the cancel message using SendUDC

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -342,16 +342,26 @@ CHIP_ERROR CastingPlayer::StopConnecting(bool shouldSendIdentificationDeclaratio
 {
     ChipLogProgress(AppServer, "CastingPlayer::StopConnecting() called, while ChipDeviceEventHandler.sUdcInProgress: %s",
                     support::ChipDeviceEventHandler::isUdcInProgress() ? "true" : "false");
-    VerifyOrReturnValue(mConnectionState == CASTING_PLAYER_CONNECTING, CHIP_ERROR_INCORRECT_STATE,
-                        ChipLogError(AppServer, "CastingPlayer::StopConnecting() called while not in connecting state"););
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    mIdOptions.resetState();
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    mTargetCastingPlayer = weak_from_this();
+    mIdOptions.LogDetail();
+
+    // hack to re-populate mUdcClients cache on TV in order to allow cancel to pass through
+    mIdOptions.mCommissionerPasscode      = true;
+    mIdOptions.mNoPasscode                = true;
+    mIdOptions.mCancelPasscode            = false;
+    mIdOptions.mCommissionerPasscodeReady = false;
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+    err = SendUserDirectedCommissioningRequest();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingPlayer::StopConnecting() hack failed with %" CHIP_ERROR_FORMAT, err.Format());
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+
     mIdOptions.mCancelPasscode     = true;
     mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
     mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-    mTargetCastingPlayer.reset();
-    CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
-
     if (!shouldSendIdentificationDeclarationMessage)
     {
         ChipLogProgress(AppServer,
@@ -735,6 +745,8 @@ void CastingPlayer::OnCommissioningSessionStarted()
 void CastingPlayer::OnCommissioningSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogProgress(AppServer, "CastingPlayer::OnCommissioningSessionEstablishmentError() err: %" CHIP_ERROR_FORMAT, err.Format());
+    mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
+    LogErrorOnFailure(support::ChipDeviceEventHandler::SetUdcStatus(false));
     if (mOnCompleted != nullptr)
     {
         // err = 0x38 = CHIP_ERROR_INVALID_PASE_PARAMETER upon bad passcode

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -107,12 +107,6 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
                                  "ChipDeviceEventHandler::Handle() Target CastingPlayer no longer exists, skipping cleanup"));
 
                 targetCastingPlayer->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-                targetCastingPlayer->RemoveFabric();
-                CHIP_ERROR err = support::CastingStore::GetInstance()->Delete(*targetCastingPlayer);
-                if (err != CHIP_NO_ERROR)
-                {
-                    ChipLogError(AppServer, "CastingStore::Delete() failed. Err: %" CHIP_ERROR_FORMAT, err.Format());
-                }
                 if (targetCastingPlayer->mOnCompleted)
                 {
                     targetCastingPlayer->mOnCompleted(error, nullptr);


### PR DESCRIPTION
#### Summary

* Matter Casting - developer docs (passcode handling)

* automatically reset UdcStatus upon commissioning errors to allow passcode retry

* update mConnectionState upon pin failure

* address feedback

* editorial

* CI

* test

* preserve instanceName in stopConnecting

* address feedback

* address feedback

* fix: Address PR review feedback from andy31415

Remove commented-out VerifyOrReturnValue in StopConnecting() and replace TEMPORARY_RETURN_IGNORED with LogErrorOnFailure in OnCommissioningSessionEstablishmentError() per review guidance that new code should not use TEMPORARY_RETURN_IGNORED.

* cleanup commented-out code

* fix: Guard SendUserDirectedCommissioningRequest call with preprocessor check

Wrap the 'hack' call to SendUserDirectedCommissioningRequest() in StopConnecting(bool) with the CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT guard, matching all other call sites. This fixes the build error when the commissioner discovery client feature is disabled.

* Restyled by clang-format

---------


(cherry picked from commit e43b7fb54ec347df80ccb66feed1abc0b7d295a5)

#### Testing

build, linux and android testing