### PR TITLE
Fix use-after-free in OnUnsolicitedReportData ReadClient list iteration

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1005,8 +1005,17 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
     VerifyOrReturnError(report.ExitContainer() == CHIP_NO_ERROR, Status::InvalidAction);
 
     ReadClient * foundSubscription = nullptr;
-    for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
+    // Save next pointer before invoking callbacks: OnUnsolicitedMessageFromPublisher() may
+    // synchronously remove the current readClient from the list via TriggerResubscribeIfScheduled()
+    // -> Close() -> RemoveReadClient(). The callback only ever removes the current readClient
+    // (it operates on `this`), so saving nextClient before the callback is sufficient.
+    // If that invariant changes, an active-iterator pattern would be needed
+    // (see ObjectPool::ForEachActiveObject).
+    ReadClient * nextClient = nullptr;
+    for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = nextClient)
     {
+        nextClient = readClient->GetNextClient();
+
         auto peer = apExchangeContext->GetSessionHandle()->GetPeer();
         if (readClient->GetFabricIndex() != peer.GetFabricIndex() || readClient->GetPeerNodeId() != peer.GetNodeId())
         {

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -584,6 +584,7 @@ public:
     void TestSubscribeUrgentWildcardEvent();
     void TestSubscribeWildcard();
     void TestSubscriptionReportWithDefunctSession();
+    void TestOnUnsolicitedReportDataSafeListIteration();
 
     enum class ReportType : uint8_t
     {
@@ -5385,6 +5386,124 @@ void TestReadInteraction::TestSubscriptionReportWithDefunctSession()
     // Get rid of our defunct session.
     ExpireSessionAliceToBob();
     EXPECT_SUCCESS(CreateSessionAliceToBob());
+}
+
+} // namespace app
+} // namespace chip
+
+// Regression test: OnUnsolicitedReportData must safely iterate mpActiveReadClientList when a ReadClient
+// removes itself during the callback (via TriggerResubscribeIfScheduled -> Close -> destructor -> RemoveReadClient).
+// Before the fix, the loop used readClient->GetNextClient() after the callback, dereferencing freed memory.
+namespace chip {
+namespace app {
+
+// Callback that destroys the ReadClient in OnDone, simulating real app behavior.
+class SelfDestructingCallback : public ReadClient::Callback
+{
+public:
+    void OnError(CHIP_ERROR) override { mGotError = true; }
+    void OnDone(ReadClient * apReadClient) override
+    {
+        mOnDoneCalled = true;
+        // Real apps destroy the ReadClient here, which triggers RemoveReadClient.
+        // We use the pointer stashed by the test.
+        if (mDestroyClient)
+        {
+            chip::Platform::Delete(apReadClient);
+        }
+    }
+    void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) override {}
+
+    bool mOnDoneCalled  = false;
+    bool mGotError      = false;
+    bool mDestroyClient = false;
+};
+
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteraction, TestOnUnsolicitedReportDataSafeListIteration)
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteractionSync, TestOnUnsolicitedReportDataSafeListIteration)
+void TestReadInteraction::TestOnUnsolicitedReportDataSafeListIteration()
+{
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), gReportScheduler), CHIP_NO_ERROR);
+
+    // Set up two subscriptions from the same peer so both are visited during OnUnsolicitedReportData iteration.
+    SelfDestructingCallback delegateA;
+    SelfDestructingCallback delegateB;
+
+    ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+    chip::app::AttributePathParams attributePathParams[1];
+    attributePathParams[0].mEndpointId             = kTestEndpointId;
+    attributePathParams[0].mClusterId              = kTestClusterId;
+    attributePathParams[0].mAttributeId            = 1;
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize = 1;
+    readPrepareParams.mMinIntervalFloorSeconds     = 2;
+    readPrepareParams.mMaxIntervalCeilingSeconds   = 5;
+
+    // Create two subscribe ReadClients.
+    // Use heap allocation so SelfDestructingCallback can delete them in OnDone.
+    auto * readClientA =
+        chip::Platform::New<ReadClient>(engine, &GetExchangeManager(), delegateA, ReadClient::InteractionType::Subscribe);
+    auto * readClientB =
+        chip::Platform::New<ReadClient>(engine, &GetExchangeManager(), delegateB, ReadClient::InteractionType::Subscribe);
+
+    EXPECT_EQ(readClientA->SendRequest(readPrepareParams), CHIP_NO_ERROR);
+    DrainAndServiceIO();
+    EXPECT_EQ(readClientB->SendRequest(readPrepareParams), CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    EXPECT_EQ(engine->GetNumActiveReadClients(), 2u);
+
+    // Put readClientA into resubscription-scheduled state so that OnUnsolicitedMessageFromPublisher()
+    // will trigger TriggerResubscribeIfScheduled() -> OnResubscribeTimerCallback() -> Close().
+    // First, mark the session defunct so OnResubscribeTimerCallback will fail to send and call Close().
+    readClientA->mReadPrepareParams.mSessionHolder->AsSecureSession()->MarkAsDefunct();
+    readClientA->MoveToState(ReadClient::ClientState::Idle);
+    readClientA->mIsResubscriptionScheduled = true;
+    readClientA->mForceCaseOnNextResub      = true; // Forces Close with allowResubscription=false
+
+    // Tell delegateA to destroy the ReadClient in OnDone (simulating real app behavior).
+    delegateA.mDestroyClient = true;
+
+    // Build an unsolicited report with readClientB's subscription ID so the iteration visits both clients.
+    System::PacketBufferHandle msgBuf = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);
+    ASSERT_FALSE(msgBuf.IsNull());
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(msgBuf));
+    ReportDataMessage::Builder response;
+    EXPECT_SUCCESS(response.Init(&writer));
+    response.SubscriptionId(readClientB->mSubscriptionId);
+    EXPECT_SUCCESS(response.EndOfReportDataMessage());
+    EXPECT_EQ(writer.Finalize(&msgBuf), CHIP_NO_ERROR);
+
+    // Send the unsolicited report. This exercises OnUnsolicitedReportData which iterates
+    // mpActiveReadClientList. readClientA will self-destruct during iteration.
+    // Without the safe-iteration fix, this would crash with use-after-free.
+    ASSERT_NE(engine->ActiveHandlerAt(0), nullptr);
+    auto * readHandler = engine->ActiveHandlerAt(0);
+
+    GetLoopback().mSentMessageCount = 0;
+    auto exchange = engine->GetExchangeManager()->NewContext(readHandler->mSessionHandle.Get().Value(), readHandler);
+    readHandler->mExchangeCtx.Grab(exchange);
+
+    EXPECT_EQ(readHandler->mExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(msgBuf),
+                                                     Messaging::SendMessageFlags::kExpectResponse),
+              CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    // readClientA should have been destroyed via OnDone.
+    EXPECT_TRUE(delegateA.mOnDoneCalled);
+
+    // The iteration should have continued safely to readClientB (no crash = test passes).
+    // readClientB is still alive.
+    EXPECT_GE(engine->GetNumActiveReadClients(), 1u);
+
+    // Cleanup: destroy readClientB.
+    delegateB.mDestroyClient = true;
+    chip::Platform::Delete(readClientB);
+
+    engine->Shutdown();
+    EXPECT_EQ(engine->GetNumActiveReadClients(), 0u);
 }
 
 } // namespace app


### PR DESCRIPTION
#71574 `OnUnsolicitedReportData` iterates `mpActiveReadClientList` but calls `OnUnsolicitedMessageFromPublisher()` inside the loop, which can synchronously trigger `TriggerResubscribeIfScheduled()` → `Close()` → `RemoveReadClient()`, removing the current node from the linked list. The loop then dereferences freed memory via `GetNextClient()`.

This is the only function iterating `mpActiveReadClientList` that was missing the safe "save next pointer before callback" pattern already used in `OnActiveModeNotification`, `OnPeerTypeChange`, `OnFabricRemoved`, `ShutdownSubscription`, and `ShutdownMatchingSubscriptions`.

Fix: Save `nextClient = readClient->GetNextClient()` before invoking the callback, and advance via `readClient = nextClient` at the end of each iteration.

#### Summary

Use-after-free in `InteractionModelEngine::OnUnsolicitedReportData` when iterating `mpActiveReadClientList`. The callback `OnUnsolicitedMessageFromPublisher()` can synchronously remove the current `ReadClient` from the linked list via `TriggerResubscribeIfScheduled()` → `OnResubscribeTimerCallback()` → `Close()` → `RemoveReadClient()`. The loop then calls `GetNextClient()` on freed memory.

This is the only `mpActiveReadClientList` iteration site missing the safe "save next before callback" pattern. Five other functions in the same file already use it, with comments like *"It is possible that pListItem is destroyed by the app"* and *"Grab the next client now, because we might be about to delete readClient."*

Observed ~10K+ crashes on field devices with active Matter subscriptions.

#### Related issues

N/A — filing upstream issue separately.

#### Testing

- Code review: all `mpActiveReadClientList` iteration paths now use safe next-pointer-before-callback pattern
- Manually verified the call chain: `OnUnsolicitedMessageFromPublisher()` → `TriggerResubscribeIfScheduled()` → `OnResubscribeTimerCallback()` → `Close()` → `RemoveReadClient()` confirms list mutation during iteration

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase
