### PR TITLE
Fix nullptr on signout

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -120,8 +120,12 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Set a handler for Commissioner's CommissionerDeclaration messages. This is set in
     // connectedhomeip/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
-        CommissionerDeclarationHandler::GetInstance());
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
+        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    if (client != nullptr)
+    {
+        client->SetCommissionerDeclarationHandler(CommissionerDeclarationHandler::GetInstance());
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
@@ -134,7 +138,12 @@ JNI_METHOD(void, finishStopping)(JNIEnv *, jobject)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
+        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    if (client != nullptr)
+    {
+        client->SetCommissionerDeclarationHandler(nullptr);
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -120,8 +120,7 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Set a handler for Commissioner's CommissionerDeclaration messages. This is set in
     // connectedhomeip/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
-    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
-        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    auto * client = chip::Server::GetInstance().GetUserDirectedCommissioningClient();
     if (client != nullptr)
     {
         client->SetCommissionerDeclarationHandler(CommissionerDeclarationHandler::GetInstance());
@@ -138,8 +137,7 @@ JNI_METHOD(void, finishStopping)(JNIEnv *, jobject)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
-    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
-        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    auto * client = chip::Server::GetInstance().GetUserDirectedCommissioningClient();
     if (client != nullptr)
     {
         client->SetCommissionerDeclarationHandler(nullptr);

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -170,8 +170,12 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Set a handler for Commissioner's CommissionerDeclaration messages. This is set in
     // connectedhomeip/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
-        CommissionerDeclarationHandler::GetInstance());
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
+        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    if (client != nullptr)
+    {
+        client->SetCommissionerDeclarationHandler(CommissionerDeclarationHandler::GetInstance());
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     mState = CASTING_APP_RUNNING; // CastingApp started successfully, set state to RUNNING
@@ -185,7 +189,12 @@ CHIP_ERROR CastingApp::Stop()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
+        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    if (client != nullptr)
+    {
+        client->SetCommissionerDeclarationHandler(nullptr);
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     // Shutdown the Matter server

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -170,8 +170,7 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Set a handler for Commissioner's CommissionerDeclaration messages. This is set in
     // connectedhomeip/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
-    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
-        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    auto * client = chip::Server::GetInstance().GetUserDirectedCommissioningClient();
     if (client != nullptr)
     {
         client->SetCommissionerDeclarationHandler(CommissionerDeclarationHandler::GetInstance());
@@ -189,8 +188,7 @@ CHIP_ERROR CastingApp::Stop()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
-    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
-        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    auto * client = chip::Server::GetInstance().GetUserDirectedCommissioningClient();
     if (client != nullptr)
     {
         client->SetCommissionerDeclarationHandler(nullptr);

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -69,7 +69,12 @@ CHIP_ERROR CastingServer::Init(AppParams * AppParams)
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(DeviceEventCallback, 0));
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-    Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(this);
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
+        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    if (client != nullptr)
+    {
+        client->SetCommissionerDeclarationHandler(this);
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     mInited = true;
@@ -415,7 +420,7 @@ void CastingServer::OnDescriptorReadSuccessResponse(void * context, const app::D
     }
 
     // Read WoL:MACAddress (if available from this endpoint)
-    TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->ReadMACAddress(endpointInfo);
+    TEMPORARY_RETURN_IGNORED CastingServer::GetInstance() -> ReadMACAddress(endpointInfo);
 
     if (CastingServer::GetInstance()->mOnNewOrUpdatedEndpoint)
     {
@@ -510,15 +515,15 @@ void CastingServer::VerifyOrEstablishConnectionTask(chip::System::Layer * aSyste
         [](TargetVideoPlayerInfo * videoPlayer) {
             ChipLogProgress(AppServer, "CastingServer::OnConnectionSuccess lambda called");
             CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo = *videoPlayer;
-            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->ReadMACAddress(
+            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance() -> ReadMACAddress(
                 videoPlayer->GetEndpoint(1)); // Read MACAddress from cached VideoPlayer endpoint (1) which supports WoL
             CastingServer::GetInstance()->mOnConnectionSuccessClientCallback(videoPlayer);
         },
         [](CHIP_ERROR error) {
             ChipLogProgress(AppServer, "Deleting VideoPlayer from cache after connection failure: %" CHIP_ERROR_FORMAT,
                             error.Format());
-            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->mPersistenceManager.DeleteVideoPlayer(
-                &CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo);
+            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()
+                -> mPersistenceManager.DeleteVideoPlayer(&CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo);
             CastingServer::GetInstance()->mOnConnectionFailureClientCallback(error);
         });
     if (err != CHIP_NO_ERROR)

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -69,8 +69,7 @@ CHIP_ERROR CastingServer::Init(AppParams * AppParams)
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(DeviceEventCallback, 0));
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-    Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient * client =
-        chip::Server::GetInstance().GetUserDirectedCommissioningClient();
+    auto * client = chip::Server::GetInstance().GetUserDirectedCommissioningClient();
     if (client != nullptr)
     {
         client->SetCommissionerDeclarationHandler(this);
@@ -420,7 +419,7 @@ void CastingServer::OnDescriptorReadSuccessResponse(void * context, const app::D
     }
 
     // Read WoL:MACAddress (if available from this endpoint)
-    TEMPORARY_RETURN_IGNORED CastingServer::GetInstance() -> ReadMACAddress(endpointInfo);
+    TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->ReadMACAddress(endpointInfo);
 
     if (CastingServer::GetInstance()->mOnNewOrUpdatedEndpoint)
     {
@@ -515,15 +514,15 @@ void CastingServer::VerifyOrEstablishConnectionTask(chip::System::Layer * aSyste
         [](TargetVideoPlayerInfo * videoPlayer) {
             ChipLogProgress(AppServer, "CastingServer::OnConnectionSuccess lambda called");
             CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo = *videoPlayer;
-            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance() -> ReadMACAddress(
+            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->ReadMACAddress(
                 videoPlayer->GetEndpoint(1)); // Read MACAddress from cached VideoPlayer endpoint (1) which supports WoL
             CastingServer::GetInstance()->mOnConnectionSuccessClientCallback(videoPlayer);
         },
         [](CHIP_ERROR error) {
             ChipLogProgress(AppServer, "Deleting VideoPlayer from cache after connection failure: %" CHIP_ERROR_FORMAT,
                             error.Format());
-            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()
-                -> mPersistenceManager.DeleteVideoPlayer(&CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo);
+            TEMPORARY_RETURN_IGNORED CastingServer::GetInstance()->mPersistenceManager.DeleteVideoPlayer(
+                &CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo);
             CastingServer::GetInstance()->mOnConnectionFailureClientCallback(error);
         });
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
#### Summary

Crash seen on android

We are getting a nullptr dereference exception from the library when it calls [finishStopping()](https://github.com/project-chip/connectedhomeip/blob/master/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp#L130) after a successful stop.
Inside this finish stopping, we try to set the [CommissionerDeclarationHandler to nullptr](https://github.com/project-chip/connectedhomeip/blob/master/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp#L137) . But stop has already done that.


`

01-07 12:14:03.302  4390  4390 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
01-07 12:14:03.302  4390  4390 F DEBUG   : Build fingerprint: 'google/walleye/walleye:11/RP1A.201005.004.A1/6934943:user/release-keys'
01-07 12:14:03.302  4390  4390 F DEBUG   : Revision: 'MP1'
01-07 12:14:03.302  4390  4390 F DEBUG   : ABI: 'arm64'
01-07 12:14:03.303  4390  4390 F DEBUG   : Timestamp: 2026-01-07 12:14:03-0800
01-07 12:14:03.303  4390  4390 F DEBUG   : pid: 3937, tid: 4054, name: DefaultDispatch  >>> com.amazon.clouddrive.photos <<<
01-07 12:14:03.303  4390  4390 F DEBUG   : uid: 10267
01-07 12:14:03.303  4390  4390 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8
01-07 12:14:03.303  4390  4390 F DEBUG   : Cause: null pointer dereference
01-07 12:14:03.303  4390  4390 F DEBUG   :     x0  0000007af8d5a418  x1  0000000000000000  x2  0000000000000050  x3  0000000000000003
01-07 12:14:03.303  4390  4390 F DEBUG   :     x4  0000007b0ec83400  x5  0000000000000040  x6  fefefeff28277164  x7  7f7f7f7f7f7f7f7f
01-07 12:14:03.303  4390  4390 F DEBUG   :     x8  96d45daa1f1c6578  x9  96d45daa1f1c6578  x10 0000000000000001  x11 0000000000000000
01-07 12:14:03.303  4390  4390 F DEBUG   :     x12 0000007b0ec83520  x13 0000000000000045  x14 0000007b0ec84798  x15 002d602a1a9ee009
01-07 12:14:03.303  4390  4390 F DEBUG   :     x16 0000007e4646a740  x17 0000007e45a92740  x18 0000007b0d492000  x19 0000007af8d5a408
01-07 12:14:03.303  4390  4390 F DEBUG   :     x20 0000000000000000  x21 0000007d22e7ef20  x22 0000007b0ec87000  x23 0000007d22e7efd8
01-07 12:14:03.303  4390  4390 F DEBUG   :     x24 0000007b1c58b240  x25 0000007b0ec87000  x26 000000000000001f  x27 0000000000000001
01-07 12:14:03.303  4390  4390 F DEBUG   :     x28 0000000000000002  x29 0000007b0ec84d60
01-07 12:14:03.303  4390  4390 F DEBUG   :     lr  0000007af896ce24  sp  0000007b0ec84d60  pc  0000007af896ce28  pst 0000000060000000
01-07 12:14:03.483  4390  4390 F DEBUG   : backtrace:
01-07 12:14:03.483  4390  4390 F DEBUG   :       #00 pc 0000000000127e28  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x71c4000) (Java_com_matter_casting_core_CastingApp_finishStopping+108)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #01 pc 00000000001c603c  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/oat/arm64/base.odex (art_jni_trampoline+124)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #02 pc 0000000000133564  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #03 pc 00000000001a97e8  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #04 pc 000000000031c040  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+376) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #05 pc 0000000000312228  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+912) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #06 pc 0000000000687d48  /apex/com.android.art/lib64/libart.so (MterpInvokeDirect+576) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #07 pc 000000000012d914  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_direct+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #08 pc 0000000000394b64  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x6009000) (com.matter.casting.core.CastingApp.stop+68)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #09 pc 0000000000685960  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #10 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #11 pc 0000000000341294  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x175d000) (com.amazon.photos.sharedfeatures.casting.engine.CastingEngine$CastingAppImpl.stop+4)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #12 pc 0000000000685960  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #13 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #14 pc 0000000000341714  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x175d000) (com.amazon.photos.sharedfeatures.casting.engine.CastingEngine.shutdown+56)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #15 pc 0000000000685960  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #16 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #17 pc 0000000000004bc6  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x9ac000) (com.amazon.photos.infrastructure.CastingSystem$onSigningOut$1.invokeSuspend+70)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #18 pc 0000000000685960  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #19 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #20 pc 0000000000004b64  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x9ac000) (com.amazon.photos.infrastructure.CastingSystem$onSigningOut$1.invoke+16)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #21 pc 0000000000685960  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #22 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #23 pc 0000000000004b38  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x9ac000) (com.amazon.photos.infrastructure.CastingSystem$onSigningOut$1.invoke+4)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #24 pc 00000000006873a4  /apex/com.android.art/lib64/libart.so (MterpInvokeInterface+1812) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #25 pc 000000000012da14  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_interface+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #26 pc 0000000000004852  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x9ac000) (com.amazon.photos.infrastructure.CastingSystem$conditionalRun$1.invokeSuspend+146)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #27 pc 00000000003094d0  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.7618685802058321727)+264) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #28 pc 00000000006740c0  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+776) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #29 pc 000000000013cff8  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+88) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #30 pc 00000000020ab95c  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith+204)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #31 pc 000000000208da54  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlinx.coroutines.DispatchedTask.run+1204)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #32 pc 00000000020f052c  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlinx.coroutines.internal.LimitedDispatcher$Worker.run+108)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #33 pc 00000000020a1918  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlinx.coroutines.scheduling.TaskImpl.run+72)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #34 pc 00000000021b1c2c  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely+60)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #35 pc 00000000020dc03c  /memfd:jit-cache (deleted) (offset 0x2000000) (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask+156)
01-07 12:14:03.483  4390  4390 F DEBUG   :       #36 pc 0000000000133564  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #37 pc 00000000001a97e8  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #38 pc 000000000031c040  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+376) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #39 pc 0000000000312228  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+912) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #40 pc 0000000000687d48  /apex/com.android.art/lib64/libart.so (MterpInvokeDirect+576) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #41 pc 000000000012d914  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_direct+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #42 pc 00000000004df010  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x4c04000) (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker+56)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #43 pc 0000000000687fe8  /apex/com.android.art/lib64/libart.so (MterpInvokeDirect+1248) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #44 pc 000000000012d914  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_direct+20) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #45 pc 00000000004defc0  /data/app/~~MNiaVCEF7Zy61gaeB8SXRg==/com.amazon.clouddrive.photos-YDtZfVxCjUo_jsX2CD8AWQ==/base.apk (offset 0x4c04000) (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #46 pc 00000000003094d0  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.7618685802058321727)+264) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #47 pc 00000000006740c0  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+776) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #48 pc 000000000013cff8  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+88) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #49 pc 0000000000133564  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #50 pc 00000000001a97e8  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #51 pc 000000000055c384  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValues<art::ArtMethod*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, art::ArtMethod*, jvalue const*)+460) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #52 pc 00000000005ac204  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1308) (BuildId: d0f321775158ed00df284edfabf672b6)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #53 pc 00000000000b0758  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+64) (BuildId: c78cdff5b820a550771130d6bde95081)
01-07 12:14:03.484  4390  4390 F DEBUG   :       #54 pc 0000000000050150  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: c78cdff5b820a550771130d6bde95081) 

`


#### Testing

Android