### PR TITLE
Follow-up Fixes for TC_ACE_1_6

### DIFF
--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -63,6 +63,7 @@ from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
+from TC_GC_common import get_operate_only_commands
 
 log = logging.getLogger(__name__)
 
@@ -143,16 +144,16 @@ class TC_ACE_1_6(MatterBaseTest):
             asserts.assert_not_equal(pixit_g_endpoint, 0, "Not allowed to have groups clusters on endpoint 0.")
             log.info(f"Endpoint value for PIXIT.G.ENDPOINT used for test steps with groups cluster: {pixit_g_endpoint}")
         else:
-            # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later
-            parts_list = await self.read_single_attribute_check_success(
-                cluster=Clusters.Descriptor,
-                attribute=Clusters.Descriptor.Attributes.PartsList,
-                endpoint=0
-            )
-            # TODO: ep~1~ should be fetched using code to find an endpoint with a cluster with attributes that can be modified by a cluster command,
-            # should replace hard-coded uses of OnOff
-            ep1 = parts_list[0] if (parts_list is not None and parts_list[0] is not None) else 1
+            # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least 
+            # one cluster with a command that has operate priviliege.
+            operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, self.get_endpoint())
+            asserts.assert_greater(len(operate_only_command_list), 0, "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
+            operate_only_command = operate_only_command_list[0]
+            ep1 = operate_only_command.endpoint_id
+
             log.info(f"Endpoint value for ep~1~ used for test steps with groupcast cluster: {ep1}")
+            log.info(f"Targeted cluster used for groupcast case is: {operate_only_command.cluster_object.__name__} ({operate_only_command.cluster_object.id})")
+            log.info(f"Targeted command with operate priviliege on the targeted cluster used for groupcast case is: {operate_only_command.command_object.__name__}")
 
         # Step 1a: KeySetWrite 0x01a3
         self.step("1a")
@@ -273,9 +274,9 @@ class TC_ACE_1_6(MatterBaseTest):
         )
 
         if gc_on_root:
-            # Cluster on ep1 with modified attributes (using OnOff as example)
-            target_cluster = Clusters.OnOff.id
+            # Cluster on ep1 with modified attributes
             # TODO: fix possubly unbound
+            target_cluster = operate_only_command.cluster_object.id
             target_endpoint = ep1
         else:
             target_cluster = Clusters.Groups.id
@@ -339,7 +340,7 @@ class TC_ACE_1_6(MatterBaseTest):
 
             # Step 10: Group command to Group 0x0103
             self.step(10)
-            self.default_controller.SendGroupCommand(groupID3, Clusters.OnOff.Commands.Toggle())
+            self.default_controller.SendGroupCommand(groupID3, operate_only_command.command_object())
             await asyncio.sleep(3)
 
             # Step 11: Verify GroupcastTesting event (AccessAllowed: true)
@@ -351,7 +352,7 @@ class TC_ACE_1_6(MatterBaseTest):
 
             # Step 12: Group command to Group 0x0102
             self.step(12)
-            self.default_controller.SendGroupCommand(groupID2, Clusters.OnOff.Commands.Toggle())
+            self.default_controller.SendGroupCommand(groupID2, operate_only_command.command_object())
             await asyncio.sleep(3)
 
             # Step 13: Verify GroupcastTesting event (AccessAllowed: false)
@@ -375,7 +376,7 @@ class TC_ACE_1_6(MatterBaseTest):
             self.mark_step_range_skipped(15, 20)
         else:
             self.step(15)
-            self.default_controller.SendGroupCommand(groupID3, Clusters.OnOff.Commands.Toggle())
+            self.default_controller.SendGroupCommand(groupID3, operate_only_command.command_object())
             await asyncio.sleep(3)
 
             # Step 16: Verify GroupcastTesting event (AccessAllowed: false)
@@ -391,7 +392,7 @@ class TC_ACE_1_6(MatterBaseTest):
 
             # Step 18: Generic group command to Group 0x0103
             self.step(18)
-            self.default_controller.SendGroupCommand(groupID3, Clusters.OnOff.Commands.Toggle())
+            self.default_controller.SendGroupCommand(groupID3, operate_only_command.command_object())
             await asyncio.sleep(3)
 
             # Step 19: Verify GroupcastTesting event (AccessAllowed: true)

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -137,18 +137,18 @@ class TC_ACE_1_6(MatterBaseTest):
         # Check if Groupcast cluster is on RootNode (endpoint 0)
         gc_on_root = await is_groupcast_on_root_node(self)
 
-        # Indicate endpoints to be used for test. These default values will be 
+        # Indicate endpoints to be used for test. These default values will be
         # verified or changed depending on use of groupcast or groups clusters
         operate_only_command = None
         ep1 = self.get_endpoint()
         pixit_g_endpoint = self.get_endpoint()
-        
+
         if not gc_on_root:
             asserts.assert_false(pixit_g_endpoint is None, "--endpoint <endpoint> with Groups cluster must be included on the command line.")
             asserts.assert_not_equal(pixit_g_endpoint, 0, "Not allowed to have groups clusters on endpoint 0.")
             log.info(f"Endpoint value for PIXIT.G.ENDPOINT used for test steps with groups cluster: {pixit_g_endpoint}")
         else:
-            # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least 
+            # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least
             # one cluster with a command that has operate priviliege.
             operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, self.get_endpoint())
             asserts.assert_greater(len(operate_only_command_list), 0, "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
@@ -189,7 +189,7 @@ class TC_ACE_1_6(MatterBaseTest):
             )
         ))
 
-        # Must manually set the group key sets for the controller. 
+        # Must manually set the group key sets for the controller.
         self.default_controller.SetGroupKeySet(
             keyset_id=keySetID1,
             policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -54,7 +54,7 @@ import asyncio
 import logging
 
 from mobly import asserts
-from TC_GC_common import is_groupcast_on_root_node
+from TC_GC_common import get_operate_only_commands, is_groupcast_on_root_node
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
@@ -63,7 +63,6 @@ from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
-from TC_GC_common import get_operate_only_commands
 
 log = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -137,9 +137,13 @@ class TC_ACE_1_6(MatterBaseTest):
         # Check if Groupcast cluster is on RootNode (endpoint 0)
         gc_on_root = await is_groupcast_on_root_node(self)
 
-        # Indicate endpoints to be used for test
+        # Indicate endpoints to be used for test. These default values will be 
+        # verified or changed depending on use of groupcast or groups clusters
+        operate_only_command = None
+        ep1 = self.get_endpoint()
+        pixit_g_endpoint = self.get_endpoint()
+        
         if not gc_on_root:
-            pixit_g_endpoint = self.get_endpoint()
             asserts.assert_false(pixit_g_endpoint is None, "--endpoint <endpoint> with Groups cluster must be included on the command line.")
             asserts.assert_not_equal(pixit_g_endpoint, 0, "Not allowed to have groups clusters on endpoint 0.")
             log.info(f"Endpoint value for PIXIT.G.ENDPOINT used for test steps with groups cluster: {pixit_g_endpoint}")
@@ -275,7 +279,6 @@ class TC_ACE_1_6(MatterBaseTest):
 
         if gc_on_root:
             # Cluster on ep1 with modified attributes
-            # TODO: fix possubly unbound
             target_cluster = operate_only_command.cluster_object.id
             target_endpoint = ep1
         else:

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -144,20 +144,24 @@ class TC_ACE_1_6(MatterBaseTest):
         pixit_g_endpoint = self.get_endpoint()
 
         if not gc_on_root:
-            asserts.assert_false(pixit_g_endpoint is None, "--endpoint <endpoint> with Groups cluster must be included on the command line.")
+            asserts.assert_false(pixit_g_endpoint is None,
+                                 "--endpoint <endpoint> with Groups cluster must be included on the command line.")
             asserts.assert_not_equal(pixit_g_endpoint, 0, "Not allowed to have groups clusters on endpoint 0.")
             log.info(f"Endpoint value for PIXIT.G.ENDPOINT used for test steps with groups cluster: {pixit_g_endpoint}")
         else:
             # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least
             # one cluster with a command that has operate priviliege.
             operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, self.get_endpoint())
-            asserts.assert_greater(len(operate_only_command_list), 0, "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
+            asserts.assert_greater(len(operate_only_command_list), 0,
+                                   "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
             operate_only_command = operate_only_command_list[0]
             ep1 = operate_only_command.endpoint_id
 
             log.info(f"Endpoint value for ep~1~ used for test steps with groupcast cluster: {ep1}")
-            log.info(f"Targeted cluster used for groupcast case is: {operate_only_command.cluster_object.__name__} ({operate_only_command.cluster_object.id})")
-            log.info(f"Targeted command with operate priviliege on the targeted cluster used for groupcast case is: {operate_only_command.command_object.__name__}")
+            log.info(
+                f"Targeted cluster used for groupcast case is: {operate_only_command.cluster_object.__name__} ({operate_only_command.cluster_object.id})")
+            log.info(
+                f"Targeted command with operate priviliege on the targeted cluster used for groupcast case is: {operate_only_command.command_object.__name__}")
 
         # Step 1a: KeySetWrite 0x01a3
         self.step("1a")
@@ -458,6 +462,7 @@ class TC_ACE_1_6(MatterBaseTest):
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(groupKeySetID=keySetID1))
 
         # TODO(#71506): A step should be added in this test to restore a wildcard ACL entry.
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -64,7 +64,7 @@ from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class TC_ACE_1_6(MatterBaseTest):
@@ -115,9 +115,8 @@ class TC_ACE_1_6(MatterBaseTest):
 
     @async_test_body
     async def test_TC_ACE_1_6(self):
-        self.default_controller.InitGroupTestingData()
 
-        # Configuration
+        # Declare group ids and key sets
         groupID1 = 0x0101
         groupID2 = 0x0102
         groupID3 = 0x0103
@@ -125,9 +124,8 @@ class TC_ACE_1_6(MatterBaseTest):
         groupID5 = 0x0105
         keySetID1 = 0x01a1
         keySetID3 = 0x01a3
-        pixit_g_endpoint = 1
 
-        # Keys
+        # Declare Keys
         key1 = bytes.fromhex("a0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
         key3 = bytes.fromhex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
 
@@ -137,6 +135,24 @@ class TC_ACE_1_6(MatterBaseTest):
 
         # Check if Groupcast cluster is on RootNode (endpoint 0)
         gc_on_root = await is_groupcast_on_root_node(self)
+
+        # Indicate endpoints to be used for test
+        if not gc_on_root:
+            pixit_g_endpoint = self.get_endpoint()
+            asserts.assert_false(pixit_g_endpoint is None, "--endpoint <endpoint> with Groups cluster must be included on the command line.")
+            asserts.assert_not_equal(pixit_g_endpoint, 0, "Not allowed to have groups clusters on endpoint 0.")
+            log.info(f"Endpoint value for PIXIT.G.ENDPOINT used for test steps with groups cluster: {pixit_g_endpoint}")
+        else:
+            # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later
+            parts_list = await self.read_single_attribute_check_success(
+                cluster=Clusters.Descriptor,
+                attribute=Clusters.Descriptor.Attributes.PartsList,
+                endpoint=0
+            )
+            # TODO: ep~1~ should be fetched using code to find an endpoint with a cluster with attributes that can be modified by a cluster command,
+            # should replace hard-coded uses of OnOff
+            ep1 = parts_list[0] if (parts_list is not None and parts_list[0] is not None) else 1
+            log.info(f"Endpoint value for ep~1~ used for test steps with groupcast cluster: {ep1}")
 
         # Step 1a: KeySetWrite 0x01a3
         self.step("1a")
@@ -168,18 +184,28 @@ class TC_ACE_1_6(MatterBaseTest):
             )
         ))
 
-        # TODO: can this be replaced with the one from InitGroupTestingData() ?
-        # Must manually set the group key set for the controller. This is only needed for key1 and not
-        # key3, as this key is not included as part of the test group data initialized in InitGroupTestingData()
+        # Must manually set the group key sets for the controller. 
         self.default_controller.SetGroupKeySet(
             keyset_id=keySetID1,
-            policy=0,
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
             num_keys=3,
             epoch_key0=key1,
             epoch_start_time0=2220000,
             epoch_key1=b"\xb1" + key1[1:],
             epoch_start_time1=2220001,
             epoch_key2=b"\xc2" + key1[1:],
+            epoch_start_time2=2220002
+        )
+
+        self.default_controller.SetGroupKeySet(
+            keyset_id=keySetID3,
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
+            num_keys=3,
+            epoch_key0=key3,
+            epoch_start_time0=2220000,
+            epoch_key1=b"\xd1" + key3[1:],
+            epoch_start_time1=2220001,
+            epoch_key2=b"\xd2" + key3[1:],
             epoch_start_time2=2220002
         )
 
@@ -215,14 +241,6 @@ class TC_ACE_1_6(MatterBaseTest):
             ]))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap attribute write failed")
 
-        # Find ep1 (non-root node endpoint)
-        parts_list = await self.read_single_attribute_check_success(
-            cluster=Clusters.Descriptor,
-            attribute=Clusters.Descriptor.Attributes.PartsList,
-            endpoint=0
-        )
-        ep1 = parts_list[0] if (parts_list is not None and parts_list[0] is not None) else 1
-
         # Step 3a: AddGroup 0x0103 over CASE (if GC not on root)
         if gc_on_root:
             self.skip_step("3a")
@@ -257,6 +275,7 @@ class TC_ACE_1_6(MatterBaseTest):
         if gc_on_root:
             # Cluster on ep1 with modified attributes (using OnOff as example)
             target_cluster = Clusters.OnOff.id
+            # TODO: fix possubly unbound
             target_endpoint = ep1
         else:
             target_cluster = Clusters.Groups.id
@@ -277,14 +296,6 @@ class TC_ACE_1_6(MatterBaseTest):
                 targets=[Clusters.AccessControl.Structs.AccessControlTargetStruct(endpoint=0, cluster=Clusters.Groupcast.id)]
             )
             acl_entries.append(groupcast_admin)
-        else:
-            groups_admin = Clusters.AccessControl.Structs.AccessControlEntryStruct(
-                privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister,
-                authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                subjects=[th1_nodeid],
-                targets=[Clusters.AccessControl.Structs.AccessControlTargetStruct(endpoint=0, cluster=Clusters.Groups.id)]
-            )
-            acl_entries.append(groups_admin)
 
         await self.default_controller.WriteAttribute(self.dut_node_id, [(0, Clusters.AccessControl.Attributes.Acl(acl_entries))])
 
@@ -442,6 +453,7 @@ class TC_ACE_1_6(MatterBaseTest):
         self.step(30)
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(groupKeySetID=keySetID1))
 
+        # TODO(#71506): A step should be added in this test to restore a wildcard ACL entry.
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -336,7 +336,9 @@ async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int
     if endpoint_id_to_search is not None:
         asserts.assert_false((exclude_ep0 and endpoint_id_to_search == 0),
                              "Endpoint 0 was both specified to be searched in and to be ignored.")
-        endpoint_data = attributes[endpoint_id_to_search]
+        endpoint_data = attributes.get(endpoint_id_to_search)
+        if endpoint_data is None:
+            asserts.fail(f"Endpoint {endpoint_id_to_search} not found on the device.")
         find_commands_on_endpoint_and_cluster(endpoint_id_to_search, endpoint_data, operate_only_commands)
     else:
         for endpoint_id, endpoint_data in attributes.items():

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -16,15 +16,15 @@
 #
 
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
 from mobly import asserts
 
 import matter.clusters as Clusters
-from dataclasses import dataclass
+from matter.ChipDeviceCtrl import ChipDeviceController
 from matter.clusters.Types import NullValue
 from matter.testing.matter_testing import AttributeMatcher
-from matter.ChipDeviceCtrl import ChipDeviceController
 from matter.testing.spec_parsing import build_xml_clusters, dm_from_spec_version
 
 logger = logging.getLogger(__name__)

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -303,7 +303,7 @@ async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int
         dm = dm_from_spec_version(spec_version)
         xml_clusters, _ = build_xml_clusters(dm)
         return xml_clusters
-    
+
     def find_commands_on_endpoint_and_cluster(endpoint_id, endpoint_data, operate_only_commands):
         for cluster, cluster_data in endpoint_data.items():
             if cluster.Attributes.AcceptedCommandList in cluster_data:

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -311,13 +311,18 @@ async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int
                 for cmd_id in command_list:
                     try:
                         xml_command = xml_clusters[cluster.id].accepted_commands[cmd_id]
-                        # TODO: Must also be a client -> server command, not a response
-                        # TODO: Need to find a way to instantiate it with default args if not the case!!!
                         if xml_command.privilege == Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kOperate:
                             cluster_object = Clusters.ClusterObjects.ALL_CLUSTERS[cluster.id]
                             command_object = Clusters.ClusterObjects.ALL_ACCEPTED_COMMANDS[cluster.id][cmd_id]
+
+                            # Only client-to-server commands (no response commands)
+                            if not command_object.is_client:
+                                continue
+
+                            # In this codebase, all generated ClusterCommand subclasses have defaults for all fields.
                             operate_only_commands.append(OperateOnlyCommand(
                                 endpoint_id=endpoint_id, cluster_object=cluster_object, command_object=command_object))
+
                     except KeyError:
                         logger.warning(
                             f"Command ID {cmd_id} on cluster {cluster.id} not found in spec XMLs. This may be a manufacturer-specific command.")

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -21,8 +21,11 @@ from typing import Optional
 from mobly import asserts
 
 import matter.clusters as Clusters
+from dataclasses import dataclass
 from matter.clusters.Types import NullValue
 from matter.testing.matter_testing import AttributeMatcher
+from matter.ChipDeviceCtrl import ChipDeviceController
+from matter.testing.spec_parsing import build_xml_clusters, dm_from_spec_version
 
 logger = logging.getLogger(__name__)
 
@@ -265,3 +268,73 @@ def generate_usedMcastAddrCount_entry_matcher(expected_count: int) -> AttributeM
 
     description = f"UsedMcastAddrCount == {expected_count}"
     return AttributeMatcher.from_callable(description=description, matcher=predicate)
+
+@dataclass
+class OperateOnlyCommand:
+    endpoint_id: int
+    cluster_object: Clusters.ClusterObjects.Cluster
+    command_object: Clusters.ClusterObjects.ClusterCommand
+
+
+async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int, exclude_ep0: bool=True, endpoint_id_to_search:Optional[int]=None) -> list[OperateOnlyCommand]:
+    """
+    Reads all AcceptedCommandList attributes and the SpecificationVersion to determine all
+    commands that only require Operate privilege.
+
+    Args:
+        dev_ctrl: The ChipDeviceController instance.
+        node_id: The node ID of the device to query.
+        exclude_ep0: Boolean to determine if endpoint 0 should be excluded in the search for valid cluster commands
+        endpoint_id_to_search: Optional argument. When specified, search for commands will only be on clusters on the specified endpoint. Search all endpoints if not specified
+
+    Returns:
+        A list of OperateOnlyCommand dataclass objects for each command that only requires
+        Operate privilege.
+    """
+    # Helper function to perform wildcard read and get spec info
+    async def get_device_composition_and_spec(dev_ctrl, node_id) -> tuple[dict, int]:
+        wildcard_read = await dev_ctrl.Read(node_id, [()])
+        attributes = wildcard_read.attributes
+        spec_version = attributes[0][Clusters.BasicInformation][Clusters.BasicInformation.Attributes.SpecificationVersion]
+        return attributes, spec_version
+
+    # Helper function to parse spec
+    def get_xml_clusters(spec_version: int):
+        dm = dm_from_spec_version(spec_version)
+        xml_clusters, _ = build_xml_clusters(dm)
+        return xml_clusters
+    
+    def find_commands_on_endpoint_and_cluster(endpoint_id, endpoint_data, operate_only_commands):
+        for cluster, cluster_data in endpoint_data.items():
+            if cluster.Attributes.AcceptedCommandList in cluster_data:
+                command_list = cluster_data[cluster.Attributes.AcceptedCommandList]
+                for cmd_id in command_list:
+                    try:
+                        xml_command = xml_clusters[cluster.id].accepted_commands[cmd_id]
+                        # TODO: Must also be a client -> server command, not a response
+                        # TODO: Need to find a way to instantiate it with default args if not the case!!!
+                        if xml_command.privilege == Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kOperate:
+                            cluster_object = Clusters.ClusterObjects.ALL_CLUSTERS[cluster.id]
+                            command_object = Clusters.ClusterObjects.ALL_ACCEPTED_COMMANDS[cluster.id][cmd_id]
+                            operate_only_commands.append(OperateOnlyCommand(
+                                endpoint_id=endpoint_id, cluster_object=cluster_object, command_object=command_object))
+                    except KeyError:
+                        logger.warning(
+                            f"Command ID {cmd_id} on cluster {cluster.id} not found in spec XMLs. This may be a manufacturer-specific command.")
+
+    # Main logic
+    attributes, spec_version = await get_device_composition_and_spec(dev_ctrl, node_id)
+    xml_clusters = get_xml_clusters(spec_version)
+    operate_only_commands = []
+
+    if endpoint_id_to_search is not None:
+        asserts.assert_false((exclude_ep0 and endpoint_id_to_search==0), "Endpoint 0 was both specified to be searched in and to be ignored.")
+        endpoint_data = attributes[endpoint_id_to_search]
+        find_commands_on_endpoint_and_cluster(endpoint_id_to_search, endpoint_data, operate_only_commands)
+    else:
+        for endpoint_id, endpoint_data in attributes.items():
+            if exclude_ep0 and endpoint_id==0:
+                continue
+            find_commands_on_endpoint_and_cluster(endpoint_id, endpoint_data, operate_only_commands)
+
+    return operate_only_commands

--- a/src/python_testing/TC_GC_common.py
+++ b/src/python_testing/TC_GC_common.py
@@ -269,6 +269,7 @@ def generate_usedMcastAddrCount_entry_matcher(expected_count: int) -> AttributeM
     description = f"UsedMcastAddrCount == {expected_count}"
     return AttributeMatcher.from_callable(description=description, matcher=predicate)
 
+
 @dataclass
 class OperateOnlyCommand:
     endpoint_id: int
@@ -276,7 +277,7 @@ class OperateOnlyCommand:
     command_object: Clusters.ClusterObjects.ClusterCommand
 
 
-async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int, exclude_ep0: bool=True, endpoint_id_to_search:Optional[int]=None) -> list[OperateOnlyCommand]:
+async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int, exclude_ep0: bool = True, endpoint_id_to_search: Optional[int] = None) -> list[OperateOnlyCommand]:
     """
     Reads all AcceptedCommandList attributes and the SpecificationVersion to determine all
     commands that only require Operate privilege.
@@ -333,12 +334,13 @@ async def get_operate_only_commands(dev_ctrl: ChipDeviceController, node_id: int
     operate_only_commands = []
 
     if endpoint_id_to_search is not None:
-        asserts.assert_false((exclude_ep0 and endpoint_id_to_search==0), "Endpoint 0 was both specified to be searched in and to be ignored.")
+        asserts.assert_false((exclude_ep0 and endpoint_id_to_search == 0),
+                             "Endpoint 0 was both specified to be searched in and to be ignored.")
         endpoint_data = attributes[endpoint_id_to_search]
         find_commands_on_endpoint_and_cluster(endpoint_id_to_search, endpoint_data, operate_only_commands)
     else:
         for endpoint_id, endpoint_data in attributes.items():
-            if exclude_ep0 and endpoint_id==0:
+            if exclude_ep0 and endpoint_id == 0:
                 continue
             find_commands_on_endpoint_and_cluster(endpoint_id, endpoint_data, operate_only_commands)
 


### PR DESCRIPTION
#### Summary

This PR makes some updates to TC_ACE_1_6. It includes fixes for the following:
- Adds a new function in `TC_GC_common.py` called `get_operate_only_commands()`. This can be used to find clusters on an endpoint that have commands with the operate privilege. This expands the use of TC_ACE_1_6, by no longer hard-coding the use of a specific cluster and command (was using Toggle() from OnOff previously)
- Remove unnecessary acl write on groups cluster 
- Fix minor TODOs (unbound variables, streamline init data, etc)

#### Testing

- CI should still pass