### PR TITLE
[ESP32] Forward IDF ccache setup to Matter SDK GN setup

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -78,6 +78,12 @@ chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                ${is_debug})
 
+# If ccache was enabled by IDF and the ccache executable was found,
+# use it as the command launcher for GN to speed up subsequent builds.
+if (CCACHE_ENABLE AND CCACHE_FOUND)
+    chip_gn_arg_append("pw_command_launcher" "\"${CCACHE_FOUND}\"")
+endif()
+
 if (CONFIG_CHIP_CONFIG_IM_PRETTY_PRINT)
     chip_gn_arg_bool("enable_im_pretty_print" "true")
 endif()


### PR DESCRIPTION
#### Summary

Building project with `idf.py --ccache build` applies ccache only for ESP SDK, but Matter SDK is complied over and over again.

This change forwards IDF ccache setup to Matter SDK GN setup.

#### Testing

Locally verified that IDF ccache setup is forwarded to Matter SDK.
CI will verify potential breaks.