### PR TITLE
fix: Support chip_crypto backend selection in libdatachannel build

### DIFF
--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
 import("${build_root}/config/compiler/compiler.gni")
+import("${chip_root}/src/crypto/crypto.gni")
 
 _compiler_subdir = "gcc"
 if (is_clang) {
@@ -33,6 +35,10 @@ action("build_libdatachannel") {
       args += [ "--cross-compile-cpu-type=arm64" ]
     }
   }
+
+  if (chip_crypto == "mbedtls" || chip_crypto == "psa") {
+    args += [ "--use-mbedtls" ]
+  }
 }
 
 config("datachannel_config") {
@@ -48,13 +54,25 @@ config("datachannel_config") {
   # suppress known `libdatachannel` int conversion issues
   cflags = [ "-Wno-implicit-int-conversion" ]
 
-  if (is_clang) {
-    # We build static libraries and srtp2 depends on openssl
-    # TODO: can we somehow query this dynamically?
+  if (chip_crypto == "mbedtls" || chip_crypto == "psa") {
+    libs += [
+      "mbedtls",
+      "mbedcrypto",
+      "mbedx509",
+    ]
+  } else if (chip_crypto == "openssl" || chip_crypto == "boringssl") {
     libs += [
       "ssl",
       "crypto",
     ]
+  } else {
+    # chip_crypto not explicitly set - preserve original behavior
+    if (is_clang) {
+      libs += [
+        "ssl",
+        "crypto",
+      ]
+    }
   }
 
   lib_dirs = [

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -10,7 +10,8 @@ import click
 @click.option("--clang", is_flag=True, default=False, help="If specified, use clang instead of gcc")
 @click.option("--output-dir", default="build", help="Output directory for libdatachannel build")
 @click.option("--cross-compile-cpu-type", default=None, help="CPU type for cross compilation if needed")
-def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None):
+@click.option("--use-mbedtls", is_flag=True, default=False, help="Use Mbed TLS instead of OpenSSL")
+def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None, use_mbedtls: bool):
     # figure out paths for building
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_dir = os.path.join(script_dir, "..", "repo")
@@ -27,6 +28,9 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None):
         "-DCMAKE_CXX_FLAGS=-Wno-shadow",
         "-DBUILD_SHARED_LIBS=OFF",
     ]
+
+    if use_mbedtls:
+        cmake_cmd.append("-DUSE_MBEDTLS=ON")
 
     if clang:
         cmake_cmd.extend(


### PR DESCRIPTION
The libdatachannel BUILD.gn hardcoded OpenSSL linking via the is_clang condition, ignoring the chip_crypto setting from crypto.gni. When a user explicitly sets chip_crypto="mbedtls" (e.g., for a lightweight Linux build), libdatachannel would still try to link OpenSSL and fail.

- Import crypto.gni and select link libraries based on chip_crypto
- Pass --use-mbedtls to build script when chip_crypto is mbedtls/psa
- Add -DUSE_MBEDTLS=ON CMake flag in build_libdatachannel.py
- Preserve original is_clang fallback when chip_crypto is not set

