### PR TITLE
docs: Recommend builder pattern for cluster initialization

### DIFF
--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -101,7 +101,7 @@ unnecessary overhead.
 
 To ensure that a cluster is initialized correctly and that feature flags remain
 in sync with their mandatory attributes or parameters, all new code-driven
-clusters should use a **builder-style Config struct** pattern. This pattern
+clusters should use a **builder-style Config** pattern. This pattern
 prevents common errors where a feature is enabled but its mandatory parameters
 are missing.
 
@@ -111,8 +111,8 @@ is the primary reference for this implementation pattern.
 
 **Pattern Principles:**
 
--   **Nested Config Struct:** Define a `struct Config` within the main cluster
-    class to hold all startup state.
+-   **Nested Config Struct/Class:** Define a `Config` struct or class within the main cluster
+    class to hold all startup state. Use a `class` with private members for non-trivial configurations to prevent direct manipulation of members and enforce the use of builder methods. A `struct` with public members is acceptable for very simple configurations without complex rules.
 -   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a
     reference to the `Config` object to allow for chained configuration calls.
 -   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit
@@ -121,6 +121,7 @@ is the primary reference for this implementation pattern.
 -   **Encapsulated Logic:** This approach encapsulates the cluster's complex
     conformance logic directly into the configuration API, making it much harder
     for application developers to create an invalid configuration.
+-   **External Endpoint ID:** The `EndpointId` should be passed to the cluster constructor directly, not stored in the `Config` object. This allows the same `Config` instance to be reused across multiple cluster instances on different endpoints.
 
 **Example Implementation (from LevelControlCluster):**
 
@@ -128,10 +129,11 @@ is the primary reference for this implementation pattern.
 class LevelControlCluster : public DefaultServerCluster ...
 {
 public:
-    struct Config
+    class Config
     {
-        Config(EndpointId endpoint, TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
-            mEndpointId(endpoint), mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
+    public:
+        Config(TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
+            mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
 
         // Automatically sets the Lighting feature and sets required attribute values
         Config & WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel)
@@ -155,7 +157,8 @@ public:
             return *this;
         }
 
-        EndpointId mEndpointId;
+    private:
+        friend class LevelControlCluster;
         LevelControlDelegate & mDelegate;
         TimerDelegate & mTimerDelegate;
         BitMask<LevelControl::Feature> mFeatureMap;
@@ -163,7 +166,7 @@ public:
         // ... other members
     };
 
-    LevelControlCluster(const Config & config);
+    LevelControlCluster(EndpointId endpoint, const Config & config);
 };
 ```
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -135,44 +135,40 @@ is the primary reference for this implementation pattern.
 class LevelControlCluster : public DefaultServerCluster ...
 {
 public:
-    class Config
-    {
-    public:
-        Config(TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
-            mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
+  class Config {
+  public:
+    Config(TimerDelegate &timerDelegate, LevelControlDelegate &delegate)
+        : mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
 
-        // Automatically sets the Lighting feature and sets required attribute values
-        Config & WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel)
-        {
-            mFeatureMap.Set(LevelControl::Feature::kLighting);
-            WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
-            WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
-            mStartUpCurrentLevel = startUpCurrentLevel;
-            return *this;
-        }
+    // Automatically sets the Lighting feature and sets required attribute values
+    Config &WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel) {
+      mFeatureMap.Set(LevelControl::Feature::kLighting);
+      WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
+      WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
+      mStartUpCurrentLevel = startUpCurrentLevel;
+      return *this;
+    }
 
-        Config & WithMinLevel(uint8_t minLevel)
-        {
-            // ... implementation
-            return *this;
-        }
+    Config &WithMinLevel(uint8_t minLevel) {
+      // ... implementation
+      return *this;
+    }
 
-        Config & WithMaxLevel(uint8_t maxLevel)
-        {
-            // ... implementation
-            return *this;
-        }
+    Config &WithMaxLevel(uint8_t maxLevel) {
+      // ... implementation
+      return *this;
+    }
 
-    private:
-        friend class LevelControlCluster;
-        LevelControlDelegate & mDelegate;
-        TimerDelegate & mTimerDelegate;
-        BitMask<LevelControl::Feature> mFeatureMap;
-        DataModel::Nullable<uint8_t> mStartUpCurrentLevel;
-        // ... other members
-    };
+  private:
+    friend class LevelControlCluster;
+    LevelControlDelegate &mDelegate;
+    TimerDelegate &mTimerDelegate;
+    BitMask<LevelControl::Feature> mFeatureMap;
+    DataModel::Nullable<uint8_t> mStartUpCurrentLevel;
+    // ... other members
+  };
 
-    LevelControlCluster(EndpointId endpoint, const Config & config);
+  LevelControlCluster(EndpointId endpoint, const Config &config);
 };
 ```
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -99,16 +99,28 @@ unnecessary overhead.
 
 #### Cluster Initialization and Configuration (Builder Pattern)
 
-To ensure that a cluster is initialized correctly and that feature flags remain in sync with their mandatory attributes or parameters, all new code-driven clusters should use a **builder-style Config struct** pattern. This pattern prevents common errors where a feature is enabled but its mandatory parameters are missing.
+To ensure that a cluster is initialized correctly and that feature flags remain
+in sync with their mandatory attributes or parameters, all new code-driven
+clusters should use a **builder-style Config struct** pattern. This pattern
+prevents common errors where a feature is enabled but its mandatory parameters
+are missing.
 
-**Reference Example:** The [Level Control Cluster](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/level-control/LevelControlCluster.h) is the primary reference for this implementation pattern.
+**Reference Example:** The
+[Level Control Cluster](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/level-control/LevelControlCluster.h)
+is the primary reference for this implementation pattern.
 
 **Pattern Principles:**
 
-*   **Nested Config Struct:** Define a `struct Config` within the main cluster class to hold all startup state.
-*   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a reference to the `Config` object to allow for chained configuration calls.
-*   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit setting and the initialization of any associated attributes to prevent invalid states.
-*   **Encapsulated Logic:** This approach encapsulates the cluster's complex conformance logic directly into the configuration API, making it much harder for application developers to create an invalid configuration.
+-   **Nested Config Struct:** Define a `struct Config` within the main cluster
+    class to hold all startup state.
+-   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a
+    reference to the `Config` object to allow for chained configuration calls.
+-   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit
+    setting and the initialization of any associated attributes to prevent
+    invalid states.
+-   **Encapsulated Logic:** This approach encapsulates the cluster's complex
+    conformance logic directly into the configuration API, making it much harder
+    for application developers to create an invalid configuration.
 
 **Example Implementation (from LevelControlCluster):**
 
@@ -119,7 +131,7 @@ public:
     struct Config
     {
         Config(EndpointId endpoint, TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
-            mEndpointId(endpoint), mDelegate(delegate), mTimerDelegate(timerDelegate) {}
+            mEndpointId(endpoint), mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
 
         // Automatically sets the Lighting feature and sets required attribute values
         Config & WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel)
@@ -128,6 +140,18 @@ public:
             WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
             WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
             mStartUpCurrentLevel = startUpCurrentLevel;
+            return *this;
+        }
+
+        Config & WithMinLevel(uint8_t minLevel)
+        {
+            // ... implementation
+            return *this;
+        }
+
+        Config & WithMaxLevel(uint8_t maxLevel)
+        {
+            // ... implementation
             return *this;
         }
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -97,6 +97,51 @@ unnecessary overhead.
         interactions. We recommend the term `Driver` to avoid confusion with the
         overloaded term `Delegate`.
 
+#### Cluster Initialization and Configuration (Builder Pattern)
+
+To ensure that a cluster is initialized correctly and that feature flags remain in sync with their mandatory attributes or parameters, all new code-driven clusters should use a **builder-style Config struct** pattern. This pattern prevents common errors where a feature is enabled but its mandatory parameters are missing.
+
+**Reference Example:** The [Level Control Cluster](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/level-control/LevelControlCluster.h) is the primary reference for this implementation pattern.
+
+**Pattern Principles:**
+*   **Nested Config Struct:** Define a `struct Config` within the main cluster class to hold all startup state.
+*   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a reference to the `Config` object to allow for chained configuration calls.
+*   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit setting and the initialization of any associated attributes to prevent invalid states.
+*   **Encapsulated Logic:** This approach encapsulates the cluster's complex conformance logic directly into the configuration API, making it much harder for application developers to create an invalid configuration.
+
+**Example Implementation (from LevelControlCluster):**
+
+```cpp
+class LevelControlCluster : public DefaultServerCluster ...
+{
+public:
+    struct Config
+    {
+        Config(EndpointId endpoint, TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
+            mEndpointId(endpoint), mDelegate(delegate), mTimerDelegate(timerDelegate) {}
+
+        // Automatically sets the Lighting feature and sets required attribute values
+        Config & WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel)
+        {
+            mFeatureMap.Set(LevelControl::Feature::kLighting);
+            WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
+            WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
+            mStartUpCurrentLevel = startUpCurrentLevel;
+            return *this;
+        }
+
+        EndpointId mEndpointId;
+        LevelControlDelegate & mDelegate;
+        TimerDelegate & mTimerDelegate;
+        BitMask<LevelControl::Feature> mFeatureMap;
+        DataModel::Nullable<uint8_t> mStartUpCurrentLevel;
+        // ... other members
+    };
+
+    LevelControlCluster(const Config & config);
+};
+```
+
 ### Design Principles
 
 When designing and implementing a cluster, adhere to the following principles to

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -101,9 +101,9 @@ unnecessary overhead.
 
 To ensure that a cluster is initialized correctly and that feature flags remain
 in sync with their mandatory attributes or parameters, all new code-driven
-clusters should use a **builder-style Config** pattern. This pattern
-prevents common errors where a feature is enabled but its mandatory parameters
-are missing.
+clusters should use a **builder-style Config** pattern. This pattern prevents
+common errors where a feature is enabled but its mandatory parameters are
+missing.
 
 **Reference Example:** The
 [Level Control Cluster](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/level-control/LevelControlCluster.h)

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -111,8 +111,11 @@ is the primary reference for this implementation pattern.
 
 **Pattern Principles:**
 
--   **Nested Config Struct/Class:** Define a `Config` struct or class within the main cluster
-    class to hold all startup state. Use a `class` with private members for non-trivial configurations to prevent direct manipulation of members and enforce the use of builder methods. A `struct` with public members is acceptable for very simple configurations without complex rules.
+-   **Nested Config Struct/Class:** Define a `Config` struct or class within the
+    main cluster class to hold all startup state. Use a `class` with private
+    members for non-trivial configurations to prevent direct manipulation of
+    members and enforce the use of builder methods. A `struct` with public
+    members is acceptable for very simple configurations without complex rules.
 -   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a
     reference to the `Config` object to allow for chained configuration calls.
 -   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit
@@ -121,7 +124,10 @@ is the primary reference for this implementation pattern.
 -   **Encapsulated Logic:** This approach encapsulates the cluster's complex
     conformance logic directly into the configuration API, making it much harder
     for application developers to create an invalid configuration.
--   **External Endpoint ID:** The `EndpointId` should be passed to the cluster constructor directly, not stored in the `Config` object. This allows the same `Config` instance to be reused across multiple cluster instances on different endpoints.
+-   **External Endpoint ID:** The `EndpointId` should be passed to the cluster
+    constructor directly, not stored in the `Config` object. This allows the
+    same `Config` instance to be reused across multiple cluster instances on
+    different endpoints.
 
 **Example Implementation (from LevelControlCluster):**
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -104,6 +104,7 @@ To ensure that a cluster is initialized correctly and that feature flags remain 
 **Reference Example:** The [Level Control Cluster](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/level-control/LevelControlCluster.h) is the primary reference for this implementation pattern.
 
 **Pattern Principles:**
+
 *   **Nested Config Struct:** Define a `struct Config` within the main cluster class to hold all startup state.
 *   **Fluent Builder API:** Provide `With<Feature>(...)` methods that return a reference to the `Config` object to allow for chained configuration calls.
 *   **Atomic Configuration:** Methods must handle both the `FeatureMap` bit setting and the initialization of any associated attributes to prevent invalid states.

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -135,40 +135,44 @@ is the primary reference for this implementation pattern.
 class LevelControlCluster : public DefaultServerCluster ...
 {
 public:
-  class Config {
-  public:
-    Config(TimerDelegate &timerDelegate, LevelControlDelegate &delegate)
-        : mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
+    class Config
+    {
+    public:
+        Config(TimerDelegate & timerDelegate, LevelControlDelegate & delegate) :
+            mDelegate(delegate), mTimerDelegate(timerDelegate), mFeatureMap(0) {}
 
-    // Automatically sets the Lighting feature and sets required attribute values
-    Config &WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel) {
-      mFeatureMap.Set(LevelControl::Feature::kLighting);
-      WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
-      WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
-      mStartUpCurrentLevel = startUpCurrentLevel;
-      return *this;
-    }
+        // Automatically sets the Lighting feature and sets required attribute values
+        Config & WithLighting(DataModel::Nullable<uint8_t> startUpCurrentLevel)
+        {
+            mFeatureMap.Set(LevelControl::Feature::kLighting);
+            WithMinLevel(1);   // Spec mandates MinLevel=1 for Lighting feature
+            WithMaxLevel(254); // Spec mandates MaxLevel=254 for Lighting feature
+            mStartUpCurrentLevel = startUpCurrentLevel;
+            return *this;
+        }
 
-    Config &WithMinLevel(uint8_t minLevel) {
-      // ... implementation
-      return *this;
-    }
+        Config & WithMinLevel(uint8_t minLevel)
+        {
+            // ... implementation
+            return *this;
+        }
 
-    Config &WithMaxLevel(uint8_t maxLevel) {
-      // ... implementation
-      return *this;
-    }
+        Config & WithMaxLevel(uint8_t maxLevel)
+        {
+            // ... implementation
+            return *this;
+        }
 
-  private:
-    friend class LevelControlCluster;
-    LevelControlDelegate &mDelegate;
-    TimerDelegate &mTimerDelegate;
-    BitMask<LevelControl::Feature> mFeatureMap;
-    DataModel::Nullable<uint8_t> mStartUpCurrentLevel;
-    // ... other members
-  };
+    private:
+        friend class LevelControlCluster;
+        LevelControlDelegate & mDelegate;
+        TimerDelegate & mTimerDelegate;
+        BitMask<LevelControl::Feature> mFeatureMap;
+        DataModel::Nullable<uint8_t> mStartUpCurrentLevel;
+        // ... other members
+    };
 
-  LevelControlCluster(EndpointId endpoint, const Config &config);
+    LevelControlCluster(EndpointId endpoint, const Config & config);
 };
 ```
 


### PR DESCRIPTION
This PR adds a section to the cluster writing guide recommending the builder pattern for cluster configuration.

#### Testing
Doc update only.