### PR TITLE
Set a log filtering default to 0, let platforms override if they so wish

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -471,7 +471,7 @@
  *    If asserted (1), enable runtime log level configuration.
  */
 #ifndef CHIP_LOG_FILTERING
-#define CHIP_LOG_FILTERING 1
+#define CHIP_LOG_FILTERING 0
 #endif
 
 /**


### PR DESCRIPTION
#### Summary

Test out effect of disabling event log filtering by default if not overridden by platform configurations.

#### Testing

Trivial change code-wise. CI will validate size changes. I saw CC32xx decreasing by 8KB.