### PR TITLE
[ESP32] Fix doc code snippet for static info provider

### DIFF
--- a/docs/platforms/esp32/providers.md
+++ b/docs/platforms/esp32/providers.md
@@ -36,34 +36,36 @@ Currently, there are two implementations for this provider:
     data via OTA, they should switch to the second implementation in the OTA
     image and use the `Set...()` APIs to set the fixed data.
 
-#### Example:
+#### Example
 
 ```cpp
-#include <platform/ESP32/StaticESP32FactoryDataProvider.h>
+#include <platform/ESP32/StaticESP32DeviceInfoProvider.h>
+
+using namespace chip;
+using namespace chip::app::Clusters::TimeFormatLocalization;
 
 DeviceLayer::StaticESP32DeviceInfoProvider deviceInfoProvider;
 
 // Define array for Supported Calendar Types
-using namespace chip::app::Clusters::TimeFormatLocalization::CalendarTypeEnum;
 CalendarTypeEnum supportedCalendarTypes[] = {
     CalendarTypeEnum::kGregorian,
 };
 
 // Define array for Supported Locales
-const char* supportedLocales[] = {
-    "en-US",
-    "en-GB",
+CharSpan supportedLocales[] = {
+    "en-US"_span,
+    "en-GB"_span,
 };
 
 // Define array for Fixed labels { EndpointId, Label, Value }
-struct StaticESP32DeviceInfoProvider::FixedLabelEntry fixedLabels[] = {
-    { 0, "Orientation", "North" },
-    { 0, "Direction", "Up" },
+struct DeviceLayer::StaticESP32DeviceInfoProvider::FixedLabelEntry fixedLabels[] = {
+    { 0, "Orientation"_span, "North"_span },
+    { 0, "Direction"_span, "Up"_span },
 };
 
 Span<CalendarTypeEnum> sSupportedCalendarTypes(supportedCalendarTypes);
-Span<const char*> sSupportedLocales(supportedLocales);
-Span<StaticESP32DeviceInfoProvider::FixedLabelEntry> sFixedLabels(fixedLabels);
+Span<CharSpan> sSupportedLocales(supportedLocales);
+Span<DeviceLayer::StaticESP32DeviceInfoProvider::FixedLabelEntry> sFixedLabels(fixedLabels);
 
 {
     deviceInfoProvider.SetSupportedLocales(sSupportedLocales);

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -433,8 +433,8 @@ def gen_raw_ec_keypair_from_der(key_file, pubkey_raw_file, privkey_raw_file):
     with open(key_file, 'rb') as f:
         key_data = f.read()
 
-    log.warning("Leaking of DAC private keys may lead to attestation chain revokation")
-    log.warning("Please make sure the DAC private is key protected using a password")
+    log.warning("Leaking of DAC private keys may lead to attestation chain revocation")
+    log.warning("Please make sure the DAC private key is protected using a password")
 
     # WARNING: Below line assumes that the DAC private key is not protected by a password,
     #          please be careful and use the password-protected key if reusing this code

--- a/src/platform/ESP32/StaticESP32DeviceInfoProvider.h
+++ b/src/platform/ESP32/StaticESP32DeviceInfoProvider.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <lib/support/Span.h>
 #include <platform/ESP32/ESP32DeviceInfoProvider.h>
 
 namespace chip {


### PR DESCRIPTION
#### Summary

The code snippet provided in the ESP32 doc does not compile.

Changes:

- Fix typo in the include file name
- Fix `using namespace` usage (`CalendarTypeEnum` is not a namespace)
- API requires `CharSpan`, not literals
- Added `<lib/support/Span.h>` to `StaticESP32DeviceInfoProvider.h` so the include will be self contained

#### Testing

Locally tested that it's possible to create `StaticESP32DeviceInfoProvider` using provided snippet.
