### PR TITLE
[Silabs] NULL-terminate string Get for DeviceInstanceInfoProvider.

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -257,10 +257,10 @@ CHIP_ERROR Set(uint16_t id, const char * value, size_t size)
 
 CHIP_ERROR Get(uint16_t id, char * value, size_t max_size, size_t & size)
 {
+    // No room for a NUL-terminated C string; reject before max_size - 1 (avoids underflow) and skip storage.
+    VerifyOrReturnError(max_size > 0, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(Get(id, (uint8_t *) value, max_size - 1, size));
     // Binary Get does not NUL-terminate; DeviceInstanceInfoProvider requires it on success.
-    VerifyOrReturnError(max_size > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(size < max_size, CHIP_ERROR_BUFFER_TOO_SMALL);
     value[size] = '\0';
     return CHIP_NO_ERROR;
 }

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -257,7 +257,12 @@ CHIP_ERROR Set(uint16_t id, const char * value, size_t size)
 
 CHIP_ERROR Get(uint16_t id, char * value, size_t max_size, size_t & size)
 {
-    return Get(id, (uint8_t *) value, max_size - 1, size);
+    ReturnErrorOnFailure(Get(id, (uint8_t *) value, max_size - 1, size));
+    // Binary Get does not NUL-terminate; DeviceInstanceInfoProvider requires it on success.
+    VerifyOrReturnError(max_size > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(size < max_size, CHIP_ERROR_BUFFER_TOO_SMALL);
+    value[size] = '\0';
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Flash


### PR DESCRIPTION
#### Summary
Fixes the char * overload of Flash::Get so string reads match what DeviceInstanceInfoProvider expects: a NUL-terminated C string on success.
The underlying binary Get copies raw bytes and does not append a terminator. This change reserves one byte for the terminator by calling the binary Get with max_size - 1, then writes value[size] = '\0' after a successful read.

#### Related issues
NA

#### Testing
Tested with multiple provisioning string like product-name, vendor-name and many more multiple times and didn't see any garbage data with them.

