### PR TITLE
Bump cloudbuild image to 191, to fix efr32 compile errors

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -66,7 +66,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -139,7 +139,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:190"
+    - name: "ghcr.io/project-chip/chip-build-vscode:191"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Summary

EFR32 builds are failing in cloudbuild with:

```
2026-04-13 17:59:50.596 INFO    /opt/silabs/simplicity_sdk/openthread/platform-abstraction/efr32/system.c:71:30: error: "SL_OPENTHREAD_ENABLE_SERIAL_TASK" is not defined, evaluates to 0 [-Werror=undef]
2026-04-13 17:59:50.596 INFO       71 | #define SERIAL_TASK_ENABLED (SL_OPENTHREAD_ENABLE_SERIAL_TASK)
2026-04-13 17:59:50.596 INFO          |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-04-13 17:59:50.596 INFO    /opt/silabs/simplicity_sdk/openthread/platform-abstraction/efr32/system.c:131:6: note: in expansion of macro 'SERIAL_TASK_ENABLED'
2026-04-13 17:59:50.596 INFO      131 | #if (SERIAL_TASK_ENABLED == 0)
```

Matching the image version with what efr32 github flows have.

#### Testing

Manual change: efr32 image in master is running on 191 and compiling, so assuming this is the problem.