### PR TITLE
[MSAN] Fix reading uninitialized mHoldTime when deactivated in OccupancySensing Cluster

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
@@ -96,8 +96,11 @@ OccupancySensingCluster::OccupancySensingCluster(const Config & config) :
     DefaultServerCluster({ config.mEndpointId, OccupancySensing::Id }), mHoldTimeDelegate(config.mHoldTimeDelegate),
     mDelegate(config.mDelegate), mFeatureMap(config.mFeatureMap), mShowDeprecatedAttributes(config.mShowDeprecatedAttributes)
 {
-    SetHoldTimeLimits(config.mHoldTimeLimits);
-    mHoldTime = std::clamp(config.mHoldTime, mHoldTimeLimits.holdTimeMin, mHoldTimeLimits.holdTimeMax);
+    if (mHoldTimeDelegate)
+    {
+        SetHoldTimeLimits(config.mHoldTimeLimits);
+        mHoldTime = std::clamp(config.mHoldTime, mHoldTimeLimits.holdTimeMin, mHoldTimeLimits.holdTimeMax);
+    }
 }
 
 CHIP_ERROR OccupancySensingCluster::Startup(ServerClusterContext & context)

--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
@@ -96,18 +96,19 @@ OccupancySensingCluster::OccupancySensingCluster(const Config & config) :
     DefaultServerCluster({ config.mEndpointId, OccupancySensing::Id }), mHoldTimeDelegate(config.mHoldTimeDelegate),
     mDelegate(config.mDelegate), mFeatureMap(config.mFeatureMap), mShowDeprecatedAttributes(config.mShowDeprecatedAttributes)
 {
-    if (mHoldTimeDelegate)
-    {
-        SetHoldTimeLimits(config.mHoldTimeLimits);
-        mHoldTime = std::clamp(config.mHoldTime, mHoldTimeLimits.holdTimeMin, mHoldTimeLimits.holdTimeMax);
-    }
+    SetHoldTimeLimits(config.mHoldTimeLimits);
+    mHoldTime = std::clamp(config.mHoldTime, mHoldTimeLimits.holdTimeMin, mHoldTimeLimits.holdTimeMax);
 }
 
 CHIP_ERROR OccupancySensingCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    if (mHoldTimeDelegate)
+    // The spec forbids 0 as a HoldTime value. mHoldTime is zero-initialized for safety, so return error when hold time is
+    // supported.
+    VerifyOrReturnError(!IsHoldTimeEnabled() || mHoldTime != 0, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (IsHoldTimeEnabled())
     {
         AttributePersistence persistence(context.attributeStorage);
         uint16_t storedHoldTime;
@@ -170,7 +171,7 @@ DataModel::ActionReturnStatus OccupancySensingCluster::WriteAttribute(const Data
     case Attributes::PIROccupiedToUnoccupiedDelay::Id:
     case Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id:
     case Attributes::PhysicalContactOccupiedToUnoccupiedDelay::Id: {
-        if (!mHoldTimeDelegate)
+        if (!IsHoldTimeEnabled())
         {
             return Protocols::InteractionModel::Status::UnsupportedAttribute;
         }
@@ -189,13 +190,13 @@ CHIP_ERROR OccupancySensingCluster::Attributes(const ConcreteClusterPath & clust
     AttributeListBuilder listBuilder(builder);
 
     const AttributeListBuilder::OptionalAttributeEntry optionalAttributes[] = {
-        { mHoldTimeDelegate != nullptr, Attributes::HoldTime::kMetadataEntry },
-        { mHoldTimeDelegate != nullptr, Attributes::HoldTimeLimits::kMetadataEntry },
-        { mHoldTimeDelegate != nullptr && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kPassiveInfrared),
+        { IsHoldTimeEnabled(), Attributes::HoldTime::kMetadataEntry },
+        { IsHoldTimeEnabled(), Attributes::HoldTimeLimits::kMetadataEntry },
+        { IsHoldTimeEnabled() && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kPassiveInfrared),
           Attributes::PIROccupiedToUnoccupiedDelay::kMetadataEntry },
-        { mHoldTimeDelegate != nullptr && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kUltrasonic),
+        { IsHoldTimeEnabled() && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kUltrasonic),
           Attributes::UltrasonicOccupiedToUnoccupiedDelay::kMetadataEntry },
-        { mHoldTimeDelegate != nullptr && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kPhysicalContact),
+        { IsHoldTimeEnabled() && mShowDeprecatedAttributes && mFeatureMap.Has(Feature::kPhysicalContact),
           Attributes::PhysicalContactOccupiedToUnoccupiedDelay::kMetadataEntry },
     };
 
@@ -204,7 +205,7 @@ CHIP_ERROR OccupancySensingCluster::Attributes(const ConcreteClusterPath & clust
 
 DataModel::ActionReturnStatus OccupancySensingCluster::SetHoldTime(uint16_t holdTime)
 {
-    VerifyOrReturnError(mHoldTimeDelegate, Protocols::InteractionModel::Status::UnsupportedAttribute);
+    VerifyOrReturnError(IsHoldTimeEnabled(), Protocols::InteractionModel::Status::UnsupportedAttribute);
     VerifyOrReturnError(holdTime >= mHoldTimeLimits.holdTimeMin, Protocols::InteractionModel::Status::ConstraintError);
     VerifyOrReturnError(holdTime <= mHoldTimeLimits.holdTimeMax, Protocols::InteractionModel::Status::ConstraintError);
 

--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.h
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.h
@@ -77,10 +77,10 @@ public:
         }
 
         EndpointId mEndpointId;
-        BitFlags<OccupancySensing::Feature> mFeatureMap = OccupancySensing::Feature::kOccupancyEvent;
-        bool mShowDeprecatedAttributes                  = true;
-        uint16_t mHoldTime;
-        OccupancySensing::Structs::HoldTimeLimitsStruct::Type mHoldTimeLimits;
+        BitFlags<OccupancySensing::Feature> mFeatureMap                       = OccupancySensing::Feature::kOccupancyEvent;
+        bool mShowDeprecatedAttributes                                        = true;
+        uint16_t mHoldTime                                                    = 0;
+        OccupancySensing::Structs::HoldTimeLimitsStruct::Type mHoldTimeLimits = {};
         // The presence of mHoldTimeDelegate indicates that hold time limits are enforced and hold time functionality is active.
         TimerDelegate * mHoldTimeDelegate    = nullptr;
         OccupancySensingDelegate * mDelegate = nullptr;
@@ -120,10 +120,10 @@ private:
     OccupancySensingDelegate * mDelegate;
     const BitFlags<OccupancySensing::Feature> mFeatureMap;
     const bool mShowDeprecatedAttributes;
-    uint16_t mHoldTime;
-    OccupancySensing::Structs::HoldTimeLimitsStruct::Type mHoldTimeLimits;
-    BitMask<OccupancySensing::OccupancyBitmap> mOccupancy = 0;
-    System::Clock::Timestamp mTimerStartedTimestamp       = System::Clock::Milliseconds64(0);
+    uint16_t mHoldTime                                                    = 0;
+    OccupancySensing::Structs::HoldTimeLimitsStruct::Type mHoldTimeLimits = {};
+    BitMask<OccupancySensing::OccupancyBitmap> mOccupancy                 = 0;
+    System::Clock::Timestamp mTimerStartedTimestamp                       = System::Clock::Milliseconds64(0);
 };
 
 } // namespace chip::app::Clusters


### PR DESCRIPTION
#### Summary

- MemorySanitized `TestOccupancySensingCluster` fails with a use-of-uninitialised-value

- `std::clamp` in the constructor for `OccupancySensingCluster` reads an uninitialized  `config.mHoldTime`  when HoldTime is deactivated ( i.e. `Config::WithHoldTime()` was not called).
- Guard std::clamp and HoldTime related assignments with `mHoldTimeDelegate`

- NOTE: mHoldTime can NOT be initialised to 0 since it is forbidden in Spec 
>A value 0 for HoldTime SHALL NOT be used.

#### MSan Stack Trace

<details>
<summary>Click for MSAN stack trace</summary>

```cpp
(matter-repl) linux@linux:~/repos/connectedhomeipPRClean/connectedhomeip$ out/linux-x64-tests-msan-clang/tests/TestOccupancySensingCluster 
[==========] Running all tests.
[ RUN      ] TestOccupancySensingCluster.TestFeatureMapHasOccupancyEvent
==3382985==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55555596fb93 in bool std::__1::__less<void, void>::operator()[abi:nqn230000]<unsigned short, unsigned short>(unsigned short const&, unsigned short const&) const /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../msan_sysroot/include/c++/v1/__algorithm/comp.h:42:5
    #1 0x55555596f72b in unsigned short const& std::__1::clamp[abi:nqn230000]<unsigned short, std::__1::__less<void, void>>(unsigned short const&, unsigned short const&, unsigned short const&, std::__1::__less<void, void>) /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../msan_sysroot/include/c++/v1/__algorithm/clamp.h:30:10
    #2 0x555555961796 in unsigned short const& std::__1::clamp[abi:nqn230000]<unsigned short>(unsigned short const&, unsigned short const&, unsigned short const&) /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../msan_sysroot/include/c++/v1/__algorithm/clamp.h:38:10
    #3 0x5555559601b5 in chip::app::Clusters::OccupancySensingCluster::OccupancySensingCluster(chip::app::Clusters::OccupancySensingCluster::Config const&) /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp:102:17
    #4 0x5555559e2f73 in (anonymous namespace)::TestOccupancySensingCluster_TestFeatureMapHasOccupancyEvent_Test::PigweedTestBody() /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp:82:29
    #5 0x5555559dc7e4 in pw::unit_test::internal::Test::PigweedTestRun() /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:751:7
    #6 0x5555559d4353 in void pw::unit_test::internal::Framework::CreateAndRunTest<(anonymous namespace)::TestOccupancySensingCluster_TestFeatureMapHasOccupancyEvent_Test>(pw::unit_test::internal::TestInfo const&) /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:548:20
    #7 0x555555ceba81 in pw::unit_test::internal::TestInfo::run() const /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:705:22
    #8 0x555555ceac5d in pw::unit_test::internal::Framework::RunAllTests() /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../third_party/pigweed/repo/pw_unit_test/framework_light.cc:71:13
    #9 0x555555b82580 in RUN_ALL_TESTS() /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../third_party/pigweed/repo/pw_unit_test/light_public_overrides/pw_unit_test/framework_backend.h:803:54
    #10 0x555555b821f2 in main /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../src/test_driver/posix/unit_test_main.cpp:227:12
    #11 0x7ffff7c2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #12 0x7ffff7c2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #13 0x5555558d5024 in _start (/home/connectedhomeip/out/linux-x64-tests-msan-clang/tests/TestOccupancySensingCluster+0x381024) (BuildId: c9495120d8cb94de245af7aba4503233b77bb49a)

  Uninitialized value was created by an allocation of 'ref.tmp' in the stack frame
    #0 0x5555559e2f4f in (anonymous namespace)::TestOccupancySensingCluster_TestFeatureMapHasOccupancyEvent_Test::PigweedTestBody() /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp:82:38

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/connectedhomeip/out/linux-x64-tests-msan-clang/../../src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp:102:17 in chip::app::Clusters::OccupancySensingCluster::OccupancySensingCluster(chip::app::Clusters::OccupancySensingCluster::Config const&)
Exiting

```

</details>

#### Testing

- ran MemorySanitized `TestOccupancySensingCluster` locally
