### PR TITLE
Fix Group Data Provider Init In All Devices App

### DIFF
--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -289,6 +289,12 @@ void InitServer(intptr_t context)
         return;
     }
 
+    initParams.groupDataProvider = &gGroupDataProvider;
+    gGroupDataProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    gGroupDataProvider.SetSessionKeystore(initParams.sessionKeystore);
+    SuccessOrDie(gGroupDataProvider.Init());
+    Credentials::SetGroupDataProvider(&gGroupDataProvider);
+
     initParams.dataModelProvider =
         PopulateCodeDrivenDataModelProvider(initParams.persistentStorageDelegate, initParams.testEventTriggerDelegate);
     initParams.operationalServicePort        = CHIP_PORT;

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -204,6 +204,8 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 #endif // CHIP_CONFIG_ENABLE_GROUPCAST
 
     gGroupDataProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    gGroupDataProvider.SetSessionKeystore(initParams.sessionKeystore);
+    SuccessOrDie(gGroupDataProvider.Init());
     Credentials::SetGroupDataProvider(&gGroupDataProvider);
 
     DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();

--- a/src/python_testing/TC_SC_5_1.py
+++ b/src/python_testing/TC_SC_5_1.py
@@ -48,6 +48,20 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run3:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device on-off-light:1 --discriminator 1234
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -48,6 +48,20 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run3:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device on-off-light:1 --discriminator 1234
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio


### PR DESCRIPTION
#### Summary

A segmentation fault was discovered when running `TC_SC_5_2.py` with the linux all devices app. The issue was caused because the session key store was never set, and the `Init()` call on the group data provider that checks for this being set was also missing. This PR fixes those issues. The same problem was discovered in the esp32 version of the all devices app, and so the fix is added there as well.

#### Testing

- CI Should still pass
- Added runs in `TC_SC_5_1` and `TC_SC_5_2` with all devices app
