### PR TITLE
[MSAN] more unit test fixes + Clarify API Contract for IPPacketInfo::Clear 

### DIFF
--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -171,7 +171,7 @@ public:
     static constexpr uint16_t kMaxStringLength = OT_IP6_ADDRESS_STRING_SIZE;
 #endif
 
-    constexpr IPAddress() : Addr{} {}
+    IPAddress() = default;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     explicit IPAddress(const ip6_addr_t & ipv6Addr);
@@ -710,7 +710,7 @@ public:
     static IPAddress Loopback(IPAddressType type);
 };
 
-static_assert(std::is_trivially_copyable_v<IPAddress>, "IPAddress is not trivially copyable");
+static_assert(std::is_trivial<IPAddress>::value, "IPAddress is not trivial");
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -171,7 +171,7 @@ public:
     static constexpr uint16_t kMaxStringLength = OT_IP6_ADDRESS_STRING_SIZE;
 #endif
 
-    IPAddress() = default;
+    constexpr IPAddress() : Addr{} {}
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     explicit IPAddress(const ip6_addr_t & ipv6Addr);
@@ -710,7 +710,7 @@ public:
     static IPAddress Loopback(IPAddressType type);
 };
 
-static_assert(std::is_trivial<IPAddress>::value, "IPAddress is not trivial");
+static_assert(std::is_trivially_copyable_v<IPAddress>, "IPAddress is not trivially copyable");
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/IPPacketInfo.h
+++ b/src/inet/IPPacketInfo.h
@@ -37,8 +37,8 @@ public:
     IPAddress SrcAddress;  /**< The source IPAddress in the packet. */
     IPAddress DestAddress; /**< The destination IPAddress in the packet. */
     InterfaceId Interface; /**< The interface identifier for the connection. */
-    uint16_t SrcPort;      /**< The source port in the packet. */
-    uint16_t DestPort;     /**< The destination port in the packet. */
+    uint16_t SrcPort  = 0; /**< The source port in the packet. */
+    uint16_t DestPort = 0; /**< The destination port in the packet. */
 
     /**
      *  Reset the members of the IPPacketInfo object.

--- a/src/inet/IPPacketInfo.h
+++ b/src/inet/IPPacketInfo.h
@@ -37,11 +37,13 @@ public:
     IPAddress SrcAddress;  /**< The source IPAddress in the packet. */
     IPAddress DestAddress; /**< The destination IPAddress in the packet. */
     InterfaceId Interface; /**< The interface identifier for the connection. */
-    uint16_t SrcPort  = 0; /**< The source port in the packet. */
-    uint16_t DestPort = 0; /**< The destination port in the packet. */
+    uint16_t SrcPort;      /**< The source port in the packet. */
+    uint16_t DestPort;     /**< The destination port in the packet. */
 
     /**
      *  Reset the members of the IPPacketInfo object.
+     *  Clear() MUST be called before using a newly constructed IPPacketInfo,
+     *  as some members contain uninitialized memory after construction.
      */
     void Clear();
 };

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -140,7 +140,7 @@ TEST_F(TestInetEndPoint, TestInetInterface)
     InterfaceAddressIterator addrIterator;
     char intName[InterfaceId::kMaxIfNameLength];
     InterfaceId intId;
-    IPAddress addr;
+    IPAddress addr{};
     InterfaceType intType;
     // 64 bit IEEE MAC address
     const uint8_t kMaxHardwareAddressSize = 8;
@@ -252,7 +252,7 @@ TEST_F(TestInetEndPoint, TestInetEndPointInternal)
 {
     CHIP_ERROR err;
     IPAddress addr_any = IPAddress::Any;
-    IPAddress addr;
+    IPAddress addr{};
 #if INET_CONFIG_ENABLE_IPV4
     IPAddress addr_v4;
 #endif // INET_CONFIG_ENABLE_IPV4

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -217,7 +217,7 @@ TxtResourceRecord txtCommissionableNodeParamsEnhancedAsICDLIT =
 #endif
 
 // Our server doesn't do anything with this, blank is fine.
-Inet::IPPacketInfo packetInfo;
+Inet::IPPacketInfo packetInfo = {};
 
 CHIP_ERROR SendQuery(FullQName qname)
 {

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -70,7 +70,7 @@ struct CommonTestElements
 
     CheckOnlyServer server;
     QueryResponder<10> queryResponder;
-    Inet::IPPacketInfo packetInfo{};
+    Inet::IPPacketInfo packetInfo;
 
     CommonTestElements(const char * tag) :
         recordWriter(&requestBufferWriter),
@@ -80,6 +80,7 @@ struct CommonTestElements
         host(FlatAllocatedQName::Build(hostNameStorage, tag, "host")),
         txt(FlatAllocatedQName::Build(txtStorage, tag, "L1=something", "L2=other")), server()
     {
+        packetInfo.Clear();
         queryResponder.Init();
         header.SetQueryCount(1);
     }

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -70,7 +70,7 @@ struct CommonTestElements
 
     CheckOnlyServer server;
     QueryResponder<10> queryResponder;
-    Inet::IPPacketInfo packetInfo;
+    Inet::IPPacketInfo packetInfo{};
 
     CommonTestElements(const char * tag) :
         recordWriter(&requestBufferWriter),


### PR DESCRIPTION
#### Summary

-  More MSAN unit test fixed 
- Clarifient API Contract for IPPacketInfo::Clear; in unit tests, we were sometimes reading  IPPacketInfo without first initializing it
#### Related issues

- https://github.com/project-chip/connectedhomeip/issues/71500

#### Testing

- Ran MSAN unit tests


