### PR TITLE
[NXP][wifi] Adding implementation of GetWiFiCurrentMaxRate for freeRTOS based NXP MCU host

### DIFF
--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -504,18 +504,17 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentM
         24000, 36000, 48000, 54000  /* 11a/g: 24, 36, 48, 54 Mbps */
     };
 
-    if (datarate != nullptr && datarate->tx_rate_format == MLAN_RATE_FORMAT_LG &&
+    if (datarate->tx_rate_format == MLAN_RATE_FORMAT_LG &&
         datarate->tx_data_rate < (sizeof(lg_rate_kbps) / sizeof(lg_rate_kbps[0])))
     {
         /* Legacy rates (in bps) */
         currentMaxRate = lg_rate_kbps[datarate->tx_data_rate] * 1000U;
     }
-    else if (datarate != nullptr &&
-             datarate->tx_rate_format <=
-                 3 /* MLAN_RATE_FORMAT_HE=3 but use hardcoded value as in some condition MLAN_RATE_FORMAT_HE may not be defined  */)
+    else if (datarate->tx_rate_format <=
+             3 /* MLAN_RATE_FORMAT_HE=3 but use hardcoded value as in some condition MLAN_RATE_FORMAT_HE may not be defined  */)
     {
         /* HT, VHT, HE rates - tx_data_rate is in 0.5 Mbps units transform it in bps */
-        currentMaxRate = (static_cast<uint64_t>(datarate->tx_data_rate) >> 1) * 1000000ULL;
+        currentMaxRate = static_cast<uint64_t>(datarate->tx_data_rate) * 500000ULL;
     }
     else
     {

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -480,6 +480,55 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts(void)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
+{
+#if CONFIG_WIFI_GET_LOG
+    wlan_ds_rate ds_rate;
+    mlan_bss_type bss_type = MLAN_BSS_TYPE_STA;
+
+    (void) memset(&ds_rate, 0, sizeof(wlan_ds_rate));
+    ds_rate.sub_command = WIFI_DS_GET_DATA_RATE;
+
+    int ret = wlan_get_data_rate(&ds_rate, bss_type);
+    if (ret != WM_SUCCESS)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    wifi_data_rate_t * datarate = (wifi_data_rate_t *) &ds_rate.param.data_rate;
+
+    /* Legacy rates in Mbps (index 2 is 5.5 Mbps) */
+    static const uint32_t lg_rate_kbps[12] = {
+        1000,  2000,  5500,  11000, /* 11b: 1, 2, 5.5, 11 Mbps */
+        6000,  9000,  12000, 18000, /* 11a/g: 6, 9, 12, 18 Mbps */
+        24000, 36000, 48000, 54000  /* 11a/g: 24, 36, 48, 54 Mbps */
+    };
+
+    if (datarate != nullptr && datarate->tx_rate_format == MLAN_RATE_FORMAT_LG &&
+        datarate->tx_data_rate < (sizeof(lg_rate_kbps) / sizeof(lg_rate_kbps[0])))
+    {
+        /* Legacy rates (in bps) */
+        currentMaxRate = lg_rate_kbps[datarate->tx_data_rate] * 1000U;
+    }
+    else if (datarate != nullptr &&
+             datarate->tx_rate_format <=
+                 3 /* MLAN_RATE_FORMAT_HE=3 but use hardcoded value as in some condition MLAN_RATE_FORMAT_HE may not be defined  */)
+    {
+        /* HT, VHT, HE rates - tx_data_rate is in 0.5 Mbps units transform it in bps */
+        currentMaxRate = (static_cast<uint64_t>(datarate->tx_data_rate) >> 1) * 1000000ULL;
+    }
+    else
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    return CHIP_NO_ERROR;
+
+#else /* CONFIG_WIFI_GET_LOG */
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
+}
+
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_WPA */
 
 #if CONFIG_CHIP_ETHERNET

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.h
@@ -68,7 +68,8 @@ public:
     CHIP_ERROR GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount) override;
     CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
     CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
-    CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastTxCount) override;
+    CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount) override;
+    CHIP_ERROR GetWiFiCurrentMaxRate(uint64_t & currentMaxRate) override;
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_WPA */
 #if CONFIG_CHIP_ETHERNET
     /**


### PR DESCRIPTION
#### Summary

Current implementation of GetWiFiCurrentMaxRate was empty for Matter NXP freeRTOS based NXP MCU host. The aim of this PR is to add an implementation according to Matter spec to retreive the current maximum PHY rate of transfer of data in bitsper-second.

#### Testing
Build thermostat app on RW612 NXP platform:

west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp -DCONF_FILE_NAME=prj_wifi.conf

Run  ./chip-tool wifinetworkdiagnostics read current-max-rate 1 0 to read attribute value.

