### PR TITLE
[ESP32] fix light-switch-app build for ESP-IDF v6.0

### DIFF
--- a/examples/light-switch-app/esp32/CMakeLists.txt
+++ b/examples/light-switch-app/esp32/CMakeLists.txt
@@ -44,4 +44,8 @@ idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-secur
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
 idf_build_set_property(COMPILE_OPTIONS "-Wno-error=maybe-uninitialized" APPEND)
 
+# GCC 15 (ESP-IDF v6.0) is stricter about designated initializers that skip
+# optional fields. Demote to warning until upstream fixes land.
+idf_build_set_property(COMPILE_OPTIONS "-Wno-error=missing-field-initializers" APPEND)
+
 flashing_script()

--- a/examples/light-switch-app/esp32/main/AppTask.cpp
+++ b/examples/light-switch-app/esp32/main/AppTask.cpp
@@ -129,8 +129,9 @@ void AppTask::SwitchActionEventHandler(AppEvent * aEvent)
     if (aEvent->Type == AppEvent::kEventType_Button)
     {
         BindingCommandData * data = Platform::New<BindingCommandData>();
-        data->commandId           = chip::app::Clusters::OnOff::Commands::Toggle::Id;
-        data->clusterId           = chip::app::Clusters::OnOff::Id;
+        VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "CHIP_ERROR_NO_MEMORY"));
+        data->commandId = app::Clusters::OnOff::Commands::Toggle::Id;
+        data->clusterId = app::Clusters::OnOff::Id;
 
         if (DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
         {

--- a/examples/light-switch-app/esp32/main/AppTask.cpp
+++ b/examples/light-switch-app/esp32/main/AppTask.cpp
@@ -132,7 +132,10 @@ void AppTask::SwitchActionEventHandler(AppEvent * aEvent)
         data->commandId           = chip::app::Clusters::OnOff::Commands::Toggle::Id;
         data->clusterId           = chip::app::Clusters::OnOff::Id;
 
-        DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+        if (DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+        {
+            Platform::Delete(data);
+        }
     }
 }
 

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -403,8 +403,15 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    LogErrorOnFailure(Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId,
-                                                                                static_cast<void *>(data)));
+    CHIP_ERROR err = Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId,
+                                                                                static_cast<void *>(data));
+    // In case of success, the binding manager calls LightSwitchContextReleaseHandler which does Platform::Delete(data)
+    // so it's freed by the callback. We only need to free the data if the operation failed.
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "SwitchWorkerFunction - Failed to notify bound cluster changed: %" CHIP_ERROR_FORMAT, err.Format());
+        Platform::Delete(data);
+    }
 }
 
 void BindingWorkerFunction(intptr_t context)

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -63,20 +63,24 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::Table
 
     switch (commandId)
     {
-    case Clusters::OnOff::Commands::Toggle::Id:
+    case Clusters::OnOff::Commands::Toggle::Id: {
         Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-        Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
+        LogErrorOnFailure(
+            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure));
         break;
-
-    case Clusters::OnOff::Commands::On::Id:
+    }
+    case Clusters::OnOff::Commands::On::Id: {
         Clusters::OnOff::Commands::On::Type onCommand;
-        Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, onCommand, onSuccess, onFailure);
+        LogErrorOnFailure(
+            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, onCommand, onSuccess, onFailure));
         break;
-
-    case Clusters::OnOff::Commands::Off::Id:
+    }
+    case Clusters::OnOff::Commands::Off::Id: {
         Clusters::OnOff::Commands::Off::Type offCommand;
-        Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, offCommand, onSuccess, onFailure);
+        LogErrorOnFailure(
+            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, offCommand, onSuccess, onFailure));
         break;
+    }
     }
 }
 
@@ -86,21 +90,21 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEn
 
     switch (commandId)
     {
-    case Clusters::OnOff::Commands::Toggle::Id:
+    case Clusters::OnOff::Commands::Toggle::Id: {
         Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, toggleCommand);
+        LogErrorOnFailure(Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, toggleCommand));
         break;
-
-    case Clusters::OnOff::Commands::On::Id:
+    }
+    case Clusters::OnOff::Commands::On::Id: {
         Clusters::OnOff::Commands::On::Type onCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, onCommand);
-
+        LogErrorOnFailure(Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, onCommand));
         break;
-
-    case Clusters::OnOff::Commands::Off::Id:
+    }
+    case Clusters::OnOff::Commands::Off::Id: {
         Clusters::OnOff::Commands::Off::Type offCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, offCommand);
+        LogErrorOnFailure(Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, offCommand));
         break;
+    }
     }
 }
 
@@ -141,8 +145,13 @@ void LightSwitchContextReleaseHandler(void * context)
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    Binding::Manager::GetInstance().Init(
+    CHIP_ERROR err = Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Failed to initialize Binding Manager: %" CHIP_ERROR_FORMAT, err.Format());
+        return;
+    }
     Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
     Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
@@ -195,7 +204,8 @@ CHIP_ERROR OnSwitchCommandHandler(int argc, char ** argv)
     data->commandId           = Clusters::OnOff::Commands::On::Id;
     data->clusterId           = Clusters::OnOff::Id;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -205,7 +215,8 @@ CHIP_ERROR OffSwitchCommandHandler(int argc, char ** argv)
     data->commandId           = Clusters::OnOff::Commands::Off::Id;
     data->clusterId           = Clusters::OnOff::Id;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -215,7 +226,8 @@ CHIP_ERROR ToggleSwitchCommandHandler(int argc, char ** argv)
     data->commandId           = Clusters::OnOff::Commands::Toggle::Id;
     data->clusterId           = Clusters::OnOff::Id;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -245,7 +257,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
-    DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(entry), err));
     return CHIP_NO_ERROR;
 }
 
@@ -255,7 +268,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
-    DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(entry), err));
     return CHIP_NO_ERROR;
 }
 
@@ -306,7 +320,8 @@ CHIP_ERROR GroupOnSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::OnOff::Id;
     data->isGroup             = true;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -317,7 +332,8 @@ CHIP_ERROR GroupOffSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::OnOff::Id;
     data->isGroup             = true;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -328,7 +344,8 @@ CHIP_ERROR GroupToggleSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::OnOff::Id;
     data->isGroup             = true;
 
-    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
     return CHIP_NO_ERROR;
 }
 
@@ -395,7 +412,8 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    LogErrorOnFailure(Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId,
+                                                                                static_cast<void *>(data)));
 }
 
 void BindingWorkerFunction(intptr_t context)
@@ -403,7 +421,7 @@ void BindingWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
     Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
-    AddBindingEntry(*entry);
+    LogErrorOnFailure(AddBindingEntry(*entry));
 
     Platform::Delete(entry);
 }
@@ -413,7 +431,7 @@ CHIP_ERROR InitBindingHandler()
     // The initialization of binding manager will try establishing connection with unicast peers
     // so it requires the Server instance to be correctly initialized. Post the init function to
     // the event queue so that everything is ready when initialization is conducted.
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitBindingHandlerInternal);
+    ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgr().ScheduleWork(InitBindingHandlerInternal));
 #if CONFIG_ENABLE_CHIP_SHELL
     RegisterSwitchCommands();
 #endif

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -203,6 +203,7 @@ namespace {
 CHIP_ERROR CommandDispatcher_Internal(ClusterId clusterId, CommandId commandId, bool isGroup = false)
 {
     BindingCommandData * data = Platform::New<BindingCommandData>();
+    VerifyOrReturnError(data != nullptr, CHIP_ERROR_NO_MEMORY);
     data->commandId           = commandId;
     data->clusterId           = clusterId;
     data->isGroup             = isGroup;
@@ -258,6 +259,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
+    VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
 
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     if (err != CHIP_NO_ERROR)
@@ -273,6 +275,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
+    VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
 
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     if (err != CHIP_NO_ERROR)

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -204,9 +204,9 @@ CHIP_ERROR CommandDispatcher_Internal(ClusterId clusterId, CommandId commandId, 
 {
     BindingCommandData * data = Platform::New<BindingCommandData>();
     VerifyOrReturnError(data != nullptr, CHIP_ERROR_NO_MEMORY);
-    data->commandId           = commandId;
-    data->clusterId           = clusterId;
-    data->isGroup             = isGroup;
+    data->commandId = commandId;
+    data->clusterId = clusterId;
+    data->isGroup   = isGroup;
 
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     if (err != CHIP_NO_ERROR)

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -144,7 +144,7 @@ void LightSwitchContextReleaseHandler(void * context)
 
 void InitBindingHandlerInternal(intptr_t arg)
 {
-    auto & server = chip::Server::GetInstance();
+    auto & server  = chip::Server::GetInstance();
     CHIP_ERROR err = Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     if (err != CHIP_NO_ERROR)

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -198,37 +198,38 @@ CHIP_ERROR OnOffSwitchCommandHandler(int argc, char ** argv)
     return sShellSwitchOnOffSubCommands.ExecCommand(argc, argv);
 }
 
-CHIP_ERROR OnSwitchCommandHandler(int argc, char ** argv)
+namespace {
+
+CHIP_ERROR CommandDispatcher_Internal(ClusterId clusterId, CommandId commandId, bool isGroup = false)
 {
     BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::On::Id;
-    data->clusterId           = Clusters::OnOff::Id;
+    data->commandId           = commandId;
+    data->clusterId           = clusterId;
+    data->isGroup             = isGroup;
 
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    if (err != CHIP_NO_ERROR)
+    {
+        Platform::Delete(data);
+    }
+    return err;
+}
+
+} // anonymous namespace
+
+CHIP_ERROR OnSwitchCommandHandler(int argc, char ** argv)
+{
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::On::Id);
 }
 
 CHIP_ERROR OffSwitchCommandHandler(int argc, char ** argv)
 {
-    BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::Off::Id;
-    data->clusterId           = Clusters::OnOff::Id;
-
-    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::Off::Id);
 }
 
 CHIP_ERROR ToggleSwitchCommandHandler(int argc, char ** argv)
 {
-    BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::Toggle::Id;
-    data->clusterId           = Clusters::OnOff::Id;
-
-    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::Toggle::Id);
 }
 
 /********************************************************
@@ -257,9 +258,13 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
+
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(entry), err));
-    return CHIP_NO_ERROR;
+    if (err != CHIP_NO_ERROR)
+    {
+        Platform::Delete(entry);
+    }
+    return err;
 }
 
 CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
@@ -268,9 +273,13 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 
     Binding::TableEntry * entry =
         Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
+
     CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(entry), err));
-    return CHIP_NO_ERROR;
+    if (err != CHIP_NO_ERROR)
+    {
+        Platform::Delete(entry);
+    }
+    return err;
 }
 
 /********************************************************
@@ -315,38 +324,17 @@ CHIP_ERROR GroupsOnOffSwitchCommandHandler(int argc, char ** argv)
 
 CHIP_ERROR GroupOnSwitchCommandHandler(int argc, char ** argv)
 {
-    BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::On::Id;
-    data->clusterId           = Clusters::OnOff::Id;
-    data->isGroup             = true;
-
-    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::On::Id, true /* isGroup */);
 }
 
 CHIP_ERROR GroupOffSwitchCommandHandler(int argc, char ** argv)
 {
-    BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::Off::Id;
-    data->clusterId           = Clusters::OnOff::Id;
-    data->isGroup             = true;
-
-    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::Off::Id, true /* isGroup */);
 }
 
 CHIP_ERROR GroupToggleSwitchCommandHandler(int argc, char ** argv)
 {
-    BindingCommandData * data = Platform::New<BindingCommandData>();
-    data->commandId           = Clusters::OnOff::Commands::Toggle::Id;
-    data->clusterId           = Clusters::OnOff::Id;
-    data->isGroup             = true;
-
-    CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
-    ReturnErrorCodeIf(err != CHIP_NO_ERROR, (Platform::Delete(data), err));
-    return CHIP_NO_ERROR;
+    return CommandDispatcher_Internal(Clusters::OnOff::Id, Clusters::OnOff::Commands::Toggle::Id, true /* isGroup */);
 }
 
 /**

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -403,13 +403,14 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    CHIP_ERROR err = Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId,
-                                                                                static_cast<void *>(data));
+    CHIP_ERROR err            = Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId,
+                                                                                          static_cast<void *>(data));
     // In case of success, the binding manager calls LightSwitchContextReleaseHandler which does Platform::Delete(data)
     // so it's freed by the callback. We only need to free the data if the operation failed.
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "SwitchWorkerFunction - Failed to notify bound cluster changed: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(NotSpecified, "SwitchWorkerFunction - Failed to notify bound cluster changed: %" CHIP_ERROR_FORMAT,
+                     err.Format());
         Platform::Delete(data);
     }
 }

--- a/examples/light-switch-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/light-switch-app/esp32/main/include/DeviceCallbacks.h
@@ -44,5 +44,5 @@ class AppDeviceCallbacksDelegate : public DeviceCallbacksDelegate
 public:
     void OnIPv4ConnectivityEstablished(void) override {}
     void OnIPv4ConnectivityLost(void) override {}
-    void OnDnssdInitialized(void) override { InitBindingHandler(); }
+    void OnDnssdInitialized(void) override { LogErrorOnFailure(InitBindingHandler()); }
 };

--- a/examples/light-switch-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/light-switch-app/esp32/main/include/DeviceCallbacks.h
@@ -28,6 +28,7 @@
 #include <BindingHandler.h>
 #include <common/CHIPDeviceManager.h>
 #include <common/CommonDeviceCallbacks.h>
+#include <lib/support/CodeUtils.h>
 
 class AppDeviceCallbacks : public CommonDeviceCallbacks
 {

--- a/examples/light-switch-app/esp32/main/main.cpp
+++ b/examples/light-switch-app/esp32/main/main.cpp
@@ -136,7 +136,12 @@ extern "C" void app_main()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    error = chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    if (error != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().ScheduleWork() failed: %" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
 
     error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)


### PR DESCRIPTION
#### Summary
- When building the light-switch-app with esp-idf v6.0 came across a bunch of errors, so fixing them

- fixed nodiscard warnings: use `LogErrorOnFailure` or `ReturnErrorOnFailure`
- added `-Wno-error=missing-field-initializers` for missing initializers

#### Testing

- locally built and verified that app boots up on an esp32-c3