### PR TITLE
minimal_mdns: Simplify some redundant Qname parsing validation

### DIFF
--- a/src/lib/dnssd/minimal_mdns/core/QName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/QName.cpp
@@ -61,22 +61,10 @@ bool SerializedQNameIterator::Next(bool followIndirectPointers)
             }
 
             size_t offset = static_cast<size_t>(((*mCurrentPosition & 0x3F) << 8) | *(mCurrentPosition + 1));
+            // Look behind has to keep going backwards to avoid potential infinite recursion.
+            // mLookBehindMax starts out <= mValidData.Size() and only decreases;
+            // mLookBehindMax <= mCurrentPosition - mValidData.Start() remains true throughout.
             if (offset >= mLookBehindMax)
-            {
-                // Potential infinite recursion.
-                mIsValid = false;
-                return false;
-            }
-            if (offset > mValidData.Size())
-            {
-                // offset too large
-                mIsValid = false;
-                return false;
-            }
-
-            // Look behind has to keep going backwards, otherwise we may
-            // get into an infinite list
-            if (offset >= static_cast<size_t>(mCurrentPosition - mValidData.Start()))
             {
                 mIsValid = false;
                 return false;


### PR DESCRIPTION
#### Summary

The mLookBehindMax check is at least as strict as the checks against Size() and mCurrentPosition. Rememove the redundant checks and document the invariants.

#### Testing

Existing TestQName test covers the invalid compression pointers guarded against in this code.