### PR TITLE
Allow more types in TLV data in onboarding payloads

### DIFF
--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR SetupPayloadGenerateQRCodeCommand::PopulatePayloadTLVFromBytes(SetupP
             return CHIP_ERROR_WRONG_TLV_TYPE;
         }
 
-        // Vendor tag.  We support strings and signed integers.
+        // Vendor tag.  We support strings and integers.
         if (reader.GetType() == TLV::kTLVType_UTF8String)
         {
             CharSpan data;
@@ -195,7 +195,15 @@ CHIP_ERROR SetupPayloadGenerateQRCodeCommand::PopulatePayloadTLVFromBytes(SetupP
 
         if (reader.GetType() == TLV::kTLVType_SignedInteger)
         {
-            int32_t value;
+            int64_t value;
+            ReturnErrorOnFailure(reader.Get(value));
+            ReturnErrorOnFailure(payload.addOptionalVendorData(tagNum, value));
+            continue;
+        }
+
+        if (reader.GetType() == TLV::kTLVType_UnsignedInteger)
+        {
+            uint64_t value;
             ReturnErrorOnFailure(reader.Get(value));
             ReturnErrorOnFailure(payload.addOptionalVendorData(tagNum, value));
             continue;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -22,6 +22,7 @@
 #include <setup_payload/QRCodeSetupPayloadParser.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <inttypes.h>
 #include <string>
 
 using namespace ::chip;
@@ -168,8 +169,8 @@ CHIP_ERROR SetupPayloadParseCommand::Print(const SetupPayload & payload)
             [&](const std::string & v) {
                 ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", info.tag, v.c_str());
             },
-            [&](int64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%i", info.tag, v); },
-            [&](uint64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", info.tag, v); });
+            [&](int64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%" PRId64, info.tag, v); },
+            [&](uint64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%" PRIu64, info.tag, v); });
     }
 
     return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -164,18 +164,12 @@ CHIP_ERROR SetupPayloadParseCommand::Print(const SetupPayload & payload)
     std::vector<OptionalQRCodeInfo> optionalVendorData = payload.getAllOptionalVendorData();
     for (const OptionalQRCodeInfo & info : optionalVendorData)
     {
-        bool isTypeString = info.type == optionalQRCodeInfoTypeString;
-        bool isTypeInt32  = info.type == optionalQRCodeInfoTypeInt32;
-        VerifyOrReturnError(isTypeString || isTypeInt32, CHIP_ERROR_INVALID_ARGUMENT);
-
-        if (isTypeString)
-        {
-            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", info.tag, info.data.c_str());
-        }
-        else
-        {
-            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", info.tag, info.int32);
-        }
+        info.visitValue(
+            [&](const std::string & v) {
+                ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", tag, v.c_str());
+            },
+            [&](int64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%i", tag, v); },
+            [&](uint64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", tag, v); });
     }
 
     return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -166,10 +166,10 @@ CHIP_ERROR SetupPayloadParseCommand::Print(const SetupPayload & payload)
     {
         info.visitValue(
             [&](const std::string & v) {
-                ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", tag, v.c_str());
+                ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", info.tag, v.c_str());
             },
-            [&](int64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%i", tag, v); },
-            [&](uint64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", tag, v); });
+            [&](int64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%i", info.tag, v); },
+            [&](uint64_t v) { ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", info.tag, v); });
     }
 
     return CHIP_NO_ERROR;

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -125,18 +125,8 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
     if (payload.serialNumber) {
         NSLog(@"SerialNumber: %@", payload.serialNumber);
     }
-    NSError * error;
-    NSArray<MTROptionalQRCodeInfo *> * optionalVendorData = [payload getAllOptionalVendorData:&error];
-    if (error) {
-        LogNSError("Error: ", error);
-        return CHIP_ERROR_INTERNAL;
-    }
-    for (const MTROptionalQRCodeInfo * info : optionalVendorData) {
-        bool isTypeString = (info.type == MTROptionalQRCodeInfoTypeString);
-        bool isTypeInt32 = (info.type == MTROptionalQRCodeInfoTypeInt32);
-        VerifyOrReturnError(isTypeString || isTypeInt32, CHIP_ERROR_INVALID_ARGUMENT);
-
-        if (isTypeString) {
+    for (const MTROptionalQRCodeInfo * info : [payload vendorElements]) {
+        if (info.type == MTROptionalQRCodeInfoTypeString) {
             NSLog(@"OptionalQRCodeInfo: tag=%@,string value=%@", info.tag, info.stringValue);
         } else {
             NSLog(@"OptionalQRCodeInfo: tag=%@,int value=%@", info.tag, info.integerValue);

--- a/src/controller/python/matter/setup_payload/Parser.cpp
+++ b/src/controller/python/matter/setup_payload/Parser.cpp
@@ -58,11 +58,9 @@ void YieldSetupPayloadAttributes(const SetupPayload & payload, AttributeVisitor 
 
     for (const OptionalQRCodeInfo & info : payload.getAllOptionalVendorData())
     {
-        if (info.type == optionalQRCodeInfoTypeString)
-            vendorAttrVisitor(info.tag, info.data.c_str());
-
-        if (info.type == optionalQRCodeInfoTypeInt32)
-            vendorAttrVisitor(info.tag, std::to_string(info.int32).c_str());
+        info.visitValue([&](const std::string & v) { vendorAttrVisitor(info.tag, v.c_str()); },
+                        [&](int64_t v) { vendorAttrVisitor(info.tag, std::to_string(v).c_str()); },
+                        [&](uint64_t v) { vendorAttrVisitor(info.tag, std::to_string(v).c_str()); });
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -43,10 +43,13 @@ typedef NS_ENUM(NSUInteger, MTRCommissioningFlow) {
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
-    MTROptionalQRCodeInfoTypeUnknown MTR_DEPRECATED(
-        "The type is never actually unknown", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4)),
+    MTROptionalQRCodeInfoTypeUnknown MTR_DEPRECATED("The type is never actually unknown", ios(16.1, 16.4), macos(13.0, 13.3),
+                                                    watchos(9.1, 9.4), tvos(16.1, 16.4)),
     MTROptionalQRCodeInfoTypeString,
-    MTROptionalQRCodeInfoTypeInt32,
+    MTROptionalQRCodeInfoTypeInt32 MTR_DEPRECATED_WITH_REPLACEMENT("MTROptionalQRCodeInfoTypeSignedInt", ios(16.1, 26.0), macos(13.0, 26.0),
+                                                    watchos(9.1, 26.0), tvos(16.1, 26.0)),
+    MTROptionalQRCodeInfoTypeSignedInt,
+    MTROptionalQRCodeInfoTypeUnsignedInt,
 };
 
 /**
@@ -72,7 +75,19 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Initializes the object with a tag and int32 value.
  * The tag must be in the range 0x80 - 0xFF.
  */
-- (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
+- (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value MTR_DEPRECATED_WITH_REPLACEMENT("initWithTag:int64:", ios(17.6, 26.0), macos(14.6, 26.0), watchos(10.6, 26.0), tvos(17.6, 26.0));
+
+/**
+ * Initializes the object with a tag and int64 value.
+ * The tag must be in the range 0x80 - 0xFF.
+ */
+- (instancetype)initWithTag:(NSNumber *)tag int64Value:(int64_t)value MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+
+/**
+ * Initializes the object with a tag and uint64 value.
+ * The tag must be in the range 0x80 - 0xFF.
+ */
+- (instancetype)initWithTag:(NSNumber *)tag uint64Value:(uint64_t)value MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
 
 @property (nonatomic, readonly, assign) MTROptionalQRCodeInfoType type MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -44,13 +44,13 @@ typedef NS_ENUM(NSUInteger, MTRCommissioningFlow) {
 
 typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
     MTROptionalQRCodeInfoTypeUnknown MTR_DEPRECATED("The type is never actually unknown", ios(16.1, 16.4), macos(13.0, 13.3),
-                                                    watchos(9.1, 9.4), tvos(16.1, 16.4)),
+        watchos(9.1, 9.4), tvos(16.1, 16.4)),
     MTROptionalQRCodeInfoTypeString,
-    MTROptionalQRCodeInfoTypeInt32 MTR_DEPRECATED_WITH_REPLACEMENT("MTROptionalQRCodeInfoTypeSignedInt", ios(16.1, 26.0), macos(13.0, 26.0),
-                                                    watchos(9.1, 26.0), tvos(16.1, 26.0)),
-    MTROptionalQRCodeInfoTypeSignedInt,
-    MTROptionalQRCodeInfoTypeUnsignedInt,
-};
+    MTROptionalQRCodeInfoTypeInt32 MTR_DEPRECATED_WITH_REPLACEMENT("MTROptionalQRCodeInfoTypeSignedInt", ios(16.1, 27.0), macos(13.0, 27.0),
+        watchos(9.1, 27.0), tvos(16.1, 27.0)),
+    MTROptionalQRCodeInfoTypeSignedInt MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0)),
+    MTROptionalQRCodeInfoTypeUnsignedInt MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0)),
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 /**
  * An optional information item present in the setup payload.
@@ -75,19 +75,19 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Initializes the object with a tag and int32 value.
  * The tag must be in the range 0x80 - 0xFF.
  */
-- (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value MTR_DEPRECATED_WITH_REPLACEMENT("initWithTag:int64:", ios(17.6, 26.0), macos(14.6, 26.0), watchos(10.6, 26.0), tvos(17.6, 26.0));
+- (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value MTR_DEPRECATED_WITH_REPLACEMENT("initWithTag:int64:", ios(17.6, 27.0), macos(14.6, 27.0), watchos(10.6, 27.0), tvos(17.6, 27.0));
 
 /**
  * Initializes the object with a tag and int64 value.
  * The tag must be in the range 0x80 - 0xFF.
  */
-- (instancetype)initWithTag:(NSNumber *)tag int64Value:(int64_t)value MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+- (instancetype)initWithTag:(NSNumber *)tag int64Value:(int64_t)value MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0));
 
 /**
  * Initializes the object with a tag and uint64 value.
  * The tag must be in the range 0x80 - 0xFF.
  */
-- (instancetype)initWithTag:(NSNumber *)tag uint64Value:(uint64_t)value MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+- (instancetype)initWithTag:(NSNumber *)tag uint64Value:(uint64_t)value MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0));
 
 @property (nonatomic, readonly, assign) MTROptionalQRCodeInfoType type MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -118,15 +118,14 @@ static uint8_t ValidateVendorTag(NSNumber * tag)
 
 - (NSUInteger)hash
 {
-    return _info->value.index() << 8 | _info->tag;
+    return _info->hash();
 }
 
 - (BOOL)isEqual:(id)object
 {
     VerifyOrReturnValue([object class] == [self class], NO);
     MTROptionalQRCodeInfo * other = object;
-    VerifyOrReturnValue(_info->tag == other->_info->tag, NO);
-    return _info->value == other->_info->value;
+    return _info == other->_info;
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -33,7 +33,7 @@
 
 MTR_DIRECT_MEMBERS
 @implementation MTROptionalQRCodeInfo {
-    chip::OptionalQRCodeInfo _info;
+    std::optional<chip::OptionalQRCodeInfo> _info;
 }
 
 static uint8_t ValidateVendorTag(NSNumber * tag)
@@ -46,20 +46,28 @@ static uint8_t ValidateVendorTag(NSNumber * tag)
 
 - (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value
 {
+    return [self initWithTag:tag int64Value:value];
+}
+
+- (instancetype)initWithTag:(NSNumber *)tag int64Value:(int64_t)value
+{
     self = [super init];
-    _info.type = chip::optionalQRCodeInfoTypeInt32;
-    _info.tag = ValidateVendorTag(tag);
-    _info.int32 = value;
+    _info.emplace(ValidateVendorTag(tag), value);
+    return self;
+}
+
+- (instancetype)initWithTag:(NSNumber *)tag uint64Value:(uint64_t)value
+{
+    self = [super init];
+    _info.emplace(ValidateVendorTag(tag), value);
     return self;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag stringValue:(NSString *)value
 {
     self = [super init];
-    _info.type = chip::optionalQRCodeInfoTypeString;
-    _info.tag = ValidateVendorTag(tag);
     MTRVerifyArgumentOrDie(value != nil, @"value");
-    _info.data = value.UTF8String;
+    _info.emplace(ValidateVendorTag(tag), std::string(value.UTF8String));
     return self;
 }
 
@@ -68,62 +76,39 @@ static uint8_t ValidateVendorTag(NSNumber * tag)
     self = [super init];
     _info = info;
     // Don't expose objects with an out-of-range tag or invalid type
-    VerifyOrReturnValue(chip::SetupPayload::IsVendorTag(_info.tag), nil);
-    VerifyOrReturnValue(self.type != MTROptionalQRCodeInfoTypeUnknown, nil);
+    VerifyOrReturnValue(chip::SetupPayload::IsVendorTag(_info->tag), nil);
     return self;
 }
 
 - (CHIP_ERROR)addAsVendorElementTo:(chip::SetupPayload &)payload
 {
-    switch (_info.type) {
-    case chip::optionalQRCodeInfoTypeString:
-        return payload.addOptionalVendorData(_info.tag, _info.data);
-    case chip::optionalQRCodeInfoTypeInt32:
-        return payload.addOptionalVendorData(_info.tag, _info.int32);
-    default:
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
+    return payload.addOptionalVendorData(_info.value());
 }
 
 - (MTROptionalQRCodeInfoType)type
 {
-    // The way OptionalQRCodeInfo uses what are effectively C type identifiers (uint32 etc)
-    // rather than TLV types is not ideal. If we add support for additional integer types
-    // we should consider replacing MTROptionalQRCodeInfoTypeInt32 with
-    // MTROptionalQRCodeInfoTypeInteger and hiding the low-level C representation.
-    switch (_info.type) {
-    case chip::optionalQRCodeInfoTypeString:
-        return MTROptionalQRCodeInfoTypeString;
-    case chip::optionalQRCodeInfoTypeInt32:
-        return MTROptionalQRCodeInfoTypeInt32;
-    // No 'default:' so we get a warning if new types are added.
-    // Note: isEqual: also switches over these types.
-    // OptionalQRCodeInfo does not support these types
-    case chip::optionalQRCodeInfoTypeInt64:
-    case chip::optionalQRCodeInfoTypeUInt32:
-    case chip::optionalQRCodeInfoTypeUInt64:
-    // We should never see the unknown type
-    case chip::optionalQRCodeInfoTypeUnknown:
-        /* fall through */;
-    }
-    return MTROptionalQRCodeInfoTypeUnknown;
+    return _info->visitValue([](const std::string &) { return MTROptionalQRCodeInfoTypeString; },
+        [](int64_t) { return MTROptionalQRCodeInfoTypeSignedInt; },
+        [](uint64_t) { return MTROptionalQRCodeInfoTypeUnsignedInt; });
 }
 
 - (NSNumber *)tag
 {
-    return @(_info.tag);
+    return @(_info->tag);
 }
 
 - (NSNumber *)integerValue
 {
-    VerifyOrReturnValue(_info.type == chip::optionalQRCodeInfoTypeInt32, nil);
-    return @(_info.int32);
+    return _info->visitValue([](const std::string &) -> NSNumber * { return nil; },
+        [](int64_t v) -> NSNumber * { return @(v); },
+        [](uint64_t v) -> NSNumber * { return @(v); });
 }
 
 - (NSString *)stringValue
 {
-    VerifyOrReturnValue(_info.type == chip::optionalQRCodeInfoTypeString, nil);
-    return [NSString stringWithUTF8String:_info.data.c_str()];
+    return _info->visitValue([](const std::string & v) -> NSString * { return [NSString stringWithUTF8String:v.c_str()]; },
+        [](int64_t) -> NSString * { return nil; },
+        [](uint64_t) -> NSString * { return nil; });
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -133,23 +118,15 @@ static uint8_t ValidateVendorTag(NSNumber * tag)
 
 - (NSUInteger)hash
 {
-    return _info.type << 8 | _info.tag;
+    return _info->value.index() << 8 | _info->tag;
 }
 
 - (BOOL)isEqual:(id)object
 {
     VerifyOrReturnValue([object class] == [self class], NO);
     MTROptionalQRCodeInfo * other = object;
-    VerifyOrReturnValue(_info.tag == other->_info.tag, NO);
-    VerifyOrReturnValue(_info.type == other->_info.type, NO);
-    switch (_info.type) {
-    case chip::optionalQRCodeInfoTypeString:
-        return _info.data == other->_info.data;
-    case chip::optionalQRCodeInfoTypeInt32:
-        return _info.int32 == other->_info.int32;
-    default:
-        return NO; // unreachable, type is checked in init
-    }
+    VerifyOrReturnValue(_info->tag == other->_info->tag, NO);
+    return _info->value == other->_info->value;
 }
 
 - (NSString *)description
@@ -503,9 +480,9 @@ MTR_DIRECT_MEMBERS
 
 - (MTROptionalQRCodeInfo *)vendorElementWithTag:(NSNumber *)tag
 {
-    chip::OptionalQRCodeInfo element;
-    VerifyOrReturnValue(_payload.getOptionalVendorData(ValidateVendorTag(tag), element) == CHIP_NO_ERROR, nil);
-    return [[MTROptionalQRCodeInfo alloc] initWithQRCodeInfo:element];
+    std::optional<chip::OptionalQRCodeInfo> element = _payload.getOptionalVendorData(ValidateVendorTag(tag));
+    VerifyOrReturnValue(element.has_value(), nil);
+    return [[MTROptionalQRCodeInfo alloc] initWithQRCodeInfo:element.value()];
 }
 
 - (void)removeVendorElementWithTag:(NSNumber *)tag

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -97,14 +97,14 @@ static uint8_t ValidateVendorTag(NSNumber * tag)
     return @(_info->tag);
 }
 
-- (NSNumber *)integerValue
+- (nullable NSNumber *)integerValue
 {
     return _info->visitValue([](const std::string &) -> NSNumber * { return nil; },
         [](int64_t v) -> NSNumber * { return @(v); },
         [](uint64_t v) -> NSNumber * { return @(v); });
 }
 
-- (NSString *)stringValue
+- (nullable NSString *)stringValue
 {
     return _info->visitValue([](const std::string & v) -> NSString * { return [NSString stringWithUTF8String:v.c_str()]; },
         [](int64_t) -> NSString * { return nil; },
@@ -478,7 +478,7 @@ MTR_DIRECT_MEMBERS
     return infos;
 }
 
-- (MTROptionalQRCodeInfo *)vendorElementWithTag:(NSNumber *)tag
+- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(NSNumber *)tag
 {
     std::optional<chip::OptionalQRCodeInfo> element = _payload.getOptionalVendorData(ValidateVendorTag(tag));
     VerifyOrReturnValue(element.has_value(), nil);

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -165,7 +165,7 @@
 {
     NSError * error;
     MTRSetupPayload * payload =
-        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23I71Q7SMTC1WISA0DK5N1K8SQ1RYCU1O0"
                                                      error:&error];
 
     XCTAssertNotNil(payload);
@@ -183,22 +183,27 @@
 
     NSArray<MTROptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];
     XCTAssertNil(error);
-    XCTAssertEqual([vendorOptionalInfo count], 2);
+    XCTAssertEqual([vendorOptionalInfo count], 3);
     for (MTROptionalQRCodeInfo * info in vendorOptionalInfo) {
         if (info.tag.intValue == 130) {
             XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeString);
             XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeString);
             XCTAssertTrue([info.stringValue isEqualToString:@"myData"]);
         } else if (info.tag.intValue == 131) {
-            XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeInt32);
-            XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeInt32);
-            XCTAssertEqual(info.integerValue.intValue, 12);
+            XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeSignedInt);
+            XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeSignedInt);
+            XCTAssertEqual(info.integerValue.intValue, -12);
+        } else if (info.tag.intValue == 132) {
+            XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeUnsignedInt);
+            XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeUnsignedInt);
+            XCTAssertEqual(info.integerValue.intValue, 42);
         }
     }
 
     // Test access by tag
     XCTAssertEqualObjects([payload vendorElementWithTag:@130].stringValue, @"myData");
-    XCTAssertEqualObjects([payload vendorElementWithTag:@131].integerValue, @12);
+    XCTAssertEqualObjects([payload vendorElementWithTag:@131].integerValue, @-12);
+    XCTAssertEqualObjects([payload vendorElementWithTag:@132].integerValue, @42);
 }
 
 - (void)testAddVendorElement

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -74,59 +74,17 @@ static CHIP_ERROR populateTLVBits(uint8_t * bits, size_t & offset, const uint8_t
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR writeTag(TLV::TLVWriter & writer, TLV::Tag tag, OptionalQRCodeInfo & info)
+CHIP_ERROR writeTag(TLV::TLVWriter & writer, TLV::Tag tag, const OptionalQRCodeInfo & info)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    if (info.type == optionalQRCodeInfoTypeString)
-    {
-        err = writer.PutString(tag, info.data.c_str());
-    }
-    else if (info.type == optionalQRCodeInfoTypeInt32)
-    {
-        err = writer.Put(tag, info.int32);
-    }
-    else
-    {
-        err = CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    return err;
-}
-
-CHIP_ERROR writeTag(TLV::TLVWriter & writer, TLV::Tag tag, OptionalQRCodeInfoExtension & info)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    if (info.type == optionalQRCodeInfoTypeString || info.type == optionalQRCodeInfoTypeInt32)
-    {
-        err = writeTag(writer, tag, static_cast<OptionalQRCodeInfo &>(info));
-    }
-    else if (info.type == optionalQRCodeInfoTypeInt64)
-    {
-        err = writer.Put(tag, info.int64);
-    }
-    else if (info.type == optionalQRCodeInfoTypeUInt32)
-    {
-        err = writer.Put(tag, info.uint32);
-    }
-    else if (info.type == optionalQRCodeInfoTypeUInt64)
-    {
-        err = writer.Put(tag, info.uint64);
-    }
-    else
-    {
-        err = CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    return err;
+    return info.visitValue([&](const std::string & v) { return writer.PutString(tag, v.c_str()); },
+                           [&](int64_t v) { return writer.Put(tag, v); }, [&](uint64_t v) { return writer.Put(tag, v); });
 }
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart,
                                                                     uint32_t maxLen, size_t & tlvDataLengthInBytes)
 {
-    std::vector<OptionalQRCodeInfo> optionalData                   = outPayload.getAllOptionalVendorData();
-    std::vector<OptionalQRCodeInfoExtension> optionalExtensionData = outPayload.getAllOptionalExtensionData();
+    std::vector<OptionalQRCodeInfo> optionalData          = outPayload.getAllOptionalVendorData();
+    std::vector<OptionalQRCodeInfo> optionalExtensionData = outPayload.getAllOptionalExtensionData();
     VerifyOrReturnError(!optionalData.empty() || !optionalExtensionData.empty(), CHIP_NO_ERROR);
 
     TLV::TLVWriter rootWriter;
@@ -136,12 +94,12 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload
 
     ReturnErrorOnFailure(rootWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, innerStructureWriter));
 
-    for (OptionalQRCodeInfo info : optionalData)
+    for (const OptionalQRCodeInfo & info : optionalData)
     {
         ReturnErrorOnFailure(writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info));
     }
 
-    for (OptionalQRCodeInfoExtension info : optionalExtensionData)
+    for (const OptionalQRCodeInfo & info : optionalExtensionData)
     {
         ReturnErrorOnFailure(writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info));
     }
@@ -231,18 +189,21 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase38RepresentationWithAutoTLVBu
         // Each data item needs a control byte and a context tag.
         size_t size = 2;
 
-        if (item.type == optionalQRCodeInfoTypeString)
-        {
-            // We'll need to encode the string length and then the string data.
-            // Length is at most 8 bytes.
-            size += 8;
-            size += item.data.size();
-        }
-        else
-        {
-            // Integer.  Assume it might need up to 8 bytes, for simplicity.
-            size += 8;
-        }
+        size += item.visitValue(
+            [](const std::string & v) -> size_t {
+                // We'll need to encode the string length and then the string data.
+                // Length is at most 8 bytes.
+                return 8 + v.size();
+            },
+            [](int64_t) -> size_t {
+                // Integer.  Assume it might need up to 8 bytes, for simplicity.
+                return 8;
+            },
+            [](uint64_t) -> size_t {
+                // Integer.  Assume it might need up to 8 bytes, for simplicity.
+                return 8;
+            });
+
         return size;
     };
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -23,6 +23,7 @@
 
 #include "QRCodeSetupPayloadParser.h"
 #include "Base38Decode.h"
+#include "SetupPayload.h"
 
 #include <algorithm>
 #include <string.h>
@@ -77,111 +78,6 @@ static CHIP_ERROR openTLVContainer(TLV::ContiguousBufferTLVReader & reader, TLV:
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR retrieveOptionalInfoString(TLV::ContiguousBufferTLVReader & reader, OptionalQRCodeInfo & info)
-{
-    Span<const char> data;
-    ReturnErrorOnFailure(reader.GetStringView(data));
-
-    info.type = optionalQRCodeInfoTypeString;
-    info.data = std::string(data.data(), data.size());
-
-    return CHIP_NO_ERROR;
-}
-
-static CHIP_ERROR retrieveOptionalInfoInt32(TLV::TLVReader & reader, OptionalQRCodeInfo & info)
-{
-    int32_t value;
-    ReturnErrorOnFailure(reader.Get(value));
-
-    info.type  = optionalQRCodeInfoTypeInt32;
-    info.int32 = value;
-
-    return CHIP_NO_ERROR;
-}
-
-static CHIP_ERROR retrieveOptionalInfoInt64(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
-{
-    int64_t value;
-    ReturnErrorOnFailure(reader.Get(value));
-
-    info.type  = optionalQRCodeInfoTypeInt64;
-    info.int64 = value;
-
-    return CHIP_NO_ERROR;
-}
-
-static CHIP_ERROR retrieveOptionalInfoUInt32(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
-{
-    uint32_t value;
-    ReturnErrorOnFailure(reader.Get(value));
-
-    info.type   = optionalQRCodeInfoTypeUInt32;
-    info.uint32 = value;
-
-    return CHIP_NO_ERROR;
-}
-
-static CHIP_ERROR retrieveOptionalInfoUInt64(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
-{
-    uint64_t value;
-    ReturnErrorOnFailure(reader.Get(value));
-
-    info.type   = optionalQRCodeInfoTypeUInt64;
-    info.uint64 = value;
-
-    return CHIP_NO_ERROR;
-}
-
-static CHIP_ERROR retrieveOptionalInfo(TLV::ContiguousBufferTLVReader & reader, OptionalQRCodeInfo & info,
-                                       optionalQRCodeInfoType type)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    if (type == optionalQRCodeInfoTypeString)
-    {
-        err = retrieveOptionalInfoString(reader, info);
-    }
-    else if (type == optionalQRCodeInfoTypeInt32)
-    {
-        err = retrieveOptionalInfoInt32(reader, info);
-    }
-    else
-    {
-        err = CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    return err;
-}
-
-static CHIP_ERROR retrieveOptionalInfo(TLV::ContiguousBufferTLVReader & reader, OptionalQRCodeInfoExtension & info,
-                                       optionalQRCodeInfoType type)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    if (type == optionalQRCodeInfoTypeString || type == optionalQRCodeInfoTypeInt32)
-    {
-        err = retrieveOptionalInfo(reader, static_cast<OptionalQRCodeInfo &>(info), type);
-    }
-    else if (type == optionalQRCodeInfoTypeInt64)
-    {
-        err = retrieveOptionalInfoInt64(reader, info);
-    }
-    else if (type == optionalQRCodeInfoTypeUInt32)
-    {
-        err = retrieveOptionalInfoUInt32(reader, info);
-    }
-    else if (type == optionalQRCodeInfoTypeUInt64)
-    {
-        err = retrieveOptionalInfoUInt64(reader, info);
-    }
-    else
-    {
-        err = CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    return err;
-}
-
 CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPayload, TLV::ContiguousBufferTLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -198,31 +94,36 @@ CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPay
         VerifyOrReturnError(TLV::IsContextTag(tag), CHIP_ERROR_INVALID_TLV_TAG);
         const uint8_t tagNumber = static_cast<uint8_t>(TLV::TagNumFromTag(tag));
 
-        optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
+        std::optional<OptionalQRCodeInfo> info;
         if (type == TLV::kTLVType_UTF8String)
         {
-            elemType = optionalQRCodeInfoTypeString;
+            Span<const char> data;
+            ReturnErrorOnFailure(reader.GetStringView(data));
+
+            info.emplace(tagNumber, std::string(data.data(), data.size()));
         }
-        if (type == TLV::kTLVType_SignedInteger || type == TLV::kTLVType_UnsignedInteger)
+        else if (type == TLV::kTLVType_SignedInteger)
         {
-            elemType = outPayload.getNumericTypeFor(tagNumber);
+            int64_t value;
+            ReturnErrorOnFailure(reader.Get(value));
+
+            info.emplace(tagNumber, value);
+        }
+        else if (type == TLV::kTLVType_UnsignedInteger)
+        {
+            uint64_t value;
+            ReturnErrorOnFailure(reader.Get(value));
+
+            info.emplace(tagNumber, value);
         }
 
         if (SetupPayload::IsCommonTag(tagNumber))
         {
-            OptionalQRCodeInfoExtension info;
-            info.tag = tagNumber;
-            ReturnErrorOnFailure(retrieveOptionalInfo(reader, info, elemType));
-
-            ReturnErrorOnFailure(outPayload.addOptionalExtensionData(info));
+            ReturnErrorOnFailure(outPayload.addOptionalExtensionData(info.value()));
         }
         else
         {
-            OptionalQRCodeInfo info;
-            info.tag = tagNumber;
-            ReturnErrorOnFailure(retrieveOptionalInfo(reader, info, elemType));
-
-            ReturnErrorOnFailure(outPayload.addOptionalVendorData(info));
+            ReturnErrorOnFailure(outPayload.addOptionalVendorData(info.value()));
         }
         err = reader.Next();
     }

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -228,36 +228,69 @@ CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)
     return CHIP_NO_ERROR;
 }
 
+namespace {
+
+enum class ValueType
+{
+    String,
+    SignedInt,
+    UnsignedInt,
+};
+
+bool contains(const std::vector<ValueType> & vector, ValueType value)
+{
+    return std::find(vector.cbegin(), vector.cend(), value) != vector.cend();
+}
+
+bool isValidValueForCommonTag(const OptionalQRCodeInfo & info)
+{
+    static const std::map<uint8_t, std::vector<ValueType>> knownCommonTags = {
+        { kSerialNumberTag, { ValueType::String, ValueType::UnsignedInt } },
+        { kPBKDFIterationsTag, { ValueType::UnsignedInt } },
+        { kPBKFSaltTag, { ValueType::String } },
+        { kNumberOFDevicesTag, { ValueType::UnsignedInt } },
+        { kCommissioningTimeoutTag, { ValueType::UnsignedInt } }
+    };
+
+    const auto & knownTag = knownCommonTags.find(info.tag);
+
+    // We're lenient for tags that are reserved for future use, for forward-compatibility reasons.
+    if (knownTag == knownCommonTags.cend())
+    {
+        return true;
+    }
+
+    const auto & validTypes = knownTag->second;
+    return info.visitValue([&](const std::string &) { return contains(validTypes, ValueType::String); },
+                           [&](int64_t) { return contains(validTypes, ValueType::SignedInt); },
+                           [&](uint64_t v) {
+                               if (!contains(validTypes, ValueType::UnsignedInt))
+                               {
+                                   return false;
+                               }
+                               if (info.tag == kSerialNumberTag)
+                               {
+                                   return CanCastTo<uint32_t>(v);
+                               }
+                               if (info.tag == kPBKDFIterationsTag)
+                               {
+                                   return Crypto::kSpake2p_Min_PBKDF_Iterations <= v && v <= Crypto::kSpake2p_Max_PBKDF_Iterations;
+                               }
+                               if (info.tag == kNumberOFDevicesTag)
+                               {
+                                   return 0 < v && v <= 255;
+                               }
+                               return true;
+                           });
+}
+
+} // namespace
+
 CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfo & info)
 {
     VerifyOrReturnError(IsCommonTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
 
-    // We're lenient for tags that are reserved for future use, for forward-compatibility reasons.
-    bool validValue = info.visitValue(
-        [&](const std::string & v) {
-            return !(info.tag == kPBKDFIterationsTag || info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
-        },
-        [&](int64_t v) {
-            return !(info.tag == kSerialNumberTag || info.tag == kPBKDFIterationsTag || info.tag == kPBKFSaltTag ||
-                     info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
-        },
-        [&](uint64_t v) {
-            if (info.tag == kSerialNumberTag)
-            {
-                return CanCastTo<uint32_t>(v);
-            }
-            if (info.tag == kPBKDFIterationsTag)
-            {
-                return Crypto::kSpake2p_Min_PBKDF_Iterations <= v && v <= Crypto::kSpake2p_Max_PBKDF_Iterations;
-            }
-            if (info.tag == kNumberOFDevicesTag)
-            {
-                return 0 < v && v <= 255;
-            }
-            return info.tag != kPBKFSaltTag;
-        });
-    // It is not clearly specified whether this should return an error, or simply ignore.
-    VerifyOrReturnError(validValue, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(isValidValueForCommonTag(info), CHIP_ERROR_INVALID_ARGUMENT);
 
     optionalExtensionData.insert_or_assign(info.tag, info);
 

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -223,7 +223,7 @@ CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
 CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)
 {
     VerifyOrReturnError(IsVendorTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
-    optionalVendorData.emplace(info.tag, info);
+    optionalVendorData.insert_or_assign(info.tag, info);
 
     return CHIP_NO_ERROR;
 }
@@ -238,7 +238,7 @@ CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfo & inf
             return !(info.tag == kPBKDFIterationsTag || info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
         },
         [&](int64_t v) {
-            return !(info.tag == kSerialNumberTag || info.tag == kPBKDFIterationsTag || info.tag == kBPKFSaltTag ||
+            return !(info.tag == kSerialNumberTag || info.tag == kPBKDFIterationsTag || info.tag == kPBKFSaltTag ||
                      info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
         },
         [&](uint64_t v) {
@@ -254,12 +254,12 @@ CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfo & inf
             {
                 return 0 < v && v <= 255;
             }
-            return info.tag != kBPKFSaltTag;
+            return info.tag != kPBKFSaltTag;
         });
     // It is not clearly specified whether this should return an error, or simply ignore.
     VerifyOrReturnError(validValue, CHIP_ERROR_INVALID_ARGUMENT);
 
-    optionalExtensionData.emplace(info.tag, info);
+    optionalExtensionData.insert_or_assign(info.tag, info);
 
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -30,6 +30,7 @@
 #include <lib/core/TLVData.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 #include <setup_payload/ManualSetupPayloadParser.h>
 #include <setup_payload/QRCodeSetupPayloadParser.h>
 #include <utility>
@@ -125,22 +126,17 @@ bool PayloadContents::operator==(const PayloadContents & input) const
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, std::string data)
 {
-    OptionalQRCodeInfo info;
-    info.tag  = tag;
-    info.type = optionalQRCodeInfoTypeString;
-    info.data = std::move(data);
-
-    return addOptionalVendorData(info);
+    return addOptionalVendorData(OptionalQRCodeInfo{ tag, std::move(data) });
 }
 
-CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, int32_t data)
+CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, int64_t data)
 {
-    OptionalQRCodeInfo info;
-    info.tag   = tag;
-    info.type  = optionalQRCodeInfoTypeInt32;
-    info.int32 = data;
+    return addOptionalVendorData(OptionalQRCodeInfo{ tag, data });
+}
 
-    return addOptionalVendorData(info);
+CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, uint64_t data)
+{
+    return addOptionalVendorData(OptionalQRCodeInfo{ tag, data });
 }
 
 std::vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData() const
@@ -163,44 +159,29 @@ CHIP_ERROR SetupPayload::removeOptionalVendorData(uint8_t tag)
 
 CHIP_ERROR SetupPayload::addSerialNumber(std::string serialNumber)
 {
-    OptionalQRCodeInfoExtension info;
-    info.tag  = kSerialNumberTag;
-    info.type = optionalQRCodeInfoTypeString;
-    info.data = std::move(serialNumber);
-
-    return addOptionalExtensionData(info);
+    return addOptionalExtensionData(OptionalQRCodeInfo{ kSerialNumberTag, std::move(serialNumber) });
 }
 
 CHIP_ERROR SetupPayload::addSerialNumber(uint32_t serialNumber)
 {
-    OptionalQRCodeInfoExtension info;
-    info.tag    = kSerialNumberTag;
-    info.type   = optionalQRCodeInfoTypeUInt32;
-    info.uint32 = serialNumber;
-
-    return addOptionalExtensionData(info);
+    return addOptionalExtensionData(OptionalQRCodeInfo{ kSerialNumberTag, uint64_t(serialNumber) });
 }
 
 CHIP_ERROR SetupPayload::getSerialNumber(std::string & outSerialNumber) const
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    OptionalQRCodeInfoExtension info;
-    ReturnErrorOnFailure(getOptionalExtensionData(kSerialNumberTag, info));
+    std::optional<OptionalQRCodeInfo> info = getOptionalExtensionData(kSerialNumberTag);
+    VerifyOrReturnError(info.has_value(), CHIP_ERROR_KEY_NOT_FOUND);
 
-    switch (info.type)
-    {
-    case (optionalQRCodeInfoTypeString):
-        outSerialNumber = info.data;
-        break;
-    case (optionalQRCodeInfoTypeUInt32):
-        outSerialNumber = std::to_string(info.uint32);
-        break;
-    default:
-        err = CHIP_ERROR_INVALID_ARGUMENT;
-        break;
-    }
-
-    return err;
+    return info->visitValue(
+        [&](const std::string & v) {
+            outSerialNumber = v;
+            return CHIP_NO_ERROR;
+        },
+        [](int64_t) { return CHIP_ERROR_INVALID_ARGUMENT; },
+        [&](uint64_t v) {
+            outSerialNumber = std::to_string(v);
+            return CHIP_NO_ERROR;
+        });
 }
 
 CHIP_ERROR SetupPayload::removeSerialNumber()
@@ -242,55 +223,64 @@ CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
 CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)
 {
     VerifyOrReturnError(IsVendorTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
-    optionalVendorData[info.tag] = info;
+    optionalVendorData.emplace(info.tag, info);
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfoExtension & info)
+CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfo & info)
 {
     VerifyOrReturnError(IsCommonTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
-    optionalExtensionData[info.tag] = info;
+
+    // We're lenient for tags that are reserved for future use, for forward-compatibility reasons.
+    bool validValue = info.visitValue(
+        [&](const std::string & v) {
+            return !(info.tag == kPBKDFIterationsTag || info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
+        },
+        [&](int64_t v) {
+            return !(info.tag == kSerialNumberTag || info.tag == kPBKDFIterationsTag || info.tag == kBPKFSaltTag ||
+                     info.tag == kNumberOFDevicesTag || info.tag == kCommissioningTimeoutTag);
+        },
+        [&](uint64_t v) {
+            if (info.tag == kSerialNumberTag)
+            {
+                return CanCastTo<uint32_t>(v);
+            }
+            if (info.tag == kPBKDFIterationsTag)
+            {
+                return Crypto::kSpake2p_Min_PBKDF_Iterations <= v && v <= Crypto::kSpake2p_Max_PBKDF_Iterations;
+            }
+            if (info.tag == kNumberOFDevicesTag)
+            {
+                return 0 < v && v <= 255;
+            }
+            return info.tag != kBPKFSaltTag;
+        });
+    // It is not clearly specified whether this should return an error, or simply ignore.
+    VerifyOrReturnError(validValue, CHIP_ERROR_INVALID_ARGUMENT);
+
+    optionalExtensionData.emplace(info.tag, info);
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetupPayload::getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info) const
+std::optional<OptionalQRCodeInfo> SetupPayload::getOptionalVendorData(uint8_t tag) const
 {
     const auto it = optionalVendorData.find(tag);
-    VerifyOrReturnError(it != optionalVendorData.end(), CHIP_ERROR_KEY_NOT_FOUND);
-    info = it->second;
-
-    return CHIP_NO_ERROR;
+    VerifyOrReturnError(it != optionalVendorData.end(), std::nullopt);
+    return it->second;
 }
 
-CHIP_ERROR SetupPayload::getOptionalExtensionData(uint8_t tag, OptionalQRCodeInfoExtension & info) const
+std::optional<OptionalQRCodeInfo> SetupPayload::getOptionalExtensionData(uint8_t tag) const
 {
     const auto it = optionalExtensionData.find(tag);
-    VerifyOrReturnError(it != optionalExtensionData.end(), CHIP_ERROR_KEY_NOT_FOUND);
-    info = it->second;
-    return CHIP_NO_ERROR;
+    VerifyOrReturnError(it != optionalExtensionData.end(), std::nullopt);
+    return it->second;
 }
 
-optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag) const
+std::vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalExtensionData() const
 {
-    optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
-
-    if (IsVendorTag(tag))
-    {
-        elemType = optionalQRCodeInfoTypeInt32;
-    }
-    else if (tag == kSerialNumberTag)
-    {
-        elemType = optionalQRCodeInfoTypeUInt32;
-    }
-
-    return elemType;
-}
-
-std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData() const
-{
-    std::vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
+    std::vector<OptionalQRCodeInfo> returnedOptionalInfo;
     for (auto & entry : optionalExtensionData)
     {
         returnedOptionalInfo.push_back(entry.second);
@@ -301,7 +291,7 @@ std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionDa
 bool SetupPayload::operator==(const SetupPayload & input) const
 {
     std::vector<OptionalQRCodeInfo> inputOptionalVendorData;
-    std::vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
+    std::vector<OptionalQRCodeInfo> inputOptionalExtensionData;
 
     VerifyOrReturnError(PayloadContents::operator==(input), false);
 
@@ -310,28 +300,19 @@ bool SetupPayload::operator==(const SetupPayload & input) const
 
     for (const OptionalQRCodeInfo & inputInfo : inputOptionalVendorData)
     {
-        OptionalQRCodeInfo info;
-        CHIP_ERROR err = getOptionalVendorData(inputInfo.tag, info);
-        VerifyOrReturnError(err == CHIP_NO_ERROR, false);
-        VerifyOrReturnError(inputInfo.type == info.type, false);
-        VerifyOrReturnError(inputInfo.data == info.data, false);
-        VerifyOrReturnError(inputInfo.int32 == info.int32, false);
+        std::optional<OptionalQRCodeInfo> info = getOptionalVendorData(inputInfo.tag);
+        VerifyOrReturnError(info.has_value(), false);
+        VerifyOrReturnError(inputInfo.value == info->value, false);
     }
 
     inputOptionalExtensionData = input.getAllOptionalExtensionData();
     VerifyOrReturnError(optionalExtensionData.size() == inputOptionalExtensionData.size(), false);
 
-    for (const OptionalQRCodeInfoExtension & inputInfo : inputOptionalExtensionData)
+    for (const OptionalQRCodeInfo & inputInfo : inputOptionalExtensionData)
     {
-        OptionalQRCodeInfoExtension info;
-        CHIP_ERROR err = getOptionalExtensionData(inputInfo.tag, info);
-        VerifyOrReturnError(err == CHIP_NO_ERROR, false);
-        VerifyOrReturnError(inputInfo.type == info.type, false);
-        VerifyOrReturnError(inputInfo.data == info.data, false);
-        VerifyOrReturnError(inputInfo.int32 == info.int32, false);
-        VerifyOrReturnError(inputInfo.int64 == info.int64, false);
-        VerifyOrReturnError(inputInfo.uint32 == info.uint32, false);
-        VerifyOrReturnError(inputInfo.uint64 == info.uint64, false);
+        std::optional<OptionalQRCodeInfo> info = getOptionalExtensionData(inputInfo.tag);
+        VerifyOrReturnError(info.has_value(), false);
+        VerifyOrReturnError(inputInfo.value == info->value, false);
     }
 
     return true;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -69,9 +69,11 @@ const int kManualSetupVendorIdCharLength   = 5;
 const int kManualSetupProductIdCharLength  = 5;
 
 // Spec 5.1.4.2 CHIP-Common Reserved Tags
-inline constexpr uint8_t kSerialNumberTag         = 0x00;
-inline constexpr uint8_t kPBKDFIterationsTag      = 0x01;
-inline constexpr uint8_t kPBKFSaltTag             = 0x02;
+inline constexpr uint8_t kSerialNumberTag    = 0x00;
+inline constexpr uint8_t kPBKDFIterationsTag = 0x01;
+inline constexpr uint8_t kPBKFSaltTag        = 0x02;
+// The constant was originally added with this spelling error. Keeping an alias for API stability.
+inline constexpr uint8_t kBPKFSaltTag             = kPBKFSaltTag;
 inline constexpr uint8_t kNumberOFDevicesTag      = 0x03;
 inline constexpr uint8_t kCommissioningTimeoutTag = 0x04;
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -71,7 +71,7 @@ const int kManualSetupProductIdCharLength  = 5;
 // Spec 5.1.4.2 CHIP-Common Reserved Tags
 inline constexpr uint8_t kSerialNumberTag         = 0x00;
 inline constexpr uint8_t kPBKDFIterationsTag      = 0x01;
-inline constexpr uint8_t kBPKFSaltTag             = 0x02;
+inline constexpr uint8_t kPBKFSaltTag             = 0x02;
 inline constexpr uint8_t kNumberOFDevicesTag      = 0x03;
 inline constexpr uint8_t kCommissioningTimeoutTag = 0x04;
 
@@ -172,13 +172,13 @@ struct OptionalQRCodeInfo
     {
         if (std::holds_alternative<std::string>(value))
         {
-            return stringVisitor(const_cast<const std::string &>(std::get<std::string>(value)));
+            return stringVisitor(std::get<std::string>(value));
         }
         if (std::holds_alternative<int64_t>(value))
         {
-            return signedIntVisitor(int64_t(std::get<int64_t>(value)));
+            return signedIntVisitor(std::get<int64_t>(value));
         }
-        return unsignedIntVisitor(uint64_t(std::get<uint64_t>(value)));
+        return unsignedIntVisitor(std::get<uint64_t>(value));
     }
 
     uint8_t tag;                                        /**< the tag number of the optional info */

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -167,6 +167,13 @@ struct OptionalQRCodeInfo
     OptionalQRCodeInfo(uint8_t t, int64_t v) : tag(t), value(v) {}
     OptionalQRCodeInfo(uint8_t t, uint64_t v) : tag(t), value(v) {}
 
+    // visitValue will call one of the passed in visitor callbacks for the type that the
+    // value has. The value itself will be passed to the callback.
+    //
+    // We should keep this API working as-is, even when support for more types is added.
+    // So if support for a new type is added, add a new visitValue method with another
+    // visitor callback for that type, and make this method forward to the new one with
+    // a noop visitor for the new type.
     template <typename StringVisitor, typename SignedIntVisitor, typename UnsignedIntVisitor,
               typename ReturnValue = decltype(std::declval<StringVisitor>()(std::string()))>
     ReturnValue visitValue(StringVisitor stringVisitor, SignedIntVisitor signedIntVisitor,
@@ -183,7 +190,13 @@ struct OptionalQRCodeInfo
         return unsignedIntVisitor(std::get<uint64_t>(value));
     }
 
-    uint8_t tag;                                        /**< the tag number of the optional info */
+    bool operator==(const OptionalQRCodeInfo & info) const { return info.tag == tag && info.value == value; }
+    std::size_t hash() const { return value.index() << 8 | tag; }
+
+    uint8_t tag; /**< the tag number of the optional info */
+
+private:
+    friend class SetupPayload;
     std::variant<std::string, int64_t, uint64_t> value; /**< the value of the optional info */
 };
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <lib/core/CHIPError.h>
@@ -155,34 +156,33 @@ private:
     bool CheckPayloadCommonConstraints() const;
 };
 
-enum optionalQRCodeInfoType
-{
-    optionalQRCodeInfoTypeUnknown,
-    optionalQRCodeInfoTypeString,
-    optionalQRCodeInfoTypeInt32,
-    optionalQRCodeInfoTypeInt64,
-    optionalQRCodeInfoTypeUInt32,
-    optionalQRCodeInfoTypeUInt64
-};
-
 /**
  * A structure to hold optional QR Code info
  */
 struct OptionalQRCodeInfo
 {
-    /*@{*/
-    uint8_t tag;                      /**< the tag number of the optional info */
-    enum optionalQRCodeInfoType type; /**< the type (String or Int) of the optional info */
-    std::string data;                 /**< the string value if type is optionalQRCodeInfoTypeString, otherwise should not be set */
-    int32_t int32 = 0;                /**< the integer value if type is optionalQRCodeInfoTypeInt32, otherwise should not be set */
-    /*@}*/
-};
+    OptionalQRCodeInfo(uint8_t t, std::string && v) : tag(t), value(std::move(v)) {}
+    OptionalQRCodeInfo(uint8_t t, int64_t v) : tag(t), value(v) {}
+    OptionalQRCodeInfo(uint8_t t, uint64_t v) : tag(t), value(v) {}
 
-struct OptionalQRCodeInfoExtension : OptionalQRCodeInfo
-{
-    int64_t int64   = 0; /**< the integer value if type is optionalQRCodeInfoTypeInt64, otherwise should not be set */
-    uint64_t uint32 = 0; /**< the integer value if type is optionalQRCodeInfoTypeUInt32, otherwise should not be set */
-    uint64_t uint64 = 0; /**< the integer value if type is optionalQRCodeInfoTypeUInt64, otherwise should not be set */
+    template <typename StringVisitor, typename SignedIntVisitor, typename UnsignedIntVisitor,
+              typename ReturnValue = decltype(std::declval<StringVisitor>()(std::string()))>
+    ReturnValue visitValue(StringVisitor stringVisitor, SignedIntVisitor signedIntVisitor,
+                           UnsignedIntVisitor unsignedIntVisitor) const
+    {
+        if (std::holds_alternative<std::string>(value))
+        {
+            return stringVisitor(const_cast<const std::string &>(std::get<std::string>(value)));
+        }
+        if (std::holds_alternative<int64_t>(value))
+        {
+            return signedIntVisitor(int64_t(std::get<int64_t>(value)));
+        }
+        return unsignedIntVisitor(uint64_t(std::get<uint64_t>(value)));
+    }
+
+    uint8_t tag;                                        /**< the tag number of the optional info */
+    std::variant<std::string, int64_t, uint64_t> value; /**< the value of the optional info */
 };
 
 class SetupPayload : public PayloadContents
@@ -201,10 +201,23 @@ public:
 
     /** @brief A function to add an optional vendor data
      * @param tag tag number in the [0x80-0xFF] range
-     * @param data Integer representation of data to add
+     * @param data 64-bit signed integer representation of data to add
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addOptionalVendorData(uint8_t tag, int32_t data);
+    CHIP_ERROR addOptionalVendorData(uint8_t tag, int64_t data);
+
+    /** @brief A function to add an optional vendor data
+     * @param tag tag number in the [0x80-0xFF] range
+     * @param data 64-bit unsigned integer representation of data to add
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalVendorData(uint8_t tag, uint64_t data);
+
+    /** @brief A function to add an optional QR Code info vendor object
+     * @param info Optional QR code info object to add
+     * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalVendorData(const OptionalQRCodeInfo & info);
 
     /** @brief A function to remove an optional vendor data
      * @param tag tag number in the [0x80-0xFF] range
@@ -214,10 +227,9 @@ public:
 
     /** @brief A function to retrieve an optional QR Code info vendor object
      * @param tag tag number in the [0x80-0xFF] range
-     * @param info retrieved OptionalQRCodeInfo object
-     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     * @return retrieved OptionalQRCodeInfo object, or std::nullopt if no object was found for tag
      **/
-    CHIP_ERROR getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info) const;
+    std::optional<OptionalQRCodeInfo> getOptionalVendorData(uint8_t tag) const;
 
     /**
      * @brief A function to retrieve the vector of OptionalQRCodeInfo infos
@@ -290,38 +302,26 @@ public:
 
 private:
     std::map<uint8_t, OptionalQRCodeInfo> optionalVendorData;
-    std::map<uint8_t, OptionalQRCodeInfoExtension> optionalExtensionData;
-
-    /** @brief A function to add an optional QR Code info vendor object
-     * @param info Optional QR code info object to add
-     * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
-     **/
-    CHIP_ERROR addOptionalVendorData(const OptionalQRCodeInfo & info);
+    std::map<uint8_t, OptionalQRCodeInfo> optionalExtensionData;
 
     /** @brief A function to add an optional QR Code info CHIP object
      * @param info Optional QR code info object to add
      * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addOptionalExtensionData(const OptionalQRCodeInfoExtension & info);
+    CHIP_ERROR addOptionalExtensionData(const OptionalQRCodeInfo & info);
 
     /**
      * @brief A function to retrieve the vector of CHIPQRCodeInfo infos
      * @return Returns a vector of CHIPQRCodeInfos
      **/
-    std::vector<OptionalQRCodeInfoExtension> getAllOptionalExtensionData() const;
+    std::vector<OptionalQRCodeInfo> getAllOptionalExtensionData() const;
 
     /** @brief A function to retrieve an optional QR Code info extended object
-     * @param tag 8 bit [128-255] tag number
-     * @param info retrieved OptionalQRCodeInfoExtension object
-     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     * @param tag 8 bit [0-127] tag number
+     * @param info retrieved OptionalQRCodeInfo object
+     * @return retrieved OptionalQRCodeInfo object, or std::nullopt if no object was found for tag
      **/
-    CHIP_ERROR getOptionalExtensionData(uint8_t tag, OptionalQRCodeInfoExtension & info) const;
-
-    /** @brief A function to retrieve the associated expected numeric value for a tag
-     * @param tag 8 bit [0-255] tag number
-     * @return Returns an optionalQRCodeInfoType value
-     **/
-    optionalQRCodeInfoType getNumericTypeFor(uint8_t tag) const;
+    std::optional<OptionalQRCodeInfo> getOptionalExtensionData(uint8_t tag) const;
 };
 
 } // namespace chip

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -35,8 +35,11 @@ const uint16_t kDefaultBufferSizeInBytes = 512;
 const uint8_t kOptionalDefaultStringTag             = 0x82; // Vendor "test" tag
 inline constexpr char kOptionalDefaultStringValue[] = "myData";
 
-const uint8_t kOptionalDefaultIntTag    = 0x83; // Vendor "test" tag
-const uint32_t kOptionalDefaultIntValue = 12;
+const uint8_t kOptionalDefaultSignedIntTag   = 0x83; // Vendor "test" tag
+const int64_t kOptionalDefaultSignedIntValue = -12;
+
+const uint8_t kOptionalDefaultUnsignedIntTag    = 0x84; // Vendor "test" tag
+const uint64_t kOptionalDefaultUnsignedIntValue = 42;
 
 inline constexpr char kSerialNumberDefaultStringValue[] = "123456789";
 const uint32_t kSerialNumberDefaultUInt32Value          = 123456789;
@@ -74,7 +77,8 @@ inline SetupPayload GetDefaultPayloadWithOptionalDefaults()
     SetupPayload payload = GetDefaultPayloadWithSerialNumber();
 
     TEMPORARY_RETURN_IGNORED payload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
-    TEMPORARY_RETURN_IGNORED payload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
+    TEMPORARY_RETURN_IGNORED payload.addOptionalVendorData(kOptionalDefaultSignedIntTag, kOptionalDefaultSignedIntValue);
+    TEMPORARY_RETURN_IGNORED payload.addOptionalVendorData(kOptionalDefaultUnsignedIntTag, kOptionalDefaultUnsignedIntValue);
 
     return payload;
 }

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -50,19 +50,28 @@ TEST_F(TestQRCodeTLV, TestOptionalDataAddRemove)
     optionalData = payload.getAllOptionalVendorData();
     EXPECT_TRUE(optionalData.size());
 
-    err = payload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
+    err = payload.addOptionalVendorData(kOptionalDefaultSignedIntTag, kOptionalDefaultSignedIntValue);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = payload.addOptionalVendorData(kOptionalDefaultUnsignedIntTag, kOptionalDefaultUnsignedIntValue);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     optionalData = payload.getAllOptionalVendorData();
-    EXPECT_EQ(optionalData.size(), 2u);
+    EXPECT_EQ(optionalData.size(), 3u);
 
     err = payload.removeOptionalVendorData(kOptionalDefaultStringTag);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     optionalData = payload.getAllOptionalVendorData();
+    EXPECT_EQ(optionalData.size(), 2u);
+
+    err = payload.removeOptionalVendorData(kOptionalDefaultSignedIntTag);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    optionalData = payload.getAllOptionalVendorData();
     EXPECT_EQ(optionalData.size(), 1u);
 
-    EXPECT_SUCCESS(payload.removeOptionalVendorData(kOptionalDefaultIntTag));
+    err = payload.removeOptionalVendorData(kOptionalDefaultUnsignedIntTag);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     optionalData = payload.getAllOptionalVendorData();
@@ -74,7 +83,7 @@ TEST_F(TestQRCodeTLV, TestOptionalDataAddRemove)
     optionalData = payload.getAllOptionalVendorData();
     EXPECT_TRUE(optionalData.empty());
 
-    err = payload.removeOptionalVendorData(kOptionalDefaultIntTag);
+    err = payload.removeOptionalVendorData(kOptionalDefaultSignedIntTag);
     EXPECT_EQ(err, CHIP_ERROR_KEY_NOT_FOUND);
 
     optionalData = payload.getAllOptionalVendorData();
@@ -210,7 +219,15 @@ TEST_F(TestQRCodeTLV, TestOptionalDataReadSerial)
 TEST_F(TestQRCodeTLV, TestOptionalDataReadVendorInt)
 {
     SetupPayload inPayload = GetDefaultPayload();
-    EXPECT_SUCCESS(inPayload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue));
+    EXPECT_SUCCESS(inPayload.addOptionalVendorData(kOptionalDefaultSignedIntTag, kOptionalDefaultSignedIntValue));
+
+    EXPECT_TRUE(CheckWriteRead(inPayload));
+}
+
+TEST_F(TestQRCodeTLV, TestOptionalDataReadVendorUnsignedInt)
+{
+    SetupPayload inPayload = GetDefaultPayload();
+    EXPECT_SUCCESS(inPayload.addOptionalVendorData(kOptionalDefaultUnsignedIntTag, kOptionalDefaultUnsignedIntValue));
 
     EXPECT_TRUE(CheckWriteRead(inPayload));
 }


### PR DESCRIPTION
#### Summary

- Allow more integer types for manufacturer-specific TLV data in onboarding payloads.
- Merge the structs for manufacturer-specific and common TLV data in onboarding payloads.
- Use a std::variant to store the data (to avoid increasing the size of the struct).
- Add some checks for valid data for the known tags in the common TLV data (see 5.1.5.2. Matter-common Elements), hopefully avoiding some future compat issues if these ever start to be supported.

#### Related issues

NA

#### Testing

- Added some checks for unsigned integer vendor data in existing unit tests.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
