### PR TITLE
Session Resumption: Avoid leaking link file if SaveIndex fails

### DIFF
--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -98,19 +98,11 @@ CHIP_ERROR DefaultSessionResumptionStorage::Save(const ScopedNodeId & node, Cons
     }
 
     ReturnErrorOnFailure(SaveState(node, resumptionId, sharedSecret, peerCATs));
-    ReturnErrorOnFailure(SaveLink(resumptionId, node));
 
     index.mNodes[index.mSize++] = node;
-    err = SaveIndex(index);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(SecureChannel,
-                     "SaveIndex failed; unable to persist reference for node " ChipLogFormatX64
-                     ": %" CHIP_ERROR_FORMAT,
-                     ChipLogValueX64(node.GetNodeId()), err.Format());
-        ReturnErrorOnFailure(DeleteLink(resumptionId));
-        return err;
-    }
+    ReturnErrorOnFailure(SaveIndex(index));
+
+    ReturnErrorOnFailure(SaveLink(resumptionId, node));
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -101,7 +101,16 @@ CHIP_ERROR DefaultSessionResumptionStorage::Save(const ScopedNodeId & node, Cons
     ReturnErrorOnFailure(SaveLink(resumptionId, node));
 
     index.mNodes[index.mSize++] = node;
-    ReturnErrorOnFailure(SaveIndex(index));
+    err = SaveIndex(index);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(SecureChannel,
+                     "SaveIndex failed; unable to persist reference for node " ChipLogFormatX64
+                     ": %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(node.GetNodeId()), err.Format());
+        ReturnErrorOnFailure(DeleteLink(resumptionId));
+        return err;
+    }
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary
During a `DefaultSessionResumptionStorage::Save` call, we save the resumption session values for the node, a pointer file to resolve the node id from the resumption ID, and (if this node hasn't been already cached) a value in the session resumption index to look up nodes with cached session values. In this process, two files are likely updates (node's session resumption info, and SRI) and one is always a new creation (resumption index pointer file).

In the current system, we save the session information and create the new file, then save the SRI. However, all of these things need to succeed for session resumption to work properly. So if saving the SRI fails, we don't retain the resumption information. Since the pointer file has already been created, this guarantees that the pointer file will then be leaked and not deleted later.

Two solutions are readily proposed - we can delete the created file if the SRI save fails, or we can just create the file last to minimize cleanup. I have commits for both approaches, but preferred the latter to minimize impact.

#### Related issues
Unaware of existing tickets for this exact issue - we experienced this in the field with our product. Related to some of the discussion in #18433 around leaking expired sessions.

#### Testing
Manually tested using multiple chip-tool instances to simulate different connecting hubs hammering a device with new sessions. Occasional filesystem failures were injected to cause different steps of session resumption to error out. At the end of cycle testing, the file system was inspected to find any leaked files.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
