### PR TITLE
Fix TCP connection leak for non-active secure sessions

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1338,17 +1338,23 @@ void SessionManager::MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPCon
 {
     // Mark the corresponding secure sessions for eviction
     mSecureSessions.ForEachSession([&](auto session) {
-        if (session->IsActiveSession() && session->GetTCPConnection() == conn)
+        if (session->GetTCPConnection() == conn)
         {
-            SessionHandle handle(*session);
-            // Notify the SessionConnection delegate of the connection
-            // closure.
-            if (mConnDelegate != nullptr)
+            if (session->IsActiveSession())
             {
-                mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);
+                SessionHandle handle(*session);
+                // Notify the SessionConnection delegate of the connection
+                // closure.
+                if (mConnDelegate != nullptr)
+                {
+                    mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);
+                }
             }
 
-            // Mark session for eviction.
+            // Explicitly release the TCP connection handle to ensure the transport resource is reclaimed immediately.
+            session->ReleaseTCPConnection();
+
+            // Mark session for eviction regardless of its current state (Active, Defunct, or Establishing).
             session->MarkForEviction();
         }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1341,7 +1341,6 @@ void SessionManager::MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPCon
         if (session->GetTCPConnection() == conn)
         {
             bool isActive = session->IsActiveSession();
-            SessionHandle handle(*session);
 
             if (isActive)
             {
@@ -1350,6 +1349,7 @@ void SessionManager::MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPCon
                 // releases exchanges.
                 if (mConnDelegate != nullptr)
                 {
+                    SessionHandle handle(*session);
                     mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);
                 }
             }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1340,11 +1340,14 @@ void SessionManager::MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPCon
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetTCPConnection() == conn)
         {
-            if (session->IsActiveSession())
+            bool isActive = session->IsActiveSession();
+            SessionHandle handle(*session);
+
+            if (isActive)
             {
-                SessionHandle handle(*session);
                 // Notify the SessionConnection delegate of the connection
-                // closure.
+                // closure before session eviction detaches holders and
+                // releases exchanges.
                 if (mConnDelegate != nullptr)
                 {
                     mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);

--- a/src/transport/tests/TestTCPConnection.cpp
+++ b/src/transport/tests/TestTCPConnection.cpp
@@ -273,12 +273,12 @@ TEST_F(TestTCPConnection, TestDefunctSecureSessionReleaseOnConnectionClose)
     // Drive IO to process TCP closure and session eviction logic
     mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(1), [&]() { return false; });
 
-    // 5. Exhaust the pool.
-    // Since kMaxTcpActiveConnectionCount = 2, we have 1 outgoing and 1 incoming slot total.
-    // If the defunct session still held the first connection's refcount (Slot 0),
-    // and we establish a second connection (Slot 1), a third attempt MUST fail.
-
-    // 5.1 Use the 2nd (and last) available slot
+    // Verify the closed connection's slot was released.
+    // With loopback and kMaxTcpActiveConnectionCount = 2,
+    // a new connection needs both slots.
+    // If the defunct secure session still retains the closed
+    // connection handle, this reconnect will fail due to pool
+    // exhaustion.
     ActiveTCPConnectionHandle secondConnHandle;
     EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, secondConnHandle));
 
@@ -286,12 +286,6 @@ TEST_F(TestTCPConnection, TestDefunctSecureSessionReleaseOnConnectionClose)
                              [&]() { return !secondConnHandle.IsNull() && secondConnHandle->IsConnected(); });
     ASSERT_FALSE(secondConnHandle.IsNull());
     ASSERT_TRUE(secondConnHandle->IsConnected());
-
-    // 5.2 Attempt a 3rd connection. This MUST fail if there is a leak.
-    ActiveTCPConnectionHandle thirdConnHandle;
-    CHIP_ERROR err = mTCP.TCPConnect(peerAddr, nullptr, thirdConnHandle);
-    EXPECT_NE(err, CHIP_NO_ERROR);
-    EXPECT_EQ(err, CHIP_ERROR_NO_MEMORY);
 }
 
 } // namespace

--- a/src/transport/tests/TestTCPConnection.cpp
+++ b/src/transport/tests/TestTCPConnection.cpp
@@ -232,4 +232,66 @@ TEST_F(TestTCPConnection, TestUnauthenticatedSessionReleaseOnConnectionClose)
     EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, connHandle));
 }
 
+TEST_F(TestTCPConnection, TestDefunctSecureSessionReleaseOnConnectionClose)
+{
+    uint16_t port;
+    EXPECT_SUCCESS(InitTCP(port));
+    EXPECT_SUCCESS(InitSessionManager());
+
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+
+    // Connect to self (loopback)
+    Transport::PeerAddress peerAddr = Transport::PeerAddress::TCP(addr, port);
+
+    // 1. Establish initial connection
+    ActiveTCPConnectionHandle connHandle;
+    EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, connHandle));
+
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5),
+                             [&]() { return !connHandle.IsNull() && connHandle->IsConnected(); });
+    ASSERT_FALSE(connHandle.IsNull());
+    ASSERT_TRUE(connHandle->IsConnected());
+
+    // 2. Inject a Secure CASE Session associated with this connection
+    SessionHolder sessionHolder;
+    EXPECT_SUCCESS(mSessionManager.InjectCaseSessionWithTestKey(sessionHolder, 1, 2, 1234, 5678, 1, peerAddr,
+                                                                CryptoContext::SessionRole::kInitiator));
+
+    // Manually link the TCP connection handle to the session
+    sessionHolder->AsSecureSession()->SetTCPConnection(connHandle);
+
+    // 3. Mark the session as DEFUNCT
+    sessionHolder->AsSecureSession()->MarkAsDefunct();
+    ASSERT_FALSE(sessionHolder->AsSecureSession()->IsActiveSession());
+
+    // 4. Simulate TCP connection closure
+    // Close TCP connection & release local handle
+    connHandle->ForceDisconnect();
+    connHandle.Release();
+
+    // Drive IO to process TCP closure and session eviction logic
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(1), [&]() { return false; });
+
+    // 5. Exhaust the pool.
+    // Since kMaxTcpActiveConnectionCount = 2, we have 1 outgoing and 1 incoming slot total.
+    // If the defunct session still held the first connection's refcount (Slot 0),
+    // and we establish a second connection (Slot 1), a third attempt MUST fail.
+
+    // 5.1 Use the 2nd (and last) available slot
+    ActiveTCPConnectionHandle secondConnHandle;
+    EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, secondConnHandle));
+
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5),
+                             [&]() { return !secondConnHandle.IsNull() && secondConnHandle->IsConnected(); });
+    ASSERT_FALSE(secondConnHandle.IsNull());
+    ASSERT_TRUE(secondConnHandle->IsConnected());
+
+    // 5.2 Attempt a 3rd connection. This MUST fail if there is a leak.
+    ActiveTCPConnectionHandle thirdConnHandle;
+    CHIP_ERROR err = mTCP.TCPConnect(peerAddr, nullptr, thirdConnHandle);
+    EXPECT_NE(err, CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_ERROR_NO_MEMORY);
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

Ensures that all secure sessions associated with a closed TCP connection properly release their transport resources and are marked for eviction.

- Removed IsActiveSession() filter in MarkSecureSessionOverTCPForEviction to ensure kDefunct and kEstablishing sessions are also processed.
- Added explicit session->ReleaseTCPConnection() call to immediately decrement the transport reference count upon connection closure.
- Ensured session->MarkForEviction() is called for all sessions matching the closed connection to prevent session table saturation.
- Added regression test TestDefunctSecureSessionReleaseOnConnectionClose to verify reclamation when sessions are in kDefunct state.
- Fixes https://github.com/project-chip/connectedhomeip/issues/43369

##### Cause of Issue
The leak occurred because SessionManager::MarkSecureSessionOverTCPForEviction only processed sessions in the `kActive` state. If a connection closed while the session was `kDefunct` or in `kEstablishing` state, the session was skipped, leaving it holding an `ActiveTCPConnectionHandle`. This kept the TCP connection's reference count above zero, preventing the transport layer from reclaiming the slot and eventually causing connection exhaustion.

Having device interactions over a relatively longer period of time with multiple session and connection establishments and exchanges running on top, would precipitate this leak scenario, potentially.

#### Testing

Added unit test for testing a connection closure with the corresponding session marked as defunct

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
