### PR TITLE
[Silabs] : use different markers to save user preferences and install done

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -348,8 +348,9 @@ EOF
                     break
                     ;; # Case for yes/Y
                 [Nn]*)
-                    echo "You won't be asked again"
+                    echo "You won't be asked again, cannot proceed with build. Exiting..."
                     touch "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages"
+                    exit 1
                     break
                     ;;                                                  # Case for no/N
                 *) echo "Invalid response. Please answer yes or no." ;; # Case for invalid input

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -361,7 +361,7 @@ EOF
         pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
         python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
     fi # run install-packages
-    
+
     # Zap generation requires activation
     source "$CHIP_ROOT/scripts/activate.sh"
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -359,7 +359,7 @@ EOF
 
     # Local Silabs package install when agreed (INSTALL_EVERYTHING). Never under Docker.
     if [ "$INSTALL_EVERYTHING" == true ] && [ "$USE_DOCKER" != true ]; then # run install-packages
-        pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
+        pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt" || exit 1
         python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
     fi # run install-packages
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -319,7 +319,7 @@ else
         } &>/dev/null
     fi
 
-# After a completed local install (.install-packages-done), run the Silabs package install step to check for updates. Docker never runs it (SDK is in the image).
+    # After a completed local install (.install-packages-done), run the Silabs package install step to check for updates. Docker never runs it (SDK is in the image).
     if [ -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then # INSTALL_EVERYTHING
         INSTALL_EVERYTHING=true
     else

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -341,12 +341,13 @@ else
 EOF
 
         while true; do
-            read -p "Do you want to proceed? (y/n): " yn
+            read -p "Do you want to proceed? [Y/n]: " yn
             case $yn in
-                [Yy]*)
+                "" | [Yy]*)
                     INSTALL_EVERYTHING=true
+                    python3 -m pip install -q -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt" > /dev/null 2>&1 || true
                     break
-                    ;; # Case for yes/Y
+                    ;; # Case for yes/Y (Enter accepts default)
                 [Nn]*)
                     echo "You won't be asked again, cannot proceed with build. Exiting..."
                     touch "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages"
@@ -360,7 +361,6 @@ EOF
 
     # Local Silabs package install when agreed (INSTALL_EVERYTHING). Never under Docker.
     if [ "$INSTALL_EVERYTHING" == true ] && [ "$USE_DOCKER" != true ]; then # run install-packages
-        pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt" || exit 1
         python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
     fi # run install-packages
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -319,7 +319,7 @@ else
         } &>/dev/null
     fi
 
-    # After a completed local install (.install-packages-done), skip the Silabs package install step. Docker never runs it (SDK is in the image).
+# After a completed local install (.install-packages-done), run the Silabs package install step to check for updates. Docker never runs it (SDK is in the image).
     if [ -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then # INSTALL_EVERYTHING
         INSTALL_EVERYTHING=true
     else

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -345,7 +345,7 @@ EOF
             case $yn in
                 "" | [Yy]*)
                     INSTALL_EVERYTHING=true
-                    python3 -m pip install -q -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt" > /dev/null 2>&1 || true
+                    python3 -m pip install -q -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt" >/dev/null 2>&1 || true
                     break
                     ;; # Case for yes/Y (Enter accepts default)
                 [Nn]*)

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -319,14 +319,15 @@ else
         } &>/dev/null
     fi
 
-    # Treat packages as ready in Docker or after a completed local install (.install-packages-done).
-    INSTALL_EVERYTHING=false
-    if [ "$USE_DOCKER" == true ] || [ -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then # INSTALL_EVERYTHING
+    # After a completed local install (.install-packages-done), skip the Silabs package install step. Docker never runs it (SDK is in the image).
+    if [ -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then # INSTALL_EVERYTHING
         INSTALL_EVERYTHING=true
+    else
+        INSTALL_EVERYTHING=false
     fi # INSTALL_EVERYTHING
 
-    # First-time local install: INSTALL_EVERYTHING is false until Docker or .install-packages-done (see above); respect opt-out.
-    if [ "$INSTALL_EVERYTHING" != true ] && [ ! -f "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages" ]; then # first-time install prompt
+    # First-time local install: INSTALL_EVERYTHING is false until .install-packages-done (see above); respect opt-out. No prompt in Docker.
+    if [ "$USE_DOCKER" != true ] && [ "$INSTALL_EVERYTHING" != true ] && [ ! -f "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages" ]; then # first-time install prompt
         cat <<'EOF'
         !!!!!!!!! FIRST TIME INSTALL !!!!!!!!!
         Do you agree to install SILICON LABS PACKAGES MANAGER?
@@ -356,8 +357,8 @@ EOF
         done
     fi # first-time install prompt
 
-    # Local Silabs package install when agreed (INSTALL_EVERYTHING) and not already done; skip in Docker (SDK in image).
-    if [ "$INSTALL_EVERYTHING" == true ]; then # run install-packages
+    # Local Silabs package install when agreed (INSTALL_EVERYTHING). Never under Docker.
+    if [ "$INSTALL_EVERYTHING" == true ] && [ "$USE_DOCKER" != true ]; then # run install-packages
         pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
         python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
     fi # run install-packages

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -319,10 +319,14 @@ else
         } &>/dev/null
     fi
 
-    # Run install-packages once (creates .install-packages-done when done); skip when using Docker (SDK is in image)
-    if [ "$USE_DOCKER" != true ] && [ ! -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then
+    # Treat packages as ready in Docker or after a completed local install (.install-packages-done).
+    INSTALL_EVERYTHING=false
+    if [ "$USE_DOCKER" == true ] || [ -f "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done" ]; then # INSTALL_EVERYTHING
+        INSTALL_EVERYTHING=true
+    fi # INSTALL_EVERYTHING
 
-        INSTALL_EVERYTHING=false
+    # First-time local install: INSTALL_EVERYTHING is false until Docker or .install-packages-done (see above); respect opt-out.
+    if [ "$INSTALL_EVERYTHING" != true ] && [ ! -f "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages" ]; then # first-time install prompt
         cat <<'EOF'
         !!!!!!!!! FIRST TIME INSTALL !!!!!!!!!
         Do you agree to install SILICON LABS PACKAGES MANAGER?
@@ -332,6 +336,7 @@ else
 
         Most of the files will be located under ~/.silabs,
         some symbolic link will be created and it will replace simplicity_sdk submodule
+        This is required for the build to succeed.
 EOF
 
         while true; do
@@ -343,20 +348,20 @@ EOF
                     ;; # Case for yes/Y
                 [Nn]*)
                     echo "You won't be asked again"
+                    touch "$CHIP_ROOT/scripts/setup/silabs/.do-not-install-packages"
                     break
                     ;;                                                  # Case for no/N
                 *) echo "Invalid response. Please answer yes or no." ;; # Case for invalid input
             esac
         done
+    fi # first-time install prompt
 
-        if [ "$INSTALL_EVERYTHING" == true ]; then
-            pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
-            python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
-        else
-            touch "$CHIP_ROOT/scripts/setup/silabs/.install-packages-done"
-        fi
-    fi
-
+    # Local Silabs package install when agreed (INSTALL_EVERYTHING) and not already done; skip in Docker (SDK in image).
+    if [ "$INSTALL_EVERYTHING" == true ]; then # run install-packages
+        pip install -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
+        python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
+    fi # run install-packages
+    
     # Zap generation requires activation
     source "$CHIP_ROOT/scripts/activate.sh"
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -361,6 +361,7 @@ EOF
 
     # Local Silabs package install when agreed (INSTALL_EVERYTHING). Never under Docker.
     if [ "$INSTALL_EVERYTHING" == true ] && [ "$USE_DOCKER" != true ]; then # run install-packages
+        python3 -m pip install -q -r "$CHIP_ROOT/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt"
         python3 "$CHIP_ROOT/scripts/setup/silabs/install-packages.py" || exit 1
     fi # run install-packages
 

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -223,11 +223,9 @@ def update_slt_cli(slt_cli_path):
         subprocess.run(update_cmd, check=True)
         logger.info("SLT CLI updated successfully")
     except subprocess.CalledProcessError as e:
-        logger.error("Failed to update slt-cli: %s", e)
-        sys.exit(1)
+        logger.warning("Failed to update slt-cli: %s", e)
     except FileNotFoundError:
-        logger.error("SLT CLI not found at %s", slt_cli_path)
-        sys.exit(1)
+        logger.warning("SLT CLI not found at %s, skipping update", slt_cli_path)
 
 
 def get_pkg_manifest_paths():

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -223,9 +223,11 @@ def update_slt_cli(slt_cli_path):
         subprocess.run(update_cmd, check=True)
         logger.info("SLT CLI updated successfully")
     except subprocess.CalledProcessError as e:
-        logger.warning("Failed to update slt-cli: %s", e)
+        logger.error("Failed to update slt-cli: %s", e)
+        sys.exit(1)
     except FileNotFoundError:
-        logger.warning("SLT CLI not found at %s, skipping update", slt_cli_path)
+        logger.error("SLT CLI not found at %s", slt_cli_path)
+        sys.exit(1)
 
 
 def get_pkg_manifest_paths():


### PR DESCRIPTION
#### Summary
The install marker changes from https://github.com/project-chip/connectedhomeip/pull/43611 skips the installation steps for checking new versions of SiSDK.
Updated the flow to introduce a new user consent marker
Following the flow chart
<img width="1812" height="2262" alt="image" src="https://github.com/user-attachments/assets/55783b48-6924-46fb-89a3-16c6ba06943c" />



#### Related issues


#### Testing
Run scripts/examples/gn_silabs_example.sh 
- user consents no in the first run, not going to install anything, and will not ask for permission again, build failures
- User says yes, installation done, next run still checks for versions, ( not asking for permissions again)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
