### PR TITLE
[CI][REPL] publish test reports to dashboard with history

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -248,6 +248,9 @@ jobs:
         if: ${{ !cancelled() && github.actor != 'restyled-io[bot]' }}
 
         runs-on: ubuntu-latest
+        concurrency:
+          group: gh-pages-deploy
+          cancel-in-progress: false
         permissions:
             contents: write
             checks: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1076,13 +1076,13 @@ jobs:
                 filter: ["", "TC_[A-C]", "TC_[D-O]", "!TC_[A-O]" ]
                 include:
                     - filter: ""
-                      name: Other
+                      junitxml: out/junit-results/Other-results.xml
                     - filter: "TC_[A-C]"
-                      name: TC_A-C
+                      junitxml: out/junit-results/TC_A-C-results.xml
                     - filter: "TC_[D-O]"
-                      name: TC_D-O
+                      junitxml: out/junit-results/TC_D-O-results.xml
                     - filter: "!TC_[A-O]"
-                      name: TC_Non-A-O
+                      junitxml: out/junit-results/TC_Non-A-O-results.xml
 
         env:
             BUILD_VARIANT: ipv6only-no-ble-no-wifi-asan
@@ -1208,7 +1208,7 @@ jobs:
             - name: Run Tests ${{matrix.filter}}
               if: ${{matrix.filter != ''}}
               run: |
-                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json --junit-file out/junit-results/${{matrix.name}}-results.xml --junit-suite-name "REPL Tests Linux - ${{github.ref_name}}"'
+                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json --junit-file ${{matrix.junitxml}} --junit-suite-name "REPL Tests Linux - ${{github.ref_name}}"'
             - name: Print python test summary
               if: ${{ matrix.filter != '' && always() }}
               run: |
@@ -1228,7 +1228,7 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: junit-results-repl-${{ matrix.filter }}
-                  path: out/junit-results/${{ matrix.name }}-results.xml
+                  path: ${{matrix.junitxml}}
                   retention-days: 30
                   if-no-files-found: warn
             - name: Execute Jupyter Notebooks

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1271,7 +1271,7 @@ jobs:
     repl_tests_linux_report:
       name: REPL Tests - Linux (REPORT RESULTS)
       needs: repl_tests_linux_run
-      if: ${{ !cancelled() && github.actor != 'restyled-io[bot]' }}
+      if: ${{ !cancelled() && needs.repl_tests_linux_run.result != 'skipped' && github.actor != 'restyled-io[bot]' }}
 
       runs-on: ubuntu-latest
       concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1074,6 +1074,15 @@ jobs:
                 # This list is empirically created to have a reasonable time split. The "" that runs the "other"
                 # tests is reasonably fast, the others take about 20-30 minutes each at the time this was split.
                 filter: ["", "TC_[A-C]", "TC_[D-O]", "!TC_[A-O]" ]
+                include:
+                    - filter: ""
+                      name: Other
+                    - filter: "TC_[A-C]"
+                      name: TC_A-C
+                    - filter: "TC_[D-O]"
+                      name: TC_D-O
+                    - filter: "!TC_[A-O]"
+                      name: TC_Non-A-O
 
         env:
             BUILD_VARIANT: ipv6only-no-ble-no-wifi-asan
@@ -1199,7 +1208,7 @@ jobs:
             - name: Run Tests ${{matrix.filter}}
               if: ${{matrix.filter != ''}}
               run: |
-                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json --junit-file out/junit-results/${{matrix.filter}}-results.xml --junit-suite-name "REPL Tests Linux - ${{github.ref_name}}"'
+                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json --junit-file out/junit-results/${{matrix.name}}-results.xml --junit-suite-name "REPL Tests Linux - ${{github.ref_name}}"'
             - name: Print python test summary
               if: ${{ matrix.filter != '' && always() }}
               run: |
@@ -1219,7 +1228,7 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: junit-results-repl-${{ matrix.filter }}
-                  path: out/junit-results/${{ matrix.filter }}-results.xml
+                  path: out/junit-results/${{ matrix.name }}-results.xml
                   retention-days: 30
                   if-no-files-found: warn
             - name: Execute Jupyter Notebooks

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1199,7 +1199,7 @@ jobs:
             - name: Run Tests ${{matrix.filter}}
               if: ${{matrix.filter != ''}}
               run: |
-                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json'
+                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json --junit-file out/junit-results/${{matrix.filter}}-results.xml --junit-suite-name "REPL Tests Linux - ${{github.ref_name}}"'
             - name: Print python test summary
               if: ${{ matrix.filter != '' && always() }}
               run: |
@@ -1214,6 +1214,14 @@ jobs:
                   path: test-summaries/python-tests.json
                   retention-days: 30
 
+            - name: Upload JUnit XML Results
+              if: always() && matrix.filter != ''
+              uses: actions/upload-artifact@v7
+              with:
+                  name: junit-results-repl-${{ matrix.filter }}
+                  path: out/junit-results/${{ matrix.filter }}-results.xml
+                  retention-days: 30
+                  if-no-files-found: warn
             - name: Execute Jupyter Notebooks
               if: ${{matrix.filter == ''}}
               run: |
@@ -1250,10 +1258,75 @@ jobs:
             #   with:
             #     duration: 30m
             #     authorized-users: andy31415
+    # TODO, factor out this job and the one in nightly.yaml into a separate action that can be called
+    repl_tests_linux_report:
+      name: REPL Tests - Linux (REPORT RESULTS)
+      needs: repl_tests_linux_run
+      if: ${{ !cancelled() && github.actor != 'restyled-io[bot]' }}
+
+      runs-on: ubuntu-latest
+      concurrency:
+          group: gh-pages-deploy
+          cancel-in-progress: false
+      permissions:
+          contents: write
+          checks: write
+
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v6
+
+          - name: Download all JUnit XML results
+            uses: actions/download-artifact@v7
+            with:
+                pattern: junit-results-*
+                path: junit-results
+                merge-multiple: true
+
+          - name: Publish test results to GitHub Actions
+            uses: mikepenz/action-junit-report@v5
+            with:
+                report_paths: junit-results/**/*.xml
+                detailed_summary: true
+                require_tests: false
+
+          - name: Checkout gh-pages for Allure history
+            uses: actions/checkout@v6
+            with:
+                ref: gh-pages
+                path: gh-pages
+
+          - name: Generate Allure Report
+            uses: simple-elf/allure-report-action@v1.13
+            with:
+                allure_results: junit-results
+                allure_report: allure-report
+                gh_pages: gh-pages
+                allure_history: allure-history
+                subfolder: allure-report/ci_tests
+                keep_reports: 200
+                # This is the name that will show up in the Dashboard Overview
+                report_name: "CI Tests"
+
+          - name: Upload Allure Report
+            uses: actions/upload-artifact@v7
+            with:
+                name: allure-report-ci-repl
+                path: allure-report
+                retention-days: 30
+                if-no-files-found: warn
+
+          - name: Deploy to GitHub Pages
+            if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+            uses: peaceiris/actions-gh-pages@v4
+            with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: allure-history/allure-report/ci_tests
+                destination_dir: allure-report/ci_tests
+                keep_files: true
 
     repl_tests_darwin:
         name: REPL Tests - Darwin (Build Only)
-
         strategy:
             matrix:
                 include:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Documentation links
 
-- [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/project-chip/connectedhomeip)
-- [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
-- [Matter SDK Coverage Report](https://matter-build-automation.ue.r.appspot.com/)
-- [CI REPL Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/ci_tests/)
-- [Nightly Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/nightly/)
+-   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/project-chip/connectedhomeip)
+-   [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
+-   [Matter SDK Coverage Report](https://matter-build-automation.ue.r.appspot.com/)
+-   [CI REPL Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/ci_tests/)
+-   [Nightly Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/nightly/)
 
 # Matter
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Documentation links
 
--   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/project-chip/connectedhomeip)
--   [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
--   [Matter SDK Coverage Report](https://matter-build-automation.ue.r.appspot.com/)
+- [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/project-chip/connectedhomeip)
+- [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
+- [Matter SDK Coverage Report](https://matter-build-automation.ue.r.appspot.com/)
+- [CI REPL Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/ci_tests/)
+- [Nightly Tests Dashboard](https://project-chip.github.io/connectedhomeip/allure-report/nightly/)
 
 # Matter
 
@@ -33,7 +35,7 @@
 **Tests**
 
 [![Tests-Master](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml)
-[![Tests-LTS](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml/badge.svg?branch=v1.4.2-branch)](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml)
+[![Tests-LTS](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml/badge.svg?branch=v1.4.2-branch)](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml?query=branch:v1.4.2-branch)
 [![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
 [![Cirque](https://github.com/project-chip/connectedhomeip/workflows/Cirque/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/cirque.yaml)
 [![QEMU](https://github.com/project-chip/connectedhomeip/workflows/QEMU/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/qemu.yaml)


### PR DESCRIPTION
#### Summary

- generate JUnit test reports for REPL Linux tests.
- Use these reports to push test reports to Dashboard, that we can use to track flaky tests. 


#### Related issues

- similar effort was done for nightly.yaml in https://github.com/project-chip/connectedhomeip/pull/71406

#### Testing

- CI will test