### PR TITLE
Fix TC_SC_5_2.py when groups cluster is used

### DIFF
--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -125,6 +125,7 @@ class TC_SC_5_2(MatterBaseTest):
         if groupcast_enabled:
             self.mark_step_range_skipped("3", "11")
         else:
+            dev_ctrl.SetGroupInfo(0x0103, "Group #3")
             # Step 3: GroupKeyMap binding
             self.step("3")
             mapping = [
@@ -145,14 +146,14 @@ class TC_SC_5_2(MatterBaseTest):
 
             # Step 6: AddGroup 0x0101 as group command via GroupID 0x0103
             self.step("6")
-            await dev_ctrl.SendGroupCommand(0x0103, Clusters.Groups.Commands.AddGroup(0x0101, "Test Group 0101"))
+            dev_ctrl.SendGroupCommand(0x0103, Clusters.Groups.Commands.AddGroup(0x0101, "Test Group 0101"))
             await asyncio.sleep(3)
 
             # Check if GroupNames are supported
-            group_feature_map = await dev_ctrl.read_single_attribute_check_success(
+            group_feature_map = await self.read_single_attribute_check_success(
                 cluster=Clusters.Groups,
                 attribute=Clusters.Groups.Attributes.FeatureMap,
-                endpoint=0)
+                endpoint=groups_endpoint)
             group_names_supported = bool(group_feature_map & Clusters.Groups.Bitmaps.Feature.kGroupNames)
 
             # Step 7: ViewGroup 0x0101 with GroupNames


### PR DESCRIPTION
#### Summary
This PR fix 2 steps that where not properly working when group cluster is enable and not groupcast cluster (older matter versions).

- Fix 1: remove `await` from SendGroupCommand . MulticastMessage has no response.
- Fix 2: Fix endpoint used on reading the groups featuremap.
- Misc: Ensure the group in test (0x103) is properly set for legacy groups (AddressPolicy default to PerGroup)


#### Related issues
N/A

#### Testing
run the test on Silabs lighting-app groups cluster and disabling groupcast cluster

[MatterTest] 04-09 18:48:06.266 INFO ===== EXECUTION FLAGS SUMMARY END =====
[MatterTest] 04-09 18:48:06.267 INFO Summary for test class TC_SC_5_2: Error 0, Executed 1, Failed 0, Passed 1, Requested 1, Skipped 0
[MatterTest] 04-09 18:48:06.269 INFO Summary for test run MatterTest@04-09-2026_18-47-42-895:
Total time elapsed 23.37033660299994s
Artifacts are saved in "/tmp/matter_testing/logs/MatterTest/04-09-2026_18-47-42-895"
Test summary saved in "/tmp/matter_testing/logs/MatterTest/04-09-2026_18-47-42-895/test_summary.yaml"
Test results: Error 0, Executed 2, Failed 0, Passed 2, Requested 2, Skipped 0
[TC_SC_5_3.txt](https://github.com/user-attachments/files/26612694/TC_SC_5_3.txt)
