### PR TITLE
Replace CharSpan::fromCharString() with _span literals

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/src/filter-delegates.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/filter-delegates.cpp
@@ -80,23 +80,23 @@ CHIP_ERROR ImmutableReplacementProductListManager::Next(ReplacementProductStruct
     {
     case 0: {
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kUpc);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("111112222233"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("111112222233"_span);
         break;
     case 1:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin8);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin8xxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin8xxx"_span);
         break;
     case 2:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kEan);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("4444455555666"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("4444455555666"_span);
         break;
     case 3:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin14);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin14xxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin14xxxxxxxx"_span);
         break;
     case 4:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kOem);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("oem20xxxxxxxxxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("oem20xxxxxxxxxxxxxxx"_span);
         break;
     default:
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/all-clusters-app/all-clusters-common/include/bridged-actions-stub.h
+++ b/examples/all-clusters-app/all-clusters-common/include/bridged-actions-stub.h
@@ -34,9 +34,9 @@ class ActionsDelegateImpl : public Delegate
 {
 private:
     std::vector<ActionStructStorage> kActionList = {
-        ActionStructStorage(0, CharSpan::fromCharString("TurnOnLight"), ActionTypeEnum::kScene, 0, 0, ActionStateEnum::kInactive),
-        ActionStructStorage(1, CharSpan::fromCharString("TurnOffLight"), ActionTypeEnum::kScene, 1, 0, ActionStateEnum::kInactive),
-        ActionStructStorage(2, CharSpan::fromCharString("ToggleLight"), ActionTypeEnum::kScene, 2, 0, ActionStateEnum::kInactive)
+        ActionStructStorage(0, "TurnOnLight"_span, ActionTypeEnum::kScene, 0, 0, ActionStateEnum::kInactive),
+        ActionStructStorage(1, "TurnOffLight"_span, ActionTypeEnum::kScene, 1, 0, ActionStateEnum::kInactive),
+        ActionStructStorage(2, "ToggleLight"_span, ActionTypeEnum::kScene, 2, 0, ActionStateEnum::kInactive)
     };
 
     std::vector<EndpointId> firstEpList  = { 1 };
@@ -44,11 +44,11 @@ private:
     std::vector<EndpointId> thirdEpList  = { 1, 2, 3 };
 
     std::vector<EndpointListStorage> kEndpointList = {
-        EndpointListStorage(0, CharSpan::fromCharString("On"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(0, "On"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(firstEpList.data(), firstEpList.size())),
-        EndpointListStorage(1, CharSpan::fromCharString("Off"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(1, "Off"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(secondEpList.data(), secondEpList.size())),
-        EndpointListStorage(2, CharSpan::fromCharString("Toggle"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(2, "Toggle"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(thirdEpList.data(), thirdEpList.size()))
     };
 

--- a/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
@@ -46,15 +46,12 @@ private:
                                             { .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Heavy"),
-                                                 .mode     = ModeHeavy,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Light"),
-                                                 .mode     = ModeLight,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsLight) }
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Heavy"_span, .mode = ModeHeavy, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Light"_span, .mode = ModeLight, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsLight) }
     };
 
     CHIP_ERROR Init() override;

--- a/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
@@ -48,18 +48,15 @@ private:
     ModeTagStructType modeTagsWhites[1]   = { { .value = to_underlying(ModeTag::kWhites) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[4] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Delicate"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Delicate"_span,
                                                  .mode     = ModeDelicate,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDelicate) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Heavy"),
-                                                 .mode     = ModeHeavy,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Whites"),
-                                                 .mode     = ModeWhites,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsWhites) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Heavy"_span, .mode = ModeHeavy, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Whites"_span, .mode = ModeWhites, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsWhites) },
     };
 
     CHIP_ERROR Init() override;

--- a/examples/all-clusters-app/all-clusters-common/include/microwave-oven-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/microwave-oven-mode.h
@@ -41,12 +41,10 @@ private:
     ModeTagStructType modeTagsDefrost[1] = { { .value = to_underlying(ModeTag::kDefrost) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[2] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Defrost"),
-                                                 .mode     = ModeDefrost,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDefrost) }
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Defrost"_span, .mode = ModeDefrost, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDefrost) }
     };
 
     CHIP_ERROR Init() override;

--- a/examples/all-clusters-app/all-clusters-common/include/oven-modes.h
+++ b/examples/all-clusters-app/all-clusters-common/include/oven-modes.h
@@ -55,31 +55,26 @@ private:
     ModeTagStructType ModeTagsProofing[1]        = { { .value = to_underlying(ModeTag::kProofing) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[9] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Bake"),
-                                                 .mode     = ModeBake,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsBake) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Bake"_span, .mode = ModeBake, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsBake) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection"_span,
                                                  .mode     = ModeConvection,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvection) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Grill"),
-                                                 .mode     = ModeGrill,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsGrill) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Roast"),
-                                                 .mode     = ModeRoast,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsRoast) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Clean"),
-                                                 .mode     = ModeClean,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsClean) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Bake"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Grill"_span, .mode = ModeGrill, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsGrill) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Roast"_span, .mode = ModeRoast, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsRoast) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Clean"_span, .mode = ModeClean, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsClean) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection Bake"_span,
                                                  .mode     = ModeConvectionBake,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionBake) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Roast"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection Roast"_span,
                                                  .mode     = ModeConvectionRoast,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionRoast) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Warming"),
-                                                 .mode     = ModeWarming,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsWarming) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Proofing"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Warming"_span, .mode = ModeWarming, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsWarming) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Proofing"_span,
                                                  .mode     = ModeProofing,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsProofing) },
     };

--- a/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
+++ b/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
@@ -43,15 +43,13 @@ private:
     ModeTagStructType ModeTagsMapping[1]  = { { .value = to_underlying(ModeTag::kMapping) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Idle"),
-                                                 .mode     = ModeIdle,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Cleaning"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Idle"_span, .mode = ModeIdle, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Cleaning"_span,
                                                  .mode     = ModeCleaning,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsCleaning) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Mapping"),
-                                                 .mode     = ModeMapping,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Mapping"_span, .mode = ModeMapping, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
     };
 
     CHIP_ERROR Init() override;
@@ -88,13 +86,11 @@ private:
                                            { .value = to_underlying(ModeTag::kDeepClean) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Vacuum"),
-                                                 .mode     = ModeVacuum,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVac) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Wash"),
-                                                 .mode     = ModeWash,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMop) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Deep clean"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Vacuum"_span, .mode = ModeVacuum, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVac) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Wash"_span, .mode = ModeWash, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMop) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Deep clean"_span,
                                                  .mode     = ModeDeepClean,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsBoost) },
     };

--- a/examples/all-clusters-app/all-clusters-common/include/tcc-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/tcc-mode.h
@@ -44,13 +44,12 @@ private:
     ModeTagStructType modeTagsTccRapidFreeze[1] = { { .value = to_underlying(ModeTag::kRapidFreeze) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Cool"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccNormal) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Cool"_span,
                                                  .mode     = ModeRapidCool,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccRapidCool) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Freeze"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Freeze"_span,
                                                  .mode     = ModeRapidFreeze,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccRapidFreeze) },
     };

--- a/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
@@ -39,7 +39,7 @@ void DishwasherModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Comma
     if (gDishwasherModeInstance->GetFailTransition())
     {
         response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-        response.statusText.SetValue(chip::CharSpan::fromCharString("Mode change not allowed due to device state"));
+        response.statusText.SetValue("Mode change not allowed due to device state"_span);
         return;
     }
 

--- a/examples/all-clusters-app/all-clusters-common/src/laundry-washer-controls-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/laundry-washer-controls-delegate-impl.cpp
@@ -23,10 +23,10 @@ using namespace chip;
 using namespace chip::app::Clusters::LaundryWasherControls;
 
 const CharSpan LaundryWasherControlDelegate::spinSpeedsNameOptions[] = {
-    CharSpan::fromCharString("Off"),
-    CharSpan::fromCharString("Low"),
-    CharSpan::fromCharString("Medium"),
-    CharSpan::fromCharString("High"),
+    "Off"_span,
+    "Low"_span,
+    "Medium"_span,
+    "High"_span,
 };
 
 const NumberOfRinsesEnum LaundryWasherControlDelegate::supportRinsesOptions[] = {

--- a/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
@@ -152,23 +152,23 @@ CHIP_ERROR ImmutableReplacementProductListManager::Next(ReplacementProductStruct
     {
     case 0: {
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kUpc);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("111112222233"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("111112222233"_span);
         break;
     case 1:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin8);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin8xxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin8xxx"_span);
         break;
     case 2:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kEan);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("4444455555666"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("4444455555666"_span);
         break;
     case 3:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin14);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin14xxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin14xxxxxxxx"_span);
         break;
     case 4:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kOem);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("oem20xxxxxxxxxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("oem20xxxxxxxxxxxxxxx"_span);
         break;
     default:
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
@@ -48,7 +48,7 @@ void RvcRunModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands:
         if (NewMode != RvcRunMode::ModeIdle && currentMode != RvcRunMode::ModeIdle)
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-            response.statusText.SetValue(chip::CharSpan::fromCharString("Change to a running mode is only allowed from idle"));
+            response.statusText.SetValue("Change to a running mode is only allowed from idle"_span);
             return;
         }
     }
@@ -161,8 +161,7 @@ void RvcCleanModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Command
         if (rvcRunCurrentMode != RvcRunMode::ModeIdle)
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-            response.statusText.SetValue(
-                chip::CharSpan::fromCharString("Cannot change the cleaning mode when the device is not in idle"));
+            response.statusText.SetValue("Cannot change the cleaning mode when the device is not in idle"_span);
             return;
         }
     }

--- a/examples/bridge-app/bridge-common/include/bridged-actions-stub.h
+++ b/examples/bridge-app/bridge-common/include/bridged-actions-stub.h
@@ -34,9 +34,9 @@ class ActionsDelegateImpl : public Delegate
 {
 private:
     std::vector<ActionStructStorage> kActionList = {
-        ActionStructStorage(0, CharSpan::fromCharString("TurnOnLight"), ActionTypeEnum::kScene, 0, 0, ActionStateEnum::kInactive),
-        ActionStructStorage(1, CharSpan::fromCharString("TurnOffLight"), ActionTypeEnum::kScene, 1, 0, ActionStateEnum::kInactive),
-        ActionStructStorage(2, CharSpan::fromCharString("ToggleLight"), ActionTypeEnum::kScene, 2, 0, ActionStateEnum::kInactive)
+        ActionStructStorage(0, "TurnOnLight"_span, ActionTypeEnum::kScene, 0, 0, ActionStateEnum::kInactive),
+        ActionStructStorage(1, "TurnOffLight"_span, ActionTypeEnum::kScene, 1, 0, ActionStateEnum::kInactive),
+        ActionStructStorage(2, "ToggleLight"_span, ActionTypeEnum::kScene, 2, 0, ActionStateEnum::kInactive)
     };
 
     std::vector<EndpointId> firstEpList  = { 1 };
@@ -44,11 +44,11 @@ private:
     std::vector<EndpointId> thirdEpList  = { 1, 2, 3 };
 
     std::vector<EndpointListStorage> kEndpointList = {
-        EndpointListStorage(0, CharSpan::fromCharString("On"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(0, "On"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(firstEpList.data(), firstEpList.size())),
-        EndpointListStorage(1, CharSpan::fromCharString("Off"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(1, "Off"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(secondEpList.data(), secondEpList.size())),
-        EndpointListStorage(2, CharSpan::fromCharString("Toggle"), EndpointListTypeEnum::kOther,
+        EndpointListStorage(2, "Toggle"_span, EndpointListTypeEnum::kOther,
                             DataModel::List<const EndpointId>(thirdEpList.data(), thirdEpList.size()))
     };
 

--- a/examples/camera-app/linux/include/clusters/chime/chime-manager.h
+++ b/examples/camera-app/linux/include/clusters/chime/chime-manager.h
@@ -39,9 +39,9 @@ private:
     using ChimeSoundStructType = chip::app::Clusters::Chime::Structs::ChimeSoundStruct::Type;
 
     const ChimeSoundStructType mChimeSounds[3] = {
-        ChimeSoundStructType{ .chimeID = 0, .name = chip::CharSpan::fromCharString("Basic Door Chime") },
-        ChimeSoundStructType{ .chimeID = 1, .name = chip::CharSpan::fromCharString("Enhanced Door Chime") },
-        ChimeSoundStructType{ .chimeID = 2, .name = chip::CharSpan::fromCharString("Star Wars Door Chime") },
+        ChimeSoundStructType{ .chimeID = 0, .name = "Basic Door Chime"_span },
+        ChimeSoundStructType{ .chimeID = 1, .name = "Enhanced Door Chime"_span },
+        ChimeSoundStructType{ .chimeID = 2, .name = "Star Wars Door Chime"_span },
     };
 };
 

--- a/examples/chef/common/chef-dishwasher-mode-delegate-impl.h
+++ b/examples/chef/common/chef-dishwasher-mode-delegate-impl.h
@@ -48,15 +48,12 @@ private:
                                             { .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Heavy"),
-                                                 .mode     = ModeHeavy,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Light"),
-                                                 .mode     = ModeLight,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsLight) }
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Heavy"_span, .mode = ModeHeavy, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Light"_span, .mode = ModeLight, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsLight) }
     };
 
     CHIP_ERROR Init() override;

--- a/examples/chef/common/chef-laundry-washer-controls-delegate-impl.cpp
+++ b/examples/chef/common/chef-laundry-washer-controls-delegate-impl.cpp
@@ -23,10 +23,10 @@ using namespace chip;
 using namespace chip::app::Clusters::LaundryWasherControls;
 
 const CharSpan LaundryWasherControlDelegate::spinSpeedsNameOptions[] = {
-    CharSpan::fromCharString("Off"),
-    CharSpan::fromCharString("Low"),
-    CharSpan::fromCharString("Medium"),
-    CharSpan::fromCharString("High"),
+    "Off"_span,
+    "Low"_span,
+    "Medium"_span,
+    "High"_span,
 };
 
 const NumberOfRinsesEnum LaundryWasherControlDelegate::supportRinsesOptions[] = {

--- a/examples/chef/common/chef-laundry-washer-mode.h
+++ b/examples/chef/common/chef-laundry-washer-mode.h
@@ -48,18 +48,15 @@ private:
     ModeTagStructType modeTagsWhites[1]   = { { .value = to_underlying(ModeTag::kWhites) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[4] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Delicate"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Delicate"_span,
                                                  .mode     = ModeDelicate,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDelicate) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Heavy"),
-                                                 .mode     = ModeHeavy,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Whites"),
-                                                 .mode     = ModeWhites,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsWhites) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Heavy"_span, .mode = ModeHeavy, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsHeavy) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Whites"_span, .mode = ModeWhites, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsWhites) },
     };
 
     CHIP_ERROR Init() override;

--- a/examples/chef/common/chef-rvc-mode-delegate.cpp
+++ b/examples/chef/common/chef-rvc-mode-delegate.cpp
@@ -57,7 +57,7 @@ void RvcRunModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands:
     if (NewMode == RvcRunMode::ModeMapping && currentMode != RvcRunMode::ModeIdle)
     {
         response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
-        response.statusText.SetValue(chip::CharSpan::fromCharString("Change to the mapping mode is only allowed from idle"));
+        response.statusText.SetValue("Change to the mapping mode is only allowed from idle"_span);
         return;
     }
 
@@ -218,7 +218,7 @@ void RvcCleanModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Command
     if (rvcRunCurrentMode == RvcRunMode::ModeCleaning)
     {
         response.status = to_underlying(RvcCleanMode::StatusCode::kCleaningInProgress);
-        response.statusText.SetValue(chip::CharSpan::fromCharString("Cannot change the cleaning mode during a clean"));
+        response.statusText.SetValue("Cannot change the cleaning mode during a clean"_span);
         return;
     }
 

--- a/examples/chef/common/chef-rvc-mode-delegate.h
+++ b/examples/chef/common/chef-rvc-mode-delegate.h
@@ -45,15 +45,13 @@ private:
     ModeTagStructType ModeTagsMapping[1]  = { { .value = to_underlying(ModeTag::kMapping) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Idle"),
-                                                 .mode     = ModeIdle,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Cleaning"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Idle"_span, .mode = ModeIdle, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Cleaning"_span,
                                                  .mode     = ModeCleaning,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsCleaning) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Mapping"),
-                                                 .mode     = ModeMapping,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Mapping"_span, .mode = ModeMapping, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
     };
 
     CHIP_ERROR Init() override;
@@ -90,13 +88,11 @@ private:
                                            { .value = to_underlying(ModeTag::kDeepClean) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Vacuum"),
-                                                 .mode     = ModeVacuum,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVac) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Wash"),
-                                                 .mode     = ModeWash,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMop) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Deep clean"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Vacuum"_span, .mode = ModeVacuum, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVac) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Wash"_span, .mode = ModeWash, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMop) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Deep clean"_span,
                                                  .mode     = ModeDeepClean,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsBoost) },
     };

--- a/examples/chef/common/clusters/channel/ChannelManager.cpp
+++ b/examples/chef/common/clusters/channel/ChannelManager.cpp
@@ -36,33 +36,33 @@ using namespace chip::Uint8;
 ChannelManager::ChannelManager()
 {
     ChannelInfoType abc;
-    abc.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KAAL"));
-    abc.callSign          = MakeOptional(chip::CharSpan::fromCharString("KAAL-TV"));
-    abc.name              = MakeOptional(chip::CharSpan::fromCharString("ABC"));
+    abc.affiliateCallSign = MakeOptional("KAAL"_span);
+    abc.callSign          = MakeOptional("KAAL-TV"_span);
+    abc.name              = MakeOptional("ABC"_span);
     abc.majorNumber       = static_cast<uint8_t>(6);
     abc.minorNumber       = static_cast<uint16_t>(0);
     mChannels.push_back(abc);
 
     ChannelInfoType pbs;
-    pbs.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    pbs.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    pbs.name              = MakeOptional(chip::CharSpan::fromCharString("PBS"));
+    pbs.affiliateCallSign = MakeOptional("KCTS"_span);
+    pbs.callSign          = MakeOptional("KCTS-TV"_span);
+    pbs.name              = MakeOptional("PBS"_span);
     pbs.majorNumber       = static_cast<uint8_t>(9);
     pbs.minorNumber       = static_cast<uint16_t>(1);
     mChannels.push_back(pbs);
 
     ChannelInfoType pbsKids;
-    pbsKids.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    pbsKids.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    pbsKids.name              = MakeOptional(chip::CharSpan::fromCharString("PBS Kids"));
+    pbsKids.affiliateCallSign = MakeOptional("KCTS"_span);
+    pbsKids.callSign          = MakeOptional("KCTS-TV"_span);
+    pbsKids.name              = MakeOptional("PBS Kids"_span);
     pbsKids.majorNumber       = static_cast<uint8_t>(9);
     pbsKids.minorNumber       = static_cast<uint16_t>(2);
     mChannels.push_back(pbsKids);
 
     ChannelInfoType worldChannel;
-    worldChannel.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    worldChannel.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    worldChannel.name              = MakeOptional(chip::CharSpan::fromCharString("World Channel"));
+    worldChannel.affiliateCallSign = MakeOptional("KCTS"_span);
+    worldChannel.callSign          = MakeOptional("KCTS-TV"_span);
+    worldChannel.name              = MakeOptional("World Channel"_span);
     worldChannel.majorNumber       = static_cast<uint8_t>(9);
     worldChannel.minorNumber       = static_cast<uint16_t>(3);
     mChannels.push_back(worldChannel);
@@ -71,40 +71,40 @@ ChannelManager::ChannelManager()
     mCurrentChannel      = mChannels[mCurrentChannelIndex];
 
     ProgramType program1;
-    program1.identifier = chip::CharSpan::fromCharString("progid-abc1");
+    program1.identifier = "progid-abc1"_span;
     program1.channel    = abc;
-    program1.title      = chip::CharSpan::fromCharString("ABC Title1");
-    program1.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle1"));
+    program1.title      = "ABC Title1"_span;
+    program1.subtitle   = MakeOptional("My Program Subtitle1"_span);
     program1.startTime  = 0;
     program1.endTime    = 30 * 60;
 
     mPrograms.push_back(program1);
 
     ProgramType program_pbs1;
-    program_pbs1.identifier = chip::CharSpan::fromCharString("progid-pbs1");
+    program_pbs1.identifier = "progid-pbs1"_span;
     program_pbs1.channel    = pbs;
-    program_pbs1.title      = chip::CharSpan::fromCharString("PBS Title1");
-    program_pbs1.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle1"));
+    program_pbs1.title      = "PBS Title1"_span;
+    program_pbs1.subtitle   = MakeOptional("My Program Subtitle1"_span);
     program_pbs1.startTime  = 0;
     program_pbs1.endTime    = 30 * 60;
 
     mPrograms.push_back(program_pbs1);
 
     ProgramType program2;
-    program2.identifier = chip::CharSpan::fromCharString("progid-abc2");
+    program2.identifier = "progid-abc2"_span;
     program2.channel    = abc;
-    program2.title      = chip::CharSpan::fromCharString("My Program Title2");
-    program2.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle2"));
+    program2.title      = "My Program Title2"_span;
+    program2.subtitle   = MakeOptional("My Program Subtitle2"_span);
     program2.startTime  = 30 * 60;
     program2.endTime    = 60 * 60;
 
     mPrograms.push_back(program2);
 
     ProgramType program3;
-    program3.identifier = chip::CharSpan::fromCharString("progid-abc3");
+    program3.identifier = "progid-abc3"_span;
     program3.channel    = abc;
-    program3.title      = chip::CharSpan::fromCharString("My Program Title3");
-    program3.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle3"));
+    program3.title      = "My Program Title3"_span;
+    program3.subtitle   = MakeOptional("My Program Subtitle3"_span);
     program3.startTime  = 0;
     program3.endTime    = 60 * 60;
 
@@ -125,9 +125,9 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
 CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
 {
     LineupInfoType lineup;
-    lineup.operatorName   = chip::CharSpan::fromCharString("Comcast");
-    lineup.lineupName     = MakeOptional(chip::CharSpan::fromCharString("Comcast King County"));
-    lineup.postalCode     = MakeOptional(chip::CharSpan::fromCharString("98052"));
+    lineup.operatorName   = "Comcast"_span;
+    lineup.lineupName     = MakeOptional("Comcast King County"_span);
+    lineup.postalCode     = MakeOptional("98052"_span);
     lineup.lineupInfoType = LineupInfoTypeEnum::kMso;
 
     return aEncoder.Encode(lineup);
@@ -180,7 +180,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     else
     {
         response.status      = StatusEnum::kSuccess;
-        response.data        = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data        = chip::MakeOptional("data response"_span);
         mCurrentChannel      = mChannels[iMatchedChannel];
         mCurrentChannelIndex = iMatchedChannel;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
@@ -244,8 +244,8 @@ void ChannelManager::HandleGetProgramGuide(CommandResponseHelper<ProgramGuideRes
 
     // PageTokenType paging;
     // paging.limit  = MakeOptional(static_cast<uint16_t>(10));
-    // paging.after  = MakeOptional(chip::CharSpan::fromCharString("after-token"));
-    // paging.before = MakeOptional(chip::CharSpan::fromCharString("before-token"));
+    // paging.after  = MakeOptional("after-token"_span);
+    // paging.before = MakeOptional("before-token"_span);
 
     // ChannelPagingStructType channelPaging;
     // channelPaging.nextToken = MakeOptional<DataModel::Nullable<Structs::PageTokenStruct::Type>>(paging);

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -117,7 +117,7 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
     uint16_t userIndex(1);
     chip::FabricIndex creator(1);
     chip::FabricIndex modifier(1);
-    const chip::CharSpan userName = chip::CharSpan::fromCharString("user1"); // default
+    const chip::CharSpan userName = "user1"_span;                            // default
                                                                              // username
     uint32_t uniqueId         = 0xFFFFFFFF;                                  // null
     UserStatusEnum userStatus = UserStatusEnum::kOccupiedEnabled;

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -120,7 +120,7 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
     chip::FabricIndex creator(1);
     chip::FabricIndex modifier(1);
     const chip::CharSpan userName{ "user1"_span }; // default username
-    uint32_t uniqueId         = 0xFFFFFFFF;       // null
+    uint32_t uniqueId         = 0xFFFFFFFF;        // null
     UserStatusEnum userStatus = UserStatusEnum::kOccupiedEnabled;
     // Set to programming user instead of unrestrict user to perform
     // priviledged function

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -117,9 +117,9 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
     uint16_t userIndex(1);
     chip::FabricIndex creator(1);
     chip::FabricIndex modifier(1);
-    const chip::CharSpan userName = "user1"_span;                            // default
-                                                                             // username
-    uint32_t uniqueId         = 0xFFFFFFFF;                                  // null
+    const chip::CharSpan userName = "user1"_span; // default
+                                                  // username
+    uint32_t uniqueId         = 0xFFFFFFFF;       // null
     UserStatusEnum userStatus = UserStatusEnum::kOccupiedEnabled;
     // Set to programming user instead of unrestrict user to perform
     // priviledged function

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 #include <app/util/config.h>
+#include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER
@@ -24,6 +25,7 @@
 #include <algorithm>
 #include <iostream>
 
+using namespace chip::literals;
 using chip::to_underlying;
 
 LockManager LockManager::instance;
@@ -117,8 +119,7 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
     uint16_t userIndex(1);
     chip::FabricIndex creator(1);
     chip::FabricIndex modifier(1);
-    const chip::CharSpan userName = "user1"_span; // default
-                                                  // username
+    const chip::CharSpan userName{ "user1"_span }; // default username
     uint32_t uniqueId         = 0xFFFFFFFF;       // null
     UserStatusEnum userStatus = UserStatusEnum::kOccupiedEnabled;
     // Set to programming user instead of unrestrict user to perform

--- a/examples/chef/common/clusters/media-playback/MediaPlaybackManager.cpp
+++ b/examples/chef/common/clusters/media-playback/MediaPlaybackManager.cpp
@@ -145,7 +145,7 @@ void MediaPlaybackManager::HandlePlay(CommandResponseHelper<Commands::PlaybackRe
     TEMPORARY_RETURN_IGNORED HandleSetPlaybackSpeed(1);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -156,7 +156,7 @@ void MediaPlaybackManager::HandlePause(CommandResponseHelper<Commands::PlaybackR
     TEMPORARY_RETURN_IGNORED HandleSetPlaybackSpeed(0);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -169,7 +169,7 @@ void MediaPlaybackManager::HandleStop(CommandResponseHelper<Commands::PlaybackRe
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -183,7 +183,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
     {
         // if already at max speed, return error
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSpeedOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
@@ -199,7 +199,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
     TEMPORARY_RETURN_IGNORED HandleSetPlaybackSpeed(playbackSpeed);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -212,7 +212,7 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -226,7 +226,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     {
         // if already at max speed in reverse, return error
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSpeedOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
@@ -242,7 +242,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     TEMPORARY_RETURN_IGNORED HandleSetPlaybackSpeed(playbackSpeed);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -257,7 +257,7 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -271,7 +271,7 @@ void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::Pla
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -282,7 +282,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
     if (positionMilliseconds > mDuration)
     {
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSeekOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
     }
@@ -292,7 +292,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
         MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSuccess;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
     }
@@ -306,7 +306,7 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -317,7 +317,7 @@ void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::Playb
     MatterReportingAttributeChangeCallback(mEndpoint, MediaPlayback::Id, MediaPlayback::Attributes::SampledPosition::Id);
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/chef/common/clusters/microwave-oven-mode/chef-microwave-oven-mode.h
+++ b/examples/chef/common/clusters/microwave-oven-mode/chef-microwave-oven-mode.h
@@ -41,12 +41,10 @@ private:
     ModeTagStructType ModeTagsDefrost[1] = { { .value = to_underlying(ModeTag::kDefrost) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[2] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Defrost"),
-                                                 .mode     = ModeDefrost,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsDefrost) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Defrost"_span, .mode = ModeDefrost, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsDefrost) },
     };
 
 public:

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
@@ -55,31 +55,26 @@ private:
     ModeTagStructType ModeTagsProofing[1]        = { { .value = to_underlying(ModeTag::kProofing) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[9] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Bake"),
-                                                 .mode     = ModeBake,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsBake) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Bake"_span, .mode = ModeBake, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsBake) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection"_span,
                                                  .mode     = ModeConvection,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvection) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Grill"),
-                                                 .mode     = ModeGrill,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsGrill) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Roast"),
-                                                 .mode     = ModeRoast,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsRoast) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Clean"),
-                                                 .mode     = ModeClean,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsClean) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Bake"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Grill"_span, .mode = ModeGrill, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsGrill) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Roast"_span, .mode = ModeRoast, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsRoast) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Clean"_span, .mode = ModeClean, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsClean) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection Bake"_span,
                                                  .mode     = ModeConvectionBake,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionBake) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Roast"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Convection Roast"_span,
                                                  .mode     = ModeConvectionRoast,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionRoast) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Warming"),
-                                                 .mode     = ModeWarming,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsWarming) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Proofing"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Warming"_span, .mode = ModeWarming, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsWarming) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Proofing"_span,
                                                  .mode     = ModeProofing,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsProofing) },
     };

--- a/examples/chef/common/clusters/refrigerator-and-temperature-controlled-cabinet-mode/tcc-mode.h
+++ b/examples/chef/common/clusters/refrigerator-and-temperature-controlled-cabinet-mode/tcc-mode.h
@@ -44,13 +44,12 @@ private:
     ModeTagStructType modeTagsTccRapidFreeze[1] = { { .value = to_underlying(ModeTag::kRapidFreeze) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Cool"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccNormal) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Cool"_span,
                                                  .mode     = ModeRapidCool,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccRapidCool) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Freeze"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Freeze"_span,
                                                  .mode     = ModeRapidFreeze,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsTccRapidFreeze) },
     };

--- a/examples/chef/common/clusters/resource-monitoring/chef-resource-monitoring-delegates.cpp
+++ b/examples/chef/common/clusters/resource-monitoring/chef-resource-monitoring-delegates.cpp
@@ -285,23 +285,23 @@ CHIP_ERROR ImmutableReplacementProductListManager::Next(ReplacementProductStruct
     {
     case 0:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kUpc);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("111112222233"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("111112222233"_span);
         break;
     case 1:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin8);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin8xxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin8xxx"_span);
         break;
     case 2:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kEan);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("4444455555666"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("4444455555666"_span);
         break;
     case 3:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin14);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin14xxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin14xxxxxxxx"_span);
         break;
     case 4:
         item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kOem);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("oem20xxxxxxxxxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("oem20xxxxxxxxxxxxxxx"_span);
         break;
     default:
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -64,14 +64,14 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     NavigateTargetResponseType response;
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("error"));
+        response.data   = chip::MakeOptional("error"_span);
         response.status = StatusEnum::kTargetNotFound;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -19,12 +19,14 @@
 #ifdef MATTER_DM_PLUGIN_TARGET_NAVIGATOR_SERVER
 #include "TargetNavigatorManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <lib/support/Span.h>
 
 #include <list>
 #include <string>
 
 using namespace chip::app;
 using namespace chip::app::Clusters::TargetNavigator;
+using namespace chip::literals;
 
 using chip::CharSpan;
 using chip::app::AttributeValueEncoder;

--- a/examples/chef/common/clusters/water-heater-mode/chef-water-heater-mode.h
+++ b/examples/chef/common/clusters/water-heater-mode/chef-water-heater-mode.h
@@ -40,10 +40,10 @@ static const detail::Structs::ModeTagStruct::Type modeTagsOff[]    = { { .value 
 static const detail::Structs::ModeTagStruct::Type modeTagsManual[] = { { .value = to_underlying(ModeTag::kManual) } };
 
 static const detail::Structs::ModeOptionStruct::Type kModeOptions[] = {
-    detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Off"),
+    detail::Structs::ModeOptionStruct::Type{ .label    = "Off"_span,
                                              .mode     = ModeOff,
                                              .modeTags = DataModel::List<const detail::Structs::ModeTagStruct::Type>(modeTagsOff) },
-    detail::Structs::ModeOptionStruct::Type{ .label = CharSpan::fromCharString("Manual"),
+    detail::Structs::ModeOptionStruct::Type{ .label = "Manual"_span,
                                              .mode  = ModeManual,
                                              .modeTags =
                                                  DataModel::List<const detail::Structs::ModeTagStruct::Type>(modeTagsManual) },

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -75,7 +75,7 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
             chip::Tracing::Register(mJsonBackend);
         }
 #if ENABLE_PERFETTO_TRACING
-        else if (value.data_equal(CharSpan::fromCharString("perfetto")))
+        else if (value.data_equal("perfetto"_span))
         {
             chip::Tracing::Perfetto::Initialize(perfetto::kSystemBackend);
             chip::Tracing::Perfetto::RegisterEventTrackingStorage();

--- a/examples/energy-gateway-app/commodity-tariff/include/CommodityTariffSamples.h
+++ b/examples/energy-gateway-app/commodity-tariff/include/CommodityTariffSamples.h
@@ -144,11 +144,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 10,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                  .price      = MakeOptional(static_cast<int64_t>(15)),
-                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
+                                                                              .price      = MakeOptional(static_cast<int64_t>(15)),
+                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -161,11 +161,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 20,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                  .price      = MakeOptional(static_cast<int64_t>(20)),
-                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                              .price      = MakeOptional(static_cast<int64_t>(20)),
+                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -279,11 +279,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 10,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                  .price      = MakeOptional(static_cast<int64_t>(15)),
-                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
+                                                                              .price      = MakeOptional(static_cast<int64_t>(15)),
+                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -296,11 +296,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 20,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                  .price      = MakeOptional(static_cast<int64_t>(20)),
-                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                              .price      = MakeOptional(static_cast<int64_t>(20)),
+                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -313,11 +313,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 30,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                  .price      = MakeOptional(static_cast<int64_t>(50)),
-                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                              .price      = MakeOptional(static_cast<int64_t>(50)),
+                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(true),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{

--- a/examples/energy-gateway-app/commodity-tariff/include/CommodityTariffSamples.h
+++ b/examples/energy-gateway-app/commodity-tariff/include/CommodityTariffSamples.h
@@ -32,8 +32,8 @@ namespace Sample1 {
 // Tariff Information
 static inline Structs::TariffInformationStruct::Type TariffInfo()
 {
-    return { .tariffLabel  = DataModel::MakeNullable(CharSpan::fromCharString("Full Tariff One")),
-             .providerName = DataModel::MakeNullable(CharSpan::fromCharString("Default Provider")),
+    return { .tariffLabel  = DataModel::MakeNullable("Full Tariff One"_span),
+             .providerName = DataModel::MakeNullable("Default Provider"_span),
              .currency     = MakeOptional(
                  DataModel::MakeNullable<Globals::Structs::CurrencyStruct::Type>({ .currency = 120, .decimalPoints = 0 })),
              .blockMode = DataModel::MakeNullable(static_cast<BlockModeEnum>(0)) };
@@ -144,11 +144,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 10,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                              .price      = MakeOptional(static_cast<int64_t>(15)),
-                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
+                                                                  .price      = MakeOptional(static_cast<int64_t>(15)),
+                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -156,16 +156,16 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
           .apparentPowerThreshold = MakeOptional(120),
           .powerThresholdSource   = static_cast<Globals::PowerThresholdSourceEnum>(0) }),
       .threshold      = NullOptional,
-      .label          = MakeOptional(DataModel::MakeNullable(CharSpan::fromCharString("Tariff Component 1"))),
+      .label          = MakeOptional(DataModel::MakeNullable("Tariff Component 1"_span)),
       .predicted      = MakeOptional(false) },
     { .tariffComponentID = 20,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                              .price      = MakeOptional(static_cast<int64_t>(20)),
-                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                  .price      = MakeOptional(static_cast<int64_t>(20)),
+                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -173,7 +173,7 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
           .apparentPowerThreshold = MakeOptional(240),
           .powerThresholdSource   = static_cast<Globals::PowerThresholdSourceEnum>(0) }),
       .threshold      = NullOptional,
-      .label          = MakeOptional(DataModel::MakeNullable(CharSpan::fromCharString("Tariff Component 2"))),
+      .label          = MakeOptional(DataModel::MakeNullable("Tariff Component 2"_span)),
       .predicted      = MakeOptional(false) }
 };
 
@@ -189,19 +189,19 @@ static const uint32_t period5DayEntries[] = { 30 };
 static const uint32_t period5Components[] = { 10 };
 
 static inline Structs::TariffPeriodStruct::Type TariffPeriods[] = {
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 1")),
+    { .label              = DataModel::MakeNullable("Period 1"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period1DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period1Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 2")),
+    { .label              = DataModel::MakeNullable("Period 2"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period2DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period2Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 3")),
+    { .label              = DataModel::MakeNullable("Period 3"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period3DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period3Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 4")),
+    { .label              = DataModel::MakeNullable("Period 4"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period4DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period4Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 5")),
+    { .label              = DataModel::MakeNullable("Period 5"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period5DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period5Components) }
 };
@@ -214,8 +214,8 @@ namespace Sample2 {
 // Tariff Information
 static inline Structs::TariffInformationStruct::Type TariffInfo()
 {
-    return { .tariffLabel  = DataModel::MakeNullable(CharSpan::fromCharString("Full Tariff Two")),
-             .providerName = DataModel::MakeNullable(CharSpan::fromCharString("Example Provider")),
+    return { .tariffLabel  = DataModel::MakeNullable("Full Tariff Two"_span),
+             .providerName = DataModel::MakeNullable("Example Provider"_span),
              .currency =
                  MakeOptional(DataModel::Nullable<Globals::Structs::CurrencyStruct::Type>({ .currency = 200, .decimalPoints = 1 })),
              .blockMode = DataModel::MakeNullable(static_cast<BlockModeEnum>(1)) };
@@ -279,11 +279,11 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
     { .tariffComponentID = 10,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                              .price      = MakeOptional(static_cast<int64_t>(15)),
-                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
+                                                                  .price      = MakeOptional(static_cast<int64_t>(15)),
+                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(1)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -291,16 +291,16 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
           .apparentPowerThreshold = MakeOptional(120),
           .powerThresholdSource   = static_cast<Globals::PowerThresholdSourceEnum>(0) }),
       .threshold      = DataModel::Nullable<int64_t>(120),
-      .label          = MakeOptional(DataModel::MakeNullable(CharSpan::fromCharString("Tariff Component 1"))),
+      .label          = MakeOptional(DataModel::MakeNullable("Tariff Component 1"_span)),
       .predicted      = MakeOptional(false) },
     { .tariffComponentID = 20,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                              .price      = MakeOptional(static_cast<int64_t>(20)),
-                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                  .price      = MakeOptional(static_cast<int64_t>(20)),
+                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(false),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -308,16 +308,16 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
           .apparentPowerThreshold = MakeOptional(240),
           .powerThresholdSource   = static_cast<Globals::PowerThresholdSourceEnum>(0) }),
       .threshold      = DataModel::Nullable<int64_t>(240),
-      .label          = MakeOptional(DataModel::MakeNullable(CharSpan::fromCharString("Tariff Component 2"))),
+      .label          = MakeOptional(DataModel::MakeNullable("Tariff Component 2"_span)),
       .predicted      = MakeOptional(false) },
     { .tariffComponentID = 30,
       .price             = MakeOptional(
           DataModel::Nullable<Structs::TariffPriceStruct::Type>({ .priceType  = static_cast<Globals::TariffPriceTypeEnum>(0),
-                                                                              .price      = MakeOptional(static_cast<int64_t>(50)),
-                                                                              .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
+                                                                  .price      = MakeOptional(static_cast<int64_t>(50)),
+                                                                  .priceLevel = MakeOptional(static_cast<int16_t>(0)) })),
       .friendlyCredit = MakeOptional(true),
       .auxiliaryLoad  = MakeOptional(Structs::AuxiliaryLoadSwitchSettingsStruct::Type{
-           .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
+          .number = 1, .requiredState = static_cast<AuxiliaryLoadSettingEnum>(0) }),
       .peakPeriod =
           MakeOptional(Structs::PeakPeriodStruct::Type{ .severity = static_cast<PeakPeriodSeverityEnum>(1), .peakPeriod = 1 }),
       .powerThreshold = MakeOptional(Globals::Structs::PowerThresholdStruct::Type{
@@ -325,7 +325,7 @@ static inline Structs::TariffComponentStruct::Type TariffComponents[] = {
           .apparentPowerThreshold = MakeOptional(320),
           .powerThresholdSource   = static_cast<Globals::PowerThresholdSourceEnum>(0) }),
       .threshold      = DataModel::Nullable<int64_t>(320),
-      .label          = MakeOptional(DataModel::MakeNullable(CharSpan::fromCharString("Tariff Component 3"))),
+      .label          = MakeOptional(DataModel::MakeNullable("Tariff Component 3"_span)),
       .predicted      = MakeOptional(true) }
 };
 
@@ -338,13 +338,13 @@ static const uint32_t period3Components[] = { 30 };
 
 // Tariff Periods
 static inline Structs::TariffPeriodStruct::Type TariffPeriods[] = {
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 1")),
+    { .label              = DataModel::MakeNullable("Period 1"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period1DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period1Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 2")),
+    { .label              = DataModel::MakeNullable("Period 2"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period2DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period2Components) },
-    { .label              = DataModel::MakeNullable(CharSpan::fromCharString("Period 3")),
+    { .label              = DataModel::MakeNullable("Period 3"_span),
       .dayEntryIDs        = DataModel::List<const uint32_t>(period3DayEntries),
       .tariffComponentIDs = DataModel::List<const uint32_t>(period3Components) }
 };

--- a/examples/energy-gateway-app/meter-identification/src/MeterIdentificationEventTriggers.cpp
+++ b/examples/energy-gateway-app/meter-identification/src/MeterIdentificationEventTriggers.cpp
@@ -54,15 +54,15 @@ private:
 
     const DataPresets_s TestsDataPresets[kMaxPresetItems] = {
         { .meterType         = DataModel::MakeNullable(MeterTypeEnum::kUtility),
-          .pointOfDelivery   = DataModel::MakeNullable(CharSpan::fromCharString("Test delivery point")),
-          .meterSerialNumber = DataModel::MakeNullable(CharSpan::fromCharString("TST-123456789")),
-          .protocolVersion   = DataModel::MakeNullable(CharSpan::fromCharString("1.2.3")),
+          .pointOfDelivery   = DataModel::MakeNullable("Test delivery point"_span),
+          .meterSerialNumber = DataModel::MakeNullable("TST-123456789"_span),
+          .protocolVersion   = DataModel::MakeNullable("1.2.3"_span),
           .powerThreshold    = DataModel::MakeNullable(Globals::Structs::PowerThresholdStruct::Type(
               { Optional<int64_t>(2400000), Optional<int64_t>(120), Globals::PowerThresholdSourceEnum::kContract })) },
         { .meterType         = DataModel::MakeNullable(MeterTypeEnum::kPrivate),
-          .pointOfDelivery   = DataModel::MakeNullable(CharSpan::fromCharString("New delivery point")),
-          .meterSerialNumber = DataModel::MakeNullable(CharSpan::fromCharString("NEW-987654321")),
-          .protocolVersion   = DataModel::MakeNullable(CharSpan::fromCharString("3.4.5")),
+          .pointOfDelivery   = DataModel::MakeNullable("New delivery point"_span),
+          .meterSerialNumber = DataModel::MakeNullable("NEW-987654321"_span),
+          .protocolVersion   = DataModel::MakeNullable("3.4.5"_span),
           .powerThreshold    = DataModel::MakeNullable(Globals::Structs::PowerThresholdStruct::Type(
               { Optional<int64_t>(4800000), Optional<int64_t>(240), Globals::PowerThresholdSourceEnum::kRegulator })) }
     };

--- a/examples/energy-management/device-energy-management/include/device-energy-management-modes.h
+++ b/examples/energy-management/device-energy-management/include/device-energy-management-modes.h
@@ -50,22 +50,22 @@ private:
                                                                 { .value = to_underlying(ModeTag::kGridOptimization) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[5] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("No energy management (forecast only)"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "No energy management (forecast only)"_span,
                                                  .mode     = kModeNoOptimization,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsNoOptimization) },
-        detail::Structs::ModeOptionStruct::Type{ .label = CharSpan::fromCharString("Device optimizes (no local or grid control)"),
+        detail::Structs::ModeOptionStruct::Type{ .label = "Device optimizes (no local or grid control)"_span,
                                                  .mode  = kModeDeviceOnlyOptimization,
                                                  .modeTags =
                                                      DataModel::List<const ModeTagStructType>(ModeTagsDeviceOnlyOptimization) },
-        detail::Structs::ModeOptionStruct::Type{ .label = CharSpan::fromCharString("Optimized within building"),
+        detail::Structs::ModeOptionStruct::Type{ .label = "Optimized within building"_span,
                                                  .mode  = kModeDeviceAndLocalOptimization,
                                                  .modeTags =
                                                      DataModel::List<const ModeTagStructType>(ModeTagsDeviceAndLocalOptimization) },
-        detail::Structs::ModeOptionStruct::Type{ .label = CharSpan::fromCharString("Optimized for grid"),
+        detail::Structs::ModeOptionStruct::Type{ .label = "Optimized for grid"_span,
                                                  .mode  = kModeDeviceAndGridOptimization,
                                                  .modeTags =
                                                      DataModel::List<const ModeTagStructType>(ModeTagsDeviceAndGridOptimization) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Optimized for grid and building"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Optimized for grid and building"_span,
                                                  .mode     = kModeAllOptimization,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsAllOptimization) },
 

--- a/examples/evse-app/evse-common/include/energy-evse-modes.h
+++ b/examples/evse-app/evse-common/include/energy-evse-modes.h
@@ -47,16 +47,15 @@ private:
     };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[4] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Manual"),
-                                                 .mode     = kModeManual,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsManual) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Auto-scheduled"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Manual"_span, .mode = kModeManual, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsManual) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Auto-scheduled"_span,
                                                  .mode     = kModeTimeOfUse,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsTimeOfUse) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Solar"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Solar"_span,
                                                  .mode     = kModeSolarCharging,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsSolarCharging) },
-        detail::Structs::ModeOptionStruct::Type{ .label = CharSpan::fromCharString("Auto-scheduled with Solar charging"),
+        detail::Structs::ModeOptionStruct::Type{ .label = "Auto-scheduled with Solar charging"_span,
                                                  .mode  = kModeTimeOfUseAndSolarCharging,
                                                  .modeTags =
                                                      DataModel::List<const ModeTagStructType>(ModeTagsTimeOfUseAndSolarCharging) },

--- a/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
+++ b/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
@@ -111,7 +111,7 @@ CHIP_ERROR EVSEManufacturer::Init(chip::EndpointId powerSourceEndpointId)
  *
  *
  * If the vehicle ID can be retrieved (e.g. over Powerline)
- *   dg->HwSetVehicleID(CharSpan::fromCharString("TEST_VEHICLE_123456789"));
+ *   dg->HwSetVehicleID("TEST_VEHICLE_123456789"_span);
  *
  *
  * If the EVSE has an RFID sensor, the RFID value read can cause an event to be sent
@@ -458,7 +458,7 @@ CHIP_ERROR EVSEManufacturer::InitializePowerSourceCluster(chip::EndpointId endpo
 
     status = PowerSource::Attributes::WiredCurrentType::Set(endpointId, PowerSource::WiredCurrentTypeEnum::kAc);
     VerifyOrReturnError(status == Protocols::InteractionModel::Status::Success, CHIP_ERROR_INTERNAL);
-    status = PowerSource::Attributes::Description::Set(endpointId, CharSpan::fromCharString("Primary Mains Power"));
+    status = PowerSource::Attributes::Description::Set(endpointId, "Primary Mains Power"_span);
     VerifyOrReturnError(status == Protocols::InteractionModel::Status::Success, CHIP_ERROR_INTERNAL);
 
     chip::EndpointId endpointArray[] = { endpointId };

--- a/examples/jf-admin-app/linux/JFADatastoreSync.cpp
+++ b/examples/jf-admin-app/linux/JFADatastoreSync.cpp
@@ -133,7 +133,7 @@ public:
                     // Invoke Groups:AddGroup on the device's endpoint
                     chip::app::Clusters::Groups::Commands::AddGroup::Type addGroup;
                     addGroup.groupID   = cbContext->objectToWrite.groupID;
-                    addGroup.groupName = chip::CharSpan::fromCharString("GroupName");
+                    addGroup.groupName = "GroupName"_span;
 
                     chip::Controller::ClusterBase groupsCluster(exchangeMgr, sessionHandle, cbContext->objectToWrite.endpointID);
 

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -178,7 +178,7 @@ void JFAManager::HandleCommissioningCompleteEvent()
                 // Uses internal method that bypasses CAT restrictions since JFA setup needs both Admin and Anchor CATs
                 Clusters::JointFabricDatastore::Commands::AddGroup::DecodableType addGroupCommandData;
                 addGroupCommandData.groupID       = 0;
-                addGroupCommandData.friendlyName  = CharSpan::fromCharString("Default JFA Group");
+                addGroupCommandData.friendlyName  = "Default JFA Group"_span;
                 addGroupCommandData.groupKeySetID = 0;
                 addGroupCommandData.groupCAT      = kAdminCATIdentifier; // Use Admin CAT for default group
                 addGroupCommandData.groupCATVersion.SetNonNull(1);
@@ -191,7 +191,7 @@ void JFAManager::HandleCommissioningCompleteEvent()
 
                 Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type newAdmin;
                 newAdmin.nodeID       = nodeId;
-                newAdmin.friendlyName = CharSpan::fromCharString("Default JFA Admin");
+                newAdmin.friendlyName = "Default JFA Admin"_span;
                 newAdmin.vendorID     = vendorId;
                 newAdmin.icac         = ByteSpan(mICACBuffer, mICACBufferLen);
 

--- a/examples/microwave-oven-app/microwave-oven-common/include/microwave-oven-device.h
+++ b/examples/microwave-oven-app/microwave-oven-common/include/microwave-oven-device.h
@@ -255,12 +255,10 @@ private:
     ModeTagStructType modeTagsDefrost[1] = { { .value = to_underlying(MicrowaveOvenMode::ModeTag::kDefrost) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[2] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = kModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Defrost"),
-                                                 .mode     = kModeDefrost,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDefrost) }
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = kModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Defrost"_span, .mode = kModeDefrost, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDefrost) }
     };
 
     // Operational States

--- a/examples/placeholder/linux/resource-monitoring-delegates.cpp
+++ b/examples/placeholder/linux/resource-monitoring-delegates.cpp
@@ -116,23 +116,23 @@ CHIP_ERROR ImmutableReplacementProductListManager::Next(ReplacementProductStruct
     {
     case 0: {
         TEMPORARY_RETURN_IGNORED item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kUpc);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("111112222233"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("111112222233"_span);
         break;
     case 1:
         TEMPORARY_RETURN_IGNORED item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin8);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin8xxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin8xxx"_span);
         break;
     case 2:
         TEMPORARY_RETURN_IGNORED item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kEan);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("4444455555666"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("4444455555666"_span);
         break;
     case 3:
         TEMPORARY_RETURN_IGNORED item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kGtin14);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("gtin14xxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("gtin14xxxxxxxx"_span);
         break;
     case 4:
         TEMPORARY_RETURN_IGNORED item.SetProductIdentifierType(ResourceMonitoring::ProductIdentifierTypeEnum::kOem);
-        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue(CharSpan::fromCharString("oem20xxxxxxxxxxxxxxx"));
+        TEMPORARY_RETURN_IGNORED item.SetProductIdentifierValue("oem20xxxxxxxxxxxxxxx"_span);
         break;
     default:
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/refrigerator-app/refrigerator-common/src/static-supported-temperature-levels.cpp
+++ b/examples/refrigerator-app/refrigerator-common/src/static-supported-temperature-levels.cpp
@@ -25,9 +25,7 @@ using namespace chip::app::Clusters::TemperatureControl;
 using chip::Protocols::InteractionModel::Status;
 
 // TODO: Configure your options for each endpoint
-CharSpan AppSupportedTemperatureLevelsDelegate::temperatureLevelOptions[] = { CharSpan::fromCharString("Hot"),
-                                                                              CharSpan::fromCharString("Warm"),
-                                                                              CharSpan::fromCharString("Freezing") };
+CharSpan AppSupportedTemperatureLevelsDelegate::temperatureLevelOptions[] = { "Hot"_span, "Warm"_span, "Freezing"_span };
 
 const AppSupportedTemperatureLevelsDelegate::EndpointPair AppSupportedTemperatureLevelsDelegate::supportedOptionsByEndpoints
     [MATTER_DM_TEMPERATURE_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT] = {

--- a/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
+++ b/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
@@ -45,13 +45,12 @@ private:
                                                  { .value = to_underlying(ModeTag::kRapidFreeze) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
-                                                 .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Cool"),
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Normal"_span, .mode = ModeNormal, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Cool"_span,
                                                  .mode     = ModeRapidCool,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsRapidCool) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Freeze"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Rapid Freeze"_span,
                                                  .mode     = ModeRapidFreeze,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsRapidFreeze) },
     };

--- a/examples/refrigerator-app/silabs/src/refrigerator-and-temperature-controlled-cabinet-mode.cpp
+++ b/examples/refrigerator-app/silabs/src/refrigerator-and-temperature-controlled-cabinet-mode.cpp
@@ -39,7 +39,7 @@ void RefrigeratorAndTemperatureControlledCabinetModeDelegate::HandleChangeToMode
     if (gRefrigeratorAndTemperatureControlledCabinetModeDelegate == nullptr)
     {
         response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
-        response.statusText.SetValue(chip::CharSpan::fromCharString("Delegate not initialized"));
+        response.statusText.SetValue("Delegate not initialized"_span);
         return;
     }
     uint8_t currentMode = GetInstance()->GetCurrentMode();
@@ -48,8 +48,7 @@ void RefrigeratorAndTemperatureControlledCabinetModeDelegate::HandleChangeToMode
     if ((currentMode == ModeNormal && NewMode == ModeRapidFreeze) || (currentMode == ModeRapidFreeze && NewMode == ModeNormal))
     {
         response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
-        response.statusText.SetValue(
-            chip::CharSpan::fromCharString("Direct transition between Normal and Rapid Freeze not allowed"));
+        response.statusText.SetValue("Direct transition between Normal and Rapid Freeze not allowed"_span);
         return;
     }
 

--- a/examples/refrigerator-app/silabs/src/refrigerator-and-temperature-controlled-cabinet-mode.cpp
+++ b/examples/refrigerator-app/silabs/src/refrigerator-and-temperature-controlled-cabinet-mode.cpp
@@ -15,11 +15,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <lib/support/Span.h>
 #include <refrigerator-and-temperature-controlled-cabinet-mode.h>
 
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::RefrigeratorAndTemperatureControlledCabinetMode;
+using namespace chip::literals;
 using chip::Protocols::InteractionModel::Status;
 template <typename T>
 using List              = chip::app::DataModel::List<T>;

--- a/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
@@ -18,8 +18,11 @@
 
 #include "AudioOutputManager.h"
 
+#include <lib/support/Span.h>
+
 using namespace chip::app;
 using namespace chip::app::Clusters::AudioOutput;
+using namespace chip::literals;
 
 AudioOutputManager::AudioOutputManager()
 {

--- a/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
@@ -30,7 +30,7 @@ AudioOutputManager::AudioOutputManager()
         OutputInfoType outputInfo;
         outputInfo.outputType = chip::app::Clusters::AudioOutput::OutputTypeEnum::kHdmi;
         // note: safe only because of use of string literal
-        outputInfo.name  = chip::CharSpan::fromCharString("HDMI");
+        outputInfo.name  = "HDMI"_span;
         outputInfo.index = static_cast<uint8_t>(i);
         mOutputs.push_back(outputInfo);
     }

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -17,9 +17,11 @@
  */
 
 #include "AppContentLauncherManager.h"
+
 #include "../../java/ContentAppAttributeDelegate.h"
 #include <app/util/config.h>
 #include <json/json.h>
+#include <lib/support/Span.h>
 
 #include <list>
 #include <string>
@@ -28,6 +30,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::ContentLauncher;
+using namespace chip::literals;
 using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
 AppContentLauncherManager::AppContentLauncherManager(ContentAppAttributeDelegate * attributeDelegate,

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -66,7 +66,7 @@ void AppContentLauncherManager::HandleLaunchContent(CommandResponseHelper<Launch
 
     LaunchResponseType response;
     // TODO: Insert code here
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
+    response.data   = chip::MakeOptional("exampleData"_span);
     response.status = ContentLauncher::StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -81,7 +81,7 @@ void AppContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchResp
 
     // TODO: Insert code here
     LaunchResponseType response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("Success"));
+    response.data   = chip::MakeOptional("Success"_span);
     response.status = ContentLauncher::StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -134,14 +134,14 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     NavigateTargetResponseType response;
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("error"));
+        response.data   = chip::MakeOptional("error"_span);
         response.status = StatusEnum::kTargetNotFound;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -16,15 +16,18 @@
  */
 
 #include "TargetNavigatorManager.h"
+
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
 #include <json/json.h>
+#include <lib/support/Span.h>
 
 #include <list>
 #include <string>
 
 using namespace chip::app;
 using namespace chip::app::Clusters::TargetNavigator;
+using namespace chip::literals;
 using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
 TargetNavigatorManager::TargetNavigatorManager(ContentAppAttributeDelegate * attributeDelegate, std::list<std::string> targets,

--- a/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
@@ -18,8 +18,11 @@
 
 #include "AudioOutputManager.h"
 
+#include <lib/support/Span.h>
+
 using namespace chip::app;
 using namespace chip::app::Clusters::AudioOutput;
+using namespace chip::literals;
 
 AudioOutputManager::AudioOutputManager()
 {

--- a/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
@@ -30,7 +30,7 @@ AudioOutputManager::AudioOutputManager()
         OutputInfoType outputInfo;
         outputInfo.outputType = chip::app::Clusters::AudioOutput::OutputTypeEnum::kHdmi;
         // note: safe only because of use of string literal
-        outputInfo.name  = chip::CharSpan::fromCharString("HDMI");
+        outputInfo.name  = "HDMI"_span;
         outputInfo.index = static_cast<uint8_t>(i);
         mOutputs.push_back(outputInfo);
     }

--- a/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
+++ b/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
@@ -30,33 +30,33 @@ using namespace chip::Uint8;
 ChannelManager::ChannelManager()
 {
     ChannelInfoType abc;
-    abc.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KAAL"));
-    abc.callSign          = MakeOptional(chip::CharSpan::fromCharString("KAAL-TV"));
-    abc.name              = MakeOptional(chip::CharSpan::fromCharString("ABC"));
+    abc.affiliateCallSign = MakeOptional("KAAL"_span);
+    abc.callSign          = MakeOptional("KAAL-TV"_span);
+    abc.name              = MakeOptional("ABC"_span);
     abc.majorNumber       = static_cast<uint8_t>(6);
     abc.minorNumber       = static_cast<uint16_t>(0);
     mChannels.push_back(abc);
 
     ChannelInfoType pbs;
-    pbs.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    pbs.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    pbs.name              = MakeOptional(chip::CharSpan::fromCharString("PBS"));
+    pbs.affiliateCallSign = MakeOptional("KCTS"_span);
+    pbs.callSign          = MakeOptional("KCTS-TV"_span);
+    pbs.name              = MakeOptional("PBS"_span);
     pbs.majorNumber       = static_cast<uint8_t>(9);
     pbs.minorNumber       = static_cast<uint16_t>(1);
     mChannels.push_back(pbs);
 
     ChannelInfoType pbsKids;
-    pbsKids.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    pbsKids.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    pbsKids.name              = MakeOptional(chip::CharSpan::fromCharString("PBS Kids"));
+    pbsKids.affiliateCallSign = MakeOptional("KCTS"_span);
+    pbsKids.callSign          = MakeOptional("KCTS-TV"_span);
+    pbsKids.name              = MakeOptional("PBS Kids"_span);
     pbsKids.majorNumber       = static_cast<uint8_t>(9);
     pbsKids.minorNumber       = static_cast<uint16_t>(2);
     mChannels.push_back(pbsKids);
 
     ChannelInfoType worldChannel;
-    worldChannel.affiliateCallSign = MakeOptional(chip::CharSpan::fromCharString("KCTS"));
-    worldChannel.callSign          = MakeOptional(chip::CharSpan::fromCharString("KCTS-TV"));
-    worldChannel.name              = MakeOptional(chip::CharSpan::fromCharString("World Channel"));
+    worldChannel.affiliateCallSign = MakeOptional("KCTS"_span);
+    worldChannel.callSign          = MakeOptional("KCTS-TV"_span);
+    worldChannel.name              = MakeOptional("World Channel"_span);
     worldChannel.majorNumber       = static_cast<uint8_t>(9);
     worldChannel.minorNumber       = static_cast<uint16_t>(3);
     mChannels.push_back(worldChannel);
@@ -65,40 +65,40 @@ ChannelManager::ChannelManager()
     mCurrentChannel      = mChannels[mCurrentChannelIndex];
 
     ProgramType program1;
-    program1.identifier = chip::CharSpan::fromCharString("progid-abc1");
+    program1.identifier = "progid-abc1"_span;
     program1.channel    = abc;
-    program1.title      = chip::CharSpan::fromCharString("ABC Title1");
-    program1.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle1"));
+    program1.title      = "ABC Title1"_span;
+    program1.subtitle   = MakeOptional("My Program Subtitle1"_span);
     program1.startTime  = 0;
     program1.endTime    = 30 * 60;
 
     mPrograms.push_back(program1);
 
     ProgramType program_pbs1;
-    program_pbs1.identifier = chip::CharSpan::fromCharString("progid-pbs1");
+    program_pbs1.identifier = "progid-pbs1"_span;
     program_pbs1.channel    = pbs;
-    program_pbs1.title      = chip::CharSpan::fromCharString("PBS Title1");
-    program_pbs1.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle1"));
+    program_pbs1.title      = "PBS Title1"_span;
+    program_pbs1.subtitle   = MakeOptional("My Program Subtitle1"_span);
     program_pbs1.startTime  = 0;
     program_pbs1.endTime    = 30 * 60;
 
     mPrograms.push_back(program_pbs1);
 
     ProgramType program2;
-    program2.identifier = chip::CharSpan::fromCharString("progid-abc2");
+    program2.identifier = "progid-abc2"_span;
     program2.channel    = abc;
-    program2.title      = chip::CharSpan::fromCharString("My Program Title2");
-    program2.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle2"));
+    program2.title      = "My Program Title2"_span;
+    program2.subtitle   = MakeOptional("My Program Subtitle2"_span);
     program2.startTime  = 30 * 60;
     program2.endTime    = 60 * 60;
 
     mPrograms.push_back(program2);
 
     ProgramType program3;
-    program3.identifier = chip::CharSpan::fromCharString("progid-abc3");
+    program3.identifier = "progid-abc3"_span;
     program3.channel    = abc;
-    program3.title      = chip::CharSpan::fromCharString("My Program Title3");
-    program3.subtitle   = MakeOptional(chip::CharSpan::fromCharString("My Program Subtitle3"));
+    program3.title      = "My Program Title3"_span;
+    program3.subtitle   = MakeOptional("My Program Subtitle3"_span);
     program3.startTime  = 0;
     program3.endTime    = 60 * 60;
 
@@ -120,9 +120,9 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
 CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
 {
     LineupInfoType lineup;
-    lineup.operatorName   = chip::CharSpan::fromCharString("Comcast");
-    lineup.lineupName     = MakeOptional(chip::CharSpan::fromCharString("Comcast King County"));
-    lineup.postalCode     = MakeOptional(chip::CharSpan::fromCharString("98052"));
+    lineup.operatorName   = "Comcast"_span;
+    lineup.lineupName     = MakeOptional("Comcast King County"_span);
+    lineup.postalCode     = MakeOptional("98052"_span);
     lineup.lineupInfoType = chip::app::Clusters::Channel::LineupInfoTypeEnum::kMso;
 
     return aEncoder.Encode(lineup);
@@ -184,7 +184,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     else
     {
         response.status      = chip::app::Clusters::Channel::StatusEnum::kSuccess;
-        response.data        = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data        = chip::MakeOptional("data response"_span);
         mCurrentChannel      = matchedChannels[0];
         mCurrentChannelIndex = index;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
@@ -246,8 +246,8 @@ void ChannelManager::HandleGetProgramGuide(
 
     // PageTokenType paging;
     // paging.limit  = MakeOptional(static_cast<uint16_t>(10));
-    // paging.after  = MakeOptional(chip::CharSpan::fromCharString("after-token"));
-    // paging.before = MakeOptional(chip::CharSpan::fromCharString("before-token"));
+    // paging.after  = MakeOptional("after-token"_span);
+    // paging.before = MakeOptional("before-token"_span);
 
     // ChannelPagingStructType channelPaging;
     // channelPaging.nextToken = MakeOptional<DataModel::Nullable<Structs::PageTokenStruct::Type>>(paging);

--- a/examples/tv-app/tv-common/clusters/content-app-observer/ContentAppObserver.cpp
+++ b/examples/tv-app/tv-common/clusters/content-app-observer/ContentAppObserver.cpp
@@ -42,7 +42,7 @@ void ContentAppObserverManager::HandleContentAppMessage(chip::app::CommandRespon
 
     ContentAppMessageResponse response;
     // TODO: Insert code here
-    response.data         = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
+    response.data         = chip::MakeOptional("exampleData"_span);
     response.encodingHint = chip::MakeOptional(CharSpan::fromCharString(encodingHintString.c_str()));
     response.status       = StatusEnum::kSuccess;
     helper.Success(response);

--- a/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
@@ -38,28 +38,28 @@ ContentLauncherManager::ContentLauncherManager(std::list<std::string> acceptHead
     entry1.mName = "TV Show Example";
     ParameterType parameter1;
     parameter1.type  = ParameterEnum::kActor;
-    parameter1.value = chip::CharSpan::fromCharString("Gaby sHoffman");
+    parameter1.value = "Gaby sHoffman"_span;
     ParameterType parameter2;
     parameter2.type  = ParameterEnum::kChannel;
-    parameter2.value = chip::CharSpan::fromCharString("PBS");
+    parameter2.value = "PBS"_span;
     ParameterType parameter3;
     parameter3.type  = ParameterEnum::kCharacter;
-    parameter3.value = chip::CharSpan::fromCharString("Snow White");
+    parameter3.value = "Snow White"_span;
     ParameterType parameter4;
     parameter4.type  = ParameterEnum::kDirector;
-    parameter4.value = chip::CharSpan::fromCharString("Spike Lee");
+    parameter4.value = "Spike Lee"_span;
     ParameterType parameter5;
     parameter5.type  = ParameterEnum::kFranchise;
-    parameter5.value = chip::CharSpan::fromCharString("Star Wars");
+    parameter5.value = "Star Wars"_span;
     ParameterType parameter6;
     parameter6.type  = ParameterEnum::kGenre;
-    parameter6.value = chip::CharSpan::fromCharString("Horror");
+    parameter6.value = "Horror"_span;
     ParameterType parameter7;
     parameter7.type  = ParameterEnum::kPopularity;
-    parameter7.value = chip::CharSpan::fromCharString("Popularity");
+    parameter7.value = "Popularity"_span;
     ParameterType parameter8;
     parameter8.type  = ParameterEnum::kProvider;
-    parameter8.value = chip::CharSpan::fromCharString("Netflix");
+    parameter8.value = "Netflix"_span;
     entry1.mSearchFields.push_back(parameter1);
     entry1.mSearchFields.push_back(parameter2);
     entry1.mSearchFields.push_back(parameter3);
@@ -74,19 +74,19 @@ ContentLauncherManager::ContentLauncherManager(std::list<std::string> acceptHead
     entry2.mName = "Sports Example";
     ParameterType parameter21;
     parameter21.type  = ParameterEnum::kEvent;
-    parameter21.value = chip::CharSpan::fromCharString("Football games");
+    parameter21.value = "Football games"_span;
     ParameterType parameter22;
     parameter22.type  = ParameterEnum::kLeague;
-    parameter22.value = chip::CharSpan::fromCharString("NCAA");
+    parameter22.value = "NCAA"_span;
     ParameterType parameter23;
     parameter23.type  = ParameterEnum::kSport;
-    parameter23.value = chip::CharSpan::fromCharString("football");
+    parameter23.value = "football"_span;
     ParameterType parameter24;
     parameter24.type  = ParameterEnum::kSportsTeam;
-    parameter24.value = chip::CharSpan::fromCharString("Arsenel");
+    parameter24.value = "Arsenel"_span;
     ParameterType parameter25;
     parameter25.type  = ParameterEnum::kType;
-    parameter25.value = chip::CharSpan::fromCharString("TVSeries");
+    parameter25.value = "TVSeries"_span;
     entry2.mSearchFields.push_back(parameter21);
     entry2.mSearchFields.push_back(parameter22);
     entry2.mSearchFields.push_back(parameter23);
@@ -141,7 +141,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
 
     LaunchResponseType response;
     // TODO: Insert code here
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
+    response.data   = chip::MakeOptional("exampleData"_span);
     response.status = ContentLauncher::StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -161,7 +161,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
 
     // TODO: Insert code here
     LaunchResponseType response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
+    response.data   = chip::MakeOptional("exampleData"_span);
     response.status = ContentLauncher::StatusEnum::kSuccess;
 
     // Handle test cases

--- a/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
@@ -19,6 +19,7 @@
 #include "ContentLauncherManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <lib/support/Span.h>
 
 #include <list>
 #include <string>
@@ -27,6 +28,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::ContentLauncher;
+using namespace chip::literals;
 
 ContentLauncherManager::ContentLauncherManager(std::list<std::string> acceptHeaderList, uint32_t supportedStreamingProtocols)
 {

--- a/examples/tv-app/tv-common/clusters/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-input/MediaInputManager.cpp
@@ -29,8 +29,8 @@ MediaInputManager::MediaInputManager()
     for (int i = 1; i < 3; ++i)
     {
         InputInfoType inputInfo;
-        inputInfo.description = chip::CharSpan::fromCharString("High-Definition Multimedia Interface");
-        inputInfo.name        = chip::CharSpan::fromCharString("HDMI");
+        inputInfo.description = "High-Definition Multimedia Interface"_span;
+        inputInfo.name        = "HDMI"_span;
         inputInfo.inputType   = chip::app::Clusters::MediaInput::InputTypeEnum::kHdmi;
         inputInfo.index       = static_cast<uint8_t>(i);
         mInputs.push_back(inputInfo);

--- a/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
@@ -102,7 +102,7 @@ void MediaPlaybackManager::HandlePlay(CommandResponseHelper<Commands::PlaybackRe
     mPlaybackSpeed = 1;
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -114,7 +114,7 @@ void MediaPlaybackManager::HandlePause(CommandResponseHelper<Commands::PlaybackR
     mPlaybackSpeed = 0;
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -127,7 +127,7 @@ void MediaPlaybackManager::HandleStop(CommandResponseHelper<Commands::PlaybackRe
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -140,7 +140,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
     {
         // if already at max speed, return error
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSpeedOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
@@ -155,7 +155,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
     }
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -168,7 +168,7 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -181,7 +181,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     {
         // if already at max speed in reverse, return error
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSpeedOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
@@ -196,7 +196,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     }
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -211,7 +211,7 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
     mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -225,7 +225,7 @@ void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::Pla
     mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -237,7 +237,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
     if (positionMilliseconds > mDuration)
     {
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSeekOutOfRange;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
     }
@@ -246,7 +246,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
         mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(positionMilliseconds) };
 
         Commands::PlaybackResponse::Type response;
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        response.data   = chip::MakeOptional("data response"_span);
         response.status = StatusEnum::kSuccess;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
     }
@@ -260,7 +260,7 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
@@ -271,7 +271,7 @@ void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::Playb
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
 
     Commands::PlaybackResponse::Type response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
@@ -16,15 +16,17 @@
  */
 
 #include "MediaPlaybackManager.h"
+
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <lib/support/Span.h>
 
 #include <string>
 
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;
+using namespace chip::literals;
 using namespace chip::Uint8;
-using chip::CharSpan;
 
 PlaybackStateEnum MediaPlaybackManager::HandleGetCurrentState()
 {

--- a/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -58,14 +58,14 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     NavigateTargetResponseType response;
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
-        response.data   = chip::MakeOptional(CharSpan::fromCharString("error"));
+        response.data   = chip::MakeOptional("error"_span);
         response.status = StatusEnum::kTargetNotFound;
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
-    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
+    response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }

--- a/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -16,13 +16,16 @@
  */
 
 #include "TargetNavigatorManager.h"
+
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <lib/support/Span.h>
 
 #include <string>
 
 using namespace chip::app;
 using namespace chip::app::Clusters::TargetNavigator;
+using namespace chip::literals;
 
 TargetNavigatorManager::TargetNavigatorManager(std::list<std::string> targets, uint8_t currentTarget)
 {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -274,8 +274,7 @@ JNI_METHOD(jstring, getConnectionStateNative)
 
     if (NULL == env)
     {
-        LogErrorOnFailure(
-            chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("JNIEnv interface is NULL"), jstr_obj));
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("JNIEnv interface is NULL"_span, jstr_obj));
         return static_cast<jstring>(jstr_obj);
     }
 
@@ -292,13 +291,13 @@ JNI_METHOD(jstring, getConnectionStateNative)
     switch (state)
     {
     case matter::casting::core::ConnectionState::CASTING_PLAYER_NOT_CONNECTED:
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("NOT_CONNECTED"), jstr_obj));
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("NOT_CONNECTED"_span, jstr_obj));
         break;
     case matter::casting::core::ConnectionState::CASTING_PLAYER_CONNECTING:
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("CONNECTING"), jstr_obj));
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("CONNECTING"_span, jstr_obj));
         break;
     case matter::casting::core::ConnectionState::CASTING_PLAYER_CONNECTED:
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("CONNECTED"), jstr_obj));
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("CONNECTED"_span, jstr_obj));
         break;
     default:
         snprintf(error_str, sizeof(error_str), "Unsupported Connection State: %d", state);

--- a/examples/tv-casting-app/tv-casting-common/clusters/content-app-observer/ContentAppObserver.cpp
+++ b/examples/tv-casting-app/tv-casting-common/clusters/content-app-observer/ContentAppObserver.cpp
@@ -42,7 +42,7 @@ void ContentAppObserverManager::HandleContentAppMessage(chip::app::CommandRespon
 
     ContentAppMessageResponse response;
     // TODO: Insert code here
-    response.data         = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
+    response.data         = chip::MakeOptional("exampleData"_span);
     response.encodingHint = chip::MakeOptional(CharSpan::fromCharString(encodingHintString.c_str()));
     response.status       = StatusEnum::kSuccess;
     TEMPORARY_RETURN_IGNORED helper.Success(response);

--- a/src/app/clusters/actions-server/tests/TestActionsClusterBackwardCompatability.cpp
+++ b/src/app/clusters/actions-server/tests/TestActionsClusterBackwardCompatability.cpp
@@ -219,13 +219,12 @@ TEST_F(TestActionsCluster, TestActionListConstraints)
     delegate.mNumActions = 0;
     for (uint16_t i = 0; i < delegate.kMaxActions; i++)
     {
-        ActionStructStorage action(i, CharSpan::fromCharString("Action"), ActionTypeEnum::kScene, 0, BitMask<CommandBits>(),
-                                   ActionStateEnum::kInactive);
+        ActionStructStorage action(i, "Action"_span, ActionTypeEnum::kScene, 0, BitMask<CommandBits>(), ActionStateEnum::kInactive);
         EXPECT_EQ(delegate.AddTestAction(action), CHIP_NO_ERROR);
     }
 
     // Try to add one more action beyond the limit
-    ActionStructStorage extraAction(99, CharSpan::fromCharString("Extra"), ActionTypeEnum::kScene, 0, BitMask<CommandBits>(),
+    ActionStructStorage extraAction(99, "Extra"_span, ActionTypeEnum::kScene, 0, BitMask<CommandBits>(),
                                     ActionStateEnum::kInactive);
     EXPECT_EQ(delegate.AddTestAction(extraAction), CHIP_ERROR_BUFFER_TOO_SMALL);
 }
@@ -255,14 +254,12 @@ TEST_F(TestActionsCluster, TestEndpointListConstraints)
     delegate.mNumEndpointLists = 0;
     for (uint16_t i = 0; i < delegate.kMaxEndpointLists; i++)
     {
-        EndpointListStorage epList(i, CharSpan::fromCharString("List"), EndpointListTypeEnum::kOther,
-                                   DataModel::List<const EndpointId>(endpoints));
+        EndpointListStorage epList(i, "List"_span, EndpointListTypeEnum::kOther, DataModel::List<const EndpointId>(endpoints));
         EXPECT_EQ(delegate.AddTestEndpointList(epList), CHIP_NO_ERROR);
     }
 
     // Try to add one more endpoint list beyond the limit
-    EndpointListStorage extraEpList(99, CharSpan::fromCharString("Extra"), EndpointListTypeEnum::kOther,
-                                    DataModel::List<const EndpointId>(endpoints));
+    EndpointListStorage extraEpList(99, "Extra"_span, EndpointListTypeEnum::kOther, DataModel::List<const EndpointId>(endpoints));
     EXPECT_EQ(delegate.AddTestEndpointList(extraEpList), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Test 3: Maximum endpoints per list
@@ -273,7 +270,7 @@ TEST_F(TestActionsCluster, TestEndpointListConstraints)
         tooManyEndpoints[i] = i;
     }
 
-    EndpointListStorage epListWithTooManyEndpoints(1, CharSpan::fromCharString("List"), EndpointListTypeEnum::kOther,
+    EndpointListStorage epListWithTooManyEndpoints(1, "List"_span, EndpointListTypeEnum::kOther,
                                                    DataModel::List<const EndpointId>(tooManyEndpoints));
 
     // The list should be added but truncated to kEndpointListMaxSize
@@ -290,9 +287,9 @@ TEST_F(TestActionsCluster, TestActionListAttributeAccess)
     delegate->mNumActions              = 0;
 
     // Add test actions
-    ActionStructStorage action1(1, CharSpan::fromCharString("FirstAction"), ActionTypeEnum::kScene, 0, BitMask<CommandBits>(),
+    ActionStructStorage action1(1, "FirstAction"_span, ActionTypeEnum::kScene, 0, BitMask<CommandBits>(),
                                 ActionStateEnum::kInactive);
-    ActionStructStorage action2(2, CharSpan::fromCharString("SecondAction"), ActionTypeEnum::kScene, 1, BitMask<CommandBits>(),
+    ActionStructStorage action2(2, "SecondAction"_span, ActionTypeEnum::kScene, 1, BitMask<CommandBits>(),
                                 ActionStateEnum::kActive);
 
     EXPECT_EQ(delegate->AddTestAction(action1), CHIP_NO_ERROR);
@@ -374,9 +371,9 @@ TEST_F(TestActionsCluster, TestEndpointListAttributeAccess)
     const EndpointId endpoints1[] = { 1, 2 };
     const EndpointId endpoints2[] = { 3, 4, 5 };
 
-    EndpointListStorage epList1(1, CharSpan::fromCharString("FirstList"), EndpointListTypeEnum::kOther,
+    EndpointListStorage epList1(1, "FirstList"_span, EndpointListTypeEnum::kOther,
                                 DataModel::List<const EndpointId>(endpoints1, 2));
-    EndpointListStorage epList2(2, CharSpan::fromCharString("SecondList"), EndpointListTypeEnum::kOther,
+    EndpointListStorage epList2(2, "SecondList"_span, EndpointListTypeEnum::kOther,
                                 DataModel::List<const EndpointId>(endpoints2, 3));
 
     EXPECT_EQ(delegate->AddTestEndpointList(epList1), CHIP_NO_ERROR);

--- a/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
+++ b/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
@@ -123,7 +123,7 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted)
     Commands::RetrieveLogsRequest::Type request;
     request.intent                 = DiagnosticLogs::IntentEnum::kEndUserSupport;
     request.requestedProtocol      = DiagnosticLogs::TransferProtocolEnum::kBdx;
-    request.transferFileDesignator = MakeOptional(CharSpan::fromCharString("enduser.log"));
+    request.transferFileDesignator = MakeOptional("enduser.log"_span);
 
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
@@ -145,7 +145,7 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted_with_buffer_greate
     Commands::RetrieveLogsRequest::Type request;
     request.intent                 = DiagnosticLogs::IntentEnum::kEndUserSupport;
     request.requestedProtocol      = DiagnosticLogs::TransferProtocolEnum::kBdx;
-    request.transferFileDesignator = MakeOptional(CharSpan::fromCharString("enduser.log"));
+    request.transferFileDesignator = MakeOptional("enduser.log"_span);
 
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
@@ -197,7 +197,7 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_NoDelegate_NoLogs)
     Commands::RetrieveLogsRequest::Type request;
     request.intent                 = DiagnosticLogs::IntentEnum::kEndUserSupport;
     request.requestedProtocol      = DiagnosticLogs::TransferProtocolEnum::kBdx;
-    request.transferFileDesignator = MakeOptional(CharSpan::fromCharString("enduser.log"));
+    request.transferFileDesignator = MakeOptional("enduser.log"_span);
 
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -654,8 +654,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
     EXPECT_FALSE(tester.WriteAttribute(BatteryCapacity::Id, DataModel::Nullable<int64_t>(80000000)).IsSuccess());
 
     // Test writing to VehicleID (read-only, PlugAndCharge feature)
-    EXPECT_FALSE(
-        tester.WriteAttribute(VehicleID::Id, DataModel::Nullable<CharSpan>(CharSpan::fromCharString("NEW-VIN"))).IsSuccess());
+    EXPECT_FALSE(tester.WriteAttribute(VehicleID::Id, DataModel::Nullable<CharSpan>("NEW-VIN"_span)).IsSuccess());
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
@@ -45,8 +45,8 @@ class MockFixedLabelIterator : public DeviceLayer::DeviceInfoProvider::FixedLabe
 public:
     MockFixedLabelIterator()
     {
-        mLabels[0].label = chip::CharSpan::fromCharString("test_label1");
-        mLabels[0].value = chip::CharSpan::fromCharString("test_value1");
+        mLabels[0].label = "test_label1"_span;
+        mLabels[0].value = "test_value1"_span;
     }
 
     size_t Count() override { return 1; }
@@ -129,7 +129,7 @@ TEST_F(TestFixedLabelCluster, ReadAttributeTest)
     auto it = labelList.begin();
     ASSERT_TRUE(it.Next());
     auto label = it.GetValue();
-    ASSERT_TRUE(label.label.data_equal(chip::CharSpan::fromCharString("test_label1")));
-    ASSERT_TRUE(label.value.data_equal(chip::CharSpan::fromCharString("test_value1")));
+    ASSERT_TRUE(label.label.data_equal("test_label1"_span));
+    ASSERT_TRUE(label.value.data_equal("test_value1"_span));
     ASSERT_FALSE(it.Next());
 }

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -149,11 +149,11 @@ struct TestLocalizationConfigurationCluster : public ::testing::Test
 TEST_F(TestLocalizationConfigurationCluster, TestReadAndWriteActiveLocale)
 {
     // Set up mock supported locales.
-    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
 
     // Create cluster instance with an invalid locale.
-    CharSpan initialLocale = CharSpan::fromCharString("de-DE");
+    CharSpan initialLocale = "de-DE"_span;
     MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, initialLocale);
 
     // ActiveLocale should be set to the default locale which is the first supported locale in this case.
@@ -162,7 +162,7 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAndWriteActiveLocale)
     EXPECT_EQ(actualLocale.size(), supportedLocales[0].size());
 
     // Test 1: Write a valid supported locale.
-    CharSpan validLocale                 = CharSpan::fromCharString("es-ES");
+    CharSpan validLocale                 = "es-ES"_span;
     DataModel::ActionReturnStatus status = cluster.SetActiveLocale(validLocale);
     EXPECT_EQ(status, Status::Success);
 
@@ -172,7 +172,7 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAndWriteActiveLocale)
     EXPECT_EQ(actualLocale.size(), validLocale.size());
 
     // Test 2: Write an invalid unsupported locale.
-    CharSpan invalidLocale = CharSpan::fromCharString("de-DE");
+    CharSpan invalidLocale = "de-DE"_span;
 
     status = cluster.SetActiveLocale(invalidLocale);
     EXPECT_EQ(status, Status::ConstraintError);
@@ -181,11 +181,11 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAndWriteActiveLocale)
 TEST_F(TestLocalizationConfigurationCluster, TestReadAttributes)
 {
     // Set up mock supported locales
-    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
 
     // Create cluster instance
-    CharSpan initialLocale = CharSpan::fromCharString("en-US");
+    CharSpan initialLocale = "en-US"_span;
     LocalizationConfigurationCluster cluster(*mDeviceInfoProvider, initialLocale);
 
     ASSERT_TRUE(IsAttributesListEqualTo(cluster,
@@ -197,11 +197,10 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAttributes)
 
 TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
 {
-    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES"),
-                                               CharSpan::fromCharString("fr-FR") };
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span, "fr-FR"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
 
-    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, "en-US"_span);
 
     chip::Testing::TestServerClusterContext context;
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -209,12 +208,12 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
     chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
 
-    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("es-ES"));
+    AttributeValueDecoder decoder        = writeOp.DecoderFor("es-ES"_span);
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, Status::Success);
 
     CharSpan actualLocale = cluster.GetActiveLocale();
-    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("es-ES")));
+    EXPECT_TRUE(actualLocale.data_equal("es-ES"_span));
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
     EXPECT_TRUE(
@@ -225,12 +224,12 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
 
     chip::Testing::WriteOperation writeOp2(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp2.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
-    AttributeValueDecoder decoder2 = writeOp2.DecoderFor(CharSpan::fromCharString("fr-FR"));
+    AttributeValueDecoder decoder2 = writeOp2.DecoderFor("fr-FR"_span);
     status                         = cluster.WriteAttribute(writeOp2.GetRequest(), decoder2);
     EXPECT_EQ(status, Status::Success);
 
     actualLocale = cluster.GetActiveLocale();
-    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("fr-FR")));
+    EXPECT_TRUE(actualLocale.data_equal("fr-FR"_span));
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
     EXPECT_TRUE(
@@ -242,10 +241,10 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)
 
 TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
 {
-    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
 
-    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, "en-US"_span);
 
     chip::Testing::TestServerClusterContext context;
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -254,12 +253,12 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
 
     chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
-    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("de-DE"));
+    AttributeValueDecoder decoder        = writeOp.DecoderFor("de-DE"_span);
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, Status::ConstraintError);
 
     CharSpan actualLocale = cluster.GetActiveLocale();
-    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("en-US")));
+    EXPECT_TRUE(actualLocale.data_equal("en-US"_span));
 
     EXPECT_TRUE(context.ChangeListener().DirtyList().empty());
     EXPECT_EQ(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionBefore);
@@ -269,10 +268,10 @@ TEST_F(TestLocalizationConfigurationCluster, WriteAttributeFailureDoesNotNotify)
 
 TEST_F(TestLocalizationConfigurationCluster, WriteSameLocaleIsNoOp)
 {
-    std::vector<CharSpan> supportedLocales = { CharSpan::fromCharString("en-US"), CharSpan::fromCharString("es-ES") };
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
 
-    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, CharSpan::fromCharString("en-US"));
+    MockLocalizationConfigurationCluster cluster(*mDeviceInfoProvider, "en-US"_span);
 
     chip::Testing::TestServerClusterContext context;
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -281,12 +280,12 @@ TEST_F(TestLocalizationConfigurationCluster, WriteSameLocaleIsNoOp)
 
     chip::Testing::WriteOperation writeOp(kRootEndpointId, LocalizationConfiguration::Id, ActiveLocale::Id);
     writeOp.SetSubjectDescriptor(chip::Testing::kAdminSubjectDescriptor);
-    AttributeValueDecoder decoder        = writeOp.DecoderFor(CharSpan::fromCharString("en-US"));
+    AttributeValueDecoder decoder        = writeOp.DecoderFor("en-US"_span);
     DataModel::ActionReturnStatus status = cluster.WriteAttribute(writeOp.GetRequest(), decoder);
     EXPECT_EQ(status, DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
 
     CharSpan actualLocale = cluster.GetActiveLocale();
-    EXPECT_TRUE(actualLocale.data_equal(CharSpan::fromCharString("en-US")));
+    EXPECT_TRUE(actualLocale.data_equal("en-US"_span));
 
     EXPECT_TRUE(context.ChangeListener().DirtyList().empty());
     EXPECT_EQ(cluster.GetDataVersion({ kRootEndpointId, LocalizationConfiguration::Id }), versionBefore);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -762,7 +762,7 @@ CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(Messaging::ExchangeManager
     else
     {
         // Country code unavailable or invalid, use default
-        args.location.SetValue(CharSpan::fromCharString("XX"));
+        args.location.SetValue("XX"_span);
     }
 
     args.metadataForProvider = mMetadataForProvider;

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -826,7 +826,7 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::V
 
             // Create new video stream entry with name 'video' and the provided or selected VideoStreamID i.e; finalVideoStreamID
             Structs::VideoStreamStruct::Type newVideoStream;
-            newVideoStream.videoStreamName = CharSpan::fromCharString("video");
+            newVideoStream.videoStreamName = "video"_span;
             newVideoStream.videoStreamID   = finalVideoStreamID;
 
             // Add to storage and update the list
@@ -868,7 +868,7 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::V
 
             // Create new audio stream entry with name 'audio' and the provided or selected AudioStreamID i.e; finalAudioStreamID
             Structs::AudioStreamStruct::Type newAudioStream;
-            newAudioStream.audioStreamName = CharSpan::fromCharString("audio");
+            newAudioStream.audioStreamName = "audio"_span;
             newAudioStream.audioStreamID   = finalAudioStreamID;
 
             // Add to storage and update the list

--- a/src/app/clusters/resource-monitoring-server/tests/TestResourceMonitoringCluster.cpp
+++ b/src/app/clusters/resource-monitoring-server/tests/TestResourceMonitoringCluster.cpp
@@ -163,15 +163,15 @@ TEST_F(TestResourceMonitoringCluster, ReadAttributeTest)
 
     auto it = replacementProductList.begin();
     ASSERT_TRUE(it.Next());
-    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal(CharSpan::fromCharString("PRODUCT_0")));
+    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal("PRODUCT_0"_span));
     ASSERT_TRUE(it.Next());
-    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal(CharSpan::fromCharString("PRODUCT_1")));
+    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal("PRODUCT_1"_span));
     ASSERT_TRUE(it.Next());
-    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal(CharSpan::fromCharString("PRODUCT_2")));
+    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal("PRODUCT_2"_span));
     ASSERT_TRUE(it.Next());
-    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal(CharSpan::fromCharString("PRODUCT_3")));
+    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal("PRODUCT_3"_span));
     ASSERT_TRUE(it.Next());
-    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal(CharSpan::fromCharString("PRODUCT_4")));
+    ASSERT_TRUE(it.GetValue().productIdentifierValue.data_equal("PRODUCT_4"_span));
 
     ASSERT_FALSE(it.Next());
 }

--- a/src/app/clusters/zone-management-server/tests/TestZoneManagementCluster.cpp
+++ b/src/app/clusters/zone-management-server/tests/TestZoneManagementCluster.cpp
@@ -327,8 +327,8 @@ TEST_F(TestZoneManagementCluster, StartupLoadsPersistedZonesAndTriggersFromDeleg
 {
     const auto vertices = MakeTriangle(0);
     TwoDCartesianZoneStorage zone;
-    zone.Set(CharSpan::fromCharString("Entry"), ZoneUseEnum::kMotion,
-             std::vector<TwoDCartesianVertexStruct>(vertices.begin(), vertices.end()), NullOptional);
+    zone.Set("Entry"_span, ZoneUseEnum::kMotion, std::vector<TwoDCartesianVertexStruct>(vertices.begin(), vertices.end()),
+             NullOptional);
 
     ZoneInformationStorage zoneInfo;
     zoneInfo.Set(55, ZoneTypeEnum::kTwoDCARTZone, ZoneSourceEnum::kMfg, MakeOptional(zone));
@@ -371,12 +371,12 @@ TEST_F(TestZoneManagementCluster, InvokeCreateUpdateAndRemoveZoneCommands)
     ASSERT_EQ(mDelegate.mCreateZoneCalls, 1u);
     ASSERT_EQ(cluster.GetZones().size(), 1u);
     ASSERT_TRUE(cluster.GetZones().front().twoDCartZoneStorage.HasValue());
-    ASSERT_TRUE(cluster.GetZones().front().twoDCartZoneStorage.Value().name.data_equal(CharSpan::fromCharString("Zone One")));
+    ASSERT_TRUE(cluster.GetZones().front().twoDCartZoneStorage.Value().name.data_equal("Zone One"_span));
 
     const auto updateVertices = MakeTriangle(100);
     Commands::UpdateTwoDCartesianZone::Type updateRequest;
     updateRequest.zoneID        = 1;
-    updateRequest.zone.name     = CharSpan::fromCharString("Zone Two");
+    updateRequest.zone.name     = "Zone Two"_span;
     updateRequest.zone.use      = ZoneUseEnum::kMotion;
     updateRequest.zone.vertices = DataModel::List<const TwoDCartesianVertexStruct>(updateVertices.data(), updateVertices.size());
     updateRequest.zone.color    = NullOptional;
@@ -385,7 +385,7 @@ TEST_F(TestZoneManagementCluster, InvokeCreateUpdateAndRemoveZoneCommands)
     ASSERT_TRUE(updateResult.IsSuccess());
     ASSERT_EQ(mDelegate.mUpdateZoneCalls, 1u);
     ASSERT_EQ(cluster.GetZones().size(), 1u);
-    ASSERT_TRUE(cluster.GetZones().front().twoDCartZoneStorage.Value().name.data_equal(CharSpan::fromCharString("Zone Two")));
+    ASSERT_TRUE(cluster.GetZones().front().twoDCartZoneStorage.Value().name.data_equal("Zone Two"_span));
 
     Commands::RemoveZone::Type removeRequest;
     removeRequest.zoneID = 1;

--- a/src/app/server/tests/TestJointFabricDatastore.cpp
+++ b/src/app/server/tests/TestJointFabricDatastore.cpp
@@ -23,7 +23,7 @@ TEST(JointFabricDatastoreTest, AddPendingNodeNotifiesListener)
     store.AddListener(listener);
 
     // Add a pending node — should notify the listener via MarkNodeListChange
-    CHIP_ERROR err = store.AddPendingNode(123, CharSpan::fromCharString("controller-a"));
+    CHIP_ERROR err = store.AddPendingNode(123, "controller-a"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_TRUE(listener.mNotified);
@@ -38,7 +38,7 @@ TEST(JointFabricDatastoreTest, RemoveListenerPreventsNotification)
     store.RemoveListener(listener);
     listener.Reset();
 
-    CHIP_ERROR err = store.AddPendingNode(456, CharSpan::fromCharString("controller-b"));
+    CHIP_ERROR err = store.AddPendingNode(456, "controller-b"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_FALSE(listener.mNotified);
@@ -166,7 +166,7 @@ TEST(JointFabricDatastoreTest, RefreshNodeUpdatesExistingNode)
     store.AddListener(listener);
 
     // Add initial pending node
-    err = store.AddPendingNode(123, CharSpan::fromCharString("controller-a"));
+    err = store.AddPendingNode(123, "controller-a"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_TRUE(listener.mNotified);
 
@@ -204,11 +204,11 @@ TEST(JointFabricDatastoreTest, UpdateNodeChangesNameAndNotifies)
     EXPECT_EQ(err, CHIP_NO_ERROR);
     store.AddListener(listener);
 
-    err = store.AddPendingNode(123, CharSpan::fromCharString("original-name"));
+    err = store.AddPendingNode(123, "original-name"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
     listener.Reset();
 
-    err = store.UpdateNode(123, CharSpan::fromCharString("updated-name"));
+    err = store.UpdateNode(123, "updated-name"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_TRUE(listener.mNotified);
 }
@@ -223,7 +223,7 @@ TEST(JointFabricDatastoreTest, RemoveNodeDeletesAndNotifies)
     EXPECT_EQ(err, CHIP_NO_ERROR);
     store.AddListener(listener);
 
-    err = store.AddPendingNode(123, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(123, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
     listener.Reset();
 
@@ -314,7 +314,7 @@ TEST(JointFabricDatastoreTest, UpdateAdmin)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     uint8_t icacData[] = { 0x01, 0x02 };
-    err                = store.UpdateAdmin(100, CharSpan::fromCharString("new-name"), ByteSpan(icacData));
+    err                = store.UpdateAdmin(100, "new-name"_span, ByteSpan(icacData));
     EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
@@ -333,17 +333,17 @@ TEST(JointFabricDatastoreTest, RemoveGroupIDFromEndpoint)
     err = store.TestAddNodeKeySetEntry(groupId, groupKeySetId, nodeId);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.TestAddEndpointEntry(endpointId, nodeId, CharSpan::fromCharString("test-endpoint"));
+    err = store.TestAddEndpointEntry(endpointId, nodeId, "test-endpoint"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     Clusters::JointFabricDatastore::Commands::AddGroup::DecodableType addGroupData;
     addGroupData.groupID       = groupId;
-    addGroupData.friendlyName  = CharSpan::fromCharString("test-group");
+    addGroupData.friendlyName  = "test-group"_span;
     addGroupData.groupKeySetID = groupKeySetId;
     err                        = store.AddGroup(addGroupData);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.AddPendingNode(nodeId, CharSpan::fromCharString("test"));
+    err = store.AddPendingNode(nodeId, "test"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
     err = store.AddGroupIDToEndpointForNode(nodeId, endpointId, groupId);
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -408,13 +408,13 @@ TEST(JointFabricDatastoreTest, UpdateEndpointForNode)
     NodeId nodeId         = 123;
     EndpointId endpointId = 1;
 
-    err = store.AddPendingNode(nodeId, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(nodeId, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.TestAddEndpointEntry(endpointId, nodeId, CharSpan::fromCharString("initial-endpoint"));
+    err = store.TestAddEndpointEntry(endpointId, nodeId, "initial-endpoint"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.UpdateEndpointForNode(nodeId, endpointId, CharSpan::fromCharString("endpoint-name"));
+    err = store.UpdateEndpointForNode(nodeId, endpointId, "endpoint-name"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
@@ -425,7 +425,7 @@ TEST(JointFabricDatastoreTest, UpdateEndpointForNonExistentNodeFails)
     CHIP_ERROR err = store.SetDelegate(&delegate);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.UpdateEndpointForNode(999, 1, CharSpan::fromCharString("endpoint-name"));
+    err = store.UpdateEndpointForNode(999, 1, "endpoint-name"_span);
     EXPECT_NE(err, CHIP_NO_ERROR);
 }
 
@@ -439,10 +439,10 @@ TEST(JointFabricDatastoreTest, AddBindingToEndpointForNode)
     NodeId nodeId         = 123;
     EndpointId endpointId = 1;
 
-    err = store.AddPendingNode(nodeId, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(nodeId, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.TestAddEndpointEntry(endpointId, nodeId, CharSpan::fromCharString("test-endpoint"));
+    err = store.TestAddEndpointEntry(endpointId, nodeId, "test-endpoint"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     Clusters::JointFabricDatastore::Structs::DatastoreBindingTargetStruct::Type binding;
@@ -461,10 +461,10 @@ TEST(JointFabricDatastoreTest, RemoveBindingFromEndpointForNode)
     EndpointId endpointId = 1;
     uint16_t listId       = 0;
 
-    err = store.AddPendingNode(nodeId, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(nodeId, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.TestAddEndpointEntry(endpointId, nodeId, CharSpan::fromCharString("test-endpoint"));
+    err = store.TestAddEndpointEntry(endpointId, nodeId, "test-endpoint"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     Clusters::JointFabricDatastore::Structs::DatastoreBindingTargetStruct::Type binding;
@@ -493,7 +493,7 @@ TEST(JointFabricDatastoreTest, AddACLToNode)
     CHIP_ERROR err = store.SetDelegate(&delegate);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.AddPendingNode(123, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(123, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType aclEntry;
@@ -520,7 +520,7 @@ TEST(JointFabricDatastoreTest, RemoveACLFromNode)
     CHIP_ERROR err = store.SetDelegate(&delegate);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = store.AddPendingNode(123, CharSpan::fromCharString("test-node"));
+    err = store.AddPendingNode(123, "test-node"_span);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType aclEntry;

--- a/src/controller/java/AndroidLogDownloadFromNode.cpp
+++ b/src/controller/java/AndroidLogDownloadFromNode.cpp
@@ -34,11 +34,11 @@ CharSpan toIntentCharSpan(DiagnosticLogs::IntentEnum intent)
     switch (intent)
     {
     case DiagnosticLogs::IntentEnum::kEndUserSupport:
-        return CharSpan::fromCharString("EndUser");
+        return "EndUser"_span;
     case DiagnosticLogs::IntentEnum::kNetworkDiag:
-        return CharSpan::fromCharString("Network");
+        return "Network"_span;
     case DiagnosticLogs::IntentEnum::kCrashLogs:
-        return CharSpan::fromCharString("Crash");
+        return "Crash"_span;
     default:
         return CharSpan();
     }

--- a/src/lib/support/tests/TestUtf8.cpp
+++ b/src/lib/support/tests/TestUtf8.cpp
@@ -48,35 +48,35 @@ TEST(TestUtf8, TestValidStrings)
 {
     EXPECT_TRUE(Utf8::IsValid(CharSpan())); // empty span ok
 
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("abc")));
+    EXPECT_TRUE(Utf8::IsValid(""_span));
+    EXPECT_TRUE(Utf8::IsValid("abc"_span));
 
     // Various tests from https://www.w3.org/2001/06/utf-8-wrong/UTF-8-test.html
 
     // Generic UTF8
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("κόσμε")));
+    EXPECT_TRUE(Utf8::IsValid("κόσμε"_span));
 
     // First possible sequence of a certain length
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("ࠀ")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("𐀀")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("�����")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("������")));
+    EXPECT_TRUE(Utf8::IsValid(""_span));
+    EXPECT_TRUE(Utf8::IsValid("ࠀ"_span));
+    EXPECT_TRUE(Utf8::IsValid("𐀀"_span));
+    EXPECT_TRUE(Utf8::IsValid("�����"_span));
+    EXPECT_TRUE(Utf8::IsValid("������"_span));
 
     // Last possible sequence of a certain length
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("߿")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("￿")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("����")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("�����")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("������")));
+    EXPECT_TRUE(Utf8::IsValid(""_span));
+    EXPECT_TRUE(Utf8::IsValid("߿"_span));
+    EXPECT_TRUE(Utf8::IsValid("￿"_span));
+    EXPECT_TRUE(Utf8::IsValid("����"_span));
+    EXPECT_TRUE(Utf8::IsValid("�����"_span));
+    EXPECT_TRUE(Utf8::IsValid("������"_span));
 
     // Other boundary conditions
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("퟿")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("�")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("􏿿")));
-    EXPECT_TRUE(Utf8::IsValid(CharSpan::fromCharString("����")));
+    EXPECT_TRUE(Utf8::IsValid("퟿"_span));
+    EXPECT_TRUE(Utf8::IsValid(""_span));
+    EXPECT_TRUE(Utf8::IsValid("�"_span));
+    EXPECT_TRUE(Utf8::IsValid("􏿿"_span));
+    EXPECT_TRUE(Utf8::IsValid("����"_span));
 
     // NOTE: UTF8 allows embeded NULLs
     //       even though strings like that are probably not ideal for handling


### PR DESCRIPTION
#### Summary

`chip::CharSpan::fromCharString()` checks string size in runtime with `strlen()`. For string literal we should use `_span` literal to get the size in compile time.

This PR replaces all usages of `CharSpan::fromCharString("...")` with `"..."_span` except code in `src/lib/support/tests/TestSpan.cpp` which checks the `_span` literal.

#### Testing

Locally check the size of the `chip-tool` before and after that change:

```console
$ size out/linux-x64-chip-tool-release-size/chip-tool
   text    data     bss     dec     hex filename
7076506  594496  103352 7774354  76a092 out/linux-x64-chip-tool-release-size/chip-tool

$ size out/linux-x64-chip-tool-release-size-new/chip-tool
   text    data     bss     dec     hex filename
7076430  594496  103352 7774278  76a046 out/linux-x64-chip-tool-release-size-new/chip-tool
```

We've saved 76 bytes in the .text section :)

CI should check potential build breaks.