### PR TITLE
Fix lingering PASE session after fails such as mismatch in SetuPinCode

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -838,6 +838,8 @@ public:
         mDeviceAttestationVerifier = deviceAttestationVerifier;
     }
 
+    void SetFailOnPasscodeMismatch(bool enable) { mSetUpCodePairer.SetFailOnPasscodeMismatch(enable); }
+
     Credentials::DeviceAttestationVerifier * GetDeviceAttestationVerifier() const { return mDeviceAttestationVerifier; }
 
     const CommissioningParameters & GetCommissioningParameters() { return mDefaultCommissioner->GetCommissioningParameters(); }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -783,24 +783,42 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
 {
     if (status == DevicePairingDelegate::Status::SecurePairingFailed)
     {
-        // If we're still waiting on discovery, don't propagate this failure
-        // (which is due to PASE failure with something we discovered, but the
-        // "something" may not have been the right thing) for now.  Wait until
-        // discovery completes.  Then we will either succeed and notify
-        // accordingly or time out and land in OnStatusUpdate again, but at that
-        // point we will not be waiting on discovery anymore.
-        if (!mDiscoveredParameters.empty())
+
+        if (mFailOnPasscodeMismatch)
         {
-            ChipLogProgress(Controller, "Ignoring SecurePairingFailed status for now; we have more discovered devices to try");
-            return;
+            // Stop all discovery and PASE attempts now instead of waiting for the discovery timeout.
+            ChipLogProgress(Controller,
+                            "SecurePairingFailed with mFailOnPasscodeMismatch set; aborting pairing immediately");
+            if (mWaitingForPASE)
+            {
+                PASEEstablishmentComplete();
+            }
+            ResetDiscoveryState();
+            mRemoteId = kUndefinedNodeId;
+            // Fall through so the delegate is notified below.
+        }
+        else
+        {
+            // If we're still waiting on discovery, don't propagate this failure
+            // (which is due to PASE failure with something we discovered, but the
+            // "something" may not have been the right thing) for now.  Wait until
+            // discovery completes.  Then we will either succeed and notify
+            // accordingly or time out and land in OnStatusUpdate again, but at that
+            // point we will not be waiting on discovery anymore.
+            if (!mDiscoveredParameters.empty())
+            {
+                ChipLogProgress(Controller, "Ignoring SecurePairingFailed status for now; we have more discovered devices to try");
+                return;
+            }
+
+            if (DiscoveryInProgress())
+            {
+                ChipLogProgress(Controller,
+                                "Ignoring SecurePairingFailed status for now; we are waiting to see if we discover more devices");
+                return;
+            }
         }
 
-        if (DiscoveryInProgress())
-        {
-            ChipLogProgress(Controller,
-                            "Ignoring SecurePairingFailed status for now; we are waiting to see if we discover more devices");
-            return;
-        }
     }
 
     if (mPairingDelegate)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -787,8 +787,7 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
         if (mFailOnPasscodeMismatch)
         {
             // Stop all discovery and PASE attempts now instead of waiting for the discovery timeout.
-            ChipLogProgress(Controller,
-                            "SecurePairingFailed with mFailOnPasscodeMismatch set; aborting pairing immediately");
+            ChipLogProgress(Controller, "SecurePairingFailed with mFailOnPasscodeMismatch set; aborting pairing immediately");
             if (mWaitingForPASE)
             {
                 PASEEstablishmentComplete();
@@ -818,7 +817,6 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
                 return;
             }
         }
-
     }
 
     if (mPairingDelegate)

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -129,6 +129,10 @@ public:
     // whichever node we're pairing if kUndefinedNodeId is passed.
     bool StopPairing(NodeId remoteId = kUndefinedNodeId);
 
+    // When enabled, a SecurePairingFailed status (passcode mismatch) immediately
+    // aborts pairing without waiting for discovery to complete or timeout.
+    void SetFailOnPasscodeMismatch(bool enable) { mFailOnPasscodeMismatch = enable; }
+
 private:
     // DevicePairingDelegate implementation.
     void OnStatusUpdate(DevicePairingDelegate::Status status) override;
@@ -274,6 +278,9 @@ private:
 
     // mLastPASEError is the error from the last OnPairingComplete call we got.
     CHIP_ERROR mLastPASEError = CHIP_NO_ERROR;
+
+    // When true, SecurePairingFailed is never suppressed regardless of discovery state
+    bool mFailOnPasscodeMismatch = false;
 };
 
 } // namespace Controller

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -209,7 +209,8 @@ PyChipError pychip_DeviceController_OpenJointCommissioningWindow(chip::Controlle
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len);
 
-void pychip_DeviceController_SetFailOnPasscodeMismatch(chip::Controller::DeviceCommissioner * devCtrl, bool enable){
+void pychip_DeviceController_SetFailOnPasscodeMismatch(chip::Controller::DeviceCommissioner * devCtrl, bool enable)
+{
     devCtrl->SetFailOnPasscodeMismatch(enable);
 }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -209,6 +209,10 @@ PyChipError pychip_DeviceController_OpenJointCommissioningWindow(chip::Controlle
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len);
 
+void pychip_DeviceController_SetFailOnPasscodeMismatch(chip::Controller::DeviceCommissioner * devCtrl, bool enable){
+    devCtrl->SetFailOnPasscodeMismatch(enable);
+}
+
 PyChipError pychip_DeviceController_SetTermsAcknowledgements(uint16_t tcVersion, uint16_t tcUserResponse);
 
 PyChipError pychip_DeviceController_SetSkipCommissioningComplete(bool skipCommissioningComplete);

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -2566,6 +2566,10 @@ class ChipDeviceControllerBase():
             raise MemoryError("Invalid output size for manual code")
         return buf.value.decode()
 
+    def SetFailOnPasscodeMismatch(self, enable: bool):
+        """immediately abort on passcode mismatch instead of waiting for the discovery/PASE timeout to expire."""
+        self._dmLib.pychip_DeviceController_SetFailOnPasscodeMismatch(self.devCtrl, enable)
+
     # ----- Private Members -----
     def _InitLib(self):
         if self._dmLib is None:
@@ -2590,6 +2594,9 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_DeviceController_SetThreadOperationalDataset.argtypes = [
                 c_char_p, c_uint32]
             self._dmLib.pychip_DeviceController_SetThreadOperationalDataset.restype = PyChipError
+
+            self._dmLib.pychip_DeviceController_SetFailOnPasscodeMismatch.argtypes = [c_void_p, c_bool]
+            self._dmLib.pychip_DeviceController_SetFailOnPasscodeMismatch.restype = None
 
             self._dmLib.pychip_DeviceController_SetWiFiCredentials.argtypes = [
                 c_char_p, c_char_p]


### PR DESCRIPTION
#### Summary

This pull request introduces an option to immediately abort device pairing on a passcode mismatch, rather than waiting for discovery or timeout. This behavior can be toggled via a new API, and is exposed both in the core controller and the Python bindings. The main changes are grouped below.

**Core functionality changes:**

* Added a `SetFailOnPasscodeMismatch` method to the `SetUpCodePairer` and `DeviceCommissioner` classes, allowing configuration of immediate abort behavior on passcode mismatch. [[1]](diffhunk://#diff-6b25cfee4044c1c02d2e82eb4850e581625211e3895ea8c9df988e02b8267f0aR132-R135) [[2]](diffhunk://#diff-6b25cfee4044c1c02d2e82eb4850e581625211e3895ea8c9df988e02b8267f0aR281-R283) [[3]](diffhunk://#diff-d2083ebf514c09948fa15b2d3719bc80535626a2992a6f40be8e8e3a2432b7c8R841-R842)
* Modified the pairing status update logic in `SetUpCodePairer` so that, if the new flag is enabled and a passcode mismatch occurs, pairing is aborted immediately and all relevant state is reset. [[1]](diffhunk://#diff-b4c71fa2eecb8d534428a02431866fa52eb43291ce7c3db308c7e9f811f542afR785-R800) [[2]](diffhunk://#diff-b4c71fa2eecb8d534428a02431866fa52eb43291ce7c3db308c7e9f811f542afR822-R823)

**Python bindings/API exposure:**

* Added a `pychip_DeviceController_SetFailOnPasscodeMismatch` function to the Python C++ bindings, and exposed it as a `SetFailOnPasscodeMismatch` method in the `ChipDeviceCtrl` Python class, including argument and return type setup. [[1]](diffhunk://#diff-3a4487737723239802e02e5a05c96ceac7e9c9a418ce6f421758b1beb7c2e379R212-R215) [[2]](diffhunk://#diff-ae8405b98fb42df8a52dc826720e9ff711e966cfb9572d94156462ca525de3f4R2569-R2572) [[3]](diffhunk://#diff-ae8405b98fb42df8a52dc826720e9ff711e966cfb9572d94156462ca525de3f4R2598-R2600)




#### Related issues

Fix for Issue : https://github.com/project-chip/connectedhomeip/issues/71502

#### Testing

Test the code Using Matter Python SDK

