### PR TITLE
Replace buildjet runner with ubuntu-latest

### DIFF
--- a/.github/workflows/buildjet-cache-delete.yaml
+++ b/.github/workflows/buildjet-cache-delete.yaml
@@ -8,7 +8,7 @@ on:
         type: string
 jobs:
   manually-delete-buildjet-cache:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
#### Summary

Buildjet for github actions have been removed as of Mar 31, 2026:

https://buildjet.com/for-github-actions/blog/we-are-shutting-down

#### Testing

Trivial change. Existing runners are known hanging, like https://github.com/project-chip/connectedhomeip/actions/runs/24081479174/job/70242977575