### PR TITLE
[Cherry-pick] TCP Leak fix in PR #71514 to V1.5 branch

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1304,17 +1304,26 @@ void SessionManager::MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPCon
 {
     // Mark the corresponding secure sessions for eviction
     mSecureSessions.ForEachSession([&](auto session) {
-        if (session->IsActiveSession() && session->GetTCPConnection() == conn)
+        if (session->GetTCPConnection() == conn)
         {
-            SessionHandle handle(*session);
-            // Notify the SessionConnection delegate of the connection
-            // closure.
-            if (mConnDelegate != nullptr)
+            bool isActive = session->IsActiveSession();
+
+            if (isActive)
             {
-                mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);
+                // Notify the SessionConnection delegate of the connection
+                // closure before session eviction detaches holders and
+                // releases exchanges.
+                if (mConnDelegate != nullptr)
+                {
+                    SessionHandle handle(*session);
+                    mConnDelegate->OnTCPConnectionClosed(conn, handle, conErr);
+                }
             }
 
-            // Mark session for eviction.
+            // Explicitly release the TCP connection handle to ensure the transport resource is reclaimed immediately.
+            session->ReleaseTCPConnection();
+
+            // Mark session for eviction regardless of its current state (Active, Defunct, or Establishing).
             session->MarkForEviction();
         }
 

--- a/src/transport/tests/TestTCPConnection.cpp
+++ b/src/transport/tests/TestTCPConnection.cpp
@@ -232,4 +232,60 @@ TEST_F(TestTCPConnection, TestUnauthenticatedSessionReleaseOnConnectionClose)
     EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, connHandle));
 }
 
+TEST_F(TestTCPConnection, TestDefunctSecureSessionReleaseOnConnectionClose)
+{
+    uint16_t port;
+    EXPECT_SUCCESS(InitTCP(port));
+    EXPECT_SUCCESS(InitSessionManager());
+
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+
+    // Connect to self (loopback)
+    Transport::PeerAddress peerAddr = Transport::PeerAddress::TCP(addr, port);
+
+    // 1. Establish initial connection
+    ActiveTCPConnectionHandle connHandle;
+    EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, connHandle));
+
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5),
+                             [&]() { return !connHandle.IsNull() && connHandle->IsConnected(); });
+    ASSERT_FALSE(connHandle.IsNull());
+    ASSERT_TRUE(connHandle->IsConnected());
+
+    // 2. Inject a Secure CASE Session associated with this connection
+    SessionHolder sessionHolder;
+    EXPECT_SUCCESS(mSessionManager.InjectCaseSessionWithTestKey(sessionHolder, 1, 2, 1234, 5678, 1, peerAddr,
+                                                                CryptoContext::SessionRole::kInitiator));
+
+    // Manually link the TCP connection handle to the session
+    sessionHolder->AsSecureSession()->SetTCPConnection(connHandle);
+
+    // 3. Mark the session as DEFUNCT
+    sessionHolder->AsSecureSession()->MarkAsDefunct();
+    ASSERT_FALSE(sessionHolder->AsSecureSession()->IsActiveSession());
+
+    // 4. Simulate TCP connection closure
+    // Close TCP connection & release local handle
+    connHandle->ForceDisconnect();
+    connHandle.Release();
+
+    // Drive IO to process TCP closure and session eviction logic
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(1), [&]() { return false; });
+
+    // Verify the closed connection's slot was released.
+    // With loopback and kMaxTcpActiveConnectionCount = 2,
+    // a new connection needs both slots.
+    // If the defunct secure session still retains the closed
+    // connection handle, this reconnect will fail due to pool
+    // exhaustion.
+    ActiveTCPConnectionHandle secondConnHandle;
+    EXPECT_SUCCESS(mTCP.TCPConnect(peerAddr, nullptr, secondConnHandle));
+
+    mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5),
+                             [&]() { return !secondConnHandle.IsNull() && secondConnHandle->IsConnected(); });
+    ASSERT_FALSE(secondConnHandle.IsNull());
+    ASSERT_TRUE(secondConnHandle->IsConnected());
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary
* Fix TCP connection leak for non-active secure sessions

Ensures that all secure sessions associated with a closed TCP connection properly release their transport resources and are marked for eviction.

- Removed IsActiveSession() filter in MarkSecureSessionOverTCPForEviction to ensure kDefunct and kEstablishing sessions are also processed.
- Added explicit session->ReleaseTCPConnection() call to immediately decrement the transport reference count upon connection closure.
- Ensured session->MarkForEviction() is called for all sessions matching the closed connection to prevent session table saturation.
- Added regression test TestDefunctSecureSessionReleaseOnConnectionClose to verify reclamation when sessions are in kDefunct state.

* Incorporate change recommendations from gemini

* Potential fix for pull request finding

#### Related issues

#### Testing
Unit test and CI sanity

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
