### PR TITLE
Fix --matter-file-name option in zap/generate.py

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -128,22 +128,21 @@ def detectZclFile(zapFile):
     prefix_chip_root_dir = True
     path = DEFAULT_DATA_MODEL_DESCRIPTION_FILE
 
-    if zapFile:
-        with open(zapFile) as f:
-            data = json.load(f)
-        for package in data["package"]:
-            if package["type"] != "zcl-properties":
-                continue
+    with open(zapFile) as f:
+        data = json.load(f)
+    for package in data["package"]:
+        if package["type"] != "zcl-properties":
+            continue
 
-            prefix_chip_root_dir = (package["pathRelativity"] != "resolveEnvVars")
-            # found the right path, try to figure out the actual path
-            if package["pathRelativity"] == "relativeToZap":
-                path = os.path.abspath(os.path.join(
-                    os.path.dirname(zapFile), package["path"]))
-            elif package["pathRelativity"] == "resolveEnvVars":
-                path = os.path.expandvars(package["path"])
-            else:
-                path = package["path"]
+        prefix_chip_root_dir = (package["pathRelativity"] != "resolveEnvVars")
+        # found the right path, try to figure out the actual path
+        if package["pathRelativity"] == "relativeToZap":
+            path = os.path.abspath(os.path.join(
+                os.path.dirname(zapFile), package["path"]))
+        elif package["pathRelativity"] == "resolveEnvVars":
+            path = os.path.expandvars(package["path"])
+        else:
+            path = package["path"]
 
     return getFilePath(path, prefix_chip_root_dir)
 
@@ -158,7 +157,7 @@ def runArgumentsParser() -> CmdLineArgs:
 
     parser = argparse.ArgumentParser(
         description='Generate artifacts from .zapt templates')
-    parser.add_argument('zap', help='path to the application .zap file')
+    parser.add_argument('zap', nargs="?", help='path to the application .zap file')
     parser.add_argument('-t', '--templates', metavar='FILE', default=default_templates,
                         help='path to the .zapt templates records to use for generating artifacts (default: %(default)s)')
     parser.add_argument('-z', '--zcl', metavar='FILE',
@@ -198,8 +197,10 @@ def runArgumentsParser() -> CmdLineArgs:
 
     if args.zcl:
         zcl_file = getFilePath(args.zcl)
-    else:
+    elif zap_file:
         zcl_file = detectZclFile(zap_file)
+    else:
+        zcl_file = getFilePath(DEFAULT_DATA_MODEL_DESCRIPTION_FILE)
 
     templates_file = getFilePath(args.templates)
     output_dir = getDirPath(output_dir)

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -205,9 +205,11 @@ def runArgumentsParser() -> CmdLineArgs:
     output_dir = getDirPath(output_dir)
 
     if args.matter_file_name:
-        matter_file_name = getFilePath(args.matter_file_name)
+        matter_file_name = args.matter_file_name
     else:
-        matter_file_name = None
+        # If the .matter file is going to be generated, place it next to
+        # the source .zap file (the same name but with .matter extension).
+        matter_file_name = matterPathFromZapPath(zap_file)
 
     return CmdLineArgs(
         zap_file, zcl_file, templates_file, output_dir, args.run_bootstrap,
@@ -236,15 +238,13 @@ def matterPathFromZapPath(zap_config_path):
 
 def extractGeneratedIdl(output_dir, matter_name):
     """Find a file Clusters.matter in the output directory and
-       place it along with the input zap file.
+       move it to matter_name.
 
        Intent is to make the "zap content" more humanly understandable.
     """
     idl_path = os.path.join(output_dir, "Clusters.matter")
-    if not os.path.exists(idl_path):
-        return
-
-    shutil.move(idl_path, matter_name)
+    if os.path.exists(idl_path):
+        shutil.move(idl_path, matter_name)
 
 
 def runGeneration(cmdLineArgs):
@@ -282,12 +282,7 @@ def runGeneration(cmdLineArgs):
             raise
 
     if cmdLineArgs.matter_file_name:
-        matter_name = cmdLineArgs.matter_file_name
-    else:
-        matter_name = matterPathFromZapPath(zap_file)
-
-    if matter_name:
-        extractGeneratedIdl(output_dir, matter_name)
+        extractGeneratedIdl(output_dir, cmdLineArgs.matter_file_name)
 
 
 def expandPlaceholderWildcards(path: str) -> Generator[str, None, None]:

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -158,35 +158,28 @@ def runArgumentsParser() -> CmdLineArgs:
 
     parser = argparse.ArgumentParser(
         description='Generate artifacts from .zapt templates')
-    parser.add_argument('zap', nargs="?", default=None, help='Path to the application .zap file')
-    parser.add_argument('-t', '--templates', default=default_templates,
-                        help='Path to the .zapt templates records to use for generating artifacts (default: "' + default_templates + '")')
-    parser.add_argument('-z', '--zcl',
-                        help='Path to the zcl templates records to use for generating artifacts (default: autodetect read from zap file)')
-    parser.add_argument('-o', '--output-dir', default=None,
-                        help='Output directory for the generated files (default: a temporary directory in out)')
-    parser.add_argument('-m', '--matter-file-name', default=None,
-                        help='Where to copy any generated .matter file')
-    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+    parser.add_argument('zap', help='path to the application .zap file')
+    parser.add_argument('-t', '--templates', metavar='FILE', default=default_templates,
+                        help='path to the .zapt templates records to use for generating artifacts (default: %(default)s)')
+    parser.add_argument('-z', '--zcl', metavar='FILE',
+                        help='path to the zcl templates records to use for generating artifacts (default: read from the .zap)')
+    parser.add_argument('-o', '--output-dir', metavar='DIR',
+                        help='output directory for the generated files (default: a temporary directory in out)')
+    parser.add_argument('-m', '--matter-file-name', metavar='FILE',
+                        help='move generated .matter file to the destination FILE (default: next to the source .zap)')
+    parser.add_argument('--run-bootstrap', action='store_true',
                         help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
-    parser.add_argument('--parallel', action='store_true')
-    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
-    parser.add_argument('--lock-file', help='serialize zap invocations by using the specified lock file.')
-    parser.add_argument('--prettify-output', action='store_true')
-    parser.add_argument('--no-prettify-output',
-                        action='store_false', dest='prettify_output')
-    parser.add_argument('--version-check', action='store_true')
-    parser.add_argument('--no-version-check',
-                        action='store_false', dest='version_check')
-    parser.add_argument('--retries', help='Retry running zap-cli in case of failure', default=1, type=int)
+    parser.add_argument('--parallel', action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument('--lock-file', metavar='FILE',
+                        help='serialize zap invocations by using the specified lock file')
+    parser.add_argument('--prettify-output', action=argparse.BooleanOptionalAction, default=True,
+                        help='run code prettifier (e.g. clang-format) on generated output (default: %(default)s)')
+    parser.add_argument('--version-check', action=argparse.BooleanOptionalAction, default=True,
+                        help='check zap version before running (default: %(default)s)')
+    parser.add_argument('--retries', type=int, metavar='NUM', default=1,
+                         help='retry running zap-cli in case of failure (default: %(default)s)')
     parser.add_argument('--keep-output-dir', action='store_true',
                         help='Keep any created output directory. Useful for temporary directories.')
-    parser.set_defaults(parallel=True)
-    parser.set_defaults(prettify_output=True)
-    parser.set_defaults(version_check=True)
-    parser.set_defaults(lock_file=None)
-    parser.set_defaults(keep_output_dir=False)
-    parser.set_defaults(matter_file_name=None)
     args = parser.parse_args()
 
     delete_output_dir = False

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -177,7 +177,7 @@ def runArgumentsParser() -> CmdLineArgs:
     parser.add_argument('--version-check', action=argparse.BooleanOptionalAction, default=True,
                         help='check zap version before running (default: %(default)s)')
     parser.add_argument('--retries', type=int, metavar='NUM', default=1,
-                         help='retry running zap-cli in case of failure (default: %(default)s)')
+                        help='retry running zap-cli in case of failure (default: %(default)s)')
     parser.add_argument('--keep-output-dir', action='store_true',
                         help='Keep any created output directory. Useful for temporary directories.')
     args = parser.parse_args()

--- a/scripts/tools/zap/update_cluster_revisions.py
+++ b/scripts/tools/zap/update_cluster_revisions.py
@@ -71,10 +71,7 @@ def runArgumentsParser():
                         help='If set, only clusters with this old revision will be updated.  This is a decimal integer.')
     parser.add_argument('--dry-run', default=False, action='store_true',
                         help="Don't do any generation, just log what .zap files would be updated (default: False)")
-    parser.add_argument('--parallel', action='store_true')
-    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
-    parser.set_defaults(parallel=True)
-
+    parser.add_argument('--parallel', action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args()
 
     if args.cluster_id is None:

--- a/scripts/tools/zap_convert_all.py
+++ b/scripts/tools/zap_convert_all.py
@@ -63,14 +63,10 @@ def getTargets():
 def runArgumentsParser():
     parser = argparse.ArgumentParser(
         description='Convert all .zap files to the current zap version')
-    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+    parser.add_argument('--run-bootstrap', action='store_true',
                         help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
-    parser.add_argument('--parallel', action='store_true')
-    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
-    parser.add_argument('--dry-run', action='store_true', dest='dry_run')
-    parser.set_defaults(parallel=True)
-    parser.set_defaults(dry_run=False)
-
+    parser.add_argument('--parallel', action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument('--dry-run', action=argparse.BooleanOptionalAction, default=False)
     return parser.parse_args()
 
 

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -314,12 +314,8 @@ def setupArgumentsParser():
                         help="Don't do any generation, just log what targets would be generated (default: False)")
     parser.add_argument('--run-bootstrap', default=None, action='store_true',
                         help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
-
-    parser.add_argument('--parallel', action='store_true')
-    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
-    parser.add_argument('--no-rerun-in-env', action='store_false', dest='rerun_in_env')
-    parser.set_defaults(parallel=True, rerun_in_env=True)
-
+    parser.add_argument('--parallel', action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument('--rerun-in-env', action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args()
 
     # Convert a list of target_types (as strings)


### PR DESCRIPTION
It's not possible to copy .matter file to a desired location:

```console
$ scripts/tools/zap/generate.py --matter-file-name here.matter examples/lighting-app/lighting-common/lighting-app.zap
Searching for zcl file from /home/a.bokowy/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.zap
Error: /home/a.bokowy/connectedhomeip/here.matter does not exists or is not a file.
```

Also, since Python 3.9 it is possible to use `BooleanOptionalAction` instead of manually defining yes/no options, so this PR simplifies option parser setup in all Matter SDK files where `parser.set_defaults` has been used.

#### Testing

```console
$ scripts/tools/zap/generate.py --matter-file-name here.matter examples/lighting-app/lighting-common/lighting-app.zap
Searching for zcl file from /home/a.bokowy/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.zap
...
Generation time: 925ms
$ ls here.matter
here.matter
```