### PR TITLE
[Tests] Reorganize final exception handling

### DIFF
--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -621,27 +621,32 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int, app_path: li
                 break
 
             time.sleep(0.5)
-    except KeyboardInterrupt as e:
-        log.info("Interrupting execution on user request")
-        errors.append(e)
-    except ResultError as e:
-        # We just print the message without stack trace, as the actual failure with stack trace has already been logged.
-        log.error("%s", e)
-        errors.append(SystemExit(2))
-    except Exception as e:
-        log.error("Caught exception during test execution: %r", e, exc_info=True)
+    except BaseException as e:
         errors.append(e)
     finally:
         for item in reversed(to_terminate):
+            item_name = item.__class__.__name__
             try:
-                log.info("Cleaning up %s", item.__class__.__name__)
+                log.info("Cleaning up %s", item_name)
                 item.terminate()
             except Exception as e:
-                log.warning("Encountered exception during cleanup: %r", e, exc_info=True)
+                log.warning("Encountered exception during cleanup of %s: %r", item_name, e)
                 errors.append(e)
 
+    # If there is only one error, we handle some special cases. Otherwise, we raise an exception group with all the errors
+    # encountered during execution and cleanup.
     if len(errors) == 1:
-        raise errors[0]
+        match error := errors[0]:
+            case KeyboardInterrupt():
+                log.info("Interrupting execution on user request")
+                raise error
+            case ResultError():
+                # We just print the message, as the actual test failure with stack trace has already been logged.
+                log.error("%s", error)
+                raise SystemExit(2)
+            case _:
+                raise RuntimeError("Caught an exception during test execution") from error
+
     if errors:
         raise BaseExceptionGroup("Encountered exceptions during test execution or cleanup", errors)
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -645,7 +645,8 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int, app_path: li
                 log.error("%s", error)
                 raise SystemExit(2)
             case _:
-                raise RuntimeError("Caught an exception during test execution") from error
+                # Reraise the single exception with its original traceback preserved.
+                raise error.with_traceback(error.__traceback__)
 
     if errors:
         raise BaseExceptionGroup("Encountered exceptions during test execution or cleanup", errors)


### PR DESCRIPTION
#### Summary

Small improvements to the final exception handling in YAML tests:

- Avoid printing stacktrace multiple times in logs.
- Don't pollute the stacktrace when reraising a single exception.
- Add name of resource that failed cleaning to the log.

#### Related issues

Submitted along:

- https://github.com/project-chip/connectedhomeip/pull/71558
- https://github.com/project-chip/connectedhomeip/pull/71560

#### Testing

Manual tests with `run_test_suite.py` and injected exceptions in various places to check for the behavior.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
