### PR TITLE
[SILABS] Temporarily disable quick-join feature in WiFi 

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -531,7 +531,8 @@ sl_status_t SetWifiConfigurations()
         chip::ByteSpan inBssid(wfx_rsi.ap_bssid.data(), kWiFiBSSIDLength);
         TEMPORARY_RETURN_IGNORED chip::CopySpanToMutableSpan(inBssid, bssidSpan);
         // Enabling quick-join since we have the channel and BSSID
-        join_feature_bitmap |= SL_SI91X_JOIN_FEAT_QUICK_JOIN;
+        // TODO: Uncomment this once the quick-join issue is fixed
+        // join_feature_bitmap |= SL_SI91X_JOIN_FEAT_QUICK_JOIN;
     }
 
     status = sl_wifi_set_join_configuration(SL_WIFI_CLIENT_INTERFACE, join_feature_bitmap);


### PR DESCRIPTION
#### Summary

Temporarily disabling the quick-join feature in Wi-Fi for the SiWx platform, as the feature is not working as expected with all the flows. Specifically in sleep enabled applications.

#### Related issues

N/A

#### Testing

Manually tested by restarting the device multiple times.
Steps:

1. Commission the device
2. Reboot the device
3. Wait for it to connect to the access point.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
