### PR TITLE
[Silabs] Adding the nongncheck and removing the source include

### DIFF
--- a/examples/lit-icd-app/silabs/BUILD.gn
+++ b/examples/lit-icd-app/silabs/BUILD.gn
@@ -123,10 +123,6 @@ silabs_executable("lit_icd_app") {
     deps += [ "${examples_plat_dir}:efr32-common" ]
   }
 
-  if (chip_build_libshell) {
-    sources += [ "src/ShellCommands.cpp" ]
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "PW_RPC_ENABLED",

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -38,7 +38,7 @@
 #endif // DISPLAY_ENABLED
 
 #if defined(CHIP_CONFIG_ENABLE_READ_CLIENT) && CHIP_CONFIG_ENABLE_READ_CLIENT
-#include <shell/im/IMShellCommands.h>
+#include <shell/im/IMShellCommands.h> // nogncheck
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -37,9 +37,11 @@
 #endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 
+#ifdef ENABLE_CHIP_SHELL
 #if defined(CHIP_CONFIG_ENABLE_READ_CLIENT) && CHIP_CONFIG_ENABLE_READ_CLIENT
 #include <shell/im/IMShellCommands.h> // nogncheck
-#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
+#endif                                // CHIP_CONFIG_ENABLE_READ_CLIENT
+#endif                                // ENABLE_CHIP_SHELL
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <app/icd/server/ICDNotifier.h> // nogncheck


### PR DESCRIPTION
#### Summary
The include was IMShellCommands.h was not allowed when the chip_enable_read_client was disabled as Include not allowed.

lit-icd-app didn't have the ShellCommands.cpp file causing to throw build error when shell was enabled.

#### Related issues
NA

#### Testing
Builds locally

