### PR TITLE
fix(tv-casting-app): Add placeholder DevelopmentCerts for custom VID/PID

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -125,6 +125,10 @@ chip_data_model("tv-casting-common") {
     ]
   }
 
+  # Placeholder DevelopmentCerts symbols for custom (non-development) VID/PID.
+  # Compiles to nothing when using development VIDs (0xFFF1/0xFFF2/0xFFF3).
+  sources += [ "src/DevelopmentCertsPlaceholder.cpp" ]
+
   # Add simplified casting API files here
   sources += [
     "clusters/Clusters.h",

--- a/examples/tv-casting-app/tv-casting-common/src/DevelopmentCertsPlaceholder.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/DevelopmentCertsPlaceholder.cpp
@@ -37,7 +37,7 @@
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#if !(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF1 || CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF2 ||                           \
+#if !(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF1 || CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF2 ||                            \
       CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF3)
 
 namespace chip {
@@ -47,6 +47,7 @@ ByteSpan kDacCert;
 ByteSpan kDacPrivateKey;
 ByteSpan kDacPublicKey;
 ByteSpan kPaiCert;
+ByteSpan kDeclaration;
 
 } // namespace DevelopmentCerts
 } // namespace chip

--- a/examples/tv-casting-app/tv-casting-common/src/DevelopmentCertsPlaceholder.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/DevelopmentCertsPlaceholder.cpp
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * Provides placeholder DevelopmentCerts symbols for custom VID/PID configurations
+ * where the standard ExampleDACs.cpp / ExamplePAI.cpp do not define certs.
+ *
+ * When using a non-development VID (e.g., 0x1123), ExampleDACs.cpp and
+ * ExamplePAI.cpp conditional compilation guards exclude all cert definitions,
+ * causing linker errors from code that references these symbols as fallback
+ * defaults (e.g., AndroidAppServerWrapper, TestHarnessDACProvider,
+ * ExampleDACProvider).
+ *
+ * These empty placeholders satisfy the linker. Real DAC credentials should be
+ * provided by the platform-specific DAC provider (DACProviderStub.java on
+ * Android, MCDeviceAttestationCredentialsProvider on Darwin).
+ *
+ * For development VIDs (0xFFF1/0xFFF2/0xFFF3), this file compiles to nothing
+ * since ExampleDACs.cpp and ExamplePAI.cpp already provide the symbols.
+ */
+
+#include <lib/support/Span.h>
+#include <platform/CHIPDeviceConfig.h>
+
+#if !(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF1 || CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF2 ||                           \
+      CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID == 0xFFF3)
+
+namespace chip {
+namespace DevelopmentCerts {
+
+ByteSpan kDacCert;
+ByteSpan kDacPrivateKey;
+ByteSpan kDacPublicKey;
+ByteSpan kPaiCert;
+
+} // namespace DevelopmentCerts
+} // namespace chip
+
+#endif


### PR DESCRIPTION
#### Summary

When using a non-development VID (e.g., 0x1123) in CHIPProjectAppConfig.h, ExampleDACs.cpp and ExamplePAI.cpp conditional compilation guards exclude all cert definitions, causing linker errors from AndroidAppServerWrapper, TestHarnessDACProvider, and ExampleDACProvider which reference these symbols as fallback defaults.

Add DevelopmentCertsPlaceholder.cpp to tv-casting-common that provides empty ByteSpan definitions for kDacCert, kDacPrivateKey, kDacPublicKey, and kPaiCert when the VID is not 0xFFF1/0xFFF2/0xFFF3. The placeholder compiles to nothing for development VIDs, avoiding duplicate symbols.

Real DAC credentials are provided by platform-specific providers: DACProviderStub.java on Android and MCDeviceAttestationCredentialsProvider on Darwin.


#### Testing

Android, Linux and iOS builds