### PR TITLE
Bugfix: Groupcast IANA address

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -494,6 +494,15 @@ IPAddress IPAddress::MakeIPv6PrefixMulticast(uint8_t aScope, uint8_t aPrefixLeng
     return (MakeIPv6TransientMulticast(lFlags, aScope, lGroupId));
 }
 
+IPAddress IPAddress::MakeIPv6WellKnownMulticast()
+{
+    IPAddress addr;
+    addr.Addr[0] = htonl(0xFF050000ul);
+    addr.Addr[1] = htonl(0);
+    addr.Addr[2] = htonl(0);
+    addr.Addr[3] = htonl(0xFAul);
+    return addr;
+}
 IPAddress IPAddress::MakeIPv4Broadcast()
 {
     IPAddress ipAddr;

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -686,6 +686,17 @@ public:
     static IPAddress MakeIPv6PrefixMulticast(uint8_t aScope, uint8_t aPrefixLength, const uint64_t & aPrefix, uint32_t aGroupId);
 
     /**
+     * @brief   Construct the well-known IPv6 multicast address ff05::fa.
+     *
+     * @details
+     *  Returns the site-local scoped well-known multicast address
+     *  with group identifier 0xFA, used for Matter groupcast messaging.
+     *
+     * @return  The constructed IP address.
+     */
+    static IPAddress MakeIPv6WellKnownMulticast();
+
+    /**
      * @brief   Construct an IPv4 broadcast address.
      *
      * @return  The constructed IP address.

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -259,13 +259,7 @@ public:
         return UDP(Inet::IPAddress::MakeIPv6PrefixMulticast(scope, prefixLength, prefix, groupId));
     }
 
-    static PeerAddress Groupcast()
-    {
-        constexpr uint8_t scope        = 0x05; // Site-Local
-        constexpr uint8_t prefixLength = 0x40; // 64-bit long network prefix field
-        // IANA assigned address
-        return UDP(Inet::IPAddress::MakeIPv6PrefixMulticast(scope, prefixLength, 0xff05000000000000, 0xfa));
-    }
+    static PeerAddress Groupcast() { return UDP(Inet::IPAddress::MakeIPv6WellKnownMulticast()); }
 
 private:
     constexpr PeerAddress(uint16_t shortId) : mTransportType(Type::kNfc), mId{ .mNFCShortId = shortId } {}


### PR DESCRIPTION
#### Summary

The Groupcast address is wrong, the correct value is `FF05::FA`.

#### Related issues

N/A

#### Testing

UNTESTED.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
