### PR TITLE
Suppress maybe uninitialized warning in ESP32C3 build

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1511,7 +1511,6 @@ Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, D
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
     uint16_t currentHue = 0;
-    DirectionEnum direction;
     if (isEnhanced)
     {
         Attributes::EnhancedCurrentHue::Get(endpoint, &currentHue);
@@ -1524,6 +1523,7 @@ Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, D
     }
 
     // Convert the ShortestDistance/LongestDistance moveDirection values into Up/Down.
+    DirectionEnum direction = moveDirection;
     switch (moveDirection)
     {
     case DirectionEnum::kShortest:
@@ -1550,7 +1550,6 @@ Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, D
         break;
     case DirectionEnum::kUp:
     case DirectionEnum::kDown:
-        direction = moveDirection;
         break;
     case DirectionEnum::kUnknownEnumValue:
         return Status::InvalidCommand;


### PR DESCRIPTION
#### Summary

When compiling application for ESP32-C3 with default CFLAGS there is a maybe-uninitialized warning which breaks compilation with `-Werror`:

```
src/app/clusters/color-control-server/color-control-server.cpp:1591:58: error: 'direction' may be used uninitialized [-Werror=maybe-uninitialized]
 1591 |     colorHueTransitionState->up             = (direction == DirectionEnum::kUp);
      |                                               ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
src/app/clusters/color-control-server/color-control-server.cpp:1514:19: note: 'direction' was declared here
 1514 |     DirectionEnum direction;
      |                   ^~~~~~~~~
```

#### Testing

Tested locally that the warning is gone.