### PR TITLE
[MSAN] Fix uninitialized memory issues in unit tests

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -475,6 +475,8 @@ config("sanitize_memory") {
     "-fno-omit-frame-pointer",
   ]
   ldflags = cflags
+
+  defines = [ "CHIP_MEMORY_SANITIZER_ENABLED=1" ]
 }
 
 config("sanitize_undefined_behavior") {

--- a/src/app/server-cluster/tests/TestServerClusterExtension.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterExtension.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <access/Privilege.h>
@@ -189,21 +190,19 @@ TEST_F(TestServerClusterExtension, TestGetDataVersion)
 
     TestableServerClusterExtension extension(mockPath, underlying);
 
+    TestServerClusterContext context;
+    // Startup MUST be called before calling GetDataVersion() since Data Version must be randomly initialized within it.
+    ASSERT_SUCCESS(extension.Startup(context.Get()));
+
     // Initially, version is the same as underlying (since mVersionDelta is 0).
     ASSERT_EQ(extension.GetDataVersion(mockPath), underlying.GetDataVersion(mockPath));
 
-    // Without a context, there is no need to increment (and cannot mark dirty).
-    extension.TestNotifyAttributeChanged(4);
-    ASSERT_EQ(extension.GetDataVersion(mockPath),
-              underlying.GetDataVersion(mockPath)); // Should still be the same as no context is set
-
-    // Set a context and then notify change. This time mVersionDelta should increment.
-    TestServerClusterContext context;
-    ASSERT_EQ(extension.Startup(context.Get()), CHIP_NO_ERROR);
-
+    // After notify change, mVersionDelta should increment.
     DataVersion oldVersion = extension.GetDataVersion(mockPath);
     extension.TestNotifyAttributeChanged(5);
     ASSERT_EQ(extension.GetDataVersion(mockPath), oldVersion + 1);
+
+    extension.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
 TEST_F(TestServerClusterExtension, TestNotifyAttributeChangedWithContext)

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -272,6 +272,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/icd/server:configuration-data",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server:terms_and_conditions",
+    "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/app/tests:helpers",
     "${chip_root}/src/app/util/mock:mock_codegen_data_model",
     "${chip_root}/src/app/util/mock:mock_ember",

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -449,7 +449,7 @@ TEST_F(TestAclEvent, TestUnsupportedEventWithValidClusterPath)
     const ConcreteClusterPath kTestClusterPath(kTestEndpointId, MockClusterId(2));
     FakeDefaultServerCluster fakeClusterServer(kTestClusterPath);
     chip::Testing::TestServerClusterContext testContext;
-    ASSERT_EQ(fakeClusterServer.Startup(testContext.Get()), CHIP_NO_ERROR);
+    ASSERT_SUCCESS(fakeClusterServer.Startup(testContext.Get()));
     ServerClusterRegistration registration(fakeClusterServer);
 
     CodegenDataModelProvider model;

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -44,6 +44,7 @@
 #include <protocols/interaction_model/Constants.h>
 
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
 
 #include <app/util/mock/MockNodeConfig.h>
 
@@ -447,6 +448,8 @@ TEST_F(TestAclEvent, TestUnsupportedEventWithValidClusterPath)
 
     const ConcreteClusterPath kTestClusterPath(kTestEndpointId, MockClusterId(2));
     FakeDefaultServerCluster fakeClusterServer(kTestClusterPath);
+    chip::Testing::TestServerClusterContext testContext;
+    ASSERT_EQ(fakeClusterServer.Startup(testContext.Get()), CHIP_NO_ERROR);
     ServerClusterRegistration registration(fakeClusterServer);
 
     CodegenDataModelProvider model;
@@ -500,6 +503,7 @@ TEST_F(TestAclEvent, TestUnsupportedEventWithValidClusterPath)
     engine->SetDataModelProvider(mOldProvider);
 
     EXPECT_SUCCESS(model.Registry().Unregister(&fakeClusterServer));
+    fakeClusterServer.Shutdown(app::ClusterShutdownType::kClusterShutdown);
     EXPECT_SUCCESS(model.Shutdown());
 }
 

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -1041,7 +1041,7 @@ void TestWriteChunking::RunTest(Instructions instructions, EncodingMethod encodi
     };
 
     ByteSpan list[kTestListLength];
-    uint8_t badList[kTestListLength];
+    uint8_t badList[kTestListLength] = {};
 
     if (instructions.data.size() == 0)
     {
@@ -1296,7 +1296,7 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions,
     constexpr uint8_t kTestListLength2 = 10;
 
     ByteSpan list[kTestListLength2];
-    uint8_t badList[kTestListLength2];
+    uint8_t badList[kTestListLength2] = {};
 
     if (instructions.data.size() == 0)
     {

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1274,12 +1274,25 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
+            // For E3C2, MockAttributeId(4) is encoded as a list of octet strings that contain mockAttribute4 several times (see
+            // ReadSingleMockClusterData in attribute-storage.cpp)
             ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(4));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
-            uint8_t receivedAttribute4[256];
-            EXPECT_EQ(reader.GetBytes(receivedAttribute4, 256), CHIP_ERROR_WRONG_TLV_TYPE);
-            EXPECT_TRUE(memcmp(receivedAttribute4, mockAttribute4, 256));
+            EXPECT_EQ(reader.GetType(), TLV::kTLVType_Array);
+            TLV::TLVType containerType;
+            EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
+            int count = 0;
+            while (reader.Next() == CHIP_NO_ERROR)
+            {
+                ByteSpan entry;
+                EXPECT_EQ(reader.Get(entry), CHIP_NO_ERROR);
+                EXPECT_EQ(entry.size(), sizeof(mockAttribute4));
+                EXPECT_EQ(memcmp(entry.data(), mockAttribute4, sizeof(mockAttribute4)), 0);
+                count++;
+            }
+            EXPECT_EQ(reader.ExitContainer(containerType), CHIP_NO_ERROR);
+            ASSERT_GT(count, 0);
         }
         delegate.mNumAttributeResponse = 0;
     }

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1278,20 +1278,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
             // ReadSingleMockClusterData in attribute-storage.cpp)
             ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(4));
             TLV::TLVReader reader;
-            EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
+            EXPECT_SUCCESS(cache.Get(attributePath, reader));
             EXPECT_EQ(reader.GetType(), TLV::kTLVType_Array);
             TLV::TLVType containerType;
-            EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
+            EXPECT_SUCCESS(reader.EnterContainer(containerType));
             int count = 0;
             while (reader.Next() == CHIP_NO_ERROR)
             {
                 ByteSpan entry;
-                EXPECT_EQ(reader.Get(entry), CHIP_NO_ERROR);
+                EXPECT_SUCCESS(reader.Get(entry));
                 EXPECT_EQ(entry.size(), sizeof(mockAttribute4));
                 EXPECT_EQ(memcmp(entry.data(), mockAttribute4, sizeof(mockAttribute4)), 0);
                 count++;
             }
-            EXPECT_EQ(reader.ExitContainer(containerType), CHIP_NO_ERROR);
+            EXPECT_SUCCESS(reader.ExitContainer(containerType));
             ASSERT_GT(count, 0);
         }
         delegate.mNumAttributeResponse = 0;

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -44,6 +44,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/Compiler.h>
 #include <lib/support/ScopedMemoryBuffer.h>
 #include <lib/support/Span.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
@@ -652,10 +653,9 @@ TEST_F(TestChipCryptoPAL, TestSensitiveDataBuffer)
 {
     HeapChecker heapChecker;
 
-    constexpr size_t kCapacity         = 32;
-    constexpr size_t kLength           = 16;
-    using Buffer                       = SensitiveDataBuffer<kCapacity>;
-    const uint8_t kAllZeros[kCapacity] = { 0 };
+    constexpr size_t kCapacity = 32;
+    constexpr size_t kLength   = 16;
+    using Buffer               = SensitiveDataBuffer<kCapacity>;
     uint8_t testVector[kCapacity];
 
     // Give us some data.
@@ -677,20 +677,24 @@ TEST_F(TestChipCryptoPAL, TestSensitiveDataBuffer)
     EXPECT_EQ(buffer.Length(), buffer.Span().size());
 
     // Test sanitization of entire buffer (even though length < capacity)
-    const void * bufferStorage = buffer.ConstBytes();
+    // This check reads memory after the SensitiveDataBuffer destructor is called explicitly to verify secure erasure.
+    // MSan (correctly) flags the memcpy after destructor call as use-of-uninitialized-value, so skip under MSan.
+#if !CHIP_MEMORY_SANITIZER_ENABLED
+    const uint8_t kAllZeros[kCapacity] = { 0 };
+    const void * bufferStorage         = buffer.ConstBytes();
     buffer.~Buffer();
     EXPECT_EQ(memcmp(bufferStorage, kAllZeros, kCapacity), 0);
     EXPECT_TRUE(memcmp(bufferStorage, testVector, kCapacity));
+#endif
 }
 
 TEST_F(TestChipCryptoPAL, TestSensitiveDataFixedBuffer)
 {
     HeapChecker heapChecker;
 
-    constexpr size_t kCapacity         = 32;
-    using Buffer                       = SensitiveDataFixedBuffer<kCapacity>;
-    using BufferSpan                   = FixedByteSpan<kCapacity>;
-    const uint8_t kAllZeros[kCapacity] = { 0 };
+    constexpr size_t kCapacity = 32;
+    using Buffer               = SensitiveDataFixedBuffer<kCapacity>;
+    using BufferSpan           = FixedByteSpan<kCapacity>;
     uint8_t testVector[kCapacity];
 
     // Give us some data.
@@ -704,10 +708,15 @@ TEST_F(TestChipCryptoPAL, TestSensitiveDataFixedBuffer)
     EXPECT_EQ(memcmp(buffer.ConstBytes(), testVector, kCapacity), 0);
 
     // Test sanitization
-    const void * bufferStorage = buffer.ConstBytes();
+    // This check reads memory after the SensitiveDataBuffer destructor is called explicitly to verify secure erasure.
+    // MSan (correctly) flags the memcpy after destructor call as use-of-uninitialized-value, so skip under MSan.
+#if !CHIP_MEMORY_SANITIZER_ENABLED
+    const uint8_t kAllZeros[kCapacity] = { 0 };
+    const void * bufferStorage         = buffer.ConstBytes();
     buffer.~Buffer();
     EXPECT_EQ(memcmp(bufferStorage, kAllZeros, kCapacity), 0);
     EXPECT_TRUE(memcmp(bufferStorage, testVector, kCapacity));
+#endif
 
     // Give us different data
     err = DRBG_get_bytes(testVector, sizeof(testVector));
@@ -1475,10 +1484,11 @@ TEST_F(TestChipCryptoPAL, TestECDH_EstablishSecret)
     EXPECT_EQ(keypair2.Initialize(ECPKeyTarget::ECDH), CHIP_NO_ERROR);
 
     P256ECDHDerivedSecret out_secret1;
-    out_secret1.Bytes()[0] = 0;
+    memset(out_secret1.Bytes(), 0, out_secret1.Capacity());
 
     P256ECDHDerivedSecret out_secret2;
-    out_secret2.Bytes()[0] = 1;
+    // Initialise out_secret2 to 1s to ensure that we pass the sanity check below
+    memset(out_secret2.Bytes(), 1, out_secret2.Capacity());
 
     CHIP_ERROR error = CHIP_NO_ERROR;
     EXPECT_NE(memcmp(out_secret1.ConstBytes(), out_secret2.ConstBytes(), out_secret1.Capacity()),

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -44,7 +44,6 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/Compiler.h>
 #include <lib/support/ScopedMemoryBuffer.h>
 #include <lib/support/Span.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -676,15 +676,18 @@ TEST_F(TestChipCryptoPAL, TestSensitiveDataBuffer)
     EXPECT_EQ(buffer.Length(), buffer.Span().size());
 
     // Test sanitization of entire buffer (even though length < capacity)
+    [[maybe_unused]] const void * bufferStorage = buffer.ConstBytes();
+    buffer.~Buffer();
     // This check reads memory after the SensitiveDataBuffer destructor is called explicitly to verify secure erasure.
-    // MSan (correctly) flags the memcpy after destructor call as use-of-uninitialized-value, so skip under MSan.
+    // MSan (correctly) flags the memcmp after destructor call as use-of-uninitialized-value, so skip under MSan.
 #if !CHIP_MEMORY_SANITIZER_ENABLED
     const uint8_t kAllZeros[kCapacity] = { 0 };
-    const void * bufferStorage         = buffer.ConstBytes();
-    buffer.~Buffer();
     EXPECT_EQ(memcmp(bufferStorage, kAllZeros, kCapacity), 0);
     EXPECT_TRUE(memcmp(bufferStorage, testVector, kCapacity));
 #endif
+
+    // Reconstruct so the automatic destructor at scope exit does not double-destroy.
+    new (&buffer) Buffer();
 }
 
 TEST_F(TestChipCryptoPAL, TestSensitiveDataFixedBuffer)
@@ -706,13 +709,13 @@ TEST_F(TestChipCryptoPAL, TestSensitiveDataFixedBuffer)
     EXPECT_EQ(buffer.ConstBytes(), buffer.Span().data());
     EXPECT_EQ(memcmp(buffer.ConstBytes(), testVector, kCapacity), 0);
 
-    // Test sanitization
+    // Verify that the destructor clears sensitive data
+    [[maybe_unused]] const void * bufferStorage = buffer.ConstBytes();
+    buffer.~Buffer();
     // This check reads memory after the SensitiveDataBuffer destructor is called explicitly to verify secure erasure.
-    // MSan (correctly) flags the memcpy after destructor call as use-of-uninitialized-value, so skip under MSan.
+    // MSan (correctly) flags the memcmp after destructor call as use-of-uninitialized-value, so skip under MSan.
 #if !CHIP_MEMORY_SANITIZER_ENABLED
     const uint8_t kAllZeros[kCapacity] = { 0 };
-    const void * bufferStorage         = buffer.ConstBytes();
-    buffer.~Buffer();
     EXPECT_EQ(memcmp(bufferStorage, kAllZeros, kCapacity), 0);
     EXPECT_TRUE(memcmp(bufferStorage, testVector, kCapacity));
 #endif

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2094,6 +2094,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #ifndef CHIP_CONFIG_MAX_NUM_ZONES
 #define CHIP_CONFIG_MAX_NUM_ZONES 4
 #endif // CHIP_CONFIG_MAX_NUM_ZONES
+
+/**
+ * @def CHIP_MEMORY_SANITIZER_ENABLED
+ *
+ * @brief True when building with Clang MemorySanitizer (MSan).
+ */
+#ifndef CHIP_MEMORY_SANITIZER_ENABLED
+#define CHIP_MEMORY_SANITIZER_ENABLED 0
+#endif
+
 /**
  * @}
  */

--- a/src/lib/support/Compiler.h
+++ b/src/lib/support/Compiler.h
@@ -22,3 +22,10 @@
 #else
 #define CHIP_HAVE_RTTI 0
 #endif
+
+// CHIP_MEMORY_SANITIZER_ENABLED: true when building with Clang MemorySanitizer (MSan).
+#if defined(__clang__)
+#define CHIP_MEMORY_SANITIZER_ENABLED __has_feature(memory_sanitizer)
+#else
+#define CHIP_MEMORY_SANITIZER_ENABLED 0
+#endif

--- a/src/lib/support/Compiler.h
+++ b/src/lib/support/Compiler.h
@@ -22,10 +22,3 @@
 #else
 #define CHIP_HAVE_RTTI 0
 #endif
-
-// CHIP_MEMORY_SANITIZER_ENABLED: true when building with Clang MemorySanitizer (MSan).
-#if defined(__clang__)
-#define CHIP_MEMORY_SANITIZER_ENABLED __has_feature(memory_sanitizer)
-#else
-#define CHIP_MEMORY_SANITIZER_ENABLED 0
-#endif

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -299,7 +299,8 @@ void SendAndVerifyArbitraryBlock(TransferSession & sender, TransferSession & rec
     ASSERT_FALSE(fakeDataBuf.IsNull());
 
     uint8_t * fakeBlockData = fakeDataBuf->Start();
-    fakeBlockData[0]        = dataCount++;
+    memset(fakeBlockData, 0, maxBlockSize);
+    fakeBlockData[0] = dataCount++;
 
     TransferSession::BlockData blockData;
     blockData.Data   = fakeBlockData;


### PR DESCRIPTION
#### Summary
- Fixing Unit Tests that have uninitialized memory issues  detected by an MSAN sanitized unit test build

#### Related Issues

- This is the first commit of https://github.com/project-chip/connectedhomeip/issues/71500

#### Testing

- Tested Locally using MSAN Unit Test build, this has not been committed yet since it is still WIP (too many dependencies)