### PR TITLE
[nrfconnect] Support byte string type in user data entry

### DIFF
--- a/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
+++ b/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
@@ -99,7 +99,7 @@ class PartitionCreator:
         """
         output_dict = {}
         for entry in data:
-            if not isinstance(entry, dict):
+            if not isinstance(data[entry], dict):
                 log.debug("Processing entry '%s'", entry)
                 if isinstance(data[entry], str) and data[entry].startswith(HEX_PREFIX):
                     output_dict[entry] = codecs.decode(data[entry][len(HEX_PREFIX):], "hex")
@@ -108,7 +108,7 @@ class PartitionCreator:
                 else:
                     output_dict[entry] = data[entry]
             else:
-                output_dict[entry] = entry
+                output_dict[entry] = data[entry]
         return output_dict
 
     def _load_json(self):

--- a/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
+++ b/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
@@ -98,17 +98,17 @@ class PartitionCreator:
         If "key_value" of data entry is a dictionary, algorithm appends it to the created dictionary.
         """
         output_dict = {}
-        for entry in data:
-            if not isinstance(data[entry], dict):
-                log.debug("Processing entry '%s'", entry)
-                if isinstance(data[entry], str) and data[entry].startswith(HEX_PREFIX):
-                    output_dict[entry] = codecs.decode(data[entry][len(HEX_PREFIX):], "hex")
-                elif isinstance(data[entry], str):
-                    output_dict[entry] = data[entry].encode("utf-8")
+        for name, value in data.items():
+            if not isinstance(value, dict):
+                log.debug("Processing entry '%s'", name)
+                if isinstance(value, str) and value.startswith(HEX_PREFIX):
+                    output_dict[name] = codecs.decode(value[len(HEX_PREFIX):], "hex")
+                elif isinstance(value, str):
+                    output_dict[name] = value.encode("utf-8")
                 else:
-                    output_dict[entry] = data[entry]
+                    output_dict[name] = value
             else:
-                output_dict[entry] = data[entry]
+                output_dict[name] = value
         return output_dict
 
     def _load_json(self):

--- a/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
+++ b/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
@@ -90,25 +90,34 @@ class PartitionCreator:
     @staticmethod
     def _convert_to_dict(data):
         """
-        Converts a list containing tuples ("key_name", "key_value") to a dictionary
+        Converts dictionary of {"name": "value"} entries into a CBOR-encodable output dictionary.
 
-        If "key_value" of data entry is a string-type variable and contains a HEX_PREFIX algorithm decodes it
-        to hex format to be sure that a cbor file will contain proper bytes.
+        If "value" of data entry is a string-type variable and contains a HEX_PREFIX algorithm
+        decodes it to hex format to be sure that a cbor file will contain proper bytes.
 
-        If "key_value" of data entry is a dictionary, algorithm appends it to the created dictionary.
+        If "value" of data entry is a dictionary, algorithm appends it to the created dictionary
+        while decoding string-type fields with HEX_PREFIX to hex format / bytes.
         """
+        def is_hex(value) -> bool:
+            return isinstance(value, str) and value.startswith(HEX_PREFIX)
+
+        def hex_to_bytes(value) -> bytes:
+            return codecs.decode(value[len(HEX_PREFIX):], "hex")
+
         output_dict = {}
         for name, value in data.items():
             if not isinstance(value, dict):
                 log.debug("Processing entry '%s'", name)
-                if isinstance(value, str) and value.startswith(HEX_PREFIX):
-                    output_dict[name] = codecs.decode(value[len(HEX_PREFIX):], "hex")
+                if is_hex(value):
+                    output_dict[name] = hex_to_bytes(value)
                 elif isinstance(value, str):
                     output_dict[name] = value.encode("utf-8")
                 else:
                     output_dict[name] = value
             else:
-                output_dict[name] = value
+                output_dict[name] = {
+                    k: hex_to_bytes(v) if is_hex(v) else v for k, v in value.items()
+                }
         return output_dict
 
     def _load_json(self):

--- a/scripts/tools/nrfconnect/tests/test_generate_partition.py
+++ b/scripts/tools/nrfconnect/tests/test_generate_partition.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import cbor2 as cbor
+
+TOOLS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def generate_partition(data: dict) -> bytes:
+    """Generate partition and return content of partition binary file."""
+    with tempfile.TemporaryDirectory() as out_dir:
+        input_file = Path(out_dir) / "fd.json"
+        output_file_prefix = Path(out_dir) / "partition"
+
+        with open(input_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        subprocess.check_call(["python3",
+                               os.path.join(TOOLS_DIR, "nrfconnect_generate_partition.py"),
+                               "--offset", "0x0",
+                               "--size", "0x1000",
+                               "--input", input_file,
+                               "--output", output_file_prefix,
+                               "--raw"
+                               ])
+
+        with open(output_file_prefix.with_suffix(".bin"), "rb") as f:
+            return f.read()
+
+
+class TestPartitionCreatorConvertToDict(unittest.TestCase):
+
+    def test_hex_prefix_string_converted_to_bytes(self):
+        data = {"key": "hex:deadbeef"}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["key"], bytes([0xde, 0xad, 0xbe, 0xef]))
+
+    def test_plain_string_converted_to_utf8(self):
+        data = {"name": "hello"}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["name"], b"hello")
+
+    def test_integer_not_converted(self):
+        data = {"version": 42}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["version"], 42)
+
+    def test_nested_dict_hex_prefix_string_converted_to_bytes(self):
+        data = {"user": {"raw": "hex:cafe"}}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["user"]["raw"], bytes([0xca, 0xfe]))
+
+    def test_nested_dict_plain_string_not_converted(self):
+        data = {"user": {"name": "test"}}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["user"]["name"], "test")
+
+    def test_nested_dict_integer_not_converted(self):
+        data = {"user": {"value": 11}}
+        result = cbor.loads(generate_partition(data))
+        self.assertEqual(result["user"]["value"], 11)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -55,7 +55,7 @@ static bool DecodeEntry(zcbor_state_t * states, void * buffer, size_t bufferSize
     struct zcbor_string tempString;
     int32_t tempInt = 0;
 
-    // Try to decode entry as string
+    // Try to decode entry as text string
     bool res = zcbor_tstr_decode(states, &tempString);
     if (res)
     {
@@ -78,6 +78,19 @@ static bool DecodeEntry(zcbor_state_t * states, void * buffer, size_t bufferSize
         }
         memcpy(buffer, &tempInt, sizeof(tempInt));
         *outlen = sizeof(tempInt);
+        return res;
+    }
+
+    // Try to decode entry as byte string
+    res = zcbor_bstr_decode(states, &tempString);
+    if (res)
+    {
+        if (bufferSize < tempString.len)
+        {
+            return false;
+        }
+        memcpy(buffer, tempString.value, tempString.len);
+        *outlen = tempString.len;
         return res;
     }
 


### PR DESCRIPTION
#### Summary
Adds support for **byte string** type in user data entries of factory data.
Previously, only text string type and int32 type were supported.
This change enables a user to place arbitrary binary data into the user field of factory data.

#### Related issues

#### Testing
Manually tested.
Steps to reproduce:
1) Generated factory data with script `generate_nrfconnect_chip_factory_data.py` and argument `--user`:
```json
{
  "t": "aabbcc",
  "b": "hex:aabbcc",
  "i": 11
}
```
2) Generated partition with modified script `nrfconnect_generate_partition.py` and flashed to MCU
3) Used method `GetUserKey()` in firmware to read all three keys and print byte representation:
```bash
Key 't' success: Len: 6
61 61 62 62 63 63
Key 'b' success: Len: 3
aa bb cc
Key 'i' success: Len: 4
0b 00 00 00
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
