### PR TITLE
[hotfix] fix merge error on type change: attributepathparams vs concreteattributepath

### DIFF
--- a/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
+++ b/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
@@ -258,7 +258,7 @@ TEST(TestDefaultServerCluster, SetAttributeValueNullable)
     ASSERT_FALSE(attr.IsNull());
     ASSERT_EQ(attr.Value(), 123u);
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
-    ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 1));
+    ASSERT_EQ(context.ChangeListener().DirtyList()[0], ConcreteAttributePath(kEndpointId, kClusterId, 1));
     context.ChangeListener().DirtyList().clear();
 
     // Set to same value -> should return false, no change


### PR DESCRIPTION
#### Summary

Master build fails after #71392 (conflict with tests added in #71543):

```
../../src/app/server-cluster/tests/TestDefaultServerCluster.cpp:261:5: error: invalid operands to binary expression ('const chip::app::ConcreteAttributePath' and 'const chip::app::AttributePathParams')
  261 |     ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 1));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:219:67: note: expanded from macro 'ASSERT_EQ'
  219 | #define ASSERT_EQ(lhs, rhs) _PW_TEST_ASSERT(_PW_TEST_OP(lhs, rhs, ==))
      |                                             ~~~~~~~~~~~~~~~~~~~~~~^~~
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:866:24: note: expanded from macro '_PW_TEST_OP'
  866 |         return _pw_lhs op _pw_rhs;                               \
      |                ~~~~~~~ ^  ~~~~~~~
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:845:9: note: expanded from macro '_PW_TEST_ASSERT'
  845 |   if (!(expectation))                                \
      |         ^~~~~~~~~~~
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:593:26: note: in instantiation of function template specialization 'TestDefaultServerCluster_SetAttributeValueNullable_Test::PigweedTestBody()::(anonymous class)::operator()<chip::app::ConcreteAttributePath, chip::app::AttributePathParams>' requested here
  593 |     const bool success = expectation(lhs, rhs);
      |                          ^
../../src/app/server-cluster/tests/TestDefaultServerCluster.cpp:261:5: note: in instantiation of function template specialization 'pw::unit_test::internal::Framework::CurrentTestExpect<(lambda at ../../src/app/server-cluster/tests/TestDefaultServerCluster.cpp:261:5), chip::app::ConcreteAttributePath, chip::app::AttributePathParams>' requested here
  261 |     ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 1));
      |     ^
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:219:45: note: expanded from macro 'ASSERT_EQ'
  219 | #define ASSERT_EQ(lhs, rhs) _PW_TEST_ASSERT(_PW_TEST_OP(lhs, rhs, ==))
      |                                             ^
../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:864:47: note: expanded from macro '_PW_TEST_OP'
  864 |   ::pw::unit_test::internal::Framework::Get().CurrentTestExpect( \
      |                                               ^
../../src/lib/core/CriticalFailure.h:102:44: note: candidate function not viable: no known conversion from 'const chip::app::ConcreteAttributePath' to 'const chip::ChipError' for 1st argument
  102 | __attribute__((always_inline)) inline bool operator==(const chip::ChipError & lhs, const chip::CriticalFailure & rhs)
      |                                            ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/app/MessageDef/StatusIB.h:128:16: note: candidate function not viable: no known conversion from 'const chip::app::ConcreteAttributePath' to 'const StatusIB' for 1st argument
  128 | constexpr bool operator==(const StatusIB & one, const StatusIB & two)
      |                ^          ~~~~~~~~~~~~~~~~~~~~
../../src/app/ConcreteAttributePath.h:53:10: note: candidate function not viable: no known conversion from 'const chip::app::AttributePathParams' to 'const ConcreteAttributePath' for 1st argument
   53 |     bool operator==(const ConcreteAttributePath & aOther) const
      |          ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

#### Testing

CI. Master fails in 6 minutes of build.