### PR TITLE
Fix typos in templates

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Build.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Build.jinja
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/src/app/zap-templates/templates/app/clusters-Commands.ipp.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Commands.ipp.zapt
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace {{asUpperCamelCase name}}.
+} // namespace {{asUpperCamelCase name}}
 {{/zcl_commands}}
 } // namespace Commands
 } // namespace {{asUpperCamelCase name}}

--- a/src/app/zap-templates/templates/app/clusters-Events.ipp.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Events.ipp.zapt
@@ -52,7 +52,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace {{asUpperCamelCase name}}.
+} // namespace {{asUpperCamelCase name}}
 {{/zcl_events}}
 } // namespace Events
 } // namespace {{asUpperCamelCase name}}

--- a/zzz_generated/app-common/clusters/AccessControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AccessControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AccessControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/AccessControl/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReviewFabricRestrictions.
+} // namespace ReviewFabricRestrictions
 namespace ReviewFabricRestrictionsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReviewFabricRestrictionsResponse.
+} // namespace ReviewFabricRestrictionsResponse
 } // namespace Commands
 } // namespace AccessControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AccessControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/AccessControl/Events.ipp
@@ -80,7 +80,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AccessControlEntryChanged.
+} // namespace AccessControlEntryChanged
 namespace AccessControlExtensionChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -131,7 +131,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AccessControlExtensionChanged.
+} // namespace AccessControlExtensionChanged
 namespace FabricRestrictionReviewUpdate {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -177,7 +177,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FabricRestrictionReviewUpdate.
+} // namespace FabricRestrictionReviewUpdate
 namespace AuxiliaryAccessUpdated {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -213,7 +213,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AuxiliaryAccessUpdated.
+} // namespace AuxiliaryAccessUpdated
 } // namespace Events
 } // namespace AccessControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AccountLogin/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AccountLogin/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AccountLogin/Commands.ipp
+++ b/zzz_generated/app-common/clusters/AccountLogin/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetSetupPIN.
+} // namespace GetSetupPIN
 namespace GetSetupPINResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetSetupPINResponse.
+} // namespace GetSetupPINResponse
 namespace Login {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Login.
+} // namespace Login
 namespace Logout {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Logout.
+} // namespace Logout
 } // namespace Commands
 } // namespace AccountLogin
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AccountLogin/Events.ipp
+++ b/zzz_generated/app-common/clusters/AccountLogin/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LoggedOut.
+} // namespace LoggedOut
 } // namespace Events
 } // namespace AccountLogin
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Actions/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Actions/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Actions/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Actions/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace InstantAction.
+} // namespace InstantAction
 namespace InstantActionWithTransition {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -99,7 +99,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace InstantActionWithTransition.
+} // namespace InstantActionWithTransition
 namespace StartAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -132,7 +132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartAction.
+} // namespace StartAction
 namespace StartActionWithDuration {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -170,7 +170,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartActionWithDuration.
+} // namespace StartActionWithDuration
 namespace StopAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -203,7 +203,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StopAction.
+} // namespace StopAction
 namespace PauseAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -236,7 +236,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PauseAction.
+} // namespace PauseAction
 namespace PauseActionWithDuration {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -274,7 +274,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PauseActionWithDuration.
+} // namespace PauseActionWithDuration
 namespace ResumeAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -307,7 +307,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResumeAction.
+} // namespace ResumeAction
 namespace EnableAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -340,7 +340,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnableAction.
+} // namespace EnableAction
 namespace EnableActionWithDuration {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -378,7 +378,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnableActionWithDuration.
+} // namespace EnableActionWithDuration
 namespace DisableAction {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -411,7 +411,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DisableAction.
+} // namespace DisableAction
 namespace DisableActionWithDuration {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -449,7 +449,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DisableActionWithDuration.
+} // namespace DisableActionWithDuration
 } // namespace Commands
 } // namespace Actions
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Actions/Events.ipp
+++ b/zzz_generated/app-common/clusters/Actions/Events.ipp
@@ -70,7 +70,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StateChanged.
+} // namespace StateChanged
 namespace ActionFailed {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActionFailed.
+} // namespace ActionFailed
 } // namespace Events
 } // namespace Actions
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCondition.
+} // namespace ResetCondition
 } // namespace Commands
 } // namespace ActivatedCarbonFilterMonitoring
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/Commands.ipp
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OpenCommissioningWindow.
+} // namespace OpenCommissioningWindow
 namespace OpenBasicCommissioningWindow {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OpenBasicCommissioningWindow.
+} // namespace OpenBasicCommissioningWindow
 namespace RevokeCommissioning {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -126,7 +126,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RevokeCommissioning.
+} // namespace RevokeCommissioning
 } // namespace Commands
 } // namespace AdministratorCommissioning
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AirQuality/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AirQuality/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AmbientContextSensing/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AmbientContextSensing/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AmbientContextSensing/Events.ipp
+++ b/zzz_generated/app-common/clusters/AmbientContextSensing/Events.ipp
@@ -70,7 +70,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AmbientContextDetectStarted.
+} // namespace AmbientContextDetectStarted
 namespace AmbientContextDetectEnded {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AmbientContextDetectEnded.
+} // namespace AmbientContextDetectEnded
 } // namespace Events
 } // namespace AmbientContextSensing
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ApplicationBasic/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ApplicationBasic/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LaunchApp.
+} // namespace LaunchApp
 namespace StopApp {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StopApp.
+} // namespace StopApp
 namespace HideApp {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace HideApp.
+} // namespace HideApp
 namespace LauncherResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LauncherResponse.
+} // namespace LauncherResponse
 } // namespace Commands
 } // namespace ApplicationLauncher
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/AudioOutput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AudioOutput/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/AudioOutput/Commands.ipp
+++ b/zzz_generated/app-common/clusters/AudioOutput/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelectOutput.
+} // namespace SelectOutput
 namespace RenameOutput {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RenameOutput.
+} // namespace RenameOutput
 } // namespace Commands
 } // namespace AudioOutput
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BallastConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BallastConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BasicInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BasicInformation/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BasicInformation/Commands.ipp
+++ b/zzz_generated/app-common/clusters/BasicInformation/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MfgSpecificPing.
+} // namespace MfgSpecificPing
 } // namespace Commands
 } // namespace BasicInformation
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BasicInformation/Events.ipp
+++ b/zzz_generated/app-common/clusters/BasicInformation/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartUp.
+} // namespace StartUp
 namespace ShutDown {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -82,7 +82,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ShutDown.
+} // namespace ShutDown
 namespace Leave {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -113,7 +113,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Leave.
+} // namespace Leave
 namespace ReachableChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -144,7 +144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReachableChanged.
+} // namespace ReachableChanged
 } // namespace Events
 } // namespace BasicInformation
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Binding/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Binding/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BooleanState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BooleanState/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BooleanState/Events.ipp
+++ b/zzz_generated/app-common/clusters/BooleanState/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StateChange.
+} // namespace StateChange
 } // namespace Events
 } // namespace BooleanState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/Commands.ipp
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SuppressAlarm.
+} // namespace SuppressAlarm
 namespace EnableDisableAlarm {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnableDisableAlarm.
+} // namespace EnableDisableAlarm
 } // namespace Commands
 } // namespace BooleanStateConfiguration
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/Events.ipp
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AlarmsStateChanged.
+} // namespace AlarmsStateChanged
 namespace SensorFault {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -96,7 +96,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SensorFault.
+} // namespace SensorFault
 } // namespace Events
 } // namespace BooleanStateConfiguration
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Commands.ipp
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeepActive.
+} // namespace KeepActive
 } // namespace Commands
 } // namespace BridgedDeviceBasicInformation
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Events.ipp
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartUp.
+} // namespace StartUp
 namespace ShutDown {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -82,7 +82,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ShutDown.
+} // namespace ShutDown
 namespace Leave {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Leave.
+} // namespace Leave
 namespace ReachableChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -135,7 +135,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReachableChanged.
+} // namespace ReachableChanged
 namespace ActiveChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -166,7 +166,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActiveChanged.
+} // namespace ActiveChanged
 } // namespace Events
 } // namespace BridgedDeviceBasicInformation
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MPTZSetPosition.
+} // namespace MPTZSetPosition
 namespace MPTZRelativeMove {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MPTZRelativeMove.
+} // namespace MPTZRelativeMove
 namespace MPTZMoveToPreset {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -132,7 +132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MPTZMoveToPreset.
+} // namespace MPTZMoveToPreset
 namespace MPTZSavePreset {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -165,7 +165,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MPTZSavePreset.
+} // namespace MPTZSavePreset
 namespace MPTZRemovePreset {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -193,7 +193,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MPTZRemovePreset.
+} // namespace MPTZRemovePreset
 namespace DPTZSetViewport {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -226,7 +226,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DPTZSetViewport.
+} // namespace DPTZSetViewport
 namespace DPTZRelativeMove {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -269,7 +269,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DPTZRelativeMove.
+} // namespace DPTZRelativeMove
 } // namespace Commands
 } // namespace CameraAvSettingsUserLevelManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/Commands.ipp
@@ -81,7 +81,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AudioStreamAllocate.
+} // namespace AudioStreamAllocate
 namespace AudioStreamAllocateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -109,7 +109,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AudioStreamAllocateResponse.
+} // namespace AudioStreamAllocateResponse
 namespace AudioStreamDeallocate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AudioStreamDeallocate.
+} // namespace AudioStreamDeallocate
 namespace VideoStreamAllocate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -215,7 +215,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace VideoStreamAllocate.
+} // namespace VideoStreamAllocate
 namespace VideoStreamAllocateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -243,7 +243,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace VideoStreamAllocateResponse.
+} // namespace VideoStreamAllocateResponse
 namespace VideoStreamModify {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -281,7 +281,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace VideoStreamModify.
+} // namespace VideoStreamModify
 namespace VideoStreamDeallocate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -309,7 +309,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace VideoStreamDeallocate.
+} // namespace VideoStreamDeallocate
 namespace SnapshotStreamAllocate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -367,7 +367,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SnapshotStreamAllocate.
+} // namespace SnapshotStreamAllocate
 namespace SnapshotStreamAllocateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -395,7 +395,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SnapshotStreamAllocateResponse.
+} // namespace SnapshotStreamAllocateResponse
 namespace SnapshotStreamModify {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -433,7 +433,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SnapshotStreamModify.
+} // namespace SnapshotStreamModify
 namespace SnapshotStreamDeallocate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -461,7 +461,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SnapshotStreamDeallocate.
+} // namespace SnapshotStreamDeallocate
 namespace SetStreamPriorities {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -489,7 +489,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetStreamPriorities.
+} // namespace SetStreamPriorities
 namespace CaptureSnapshot {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -522,7 +522,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CaptureSnapshot.
+} // namespace CaptureSnapshot
 namespace CaptureSnapshotResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -560,7 +560,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CaptureSnapshotResponse.
+} // namespace CaptureSnapshotResponse
 } // namespace Commands
 } // namespace CameraAvStreamManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Channel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Channel/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Channel/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Channel/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeChannel.
+} // namespace ChangeChannel
 namespace ChangeChannelResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeChannelResponse.
+} // namespace ChangeChannelResponse
 namespace ChangeChannelByNumber {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeChannelByNumber.
+} // namespace ChangeChannelByNumber
 namespace SkipChannel {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SkipChannel.
+} // namespace SkipChannel
 namespace GetProgramGuide {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -208,7 +208,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetProgramGuide.
+} // namespace GetProgramGuide
 namespace ProgramGuideResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -241,7 +241,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProgramGuideResponse.
+} // namespace ProgramGuideResponse
 namespace RecordProgram {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -284,7 +284,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RecordProgram.
+} // namespace RecordProgram
 namespace CancelRecordProgram {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -327,7 +327,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CancelRecordProgram.
+} // namespace CancelRecordProgram
 } // namespace Commands
 } // namespace Channel
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Chime/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Chime/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Chime/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Chime/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PlayChimeSound.
+} // namespace PlayChimeSound
 } // namespace Commands
 } // namespace Chime
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Chime/Events.ipp
+++ b/zzz_generated/app-common/clusters/Chime/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChimeStartedPlaying.
+} // namespace ChimeStartedPlaying
 } // namespace Events
 } // namespace Chime
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ClosureControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ClosureControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ClosureControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ClosureControl/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Stop.
+} // namespace Stop
 namespace MoveTo {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -88,7 +88,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveTo.
+} // namespace MoveTo
 namespace Calibrate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -110,7 +110,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Calibrate.
+} // namespace Calibrate
 } // namespace Commands
 } // namespace ClosureControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ClosureControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/ClosureControl/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalError.
+} // namespace OperationalError
 namespace MovementCompleted {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -82,7 +82,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MovementCompleted.
+} // namespace MovementCompleted
 namespace EngageStateChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -113,7 +113,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EngageStateChanged.
+} // namespace EngageStateChanged
 namespace SecureStateChanged {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -144,7 +144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SecureStateChanged.
+} // namespace SecureStateChanged
 } // namespace Events
 } // namespace ClosureControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ClosureDimension/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ClosureDimension/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ClosureDimension/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ClosureDimension/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTarget.
+} // namespace SetTarget
 namespace Step {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Step.
+} // namespace Step
 } // namespace Commands
 } // namespace ClosureDimension
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ColorControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ColorControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ColorControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ColorControl/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToHue.
+} // namespace MoveToHue
 namespace MoveHue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -119,7 +119,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveHue.
+} // namespace MoveHue
 namespace StepHue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -167,7 +167,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StepHue.
+} // namespace StepHue
 namespace MoveToSaturation {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -210,7 +210,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToSaturation.
+} // namespace MoveToSaturation
 namespace MoveSaturation {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -253,7 +253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveSaturation.
+} // namespace MoveSaturation
 namespace StepSaturation {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -301,7 +301,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StepSaturation.
+} // namespace StepSaturation
 namespace MoveToHueAndSaturation {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -349,7 +349,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToHueAndSaturation.
+} // namespace MoveToHueAndSaturation
 namespace MoveToColor {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -397,7 +397,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToColor.
+} // namespace MoveToColor
 namespace MoveColor {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -440,7 +440,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveColor.
+} // namespace MoveColor
 namespace StepColor {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -488,7 +488,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StepColor.
+} // namespace StepColor
 namespace MoveToColorTemperature {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -531,7 +531,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToColorTemperature.
+} // namespace MoveToColorTemperature
 namespace EnhancedMoveToHue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -579,7 +579,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnhancedMoveToHue.
+} // namespace EnhancedMoveToHue
 namespace EnhancedMoveHue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -622,7 +622,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnhancedMoveHue.
+} // namespace EnhancedMoveHue
 namespace EnhancedStepHue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -670,7 +670,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnhancedStepHue.
+} // namespace EnhancedStepHue
 namespace EnhancedMoveToHueAndSaturation {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -718,7 +718,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnhancedMoveToHueAndSaturation.
+} // namespace EnhancedMoveToHueAndSaturation
 namespace ColorLoopSet {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -776,7 +776,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ColorLoopSet.
+} // namespace ColorLoopSet
 namespace StopMoveStep {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -809,7 +809,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StopMoveStep.
+} // namespace StopMoveStep
 namespace MoveColorTemperature {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -862,7 +862,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveColorTemperature.
+} // namespace MoveColorTemperature
 namespace StepColorTemperature {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -920,7 +920,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StepColorTemperature.
+} // namespace StepColorTemperature
 } // namespace Commands
 } // namespace ColorControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CommissionerControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommissionerControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CommissionerControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/CommissionerControl/Commands.ipp
@@ -71,7 +71,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RequestCommissioningApproval.
+} // namespace RequestCommissioningApproval
 namespace CommissionNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CommissionNode.
+} // namespace CommissionNode
 namespace ReverseOpenCommissioningWindow {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -152,7 +152,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReverseOpenCommissioningWindow.
+} // namespace ReverseOpenCommissioningWindow
 } // namespace Commands
 } // namespace CommissionerControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CommissionerControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/CommissionerControl/Events.ipp
@@ -75,7 +75,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CommissioningRequestResult.
+} // namespace CommissioningRequestResult
 } // namespace Events
 } // namespace CommissionerControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CommodityMetering/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityMetering/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CommodityPrice/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityPrice/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CommodityPrice/Commands.ipp
+++ b/zzz_generated/app-common/clusters/CommodityPrice/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDetailedPriceRequest.
+} // namespace GetDetailedPriceRequest
 namespace GetDetailedPriceResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDetailedPriceResponse.
+} // namespace GetDetailedPriceResponse
 namespace GetDetailedForecastRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -112,7 +112,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDetailedForecastRequest.
+} // namespace GetDetailedForecastRequest
 namespace GetDetailedForecastResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -140,7 +140,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDetailedForecastResponse.
+} // namespace GetDetailedForecastResponse
 } // namespace Commands
 } // namespace CommodityPrice
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CommodityPrice/Events.ipp
+++ b/zzz_generated/app-common/clusters/CommodityPrice/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PriceChange.
+} // namespace PriceChange
 } // namespace Events
 } // namespace CommodityPrice
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/CommodityTariff/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityTariff/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/CommodityTariff/Commands.ipp
+++ b/zzz_generated/app-common/clusters/CommodityTariff/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetTariffComponent.
+} // namespace GetTariffComponent
 namespace GetTariffComponentResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetTariffComponentResponse.
+} // namespace GetTariffComponentResponse
 namespace GetDayEntry {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDayEntry.
+} // namespace GetDayEntry
 namespace GetDayEntryResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetDayEntryResponse.
+} // namespace GetDayEntryResponse
 } // namespace Commands
 } // namespace CommodityTariff
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ContentAppObserver/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ContentAppObserver/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ContentAppMessage.
+} // namespace ContentAppMessage
 namespace ContentAppMessageResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -99,7 +99,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ContentAppMessageResponse.
+} // namespace ContentAppMessageResponse
 } // namespace Commands
 } // namespace ContentAppObserver
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ContentControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ContentControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ContentControl/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdatePIN.
+} // namespace UpdatePIN
 namespace ResetPIN {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -83,7 +83,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetPIN.
+} // namespace ResetPIN
 namespace ResetPINResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -111,7 +111,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetPINResponse.
+} // namespace ResetPINResponse
 namespace Enable {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -133,7 +133,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Enable.
+} // namespace Enable
 namespace Disable {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -155,7 +155,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Disable.
+} // namespace Disable
 namespace AddBonusTime {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -188,7 +188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddBonusTime.
+} // namespace AddBonusTime
 namespace SetScreenDailyTime {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -216,7 +216,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetScreenDailyTime.
+} // namespace SetScreenDailyTime
 namespace BlockUnratedContent {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -238,7 +238,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BlockUnratedContent.
+} // namespace BlockUnratedContent
 namespace UnblockUnratedContent {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -260,7 +260,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UnblockUnratedContent.
+} // namespace UnblockUnratedContent
 namespace SetOnDemandRatingThreshold {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -288,7 +288,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetOnDemandRatingThreshold.
+} // namespace SetOnDemandRatingThreshold
 namespace SetScheduledContentRatingThreshold {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -316,7 +316,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetScheduledContentRatingThreshold.
+} // namespace SetScheduledContentRatingThreshold
 namespace AddBlockChannels {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -344,7 +344,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddBlockChannels.
+} // namespace AddBlockChannels
 namespace RemoveBlockChannels {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -372,7 +372,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveBlockChannels.
+} // namespace RemoveBlockChannels
 namespace AddBlockApplications {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -400,7 +400,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddBlockApplications.
+} // namespace AddBlockApplications
 namespace RemoveBlockApplications {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -428,7 +428,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveBlockApplications.
+} // namespace RemoveBlockApplications
 namespace SetBlockContentTimeWindow {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -456,7 +456,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetBlockContentTimeWindow.
+} // namespace SetBlockContentTimeWindow
 namespace RemoveBlockContentTimeWindow {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -484,7 +484,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveBlockContentTimeWindow.
+} // namespace RemoveBlockContentTimeWindow
 } // namespace Commands
 } // namespace ContentControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ContentControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/ContentControl/Events.ipp
@@ -51,7 +51,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemainingScreenTimeExpired.
+} // namespace RemainingScreenTimeExpired
 namespace EnteringBlockContentTimeWindow {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -73,7 +73,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnteringBlockContentTimeWindow.
+} // namespace EnteringBlockContentTimeWindow
 } // namespace Events
 } // namespace ContentControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ContentLauncher/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentLauncher/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ContentLauncher/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ContentLauncher/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LaunchContent.
+} // namespace LaunchContent
 namespace LaunchURL {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LaunchURL.
+} // namespace LaunchURL
 namespace LauncherResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -147,7 +147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LauncherResponse.
+} // namespace LauncherResponse
 } // namespace Commands
 } // namespace ContentLauncher
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Descriptor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Descriptor/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PowerAdjustRequest.
+} // namespace PowerAdjustRequest
 namespace CancelPowerAdjustRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -88,7 +88,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CancelPowerAdjustRequest.
+} // namespace CancelPowerAdjustRequest
 namespace StartTimeAdjustRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -121,7 +121,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartTimeAdjustRequest.
+} // namespace StartTimeAdjustRequest
 namespace PauseRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -154,7 +154,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PauseRequest.
+} // namespace PauseRequest
 namespace ResumeRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -176,7 +176,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResumeRequest.
+} // namespace ResumeRequest
 namespace ModifyForecastRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -214,7 +214,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ModifyForecastRequest.
+} // namespace ModifyForecastRequest
 namespace RequestConstraintBasedForecast {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -247,7 +247,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RequestConstraintBasedForecast.
+} // namespace RequestConstraintBasedForecast
 namespace CancelRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -269,7 +269,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CancelRequest.
+} // namespace CancelRequest
 } // namespace Commands
 } // namespace DeviceEnergyManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Events.ipp
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Events.ipp
@@ -51,7 +51,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PowerAdjustStart.
+} // namespace PowerAdjustStart
 namespace PowerAdjustEnd {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -92,7 +92,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PowerAdjustEnd.
+} // namespace PowerAdjustEnd
 namespace Paused {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Paused.
+} // namespace Paused
 namespace Resumed {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -145,7 +145,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Resumed.
+} // namespace Resumed
 } // namespace Events
 } // namespace DeviceEnergyManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace DeviceEnergyManagementMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RetrieveLogsRequest.
+} // namespace RetrieveLogsRequest
 namespace RetrieveLogsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -109,7 +109,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RetrieveLogsResponse.
+} // namespace RetrieveLogsResponse
 } // namespace Commands
 } // namespace DiagnosticLogs
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Reset.
+} // namespace Reset
 namespace ModifyEnabledAlarms {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ModifyEnabledAlarms.
+} // namespace ModifyEnabledAlarms
 } // namespace Commands
 } // namespace DishwasherAlarm
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/Events.ipp
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/Events.ipp
@@ -75,7 +75,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Notify.
+} // namespace Notify
 } // namespace Events
 } // namespace DishwasherAlarm
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DishwasherMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DishwasherMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DishwasherMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DishwasherMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace DishwasherMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DoorLock/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DoorLock/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/DoorLock/Commands.ipp
+++ b/zzz_generated/app-common/clusters/DoorLock/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LockDoor.
+} // namespace LockDoor
 namespace UnlockDoor {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UnlockDoor.
+} // namespace UnlockDoor
 namespace UnlockWithTimeout {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UnlockWithTimeout.
+} // namespace UnlockWithTimeout
 namespace SetWeekDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -175,7 +175,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetWeekDaySchedule.
+} // namespace SetWeekDaySchedule
 namespace GetWeekDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -208,7 +208,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetWeekDaySchedule.
+} // namespace GetWeekDaySchedule
 namespace GetWeekDayScheduleResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -271,7 +271,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetWeekDayScheduleResponse.
+} // namespace GetWeekDayScheduleResponse
 namespace ClearWeekDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -304,7 +304,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearWeekDaySchedule.
+} // namespace ClearWeekDaySchedule
 namespace SetYearDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -347,7 +347,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetYearDaySchedule.
+} // namespace SetYearDaySchedule
 namespace GetYearDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -380,7 +380,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetYearDaySchedule.
+} // namespace GetYearDaySchedule
 namespace GetYearDayScheduleResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -428,7 +428,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetYearDayScheduleResponse.
+} // namespace GetYearDayScheduleResponse
 namespace ClearYearDaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -461,7 +461,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearYearDaySchedule.
+} // namespace ClearYearDaySchedule
 namespace SetHolidaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -504,7 +504,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetHolidaySchedule.
+} // namespace SetHolidaySchedule
 namespace GetHolidaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -532,7 +532,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetHolidaySchedule.
+} // namespace GetHolidaySchedule
 namespace GetHolidayScheduleResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -580,7 +580,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetHolidayScheduleResponse.
+} // namespace GetHolidayScheduleResponse
 namespace ClearHolidaySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -608,7 +608,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearHolidaySchedule.
+} // namespace ClearHolidaySchedule
 namespace SetUser {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -666,7 +666,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetUser.
+} // namespace SetUser
 namespace GetUser {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -694,7 +694,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetUser.
+} // namespace GetUser
 namespace GetUserResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -767,7 +767,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetUserResponse.
+} // namespace GetUserResponse
 namespace ClearUser {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -795,7 +795,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearUser.
+} // namespace ClearUser
 namespace SetCredential {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -848,7 +848,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetCredential.
+} // namespace SetCredential
 namespace SetCredentialResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -886,7 +886,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetCredentialResponse.
+} // namespace SetCredentialResponse
 namespace GetCredentialStatus {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -914,7 +914,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetCredentialStatus.
+} // namespace GetCredentialStatus
 namespace GetCredentialStatusResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -967,7 +967,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetCredentialStatusResponse.
+} // namespace GetCredentialStatusResponse
 namespace ClearCredential {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -995,7 +995,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearCredential.
+} // namespace ClearCredential
 namespace UnboltDoor {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1023,7 +1023,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UnboltDoor.
+} // namespace UnboltDoor
 namespace SetAliroReaderConfig {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1066,7 +1066,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetAliroReaderConfig.
+} // namespace SetAliroReaderConfig
 namespace ClearAliroReaderConfig {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1088,7 +1088,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearAliroReaderConfig.
+} // namespace ClearAliroReaderConfig
 } // namespace Commands
 } // namespace DoorLock
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/DoorLock/Events.ipp
+++ b/zzz_generated/app-common/clusters/DoorLock/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DoorLockAlarm.
+} // namespace DoorLockAlarm
 namespace DoorStateChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -91,7 +91,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DoorStateChange.
+} // namespace DoorStateChange
 namespace LockOperation {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -147,7 +147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LockOperation.
+} // namespace LockOperation
 namespace LockOperationError {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -208,7 +208,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LockOperationError.
+} // namespace LockOperationError
 namespace LockUserChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -269,7 +269,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LockUserChange.
+} // namespace LockUserChange
 } // namespace Events
 } // namespace DoorLock
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/EcosystemInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EcosystemInformation/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Events.ipp
+++ b/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CumulativeEnergyMeasured.
+} // namespace CumulativeEnergyMeasured
 namespace PeriodicEnergyMeasured {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PeriodicEnergyMeasured.
+} // namespace PeriodicEnergyMeasured
 } // namespace Events
 } // namespace ElectricalEnergyMeasurement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ElectricalGridConditions/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalGridConditions/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ElectricalGridConditions/Events.ipp
+++ b/zzz_generated/app-common/clusters/ElectricalGridConditions/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CurrentConditionsChanged.
+} // namespace CurrentConditionsChanged
 } // namespace Events
 } // namespace ElectricalGridConditions
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Events.ipp
+++ b/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MeasurementPeriodRanges.
+} // namespace MeasurementPeriodRanges
 } // namespace Events
 } // namespace ElectricalPowerMeasurement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/EnergyEvse/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyEvse/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/EnergyEvse/Commands.ipp
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetTargetsResponse.
+} // namespace GetTargetsResponse
 namespace Disable {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Disable.
+} // namespace Disable
 namespace EnableCharging {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnableCharging.
+} // namespace EnableCharging
 namespace EnableDischarging {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -149,7 +149,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnableDischarging.
+} // namespace EnableDischarging
 namespace StartDiagnostics {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -171,7 +171,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartDiagnostics.
+} // namespace StartDiagnostics
 namespace SetTargets {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -199,7 +199,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTargets.
+} // namespace SetTargets
 namespace GetTargets {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -221,7 +221,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetTargets.
+} // namespace GetTargets
 namespace ClearTargets {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -243,7 +243,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearTargets.
+} // namespace ClearTargets
 } // namespace Commands
 } // namespace EnergyEvse
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/EnergyEvse/Events.ipp
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EVConnected.
+} // namespace EVConnected
 namespace EVNotDetected {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -111,7 +111,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EVNotDetected.
+} // namespace EVNotDetected
 namespace EnergyTransferStarted {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -157,7 +157,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnergyTransferStarted.
+} // namespace EnergyTransferStarted
 namespace EnergyTransferStopped {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -208,7 +208,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EnergyTransferStopped.
+} // namespace EnergyTransferStopped
 namespace Fault {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -254,7 +254,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Fault.
+} // namespace Fault
 namespace Rfid {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -285,7 +285,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Rfid.
+} // namespace Rfid
 } // namespace Events
 } // namespace EnergyEvse
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace EnergyEvseMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/EnergyPreference/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyPreference/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Commands.ipp
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCounts.
+} // namespace ResetCounts
 } // namespace Commands
 } // namespace EthernetNetworkDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/FanControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FanControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/FanControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/FanControl/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Step.
+} // namespace Step
 } // namespace Commands
 } // namespace FanControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/FaultInjection/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FaultInjection/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/FaultInjection/Commands.ipp
+++ b/zzz_generated/app-common/clusters/FaultInjection/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FailAtFault.
+} // namespace FailAtFault
 namespace FailRandomlyAtFault {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FailRandomlyAtFault.
+} // namespace FailRandomlyAtFault
 } // namespace Commands
 } // namespace FaultInjection
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/FixedLabel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FixedLabel/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/FlowMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FlowMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/Commands.ipp
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ArmFailSafe.
+} // namespace ArmFailSafe
 namespace ArmFailSafeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ArmFailSafeResponse.
+} // namespace ArmFailSafeResponse
 namespace SetRegulatoryConfig {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -132,7 +132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetRegulatoryConfig.
+} // namespace SetRegulatoryConfig
 namespace SetRegulatoryConfigResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -165,7 +165,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetRegulatoryConfigResponse.
+} // namespace SetRegulatoryConfigResponse
 namespace CommissioningComplete {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -187,7 +187,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CommissioningComplete.
+} // namespace CommissioningComplete
 namespace CommissioningCompleteResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -220,7 +220,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CommissioningCompleteResponse.
+} // namespace CommissioningCompleteResponse
 namespace SetTCAcknowledgements {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -253,7 +253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTCAcknowledgements.
+} // namespace SetTCAcknowledgements
 namespace SetTCAcknowledgementsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -281,7 +281,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTCAcknowledgementsResponse.
+} // namespace SetTCAcknowledgementsResponse
 } // namespace Commands
 } // namespace GeneralCommissioning
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/Commands.ipp
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEventTrigger.
+} // namespace TestEventTrigger
 namespace TimeSnapshot {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -83,7 +83,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TimeSnapshot.
+} // namespace TimeSnapshot
 namespace TimeSnapshotResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TimeSnapshotResponse.
+} // namespace TimeSnapshotResponse
 namespace PayloadTestRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -154,7 +154,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PayloadTestRequest.
+} // namespace PayloadTestRequest
 namespace PayloadTestResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -182,7 +182,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PayloadTestResponse.
+} // namespace PayloadTestResponse
 } // namespace Commands
 } // namespace GeneralDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/Events.ipp
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace HardwareFaultChange.
+} // namespace HardwareFaultChange
 namespace RadioFaultChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RadioFaultChange.
+} // namespace RadioFaultChange
 namespace NetworkFaultChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NetworkFaultChange.
+} // namespace NetworkFaultChange
 namespace BootReason {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -168,7 +168,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BootReason.
+} // namespace BootReason
 } // namespace Events
 } // namespace GeneralDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetWrite.
+} // namespace KeySetWrite
 namespace KeySetRead {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetRead.
+} // namespace KeySetRead
 namespace KeySetReadResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -112,7 +112,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetReadResponse.
+} // namespace KeySetReadResponse
 namespace KeySetRemove {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -140,7 +140,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetRemove.
+} // namespace KeySetRemove
 namespace KeySetReadAllIndices {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -162,7 +162,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetReadAllIndices.
+} // namespace KeySetReadAllIndices
 namespace KeySetReadAllIndicesResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -190,7 +190,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace KeySetReadAllIndicesResponse.
+} // namespace KeySetReadAllIndicesResponse
 } // namespace Commands
 } // namespace GroupKeyManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Groupcast/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Groupcast/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Groupcast/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Groupcast/Commands.ipp
@@ -86,7 +86,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace JoinGroup.
+} // namespace JoinGroup
 namespace LeaveGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -119,7 +119,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LeaveGroup.
+} // namespace LeaveGroup
 namespace LeaveGroupResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -152,7 +152,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LeaveGroupResponse.
+} // namespace LeaveGroupResponse
 namespace UpdateGroupKey {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -190,7 +190,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateGroupKey.
+} // namespace UpdateGroupKey
 namespace ConfigureAuxiliaryACL {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -223,7 +223,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ConfigureAuxiliaryACL.
+} // namespace ConfigureAuxiliaryACL
 namespace GroupcastTesting {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -256,7 +256,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GroupcastTesting.
+} // namespace GroupcastTesting
 } // namespace Commands
 } // namespace Groupcast
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Groupcast/Events.ipp
+++ b/zzz_generated/app-common/clusters/Groupcast/Events.ipp
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GroupcastTesting.
+} // namespace GroupcastTesting
 } // namespace Events
 } // namespace Groupcast
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Groups/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Groups/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Groups/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Groups/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddGroup.
+} // namespace AddGroup
 namespace AddGroupResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddGroupResponse.
+} // namespace AddGroupResponse
 namespace ViewGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ViewGroup.
+} // namespace ViewGroup
 namespace ViewGroupResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -160,7 +160,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ViewGroupResponse.
+} // namespace ViewGroupResponse
 namespace GetGroupMembership {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -188,7 +188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetGroupMembership.
+} // namespace GetGroupMembership
 namespace GetGroupMembershipResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -221,7 +221,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetGroupMembershipResponse.
+} // namespace GetGroupMembershipResponse
 namespace RemoveGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -249,7 +249,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveGroup.
+} // namespace RemoveGroup
 namespace RemoveGroupResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -282,7 +282,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveGroupResponse.
+} // namespace RemoveGroupResponse
 namespace RemoveAllGroups {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -304,7 +304,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveAllGroups.
+} // namespace RemoveAllGroups
 namespace AddGroupIfIdentifying {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -337,7 +337,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddGroupIfIdentifying.
+} // namespace AddGroupIfIdentifying
 } // namespace Commands
 } // namespace Groups
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/BUILD.gn
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/Commands.ipp
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCondition.
+} // namespace ResetCondition
 } // namespace Commands
 } // namespace HepaFilterMonitoring
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Humidistat/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Humidistat/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Humidistat/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Humidistat/Commands.ipp
@@ -81,7 +81,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetSettings.
+} // namespace SetSettings
 } // namespace Commands
 } // namespace Humidistat
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/IcdManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/IcdManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/IcdManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/IcdManagement/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RegisterClient.
+} // namespace RegisterClient
 namespace RegisterClientResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RegisterClientResponse.
+} // namespace RegisterClientResponse
 namespace UnregisterClient {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UnregisterClient.
+} // namespace UnregisterClient
 namespace StayActiveRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -165,7 +165,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StayActiveRequest.
+} // namespace StayActiveRequest
 namespace StayActiveResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -193,7 +193,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StayActiveResponse.
+} // namespace StayActiveResponse
 } // namespace Commands
 } // namespace IcdManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Identify/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Identify/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Identify/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Identify/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Identify.
+} // namespace Identify
 namespace TriggerEffect {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TriggerEffect.
+} // namespace TriggerEffect
 } // namespace Commands
 } // namespace Identify
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/IlluminanceMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/IlluminanceMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/JointFabricAdministrator/BUILD.gn
+++ b/zzz_generated/app-common/clusters/JointFabricAdministrator/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/JointFabricAdministrator/Commands.ipp
+++ b/zzz_generated/app-common/clusters/JointFabricAdministrator/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ICACCSRRequest.
+} // namespace ICACCSRRequest
 namespace ICACCSRResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ICACCSRResponse.
+} // namespace ICACCSRResponse
 namespace AddICAC {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -106,7 +106,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddICAC.
+} // namespace AddICAC
 namespace ICACResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -134,7 +134,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ICACResponse.
+} // namespace ICACResponse
 namespace OpenJointCommissioningWindow {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -182,7 +182,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OpenJointCommissioningWindow.
+} // namespace OpenJointCommissioningWindow
 namespace TransferAnchorRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -204,7 +204,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TransferAnchorRequest.
+} // namespace TransferAnchorRequest
 namespace TransferAnchorResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -232,7 +232,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TransferAnchorResponse.
+} // namespace TransferAnchorResponse
 namespace TransferAnchorComplete {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -254,7 +254,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TransferAnchorComplete.
+} // namespace TransferAnchorComplete
 namespace AnnounceJointFabricAdministrator {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -282,7 +282,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AnnounceJointFabricAdministrator.
+} // namespace AnnounceJointFabricAdministrator
 } // namespace Commands
 } // namespace JointFabricAdministrator
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/JointFabricDatastore/BUILD.gn
+++ b/zzz_generated/app-common/clusters/JointFabricDatastore/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/JointFabricDatastore/Commands.ipp
+++ b/zzz_generated/app-common/clusters/JointFabricDatastore/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddKeySet.
+} // namespace AddKeySet
 namespace UpdateKeySet {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateKeySet.
+} // namespace UpdateKeySet
 namespace RemoveKeySet {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -112,7 +112,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveKeySet.
+} // namespace RemoveKeySet
 namespace AddGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -165,7 +165,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddGroup.
+} // namespace AddGroup
 namespace UpdateGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -218,7 +218,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateGroup.
+} // namespace UpdateGroup
 namespace RemoveGroup {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -246,7 +246,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveGroup.
+} // namespace RemoveGroup
 namespace AddAdmin {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -289,7 +289,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddAdmin.
+} // namespace AddAdmin
 namespace UpdateAdmin {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -327,7 +327,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateAdmin.
+} // namespace UpdateAdmin
 namespace RemoveAdmin {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -355,7 +355,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveAdmin.
+} // namespace RemoveAdmin
 namespace AddPendingNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -388,7 +388,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddPendingNode.
+} // namespace AddPendingNode
 namespace RefreshNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -416,7 +416,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RefreshNode.
+} // namespace RefreshNode
 namespace UpdateNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -449,7 +449,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateNode.
+} // namespace UpdateNode
 namespace RemoveNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -477,7 +477,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveNode.
+} // namespace RemoveNode
 namespace UpdateEndpointForNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -515,7 +515,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateEndpointForNode.
+} // namespace UpdateEndpointForNode
 namespace AddGroupIDToEndpointForNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -553,7 +553,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddGroupIDToEndpointForNode.
+} // namespace AddGroupIDToEndpointForNode
 namespace RemoveGroupIDFromEndpointForNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -591,7 +591,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveGroupIDFromEndpointForNode.
+} // namespace RemoveGroupIDFromEndpointForNode
 namespace AddBindingToEndpointForNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -629,7 +629,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddBindingToEndpointForNode.
+} // namespace AddBindingToEndpointForNode
 namespace RemoveBindingFromEndpointForNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -667,7 +667,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveBindingFromEndpointForNode.
+} // namespace RemoveBindingFromEndpointForNode
 namespace AddACLToNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -700,7 +700,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddACLToNode.
+} // namespace AddACLToNode
 namespace RemoveACLFromNode {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -733,7 +733,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveACLFromNode.
+} // namespace RemoveACLFromNode
 } // namespace Commands
 } // namespace JointFabricDatastore
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/KeypadInput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/KeypadInput/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/KeypadInput/Commands.ipp
+++ b/zzz_generated/app-common/clusters/KeypadInput/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SendKey.
+} // namespace SendKey
 namespace SendKeyResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SendKeyResponse.
+} // namespace SendKeyResponse
 } // namespace Commands
 } // namespace KeypadInput
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/LaundryDryerControls/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryDryerControls/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LaundryWasherControls/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryWasherControls/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace LaundryWasherMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/LevelControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LevelControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LevelControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/LevelControl/Commands.ipp
@@ -71,7 +71,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToLevel.
+} // namespace MoveToLevel
 namespace Move {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Move.
+} // namespace Move
 namespace Step {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -162,7 +162,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Step.
+} // namespace Step
 namespace Stop {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -195,7 +195,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Stop.
+} // namespace Stop
 namespace MoveToLevelWithOnOff {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -238,7 +238,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToLevelWithOnOff.
+} // namespace MoveToLevelWithOnOff
 namespace MoveWithOnOff {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -281,7 +281,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveWithOnOff.
+} // namespace MoveWithOnOff
 namespace StepWithOnOff {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -329,7 +329,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StepWithOnOff.
+} // namespace StepWithOnOff
 namespace StopWithOnOff {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -362,7 +362,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StopWithOnOff.
+} // namespace StopWithOnOff
 namespace MoveToClosestFrequency {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -390,7 +390,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MoveToClosestFrequency.
+} // namespace MoveToClosestFrequency
 } // namespace Commands
 } // namespace LevelControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/LocalizationConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LocalizationConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LowPower/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LowPower/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/LowPower/Commands.ipp
+++ b/zzz_generated/app-common/clusters/LowPower/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Sleep.
+} // namespace Sleep
 } // namespace Commands
 } // namespace LowPower
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/MediaInput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MediaInput/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/MediaInput/Commands.ipp
+++ b/zzz_generated/app-common/clusters/MediaInput/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelectInput.
+} // namespace SelectInput
 namespace ShowInputStatus {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ShowInputStatus.
+} // namespace ShowInputStatus
 namespace HideInputStatus {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace HideInputStatus.
+} // namespace HideInputStatus
 namespace RenameInput {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -133,7 +133,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RenameInput.
+} // namespace RenameInput
 } // namespace Commands
 } // namespace MediaInput
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/MediaPlayback/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MediaPlayback/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/MediaPlayback/Commands.ipp
+++ b/zzz_generated/app-common/clusters/MediaPlayback/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Play.
+} // namespace Play
 namespace Pause {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Pause.
+} // namespace Pause
 namespace Stop {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Stop.
+} // namespace Stop
 namespace StartOver {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StartOver.
+} // namespace StartOver
 namespace Previous {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -138,7 +138,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Previous.
+} // namespace Previous
 namespace Next {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -160,7 +160,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Next.
+} // namespace Next
 namespace Rewind {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -188,7 +188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Rewind.
+} // namespace Rewind
 namespace FastForward {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -216,7 +216,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FastForward.
+} // namespace FastForward
 namespace SkipForward {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -244,7 +244,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SkipForward.
+} // namespace SkipForward
 namespace SkipBackward {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -272,7 +272,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SkipBackward.
+} // namespace SkipBackward
 namespace PlaybackResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -305,7 +305,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PlaybackResponse.
+} // namespace PlaybackResponse
 namespace Seek {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -333,7 +333,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Seek.
+} // namespace Seek
 namespace ActivateAudioTrack {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -366,7 +366,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActivateAudioTrack.
+} // namespace ActivateAudioTrack
 namespace ActivateTextTrack {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -394,7 +394,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActivateTextTrack.
+} // namespace ActivateTextTrack
 namespace DeactivateTextTrack {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -416,7 +416,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DeactivateTextTrack.
+} // namespace DeactivateTextTrack
 } // namespace Commands
 } // namespace MediaPlayback
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/MediaPlayback/Events.ipp
+++ b/zzz_generated/app-common/clusters/MediaPlayback/Events.ipp
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StateChanged.
+} // namespace StateChanged
 } // namespace Events
 } // namespace MediaPlayback
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Messages/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Messages/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Messages/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Messages/Commands.ipp
@@ -86,7 +86,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PresentMessagesRequest.
+} // namespace PresentMessagesRequest
 namespace CancelMessagesRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CancelMessagesRequest.
+} // namespace CancelMessagesRequest
 } // namespace Commands
 } // namespace Messages
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Messages/Events.ipp
+++ b/zzz_generated/app-common/clusters/Messages/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MessageQueued.
+} // namespace MessageQueued
 namespace MessagePresented {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -91,7 +91,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MessagePresented.
+} // namespace MessagePresented
 namespace MessageComplete {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MessageComplete.
+} // namespace MessageComplete
 } // namespace Events
 } // namespace Messages
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/MeterIdentification/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MeterIdentification/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetCookingParameters.
+} // namespace SetCookingParameters
 namespace AddMoreTime {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddMoreTime.
+} // namespace AddMoreTime
 } // namespace Commands
 } // namespace MicrowaveOvenControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/MicrowaveOvenMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ModeSelect/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ModeSelect/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ModeSelect/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ModeSelect/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 } // namespace Commands
 } // namespace ModeSelect
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/Commands.ipp
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ScanNetworks.
+} // namespace ScanNetworks
 namespace ScanNetworksResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ScanNetworksResponse.
+} // namespace ScanNetworksResponse
 namespace AddOrUpdateWiFiNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -157,7 +157,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddOrUpdateWiFiNetwork.
+} // namespace AddOrUpdateWiFiNetwork
 namespace AddOrUpdateThreadNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -190,7 +190,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddOrUpdateThreadNetwork.
+} // namespace AddOrUpdateThreadNetwork
 namespace RemoveNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -223,7 +223,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveNetwork.
+} // namespace RemoveNetwork
 namespace NetworkConfigResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -271,7 +271,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NetworkConfigResponse.
+} // namespace NetworkConfigResponse
 namespace ConnectNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -304,7 +304,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ConnectNetwork.
+} // namespace ConnectNetwork
 namespace ConnectNetworkResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -342,7 +342,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ConnectNetworkResponse.
+} // namespace ConnectNetworkResponse
 namespace ReorderNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -380,7 +380,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReorderNetwork.
+} // namespace ReorderNetwork
 namespace QueryIdentity {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -413,7 +413,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace QueryIdentity.
+} // namespace QueryIdentity
 namespace QueryIdentityResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -446,7 +446,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace QueryIdentityResponse.
+} // namespace QueryIdentityResponse
 } // namespace Commands
 } // namespace NetworkCommissioning
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OccupancySensing/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OccupancySensing/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OccupancySensing/Events.ipp
+++ b/zzz_generated/app-common/clusters/OccupancySensing/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OccupancyChanged.
+} // namespace OccupancyChanged
 } // namespace Events
 } // namespace OccupancySensing
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OnOff/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OnOff/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OnOff/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OnOff/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Off.
+} // namespace Off
 namespace On {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace On.
+} // namespace On
 namespace Toggle {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Toggle.
+} // namespace Toggle
 namespace OffWithEffect {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -127,7 +127,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OffWithEffect.
+} // namespace OffWithEffect
 namespace OnWithRecallGlobalScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -149,7 +149,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OnWithRecallGlobalScene.
+} // namespace OnWithRecallGlobalScene
 namespace OnWithTimedOff {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -187,7 +187,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OnWithTimedOff.
+} // namespace OnWithTimedOff
 } // namespace Commands
 } // namespace OnOff
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OperationalCredentials/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OperationalCredentials/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AttestationRequest.
+} // namespace AttestationRequest
 namespace AttestationResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AttestationResponse.
+} // namespace AttestationResponse
 namespace CertificateChainRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CertificateChainRequest.
+} // namespace CertificateChainRequest
 namespace CertificateChainResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -145,7 +145,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CertificateChainResponse.
+} // namespace CertificateChainResponse
 namespace CSRRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -178,7 +178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CSRRequest.
+} // namespace CSRRequest
 namespace CSRResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -211,7 +211,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CSRResponse.
+} // namespace CSRResponse
 namespace AddNOC {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -259,7 +259,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddNOC.
+} // namespace AddNOC
 namespace UpdateNOC {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -292,7 +292,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateNOC.
+} // namespace UpdateNOC
 namespace NOCResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -330,7 +330,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NOCResponse.
+} // namespace NOCResponse
 namespace UpdateFabricLabel {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -358,7 +358,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateFabricLabel.
+} // namespace UpdateFabricLabel
 namespace RemoveFabric {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -386,7 +386,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveFabric.
+} // namespace RemoveFabric
 namespace AddTrustedRootCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -414,7 +414,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddTrustedRootCertificate.
+} // namespace AddTrustedRootCertificate
 namespace SetVIDVerificationStatement {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -452,7 +452,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetVIDVerificationStatement.
+} // namespace SetVIDVerificationStatement
 namespace SignVIDVerificationRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -485,7 +485,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SignVIDVerificationRequest.
+} // namespace SignVIDVerificationRequest
 namespace SignVIDVerificationResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -523,7 +523,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SignVIDVerificationResponse.
+} // namespace SignVIDVerificationResponse
 } // namespace Commands
 } // namespace OperationalCredentials
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OperationalState/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OperationalState/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OperationalState/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Pause.
+} // namespace Pause
 namespace Stop {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Stop.
+} // namespace Stop
 namespace Start {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Start.
+} // namespace Start
 namespace Resume {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Resume.
+} // namespace Resume
 namespace OperationalCommandResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -144,7 +144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalCommandResponse.
+} // namespace OperationalCommandResponse
 } // namespace Commands
 } // namespace OperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OperationalState/Events.ipp
+++ b/zzz_generated/app-common/clusters/OperationalState/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalError.
+} // namespace OperationalError
 namespace OperationCompletion {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationCompletion.
+} // namespace OperationCompletion
 } // namespace Events
 } // namespace OperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Commands.ipp
@@ -91,7 +91,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace QueryImage.
+} // namespace QueryImage
 namespace QueryImageResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -154,7 +154,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace QueryImageResponse.
+} // namespace QueryImageResponse
 namespace ApplyUpdateRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -187,7 +187,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ApplyUpdateRequest.
+} // namespace ApplyUpdateRequest
 namespace ApplyUpdateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -220,7 +220,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ApplyUpdateResponse.
+} // namespace ApplyUpdateResponse
 namespace NotifyUpdateApplied {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -253,7 +253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NotifyUpdateApplied.
+} // namespace NotifyUpdateApplied
 } // namespace Commands
 } // namespace OtaSoftwareUpdateProvider
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AnnounceOTAProvider.
+} // namespace AnnounceOTAProvider
 } // namespace Commands
 } // namespace OtaSoftwareUpdateRequestor
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Events.ipp
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Events.ipp
@@ -75,7 +75,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StateTransition.
+} // namespace StateTransition
 namespace VersionApplied {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -111,7 +111,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace VersionApplied.
+} // namespace VersionApplied
 namespace DownloadError {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -157,7 +157,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DownloadError.
+} // namespace DownloadError
 } // namespace Events
 } // namespace OtaSoftwareUpdateRequestor
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Stop.
+} // namespace Stop
 namespace Start {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Start.
+} // namespace Start
 namespace OperationalCommandResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalCommandResponse.
+} // namespace OperationalCommandResponse
 } // namespace Commands
 } // namespace OvenCavityOperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/Events.ipp
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalError.
+} // namespace OperationalError
 namespace OperationCompletion {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationCompletion.
+} // namespace OperationCompletion
 } // namespace Events
 } // namespace OvenCavityOperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OvenMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OvenMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/OvenMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/OvenMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace OvenMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PowerSource/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerSource/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PowerSource/Events.ipp
+++ b/zzz_generated/app-common/clusters/PowerSource/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace WiredFaultChange.
+} // namespace WiredFaultChange
 namespace BatFaultChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BatFaultChange.
+} // namespace BatFaultChange
 namespace BatChargeFaultChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BatChargeFaultChange.
+} // namespace BatChargeFaultChange
 } // namespace Events
 } // namespace PowerSource
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/PowerSourceConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerSourceConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PowerTopology/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerTopology/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PressureMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PressureMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ProxyConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ProxyDiscovery/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyDiscovery/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ProxyValid/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyValid/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PulseWidthModulation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PulseWidthModulation/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Events.ipp
@@ -51,7 +51,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SupplyVoltageLow.
+} // namespace SupplyVoltageLow
 namespace SupplyVoltageHigh {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -73,7 +73,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SupplyVoltageHigh.
+} // namespace SupplyVoltageHigh
 namespace PowerMissingPhase {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -95,7 +95,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PowerMissingPhase.
+} // namespace PowerMissingPhase
 namespace SystemPressureLow {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SystemPressureLow.
+} // namespace SystemPressureLow
 namespace SystemPressureHigh {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -139,7 +139,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SystemPressureHigh.
+} // namespace SystemPressureHigh
 namespace DryRunning {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -161,7 +161,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DryRunning.
+} // namespace DryRunning
 namespace MotorTemperatureHigh {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -183,7 +183,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MotorTemperatureHigh.
+} // namespace MotorTemperatureHigh
 namespace PumpMotorFatalFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -205,7 +205,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PumpMotorFatalFailure.
+} // namespace PumpMotorFatalFailure
 namespace ElectronicTemperatureHigh {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -227,7 +227,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ElectronicTemperatureHigh.
+} // namespace ElectronicTemperatureHigh
 namespace PumpBlocked {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -249,7 +249,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PumpBlocked.
+} // namespace PumpBlocked
 namespace SensorFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -271,7 +271,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SensorFailure.
+} // namespace SensorFailure
 namespace ElectronicNonFatalFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -293,7 +293,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ElectronicNonFatalFailure.
+} // namespace ElectronicNonFatalFailure
 namespace ElectronicFatalFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -315,7 +315,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ElectronicFatalFailure.
+} // namespace ElectronicFatalFailure
 namespace GeneralFault {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -337,7 +337,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GeneralFault.
+} // namespace GeneralFault
 namespace Leakage {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -359,7 +359,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Leakage.
+} // namespace Leakage
 namespace AirDetection {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -381,7 +381,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AirDetection.
+} // namespace AirDetection
 namespace TurbineOperation {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -403,7 +403,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TurbineOperation.
+} // namespace TurbineOperation
 } // namespace Events
 } // namespace PumpConfigurationAndControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Commands.ipp
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AllocatePushTransport.
+} // namespace AllocatePushTransport
 namespace AllocatePushTransportResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -85,7 +85,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AllocatePushTransportResponse.
+} // namespace AllocatePushTransportResponse
 namespace DeallocatePushTransport {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -113,7 +113,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DeallocatePushTransport.
+} // namespace DeallocatePushTransport
 namespace ModifyPushTransport {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -146,7 +146,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ModifyPushTransport.
+} // namespace ModifyPushTransport
 namespace SetTransportStatus {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -179,7 +179,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTransportStatus.
+} // namespace SetTransportStatus
 namespace ManuallyTriggerTransport {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -222,7 +222,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ManuallyTriggerTransport.
+} // namespace ManuallyTriggerTransport
 namespace FindTransport {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -250,7 +250,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindTransport.
+} // namespace FindTransport
 namespace FindTransportResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -279,7 +279,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindTransportResponse.
+} // namespace FindTransportResponse
 } // namespace Commands
 } // namespace PushAvStreamTransport
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Events.ipp
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Events.ipp
@@ -80,7 +80,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PushTransportBegin.
+} // namespace PushTransportBegin
 namespace PushTransportEnd {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -121,7 +121,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PushTransportEnd.
+} // namespace PushTransportEnd
 } // namespace Events
 } // namespace PushAvStreamTransport
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RefrigeratorAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RefrigeratorAlarm/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RefrigeratorAlarm/Events.ipp
+++ b/zzz_generated/app-common/clusters/RefrigeratorAlarm/Events.ipp
@@ -75,7 +75,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Notify.
+} // namespace Notify
 } // namespace Events
 } // namespace RefrigeratorAlarm
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace RefrigeratorAndTemperatureControlledCabinetMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RvcCleanMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RvcCleanMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace RvcCleanMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RvcOperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RvcOperationalState/Commands.ipp
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Pause.
+} // namespace Pause
 namespace Resume {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Resume.
+} // namespace Resume
 namespace OperationalCommandResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalCommandResponse.
+} // namespace OperationalCommandResponse
 namespace GoHome {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GoHome.
+} // namespace GoHome
 } // namespace Commands
 } // namespace RvcOperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RvcOperationalState/Events.ipp
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalError.
+} // namespace OperationalError
 namespace OperationCompletion {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationCompletion.
+} // namespace OperationCompletion
 } // namespace Events
 } // namespace RvcOperationalState
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/RvcRunMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcRunMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/RvcRunMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/RvcRunMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace RvcRunMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SampleMei/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SampleMei/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/SampleMei/Commands.ipp
+++ b/zzz_generated/app-common/clusters/SampleMei/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Ping.
+} // namespace Ping
 namespace AddArgumentsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddArgumentsResponse.
+} // namespace AddArgumentsResponse
 namespace AddArguments {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -111,7 +111,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddArguments.
+} // namespace AddArguments
 } // namespace Commands
 } // namespace SampleMei
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SampleMei/Events.ipp
+++ b/zzz_generated/app-common/clusters/SampleMei/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace PingCountEvent.
+} // namespace PingCountEvent
 } // namespace Events
 } // namespace SampleMei
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ScenesManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ScenesManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ScenesManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ScenesManagement/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddScene.
+} // namespace AddScene
 namespace AddSceneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -114,7 +114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddSceneResponse.
+} // namespace AddSceneResponse
 namespace ViewScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -147,7 +147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ViewScene.
+} // namespace ViewScene
 namespace ViewSceneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -200,7 +200,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ViewSceneResponse.
+} // namespace ViewSceneResponse
 namespace RemoveScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -233,7 +233,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveScene.
+} // namespace RemoveScene
 namespace RemoveSceneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -271,7 +271,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveSceneResponse.
+} // namespace RemoveSceneResponse
 namespace RemoveAllScenes {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -299,7 +299,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveAllScenes.
+} // namespace RemoveAllScenes
 namespace RemoveAllScenesResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -332,7 +332,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveAllScenesResponse.
+} // namespace RemoveAllScenesResponse
 namespace StoreScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -365,7 +365,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StoreScene.
+} // namespace StoreScene
 namespace StoreSceneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -403,7 +403,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StoreSceneResponse.
+} // namespace StoreSceneResponse
 namespace RecallScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -441,7 +441,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RecallScene.
+} // namespace RecallScene
 namespace GetSceneMembership {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -469,7 +469,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetSceneMembership.
+} // namespace GetSceneMembership
 namespace GetSceneMembershipResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -512,7 +512,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetSceneMembershipResponse.
+} // namespace GetSceneMembershipResponse
 namespace CopyScene {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -560,7 +560,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CopyScene.
+} // namespace CopyScene
 namespace CopySceneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -598,7 +598,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CopySceneResponse.
+} // namespace CopySceneResponse
 } // namespace Commands
 } // namespace ScenesManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ServiceArea/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ServiceArea/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ServiceArea/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ServiceArea/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelectAreas.
+} // namespace SelectAreas
 namespace SelectAreasResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelectAreasResponse.
+} // namespace SelectAreasResponse
 namespace SkipArea {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SkipArea.
+} // namespace SkipArea
 namespace SkipAreaResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SkipAreaResponse.
+} // namespace SkipAreaResponse
 } // namespace Commands
 } // namespace ServiceArea
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/Commands.ipp
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelfTestRequest.
+} // namespace SelfTestRequest
 } // namespace Commands
 } // namespace SmokeCoAlarm
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/Events.ipp
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SmokeAlarm.
+} // namespace SmokeAlarm
 namespace COAlarm {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -91,7 +91,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace COAlarm.
+} // namespace COAlarm
 namespace LowBattery {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LowBattery.
+} // namespace LowBattery
 namespace HardwareFault {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -144,7 +144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace HardwareFault.
+} // namespace HardwareFault
 namespace EndOfService {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -166,7 +166,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EndOfService.
+} // namespace EndOfService
 namespace SelfTestComplete {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -188,7 +188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SelfTestComplete.
+} // namespace SelfTestComplete
 namespace AlarmMuted {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -210,7 +210,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AlarmMuted.
+} // namespace AlarmMuted
 namespace MuteEnded {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -232,7 +232,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MuteEnded.
+} // namespace MuteEnded
 namespace InterconnectSmokeAlarm {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -263,7 +263,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace InterconnectSmokeAlarm.
+} // namespace InterconnectSmokeAlarm
 namespace InterconnectCOAlarm {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -294,7 +294,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace InterconnectCOAlarm.
+} // namespace InterconnectCOAlarm
 namespace AllClear {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -316,7 +316,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AllClear.
+} // namespace AllClear
 } // namespace Events
 } // namespace SmokeCoAlarm
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/Commands.ipp
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetWatermarks.
+} // namespace ResetWatermarks
 } // namespace Commands
 } // namespace SoftwareDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/Events.ipp
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/Events.ipp
@@ -70,7 +70,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SoftwareFault.
+} // namespace SoftwareFault
 } // namespace Events
 } // namespace SoftwareDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/SoilMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SoilMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Switch/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Switch/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Switch/Events.ipp
+++ b/zzz_generated/app-common/clusters/Switch/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SwitchLatched.
+} // namespace SwitchLatched
 namespace InitialPress {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -91,7 +91,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace InitialPress.
+} // namespace InitialPress
 namespace LongPress {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LongPress.
+} // namespace LongPress
 namespace ShortRelease {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -153,7 +153,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ShortRelease.
+} // namespace ShortRelease
 namespace LongRelease {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -184,7 +184,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LongRelease.
+} // namespace LongRelease
 namespace MultiPressOngoing {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -221,7 +221,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MultiPressOngoing.
+} // namespace MultiPressOngoing
 namespace MultiPressComplete {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -258,7 +258,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MultiPressComplete.
+} // namespace MultiPressComplete
 } // namespace Events
 } // namespace Switch
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TargetNavigator/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TargetNavigator/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TargetNavigator/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TargetNavigator/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NavigateTarget.
+} // namespace NavigateTarget
 namespace NavigateTargetResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NavigateTargetResponse.
+} // namespace NavigateTargetResponse
 } // namespace Commands
 } // namespace TargetNavigator
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TargetNavigator/Events.ipp
+++ b/zzz_generated/app-common/clusters/TargetNavigator/Events.ipp
@@ -70,7 +70,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TargetUpdated.
+} // namespace TargetUpdated
 } // namespace Events
 } // namespace TargetNavigator
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TemperatureControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TemperatureControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TemperatureControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TemperatureControl/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTemperature.
+} // namespace SetTemperature
 } // namespace Commands
 } // namespace TemperatureControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TemperatureMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TemperatureMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Thermostat/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Thermostat/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Thermostat/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Thermostat/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetpointRaiseLower.
+} // namespace SetpointRaiseLower
 namespace GetWeeklyScheduleResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetWeeklyScheduleResponse.
+} // namespace GetWeeklyScheduleResponse
 namespace SetWeeklySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -147,7 +147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetWeeklySchedule.
+} // namespace SetWeeklySchedule
 namespace GetWeeklySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -180,7 +180,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetWeeklySchedule.
+} // namespace GetWeeklySchedule
 namespace AddThermostatSuggestionResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -208,7 +208,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddThermostatSuggestionResponse.
+} // namespace AddThermostatSuggestionResponse
 namespace ClearWeeklySchedule {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -230,7 +230,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClearWeeklySchedule.
+} // namespace ClearWeeklySchedule
 namespace SetActiveScheduleRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -258,7 +258,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetActiveScheduleRequest.
+} // namespace SetActiveScheduleRequest
 namespace SetActivePresetRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -286,7 +286,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetActivePresetRequest.
+} // namespace SetActivePresetRequest
 namespace AddThermostatSuggestion {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -324,7 +324,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddThermostatSuggestion.
+} // namespace AddThermostatSuggestion
 namespace RemoveThermostatSuggestion {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -352,7 +352,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveThermostatSuggestion.
+} // namespace RemoveThermostatSuggestion
 namespace AtomicResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -390,7 +390,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AtomicResponse.
+} // namespace AtomicResponse
 namespace AtomicRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -428,7 +428,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AtomicRequest.
+} // namespace AtomicRequest
 } // namespace Commands
 } // namespace Thermostat
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Thermostat/Events.ipp
+++ b/zzz_generated/app-common/clusters/Thermostat/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SystemModeChange.
+} // namespace SystemModeChange
 namespace LocalTemperatureChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -96,7 +96,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LocalTemperatureChange.
+} // namespace LocalTemperatureChange
 namespace OccupancyChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -132,7 +132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OccupancyChange.
+} // namespace OccupancyChange
 namespace SetpointChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -178,7 +178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetpointChange.
+} // namespace SetpointChange
 namespace RunningStateChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -214,7 +214,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RunningStateChange.
+} // namespace RunningStateChange
 namespace RunningModeChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -250,7 +250,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RunningModeChange.
+} // namespace RunningModeChange
 namespace ActiveScheduleChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -286,7 +286,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActiveScheduleChange.
+} // namespace ActiveScheduleChange
 namespace ActivePresetChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -322,7 +322,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ActivePresetChange.
+} // namespace ActivePresetChange
 } // namespace Events
 } // namespace Thermostat
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetActiveDatasetRequest.
+} // namespace GetActiveDatasetRequest
 namespace GetPendingDatasetRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetPendingDatasetRequest.
+} // namespace GetPendingDatasetRequest
 namespace DatasetResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DatasetResponse.
+} // namespace DatasetResponse
 namespace SetActiveDatasetRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -133,7 +133,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetActiveDatasetRequest.
+} // namespace SetActiveDatasetRequest
 namespace SetPendingDatasetRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -161,7 +161,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetPendingDatasetRequest.
+} // namespace SetPendingDatasetRequest
 } // namespace Commands
 } // namespace ThreadBorderRouterManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCounts.
+} // namespace ResetCounts
 } // namespace Commands
 } // namespace ThreadNetworkDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Events.ipp
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ConnectionStatus.
+} // namespace ConnectionStatus
 namespace NetworkFaultChange {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -96,7 +96,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NetworkFaultChange.
+} // namespace NetworkFaultChange
 } // namespace Events
 } // namespace ThreadNetworkDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddNetwork.
+} // namespace AddNetwork
 namespace RemoveNetwork {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveNetwork.
+} // namespace RemoveNetwork
 namespace GetOperationalDataset {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -112,7 +112,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GetOperationalDataset.
+} // namespace GetOperationalDataset
 namespace OperationalDatasetResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -140,7 +140,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace OperationalDatasetResponse.
+} // namespace OperationalDatasetResponse
 } // namespace Commands
 } // namespace ThreadNetworkDirectory
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TimeFormatLocalization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TimeFormatLocalization/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TimeSynchronization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Commands.ipp
@@ -66,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetUTCTime.
+} // namespace SetUTCTime
 namespace SetTrustedTimeSource {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTrustedTimeSource.
+} // namespace SetTrustedTimeSource
 namespace SetTimeZone {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTimeZone.
+} // namespace SetTimeZone
 namespace SetTimeZoneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTimeZoneResponse.
+} // namespace SetTimeZoneResponse
 namespace SetDSTOffset {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -178,7 +178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetDSTOffset.
+} // namespace SetDSTOffset
 namespace SetDefaultNTP {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -206,7 +206,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetDefaultNTP.
+} // namespace SetDefaultNTP
 } // namespace Commands
 } // namespace TimeSynchronization
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Events.ipp
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Events.ipp
@@ -51,7 +51,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DSTTableEmpty.
+} // namespace DSTTableEmpty
 namespace DSTStatus {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -82,7 +82,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DSTStatus.
+} // namespace DSTStatus
 namespace TimeZoneStatus {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -118,7 +118,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TimeZoneStatus.
+} // namespace TimeZoneStatus
 namespace TimeFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -140,7 +140,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TimeFailure.
+} // namespace TimeFailure
 namespace MissingTrustedTimeSource {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -162,7 +162,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace MissingTrustedTimeSource.
+} // namespace MissingTrustedTimeSource
 } // namespace Events
 } // namespace TimeSynchronization
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/Timer/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Timer/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/Timer/Commands.ipp
+++ b/zzz_generated/app-common/clusters/Timer/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SetTimer.
+} // namespace SetTimer
 namespace ResetTimer {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetTimer.
+} // namespace ResetTimer
 namespace AddTime {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -106,7 +106,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AddTime.
+} // namespace AddTime
 namespace ReduceTime {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -134,7 +134,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ReduceTime.
+} // namespace ReduceTime
 } // namespace Commands
 } // namespace Timer
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvisionRootCertificate.
+} // namespace ProvisionRootCertificate
 namespace ProvisionRootCertificateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvisionRootCertificateResponse.
+} // namespace ProvisionRootCertificateResponse
 namespace FindRootCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindRootCertificate.
+} // namespace FindRootCertificate
 namespace FindRootCertificateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -146,7 +146,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindRootCertificateResponse.
+} // namespace FindRootCertificateResponse
 namespace LookupRootCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -174,7 +174,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LookupRootCertificate.
+} // namespace LookupRootCertificate
 namespace LookupRootCertificateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -202,7 +202,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LookupRootCertificateResponse.
+} // namespace LookupRootCertificateResponse
 namespace RemoveRootCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -230,7 +230,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveRootCertificate.
+} // namespace RemoveRootCertificate
 namespace ClientCSR {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -263,7 +263,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClientCSR.
+} // namespace ClientCSR
 namespace ClientCSRResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -301,7 +301,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ClientCSRResponse.
+} // namespace ClientCSRResponse
 namespace ProvisionClientCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -339,7 +339,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvisionClientCertificate.
+} // namespace ProvisionClientCertificate
 namespace FindClientCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -367,7 +367,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindClientCertificate.
+} // namespace FindClientCertificate
 namespace FindClientCertificateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -396,7 +396,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindClientCertificateResponse.
+} // namespace FindClientCertificateResponse
 namespace LookupClientCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -424,7 +424,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LookupClientCertificate.
+} // namespace LookupClientCertificate
 namespace LookupClientCertificateResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -452,7 +452,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace LookupClientCertificateResponse.
+} // namespace LookupClientCertificateResponse
 namespace RemoveClientCertificate {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -480,7 +480,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveClientCertificate.
+} // namespace RemoveClientCertificate
 } // namespace Commands
 } // namespace TlsCertificateManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TlsClientManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/TlsClientManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/Commands.ipp
@@ -76,7 +76,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvisionEndpoint.
+} // namespace ProvisionEndpoint
 namespace ProvisionEndpointResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvisionEndpointResponse.
+} // namespace ProvisionEndpointResponse
 namespace FindEndpoint {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -132,7 +132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindEndpoint.
+} // namespace FindEndpoint
 namespace FindEndpointResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -160,7 +160,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace FindEndpointResponse.
+} // namespace FindEndpointResponse
 namespace RemoveEndpoint {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -188,7 +188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveEndpoint.
+} // namespace RemoveEndpoint
 } // namespace Commands
 } // namespace TlsClientManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/UnitLocalization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UnitLocalization/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/UnitTesting/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UnitTesting/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/UnitTesting/Commands.ipp
+++ b/zzz_generated/app-common/clusters/UnitTesting/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Test.
+} // namespace Test
 namespace TestSpecificResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSpecificResponse.
+} // namespace TestSpecificResponse
 namespace TestNotHandled {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -100,7 +100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestNotHandled.
+} // namespace TestNotHandled
 namespace TestAddArgumentsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -128,7 +128,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestAddArgumentsResponse.
+} // namespace TestAddArgumentsResponse
 namespace TestSpecific {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSpecific.
+} // namespace TestSpecific
 namespace TestSimpleArgumentResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -178,7 +178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSimpleArgumentResponse.
+} // namespace TestSimpleArgumentResponse
 namespace TestUnknownCommand {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -200,7 +200,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestUnknownCommand.
+} // namespace TestUnknownCommand
 namespace TestStructArrayArgumentResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -253,7 +253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestStructArrayArgumentResponse.
+} // namespace TestStructArrayArgumentResponse
 namespace TestAddArguments {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -286,7 +286,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestAddArguments.
+} // namespace TestAddArguments
 namespace TestListInt8UReverseResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -314,7 +314,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestListInt8UReverseResponse.
+} // namespace TestListInt8UReverseResponse
 namespace TestSimpleArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -342,7 +342,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSimpleArgumentRequest.
+} // namespace TestSimpleArgumentRequest
 namespace TestEnumsResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -375,7 +375,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEnumsResponse.
+} // namespace TestEnumsResponse
 namespace TestStructArrayArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -428,7 +428,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestStructArrayArgumentRequest.
+} // namespace TestStructArrayArgumentRequest
 namespace TestNullableOptionalResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -471,7 +471,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestNullableOptionalResponse.
+} // namespace TestNullableOptionalResponse
 namespace TestStructArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -499,7 +499,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestStructArgumentRequest.
+} // namespace TestStructArgumentRequest
 namespace TestComplexNullableOptionalResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -662,7 +662,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestComplexNullableOptionalResponse.
+} // namespace TestComplexNullableOptionalResponse
 namespace TestNestedStructArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -690,7 +690,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestNestedStructArgumentRequest.
+} // namespace TestNestedStructArgumentRequest
 namespace BooleanResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -718,7 +718,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BooleanResponse.
+} // namespace BooleanResponse
 namespace TestListStructArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -746,7 +746,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestListStructArgumentRequest.
+} // namespace TestListStructArgumentRequest
 namespace SimpleStructResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -774,7 +774,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SimpleStructResponse.
+} // namespace SimpleStructResponse
 namespace TestListInt8UArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -802,7 +802,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestListInt8UArgumentRequest.
+} // namespace TestListInt8UArgumentRequest
 namespace TestEmitTestEventResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -830,7 +830,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEmitTestEventResponse.
+} // namespace TestEmitTestEventResponse
 namespace TestNestedStructListArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -858,7 +858,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestNestedStructListArgumentRequest.
+} // namespace TestNestedStructListArgumentRequest
 namespace TestEmitTestFabricScopedEventResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -886,7 +886,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEmitTestFabricScopedEventResponse.
+} // namespace TestEmitTestFabricScopedEventResponse
 namespace TestListNestedStructListArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -914,7 +914,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestListNestedStructListArgumentRequest.
+} // namespace TestListNestedStructListArgumentRequest
 namespace TestBatchHelperResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -942,7 +942,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestBatchHelperResponse.
+} // namespace TestBatchHelperResponse
 namespace TestListInt8UReverseRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -970,7 +970,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestListInt8UReverseRequest.
+} // namespace TestListInt8UReverseRequest
 namespace StringEchoResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -998,7 +998,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StringEchoResponse.
+} // namespace StringEchoResponse
 namespace TestEnumsRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1031,7 +1031,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEnumsRequest.
+} // namespace TestEnumsRequest
 namespace GlobalEchoResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -1064,7 +1064,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GlobalEchoResponse.
+} // namespace GlobalEchoResponse
 namespace TestNullableOptionalRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1092,7 +1092,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestNullableOptionalRequest.
+} // namespace TestNullableOptionalRequest
 namespace TestComplexNullableOptionalRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1175,7 +1175,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestComplexNullableOptionalRequest.
+} // namespace TestComplexNullableOptionalRequest
 namespace SimpleStructEchoRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1203,7 +1203,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SimpleStructEchoRequest.
+} // namespace SimpleStructEchoRequest
 namespace TimedInvokeRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1225,7 +1225,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TimedInvokeRequest.
+} // namespace TimedInvokeRequest
 namespace TestSimpleOptionalArgumentRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1253,7 +1253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSimpleOptionalArgumentRequest.
+} // namespace TestSimpleOptionalArgumentRequest
 namespace TestEmitTestEventRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1291,7 +1291,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEmitTestEventRequest.
+} // namespace TestEmitTestEventRequest
 namespace TestEmitTestFabricScopedEventRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1319,7 +1319,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEmitTestFabricScopedEventRequest.
+} // namespace TestEmitTestFabricScopedEventRequest
 namespace TestBatchHelperRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1357,7 +1357,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestBatchHelperRequest.
+} // namespace TestBatchHelperRequest
 namespace TestSecondBatchHelperRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1395,7 +1395,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestSecondBatchHelperRequest.
+} // namespace TestSecondBatchHelperRequest
 namespace StringEchoRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1423,7 +1423,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StringEchoRequest.
+} // namespace StringEchoRequest
 namespace GlobalEchoRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1456,7 +1456,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GlobalEchoRequest.
+} // namespace GlobalEchoRequest
 namespace TestCheckCommandFlags {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1478,7 +1478,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestCheckCommandFlags.
+} // namespace TestCheckCommandFlags
 namespace TestDifferentVendorMeiRequest {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -1506,7 +1506,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestDifferentVendorMeiRequest.
+} // namespace TestDifferentVendorMeiRequest
 namespace TestDifferentVendorMeiResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -1539,7 +1539,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestDifferentVendorMeiResponse.
+} // namespace TestDifferentVendorMeiResponse
 } // namespace Commands
 } // namespace UnitTesting
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/UnitTesting/Events.ipp
+++ b/zzz_generated/app-common/clusters/UnitTesting/Events.ipp
@@ -85,7 +85,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestEvent.
+} // namespace TestEvent
 namespace TestFabricScopedEvent {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -116,7 +116,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestFabricScopedEvent.
+} // namespace TestFabricScopedEvent
 namespace TestDifferentVendorMeiEvent {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -147,7 +147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace TestDifferentVendorMeiEvent.
+} // namespace TestDifferentVendorMeiEvent
 } // namespace Events
 } // namespace UnitTesting
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/UserLabel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UserLabel/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Commands.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Open.
+} // namespace Open
 namespace Close {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -83,7 +83,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Close.
+} // namespace Close
 } // namespace Commands
 } // namespace ValveConfigurationAndControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Events.ipp
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ValveStateChanged.
+} // namespace ValveStateChanged
 namespace ValveFault {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -96,7 +96,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ValveFault.
+} // namespace ValveFault
 } // namespace Events
 } // namespace ValveConfigurationAndControl
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WakeOnLan/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WakeOnLan/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Boost.
+} // namespace Boost
 namespace CancelBoost {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CancelBoost.
+} // namespace CancelBoost
 } // namespace Commands
 } // namespace WaterHeaterManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/Events.ipp
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BoostStarted.
+} // namespace BoostStarted
 namespace BoostEnded {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -82,7 +82,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace BoostEnded.
+} // namespace BoostEnded
 } // namespace Events
 } // namespace WaterHeaterManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToMode.
+} // namespace ChangeToMode
 namespace ChangeToModeResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -89,7 +89,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ChangeToModeResponse.
+} // namespace ChangeToModeResponse
 } // namespace Commands
 } // namespace WaterHeaterMode
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCondition.
+} // namespace ResetCondition
 } // namespace Commands
 } // namespace WaterTankLevelMonitoring
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/Commands.ipp
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SolicitOffer.
+} // namespace SolicitOffer
 namespace SolicitOfferResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -144,7 +144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace SolicitOfferResponse.
+} // namespace SolicitOfferResponse
 namespace ProvideOffer {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -227,7 +227,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvideOffer.
+} // namespace ProvideOffer
 namespace ProvideOfferResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -265,7 +265,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvideOfferResponse.
+} // namespace ProvideOfferResponse
 namespace ProvideAnswer {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -298,7 +298,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvideAnswer.
+} // namespace ProvideAnswer
 namespace ProvideICECandidates {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -331,7 +331,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ProvideICECandidates.
+} // namespace ProvideICECandidates
 namespace EndSession {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -364,7 +364,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace EndSession.
+} // namespace EndSession
 } // namespace Commands
 } // namespace WebRTCTransportProvider
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Commands.ipp
@@ -71,7 +71,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Offer.
+} // namespace Offer
 namespace Answer {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -104,7 +104,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Answer.
+} // namespace Answer
 namespace ICECandidates {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -137,7 +137,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ICECandidates.
+} // namespace ICECandidates
 namespace End {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -170,7 +170,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace End.
+} // namespace End
 } // namespace Commands
 } // namespace WebRTCTransportRequestor
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ResetCounts.
+} // namespace ResetCounts
 } // namespace Commands
 } // namespace WiFiNetworkDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Events.ipp
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Events.ipp
@@ -60,7 +60,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace Disconnection.
+} // namespace Disconnection
 namespace AssociationFailure {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -96,7 +96,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace AssociationFailure.
+} // namespace AssociationFailure
 namespace ConnectionStatus {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -127,7 +127,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ConnectionStatus.
+} // namespace ConnectionStatus
 } // namespace Events
 } // namespace WiFiNetworkDiagnostics
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NetworkPassphraseRequest.
+} // namespace NetworkPassphraseRequest
 namespace NetworkPassphraseResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -78,7 +78,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace NetworkPassphraseResponse.
+} // namespace NetworkPassphraseResponse
 } // namespace Commands
 } // namespace WiFiNetworkManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/WindowCovering/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WindowCovering/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/WindowCovering/Commands.ipp
+++ b/zzz_generated/app-common/clusters/WindowCovering/Commands.ipp
@@ -50,7 +50,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpOrOpen.
+} // namespace UpOrOpen
 namespace DownOrClose {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -72,7 +72,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace DownOrClose.
+} // namespace DownOrClose
 namespace StopMotion {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -94,7 +94,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace StopMotion.
+} // namespace StopMotion
 namespace GoToLiftValue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -122,7 +122,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GoToLiftValue.
+} // namespace GoToLiftValue
 namespace GoToLiftPercentage {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -150,7 +150,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GoToLiftPercentage.
+} // namespace GoToLiftPercentage
 namespace GoToTiltValue {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -178,7 +178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GoToTiltValue.
+} // namespace GoToTiltValue
 namespace GoToTiltPercentage {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -206,7 +206,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace GoToTiltPercentage.
+} // namespace GoToTiltPercentage
 } // namespace Commands
 } // namespace WindowCovering
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ZoneManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ZoneManagement/BUILD.gn
@@ -46,7 +46,7 @@ source_set("headers") {
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
-  # Headers is a workaround for build size optmizations: what we would want is
+  # Headers is a workaround for build size optimizations: what we would want is
   # ":elements" to contain both headers and cpp files. However compiler seems
   # to be able to optimize shared code if we place all structs in one huge
   # CPP file, so "cluster-objects" contains that CPP file.

--- a/zzz_generated/app-common/clusters/ZoneManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Commands.ipp
@@ -56,7 +56,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CreateTwoDCartesianZone.
+} // namespace CreateTwoDCartesianZone
 namespace CreateTwoDCartesianZoneResponse {
 
 CHIP_ERROR Type::Encode(DataModel::FabricAwareTLVWriter & aWriter, TLV::Tag aTag) const
@@ -84,7 +84,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CreateTwoDCartesianZoneResponse.
+} // namespace CreateTwoDCartesianZoneResponse
 namespace UpdateTwoDCartesianZone {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -117,7 +117,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace UpdateTwoDCartesianZone.
+} // namespace UpdateTwoDCartesianZone
 namespace RemoveZone {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -145,7 +145,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveZone.
+} // namespace RemoveZone
 namespace CreateOrUpdateTrigger {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -173,7 +173,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace CreateOrUpdateTrigger.
+} // namespace CreateOrUpdateTrigger
 namespace RemoveTrigger {
 
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
@@ -201,7 +201,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace RemoveTrigger.
+} // namespace RemoveTrigger
 } // namespace Commands
 } // namespace ZoneManagement
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/ZoneManagement/Events.ipp
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Events.ipp
@@ -65,7 +65,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ZoneTriggered.
+} // namespace ZoneTriggered
 namespace ZoneStopped {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
@@ -101,7 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         ReturnErrorOnFailure(err);
     }
 }
-} // namespace ZoneStopped.
+} // namespace ZoneStopped
 } // namespace Events
 } // namespace ZoneManagement
 } // namespace Clusters


### PR DESCRIPTION
#### Summary

LLMs noticed some typos/oddities in templates. Fix them.

#### Testing

ZAP regen. Changes are reasonably trivial.