### PR TITLE
[Silabs] Updating the docker container to v2026.6.2 SiSDK and 4.0.1 Wiseconnect

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -41,7 +41,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-efr32:190
+      image: ghcr.io/project-chip/chip-build-efr32:191
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -64,7 +64,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:181
+            image: ghcr.io/project-chip/chip-build-efr32:191
         steps:
             - name: Checkout
               uses: actions/checkout@v6

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -543,9 +543,7 @@ template("efr32_sdk") {
     }
 
     if (defined(invoker.chip_enable_thread) && invoker.chip_enable_thread) {
-      defines += [
-        "SL_OT_ENABLE=1",
-      ]
+      defines += [ "SL_OT_ENABLE=1" ]
     }
 
     if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -545,19 +545,6 @@ template("efr32_sdk") {
     if (defined(invoker.chip_enable_thread) && invoker.chip_enable_thread) {
       defines += [
         "SL_OT_ENABLE=1",
-
-        #TODO: Remove these defines once sl_openthread_rtos_config is included in sl_ot_rtos_adaptation.c
-        "SL_OPENTHREAD_RTOS_STACK_TASK_PRIORITY=24",
-        "SL_OPENTHREAD_RTOS_APP_TASK_PRIORITY=23",
-        "SL_OPENTHREAD_RTOS_CLI_TASK_PRIORITY=16",
-        "SL_OPENTHREAD_STACK_TASK_MEM_SIZE=4608",
-        "SL_OPENTHREAD_APP_TASK_MEM_SIZE=4608",
-        "SL_OPENTHREAD_CLI_TASK_MEM_SIZE=2048",
-        "SL_OPENTHREAD_RTOS_CLI_TASK_PRIORITY=16",
-        "SL_OPENTHREAD_OS_CLI_TASK_SIZE=2048",
-        "SL_OPENTHREAD_ENABLE_APP_TASK=0",
-        "SL_OPENTHREAD_ENABLE_CLI_TASK=0",
-        "SL_OPENTHREAD_ENABLE_SERIAL_TASK=0",
       ]
     }
 


### PR DESCRIPTION
#### Summary
Updating the docker image to 191 which have the latest versions of 
SiSDK -> v2026.6.2
Wiseconnect -> 4.0.1

#### Related issues
NA

#### Testing
CI

