### PR TITLE
[Fix] Fix missing subscription reports for CameraAvStreamManagement referenceCount updates

### DIFF
--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -498,10 +498,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateVideoStreamRefCount(uint16_t v
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedVideoStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement)
@@ -516,10 +522,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateAudioStreamRefCount(uint16_t a
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedAudioStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement)
@@ -535,10 +547,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateSnapshotStreamRefCount(uint16_
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedSnapshotStreams::Id>();
 }
 
 DataModel::ActionReturnStatus CameraAVStreamManagementCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -1580,4 +1580,152 @@ TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand_NoStreamA
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateVideoStreamRefCount)
+{
+    using AllocateRequest  = Commands::VideoStreamAllocate::Type;
+    using AllocateResponse = Commands::VideoStreamAllocateResponse::DecodableType;
+
+    mVideoStreams.clear();
+
+    // First, allocate a stream
+    AllocateRequest allocRequest;
+    allocRequest.streamUsage      = StreamUsageEnum::kLiveView;
+    allocRequest.videoCodec       = VideoCodecEnum::kH264;
+    allocRequest.minFrameRate     = 30;
+    allocRequest.maxFrameRate     = 120;
+    allocRequest.minResolution    = { 640, 480 };
+    allocRequest.maxResolution    = { 1280, 720 };
+    allocRequest.minBitRate       = 10000;
+    allocRequest.maxBitRate       = 10000;
+    allocRequest.keyFrameInterval = 4;
+    allocRequest.watermarkEnabled = chip::MakeOptional(false);
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->videoStreamID;
+    EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
+
+    // Read initial referenceCount
+    Attributes::AllocatedVideoStreams::TypeInfo::DecodableType allocatedVideoStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    auto it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    // Increment
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    // Decrement back
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent stream ID
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+
+    // Already back at zero after the round-trip, so decrement should fail
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, false), CHIP_ERROR_INVALID_INTEGER_VALUE);
+}
+
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateAudioStreamRefCount)
+{
+    using AllocateRequest  = Commands::AudioStreamAllocate::Type;
+    using AllocateResponse = Commands::AudioStreamAllocateResponse::DecodableType;
+
+    mAudioStreams.clear();
+
+    AllocateRequest allocRequest;
+    allocRequest.streamUsage  = StreamUsageEnum::kLiveView;
+    allocRequest.audioCodec   = AudioCodecEnum::kOpus;
+    allocRequest.channelCount = 2;
+    allocRequest.sampleRate   = 48000;
+    allocRequest.bitRate      = 128000;
+    allocRequest.bitDepth     = 24;
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->audioStreamID;
+    EXPECT_EQ(mServer.GetAllocatedAudioStreams().size(), 1u);
+
+    Attributes::AllocatedAudioStreams::TypeInfo::DecodableType allocatedAudioStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    auto it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    // Increment and verify
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    // Decrement and verify
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent stream
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+}
+
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateSnapshotStreamRefCount)
+{
+    using AllocateRequest  = Commands::SnapshotStreamAllocate::Type;
+    using AllocateResponse = Commands::SnapshotStreamAllocateResponse::DecodableType;
+
+    mSnapshotStreams.clear();
+
+    AllocateRequest allocRequest;
+    allocRequest.imageCodec       = ImageCodecEnum::kJpeg;
+    allocRequest.maxFrameRate     = 30;
+    allocRequest.minResolution    = { 640, 480 };
+    allocRequest.maxResolution    = { 1280, 720 };
+    allocRequest.quality          = 80;
+    allocRequest.watermarkEnabled = chip::MakeOptional(false);
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->snapshotStreamID;
+    EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
+
+    Attributes::AllocatedSnapshotStreams::TypeInfo::DecodableType allocatedSnapshotStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    auto it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent ID
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

UpdateVideoStreamRefCount, UpdateAudioStreamRefCount, and UpdateSnapshotStreamRefCount modify referenceCount in memory but never call PersistAndNotify, so the change is neither persisted to storage nor reported via subscription. Add PersistAndNotify calls matching every other mutation path in the cluster.

Fixes: TC_AVSM_2_16, TC_AVSM_2_17, TC_WEBRTCP_2_23 when used with wildcard subscription report against direct read values in PR [43274](https://github.com/project-chip/connectedhomeip/pull/43274).

#### Related issues

Fixes issue: [71396](https://github.com/project-chip/connectedhomeip/issues/71396)

#### Testing

Tested in WSL:
```
scripts/tests/run_python_test.py     --factory-reset     --app  out/linux-x64-camera/chip-camera-app    --app-args "--discriminator 1234 --KVS kvs1 --app-pipe /tmp/avsm_2_17_fifo" --script src/python_testing/TC_AVSM_2_17.py  --script-args "--storage-path admin_storage.json \
                   --commissioning-method on-network \
                   --discriminator 1234 \
                   --passcode 20202021 \
                   --PICS src/app/tests/suites/certification/ci-pics-values \
                   --endpoint 1 \ 
                   --app-pipe /tmp/avsm_2_17_fifo"
```

[Notes] 
This fixes a subscription report issue surfaced after implementing base wildcard subscription that compares report values against direct reads as mentioned in PR [43274](https://github.com/project-chip/connectedhomeip/pull/43274).