### PR TITLE
[Silabs] efr32_test_runner - fix path to silabs FreeRTOSConfig.h

### DIFF
--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -45,7 +45,7 @@ pw_proto_library("nl_test_service") {
 efr32_sdk("sdk") {
   sources = [
     "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${examples_common_plat_dir}/FreeRTOSConfig.h",
+    "${examples_common_plat_dir}/freertos_config/FreeRTOSConfig.h",
   ]
 
   include_dirs = [


### PR DESCRIPTION
#### Summary

Compile was failing with:

```
2026-04-13 20:27:48.160 INFO    ERROR at //third_party/connectedhomeip/third_party/silabs/efr32_sdk.gni:689:3: Source file not found.
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO      source_set(sdk_target_name) {
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO      ^----------------------------
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO    The target:
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO      //:sdk
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO    has a source file:
Step #5 - "Linux": 2026-04-13 20:27:48.160 INFO      //third_party/connectedhomeip/examples/platform/silabs/FreeRTOSConfig.h
Step #5 - "Linux": 2026-04-13 20:27:48.161 INFO    which was not found.
```

#### Related issues

Matches changes in #60920 

#### Testing

Build the target manually
