### PR TITLE
[Zephyr][platform] Minimal adjustments in generic Zephyr platform abstraction layer

### DIFF
--- a/config/zephyr/chip-module/CMakeLists.txt
+++ b/config/zephyr/chip-module/CMakeLists.txt
@@ -59,10 +59,12 @@ if(CONFIG_CHIP)
         endif()
     endif()
 
-    # For ARM targets, use nosys.specs which provides stub implementations of
-    # system calls for embedded environments without full OS support
-    if (CONFIG_ARM)
-        matter_add_cflags(--specs=nosys.specs)
+    if(CONFIG_NEWLIB_LIBC)
+        # For ARM targets, use nosys.specs which provides stub implementations of
+        # system calls for embedded environments without full OS support
+        if (CONFIG_ARM)
+            matter_add_cflags(--specs=nosys.specs)
+        endif()
     endif()
 
     if(CONFIG_MBEDTLS)

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -49,7 +49,7 @@ PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 
 static k_timer sOperationalHoursSavingTimer;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 static bool sChipStackEntropySourceAdded = false;
 static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
 {
@@ -121,7 +121,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
     const size_t kThreshold = 16;
 #endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
@@ -130,7 +130,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     if (!sChipStackEntropySourceAdded)
     {
         // Add entropy source based on Zephyr entropy driver

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -126,7 +126,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
     const size_t kThreshold = 16;
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
@@ -141,7 +141,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
         SuccessOrExit(err);
         sChipStackEntropySourceAdded = true;
     }
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -126,7 +126,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
     const size_t kThreshold = 16;
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+       // && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
@@ -141,7 +142,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
         SuccessOrExit(err);
         sChipStackEntropySourceAdded = true;
     }
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
+       // && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -49,7 +49,8 @@ PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 
 static k_timer sOperationalHoursSavingTimer;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) &&    \
+    !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 static bool sChipStackEntropySourceAdded = false;
 static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
 {
@@ -121,7 +122,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) &&    \
+    !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
     const size_t kThreshold = 16;
 #endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
@@ -130,7 +132,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) && !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR) &&    \
+    !defined(CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY)
     if (!sChipStackEntropySourceAdded)
     {
         // Add entropy source based on Zephyr entropy driver

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -168,7 +168,6 @@ EXTERNALLY_VISIBLE void * WRAP(calloc)(size_t num, size_t size) ALIAS("_ZN4chip1
 EXTERNALLY_VISIBLE void * WRAP(realloc)(void * mem, size_t size) ALIAS("_ZN4chip11DeviceLayer6Malloc7ReallocEPvj");
 EXTERNALLY_VISIBLE void WRAP(free)(void * mem) ALIAS("_ZN4chip11DeviceLayer6Malloc4FreeEPv");
 
-
 #if defined(CONFIG_NEWLIB_LIBC)
 /* Newlib-only reentrant hooks */
 

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -168,6 +168,10 @@ EXTERNALLY_VISIBLE void * WRAP(calloc)(size_t num, size_t size) ALIAS("_ZN4chip1
 EXTERNALLY_VISIBLE void * WRAP(realloc)(void * mem, size_t size) ALIAS("_ZN4chip11DeviceLayer6Malloc7ReallocEPvj");
 EXTERNALLY_VISIBLE void WRAP(free)(void * mem) ALIAS("_ZN4chip11DeviceLayer6Malloc4FreeEPv");
 
+
+#if defined(CONFIG_NEWLIB_LIBC)
+/* Newlib-only reentrant hooks */
+
 EXTERNALLY_VISIBLE void * WRAP(_malloc_r)(_reent *, size_t size)
 {
     return WRAP(malloc)(size);
@@ -187,6 +191,8 @@ EXTERNALLY_VISIBLE void WRAP(_free_r)(_reent *, void * mem)
 {
     WRAP(free)(mem);
 }
+
+#endif /* CONFIG_NEWLIB_LIBC */
 
 } // extern "C"
 

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -191,7 +191,7 @@ EXTERNALLY_VISIBLE void WRAP(_free_r)(_reent *, void * mem)
     WRAP(free)(mem);
 }
 
-#endif /* CONFIG_NEWLIB_LIBC */
+#endif // CONFIG_NEWLIB_LIBC
 
 } // extern "C"
 


### PR DESCRIPTION

#### Summary

This PR introduces minimal, targeted updates to the generic Zephyr platform abstraction layer in preparation for switching NXP Zephyr applications to a Zephyr 4.4 baseline.
The changes are intentionally small and scoped to address build and configuration differences introduced by Zephyr SDK 1.0 and Zephyr 4.4, while preserving backward compatibility with older Zephyr versions.

#### Key changes

- Adding Kconfig-based conditions in `config/zephyr/chip-module/CMakeLists.txt` and `src/platform/Zephyr/SysHeapMalloc.cpp`, to prevent unconditional references to nosys and newlib, which are no longer available with Zephyr SDK 1.0.
- Updates entropy configuration check in `src/platform/Zephyr/PlatformManagerImpl.cpp` based on `CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY`.

#### Testing

- Tested locally against a Zephyr 4.4 baseline. Validation was performed using additional changes required for the full Zephyr 4.4 migration. Those additional changes are not included here and will be upstreamed later as part of the full switch.
- CI coverage ensures backward compatibility. CI continues to run against older Zephyr versions, ensuring that these changes do not regress existing users.