### PR TITLE
[Cherry-pick] Fix BRBINFO_2_1 step skipping from PR #43756

### DIFF
--- a/src/python_testing/TC_BINFO_2_1.py
+++ b/src/python_testing/TC_BINFO_2_1.py
@@ -37,8 +37,7 @@ from support_modules.binfo_attributes_verification import BasicInformationAttrib
 
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body
-from matter.testing.matter_testing import TestStep
-from matter.testing.runner import default_matter_test_main
+from matter.testing.runner import TestStep, default_matter_test_main
 
 
 class TC_BINFO_2_1(BasicInformationAttributesVerificationBase):

--- a/src/python_testing/TC_BRBINFO_2_1.py
+++ b/src/python_testing/TC_BRBINFO_2_1.py
@@ -37,8 +37,7 @@ from support_modules.binfo_attributes_verification import BasicInformationAttrib
 
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body
-from matter.testing.matter_testing import TestStep
-from matter.testing.runner import default_matter_test_main
+from matter.testing.runner import TestStep, default_matter_test_main
 
 
 class TC_BRBINFO_2_1(BasicInformationAttributesVerificationBase):
@@ -46,9 +45,9 @@ class TC_BRBINFO_2_1(BasicInformationAttributesVerificationBase):
         return "[TC-BRBINFO-2.1] Attributes [DUT-Server]"
 
     def steps_TC_BRBINFO_2_1(self) -> list[TestStep]:
-        # BRBINFO doesn't have DataModelRevision, Location, LocalConfigDisabled, CapabilityMinima, SpecificationVersion, MaxPathsPerInvoke
-        # and ConfigurationVersion (29) as mandatory attributes
-        # so skip steps 1, 7, 17, 20, 22, 23
+        # BRBINFO test plan omits Basic Information attributes not present on Bridged Device Basic Information:
+        # DataModelRevision (1), Location (7), LocalConfigDisabled (17), CapabilityMinima (20),
+        # SpecificationVersion (22), MaxPathsPerInvoke (23).
         return self.steps()
 
     def pics_TC_BRBINFO_2_1(self) -> list[str]:

--- a/src/python_testing/support_modules/binfo_attributes_verification.py
+++ b/src/python_testing/support_modules/binfo_attributes_verification.py
@@ -23,6 +23,7 @@ from mobly import asserts
 
 from matter.clusters.ClusterObjects import Cluster
 from matter.testing.conformance import ConformanceException
+from matter.testing.decorators import _has_attribute
 from matter.testing.matter_testing import MatterBaseTest, TestStep
 from matter.testing.spec_parsing import dm_from_spec_version
 
@@ -224,7 +225,8 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
             ret15 = await self.read_single_attribute_check_success(cluster=cluster, attribute=cluster.Attributes.ProductLabel)
             asserts.assert_true(isinstance(ret15, str), "ProductLabel should be a string")
             asserts.assert_equal(len(ret15) <= 64, True, "ProductLabel should be a string with max 64 bytes")
-            if await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.VendorName):
+            await self._populate_wildcard()
+            if _has_attribute(wildcard=self.stored_global_wildcard, endpoint=self.endpoint, attribute=cluster.Attributes.VendorName):
                 asserts.assert_not_in(
                     vendor_name, ret15, "ProductLabel should not include the name of the vendor as defined within the VendorName attribute")
 
@@ -256,7 +258,8 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
         if await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.UniqueID):
             ret19 = await self.read_single_attribute_check_success(cluster=cluster, attribute=cluster.Attributes.UniqueID)
             asserts.assert_true(isinstance(ret19, str), "UniqueID should be a string")
-            if await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.SerialNumber):
+            await self._populate_wildcard()
+            if _has_attribute(wildcard=self.stored_global_wildcard, endpoint=self.endpoint, attribute=cluster.Attributes.SerialNumber):
                 asserts.assert_not_equal(
                     ret19, serial_number, "UniqueID should not be identical to SerialNumber attribute if SerialNumber attribute is supported")
 


### PR DESCRIPTION
### Summary
Cherry-pick of PR #43756 into 1.6 SVE branch.

This includes the minimal fix for incorrect step skipping due to inner attribute_guard() checks in steps 15 and 19.

### Testing