### PR TITLE
[MSan Bugfix] Fix uninitialized epoch start time in GroupcastCluster::SetKeySet

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -632,6 +632,7 @@ Status GroupcastCluster::SetKeySet(const ConcreteCommandPath & path, const chip:
         GroupDataProvider::EpochKey & epoch = ks.epoch_keys[0];
         VerifyOrReturnValue(key.Value().size() == GroupDataProvider::EpochKey::kLengthBytes, Status::ConstraintError);
         memcpy(epoch.key, key.Value().data(), GroupDataProvider::EpochKey::kLengthBytes);
+        epoch.start_time = 1;
         {
             // Get compressed fabric
             uint8_t compressedFabricIdBuffer[sizeof(uint64_t)];

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -921,6 +921,17 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
         EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
+        // Per spec 11.27.7.1.4 (JoinGroup Command/Key Field), a keyset created via JoinGroup with a Key has exactly one epoch
+        // key (num_keys_used == 1) with EpochStartTime0 = 1.
+        {
+            Credentials::GroupDataProvider::KeySet storedKeyset;
+            EXPECT_EQ(mProvider.GetKeySet(kTestFabricIndex, kKeyset, storedKeyset), CHIP_NO_ERROR);
+            EXPECT_EQ(storedKeyset.keyset_id, kKeyset);
+            EXPECT_EQ(storedKeyset.policy, Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst);
+            EXPECT_EQ(storedKeyset.num_keys_used, 1u);
+            EXPECT_EQ(storedKeyset.epoch_keys[0].start_time, 1u);
+        }
+
         // Join group: Existing keyset and key (invalid)
         data.groupID = 2;
         result       = tester.Invoke(Commands::JoinGroup::Id, data);

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -171,9 +171,11 @@ public:
     {
         static constexpr size_t kEpochKeysMax = 3;
 
-        KeySet() = default;
+        KeySet() { ClearKeys(); }
         KeySet(uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(id), policy(policy_id), num_keys_used(num_keys)
-        {}
+        {
+            ClearKeys();
+        }
 
         // The actual keys for the group key set
         EpochKey epoch_keys[kEpochKeysMax];

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -171,11 +171,9 @@ public:
     {
         static constexpr size_t kEpochKeysMax = 3;
 
-        KeySet() { ClearKeys(); }
+        KeySet() = default;
         KeySet(uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(id), policy(policy_id), num_keys_used(num_keys)
-        {
-            ClearKeys();
-        }
+        {}
 
         // The actual keys for the group key set
         EpochKey epoch_keys[kEpochKeysMax];

--- a/src/python_testing/TC_GC_2_3.py
+++ b/src/python_testing/TC_GC_2_3.py
@@ -41,6 +41,7 @@ from mobly import asserts
 from TC_GC_common import generate_membership_entry_matcher, get_feature_map, valid_endpoints_list
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
@@ -60,7 +61,8 @@ class TC_GC_2_3(MatterBaseTest):
             TestStep("1b", "TH removes any existing group and KeySetID on the DUT"),
             TestStep("1c", "TH subscribes to Membership attribute with min interval 0s and max interval 30s"),
             TestStep("1d", "Join Group G1 generating a new Key with KeySetID K1 using JoinGroup"),
-            TestStep("1e", "Join Group G2 generating a new Key with KeySetID K2 using JoinGroup"),
+            TestStep("1e", "TH reads back KeySetID K1 via GroupKeyManagement KeySetRead and validates the returned GroupKeySetStruct"),
+            TestStep("1f", "Join Group G2 generating a new Key with KeySetID K2 using JoinGroup"),
             TestStep(2, "Update Group G1 to use a new KeySetID K3 and create it by providing a Key: TH sends command UpdateGroupKey (GroupID=G1, KeySetID=K3, Key=InputKey3)"),
             TestStep(3, "TH awaits subscription report showing KeySetID=K3 for G1"),
             TestStep(4, "Update Group G2 generating a new key with an existing KeySetID K1. UpdateGroupKey (GroupID=G2, KeySetID=K1, Key=InputKey4)"),
@@ -119,6 +121,22 @@ class TC_GC_2_3(MatterBaseTest):
         )
 
         self.step("1e")
+        response = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRead(groupKeySetID=keySetID1))
+
+        # Validate KeySet contents per spec 11.27.7.1.4 (JoinGroup Command / Key Field):
+        # a keyset created via JoinGroup with a Key SHALL have GroupKeySecurityPolicy = TrustFirst,
+        # EpochStartTime0 = 1, and EpochKey1/EpochStartTime1/EpochKey2/EpochStartTime2 = null.
+        # EpochKey0 is also null in KeySetRead responses because key material is never read back.
+        expected = Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
+            groupKeySetID=keySetID1,
+            groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
+            epochKey0=NullValue, epochStartTime0=1,
+            epochKey1=NullValue, epochStartTime1=NullValue,
+            epochKey2=NullValue, epochStartTime2=NullValue,
+        )
+        asserts.assert_equal(response.groupKeySet, expected, "Unexpected GroupKeySetStruct returned by KeySetRead")
+
+        self.step("1f")
         groupID2 = 2
         keySetID2 = 2
         inputKey2 = secrets.token_bytes(16)

--- a/src/python_testing/TC_GC_2_3.py
+++ b/src/python_testing/TC_GC_2_3.py
@@ -61,7 +61,7 @@ class TC_GC_2_3(MatterBaseTest):
             TestStep("1b", "TH removes any existing group and KeySetID on the DUT"),
             TestStep("1c", "TH subscribes to Membership attribute with min interval 0s and max interval 30s"),
             TestStep("1d", "Join Group G1 generating a new Key with KeySetID K1 using JoinGroup"),
-            TestStep("1e", "TH reads back KeySetID K1 via GroupKeyManagement KeySetRead and validates the returned GroupKeySetStruct"),
+            TestStep("1e", "TH reads back the Key Set with KeySetID K1 via GroupKeyManagement KeySetRead and validates the returned GroupKeySetStruct"),
             TestStep("1f", "Join Group G2 generating a new Key with KeySetID K2 using JoinGroup"),
             TestStep(2, "Update Group G1 to use a new KeySetID K3 and create it by providing a Key: TH sends command UpdateGroupKey (GroupID=G1, KeySetID=K3, Key=InputKey3)"),
             TestStep(3, "TH awaits subscription report showing KeySetID=K3 for G1"),


### PR DESCRIPTION
#### Summary

- Fixes https://github.com/project-chip/connectedhomeip/issues/71584


- `epoch.start_time` was left uninitialised when `GroupcastCluster::SetKeySet` created a new keyset due to a call of `GroupcastCluster::JoinGroup` with a Key provided.
- in Spec, under Groupcast Cluster (11.27.7.1. JoinGroup Command), `EpochStartTime0` SHALL be initialised to 1 in that case

- Follow-up: make initialisation of GroupDataProvider::KeySet safer

#### Related Issues

- Test Plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6051
- This is part of the effort: https://github.com/project-chip/connectedhomeip/issues/71500
#### Testing
- Added a new Step that validates the  GroupKeySet after JoinGroup command in `TC_GC_2_3.py`
- Added validation of GroupKeySet after JoinGroup command in TestGroupcastCluster


- ran MSAN Unit Tests locally and made sure TestGroupcastCluster is passing
- ran MSAN All Clusters Locally against `TC_GC_2_*.py`
