### PR TITLE
Fix key and AuxACL update checks in Groupcast cluster

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -226,6 +226,7 @@ void ApplicationInit()
             .fabricTable       = Server::GetInstance().GetFabricTable(),
             .groupDataProvider = *Credentials::GetGroupDataProvider(),
             .timerDelegate     = sTimerDelegate,
+            .accessControl     = Server::GetInstance().GetAccessControl(),
         },
         BitFlags<Clusters::Groupcast::Feature>(Clusters::Groupcast::Feature::kListener, Clusters::Groupcast::Feature::kSender,
                                                Clusters::Groupcast::Feature::kPerGroup));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -54,15 +54,15 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context{
+        GeneralCommissioningCluster::Context {
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-            .configurationManager       = mContext.configurationManager,       //
-            .deviceControlServer        = mContext.deviceControlServer,        //
-            .fabricTable                = mContext.fabricTable,                //
-            .failSafeContext            = mContext.failSafeContext,            //
-            .platformManager            = mContext.platformManager,            //
+                .configurationManager   = mContext.configurationManager,       //
+                .deviceControlServer    = mContext.deviceControlServer,        //
+                .fabricTable            = mContext.fabricTable,                //
+                .failSafeContext        = mContext.failSafeContext,            //
+                .platformManager        = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -98,6 +98,7 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
             .fabricTable       = mContext.fabricTable,
             .groupDataProvider = mContext.groupDataProvider,
             .timerDelegate     = mContext.timerDelegate,
+            .accessControl     = mContext.accessControl
         },
         BitFlags<Clusters::Groupcast::Feature>(Clusters::Groupcast::Feature::kListener, Clusters::Groupcast::Feature::kSender));
     ReturnErrorOnFailure(provider.AddCluster(mGroupcastCluster.Registration()));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -54,15 +54,15 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context {
+        GeneralCommissioningCluster::Context{
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-                .configurationManager   = mContext.configurationManager,       //
-                .deviceControlServer    = mContext.deviceControlServer,        //
-                .fabricTable            = mContext.fabricTable,                //
-                .failSafeContext        = mContext.failSafeContext,            //
-                .platformManager        = mContext.platformManager,            //
+            .configurationManager       = mContext.configurationManager,       //
+            .deviceControlServer        = mContext.deviceControlServer,        //
+            .fabricTable                = mContext.fabricTable,                //
+            .failSafeContext            = mContext.failSafeContext,            //
+            .platformManager            = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());
@@ -94,12 +94,10 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
 
 #if CHIP_CONFIG_ENABLE_GROUPCAST
     mGroupcastCluster.Create(
-        GroupcastContext{
-            .fabricTable       = mContext.fabricTable,
-            .groupDataProvider = mContext.groupDataProvider,
-            .timerDelegate     = mContext.timerDelegate,
-            .accessControl     = mContext.accessControl
-        },
+        GroupcastContext{ .fabricTable       = mContext.fabricTable,
+                          .groupDataProvider = mContext.groupDataProvider,
+                          .timerDelegate     = mContext.timerDelegate,
+                          .accessControl     = mContext.accessControl },
         BitFlags<Clusters::Groupcast::Feature>(Clusters::Groupcast::Feature::kListener, Clusters::Groupcast::Feature::kSender));
     ReturnErrorOnFailure(provider.AddCluster(mGroupcastCluster.Registration()));
 #endif // CHIP_CONFIG_ENABLE_GROUPCAST

--- a/src/app/clusters/groupcast/CodegenIntegration.cpp
+++ b/src/app/clusters/groupcast/CodegenIntegration.cpp
@@ -17,6 +17,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
 #include <app/clusters/groupcast/GroupcastContext.h>
+#include <app/server/Server.h>
 #include <app/static-cluster-config/Groupcast.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
@@ -59,6 +60,7 @@ public:
                 .fabricTable       = Server::GetInstance().GetFabricTable(),
                 .groupDataProvider = *groupDataProvider,
                 .timerDelegate     = sTimerDelegate,
+                .accessControl     = Server::GetInstance().GetAccessControl(),
             },
             BitFlags<Groupcast::Feature>(featureMap));
         return gServer.Registration();

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -108,7 +108,7 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     VerifyOrReturnValue(nullptr != handler, Protocols::InteractionModel::Status::InvalidAction);
 
     const chip::Access::SubjectDescriptor subjectDescriptor = request.subjectDescriptor;
-    FabricIndex fabric_index = subjectDescriptor.fabricIndex;
+    FabricIndex fabric_index                                = subjectDescriptor.fabricIndex;
 
     Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
 
@@ -357,8 +357,8 @@ Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Group
                                    const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
-    GroupDataProvider & groups = Provider();
-    CHIP_ERROR err             = CHIP_NO_ERROR;
+    GroupDataProvider & groups    = Provider();
+    CHIP_ERROR err                = CHIP_NO_ERROR;
 
     // Check GroupID and KeySetID constraints.
     VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
@@ -372,8 +372,11 @@ Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Group
 
         // AuxiliaryACL state can only be touched if the client has admin privileges, but this is called from a command that only
         // require Manage privileges. We do the check here before touching AuxACL.
-        Access::RequestPath requestPath{path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest, std::make_optional<uint32_t>(path.mCommandId)};
-        VerifyOrReturnError(CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister), Status::UnsupportedAccess);
+        Access::RequestPath requestPath{ path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest,
+                                         std::make_optional<uint32_t>(path.mCommandId) };
+        VerifyOrReturnError(
+            CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister),
+            Status::UnsupportedAccess);
     }
 
     // ReplaceEndpoints can only be present if kListener feature is supported
@@ -503,8 +506,8 @@ Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Group
     return Status::Success;
 }
 
-Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::DecodableType & data,
-                                    EndpointList & endpoints, const chip::Access::SubjectDescriptor & subjectDescriptor)
+Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::DecodableType & data, EndpointList & endpoints,
+                                    const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
 
@@ -536,7 +539,9 @@ Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::Decod
     return err;
 }
 
-Status GroupcastCluster::UpdateGroupKey(const ConcreteCommandPath & path, const Groupcast::Commands::UpdateGroupKey::DecodableType & data, const chip::Access::SubjectDescriptor & subjectDescriptor)
+Status GroupcastCluster::UpdateGroupKey(const ConcreteCommandPath & path,
+                                        const Groupcast::Commands::UpdateGroupKey::DecodableType & data,
+                                        const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     // Check GroupID and KeySetID constraints.
     VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
@@ -557,14 +562,14 @@ Status GroupcastCluster::ConfigureAuxiliaryACL(const Groupcast::Commands::Config
                                                const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
-    GroupDataProvider & groups = Provider();
-    CHIP_ERROR err             = CHIP_NO_ERROR;
+    GroupDataProvider & groups    = Provider();
+    CHIP_ERROR err                = CHIP_NO_ERROR;
 
     // AuxiliaryACL can only be present if LN feature is supported
     VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
     VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
 
-     // Get group info
+    // Get group info
     GroupDataProvider::GroupInfo info;
     err = groups.GetGroupInfo(fabricIndex, data.groupID, info);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
@@ -590,19 +595,21 @@ Status GroupcastCluster::ConfigureAuxiliaryACL(const Groupcast::Commands::Config
 }
 
 Status GroupcastCluster::SetKeySet(const ConcreteCommandPath & path, const chip::Access::SubjectDescriptor & subjectDescriptor,
-                                   GroupId group_id, KeysetId keyset_id,
-                                   const chip::Optional<chip::ByteSpan> & key)
+                                   GroupId group_id, KeysetId keyset_id, const chip::Optional<chip::ByteSpan> & key)
 {
     const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
-    GroupDataProvider & groups = Provider();
+    GroupDataProvider & groups    = Provider();
     GroupDataProvider::KeySet ks;
 
     // Keys can only be touched if the client has admin privileges, but this is called from commands that only require
     // Manage privileges. We do the check here before touching the keys.
     if (key.HasValue())
     {
-        Access::RequestPath requestPath{path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest, std::make_optional<uint32_t>(path.mCommandId)};
-        VerifyOrReturnError(CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister), Status::UnsupportedAccess);
+        Access::RequestPath requestPath{ path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest,
+                                         std::make_optional<uint32_t>(path.mCommandId) };
+        VerifyOrReturnError(
+            CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister),
+            Status::UnsupportedAccess);
     }
 
     CHIP_ERROR err = groups.GetKeySet(fabricIndex, keyset_id, ks);
@@ -649,9 +656,8 @@ Status GroupcastCluster::SetKeySet(const ConcreteCommandPath & path, const chip:
     return Status::Success;
 }
 
-Status GroupcastCluster::RemoveGroup(GroupId group_id,
-                                     const Groupcast::Commands::LeaveGroup::DecodableType & data, EndpointList * endpoints,
-                                     const chip::Access::SubjectDescriptor & subjectDescriptor)
+Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands::LeaveGroup::DecodableType & data,
+                                     EndpointList * endpoints, const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
 

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -33,6 +33,14 @@ constexpr CommandId kGeneratedCommands[] = {
     Groupcast::Commands::LeaveGroupResponse::Id,
 };
 
+bool HasAdminPrivileges(Access::AccessControl & accessControl, const chip::Access::SubjectDescriptor & subjectDescriptor,
+                        const ConcreteCommandPath & path)
+{
+    Access::RequestPath requestPath{ path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest,
+                                     std::make_optional<uint32_t>(path.mCommandId) };
+    return CHIP_NO_ERROR == accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister);
+}
+
 } // namespace
 
 GroupcastCluster::GroupcastCluster(GroupcastContext && context) : GroupcastCluster(std::move(context), {}) {}
@@ -372,11 +380,8 @@ Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Group
 
         // AuxiliaryACL state can only be touched if the client has admin privileges, but this is called from a command that only
         // require Manage privileges. We do the check here before touching AuxACL.
-        Access::RequestPath requestPath{ path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest,
-                                         std::make_optional<uint32_t>(path.mCommandId) };
-        VerifyOrReturnError(
-            CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister),
-            Status::UnsupportedAccess);
+        VerifyOrReturnError(HasAdminPrivileges(mGroupcastContext.accessControl, subjectDescriptor, path),
+                            Status::UnsupportedAccess);
     }
 
     // ReplaceEndpoints can only be present if kListener feature is supported
@@ -605,11 +610,8 @@ Status GroupcastCluster::SetKeySet(const ConcreteCommandPath & path, const chip:
     // Manage privileges. We do the check here before touching the keys.
     if (key.HasValue())
     {
-        Access::RequestPath requestPath{ path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest,
-                                         std::make_optional<uint32_t>(path.mCommandId) };
-        VerifyOrReturnError(
-            CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister),
-            Status::UnsupportedAccess);
+        VerifyOrReturnError(HasAdminPrivileges(mGroupcastContext.accessControl, subjectDescriptor, path),
+                            Status::UnsupportedAccess);
     }
 
     CHIP_ERROR err = groups.GetKeySet(fabricIndex, keyset_id, ks);

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -106,9 +106,9 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
                                                                              CommandHandler * handler)
 {
     VerifyOrReturnValue(nullptr != handler, Protocols::InteractionModel::Status::InvalidAction);
-    FabricIndex fabric_index = handler->GetAccessingFabricIndex();
 
     const chip::Access::SubjectDescriptor subjectDescriptor = request.subjectDescriptor;
+    FabricIndex fabric_index = subjectDescriptor.fabricIndex;
 
     Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
 
@@ -117,7 +117,7 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     case Groupcast::Commands::JoinGroup::Id: {
         Groupcast::Commands::JoinGroup::DecodableType data;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        status = JoinGroup(fabric_index, data, subjectDescriptor);
+        status = JoinGroup(request.path, data, subjectDescriptor);
     }
     break;
     case Groupcast::Commands::LeaveGroup::Id: {
@@ -125,10 +125,9 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
         Groupcast::Commands::LeaveGroupResponse::Type response;
         EndpointList endpoints;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        status = LeaveGroup(fabric_index, data, endpoints, subjectDescriptor);
+        status = LeaveGroup(data, endpoints, subjectDescriptor);
         if (Protocols::InteractionModel::Status::Success == status)
         {
-            NotifyAttributeChanged(Groupcast::Attributes::Membership::Id);
             response.groupID   = data.groupID;
             response.endpoints = DataModel::List<const chip::EndpointId>(endpoints.entries, endpoints.count);
             handler->AddResponse(request.path, response);
@@ -139,13 +138,13 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     case Groupcast::Commands::UpdateGroupKey::Id: {
         Groupcast::Commands::UpdateGroupKey::DecodableType data;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        status = UpdateGroupKey(fabric_index, data);
+        status = UpdateGroupKey(request.path, data, subjectDescriptor);
     }
     break;
     case Groupcast::Commands::ConfigureAuxiliaryACL::Id: {
         Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType data;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        status = ConfigureAuxiliaryACL(fabric_index, data, subjectDescriptor);
+        status = ConfigureAuxiliaryACL(data, subjectDescriptor);
     }
     break;
     case Groupcast::Commands::GroupcastTesting::Id: {
@@ -354,20 +353,27 @@ CHIP_ERROR GroupcastCluster::ReadUsedMcastAddrCount(EndpointId endpoint, Attribu
     return aEncoder.Encode(mUsedMcastAddrCount);
 }
 
-Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data,
+Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Groupcast::Commands::JoinGroup::DecodableType & data,
                                    const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
     GroupDataProvider & groups = Provider();
     CHIP_ERROR err             = CHIP_NO_ERROR;
 
-    // Check groupID
+    // Check GroupID and KeySetID constraints.
     VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
+    VerifyOrReturnError(data.keySetID != 0, Status::ConstraintError);
 
     // Check useAuxiliaryACL
     if (data.useAuxiliaryACL.HasValue())
     {
         // AuxiliaryACL can only be present if LN feature is supported
         VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
+
+        // AuxiliaryACL state can only be touched if the client has admin privileges, but this is called from a command that only
+        // require Manage privileges. We do the check here before touching AuxACL.
+        Access::RequestPath requestPath{path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest, std::make_optional<uint32_t>(path.mCommandId)};
+        VerifyOrReturnError(CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister), Status::UnsupportedAccess);
     }
 
     // ReplaceEndpoints can only be present if kListener feature is supported
@@ -420,7 +426,7 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
 
     // Check fabric membership entries limit
     GroupDataProvider::GroupInfo info;
-    err               = groups.GetGroupInfo(fabric_index, data.groupID, info);
+    err               = groups.GetGroupInfo(fabricIndex, data.groupID, info);
     bool is_new_group = (CHIP_ERROR_NOT_FOUND == err);
     VerifyOrReturnError(is_new_group || (CHIP_NO_ERROR == err), Status::Failure);
     // If the group is new, the fabric entries will increase
@@ -464,17 +470,17 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
     }
 
     // Key handling
-    Status stat = SetKeySet(fabric_index, data.groupID, data.keySetID, data.key);
+    Status stat = SetKeySet(path, subjectDescriptor, data.groupID, data.keySetID, data.key);
     VerifyOrReturnError(Status::Success == stat, stat);
 
     // Add/update entry in the group table
-    err = groups.SetGroupInfo(fabric_index, info);
+    err = groups.SetGroupInfo(fabricIndex, info);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
 
     if (data.replaceEndpoints.HasValue() && data.replaceEndpoints.Value())
     {
         // Replace endpoints
-        err = groups.RemoveEndpoints(fabric_index, data.groupID);
+        err = groups.RemoveEndpoints(fabricIndex, data.groupID);
         VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
     }
 
@@ -484,7 +490,7 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
         auto iter          = data.endpoints.begin();
         while (iter.Next() && (group_count++ < kMaxCommandEndpoints))
         {
-            err = groups.AddEndpoint(fabric_index, data.groupID, iter.GetValue());
+            err = groups.AddEndpoint(fabricIndex, data.groupID, iter.GetValue());
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
         }
     }
@@ -497,9 +503,11 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
     return Status::Success;
 }
 
-Status GroupcastCluster::LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
+Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::DecodableType & data,
                                     EndpointList & endpoints, const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
+
     GroupDataProvider & groups = Provider();
     Status err                 = Status::Success;
 
@@ -507,7 +515,7 @@ Status GroupcastCluster::LeaveGroup(FabricIndex fabric_index, const Groupcast::C
     if (kUndefinedGroupId == data.groupID)
     {
         // Apply changes to all groups
-        GroupInfoIterator * iter = groups.IterateGroupInfo(fabric_index);
+        GroupInfoIterator * iter = groups.IterateGroupInfo(fabricIndex);
         VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
         VerifyOrReturnError(iter->Count() > 0, Status::NotFound);
 
@@ -515,43 +523,50 @@ Status GroupcastCluster::LeaveGroup(FabricIndex fabric_index, const Groupcast::C
         while (iter->Next(info) && (Status::Success == err))
         {
             // For leave group, the leaveGroupResponse SHALL NOT contain the endpoints that were removed.
-            err = RemoveGroup(fabric_index, info.group_id, data, nullptr /* endpoints */, subjectDescriptor);
+            err = RemoveGroup(info.group_id, data, nullptr /* endpoints */, subjectDescriptor);
         }
         iter->Release();
     }
     else
     {
         // Modify specific group
-        err = RemoveGroup(fabric_index, data.groupID, data, &endpoints, subjectDescriptor);
+        err = RemoveGroup(data.groupID, data, &endpoints, subjectDescriptor);
     }
 
     return err;
 }
 
-Status GroupcastCluster::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
+Status GroupcastCluster::UpdateGroupKey(const ConcreteCommandPath & path, const Groupcast::Commands::UpdateGroupKey::DecodableType & data, const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
+    // Check GroupID and KeySetID constraints.
+    VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
+    VerifyOrReturnError(data.keySetID != 0, Status::ConstraintError);
+
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
+
     // Validate that the group exists early before trying to set the keyset
     GroupDataProvider::GroupInfo info;
-    CHIP_ERROR err = Provider().GetGroupInfo(fabric_index, data.groupID, info);
+    CHIP_ERROR err = Provider().GetGroupInfo(fabricIndex, data.groupID, info);
     VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, Status::NotFound);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
 
-    return SetKeySet(fabric_index, data.groupID, data.keySetID, data.key);
+    return SetKeySet(path, subjectDescriptor, data.groupID, data.keySetID, data.key);
 }
 
-Status GroupcastCluster::ConfigureAuxiliaryACL(FabricIndex fabric_index,
-                                               const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
+Status GroupcastCluster::ConfigureAuxiliaryACL(const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
                                                const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
     GroupDataProvider & groups = Provider();
     CHIP_ERROR err             = CHIP_NO_ERROR;
 
     // AuxiliaryACL can only be present if LN feature is supported
     VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
+    VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
 
-    // Get group info
+     // Get group info
     GroupDataProvider::GroupInfo info;
-    err = groups.GetGroupInfo(fabric_index, data.groupID, info);
+    err = groups.GetGroupInfo(fabricIndex, data.groupID, info);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
 
     // Update group info
@@ -563,7 +578,7 @@ Status GroupcastCluster::ConfigureAuxiliaryACL(FabricIndex fabric_index,
     {
         info.flags &= ~chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL);
     }
-    err = groups.SetGroupInfo(fabric_index, info);
+    err = groups.SetGroupInfo(fabricIndex, info);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
 
     if (groups.ConsumeAuxAclNotificationNeeded())
@@ -574,13 +589,23 @@ Status GroupcastCluster::ConfigureAuxiliaryACL(FabricIndex fabric_index,
     return Status::Success;
 }
 
-Status GroupcastCluster::SetKeySet(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id,
+Status GroupcastCluster::SetKeySet(const ConcreteCommandPath & path, const chip::Access::SubjectDescriptor & subjectDescriptor,
+                                   GroupId group_id, KeysetId keyset_id,
                                    const chip::Optional<chip::ByteSpan> & key)
 {
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
     GroupDataProvider & groups = Provider();
     GroupDataProvider::KeySet ks;
 
-    CHIP_ERROR err = groups.GetKeySet(fabric_index, keyset_id, ks);
+    // Keys can only be touched if the client has admin privileges, but this is called from commands that only require
+    // Manage privileges. We do the check here before touching the keys.
+    if (key.HasValue())
+    {
+        Access::RequestPath requestPath{path.mClusterId, path.mEndpointId, Access::RequestType::kCommandInvokeRequest, std::make_optional<uint32_t>(path.mCommandId)};
+        VerifyOrReturnError(CHIP_NO_ERROR == mGroupcastContext.accessControl.Check(subjectDescriptor, requestPath, Access::Privilege::kAdminister), Status::UnsupportedAccess);
+    }
+
+    CHIP_ERROR err = groups.GetKeySet(fabricIndex, keyset_id, ks);
     if (key.HasValue())
     {
         // Key provided, the keyset must not exist
@@ -588,7 +613,7 @@ Status GroupcastCluster::SetKeySet(FabricIndex fabric_index, GroupId group_id, K
         VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err, Status::Failure);
 
         // Create new key
-        const FabricInfo * fabric = Fabrics().FindFabricWithIndex(fabric_index);
+        const FabricInfo * fabric = Fabrics().FindFabricWithIndex(fabricIndex);
         VerifyOrReturnValue(nullptr != fabric, Status::NotFound);
 
         ks.keyset_id     = keyset_id;
@@ -600,12 +625,12 @@ Status GroupcastCluster::SetKeySet(FabricIndex fabric_index, GroupId group_id, K
         memcpy(epoch.key, key.Value().data(), GroupDataProvider::EpochKey::kLengthBytes);
         {
             // Get compressed fabric
-            uint8_t compressed_fabric_id_buffer[sizeof(uint64_t)];
-            MutableByteSpan compressed_fabric_id(compressed_fabric_id_buffer);
-            err = fabric->GetCompressedFabricIdBytes(compressed_fabric_id);
+            uint8_t compressedFabricIdBuffer[sizeof(uint64_t)];
+            MutableByteSpan compressedFabricId(compressedFabricIdBuffer);
+            err = fabric->GetCompressedFabricIdBytes(compressedFabricId);
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
             // Set keys
-            err = groups.SetKeySet(fabric_index, compressed_fabric_id, ks);
+            err = groups.SetKeySet(fabricIndex, compressedFabricId, ks);
             VerifyOrReturnError(CHIP_ERROR_INVALID_LIST_LENGTH != err, Status::ResourceExhausted);
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
         }
@@ -618,21 +643,23 @@ Status GroupcastCluster::SetKeySet(FabricIndex fabric_index, GroupId group_id, K
     }
 
     // Assign keyset to group
-    err = groups.SetGroupKey(fabric_index, group_id, keyset_id);
+    err = groups.SetGroupKey(fabricIndex, group_id, keyset_id);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
 
     return Status::Success;
 }
 
-Status GroupcastCluster::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
+Status GroupcastCluster::RemoveGroup(GroupId group_id,
                                      const Groupcast::Commands::LeaveGroup::DecodableType & data, EndpointList * endpoints,
                                      const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
+    const FabricIndex fabricIndex = subjectDescriptor.fabricIndex;
+
     GroupDataProvider & groups = Provider();
     Status stat                = Status::Success;
 
     GroupInfo info;
-    CHIP_ERROR err = groups.GetGroupInfo(fabric_index, group_id, info);
+    CHIP_ERROR err = groups.GetGroupInfo(fabricIndex, group_id, info);
     VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
 
     if (data.endpoints.HasValue())
@@ -642,9 +669,9 @@ Status GroupcastCluster::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
         while (iter.Next())
         {
             auto endpoint_id = iter.GetValue();
-            if (groups.HasEndpoint(fabric_index, group_id, endpoint_id))
+            if (groups.HasEndpoint(fabricIndex, group_id, endpoint_id))
             {
-                stat = RemoveGroupEndpoint(fabric_index, group_id, endpoint_id, endpoints);
+                stat = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, endpoints);
                 VerifyOrReturnError(Status::Success == stat, stat);
             }
         }
@@ -654,7 +681,7 @@ Status GroupcastCluster::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
         if (endpoints != nullptr)
         {
             // Get the endpoints list for the LeaveGroupResponse
-            EndpointIterator * epIter = groups.IterateEndpoints(fabric_index, group_id);
+            EndpointIterator * epIter = groups.IterateEndpoints(fabricIndex, group_id);
             VerifyOrReturnError(nullptr != epIter, Status::ResourceExhausted);
 
             if (epIter->Count() <= kMaxCommandEndpoints)
@@ -668,7 +695,7 @@ Status GroupcastCluster::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
             epIter->Release();
         }
         // Remove whole group (with all endpoints)
-        err = groups.RemoveGroupInfo(fabric_index, group_id);
+        err = groups.RemoveGroupInfo(fabricIndex, group_id);
         VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, Status::NotFound);
         VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
     }
@@ -680,12 +707,12 @@ Status GroupcastCluster::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
     return Status::Success;
 }
 
-Status GroupcastCluster::RemoveGroupEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id,
+Status GroupcastCluster::RemoveGroupEndpoint(FabricIndex fabricIndex, GroupId group_id, EndpointId endpoint_id,
                                              EndpointList * endpoints)
 {
     GroupDataProvider & groups = Provider();
 
-    CHIP_ERROR err = groups.RemoveEndpoint(fabric_index, group_id, endpoint_id,
+    CHIP_ERROR err = groups.RemoveEndpoint(fabricIndex, group_id, endpoint_id,
                                            mFeatures.Has(Groupcast::Feature::kSender)
                                                ? GroupDataProvider::GroupCleanupPolicy::kKeepGroupIfEmpty
                                                : GroupDataProvider::GroupCleanupPolicy::kDeleteGroupIfEmpty);

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "GroupcastContext.h"
+#include <access/AccessControl.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/Groupcast/AttributeIds.h>
 #include <clusters/Groupcast/ClusterId.h>
@@ -79,18 +80,17 @@ private:
     CHIP_ERROR ReadMaxMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadUsedMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
 
-    Protocols::InteractionModel::Status JoinGroup(FabricIndex fabric_index,
+    Protocols::InteractionModel::Status JoinGroup(const ConcreteCommandPath & path,
                                                   const Groupcast::Commands::JoinGroup::DecodableType & data,
                                                   const chip::Access::SubjectDescriptor & subjectDescriptor);
-    Protocols::InteractionModel::Status LeaveGroup(FabricIndex fabric_index,
-                                                   const Groupcast::Commands::LeaveGroup::DecodableType & data,
+    Protocols::InteractionModel::Status LeaveGroup(const Groupcast::Commands::LeaveGroup::DecodableType & data,
                                                    EndpointList & endpoints,
                                                    const chip::Access::SubjectDescriptor & subjectDescriptor);
-    Protocols::InteractionModel::Status UpdateGroupKey(FabricIndex fabric_index,
-                                                       const Groupcast::Commands::UpdateGroupKey::DecodableType & data);
-    Protocols::InteractionModel::Status
-    ConfigureAuxiliaryACL(FabricIndex fabric_index, const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
-                          const chip::Access::SubjectDescriptor & subjectDescriptor);
+    Protocols::InteractionModel::Status UpdateGroupKey(const ConcreteCommandPath & path,
+                                                       const Groupcast::Commands::UpdateGroupKey::DecodableType & data,
+                                                       const chip::Access::SubjectDescriptor & subjectDescriptor);
+    Protocols::InteractionModel::Status ConfigureAuxiliaryACL(const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
+                                                              const chip::Access::SubjectDescriptor & subjectDescriptor);
 
     void SetDataModelProvider(DataModel::Provider & provider) { mDataModelProvider = &provider; }
     void ResetDataModelProvider() { mDataModelProvider = nullptr; }
@@ -107,9 +107,10 @@ private:
     Credentials::GroupDataProvider & Provider() { return mGroupcastContext.groupDataProvider; }
     chip::FabricTable & Fabrics() { return mGroupcastContext.fabricTable; }
 
-    Protocols::InteractionModel::Status SetKeySet(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id,
+    Protocols::InteractionModel::Status SetKeySet(const ConcreteCommandPath & path, const chip::Access::SubjectDescriptor & subjectDescriptor,
+                                                  GroupId group_id, KeysetId keyset_id,
                                                   const chip::Optional<chip::ByteSpan> & key);
-    Protocols::InteractionModel::Status RemoveGroup(FabricIndex fabric_index, GroupId group_id,
+    Protocols::InteractionModel::Status RemoveGroup(GroupId group_id,
                                                     const Groupcast::Commands::LeaveGroup::DecodableType & data,
                                                     EndpointList * endpoints,
                                                     const chip::Access::SubjectDescriptor & subjectDescriptor);

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -89,8 +89,9 @@ private:
     Protocols::InteractionModel::Status UpdateGroupKey(const ConcreteCommandPath & path,
                                                        const Groupcast::Commands::UpdateGroupKey::DecodableType & data,
                                                        const chip::Access::SubjectDescriptor & subjectDescriptor);
-    Protocols::InteractionModel::Status ConfigureAuxiliaryACL(const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
-                                                              const chip::Access::SubjectDescriptor & subjectDescriptor);
+    Protocols::InteractionModel::Status
+    ConfigureAuxiliaryACL(const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data,
+                          const chip::Access::SubjectDescriptor & subjectDescriptor);
 
     void SetDataModelProvider(DataModel::Provider & provider) { mDataModelProvider = &provider; }
     void ResetDataModelProvider() { mDataModelProvider = nullptr; }
@@ -107,11 +108,10 @@ private:
     Credentials::GroupDataProvider & Provider() { return mGroupcastContext.groupDataProvider; }
     chip::FabricTable & Fabrics() { return mGroupcastContext.fabricTable; }
 
-    Protocols::InteractionModel::Status SetKeySet(const ConcreteCommandPath & path, const chip::Access::SubjectDescriptor & subjectDescriptor,
-                                                  GroupId group_id, KeysetId keyset_id,
-                                                  const chip::Optional<chip::ByteSpan> & key);
-    Protocols::InteractionModel::Status RemoveGroup(GroupId group_id,
-                                                    const Groupcast::Commands::LeaveGroup::DecodableType & data,
+    Protocols::InteractionModel::Status SetKeySet(const ConcreteCommandPath & path,
+                                                  const chip::Access::SubjectDescriptor & subjectDescriptor, GroupId group_id,
+                                                  KeysetId keyset_id, const chip::Optional<chip::ByteSpan> & key);
+    Protocols::InteractionModel::Status RemoveGroup(GroupId group_id, const Groupcast::Commands::LeaveGroup::DecodableType & data,
                                                     EndpointList * endpoints,
                                                     const chip::Access::SubjectDescriptor & subjectDescriptor);
     Protocols::InteractionModel::Status RemoveGroupEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id,

--- a/src/app/clusters/groupcast/GroupcastContext.h
+++ b/src/app/clusters/groupcast/GroupcastContext.h
@@ -16,7 +16,8 @@
  */
 #pragma once
 
-#include <app/server/Server.h>
+#include <access/AccessControl.h>
+#include <credentials/FabricTable.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -29,6 +30,7 @@ struct GroupcastContext
     chip::FabricTable & fabricTable;
     chip::Credentials::GroupDataProvider & groupDataProvider;
     chip::TimerDelegate & timerDelegate;
+    chip::Access::AccessControl & accessControl;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -16,6 +16,7 @@
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
+#include <access/AccessControl.h>
 #include <app/MessageDef/CommandDataIB.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
@@ -48,6 +49,7 @@ namespace {
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::Access;
 using namespace chip::Testing;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters::Groupcast;
@@ -59,6 +61,22 @@ using chip::Testing::IsAttributesListEqualTo;
 using chip::app::DataModel::AcceptedCommandEntry;
 using chip::app::DataModel::AttributeEntry;
 static constexpr size_t kMaxMembershipEndpoints = app::Clusters::GroupcastCluster::kMaxMembershipEndpoints;
+
+static constexpr FabricIndex kTestFabricIndex = Testing::kTestFabricIndex;
+static constexpr NodeId kNodeIdForAdmin = 1ULL;
+static constexpr NodeId kNodeIdForManage = 2ULL;
+
+static constexpr SubjectDescriptor kAdminSubjectDescriptor{
+    .fabricIndex = kTestFabricIndex,
+    .authMode = AuthMode::kCase,
+    .subject = kNodeIdForAdmin
+};
+
+static constexpr SubjectDescriptor kManageSubjectDescriptor{
+    .fabricIndex = kTestFabricIndex,
+    .authMode = AuthMode::kCase,
+    .subject = kNodeIdForManage
+};
 
 template <typename DecodableListType>
 CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
@@ -73,7 +91,6 @@ CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
     return it.GetStatus();
 }
 
-chip::FabricIndex kTestFabricIndex = Testing::kTestFabricIndex;
 class CustomDataModel : public EmptyProvider
 {
 public:
@@ -107,12 +124,49 @@ struct TestGroupcastCluster : public ::testing::Test
 
     static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
+    class TestDeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver
+    {
+    public:
+        bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
+        {
+            (void)deviceType;
+            (void)endpoint;
+            return false;
+        }
+    };
+
+    class GroupcastTestingAccessControlDelegate : public Access::AccessControl::Delegate {
+        CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
+                                 Privilege requestPrivilege) override
+        {
+            if (subjectDescriptor.authMode != AuthMode::kCase)
+            {
+                return CHIP_ERROR_ACCESS_DENIED;
+            }
+
+            switch (subjectDescriptor.subject) {
+                case kNodeIdForAdmin:
+                    // Admin always has access
+                    return CHIP_NO_ERROR;
+                case kNodeIdForManage: {
+                    // Manage can access everything but Administer-level things
+                    CHIP_ERROR err = (requestPrivilege == Access::Privilege::kAdminister) ? CHIP_ERROR_ACCESS_DENIED : CHIP_NO_ERROR;
+                    return err;
+                }
+                default:
+                    return CHIP_ERROR_ACCESS_DENIED;
+            }
+        }
+    };
+
     void SetUp() override
     {
         mProvider.SetStorageDelegate(&mTestContext.StorageDelegate());
         mProvider.SetSessionKeystore(&mKeystore);
         mProvider.SetGroupcastEnabled(true);
         ASSERT_EQ(mProvider.Init(), CHIP_NO_ERROR);
+        ASSERT_EQ(mAccessDelegate.Init(), CHIP_NO_ERROR);
+        ASSERT_EQ(mAccessControl.Init(&mAccessDelegate, mDeviceTypeResolver), CHIP_NO_ERROR);
 
         // Replace the DataModel Provider in the ServerClusterContext provided to the cluster implementation
         // with our Mock DataModel Provider so we can test endpoints validations on JoinGroup command.
@@ -127,18 +181,21 @@ struct TestGroupcastCluster : public ::testing::Test
         ASSERT_EQ(mSender.Startup(*clusterContext), CHIP_NO_ERROR);
         ASSERT_EQ(mListener.Startup(*clusterContext), CHIP_NO_ERROR);
 
-        CHIP_ERROR err = mFabricHelper.SetUpTestFabric(kTestFabricIndex);
+        CHIP_ERROR err = mFabricHelper.SetUpTestFabric(mFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
+        ASSERT_EQ(mFabricIndex, kTestFabricIndex);
         Credentials::SetGroupDataProvider(&mProvider);
     }
 
     void TearDown() override
     {
+        mAccessDelegate.Finish();
+        mAccessControl.Finish();
         mSender.Shutdown(app::ClusterShutdownType::kClusterShutdown);
         mListener.Shutdown(app::ClusterShutdownType::kClusterShutdown);
         clusterContext.reset();
         Credentials::SetGroupDataProvider(nullptr);
-        CHIP_ERROR err = mFabricHelper.TearDownTestFabric(kTestFabricIndex);
+        CHIP_ERROR err = mFabricHelper.TearDownTestFabric(mFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
         mProvider.Finish();
     }
@@ -150,16 +207,21 @@ struct TestGroupcastCluster : public ::testing::Test
         EXPECT_EQ(status->GetStatusCode().GetStatus(), expected);
     }
 
+    FabricIndex mFabricIndex = kTestFabricIndex;
     TestServerClusterContext mTestContext;
+    TestPersistentStorageDelegate mStorageDelegate;
+    GroupcastTestingAccessControlDelegate mAccessDelegate;
+    TestDeviceTypeResolver mDeviceTypeResolver;
+    Access::AccessControl mAccessControl;
     Credentials::GroupDataProviderImpl mProvider;
     TimerDelegateMock mMockTimerDelegate;
     Crypto::DefaultSessionKeystore mKeystore;
     CustomDataModel customDataModel;
     std::unique_ptr<ServerClusterContext> clusterContext;
     FabricTestFixture mFabricHelper{ &mTestContext.StorageDelegate() };
-    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
+    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate, mAccessControl },
                                              BitFlags<Feature>{ Feature::kSender } };
-    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
+    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate, mAccessControl },
                                                BitFlags<Feature>{ Feature::kListener, Feature::kPerGroup } };
 };
 
@@ -250,6 +312,178 @@ TEST_F(TestGroupcastCluster, TestAcceptedCommands)
                                               }));
 }
 
+TEST_F(TestGroupcastCluster, TestJoinGroupFailsOnBadAargs) {
+    GroupId kGroup1   = 0xab01;
+    KeysetId kKeyset1 = 0xabcd;
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[1] = { 1 };
+
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+
+    // Admin privilege, and valid arguments (including key) : JoinGroup should work.
+    {
+        Commands::JoinGroup::Type joinGroupCmd;
+        joinGroupCmd.groupID         = kGroup1;
+        joinGroupCmd.keySetID        = kKeyset1;
+        joinGroupCmd.key             = MakeOptional(ByteSpan(key));
+        joinGroupCmd.useAuxiliaryACL = NullOptional;
+        joinGroupCmd.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        joinGroupCmd.endpoints       = DataModel::List<const EndpointId>(kEndpoints, 1);
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
+    }
+
+    // Now group1 is OK and keys OK
+
+    // Constraint on groupId >= 1 must be respected.
+    {
+        Commands::JoinGroup::Type joinGroupCmd;
+        joinGroupCmd.groupID         = 0; // Disallowed
+        joinGroupCmd.keySetID        = kKeyset1;
+        joinGroupCmd.key             = MakeOptional(ByteSpan(key));
+        joinGroupCmd.useAuxiliaryACL = NullOptional;
+        joinGroupCmd.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        joinGroupCmd.endpoints       = DataModel::List<const EndpointId>(kEndpoints, 1);
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+    }
+
+
+    // Constraint on keySetId >= 1 must be respected.
+    {
+        Commands::JoinGroup::Type joinGroupCmd;
+        joinGroupCmd.groupID         = kGroup1;
+        joinGroupCmd.keySetID        = 0; // Disallowed
+        joinGroupCmd.key             = MakeOptional(ByteSpan(key));
+        joinGroupCmd.useAuxiliaryACL = NullOptional;
+        joinGroupCmd.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        joinGroupCmd.endpoints       = DataModel::List<const EndpointId>(kEndpoints, 1);
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+    }
+
+    // Manage access: can't touch keys or useAuxiliary ACL
+    tester.SetSubjectDescriptor(kManageSubjectDescriptor);
+
+    // Enabling useAuxiliaryACL should fail unless subject has administer privileges.
+    {
+        Commands::JoinGroup::Type joinGroupCmd;
+        joinGroupCmd.groupID         = kGroup1;
+        joinGroupCmd.keySetID        = kKeyset1;
+        joinGroupCmd.key             = NullOptional; // <-- Not touching key
+        joinGroupCmd.useAuxiliaryACL = NullOptional; // <-- Not touching useAuxACL
+        joinGroupCmd.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        joinGroupCmd.endpoints       = DataModel::List<const EndpointId>(kEndpoints, 1);
+
+        // Manage should work here
+        auto result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
+
+        // Touching useAuxiliaryACL, even if false should fail if present --> cannot update the field.
+        joinGroupCmd.useAuxiliaryACL = MakeOptional(false);
+        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
+
+        joinGroupCmd.useAuxiliaryACL = MakeOptional(true);
+        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
+
+        // Starts working after no longer touching AuxACL.
+        joinGroupCmd.key             = NullOptional; // <-- Not touching key
+        joinGroupCmd.useAuxiliaryACL = NullOptional; // <-- Not touching useAuxACL
+        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
+
+        // If touching key, but not useAuxiliaryACL, still not legal.
+
+        joinGroupCmd.key             = MakeOptional(ByteSpan(key)); // <-- Touching key
+        joinGroupCmd.useAuxiliaryACL = NullOptional; // <-- Not touching useAuxACL
+        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        ASSERT_TRUE(result.GetStatusCode().has_value());
+        EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
+    }
+}
+
+TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs) {
+    GroupId kGroup1   = 0xab01;
+    KeysetId kKeyset1 = 0xabcd;
+    KeysetId kKeyset2 = 0xa123;
+    const uint8_t key1[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const uint8_t key2[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[1] = { 1 };
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+
+    Commands::JoinGroup::Type joinGroupCmd;
+    joinGroupCmd.groupID         = kGroup1;
+    joinGroupCmd.keySetID        = kKeyset1;
+    joinGroupCmd.key             = MakeOptional(ByteSpan(key1));
+    joinGroupCmd.useAuxiliaryACL = MakeOptional(false);
+    joinGroupCmd.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+    joinGroupCmd.endpoints       = DataModel::List<const EndpointId>(kEndpoints, 1);
+
+    // Join must work
+    auto result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    Commands::UpdateGroupKey::Type updateGroupKeyCmd;
+    updateGroupKeyCmd.groupID         = kGroup1;
+    updateGroupKeyCmd.keySetID        = kKeyset1;
+
+    // UpdateGroupKey from Admin access should succeed (no key update).
+    result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
+
+    // If changing a key, should fail with Manage, succeed with Admin
+    tester.SetSubjectDescriptor(kManageSubjectDescriptor);
+
+    updateGroupKeyCmd.groupID         = kGroup1;
+    updateGroupKeyCmd.keySetID        = kKeyset2;
+    updateGroupKeyCmd.key             = MakeOptional(ByteSpan(key2));
+
+    result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
+
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+    result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
+
+    // Constraint on groupId >= 1 must be respected.
+    updateGroupKeyCmd.groupID = 0;
+    updateGroupKeyCmd.keySetID        = kKeyset1;
+    updateGroupKeyCmd.key = NullOptional;
+
+    result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+
+    // Constraint on keySetId >= 1 must be respected.
+    updateGroupKeyCmd.groupID         = kGroup1;
+    updateGroupKeyCmd.keySetID        = 0;
+    updateGroupKeyCmd.key = NullOptional;
+
+    result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+}
+
 TEST_F(TestGroupcastCluster, TestReadMembership)
 {
     static constexpr uint16_t kMaxEndpoints   = app::Clusters::GroupcastCluster::kMaxCommandEndpoints;
@@ -281,6 +515,7 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Join groups
     {
@@ -408,6 +643,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
     constexpr System::Clock::Milliseconds32 kChangeTemporisation = System::Clock::Milliseconds32(251);
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     app::Clusters::Groupcast::Attributes::UsedMcastAddrCount::TypeInfo::DecodableType multicastAddrCount;
     app::ConcreteAttributePath membershipAttributePath(kRootEndpointId, app::Clusters::Groupcast::Id,
@@ -552,6 +788,7 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Read MaxMcastAddrCount
     app::Clusters::Groupcast::Attributes::MaxMcastAddrCount::TypeInfo::DecodableType maxMcastAddrCount;
@@ -683,18 +920,20 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 
     // Neither Listener, nor Sender
     {
-        app::Clusters::GroupcastCluster cluster({ mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate });
+        app::Clusters::GroupcastCluster cluster({ mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate, mAccessControl });
         chip::Testing::ClusterTester tester(cluster);
         tester.SetFabricIndex(kTestFabricIndex);
+        tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
         EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     }
 
-    // Listener
+    // Listener basic flow
     {
         chip::Testing::ClusterTester tester(mListener);
         tester.SetFabricIndex(kTestFabricIndex);
+        tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
         // Join group: New keyset and key
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
@@ -736,6 +975,7 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
     {
         chip::Testing::ClusterTester tester(mSender);
         tester.SetFabricIndex(kTestFabricIndex);
+        tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
         data.endpoints = DataModel::List<const EndpointId>();
 
         // Join group: UseAuxiliaryACL can't be set
@@ -818,6 +1058,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     EndpointId all_endpoints[kTotalEndpoints];
     for (size_t i = 0; i < kTotalEndpoints; i++)
@@ -1071,11 +1312,12 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
 
     // Create a Listener and Sender capable group with 1 endpoint.
     // Remove the endpoint from the group. Verify that the group still exists for Sender.
-    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
+    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate, mAccessControl },
                                                        BitFlags<Feature>{ Feature::kListener, Feature::kSender } };
     ASSERT_EQ(ListenerAndSender.Startup(*clusterContext), CHIP_NO_ERROR);
-    chip::Testing::ClusterTester listenerAndSendertester(ListenerAndSender);
-    listenerAndSendertester.SetFabricIndex(kTestFabricIndex);
+    chip::Testing::ClusterTester listenerAndSenderTester(ListenerAndSender);
+    listenerAndSenderTester.SetFabricIndex(kTestFabricIndex);
+    listenerAndSenderTester.SetSubjectDescriptor(kAdminSubjectDescriptor);
     {
         // JoinGroup for GroupID 3
         Commands::JoinGroup::Type data;
@@ -1083,12 +1325,12 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints[0], 1);
         data.keySetID        = kKeyset;
         data.useAuxiliaryACL = MakeOptional(true);
-        auto result          = listenerAndSendertester.Invoke(Commands::JoinGroup::Id, data);
+        auto result          = listenerAndSenderTester.Invoke(Commands::JoinGroup::Id, data);
         EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Read Membership
         app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
-        ASSERT_EQ(listenerAndSendertester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        ASSERT_EQ(listenerAndSenderTester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
 
         Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership[] = {
             {
@@ -1115,11 +1357,11 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         Commands::LeaveGroup::Type data;
         data.groupID   = kGroup3;
         data.endpoints = MakeOptional(DataModel::List<const EndpointId>(kEndpoints[0], 1));
-        auto result    = listenerAndSendertester.Invoke(Commands::LeaveGroup::Id, data);
+        auto result    = listenerAndSenderTester.Invoke(Commands::LeaveGroup::Id, data);
         EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
-        ASSERT_EQ(listenerAndSendertester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        ASSERT_EQ(listenerAndSenderTester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
 
         Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership[] = {
             {
@@ -1157,6 +1399,7 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Join groups
     {
@@ -1274,6 +1517,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Join group
     {
@@ -1308,6 +1552,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
     {
         chip::Testing::ClusterTester sender_tester(mSender);
         sender_tester.SetFabricIndex(kTestFabricIndex);
+        sender_tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
         Commands::ConfigureAuxiliaryACL::Type data;
         data.groupID         = kGroupId;
@@ -1343,6 +1588,19 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
         ValidateMembership(memberships, expectedMembership, MATTER_ARRAY_SIZE(expectedMembership));
     }
 
+    // Try to update for groupID 0 --> constraint error
+    {
+        tester.SetFabricIndex(kTestFabricIndex);
+        tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+
+        Commands::ConfigureAuxiliaryACL::Type data;
+        data.groupID         = 0;
+        data.useAuxiliaryACL = false;
+
+        auto result = tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
+    }
+
     // Update (true to false)
     {
         Commands::ConfigureAuxiliaryACL::Type data;
@@ -1374,6 +1632,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
 {
     ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Default should be "no fabric under test"
     FabricIndex fabricUnderTest = kUndefinedFabricIndex;
@@ -1466,6 +1725,7 @@ TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
 
     ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     auto & logOnlyEvents = mTestContext.EventsGenerator();
 
@@ -1636,6 +1896,7 @@ TEST_F(TestGroupcastCluster, TestMaxMembershipPerFabric)
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     Commands::JoinGroup::Type data;
     data.keySetID        = kKeyset;
@@ -1679,6 +1940,7 @@ TEST_F(TestGroupcastCluster, TestTotalMaxMembership)
     ASSERT_EQ(mFabricHelper.AddAdditionalTestFabric(fabricIndex3), CHIP_NO_ERROR);
 
     chip::Testing::ClusterTester tester(mListener);
+    SubjectDescriptor adminSubjectDescriptor = kAdminSubjectDescriptor;
 
     Commands::JoinGroup::Type data;
     data.keySetID        = kKeyset;
@@ -1687,38 +1949,53 @@ TEST_F(TestGroupcastCluster, TestTotalMaxMembership)
 
     // Fabric 1: kFab1Groups (one below per-fabric limit)
     tester.SetFabricIndex(kTestFabricIndex);
+    adminSubjectDescriptor.fabricIndex = kTestFabricIndex;
+    tester.SetSubjectDescriptor(adminSubjectDescriptor);
+
     for (GroupId i = 1; i <= kFab1Groups; i++)
     {
         data.groupID = i;
         data.key     = (i == 1) ? MakeOptional(ByteSpan(key)) : Optional<ByteSpan>();
         auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success)) << "Fabric 1 group " << i;
+        ASSERT_TRUE(result.IsSuccess());
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Fabric 2: kFab2Groups
     tester.SetFabricIndex(fabricIndex2);
+    adminSubjectDescriptor.fabricIndex = fabricIndex2;
+    tester.SetSubjectDescriptor(adminSubjectDescriptor);
+
     for (GroupId i = 1; i <= kFab2Groups; i++)
     {
         data.groupID = i;
         data.key     = (i == 1) ? MakeOptional(ByteSpan(key)) : Optional<ByteSpan>();
         auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success)) << "Fabric 2 group " << i;
+        ASSERT_TRUE(result.IsSuccess());
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Fabric 3: kFab3Groups
     tester.SetFabricIndex(fabricIndex3);
+    adminSubjectDescriptor.fabricIndex = fabricIndex3;
+    tester.SetSubjectDescriptor(adminSubjectDescriptor);
+
     for (GroupId i = 1; i <= kFab3Groups; i++)
     {
         data.groupID = i;
         data.key     = (i == 1) ? MakeOptional(ByteSpan(key)) : Optional<ByteSpan>();
         auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success)) << "Fabric 3 group " << i;
+        ASSERT_TRUE(result.IsSuccess());
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Node-wide total is now kMaxCount.
     // Fabric 1 has kFab1Groups (< kMaxPerFab) so the per-fabric check passes,
     // but the node-wide check should return ResourceExhausted.
     tester.SetFabricIndex(kTestFabricIndex);
+    adminSubjectDescriptor.fabricIndex = kTestFabricIndex;
+    tester.SetSubjectDescriptor(adminSubjectDescriptor);
+
     data.groupID = kFab1Groups + 1;
     data.key.ClearValue();
     auto result = tester.Invoke(Commands::JoinGroup::Id, data);

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -1030,6 +1030,150 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
     }
 }
 
+TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
+{
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    GroupId kGroup1   = 0xab01;
+    KeysetId kKeyset1 = 0xabcd;
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+
+    EndpointId initialEndpoints[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    Commands::JoinGroup::Type data;
+    data.groupID         = kGroup1;
+    data.keySetID        = kKeyset1;
+    data.key             = MakeOptional(ByteSpan(key));
+    data.useAuxiliaryACL = MakeOptional(true);
+    data.endpoints       = DataModel::List<const EndpointId>(initialEndpoints, MATTER_ARRAY_SIZE(initialEndpoints));
+
+    auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    // Read Membership
+    app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+    ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership0[] = {
+        {
+            .groupID         = kGroup1,
+            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(initialEndpoints, MATTER_ARRAY_SIZE(initialEndpoints))),
+            .keySetID        = kKeyset1,
+            .hasAuxiliaryACL = MakeOptional(true),
+            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+        }
+    };
+    ValidateMembership(memberships, expectedMembership0, MATTER_ARRAY_SIZE(expectedMembership0));
+
+    // Replace with 8 members
+    EndpointId replacementEndpoints[8] = { 11, 12, 13, 14, 15, 16, 17, 18 };
+    data.key.ClearValue();
+    data.replaceEndpoints = MakeOptional(true);
+    data.endpoints = DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints));
+
+    result = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership1[] = {
+        {
+            .groupID         = kGroup1,
+            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints))),
+            .keySetID        = kKeyset1,
+            .hasAuxiliaryACL = MakeOptional(true),
+            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+        }
+    };
+    ValidateMembership(memberships, expectedMembership1, MATTER_ARRAY_SIZE(expectedMembership1));
+
+    // Add 40 endpoints (requires 2 JoinGroup commands)
+    EndpointId fortyEndpoints1[20];
+    EndpointId fortyEndpoints2[20];
+    for (uint16_t i = 0; i < 20; i++)
+    {
+        fortyEndpoints1[i] = static_cast<EndpointId>(100 + i);
+        fortyEndpoints2[i] = static_cast<EndpointId>(120 + i);
+    }
+
+    data.replaceEndpoints = MakeOptional(true);
+    data.endpoints        = DataModel::List<const EndpointId>(fortyEndpoints1, MATTER_ARRAY_SIZE(fortyEndpoints1));
+    result                = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    data.replaceEndpoints = MakeOptional(false);
+    data.endpoints        = DataModel::List<const EndpointId>(fortyEndpoints2, MATTER_ARRAY_SIZE(fortyEndpoints2));
+    result                = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    EndpointId expectedForty[40];
+    for (uint16_t i = 0; i < 40; i++)
+    {
+        expectedForty[i] = static_cast<EndpointId>(100 + i);
+    }
+
+    ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership2[] = {
+        {
+            .groupID         = kGroup1,
+            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedForty, MATTER_ARRAY_SIZE(expectedForty))),
+            .keySetID        = kKeyset1,
+            .hasAuxiliaryACL = MakeOptional(true),
+            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+        }
+    };
+    ValidateMembership(memberships, expectedMembership2, MATTER_ARRAY_SIZE(expectedMembership2));
+
+    // JoinGroup with replace endpoints that adds only 1 endpoint
+    EndpointId oneEndpoint[1] = { 200 };
+    data.replaceEndpoints     = MakeOptional(true);
+    data.endpoints            = DataModel::List<const EndpointId>(oneEndpoint, MATTER_ARRAY_SIZE(oneEndpoint));
+    result                    = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership3[] = {
+        {
+            .groupID         = kGroup1,
+            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(oneEndpoint, MATTER_ARRAY_SIZE(oneEndpoint))),
+            .keySetID        = kKeyset1,
+            .hasAuxiliaryACL = MakeOptional(true),
+            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+        }
+    };
+    ValidateMembership(memberships, expectedMembership3, MATTER_ARRAY_SIZE(expectedMembership3));
+
+    // Add 40 more endpoints
+    data.replaceEndpoints = MakeOptional(false);
+    data.endpoints        = DataModel::List<const EndpointId>(fortyEndpoints1, MATTER_ARRAY_SIZE(fortyEndpoints1));
+    result                = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    data.endpoints = DataModel::List<const EndpointId>(fortyEndpoints2, MATTER_ARRAY_SIZE(fortyEndpoints2));
+    result         = tester.Invoke(Commands::JoinGroup::Id, data);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+    EndpointId expectedFortyOne[41];
+    expectedFortyOne[0] = 200;
+    for (uint16_t i = 0; i < 40; i++)
+    {
+        expectedFortyOne[i + 1] = static_cast<EndpointId>(100 + i);
+    }
+
+    ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership4[] = {
+        {
+            .groupID         = kGroup1,
+            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedFortyOne, MATTER_ARRAY_SIZE(expectedFortyOne))),
+            .keySetID        = kKeyset1,
+            .hasAuxiliaryACL = MakeOptional(true),
+            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+        }
+    };
+    ValidateMembership(memberships, expectedMembership4, MATTER_ARRAY_SIZE(expectedMembership4));
+}
+
 TEST_F(TestGroupcastCluster, TestLeaveGroup)
 {
     static constexpr uint16_t kMaxEndpoints   = app::Clusters::GroupcastCluster::kMaxCommandEndpoints;

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -1033,8 +1033,8 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
 {
     const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
-    GroupId kGroup1   = 0xab01;
-    KeysetId kKeyset1 = 0xabcd;
+    GroupId kGroup1     = 0xab01;
+    KeysetId kKeyset1   = 0xabcd;
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
@@ -1055,37 +1055,33 @@ TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
     app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
     ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
 
-    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership0[] = {
-        {
-            .groupID         = kGroup1,
-            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(initialEndpoints, MATTER_ARRAY_SIZE(initialEndpoints))),
-            .keySetID        = kKeyset1,
-            .hasAuxiliaryACL = MakeOptional(true),
-            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
-        }
-    };
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership0[] = { {
+        .groupID         = kGroup1,
+        .endpoints       = MakeOptional(DataModel::List<const EndpointId>(initialEndpoints, MATTER_ARRAY_SIZE(initialEndpoints))),
+        .keySetID        = kKeyset1,
+        .hasAuxiliaryACL = MakeOptional(true),
+        .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+    } };
     ValidateMembership(memberships, expectedMembership0, MATTER_ARRAY_SIZE(expectedMembership0));
 
     // Replace with 8 members
     EndpointId replacementEndpoints[8] = { 11, 12, 13, 14, 15, 16, 17, 18 };
     data.key.ClearValue();
     data.replaceEndpoints = MakeOptional(true);
-    data.endpoints = DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints));
+    data.endpoints        = DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints));
 
     result = tester.Invoke(Commands::JoinGroup::Id, data);
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
     ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
 
-    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership1[] = {
-        {
-            .groupID         = kGroup1,
-            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints))),
-            .keySetID        = kKeyset1,
-            .hasAuxiliaryACL = MakeOptional(true),
-            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
-        }
-    };
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership1[] = { {
+        .groupID   = kGroup1,
+        .endpoints = MakeOptional(DataModel::List<const EndpointId>(replacementEndpoints, MATTER_ARRAY_SIZE(replacementEndpoints))),
+        .keySetID  = kKeyset1,
+        .hasAuxiliaryACL = MakeOptional(true),
+        .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+    } };
     ValidateMembership(memberships, expectedMembership1, MATTER_ARRAY_SIZE(expectedMembership1));
 
     // Add 40 endpoints (requires 2 JoinGroup commands)
@@ -1114,15 +1110,13 @@ TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
     }
 
     ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
-    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership2[] = {
-        {
-            .groupID         = kGroup1,
-            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedForty, MATTER_ARRAY_SIZE(expectedForty))),
-            .keySetID        = kKeyset1,
-            .hasAuxiliaryACL = MakeOptional(true),
-            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
-        }
-    };
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership2[] = { {
+        .groupID         = kGroup1,
+        .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedForty, MATTER_ARRAY_SIZE(expectedForty))),
+        .keySetID        = kKeyset1,
+        .hasAuxiliaryACL = MakeOptional(true),
+        .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+    } };
     ValidateMembership(memberships, expectedMembership2, MATTER_ARRAY_SIZE(expectedMembership2));
 
     // JoinGroup with replace endpoints that adds only 1 endpoint
@@ -1133,15 +1127,13 @@ TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
     ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
-    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership3[] = {
-        {
-            .groupID         = kGroup1,
-            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(oneEndpoint, MATTER_ARRAY_SIZE(oneEndpoint))),
-            .keySetID        = kKeyset1,
-            .hasAuxiliaryACL = MakeOptional(true),
-            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
-        }
-    };
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership3[] = { {
+        .groupID         = kGroup1,
+        .endpoints       = MakeOptional(DataModel::List<const EndpointId>(oneEndpoint, MATTER_ARRAY_SIZE(oneEndpoint))),
+        .keySetID        = kKeyset1,
+        .hasAuxiliaryACL = MakeOptional(true),
+        .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+    } };
     ValidateMembership(memberships, expectedMembership3, MATTER_ARRAY_SIZE(expectedMembership3));
 
     // Add 40 more endpoints
@@ -1162,15 +1154,13 @@ TEST_F(TestGroupcastCluster, TestReplaceEndpointsSucceedsProperly)
     }
 
     ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
-    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership4[] = {
-        {
-            .groupID         = kGroup1,
-            .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedFortyOne, MATTER_ARRAY_SIZE(expectedFortyOne))),
-            .keySetID        = kKeyset1,
-            .hasAuxiliaryACL = MakeOptional(true),
-            .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
-        }
-    };
+    Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership4[] = { {
+        .groupID         = kGroup1,
+        .endpoints       = MakeOptional(DataModel::List<const EndpointId>(expectedFortyOne, MATTER_ARRAY_SIZE(expectedFortyOne))),
+        .keySetID        = kKeyset1,
+        .hasAuxiliaryACL = MakeOptional(true),
+        .mcastAddrPolicy = app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
+    } };
     ValidateMembership(memberships, expectedMembership4, MATTER_ARRAY_SIZE(expectedMembership4));
 }
 

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -170,10 +170,10 @@ struct TestGroupcastCluster : public ::testing::Test
         // with our Mock DataModel Provider so we can test endpoints validations on JoinGroup command.
         ServerClusterContext context = mTestContext.Get();
         clusterContext               = std::make_unique<ServerClusterContext>(ServerClusterContext{
-            .provider           = customDataModel,
-            .storage            = context.storage,
-            .attributeStorage   = context.attributeStorage,
-            .interactionContext = context.interactionContext,
+                          .provider           = customDataModel,
+                          .storage            = context.storage,
+                          .attributeStorage   = context.attributeStorage,
+                          .interactionContext = context.interactionContext,
         });
 
         ASSERT_EQ(mSender.Startup(*clusterContext), CHIP_NO_ERROR);

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -63,20 +63,16 @@ using chip::app::DataModel::AttributeEntry;
 static constexpr size_t kMaxMembershipEndpoints = app::Clusters::GroupcastCluster::kMaxMembershipEndpoints;
 
 static constexpr FabricIndex kTestFabricIndex = Testing::kTestFabricIndex;
-static constexpr NodeId kNodeIdForAdmin = 1ULL;
-static constexpr NodeId kNodeIdForManage = 2ULL;
+static constexpr NodeId kNodeIdForAdmin       = 1ULL;
+static constexpr NodeId kNodeIdForManage      = 2ULL;
 
-static constexpr SubjectDescriptor kAdminSubjectDescriptor{
-    .fabricIndex = kTestFabricIndex,
-    .authMode = AuthMode::kCase,
-    .subject = kNodeIdForAdmin
-};
+static constexpr SubjectDescriptor kAdminSubjectDescriptor{ .fabricIndex = kTestFabricIndex,
+                                                            .authMode    = AuthMode::kCase,
+                                                            .subject     = kNodeIdForAdmin };
 
-static constexpr SubjectDescriptor kManageSubjectDescriptor{
-    .fabricIndex = kTestFabricIndex,
-    .authMode = AuthMode::kCase,
-    .subject = kNodeIdForManage
-};
+static constexpr SubjectDescriptor kManageSubjectDescriptor{ .fabricIndex = kTestFabricIndex,
+                                                             .authMode    = AuthMode::kCase,
+                                                             .subject     = kNodeIdForManage };
 
 template <typename DecodableListType>
 CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
@@ -129,32 +125,34 @@ struct TestGroupcastCluster : public ::testing::Test
     public:
         bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
         {
-            (void)deviceType;
-            (void)endpoint;
+            (void) deviceType;
+            (void) endpoint;
             return false;
         }
     };
 
-    class GroupcastTestingAccessControlDelegate : public Access::AccessControl::Delegate {
+    class GroupcastTestingAccessControlDelegate : public Access::AccessControl::Delegate
+    {
         CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
-                                 Privilege requestPrivilege) override
+                         Privilege requestPrivilege) override
         {
             if (subjectDescriptor.authMode != AuthMode::kCase)
             {
                 return CHIP_ERROR_ACCESS_DENIED;
             }
 
-            switch (subjectDescriptor.subject) {
-                case kNodeIdForAdmin:
-                    // Admin always has access
-                    return CHIP_NO_ERROR;
-                case kNodeIdForManage: {
-                    // Manage can access everything but Administer-level things
-                    CHIP_ERROR err = (requestPrivilege == Access::Privilege::kAdminister) ? CHIP_ERROR_ACCESS_DENIED : CHIP_NO_ERROR;
-                    return err;
-                }
-                default:
-                    return CHIP_ERROR_ACCESS_DENIED;
+            switch (subjectDescriptor.subject)
+            {
+            case kNodeIdForAdmin:
+                // Admin always has access
+                return CHIP_NO_ERROR;
+            case kNodeIdForManage: {
+                // Manage can access everything but Administer-level things
+                CHIP_ERROR err = (requestPrivilege == Access::Privilege::kAdminister) ? CHIP_ERROR_ACCESS_DENIED : CHIP_NO_ERROR;
+                return err;
+            }
+            default:
+                return CHIP_ERROR_ACCESS_DENIED;
             }
         }
     };
@@ -172,10 +170,10 @@ struct TestGroupcastCluster : public ::testing::Test
         // with our Mock DataModel Provider so we can test endpoints validations on JoinGroup command.
         ServerClusterContext context = mTestContext.Get();
         clusterContext               = std::make_unique<ServerClusterContext>(ServerClusterContext{
-                          .provider           = customDataModel,
-                          .storage            = context.storage,
-                          .attributeStorage   = context.attributeStorage,
-                          .interactionContext = context.interactionContext,
+            .provider           = customDataModel,
+            .storage            = context.storage,
+            .attributeStorage   = context.attributeStorage,
+            .interactionContext = context.interactionContext,
         });
 
         ASSERT_EQ(mSender.Startup(*clusterContext), CHIP_NO_ERROR);
@@ -312,12 +310,12 @@ TEST_F(TestGroupcastCluster, TestAcceptedCommands)
                                               }));
 }
 
-TEST_F(TestGroupcastCluster, TestJoinGroupFailsOnBadAargs) {
-    GroupId kGroup1   = 0xab01;
-    KeysetId kKeyset1 = 0xabcd;
+TEST_F(TestGroupcastCluster, TestJoinGroupFailsOnBadAargs)
+{
+    GroupId kGroup1     = 0xab01;
+    KeysetId kKeyset1   = 0xabcd;
     const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
     const EndpointId kEndpoints[1] = { 1 };
-
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
@@ -354,7 +352,6 @@ TEST_F(TestGroupcastCluster, TestJoinGroupFailsOnBadAargs) {
         EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
     }
 
-
     // Constraint on keySetId >= 1 must be respected.
     {
         Commands::JoinGroup::Type joinGroupCmd;
@@ -390,36 +387,37 @@ TEST_F(TestGroupcastCluster, TestJoinGroupFailsOnBadAargs) {
 
         // Touching useAuxiliaryACL, even if false should fail if present --> cannot update the field.
         joinGroupCmd.useAuxiliaryACL = MakeOptional(false);
-        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        result                       = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
         ASSERT_TRUE(result.GetStatusCode().has_value());
         EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
 
         joinGroupCmd.useAuxiliaryACL = MakeOptional(true);
-        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        result                       = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
         ASSERT_TRUE(result.GetStatusCode().has_value());
         EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
 
         // Starts working after no longer touching AuxACL.
         joinGroupCmd.key             = NullOptional; // <-- Not touching key
         joinGroupCmd.useAuxiliaryACL = NullOptional; // <-- Not touching useAuxACL
-        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        result                       = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
         ASSERT_TRUE(result.GetStatusCode().has_value());
         EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
 
         // If touching key, but not useAuxiliaryACL, still not legal.
 
         joinGroupCmd.key             = MakeOptional(ByteSpan(key)); // <-- Touching key
-        joinGroupCmd.useAuxiliaryACL = NullOptional; // <-- Not touching useAuxACL
-        result = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
+        joinGroupCmd.useAuxiliaryACL = NullOptional;                // <-- Not touching useAuxACL
+        result                       = tester.Invoke(Commands::JoinGroup::Id, joinGroupCmd);
         ASSERT_TRUE(result.GetStatusCode().has_value());
         EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedAccess);
     }
 }
 
-TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs) {
-    GroupId kGroup1   = 0xab01;
-    KeysetId kKeyset1 = 0xabcd;
-    KeysetId kKeyset2 = 0xa123;
+TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs)
+{
+    GroupId kGroup1      = 0xab01;
+    KeysetId kKeyset1    = 0xabcd;
+    KeysetId kKeyset2    = 0xa123;
     const uint8_t key1[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
     const uint8_t key2[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
     const EndpointId kEndpoints[1] = { 1 };
@@ -441,8 +439,8 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs) {
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
     Commands::UpdateGroupKey::Type updateGroupKeyCmd;
-    updateGroupKeyCmd.groupID         = kGroup1;
-    updateGroupKeyCmd.keySetID        = kKeyset1;
+    updateGroupKeyCmd.groupID  = kGroup1;
+    updateGroupKeyCmd.keySetID = kKeyset1;
 
     // UpdateGroupKey from Admin access should succeed (no key update).
     result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
@@ -452,9 +450,9 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs) {
     // If changing a key, should fail with Manage, succeed with Admin
     tester.SetSubjectDescriptor(kManageSubjectDescriptor);
 
-    updateGroupKeyCmd.groupID         = kGroup1;
-    updateGroupKeyCmd.keySetID        = kKeyset2;
-    updateGroupKeyCmd.key             = MakeOptional(ByteSpan(key2));
+    updateGroupKeyCmd.groupID  = kGroup1;
+    updateGroupKeyCmd.keySetID = kKeyset2;
+    updateGroupKeyCmd.key      = MakeOptional(ByteSpan(key2));
 
     result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
     ASSERT_TRUE(result.GetStatusCode().has_value());
@@ -466,18 +464,18 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKeyFailsOnBadAargs) {
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Success);
 
     // Constraint on groupId >= 1 must be respected.
-    updateGroupKeyCmd.groupID = 0;
-    updateGroupKeyCmd.keySetID        = kKeyset1;
-    updateGroupKeyCmd.key = NullOptional;
+    updateGroupKeyCmd.groupID  = 0;
+    updateGroupKeyCmd.keySetID = kKeyset1;
+    updateGroupKeyCmd.key      = NullOptional;
 
     result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
     ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
 
     // Constraint on keySetId >= 1 must be respected.
-    updateGroupKeyCmd.groupID         = kGroup1;
-    updateGroupKeyCmd.keySetID        = 0;
-    updateGroupKeyCmd.key = NullOptional;
+    updateGroupKeyCmd.groupID  = kGroup1;
+    updateGroupKeyCmd.keySetID = 0;
+    updateGroupKeyCmd.key      = NullOptional;
 
     result = tester.Invoke(Commands::UpdateGroupKey::Id, updateGroupKeyCmd);
     ASSERT_TRUE(result.GetStatusCode().has_value());
@@ -1312,7 +1310,8 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
 
     // Create a Listener and Sender capable group with 1 endpoint.
     // Remove the endpoint from the group. Verify that the group still exists for Sender.
-    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate, mAccessControl },
+    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate,
+                                                         mAccessControl },
                                                        BitFlags<Feature>{ Feature::kListener, Feature::kSender } };
     ASSERT_EQ(ListenerAndSender.Startup(*clusterContext), CHIP_NO_ERROR);
     chip::Testing::ClusterTester listenerAndSenderTester(ListenerAndSender);

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -415,7 +415,7 @@ public:
 
     void SetFabricIndex(FabricIndex fabricIndex)
     {
-        auto subjectDescriptor = mHandler.GetSubjectDescriptor();
+        auto subjectDescriptor        = mHandler.GetSubjectDescriptor();
         subjectDescriptor.fabricIndex = fabricIndex;
         mHandler.SetSubjectDescriptor(subjectDescriptor);
         mHandler.SetFabricIndex(fabricIndex);

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -413,7 +413,14 @@ public:
         return std::find(list.begin(), list.end(), target) != list.end();
     }
 
-    void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
+    void SetFabricIndex(FabricIndex fabricIndex)
+    {
+        auto subjectDescriptor = mHandler.GetSubjectDescriptor();
+        subjectDescriptor.fabricIndex = fabricIndex;
+        mHandler.SetSubjectDescriptor(subjectDescriptor);
+        mHandler.SetFabricIndex(fabricIndex);
+    }
+
     void SetSubjectDescriptor(const Access::SubjectDescriptor & subjectDescriptor)
     {
         mHandler.SetSubjectDescriptor(subjectDescriptor);


### PR DESCRIPTION
#### Summary

- Disallow touching keys or useAuxiliaryACL from Manage-privilege commands UpdateGroupKey and JoinGroup, to avoid privilege escalation.
- Disallow touching the IPK.
- Disallow GroupID 0.
- Added more test coverage to ReplaceEndpoints argument of JoinGroup.

#### Related issues

Addresses fixes in the following spec PRs:

- https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12865
- https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12868

#### Testing

- Added full unit test coverage.
- Fixed test plumbing to better enable actual testing of these types of situation.