### PR TITLE
[NXP] Fix OTBR cli init issue

### DIFF
--- a/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
@@ -90,7 +90,10 @@ void chip::NXP::App::AppCLIBase::RegisterDefaultCommands(void)
     cmd_misc_init();
     cmd_otcli_init();
 #if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
-    otAppCliAddonsInit(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
+    /* verify that otInstance is not null before initializing addons */
+    otInstance* otInstance = otInstanceGetSingle();
+    VerifyOrDie(otInstance != nullptr);
+    otAppCliAddonsInit(otInstance);
 #endif
 #if CHIP_SHELL_ENABLE_CMD_SERVER
     cmd_app_server_init();

--- a/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
@@ -91,9 +91,9 @@ void chip::NXP::App::AppCLIBase::RegisterDefaultCommands(void)
     cmd_otcli_init();
 #if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
     /* verify that otInstance is not null before initializing addons */
-    otInstance * otInstance = otInstanceGetSingle();
-    VerifyOrDie(otInstance != nullptr);
-    otAppCliAddonsInit(otInstance);
+    otInstance * instance = otInstanceGetSingle();
+    VerifyOrDie(instance != nullptr);
+    otAppCliAddonsInit(instance);
 #endif
 #if CHIP_SHELL_ENABLE_CMD_SERVER
     cmd_app_server_init();

--- a/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
@@ -91,7 +91,7 @@ void chip::NXP::App::AppCLIBase::RegisterDefaultCommands(void)
     cmd_otcli_init();
 #if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
     /* verify that otInstance is not null before initializing addons */
-    otInstance* otInstance = otInstanceGetSingle();
+    otInstance * otInstance = otInstanceGetSingle();
     VerifyOrDie(otInstance != nullptr);
     otAppCliAddonsInit(otInstance);
 #endif


### PR DESCRIPTION
#### Summary

During CLI initialization, Matter performs operations before the Thread stack has been fully initialized. As a result, chip::DeviceLayer::ThreadStackMgrImpl().OTInstance() returns a null pointer. 
This could leads to memory corruption. The OpenThread code later dereferences this null OT instance pointer (address 0x0), reading random memory contents. Specifically, in
third_party/openthread/ot-nxp/openthread/src/core/common/array.hpp (the PushBack function), the operation:
`mElements[mLength++] = aEntry` 

Fix:
Retrieve the OpenThread instance using the OpenThread API directly, instead of accessing it through the Matter ThreadStackMgr. This ensures that the OT instance is valid and initialized before use.

### Testing

Built and ran the NXP RT1060 EVKC OTBR Thermostat application.
Verified with adding a VerifyOrDie check that the OpenThread instance pointer is properly initialized before being used.
Confirmed that the pointer is never null and that the memory corruption and random crashes no longer occur.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
