### PR TITLE
[Tests] Parallelize network namespace startup

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/linux/namespace.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/linux/namespace.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import dataclasses
 import logging
 import os
@@ -295,24 +296,24 @@ class IsolatedNetworkNamespace:
         self.bridge.attach_link(self.mgmt_link)
 
         try:
-            self.app_ns.setup()
-            self.tool_ns.setup()
+            # Bring up selected links in parallel to reduce wait time.
+            with concurrent.futures.ThreadPoolExecutor(max_workers=3, thread_name_prefix="NetnsSetup") as executor:
+                concurrent.futures.wait((executor.submit(self.app_ns.setup),
+                                         executor.submit(self.tool_ns.setup)))
 
-            self.app_link.setup()
-            self.tool_link.setup()
-            self.mgmt_link.setup()
+                concurrent.futures.wait((executor.submit(self.app_link.setup),
+                                         executor.submit(self.tool_link.setup),
+                                         executor.submit(self.mgmt_link.setup)))
 
-            self.bridge.setup()
+                self.bridge.setup()
 
-            # Bring up selected links.
-            if mgmt_link_up:
-                self.mgmt_link.up()
-            if tool_link_up:
-                self.tool_link.up()
-            if app_link_up:
-                self.app_link.up()
+                concurrent.futures.wait(executor.submit(link.up)
+                                        for link, should_up in ((self.app_link, app_link_up),
+                                                                (self.tool_link, tool_link_up),
+                                                                (self.mgmt_link, mgmt_link_up))
+                                        if should_up)
 
-            self.bridge.up()
+                self.bridge.up()
 
         except BaseException:
             log.exception("Encountered error while setting up network namespaces")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/linux/namespace.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/linux/namespace.py
@@ -298,20 +298,25 @@ class IsolatedNetworkNamespace:
         try:
             # Bring up selected links in parallel to reduce wait time.
             with concurrent.futures.ThreadPoolExecutor(max_workers=3, thread_name_prefix="NetnsSetup") as executor:
-                concurrent.futures.wait((executor.submit(self.app_ns.setup),
-                                         executor.submit(self.tool_ns.setup)))
+                list(executor.map(lambda x: x(), (
+                    self.app_ns.setup,
+                    self.tool_ns.setup,
+                )))
 
-                concurrent.futures.wait((executor.submit(self.app_link.setup),
-                                         executor.submit(self.tool_link.setup),
-                                         executor.submit(self.mgmt_link.setup)))
+                list(executor.map(lambda x: x(), (
+                    self.app_link.setup,
+                    self.tool_link.setup,
+                    self.mgmt_link.setup,
+                )))
 
                 self.bridge.setup()
 
-                concurrent.futures.wait(executor.submit(link.up)
-                                        for link, should_up in ((self.app_link, app_link_up),
-                                                                (self.tool_link, tool_link_up),
-                                                                (self.mgmt_link, mgmt_link_up))
-                                        if should_up)
+                list(executor.map(lambda x: x(), (
+                    link.up for link, should_up in (
+                        (self.app_link, app_link_up),
+                        (self.tool_link, tool_link_up),
+                        (self.mgmt_link, mgmt_link_up)
+                    ) if should_up)))
 
                 self.bridge.up()
 


### PR DESCRIPTION
#### Summary

This PR improves startup speed of the test framework (on my computer about 3.5s) by parallelizing network interface startup.

#### Related issues

Submitted alongside:

- https://github.com/project-chip/connectedhomeip/pull/71557
- https://github.com/project-chip/connectedhomeip/pull/71558

#### Testing

Running `run_test_suite.py`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase – shorter

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
