### PR TITLE
[NXP][examples][common] Fix lock-app panic at startup

### DIFF
--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -40,12 +40,12 @@
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #if defined(MATTER_DM_PLUGIN_USER_LABEL) || defined(MATTER_DM_PLUGIN_FIXED_LABEL)
-#ifndef CONFIG_DEVICE_INFO_PROVIDER_IMPL
-#define CONFIG_DEVICE_INFO_PROVIDER_IMPL 1
+#ifndef CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
+#define CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER 1
 #endif
 #endif
 
-#if CONFIG_DEVICE_INFO_PROVIDER_IMPL
+#if CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
 #include <DeviceInfoProviderImpl.h>
 #endif
 
@@ -129,7 +129,7 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::app::Clusters;
 
-#if CONFIG_DEVICE_INFO_PROVIDER_IMPL
+#if CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif
 
@@ -198,7 +198,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 #endif
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
-#if CONFIG_DEVICE_INFO_PROVIDER_IMPL
+#if CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
     gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 #endif


### PR DESCRIPTION


#### Summary

The door lock application panics at startup because the device info provider is missing during server initialization. This is caused by an inconsistency between the Kconfig build option (_CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER_) and the device info provider code guards (_CONFIG_DEVICE_INFO_PROVIDER_IMPL_) in the implementation of the example applications.

#### Testing

Fix manually tested on the NXP MCXW72 platform.
