### PR TITLE
examples: fix missing-field-initializers for modes clusters in all-cl…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
@@ -38,12 +38,12 @@ class DishwasherModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType             = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsNormal[1] = { { .value = to_underlying(ModeTag::kNormal) } };
-    ModeTagStructType modeTagsHeavy[2]  = { { .value = to_underlying(ModeBase::ModeTag::kMax) },
-                                            { .value = to_underlying(ModeTag::kHeavy) } };
-    ModeTagStructType modeTagsLight[3]  = { { .value = to_underlying(ModeTag::kLight) },
-                                            { .value = to_underlying(ModeBase::ModeTag::kNight) },
-                                            { .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
+    ModeTagStructType modeTagsNormal[1] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kNormal) } };
+    ModeTagStructType modeTagsHeavy[2]  = { { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kMax) },
+                                            { .mfgCode = {}, .value = to_underlying(ModeTag::kHeavy) } };
+    ModeTagStructType modeTagsLight[3]  = { { .mfgCode = {}, .value = to_underlying(ModeTag::kLight) },
+                                            { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kNight) },
+                                            { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
         detail::Structs::ModeOptionStruct::Type{

--- a/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
@@ -39,13 +39,13 @@ class LaundryWasherModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType               = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsNormal[1]   = { { .value = to_underlying(ModeTag::kNormal) } };
-    ModeTagStructType modeTagsDelicate[3] = { { .value = to_underlying(ModeTag::kDelicate) },
-                                              { .value = to_underlying(ModeBase::ModeTag::kNight) },
-                                              { .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
-    ModeTagStructType modeTagsHeavy[2]    = { { .value = to_underlying(ModeBase::ModeTag::kMax) },
-                                              { .value = to_underlying(ModeTag::kHeavy) } };
-    ModeTagStructType modeTagsWhites[1]   = { { .value = to_underlying(ModeTag::kWhites) } };
+    ModeTagStructType modeTagsNormal[1]   = { { .mfgCode = {}, .value = to_underlying(ModeTag::kNormal) } };
+    ModeTagStructType modeTagsDelicate[3] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kDelicate) },
+                                              { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kNight) },
+                                              { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kQuiet) } };
+    ModeTagStructType modeTagsHeavy[2]    = { { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kMax) },
+                                              { .mfgCode = {}, .value = to_underlying(ModeTag::kHeavy) } };
+    ModeTagStructType modeTagsWhites[1]   = { { .mfgCode = {}, .value = to_underlying(ModeTag::kWhites) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[4] = {
         detail::Structs::ModeOptionStruct::Type{

--- a/examples/all-clusters-app/all-clusters-common/include/microwave-oven-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/microwave-oven-mode.h
@@ -37,8 +37,8 @@ class ExampleMicrowaveOvenModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType              = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsNormal[1]  = { { .value = to_underlying(ModeTag::kNormal) } };
-    ModeTagStructType modeTagsDefrost[1] = { { .value = to_underlying(ModeTag::kDefrost) } };
+    ModeTagStructType modeTagsNormal[1]  = { { .mfgCode = {}, .value = to_underlying(ModeTag::kNormal) } };
+    ModeTagStructType modeTagsDefrost[1] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kDefrost) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[2] = {
         detail::Structs::ModeOptionStruct::Type{

--- a/examples/all-clusters-app/all-clusters-common/include/oven-modes.h
+++ b/examples/all-clusters-app/all-clusters-common/include/oven-modes.h
@@ -44,15 +44,15 @@ class OvenModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType                      = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType ModeTagsBake[1]            = { { .value = to_underlying(ModeTag::kBake) } };
-    ModeTagStructType ModeTagsConvection[1]      = { { .value = to_underlying(ModeTag::kConvection) } };
-    ModeTagStructType ModeTagsGrill[1]           = { { .value = to_underlying(ModeTag::kGrill) } };
-    ModeTagStructType ModeTagsRoast[1]           = { { .value = to_underlying(ModeTag::kRoast) } };
-    ModeTagStructType ModeTagsClean[1]           = { { .value = to_underlying(ModeTag::kClean) } };
-    ModeTagStructType ModeTagsConvectionBake[1]  = { { .value = to_underlying(ModeTag::kConvectionBake) } };
-    ModeTagStructType ModeTagsConvectionRoast[1] = { { .value = to_underlying(ModeTag::kConvectionRoast) } };
-    ModeTagStructType ModeTagsWarming[1]         = { { .value = to_underlying(ModeTag::kWarming) } };
-    ModeTagStructType ModeTagsProofing[1]        = { { .value = to_underlying(ModeTag::kProofing) } };
+    ModeTagStructType ModeTagsBake[1]            = { { .mfgCode = {}, .value = to_underlying(ModeTag::kBake) } };
+    ModeTagStructType ModeTagsConvection[1]      = { { .mfgCode = {}, .value = to_underlying(ModeTag::kConvection) } };
+    ModeTagStructType ModeTagsGrill[1]           = { { .mfgCode = {}, .value = to_underlying(ModeTag::kGrill) } };
+    ModeTagStructType ModeTagsRoast[1]           = { { .mfgCode = {}, .value = to_underlying(ModeTag::kRoast) } };
+    ModeTagStructType ModeTagsClean[1]           = { { .mfgCode = {}, .value = to_underlying(ModeTag::kClean) } };
+    ModeTagStructType ModeTagsConvectionBake[1]  = { { .mfgCode = {}, .value = to_underlying(ModeTag::kConvectionBake) } };
+    ModeTagStructType ModeTagsConvectionRoast[1] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kConvectionRoast) } };
+    ModeTagStructType ModeTagsWarming[1]         = { { .mfgCode = {}, .value = to_underlying(ModeTag::kWarming) } };
+    ModeTagStructType ModeTagsProofing[1]        = { { .mfgCode = {}, .value = to_underlying(ModeTag::kProofing) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[9] = {
         detail::Structs::ModeOptionStruct::Type{

--- a/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
+++ b/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
@@ -38,9 +38,9 @@ class RvcRunModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType               = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType ModeTagsIdle[1]     = { { .value = to_underlying(ModeTag::kIdle) } };
-    ModeTagStructType ModeTagsCleaning[1] = { { .value = to_underlying(ModeTag::kCleaning) } };
-    ModeTagStructType ModeTagsMapping[1]  = { { .value = to_underlying(ModeTag::kMapping) } };
+    ModeTagStructType ModeTagsIdle[1]     = { { .mfgCode = {}, .value = to_underlying(ModeTag::kIdle) } };
+    ModeTagStructType ModeTagsCleaning[1] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kCleaning) } };
+    ModeTagStructType ModeTagsMapping[1]  = { { .mfgCode = {}, .value = to_underlying(ModeTag::kMapping) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
         detail::Structs::ModeOptionStruct::Type{
@@ -80,10 +80,10 @@ class RvcCleanModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType            = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsVac[1]   = { { .value = to_underlying(ModeTag::kVacuum) } };
-    ModeTagStructType modeTagsMop[1]   = { { .value = to_underlying(ModeTag::kMop) } };
-    ModeTagStructType modeTagsBoost[2] = { { .value = to_underlying(ModeBase::ModeTag::kMax) },
-                                           { .value = to_underlying(ModeTag::kDeepClean) } };
+    ModeTagStructType modeTagsVac[1]   = { { .mfgCode = {}, .value = to_underlying(ModeTag::kVacuum) } };
+    ModeTagStructType modeTagsMop[1]   = { { .mfgCode = {}, .value = to_underlying(ModeTag::kMop) } };
+    ModeTagStructType modeTagsBoost[2] = { { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kMax) },
+                                           { .mfgCode = {}, .value = to_underlying(ModeTag::kDeepClean) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
         detail::Structs::ModeOptionStruct::Type{

--- a/examples/all-clusters-app/all-clusters-common/include/tcc-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/tcc-mode.h
@@ -39,9 +39,9 @@ class TccModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType                     = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsTccNormal[1]      = { { .value = to_underlying(ModeBase::ModeTag::kAuto) } };
-    ModeTagStructType modeTagsTccRapidCool[1]   = { { .value = to_underlying(ModeTag::kRapidCool) } };
-    ModeTagStructType modeTagsTccRapidFreeze[1] = { { .value = to_underlying(ModeTag::kRapidFreeze) } };
+    ModeTagStructType modeTagsTccNormal[1]      = { { .mfgCode = {}, .value = to_underlying(ModeBase::ModeTag::kAuto) } };
+    ModeTagStructType modeTagsTccRapidCool[1]   = { { .mfgCode = {}, .value = to_underlying(ModeTag::kRapidCool) } };
+    ModeTagStructType modeTagsTccRapidFreeze[1] = { { .mfgCode = {}, .value = to_underlying(ModeTag::kRapidFreeze) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
         detail::Structs::ModeOptionStruct::Type{


### PR DESCRIPTION
…usters-common

#### Summary

When building all-clusters-app for esp32 with esp-idf v6.0, below errors were reported.

```
In file included from /Users/shubhampatil/esp/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp:19:
/Users/shubhampatil/esp/connectedhomeip/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h:41:90: warning: missing initializer for member 'chip::app::Clusters::detail::Structs::ModeTagStruc
t::Type::mfgCode' [-Wmissing-field-initializers]
   41 |     ModeTagStructType modeTagsNormal[1] = { { .value = to_underlying(ModeTag::kNormal) } };
      |                                                                                          ^
```

Apparently gcc 15 treats skipped fields in designated initializers as errors.

#### Testing

- Built with esp-idf v6.0 and errors gone.