### PR TITLE
[nxp] correctly register the identify cluster

### DIFF
--- a/examples/all-clusters-app/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/nxp/common/main/DeviceCallbacks.cpp
@@ -26,48 +26,17 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Dnssd.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
 
 #include <lib/support/CodeUtils.h>
 
-using namespace chip::app;
-void OnTriggerEffect(::Identify * identify)
-{
-    switch (identify->mCurrentEffectIdentifier)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBlink");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBreathe");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kOkay");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kChannelChange");
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-        return;
-    }
-}
-
-Identify gIdentify1 = {
-    chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
-    chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,
-    OnTriggerEffect,
-};
-
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 
 void AllClustersApp::DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId,

--- a/examples/laundry-washer-app/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/laundry-washer-app/nxp/common/main/DeviceCallbacks.cpp
@@ -27,7 +27,6 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Dnssd.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
@@ -35,41 +34,11 @@
 
 #include <lib/support/CodeUtils.h>
 
-using namespace chip::app;
-void OnTriggerEffect(::Identify * identify)
-{
-    switch (identify->mCurrentEffectIdentifier)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBlink");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBreathe");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kOkay");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kChannelChange");
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-        return;
-    }
-}
-
-Identify gIdentify1 = {
-    chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
-    chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,
-    OnTriggerEffect,
-};
-
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 
 void LaundryWasherApp::DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId,

--- a/examples/lock-app/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/nxp/common/main/DeviceCallbacks.cpp
@@ -26,7 +26,6 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Dnssd.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
@@ -37,41 +36,11 @@
 #include "UserInterfaceFeedback.h"
 #endif
 
-using namespace chip::app;
-void OnTriggerEffect(::Identify * identify)
-{
-    switch (identify->mCurrentEffectIdentifier)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBlink");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBreathe");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kOkay");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kChannelChange");
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-        return;
-    }
-}
-
-Identify gIdentify1 = {
-    chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
-    chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,
-    OnTriggerEffect,
-};
-
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 
 void LockApp::DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,

--- a/examples/platform/nxp/common/Kconfig
+++ b/examples/platform/nxp/common/Kconfig
@@ -32,7 +32,21 @@ config CHIP_APP_COMMON
 config CHIP_APP_CLUSTERS
     bool "App Clusters"
     help
-        Enable application common clusters implementation for the Identify and the ZCLCallbacks.
+        Enable application common clusters implementation for the ZCLCallbacks.
+
+config CHIP_APP_IDENTIFY
+    bool "App Identify"
+    default y
+    help
+        Enable application common clusters implementation for the Identify cluster.
+        Registers the Identify Clusters only for CHIP_APP_IDENTIFY_ENDPOINT.
+        If needed, specific application code must register the cluster for the other endpoints.
+
+config CHIP_APP_IDENTIFY_ENDPOINT
+	int "Endpoint ID for Identify cluster"
+	default 1
+	help
+        Set the endpoint ID for the Identify cluster implementation.
 
 config CHIP_APP_ASSERT
     bool "Application Assert"

--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -66,6 +66,15 @@ if (CONFIG_CHIP_APP_CLUSTERS)
     )
 endif()
 
+if (CONFIG_CHIP_APP_IDENTIFY)
+    target_include_directories(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/include
+    )
+    target_sources(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/source/Identify.cpp
+    )
+endif()
+
 if (CONFIG_CHIP_APP_ASSERT)
     target_sources(app PRIVATE
         ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_assert/source/AppAssert.cpp

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -122,6 +122,10 @@
 #include "ICDUtil.h"
 #endif // CONFIG_NXP_USE_POWER_DOWN
 
+#if CONFIG_CHIP_APP_IDENTIFY
+#include "Identify.h"
+#endif
+
 using namespace chip;
 using namespace chip::TLV;
 using namespace ::chip::Credentials;
@@ -154,6 +158,16 @@ extern const char sBaseServiceInstanceName[];
 static uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                                                                           0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                                                                           0xcc, 0xdd, 0xee, 0xff };
+#endif
+
+#if CONFIG_CHIP_APP_IDENTIFY
+NXP::App::IdentifyDelegate sIdentifyDelegate;
+static chip::app::DefaultTimerDelegate sTimerDelegateIdentify;
+
+app::RegisteredServerCluster<app::Clusters::IdentifyCluster>
+    gIdentifyCluster(app::Clusters::IdentifyCluster::Config(CONFIG_CHIP_APP_IDENTIFY_ENDPOINT, sTimerDelegateIdentify)
+                         .WithIdentifyType(chip::app::Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator)
+                         .WithDelegate(&sIdentifyDelegate));
 #endif
 
 #if CONFIG_NET_L2_OPENTHREAD
@@ -346,6 +360,15 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     {
         /* If an update is under test make it permanent */
         OTARequestorInitiator::Instance().HandleSelfTest();
+    }
+#endif
+
+#if CONFIG_CHIP_APP_IDENTIFY
+    err = chip::app::CodegenDataModelProvider::Instance().Registry().Register(gIdentifyCluster.Registration());
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Error during Register(gIdentifyCluster.Registration()");
+        goto exit;
     }
 #endif
 

--- a/examples/platform/nxp/common/clusters/include/Identify.h
+++ b/examples/platform/nxp/common/clusters/include/Identify.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2024, 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,17 @@
 #pragma once
 
 #include <app/clusters/identify-server/identify-server.h>
-#include <src/system/SystemLayer.h>
 
 namespace chip::NXP::App {
 
-// Identify cluster callbacks.
-void OnIdentifyStart(Identify * identify);
-void OnIdentifyStop(Identify * identify);
-void OnTriggerEffect(Identify * identify);
-void OnTriggerEffectComplete(chip::System::Layer * systemLayer, void * appState);
+// MyIdentifyDelegate class declaration
+class IdentifyDelegate : public chip::app::Clusters::IdentifyDelegate
+{
+public:
+    void OnIdentifyStart(chip::app::Clusters::IdentifyCluster & cluster) override;
+    void OnIdentifyStop(chip::app::Clusters::IdentifyCluster & cluster) override;
+    void OnTriggerEffect(chip::app::Clusters::IdentifyCluster & cluster) override;
+    bool IsTriggerEffectEnabled() const override;
+};
 
 } // namespace chip::NXP::App

--- a/examples/platform/nxp/common/clusters/source/Identify.cpp
+++ b/examples/platform/nxp/common/clusters/source/Identify.cpp
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Identify.h"
+
+using namespace chip::app;
+using namespace chip::NXP::App;
+namespace chip::NXP::App {
+void IdentifyDelegate::OnIdentifyStart(chip::app::Clusters::IdentifyCluster & cluster)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStart");
+    // TODO: logic to start identification (e.g., start blinking an LED)
+}
+
+void IdentifyDelegate::OnIdentifyStop(chip::app::Clusters::IdentifyCluster & cluster)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStop");
+    // TODO: logic to stop identification (e.g., stop blinking an LED)
+}
+
+void IdentifyDelegate::OnTriggerEffect(chip::app::Clusters::IdentifyCluster & cluster)
+{
+
+    switch (cluster.GetEffectIdentifier())
+    {
+    case Clusters::Identify::EffectIdentifierEnum::kBlink:
+        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBlink");
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
+        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBreathe");
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kOkay:
+        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kOkay");
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
+        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kChannelChange");
+        break;
+    default:
+        ChipLogProgress(Zcl, "No identifier effect");
+        return;
+    }
+    // TODO: logic to trigger a specific effect
+}
+
+bool IdentifyDelegate::IsTriggerEffectEnabled() const
+{
+    return true;
+}
+} // namespace chip::NXP::App

--- a/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
@@ -26,43 +26,11 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Dnssd.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
 
 #include <lib/support/CodeUtils.h>
-
-using namespace chip::app;
-void OnTriggerEffect(::Identify * identify)
-{
-    switch (identify->mCurrentEffectIdentifier)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBlink");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kBreathe");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kOkay");
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
-        ChipLogProgress(Zcl, "Clusters::Identify::EffectIdentifierEnum::kChannelChange");
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-        return;
-    }
-}
-
-Identify gIdentify1 = {
-    chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
-    chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,
-    OnTriggerEffect,
-};
 
 using namespace ::chip;
 using namespace ::chip::Inet;


### PR DESCRIPTION
#### Summary

This commit correctly initializes the Matter Identify cluster server, which has been switched to C++ code-driven implementation.
If the cluster is enabled in the zap file but it not correctly initialized then IM commands around it will fail with general error.
A future PR will add real implementation for identify functionality.
Reference: src/app/clusters/identify-server/README.md

#### Testing
./chip-tool identify read identify-time 1 1 was failing previously.



