### PR TITLE
Add Base85 encoding / decoding functions to the support library

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -251,6 +251,8 @@ static_library("support") {
     "AutoRelease.h",
     "Base64.cpp",
     "Base64.h",
+    "Base85.cpp",
+    "Base85.h",
     "BitFlags.h",
     "BitMask.h",
     "BufferReader.cpp",

--- a/src/lib/support/Base85.cpp
+++ b/src/lib/support/Base85.cpp
@@ -1,0 +1,219 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Base-85 utility functions (RFC 1924 alphabet, git/Python compatible).
+ */
+
+#include "Base85.h"
+
+#include <lib/support/CodeUtils.h>
+
+#include <stdint.h>
+#include <string.h>
+
+namespace chip {
+
+// RFC 1924 alphabet: 0-9 A-Z a-z !#$%&()*+-;<=>?@^_`{|}~
+// Values 0-9 map to '0'-'9', 10-35 to 'A'-'Z', 36-61 to 'a'-'z',
+// and values 62-84 map to the 23 punctuation characters below.
+
+// Convert a value in the range 0..84 to its RFC 1924 base85 character.
+static char Base85ValToChar(uint8_t val)
+{
+    switch (val)
+    {
+    // clang-format off
+    case 62: return '!';
+    case 63: return '#';
+    case 64: return '$';
+    case 65: return '%';
+    case 66: return '&';
+    case 67: return '(';
+    case 68: return ')';
+    case 69: return '*';
+    case 70: return '+';
+    case 71: return '-';
+    case 72: return ';';
+    case 73: return '<';
+    case 74: return '=';
+    case 75: return '>';
+    case 76: return '?';
+    case 77: return '@';
+    case 78: return '^';
+    case 79: return '_';
+    case 80: return '`';
+    case 81: return '{';
+    case 82: return '|';
+    case 83: return '}';
+    case 84: return '~';
+    // clang-format on
+    default:
+        if (val < 10)
+        {
+            return static_cast<char>('0' + val);
+        }
+        if (10 <= val && val < 36)
+        {
+            return static_cast<char>('A' + val - 10);
+        }
+        if (36 <= val && val < 62)
+        {
+            return static_cast<char>('a' + val - 36);
+        }
+    }
+    return 0; // not possible
+}
+
+// Convert an RFC 1924 base85 character to a value in the range 0..84,
+// or UINT8_MAX if the character is not in the alphabet.
+static uint8_t Base85CharToVal(char c)
+{
+    switch (c)
+    {
+    // clang-format off
+    case '!': return 62;
+    case '#': return 63;
+    case '$': return 64;
+    case '%': return 65;
+    case '&': return 66;
+    case '(': return 67;
+    case ')': return 68;
+    case '*': return 69;
+    case '+': return 70;
+    case '-': return 71;
+    case ';': return 72;
+    case '<': return 73;
+    case '=': return 74;
+    case '>': return 75;
+    case '?': return 76;
+    case '@': return 77;
+    case '^': return 78;
+    case '_': return 79;
+    case '`': return 80;
+    case '{': return 81;
+    case '|': return 82;
+    case '}': return 83;
+    case '~': return 84;
+    // clang-format on
+    default:
+        if (c >= '0' && c <= '9')
+        {
+            return static_cast<uint8_t>(c - '0');
+        }
+        if (c >= 'A' && c <= 'Z')
+        {
+            return static_cast<uint8_t>(c - 'A' + 10);
+        }
+        if (c >= 'a' && c <= 'z')
+        {
+            return static_cast<uint8_t>(c - 'a' + 36);
+        }
+    }
+    return UINT8_MAX;
+}
+
+static uint32_t ReadGroup(const uint8_t * src, size_t count)
+{
+    uint8_t padded[4] = { 0 };
+    memcpy(padded, src, count);
+    return (static_cast<uint32_t>(padded[0]) << 24) | //
+        (static_cast<uint32_t>(padded[1]) << 16) |    //
+        (static_cast<uint32_t>(padded[2]) << 8) |     //
+        (static_cast<uint32_t>(padded[3]));
+}
+
+static void WriteGroup(uint32_t value, uint8_t * dest, size_t count)
+{
+    uint8_t decoded[4] = {
+        static_cast<uint8_t>(value >> 24),
+        static_cast<uint8_t>(value >> 16),
+        static_cast<uint8_t>(value >> 8),
+        static_cast<uint8_t>(value),
+    };
+    memcpy(dest, decoded, count);
+}
+
+static bool DecodeGroup(const char * src, size_t count, uint32_t & outValue)
+{
+    // "|NsC0" is the largest allowed group value (UINT32_MAX); we could
+    // check against this value here directly, but it is simpler to do the
+    // calculation in a uint64_t and validate the decoded result.
+    uint64_t value = 0;
+    for (size_t j = 0; j < count; j++)
+    {
+        uint8_t digit = Base85CharToVal(src[j]);
+        VerifyOrReturnValue(digit != UINT8_MAX, false);
+        value = value * 85 + digit;
+    }
+    for (size_t j = count; j < 5; j++)
+    {
+        value = value * 85 + 84; // implicitly pad to 5 "digits" with '~' (84)
+    }
+    VerifyOrReturnValue(value <= UINT32_MAX, false);
+    outValue = static_cast<uint32_t>(value);
+    return true;
+}
+
+static void EncodeGroup(uint32_t value, char * out, size_t count)
+{
+    for (size_t j = 5; j-- > count;)
+    {
+        value /= 85; // truncate least significant "digits"
+    }
+    for (size_t j = count; j-- > 0;)
+    {
+        out[j] = Base85ValToChar(static_cast<uint8_t>(value % 85));
+        value /= 85;
+    }
+}
+
+CHIP_ERROR BytesToBase85(const uint8_t * src, size_t srcSize, char * dest, size_t destSize)
+{
+    VerifyOrReturnError(destSize >= Base85EncodedLength(srcSize), CHIP_ERROR_BUFFER_TOO_SMALL);
+    while (srcSize > 0)
+    {
+        size_t count   = srcSize >= 4 ? 4 : srcSize;
+        uint32_t value = ReadGroup(src, count);
+        src += count;
+        srcSize -= count;
+        EncodeGroup(value, dest, count + 1);
+        dest += count + 1;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Base85ToBytes(const char * src, size_t srcSize, uint8_t * dest, size_t destSize)
+{
+    VerifyOrReturnError(destSize >= Base85DecodedLength(srcSize), CHIP_ERROR_BUFFER_TOO_SMALL);
+    while (srcSize > 0)
+    {
+        VerifyOrReturnError(srcSize != 1, CHIP_ERROR_INVALID_ARGUMENT); // 1 character can't encode anything
+        size_t count = srcSize >= 5 ? 5 : srcSize;
+        uint32_t value;
+        VerifyOrReturnError(DecodeGroup(src, count, value), CHIP_ERROR_INVALID_ARGUMENT);
+        src += count;
+        srcSize -= count;
+        WriteGroup(value, dest, count - 1);
+        dest += count - 1;
+    }
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/lib/support/Base85.cpp
+++ b/src/lib/support/Base85.cpp
@@ -23,9 +23,6 @@
 
 #include "Base85.h"
 
-#include <lib/support/CodeUtils.h>
-
-#include <stdint.h>
 #include <string.h>
 
 namespace chip {
@@ -186,32 +183,48 @@ static void EncodeGroup(uint32_t value, char * out, size_t count)
 
 CHIP_ERROR BytesToBase85(const uint8_t * src, size_t srcSize, char * dest, size_t destSize)
 {
-    VerifyOrReturnError(destSize >= Base85EncodedLength(srcSize), CHIP_ERROR_BUFFER_TOO_SMALL);
-    while (srcSize > 0)
+    VerifyOrReturnError(src != nullptr || srcSize == 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(dest != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    // Base85EncodedLength(srcSize) could overflow / saturate to SIZE_MAX,
+    // checking via Base85DecodedLength(destSize) instead avoids this issue.
+    VerifyOrReturnError(Base85DecodedLength(destSize) >= srcSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    size_t remainder = srcSize % 4;
+    for (auto * end = src + (srcSize - remainder); src < end; src += 4, dest += 5)
     {
-        size_t count   = srcSize >= 4 ? 4 : srcSize;
-        uint32_t value = ReadGroup(src, count);
-        src += count;
-        srcSize -= count;
-        EncodeGroup(value, dest, count + 1);
-        dest += count + 1;
+        EncodeGroup(ReadGroup(src, 4), dest, 5);
+    }
+    if (remainder > 0)
+    {
+        EncodeGroup(ReadGroup(src, remainder), dest, remainder + 1);
     }
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Base85ToBytes(const char * src, size_t srcSize, uint8_t * dest, size_t destSize)
 {
+    VerifyOrReturnError(src != nullptr || srcSize == 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(dest != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(destSize >= Base85DecodedLength(srcSize), CHIP_ERROR_BUFFER_TOO_SMALL);
-    while (srcSize > 0)
+
+    uint32_t value;
+    size_t remainder = srcSize % 5;
+    VerifyOrReturnError(remainder != 1, CHIP_ERROR_INVALID_ARGUMENT); // 1 "digit" does not encode a full byte
+    for (auto * end = src + (srcSize - remainder); src < end; src += 5, dest += 4)
     {
-        VerifyOrReturnError(srcSize != 1, CHIP_ERROR_INVALID_ARGUMENT); // 1 character can't encode anything
-        size_t count = srcSize >= 5 ? 5 : srcSize;
-        uint32_t value;
-        VerifyOrReturnError(DecodeGroup(src, count, value), CHIP_ERROR_INVALID_ARGUMENT);
-        src += count;
-        srcSize -= count;
-        WriteGroup(value, dest, count - 1);
-        dest += count - 1;
+        VerifyOrReturnError(DecodeGroup(src, 5, value), CHIP_ERROR_INVALID_ARGUMENT);
+        WriteGroup(value, dest, 4);
+    }
+    if (remainder > 0) // 2..4
+    {
+        VerifyOrReturnError(DecodeGroup(src, remainder, value), CHIP_ERROR_INVALID_ARGUMENT);
+
+        char check[4];
+        uint32_t padding = UINT32_MAX >> (8 * (remainder - 1));
+        EncodeGroup(value & ~padding, check, remainder);
+        VerifyOrReturnError(memcmp(src, check, remainder) == 0, CHIP_ERROR_INVALID_ARGUMENT);
+
+        WriteGroup(value, dest, remainder - 1); // might clobber src
     }
     return CHIP_NO_ERROR;
 }

--- a/src/lib/support/Base85.h
+++ b/src/lib/support/Base85.h
@@ -23,6 +23,8 @@
  *      Compatible with Python's base64.b85encode / b85decode (RFC 1924 alphabet).
  *      Generally, blocks of 4 bytes are encoded into 5 characters, but arbitrary
  *      input lengths are supported via internal padding and truncation of the last block.
+ *
+ *      Note: Unlike Pythons b85decode, this decoder rejects non-canonical encodings.
  */
 
 #pragma once
@@ -36,19 +38,24 @@
 namespace chip {
 
 /**
- * Returns the Base85 encoded length for a given input length.
- */
-constexpr size_t Base85EncodedLength(size_t inputLength)
-{
-    return (inputLength / 4) * 5 + (inputLength % 4 ? inputLength % 4 + 1 : 0);
-}
-
-/**
  * Returns the decoded length for a given Base85 encoded length.
  */
 constexpr size_t Base85DecodedLength(size_t encodedLength)
 {
-    return (encodedLength / 5) * 4 + (encodedLength % 5 ? encodedLength % 5 - 1 : 0);
+    const size_t remainder = encodedLength % 5;
+    return (encodedLength / 5) * 4 + (remainder ? remainder - 1 : 0);
+}
+
+/**
+ * Returns the Base85 encoded length for a given input length, or SIZE_MAX
+ * if inputLength would require an encoded size longer than SIZE_MAX.
+ */
+constexpr size_t Base85EncodedLength(size_t inputLength)
+{
+    constexpr size_t maxInputLength = Base85DecodedLength(SIZE_MAX);
+    VerifyOrReturnValue(inputLength < maxInputLength, SIZE_MAX);
+    const size_t remainder = inputLength % 4;
+    return (inputLength / 4) * 5 + (remainder ? remainder + 1 : 0);
 }
 
 /**
@@ -59,20 +66,26 @@ constexpr size_t Base85DecodedLength(size_t encodedLength)
  * @param dest      Output buffer for the encoded string.
  * @param destSize  Size of the output buffer (must be >= Base85EncodedLength(srcSize)).
  *
+ * Note: src and dest must not overlap
+ *
  * @retval CHIP_ERROR_BUFFER_TOO_SMALL if the output buffer is too small.
  */
 CHIP_ERROR BytesToBase85(const uint8_t * src, size_t srcSize, char * dest, size_t destSize);
 
 /**
- * Decode a Base85 string to bytes. Supports decode in place (dest == src).
+ * Decode a Base85 string to bytes.
  *
  * @param src       Input Base85 string.
  * @param srcSize   Length of the input string.
  * @param dest      Output buffer for decoded bytes.
  * @param destSize  Size of the output buffer (must be >= Base85DecodedLength(srcSize)).
  *
+ * Note: src and dest must not overlap, except for the special case of
+ * in-place decoding (dest == src), which is supported.
+ *
  * @retval CHIP_ERROR_BUFFER_TOO_SMALL if the output buffer is too small.
- * @retval CHIP_ERROR_INVALID_ARGUMENT if the input contains invalid characters or has an invalid length.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT if the input contains invalid characters, has an
+ *                                     invalid length, or invalid (non-canonical) padding.
  */
 CHIP_ERROR Base85ToBytes(const char * src, size_t srcSize, uint8_t * dest, size_t destSize);
 

--- a/src/lib/support/Base85.h
+++ b/src/lib/support/Base85.h
@@ -1,0 +1,109 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Base-85 utility functions.
+ *
+ *      Compatible with Python's base64.b85encode / b85decode (RFC 1924 alphabet).
+ *      Generally, blocks of 4 bytes are encoded into 5 characters, but arbitrary
+ *      input lengths are supported via internal padding and truncation of the last block.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace chip {
+
+/**
+ * Returns the Base85 encoded length for a given input length.
+ */
+constexpr size_t Base85EncodedLength(size_t inputLength)
+{
+    return (inputLength / 4) * 5 + (inputLength % 4 ? inputLength % 4 + 1 : 0);
+}
+
+/**
+ * Returns the decoded length for a given Base85 encoded length.
+ */
+constexpr size_t Base85DecodedLength(size_t encodedLength)
+{
+    return (encodedLength / 5) * 4 + (encodedLength % 5 ? encodedLength % 5 - 1 : 0);
+}
+
+/**
+ * Encode bytes to a Base85 string. The output will NOT be null-terminated.
+ *
+ * @param src       Input bytes to encode.
+ * @param srcSize   Number of input bytes.
+ * @param dest      Output buffer for the encoded string.
+ * @param destSize  Size of the output buffer (must be >= Base85EncodedLength(srcSize)).
+ *
+ * @retval CHIP_ERROR_BUFFER_TOO_SMALL if the output buffer is too small.
+ */
+CHIP_ERROR BytesToBase85(const uint8_t * src, size_t srcSize, char * dest, size_t destSize);
+
+/**
+ * Decode a Base85 string to bytes. Supports decode in place (dest == src).
+ *
+ * @param src       Input Base85 string.
+ * @param srcSize   Length of the input string.
+ * @param dest      Output buffer for decoded bytes.
+ * @param destSize  Size of the output buffer (must be >= Base85DecodedLength(srcSize)).
+ *
+ * @retval CHIP_ERROR_BUFFER_TOO_SMALL if the output buffer is too small.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT if the input contains invalid characters or has an invalid length.
+ */
+CHIP_ERROR Base85ToBytes(const char * src, size_t srcSize, uint8_t * dest, size_t destSize);
+
+// Legacy API compatible with Base64Encode / Base64Decode.
+
+inline uint16_t Base85Encode(const uint8_t * in, uint16_t inLen, char * out)
+{
+    size_t outLen = Base85EncodedLength(inLen);
+    VerifyOrReturnValue(outLen < UINT16_MAX && BytesToBase85(in, inLen, out, outLen) == CHIP_NO_ERROR, UINT16_MAX);
+    return static_cast<uint16_t>(outLen);
+}
+
+inline uint16_t Base85Decode(const char * in, uint16_t inLen, uint8_t * out)
+{
+    size_t outLen = Base85DecodedLength(inLen);
+    VerifyOrReturnValue(outLen < UINT16_MAX && Base85ToBytes(in, inLen, out, outLen) == CHIP_NO_ERROR, UINT16_MAX);
+    return static_cast<uint16_t>(outLen);
+}
+
+inline uint32_t Base85Encode32(const uint8_t * in, uint32_t inLen, char * out)
+{
+    size_t outLen = Base85EncodedLength(inLen);
+    VerifyOrReturnValue(outLen < UINT32_MAX && BytesToBase85(in, inLen, out, outLen) == CHIP_NO_ERROR, UINT32_MAX);
+    return static_cast<uint32_t>(outLen);
+}
+
+inline uint32_t Base85Decode32(const char * in, uint32_t inLen, uint8_t * out)
+{
+    size_t outLen = Base85DecodedLength(inLen);
+    VerifyOrReturnValue(outLen < UINT32_MAX && Base85ToBytes(in, inLen, out, outLen) == CHIP_NO_ERROR, UINT32_MAX);
+    return static_cast<uint32_t>(outLen);
+}
+
+} // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -32,6 +32,7 @@ chip_test_suite("tests") {
 
   test_sources = [
     "TestAutoRelease.cpp",
+    "TestBase85.cpp",
     "TestBitMask.cpp",
     "TestBufferReader.cpp",
     "TestBufferWriter.cpp",

--- a/src/lib/support/tests/TestBase85.cpp
+++ b/src/lib/support/tests/TestBase85.cpp
@@ -1,0 +1,118 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/support/Base85.h>
+#include <lib/support/Span.h>
+
+#include <string.h>
+
+using namespace chip;
+
+namespace {
+
+struct TestVector
+{
+    ByteSpan input;
+    const char * encoded;
+};
+
+// Helper: create a ByteSpan from a string literal (excluding the null terminator).
+// This lets us write test vector inputs using hex escape sequences that
+// work in C++ (BYTES("\x01\x02\x03")) and Python (b"\x01\x02\x03").
+// Note: All bytes should be hex-escaped since C++ \x can consume more than two digits.
+#define BYTES(literal) ByteSpan(reinterpret_cast<const uint8_t *>(literal), sizeof("" literal) - 1)
+
+// To verify: python3 -c 'import base64; print(base64.b85encode(b"<input>").decode())'
+const TestVector kTestVectors[] = {
+    { BYTES(""), "" },
+    { BYTES("\x01"), "0R" },
+    { BYTES("\xca\xfe"), "%Ki" },
+    { BYTES("\xde\xad\xbe"), "-mSg" },
+    { BYTES("\xde\xad\xbe\xef"), "-mSjx" },
+    { BYTES("\x00\x00\x00\x00"), "00000" },
+    { BYTES("\xff\xff\xff\xff"), "|NsC0" },
+    { BYTES("\x01\x02\x03\x04\x05"), "0RjUA1p" },
+    { BYTES("\x48\x65\x6c\x6c\x6f\x21\x21\x21"), "NM&qnZy_Ne" },
+    { BYTES("\x49\x92\xdb\x53\xe5\xf6\xbf\x40\x9c\xd1"), "Ns`-B<@UcooY4" },
+    { BYTES("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13"), "009C61O)~M2nh-c3=Iws5D^j+" },
+    { BYTES("\x00\x2f\xdc\x0a\x6e\x3d\x4d\xb0\x02\x4c\x04\xee\xcf\xd5\xa3\xfc\xdf\x93\xa4\xdd\xef\x51\xa5\xbe\xff\x0f\x8a"),
+      "059AMZaqz~0!#$%&()*+-;<=>?@^_`{||}" },
+};
+
+TEST(TestBase85, EncodeTestVectors)
+{
+    for (const auto & tv : kTestVectors)
+    {
+        size_t expectedLen = strlen(tv.encoded);
+        EXPECT_EQ(Base85EncodedLength(tv.input.size()), expectedLen);
+
+        char output[40];
+        ASSERT_EQ(BytesToBase85(tv.input.data(), tv.input.size(), output, sizeof(output)), CHIP_NO_ERROR);
+        EXPECT_EQ(strncmp(output, tv.encoded, expectedLen), 0);
+    }
+}
+
+TEST(TestBase85, DecodeTestVectors)
+{
+    for (const auto & tv : kTestVectors)
+    {
+        size_t encodedLen = strlen(tv.encoded);
+        EXPECT_EQ(Base85DecodedLength(encodedLen), tv.input.size());
+
+        // Decode in place
+        uint8_t buf[40];
+        memcpy(buf, tv.encoded, encodedLen);
+        ASSERT_EQ(Base85ToBytes(reinterpret_cast<const char *>(buf), encodedLen, buf, sizeof(buf)), CHIP_NO_ERROR);
+        EXPECT_EQ(memcmp(buf, tv.input.data(), tv.input.size()), 0);
+    }
+}
+
+TEST(TestBase85, EncodeBufferTooSmall)
+{
+    const uint8_t input[4] = { 1, 2, 3, 4 };
+    char output[4]; // needs 5
+    EXPECT_EQ(BytesToBase85(input, sizeof(input), output, sizeof(output)), CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
+TEST(TestBase85, DecodeInvalidCharacters)
+{
+    uint8_t decoded[4];
+    EXPECT_EQ(Base85ToBytes("0 000", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(Base85ToBytes("00\\00", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(Base85ToBytes("123\x7F_", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(TestBase85, DecodeInvalidLength)
+{
+    uint8_t decoded[8];
+    EXPECT_EQ(Base85ToBytes("0", 1, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(Base85ToBytes("AAAAA0", 6, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(TestBase85, DecodeOverflow)
+{
+    uint8_t decoded[4];
+    // "~~~~~" decodes to 85^5 - 1 = 4,437,053,124 which exceeds UINT32_MAX
+    EXPECT_EQ(Base85ToBytes("~~~~~", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    // "|NsC1" is one past the maximum valid encoding "|NsC0" (0xFFFFFFFF)
+    EXPECT_EQ(Base85ToBytes("|NsC1", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+} // namespace

--- a/src/lib/support/tests/TestBase85.cpp
+++ b/src/lib/support/tests/TestBase85.cpp
@@ -65,7 +65,7 @@ TEST(TestBase85, EncodeTestVectors)
 
         char output[40];
         ASSERT_EQ(BytesToBase85(tv.input.data(), tv.input.size(), output, sizeof(output)), CHIP_NO_ERROR);
-        EXPECT_EQ(strncmp(output, tv.encoded, expectedLen), 0);
+        EXPECT_EQ(memcmp(output, tv.encoded, expectedLen), 0);
     }
 }
 
@@ -99,11 +99,14 @@ TEST(TestBase85, DecodeInvalidCharacters)
     EXPECT_EQ(Base85ToBytes("123\x7F_", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
-TEST(TestBase85, DecodeInvalidLength)
+TEST(TestBase85, DecodeNonCanonical)
 {
     uint8_t decoded[8];
+    // A remainder group of 1 "digit" would be pure padding that does not encode a complete byte
     EXPECT_EQ(Base85ToBytes("0", 1, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
     EXPECT_EQ(Base85ToBytes("AAAAA0", 6, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    // "0S" naively decodes to "\x01", but the canonical encoding is "0R"
+    EXPECT_EQ(Base85ToBytes("0S", 2, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 TEST(TestBase85, DecodeOverflow)
@@ -113,6 +116,21 @@ TEST(TestBase85, DecodeOverflow)
     EXPECT_EQ(Base85ToBytes("~~~~~", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
     // "|NsC1" is one past the maximum valid encoding "|NsC0" (0xFFFFFFFF)
     EXPECT_EQ(Base85ToBytes("|NsC1", 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(TestBase85, NullArguments)
+{
+    char encoded[8];
+    uint8_t decoded[8];
+    // null src with zero size is OK
+    EXPECT_EQ(BytesToBase85(nullptr, 0, encoded, sizeof(encoded)), CHIP_NO_ERROR);
+    EXPECT_EQ(Base85ToBytes(nullptr, 0, decoded, sizeof(decoded)), CHIP_NO_ERROR);
+    // null src with nonzero size is an error
+    EXPECT_EQ(BytesToBase85(nullptr, 1, encoded, sizeof(encoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(Base85ToBytes(nullptr, 5, decoded, sizeof(decoded)), CHIP_ERROR_INVALID_ARGUMENT);
+    // null dest is always an error
+    EXPECT_EQ(BytesToBase85(decoded, 0, nullptr, 0), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(Base85ToBytes(encoded, 0, nullptr, 0), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

Add Base85 encoding / decoding functions to the support library.

These functions are not used yet, this is a preliminary change for a use case where Base64 is not compact enough to stay under the 32 byte limit for persistent storage keys.

#### Testing

Added comprehensive unit test.