### PR TITLE
 [all-devices-app] Integrate Real Audio Playback for POSIX Chime Device

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -344,3 +344,6 @@
 	url = https://github.com/bouffalolab/bouffalo_sdk.git
 	branch = main
 	platforms = bouffalolab
+[submodule "third_party/miniaudio/repo"]
+	path = third_party/miniaudio/repo
+	url = https://github.com/mackron/miniaudio

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -21,6 +21,7 @@ executable("all-devices-app") {
     "PosixChimeDevice.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
+    "miniaudio.cpp",
   ]
 
   deps = [
@@ -53,6 +54,7 @@ executable("all-devices-app") {
   include_dirs = [
     "include",
     "${chip_root}/examples/common",
+    "${chip_root}/third_party/miniaudio/repo",
   ]
 
   output_dir = root_out_dir

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -41,8 +41,8 @@ executable("all-devices-app") {
     "${chip_root}/src/app/persistence:default",
     "${chip_root}/src/data-model-providers/codedriven",
     "${chip_root}/src/lib",
-    "${chip_root}/zzz_generated/app-common/devices/",
     "${chip_root}/third_party/miniaudio:miniaudio",
+    "${chip_root}/zzz_generated/app-common/devices/",
   ]
 
   if (chip_device_platform == "darwin") {

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -21,7 +21,6 @@ executable("all-devices-app") {
     "PosixChimeDevice.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
-    "miniaudio.cpp",
   ]
 
   deps = [
@@ -43,6 +42,7 @@ executable("all-devices-app") {
     "${chip_root}/src/data-model-providers/codedriven",
     "${chip_root}/src/lib",
     "${chip_root}/zzz_generated/app-common/devices/",
+    "${chip_root}/third_party/miniaudio:miniaudio",
   ]
 
   if (chip_device_platform == "darwin") {
@@ -54,7 +54,6 @@ executable("all-devices-app") {
   include_dirs = [
     "include",
     "${chip_root}/examples/common",
-    "${chip_root}/third_party/miniaudio/repo",
   ]
 
   output_dir = root_out_dir

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -15,47 +15,47 @@
  *    limitations under the License.
  */
 #include <PosixChimeDevice.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <cmath>
+#include <lib/support/logging/CHIPLogging.h>
 #include <sstream>
 
 namespace chip {
 namespace app {
 
 // Helper to generate a simple WAV file in memory
-static void GenerateWavMemory(std::vector<uint8_t>& buffer, double freq1, double freq2, double duration, bool pulse = false)
+static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
     std::stringstream file(std::ios::binary | std::ios::out);
 
-    const int sampleRate = 44100;
+    const int sampleRate    = 44100;
     const int bitsPerSample = 16;
-    const int numChannels = 1;
-    const int numSamples = static_cast<int>(duration * sampleRate);
-    const int dataSize = numSamples * numChannels * (bitsPerSample / 8);
+    const int numChannels   = 1;
+    const int numSamples    = static_cast<int>(duration * sampleRate);
+    const int dataSize      = numSamples * numChannels * (bitsPerSample / 8);
 
     // WAV Header
     file.write("RIFF", 4);
     uint32_t chunkSize = 36 + dataSize;
-    file.write(reinterpret_cast<const char*>(&chunkSize), 4);
+    file.write(reinterpret_cast<const char *>(&chunkSize), 4);
     file.write("WAVE", 4);
     file.write("fmt ", 4);
     uint32_t subChunk1Size = 16;
-    file.write(reinterpret_cast<const char*>(&subChunk1Size), 4);
+    file.write(reinterpret_cast<const char *>(&subChunk1Size), 4);
     uint16_t audioFormat = 1; // PCM
-    file.write(reinterpret_cast<const char*>(&audioFormat), 2);
+    file.write(reinterpret_cast<const char *>(&audioFormat), 2);
     uint16_t channels = numChannels;
-    file.write(reinterpret_cast<const char*>(&channels), 2);
+    file.write(reinterpret_cast<const char *>(&channels), 2);
     uint32_t sRate = sampleRate;
-    file.write(reinterpret_cast<const char*>(&sRate), 4);
+    file.write(reinterpret_cast<const char *>(&sRate), 4);
     uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-    file.write(reinterpret_cast<const char*>(&byteRate), 4);
+    file.write(reinterpret_cast<const char *>(&byteRate), 4);
     uint16_t blockAlign = numChannels * (bitsPerSample / 8);
-    file.write(reinterpret_cast<const char*>(&blockAlign), 2);
+    file.write(reinterpret_cast<const char *>(&blockAlign), 2);
     uint16_t bps = bitsPerSample;
-    file.write(reinterpret_cast<const char*>(&bps), 2);
+    file.write(reinterpret_cast<const char *>(&bps), 2);
     file.write("data", 4);
     uint32_t subChunk2Size = dataSize;
-    file.write(reinterpret_cast<const char*>(&subChunk2Size), 4);
+    file.write(reinterpret_cast<const char *>(&subChunk2Size), 4);
 
     // Generate samples
     for (int i = 0; i < numSamples; ++i)
@@ -63,11 +63,11 @@ static void GenerateWavMemory(std::vector<uint8_t>& buffer, double freq1, double
         double t = static_cast<double>(i) / sampleRate;
         double freq;
         double t_note;
-        
+
         if (pulse)
         {
             // For pulse (Ring Ring), we don't split into two notes
-            freq = freq1;
+            freq   = freq1;
             t_note = t;
         }
         else
@@ -75,37 +75,38 @@ static void GenerateWavMemory(std::vector<uint8_t>& buffer, double freq1, double
             // For chime (Ding Dong), we split into two notes
             if (t < duration / 2.0)
             {
-                freq = freq1;
+                freq   = freq1;
                 t_note = t;
             }
             else
             {
-                freq = freq2;
+                freq   = freq2;
                 t_note = t - (duration / 2.0);
             }
         }
-        
+
         // Exponential decay per note
         double volume = exp(-t_note * 4.0);
-        
+
         if (pulse)
         {
             // Pulse every 50ms (50ms on, 50ms off)
             bool on = (static_cast<int>(t * 20) % 2) == 0;
-            if (!on) volume = 0;
+            if (!on)
+                volume = 0;
         }
-        
+
         // Additive synthesis for richer sound (Fundamental + Harmonics)
         double sample = 0;
         sample += 0.6 * sin(2.0 * 3.14159265358979323846 * freq * t_note);
         sample += 0.3 * sin(2.0 * 3.14159265358979323846 * freq * 2.0 * t_note);
         sample += 0.1 * sin(2.0 * 3.14159265358979323846 * freq * 3.0 * t_note);
-        
+
         sample *= volume;
-        
+
         int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
-        
-        file.write(reinterpret_cast<const char*>(&pcmSample), 2);
+
+        file.write(reinterpret_cast<const char *>(&pcmSample), 2);
     }
 
     std::string str = file.str();
@@ -113,8 +114,7 @@ static void GenerateWavMemory(std::vector<uint8_t>& buffer, double freq1, double
     ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());
 }
 
-PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) :
-    ChimeDevice(timerDelegate, sounds)
+PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) : ChimeDevice(timerDelegate, sounds)
 {
     ma_result result = ma_engine_init(NULL, &mEngine);
     if (result != MA_SUCCESS)
@@ -125,9 +125,9 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     {
         mEngineInitialized = true;
         ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
-        
+
         // Generate dummy sound buffers
-        GenerateWavMemory(mChime0Buffer, 880, 660, 1.0, false); // Ding Dong
+        GenerateWavMemory(mChime0Buffer, 880, 660, 1.0, false);  // Ding Dong
         GenerateWavMemory(mChime1Buffer, 1000, 1000, 1.0, true); // Ring Ring
 
         // Initialize decoders from memory
@@ -184,9 +184,11 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
         return status;
     }
 
-    ma_sound* pSound = nullptr;
-    if (chimeID == 0) pSound = &mSound0;
-    else if (chimeID == 1) pSound = &mSound1;
+    ma_sound * pSound = nullptr;
+    if (chimeID == 0)
+        pSound = &mSound0;
+    else if (chimeID == 1)
+        pSound = &mSound1;
 
     if (pSound)
     {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -27,62 +27,23 @@ namespace {
 const double kPi = 3.14159265358979323846;
 const uint16_t kAudioFormatPCM = 1;
 
-// Helper to generate a simple WAV file in memory
-void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
+// Helper to generate raw PCM data in memory
+void GeneratePcmMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
     const int sampleRate    = 44100;
     const int bitsPerSample = 16;
     const int numChannels   = 1;
     const int numSamples    = static_cast<int>(duration * sampleRate);
     const int dataSize      = numSamples * numChannels * (bitsPerSample / 8);
-    const int totalSize     = 44 + dataSize;
 
-    buffer.resize(totalSize);
+    buffer.resize(dataSize);
     uint8_t * p = buffer.data();
-
-    // Helper to write strings
-    auto writeStr = [&](const char * str, size_t len) {
-        memcpy(p, str, len);
-        p += len;
-    };
 
     // Helper to write Little-Endian 16-bit values
     auto writeVal16 = [&](uint16_t val) {
         *p++ = static_cast<uint8_t>(val & 0xFF);
         *p++ = static_cast<uint8_t>((val >> 8) & 0xFF);
     };
-
-    // Helper to write Little-Endian 32-bit values
-    auto writeVal32 = [&](uint32_t val) {
-        *p++ = static_cast<uint8_t>(val & 0xFF);
-        *p++ = static_cast<uint8_t>((val >> 8) & 0xFF);
-        *p++ = static_cast<uint8_t>((val >> 16) & 0xFF);
-        *p++ = static_cast<uint8_t>((val >> 24) & 0xFF);
-    };
-
-    // WAV Header
-    writeStr("RIFF", 4);
-    uint32_t fileSize = totalSize - 8;
-    writeVal32(fileSize);
-    writeStr("WAVE", 4);
-    writeStr("fmt ", 4);
-    uint32_t subChunk1Size = 16;
-    writeVal32(subChunk1Size);
-    uint16_t audioFormat = kAudioFormatPCM; // PCM
-    writeVal16(audioFormat);
-    uint16_t numChans = numChannels;
-    writeVal16(numChans);
-    uint32_t sRate = sampleRate;
-    writeVal32(sRate);
-    uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-    writeVal32(byteRate);
-    uint16_t blockAlign = numChannels * (bitsPerSample / 8);
-    writeVal16(blockAlign);
-    uint16_t bps = bitsPerSample;
-    writeVal16(bps);
-    writeStr("data", 4);
-    uint32_t subChunk2Size = dataSize;
-    writeVal32(subChunk2Size);
 
     // Generate samples
     for (int i = 0; i < numSamples; ++i)
@@ -140,44 +101,49 @@ void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2
         writeVal16(static_cast<uint16_t>(pcmSample));
     }
 
-    ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());
+    ChipLogProgress(DeviceLayer, "Generated PCM buffer size %zu", buffer.size());
 }
 
 bool InitializeSoundResource(ma_engine * engine, const ChimeDevice::Sound & sound, PosixChimeDevice::SoundResource & resource)
 {
     resource.id = sound.id;
-
+ 
     // Generate sound based on ID
     if (sound.id == 0)
     {
-        GenerateWavMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
+        GeneratePcmMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
     }
     else if (sound.id == 1)
     {
-        GenerateWavMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
+        GeneratePcmMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
     }
     else
     {
-        GenerateWavMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
+        GeneratePcmMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
     }
-
-    // Initialize decoder from memory
-    ma_result res = ma_decoder_init_memory(resource.buffer.data(), resource.buffer.size(), NULL, &resource.decoder);
+ 
+    // Initialize audio buffer from raw PCM memory
+    // We use 44100 Hz, 16-bit signed PCM, mono.
+    // Frames count is buffer size / 2 (since each sample is 2 bytes).
+    ma_audio_buffer_config config = ma_audio_buffer_config_init(ma_format_s16, 1, resource.buffer.size() / 2, resource.buffer.data(), NULL);
+    config.sampleRate = 44100; // Explicitly set sample rate as it's not in the init helper arguments for audio_buffer
+    
+    ma_result res = ma_audio_buffer_init(&config, &resource.audioBuffer);
     if (res != MA_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "Failed to initialize decoder for sound %d: %d", sound.id, res);
+        ChipLogError(DeviceLayer, "Failed to initialize audio buffer for sound %d: %d", sound.id, res);
         return false;
     }
-
+ 
     // Initialize sound from data source
-    res = ma_sound_init_from_data_source(engine, &resource.decoder, 0, NULL, &resource.sound);
+    res = ma_sound_init_from_data_source(engine, &resource.audioBuffer, 0, NULL, &resource.sound);
     if (res != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
-        ma_decoder_uninit(&resource.decoder);
+        ma_audio_buffer_uninit(&resource.audioBuffer);
         return false;
     }
-
+ 
     resource.initialized = true;
     return true;
 }
@@ -223,7 +189,7 @@ PosixChimeDevice::~PosixChimeDevice()
             if (resource.initialized)
             {
                 ma_sound_uninit(&resource.sound);
-                ma_decoder_uninit(&resource.decoder);
+                ma_audio_buffer_uninit(&resource.audioBuffer);
             }
         }
         ma_engine_uninit(&mEngine);

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -29,14 +29,18 @@ constexpr uint16_t kAudioFormatPCM = 1;
 constexpr uint32_t kSampleRateHz   = 44100;
 
 // Custom data source read callback
+// Custom data source read callback. This is called by miniaudio to fetch more audio frames.
+// It generates the audio on-the-fly instead of reading from a buffer.
 ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
 {
-    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
+    // Calculate total samples for the full duration of the sound
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
 
     ma_uint64 framesToRead = frameCount;
+    // Ensure we don't read past the end of the sound
     if (pCustomDS->cursor + framesToRead > totalSamples)
     {
         framesToRead = totalSamples - pCustomDS->cursor;
@@ -48,22 +52,26 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         return MA_AT_END;
     }
 
-    int16_t* pOut = reinterpret_cast<int16_t*>(pFramesOut);
+    int16_t * pOut = reinterpret_cast<int16_t *>(pFramesOut);
 
+    // Generate samples on the fly
     for (ma_uint64 i = 0; i < framesToRead; ++i)
     {
         ma_uint64 currentSample = pCustomDS->cursor + i;
+        // Calculate current time in seconds
         double t = static_cast<double>(currentSample) / kSampleRateHz;
         double freq;
         double t_note;
 
         if (pCustomDS->pulse)
         {
+            // Pulsing sound: keep same frequency
             freq = pCustomDS->freq1;
             t_note = t;
         }
         else
         {
+            // Two-tone sound (Ding-Dong): switch frequency halfway
             if (t < pCustomDS->duration / 2.0)
             {
                 freq = pCustomDS->freq1;
@@ -72,25 +80,29 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
             else
             {
                 freq = pCustomDS->freq2;
-                t_note = t - (pCustomDS->duration / 2.0);
+                t_note = t - (pCustomDS->duration / 2.0); // Reset relative time for second tone
             }
         }
 
+        // Apply exponential decay for a natural chime fade-out effect
         double volume = exp(-t_note * 4.0);
 
         if (pCustomDS->pulse)
         {
+            // Apply a square wave modulation for the pulse effect
             bool on = (static_cast<int>(t * 20) % 2) == 0;
             if (!on) volume = 0;
         }
 
+        // Additive synthesis: combine fundamental frequency and harmonics
         double sample = 0;
-        sample += 0.6 * sin(2.0 * kPi * freq * t_note);
-        sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note);
-        sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note);
+        sample += 0.6 * sin(2.0 * kPi * freq * t_note);       // Fundamental
+        sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note); // 2nd harmonic
+        sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note); // 3rd harmonic
 
         sample *= volume;
 
+        // Scale to 16-bit signed PCM and store
         pOut[i] = static_cast<int16_t>(sample * 32767.0);
     }
 

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -36,8 +36,8 @@ namespace app {
 
 namespace {
 
-constexpr double kPi               = 3.14159265358979323846;
-constexpr uint32_t kSampleRateHz   = 44100;
+constexpr double kPi             = 3.14159265358979323846;
+constexpr uint32_t kSampleRateHz = 44100;
 
 // Custom data source read callback. This is called by miniaudio to fetch more audio frames.
 // It generates the audio on-the-fly instead of reading from a buffer.

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -17,20 +17,15 @@
 #include <PosixChimeDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <cmath>
-#include <fstream>
+#include <sstream>
 
 namespace chip {
 namespace app {
 
-// Helper to generate a simple WAV file
-static void GenerateWavFile(const char* filename, double freq1, double freq2, double duration, bool pulse = false)
+// Helper to generate a simple WAV file in memory
+static void GenerateWavMemory(std::vector<uint8_t>& buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
-    std::ofstream file(filename, std::ios::binary);
-    if (!file.is_open())
-    {
-        ChipLogError(DeviceLayer, "Failed to open file %s for writing", filename);
-        return;
-    }
+    std::stringstream file(std::ios::binary | std::ios::out);
 
     const int sampleRate = 44100;
     const int bitsPerSample = 16;
@@ -66,25 +61,56 @@ static void GenerateWavFile(const char* filename, double freq1, double freq2, do
     for (int i = 0; i < numSamples; ++i)
     {
         double t = static_cast<double>(i) / sampleRate;
-        double freq = (t < duration / 2.0) ? freq1 : freq2;
-        
-        double volume = 1.0 - (t / duration);
+        double freq;
+        double t_note;
         
         if (pulse)
         {
-            // Pulse every 50ms (10Hz)
+            // For pulse (Ring Ring), we don't split into two notes
+            freq = freq1;
+            t_note = t;
+        }
+        else
+        {
+            // For chime (Ding Dong), we split into two notes
+            if (t < duration / 2.0)
+            {
+                freq = freq1;
+                t_note = t;
+            }
+            else
+            {
+                freq = freq2;
+                t_note = t - (duration / 2.0);
+            }
+        }
+        
+        // Exponential decay per note
+        double volume = exp(-t_note * 4.0);
+        
+        if (pulse)
+        {
+            // Pulse every 50ms (50ms on, 50ms off)
             bool on = (static_cast<int>(t * 20) % 2) == 0;
             if (!on) volume = 0;
         }
         
-        double sample = volume * sin(2.0 * 3.14159265358979323846 * freq * t);
+        // Additive synthesis for richer sound (Fundamental + Harmonics)
+        double sample = 0;
+        sample += 0.6 * sin(2.0 * 3.14159265358979323846 * freq * t_note);
+        sample += 0.3 * sin(2.0 * 3.14159265358979323846 * freq * 2.0 * t_note);
+        sample += 0.1 * sin(2.0 * 3.14159265358979323846 * freq * 3.0 * t_note);
+        
+        sample *= volume;
+        
         int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
         
         file.write(reinterpret_cast<const char*>(&pcmSample), 2);
     }
 
-    file.close();
-    ChipLogProgress(DeviceLayer, "Generated WAV file %s", filename);
+    std::string str = file.str();
+    buffer.assign(str.begin(), str.end());
+    ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());
 }
 
 PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) :
@@ -100,14 +126,46 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
         mEngineInitialized = true;
         ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
         
-        // Generate dummy sound files
-        GenerateWavFile("chime_0.wav", 880, 660, 1.0, false); // Ding Dong
-        GenerateWavFile("chime_1.wav", 1000, 1000, 1.0, true); // Ring Ring
+        // Generate dummy sound buffers
+        GenerateWavMemory(mChime0Buffer, 880, 660, 1.0, false); // Ding Dong
+        GenerateWavMemory(mChime1Buffer, 1000, 1000, 1.0, true); // Ring Ring
+
+        // Initialize decoders from memory
+        ma_result res0 = ma_decoder_init_memory(mChime0Buffer.data(), mChime0Buffer.size(), NULL, &mDecoder0);
+        ma_result res1 = ma_decoder_init_memory(mChime1Buffer.data(), mChime1Buffer.size(), NULL, &mDecoder1);
+
+        if (res0 == MA_SUCCESS && res1 == MA_SUCCESS)
+        {
+            // Initialize sounds from data sources
+            res0 = ma_sound_init_from_data_source(&mEngine, &mDecoder0, 0, NULL, &mSound0);
+            res1 = ma_sound_init_from_data_source(&mEngine, &mDecoder1, 0, NULL, &mSound1);
+
+            if (res0 == MA_SUCCESS && res1 == MA_SUCCESS)
+            {
+                mSoundsInitialized = true;
+                ChipLogProgress(DeviceLayer, "In-memory sounds initialized successfully");
+            }
+            else
+            {
+                ChipLogError(DeviceLayer, "Failed to initialize sounds from data source: %d, %d", res0, res1);
+            }
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to initialize decoders from memory: %d, %d", res0, res1);
+        }
     }
 }
 
 PosixChimeDevice::~PosixChimeDevice()
 {
+    if (mSoundsInitialized)
+    {
+        ma_sound_uninit(&mSound0);
+        ma_sound_uninit(&mSound1);
+        ma_decoder_uninit(&mDecoder0);
+        ma_decoder_uninit(&mDecoder1);
+    }
     if (mEngineInitialized)
     {
         ma_engine_uninit(&mEngine);
@@ -120,20 +178,29 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     // Call base class to log the default message
     auto status = ChimeDevice::PlayChimeSound(chimeID);
 
-    if (!mEngineInitialized)
+    if (!mSoundsInitialized)
     {
-        ChipLogError(DeviceLayer, "PosixChimeDevice: Engine not initialized, cannot play sound");
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Sounds not initialized, cannot play sound");
         return status;
     }
 
-    char filePath[32];
-    snprintf(filePath, sizeof(filePath), "chime_%d.wav", chimeID);
+    ma_sound* pSound = nullptr;
+    if (chimeID == 0) pSound = &mSound0;
+    else if (chimeID == 1) pSound = &mSound1;
 
-    ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %s", filePath);
-    ma_result result = ma_engine_play_sound(&mEngine, filePath, NULL);
-    if (result != MA_SUCCESS)
+    if (pSound)
     {
-        ChipLogError(DeviceLayer, "Failed to play sound %s: %d", filePath, result);
+        ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %d from memory", chimeID);
+        ma_sound_seek_to_pcm_frame(pSound, 0);
+        ma_result result = ma_sound_start(pSound);
+        if (result != MA_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to start sound %d: %d", chimeID, result);
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Invalid chimeID %d", chimeID);
     }
 
     return status;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -24,17 +24,17 @@ namespace app {
 
 namespace {
 
-const double kPi = 3.14159265358979323846;
-const uint16_t kAudioFormatPCM = 1;
-const uint32_t kSampleRate = 44100;
+constexpr double kPi               = 3.14159265358979323846;
+constexpr uint16_t kAudioFormatPCM = 1;
+constexpr uint32_t kSampleRateHz   = 44100;
 
 // Custom data source read callback
-ma_result custom_data_source_read(ma_data_source* pDataSource, void* pFramesOut, ma_uint64 frameCount, ma_uint64* pFramesRead)
+ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
 {
     auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
 
     ma_uint64 framesToRead = frameCount;
     if (pCustomDS->cursor + framesToRead > totalSamples)
@@ -53,7 +53,7 @@ ma_result custom_data_source_read(ma_data_source* pDataSource, void* pFramesOut,
     for (ma_uint64 i = 0; i < framesToRead; ++i)
     {
         ma_uint64 currentSample = pCustomDS->cursor + i;
-        double t = static_cast<double>(currentSample) / kSampleRate;
+        double t = static_cast<double>(currentSample) / kSampleRateHz;
         double freq;
         double t_note;
 
@@ -101,12 +101,12 @@ ma_result custom_data_source_read(ma_data_source* pDataSource, void* pFramesOut,
 }
 
 // Custom data source seek callback
-ma_result custom_data_source_seek(ma_data_source* pDataSource, ma_uint64 frameIndex)
+ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
 {
     auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
 
     if (frameIndex > totalSamples)
     {
@@ -121,18 +121,18 @@ ma_result custom_data_source_seek(ma_data_source* pDataSource, ma_uint64 frameIn
 }
 
 // Custom data source get data format callback
-ma_result custom_data_source_get_data_format(ma_data_source* pDataSource, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap)
+ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels, ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
     if (pFormat) *pFormat = ma_format_s16;
     if (pChannels) *pChannels = 1;
-    if (pSampleRate) *pSampleRate = kSampleRate;
+    if (pSampleRate) *pSampleRate = kSampleRateHz;
     if (pChannelMap && channelMapCap > 0) *pChannelMap = MA_CHANNEL_MONO;
 
     return MA_SUCCESS;
 }
 
 // Custom data source get cursor callback
-ma_result custom_data_source_get_cursor(ma_data_source* pDataSource, ma_uint64* pCursor)
+ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
 {
     auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
@@ -142,17 +142,17 @@ ma_result custom_data_source_get_cursor(ma_data_source* pDataSource, ma_uint64* 
 }
 
 // Custom data source get length callback
-ma_result custom_data_source_get_length(ma_data_source* pDataSource, ma_uint64* pLength)
+ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
 {
     auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
-    if (pLength) *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
+    if (pLength) *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
     return MA_SUCCESS;
 }
 
 // Custom data source set looping callback
-ma_result custom_data_source_set_looping(ma_data_source* pDataSource, ma_bool32 isLooping)
+ma_result custom_data_source_set_looping(ma_data_source * pDataSource, ma_bool32 isLooping)
 {
     // Not supported for now
     return MA_NOT_IMPLEMENTED;
@@ -169,60 +169,68 @@ static ma_data_source_vtable g_custom_data_source_vtable = {
     0 // flags
 };
 
-bool InitializeSoundResource(ma_engine * engine, const ChimeDevice::Sound & sound, PosixChimeDevice::SoundResource & resource)
+} // namespace
+
+PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
 {
-    resource.id = sound.id;
+    id = soundInfo.id;
  
     // Configure the custom data source based on ID
-    resource.dataSource.cursor = 0;
+    dataSource.cursor = 0;
  
-    if (sound.id == 0)
+    if (soundInfo.id == 0)
     {
-        resource.dataSource.freq1 = 880;
-        resource.dataSource.freq2 = 660;
-        resource.dataSource.duration = 1.0;
-        resource.dataSource.pulse = false;
+        dataSource.freq1 = 880;
+        dataSource.freq2 = 660;
+        dataSource.duration = 1.0;
+        dataSource.pulse = false;
     }
-    else if (sound.id == 1)
+    else if (soundInfo.id == 1)
     {
-        resource.dataSource.freq1 = 1000;
-        resource.dataSource.freq2 = 1000;
-        resource.dataSource.duration = 1.0;
-        resource.dataSource.pulse = true;
+        dataSource.freq1 = 1000;
+        dataSource.freq2 = 1000;
+        dataSource.duration = 1.0;
+        dataSource.pulse = true;
     }
     else
     {
-        resource.dataSource.freq1 = 440;
-        resource.dataSource.freq2 = 440;
-        resource.dataSource.duration = 0.5;
-        resource.dataSource.pulse = false;
+        dataSource.freq1 = 440;
+        dataSource.freq2 = 440;
+        dataSource.duration = 0.5;
+        dataSource.pulse = false;
     }
  
     // Initialize the base data source with our vtable
     ma_data_source_config config = ma_data_source_config_init();
     config.vtable = &g_custom_data_source_vtable;
     
-    ma_result res = ma_data_source_init(&config, &resource.dataSource.base);
+    ma_result res = ma_data_source_init(&config, &dataSource.base);
     if (res != MA_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", sound.id, res);
-        return false;
+        ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", soundInfo.id, res);
+        return;
     }
  
     // Initialize sound from data source
-    res = ma_sound_init_from_data_source(engine, &resource.dataSource.base, 0, NULL, &resource.sound);
+    res = ma_sound_init_from_data_source(engine, &dataSource.base, 0, NULL, &sound);
     if (res != MA_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
-        ma_data_source_uninit(&resource.dataSource.base);
-        return false;
+        ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", soundInfo.id, res);
+        ma_data_source_uninit(&dataSource.base);
+        return;
     }
  
-    resource.initialized = true;
-    return true;
+    mInitialized = true;
 }
 
-} // namespace
+PosixChimeDevice::SoundResource::~SoundResource()
+{
+    if (mInitialized)
+    {
+        ma_sound_uninit(&sound);
+        ma_data_source_uninit(&dataSource.base);
+    }
+}
 
 PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) : ChimeDevice(timerDelegate, sounds)
 {
@@ -236,15 +244,15 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     mEngineInitialized = true;
     ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
 
-    mSoundResources.resize(sounds.size());
-
     bool allSoundsInitialized = true;
     for (size_t i = 0; i < sounds.size(); ++i)
     {
-        if (!InitializeSoundResource(&mEngine, sounds[i], mSoundResources[i]))
+        auto resource = std::make_unique<SoundResource>(&mEngine, sounds[i]);
+        if (!resource->mInitialized)
         {
             allSoundsInitialized = false;
         }
+        mSoundResources.push_back(std::move(resource));
     }
 
     mSoundsInitialized = allSoundsInitialized;
@@ -258,14 +266,7 @@ PosixChimeDevice::~PosixChimeDevice()
 {
     if (mEngineInitialized)
     {
-        for (auto & resource : mSoundResources)
-        {
-            if (resource.initialized)
-            {
-                ma_sound_uninit(&resource.sound);
-                ma_data_source_uninit(&resource.dataSource.base);
-            }
-        }
+        mSoundResources.clear();
         ma_engine_uninit(&mEngine);
         ChipLogProgress(DeviceLayer, "Miniaudio engine uninitialized");
     }
@@ -285,9 +286,9 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     ma_sound * pSound = nullptr;
     for (auto & resource : mSoundResources)
     {
-        if (resource.id == chimeID && resource.initialized)
+        if (resource && resource->id == chimeID && resource->mInitialized)
         {
-            pSound = &resource.sound;
+            pSound = &resource->sound;
             break;
         }
     }

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -16,17 +16,125 @@
  */
 #include <PosixChimeDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <cmath>
+#include <fstream>
 
 namespace chip {
 namespace app {
+
+// Helper to generate a simple WAV file
+static void GenerateWavFile(const char* filename, double freq1, double freq2, double duration, bool pulse = false)
+{
+    std::ofstream file(filename, std::ios::binary);
+    if (!file.is_open())
+    {
+        ChipLogError(DeviceLayer, "Failed to open file %s for writing", filename);
+        return;
+    }
+
+    const int sampleRate = 44100;
+    const int bitsPerSample = 16;
+    const int numChannels = 1;
+    const int numSamples = static_cast<int>(duration * sampleRate);
+    const int dataSize = numSamples * numChannels * (bitsPerSample / 8);
+
+    // WAV Header
+    file.write("RIFF", 4);
+    uint32_t chunkSize = 36 + dataSize;
+    file.write(reinterpret_cast<const char*>(&chunkSize), 4);
+    file.write("WAVE", 4);
+    file.write("fmt ", 4);
+    uint32_t subChunk1Size = 16;
+    file.write(reinterpret_cast<const char*>(&subChunk1Size), 4);
+    uint16_t audioFormat = 1; // PCM
+    file.write(reinterpret_cast<const char*>(&audioFormat), 2);
+    uint16_t channels = numChannels;
+    file.write(reinterpret_cast<const char*>(&channels), 2);
+    uint32_t sRate = sampleRate;
+    file.write(reinterpret_cast<const char*>(&sRate), 4);
+    uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+    file.write(reinterpret_cast<const char*>(&byteRate), 4);
+    uint16_t blockAlign = numChannels * (bitsPerSample / 8);
+    file.write(reinterpret_cast<const char*>(&blockAlign), 2);
+    uint16_t bps = bitsPerSample;
+    file.write(reinterpret_cast<const char*>(&bps), 2);
+    file.write("data", 4);
+    uint32_t subChunk2Size = dataSize;
+    file.write(reinterpret_cast<const char*>(&subChunk2Size), 4);
+
+    // Generate samples
+    for (int i = 0; i < numSamples; ++i)
+    {
+        double t = static_cast<double>(i) / sampleRate;
+        double freq = (t < duration / 2.0) ? freq1 : freq2;
+        
+        double volume = 1.0 - (t / duration);
+        
+        if (pulse)
+        {
+            // Pulse every 50ms (10Hz)
+            bool on = (static_cast<int>(t * 20) % 2) == 0;
+            if (!on) volume = 0;
+        }
+        
+        double sample = volume * sin(2.0 * 3.14159265358979323846 * freq * t);
+        int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
+        
+        file.write(reinterpret_cast<const char*>(&pcmSample), 2);
+    }
+
+    file.close();
+    ChipLogProgress(DeviceLayer, "Generated WAV file %s", filename);
+}
+
+PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) :
+    ChimeDevice(timerDelegate, sounds)
+{
+    ma_result result = ma_engine_init(NULL, &mEngine);
+    if (result != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize miniaudio engine: %d", result);
+    }
+    else
+    {
+        mEngineInitialized = true;
+        ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
+        
+        // Generate dummy sound files
+        GenerateWavFile("chime_0.wav", 880, 660, 1.0, false); // Ding Dong
+        GenerateWavFile("chime_1.wav", 1000, 1000, 1.0, true); // Ring Ring
+    }
+}
+
+PosixChimeDevice::~PosixChimeDevice()
+{
+    if (mEngineInitialized)
+    {
+        ma_engine_uninit(&mEngine);
+        ChipLogProgress(DeviceLayer, "Miniaudio engine uninitialized");
+    }
+}
 
 Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chimeID)
 {
     // Call base class to log the default message
     auto status = ChimeDevice::PlayChimeSound(chimeID);
 
-    // TODO: play a real sound on POSIX (Linux/Darwin)
-    ChipLogProgress(DeviceLayer, "PosixChimeDevice: TODO: Play real sound for ID %d", chimeID);
+    if (!mEngineInitialized)
+    {
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Engine not initialized, cannot play sound");
+        return status;
+    }
+
+    char filePath[32];
+    snprintf(filePath, sizeof(filePath), "chime_%d.wav", chimeID);
+
+    ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %s", filePath);
+    ma_result result = ma_engine_play_sound(&mEngine, filePath, NULL);
+    if (result != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to play sound %s: %d", filePath, result);
+    }
 
     return status;
 }

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -45,7 +45,8 @@ constexpr uint32_t kSampleRateHz   = 44100;
 ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+    if (pCustomDS == NULL)
+        return MA_INVALID_ARGS;
 
     // Calculate total samples for the full duration of the sound
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
@@ -59,7 +60,8 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
 
     if (framesToRead == 0)
     {
-        if (pFramesRead) *pFramesRead = 0;
+        if (pFramesRead)
+            *pFramesRead = 0;
         return MA_AT_END;
     }
 
@@ -77,7 +79,7 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         if (pCustomDS->pulse)
         {
             // Pulsing sound: keep same frequency
-            freq = pCustomDS->freq1;
+            freq   = pCustomDS->freq1;
             t_note = t;
         }
         else
@@ -85,12 +87,12 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
             // Two-tone sound (Ding-Dong): switch frequency halfway
             if (t < pCustomDS->duration / 2.0)
             {
-                freq = pCustomDS->freq1;
+                freq   = pCustomDS->freq1;
                 t_note = t;
             }
             else
             {
-                freq = pCustomDS->freq2;
+                freq   = pCustomDS->freq2;
                 t_note = t - (pCustomDS->duration / 2.0); // Reset relative time for second tone
             }
         }
@@ -102,7 +104,8 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         {
             // Apply a square wave modulation for the pulse effect
             bool on = (static_cast<int>(t * 20) % 2) == 0;
-            if (!on) volume = 0;
+            if (!on)
+                volume = 0;
         }
 
         // Additive synthesis: combine fundamental frequency and harmonics
@@ -118,7 +121,8 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
     }
 
     pCustomDS->cursor += framesToRead;
-    if (pFramesRead) *pFramesRead = framesToRead;
+    if (pFramesRead)
+        *pFramesRead = framesToRead;
 
     return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
 }
@@ -127,7 +131,8 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
 ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+    if (pCustomDS == NULL)
+        return MA_INVALID_ARGS;
 
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
 
@@ -145,12 +150,17 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
 }
 
 // Custom data source get data format callback. Tells miniaudio what format we are generating.
-ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels, ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
+ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
+                                             ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    if (pFormat) *pFormat = ma_format_s16; // 16-bit signed integer PCM
-    if (pChannels) *pChannels = 1;         // Mono
-    if (pSampleRate) *pSampleRate = kSampleRateHz;
-    if (pChannelMap && channelMapCap > 0) *pChannelMap = MA_CHANNEL_MONO;
+    if (pFormat)
+        *pFormat = ma_format_s16; // 16-bit signed integer PCM
+    if (pChannels)
+        *pChannels = 1; // Mono
+    if (pSampleRate)
+        *pSampleRate = kSampleRateHz;
+    if (pChannelMap && channelMapCap > 0)
+        *pChannelMap = MA_CHANNEL_MONO;
 
     return MA_SUCCESS;
 }
@@ -159,9 +169,11 @@ ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_fo
 ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+    if (pCustomDS == NULL)
+        return MA_INVALID_ARGS;
 
-    if (pCursor) *pCursor = pCustomDS->cursor;
+    if (pCursor)
+        *pCursor = pCustomDS->cursor;
     return MA_SUCCESS;
 }
 
@@ -169,9 +181,11 @@ ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 
 ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+    if (pCustomDS == NULL)
+        return MA_INVALID_ARGS;
 
-    if (pLength) *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
+    if (pLength)
+        *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
     return MA_SUCCESS;
 }
 
@@ -199,47 +213,47 @@ static ma_data_source_vtable g_custom_data_source_vtable = {
 PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
 {
     id = soundInfo.id;
- 
+
     // Configure the custom data source parameters based on ID.
     // These hardcoded values define the characteristics of each chime.
     dataSource.cursor = 0;
- 
+
     if (soundInfo.id == 0)
     {
         // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
-        dataSource.freq1 = 880;
-        dataSource.freq2 = 660;
+        dataSource.freq1    = 880;
+        dataSource.freq2    = 660;
         dataSource.duration = 1.0;
-        dataSource.pulse = false;
+        dataSource.pulse    = false;
     }
     else if (soundInfo.id == 1)
     {
         // Chime 1: Pulsing warning tone (1000Hz pulsing)
-        dataSource.freq1 = 1000;
-        dataSource.freq2 = 1000;
+        dataSource.freq1    = 1000;
+        dataSource.freq2    = 1000;
         dataSource.duration = 1.0;
-        dataSource.pulse = true;
+        dataSource.pulse    = true;
     }
     else
     {
         // Chime 2 (Default): Single short tone (440Hz)
-        dataSource.freq1 = 440;
-        dataSource.freq2 = 440;
+        dataSource.freq1    = 440;
+        dataSource.freq2    = 440;
         dataSource.duration = 0.5;
-        dataSource.pulse = false;
+        dataSource.pulse    = false;
     }
- 
+
     // Initialize the base data source with our vtable mapping to the callbacks above
     ma_data_source_config config = ma_data_source_config_init();
-    config.vtable = &g_custom_data_source_vtable;
-    
+    config.vtable                = &g_custom_data_source_vtable;
+
     ma_result res = ma_data_source_init(&config, &dataSource.base);
     if (res != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", soundInfo.id, res);
         return;
     }
- 
+
     // Initialize the sound object from the data source. Miniaudio will pull data from it during playback.
     res = ma_sound_init_from_data_source(engine, &dataSource.base, 0, NULL, &sound);
     if (res != MA_SUCCESS)
@@ -248,7 +262,7 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
         ma_data_source_uninit(&dataSource.base);
         return;
     }
- 
+
     mInitialized = true;
 }
 
@@ -333,10 +347,10 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     if (pSound)
     {
         ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %d from memory", chimeID);
-        
+
         // Rewind sound to the beginning before playing
         ma_sound_seek_to_pcm_frame(pSound, 0);
-        
+
         // Start playback. This will trigger callbacks to custom_data_source_read.
         ma_result result = ma_sound_start(pSound);
         if (result != MA_SUCCESS)

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -19,6 +19,24 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <sstream>
 
+/**
+ * @file PosixChimeDevice.cpp
+ * @brief Implementation of the Chime device for POSIX platforms.
+ *
+ * High-Level Overview:
+ * This file implements the audio playback for the Chime cluster on POSIX systems using the
+ * miniaudio library. To avoid shipping large audio files or consuming significant memory with
+ * pre-rendered PCM buffers, this implementation uses an "incremental synthesis" approach.
+ *
+ * A custom miniaudio data source (`CustomDataSource`) is defined. When miniaudio needs more
+ * audio data, it calls `custom_data_source_read`, which generates the audio samples on-the-fly.
+ * The sounds are synthesized using additive synthesis (combining a fundamental frequency with
+ * harmonics) and an exponential decay to simulate a natural bell or chime fade-out.
+ *
+ * The `SoundResource` class manages the lifecycle of these miniaudio structures using RAII,
+ * ensuring proper cleanup when the device is destroyed.
+ */
+
 namespace chip {
 namespace app {
 
@@ -28,7 +46,6 @@ constexpr double kPi               = 3.14159265358979323846;
 constexpr uint16_t kAudioFormatPCM = 1;
 constexpr uint32_t kSampleRateHz   = 44100;
 
-// Custom data source read callback
 // Custom data source read callback. This is called by miniaudio to fetch more audio frames.
 // It generates the audio on-the-fly instead of reading from a buffer.
 ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
@@ -112,14 +129,15 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
     return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
 }
 
-// Custom data source seek callback
+// Custom data source seek callback. Allows miniaudio to jump to a specific frame.
 ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
 {
-    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
 
+    // Cap the cursor at the end of the sound
     if (frameIndex > totalSamples)
     {
         pCustomDS->cursor = totalSamples;
@@ -132,45 +150,45 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
     return MA_SUCCESS;
 }
 
-// Custom data source get data format callback
+// Custom data source get data format callback. Tells miniaudio what format we are generating.
 ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels, ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    if (pFormat) *pFormat = ma_format_s16;
-    if (pChannels) *pChannels = 1;
+    if (pFormat) *pFormat = ma_format_s16; // 16-bit signed integer PCM
+    if (pChannels) *pChannels = 1;         // Mono
     if (pSampleRate) *pSampleRate = kSampleRateHz;
     if (pChannelMap && channelMapCap > 0) *pChannelMap = MA_CHANNEL_MONO;
 
     return MA_SUCCESS;
 }
 
-// Custom data source get cursor callback
+// Custom data source get cursor callback. Returns current playback position.
 ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
 {
-    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
     if (pCursor) *pCursor = pCustomDS->cursor;
     return MA_SUCCESS;
 }
 
-// Custom data source get length callback
+// Custom data source get length callback. Returns total duration in frames.
 ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
 {
-    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
     if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
     if (pLength) *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
     return MA_SUCCESS;
 }
 
-// Custom data source set looping callback
+// Custom data source set looping callback.
 ma_result custom_data_source_set_looping(ma_data_source * pDataSource, ma_bool32 isLooping)
 {
-    // Not supported for now
+    // Not supported for now as chime sounds are usually one-shot.
     return MA_NOT_IMPLEMENTED;
 }
 
-// Define the vtable
+// Define the vtable for the custom data source, mapping callbacks to miniaudio operations.
 static ma_data_source_vtable g_custom_data_source_vtable = {
     custom_data_source_read,
     custom_data_source_seek,
@@ -183,15 +201,18 @@ static ma_data_source_vtable g_custom_data_source_vtable = {
 
 } // namespace
 
+// SoundResource Constructor: Initializes a specific sound based on its ID.
 PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
 {
     id = soundInfo.id;
  
-    // Configure the custom data source based on ID
+    // Configure the custom data source parameters based on ID.
+    // These hardcoded values define the characteristics of each chime.
     dataSource.cursor = 0;
  
     if (soundInfo.id == 0)
     {
+        // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
         dataSource.freq1 = 880;
         dataSource.freq2 = 660;
         dataSource.duration = 1.0;
@@ -199,6 +220,7 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
     }
     else if (soundInfo.id == 1)
     {
+        // Chime 1: Pulsing warning tone (1000Hz pulsing)
         dataSource.freq1 = 1000;
         dataSource.freq2 = 1000;
         dataSource.duration = 1.0;
@@ -206,13 +228,14 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
     }
     else
     {
+        // Chime 2 (Default): Single short tone (440Hz)
         dataSource.freq1 = 440;
         dataSource.freq2 = 440;
         dataSource.duration = 0.5;
         dataSource.pulse = false;
     }
  
-    // Initialize the base data source with our vtable
+    // Initialize the base data source with our vtable mapping to the callbacks above
     ma_data_source_config config = ma_data_source_config_init();
     config.vtable = &g_custom_data_source_vtable;
     
@@ -223,7 +246,7 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
         return;
     }
  
-    // Initialize sound from data source
+    // Initialize the sound object from the data source. Miniaudio will pull data from it during playback.
     res = ma_sound_init_from_data_source(engine, &dataSource.base, 0, NULL, &sound);
     if (res != MA_SUCCESS)
     {
@@ -235,6 +258,7 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
     mInitialized = true;
 }
 
+// SoundResource Destructor: Ensures safe cleanup of miniaudio structures.
 PosixChimeDevice::SoundResource::~SoundResource()
 {
     if (mInitialized)
@@ -244,8 +268,10 @@ PosixChimeDevice::SoundResource::~SoundResource()
     }
 }
 
+// PosixChimeDevice Constructor: Initializes the audio engine and pre-loads sound resources.
 PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) : ChimeDevice(timerDelegate, sounds)
 {
+    // Initialize the miniaudio engine with default configuration
     ma_result result = ma_engine_init(NULL, &mEngine);
     if (result != MA_SUCCESS)
     {
@@ -256,6 +282,7 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     mEngineInitialized = true;
     ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
 
+    // Pre-initialize all requested sound resources
     bool allSoundsInitialized = true;
     for (size_t i = 0; i < sounds.size(); ++i)
     {
@@ -274,16 +301,19 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     }
 }
 
+// PosixChimeDevice Destructor: Cleans up resources and shuts down the engine.
 PosixChimeDevice::~PosixChimeDevice()
 {
     if (mEngineInitialized)
     {
+        // Clear the vector first to trigger SoundResource destructors before engine shutdown
         mSoundResources.clear();
         ma_engine_uninit(&mEngine);
         ChipLogProgress(DeviceLayer, "Miniaudio engine uninitialized");
     }
 }
 
+// PlayChimeSound: Triggers the playback of a sound by its ID.
 Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chimeID)
 {
     // Call base class to log the default message
@@ -295,6 +325,7 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
         return status;
     }
 
+    // Find the requested sound resource by ID
     ma_sound * pSound = nullptr;
     for (auto & resource : mSoundResources)
     {
@@ -308,7 +339,11 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     if (pSound)
     {
         ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %d from memory", chimeID);
+        
+        // Rewind sound to the beginning before playing
         ma_sound_seek_to_pcm_frame(pSound, 0);
+        
+        // Start playback. This will trigger callbacks to custom_data_source_read.
         ma_result result = ma_sound_start(pSound);
         if (result != MA_SUCCESS)
         {
@@ -317,7 +352,7 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     }
     else
     {
-        ChipLogError(DeviceLayer, "PosixChimeDevice: Invalid or uninitialized chimeID %d", chimeID);
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Sound %d not found in memory", chimeID);
     }
 
     return status;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -82,9 +82,10 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
     // Generate samples
     for (int i = 0; i < numSamples; ++i)
     {
+        // Current time in seconds
         double t = static_cast<double>(i) / sampleRate;
         double freq;
-        double t_note;
+        double t_note; // Time relative to the start of the current note
 
         if (pulse)
         {
@@ -93,6 +94,7 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
         }
         else
         {
+            // Two-tone sound: first half plays freq1, second half plays freq2
             if (t < duration / 2.0)
             {
                 freq   = freq1;
@@ -105,8 +107,10 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
             }
         }
 
+        // Exponential decay for a natural "bell-like" volume drop
         double volume = exp(-t_note * 4.0);
 
+        // If pulsing, toggle sound on and off at 20Hz rate
         if (pulse)
         {
             bool on = (static_cast<int>(t * 20) % 2) == 0;
@@ -114,13 +118,19 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
                 volume = 0;
         }
 
+        // Additive synthesis: combine fundamental frequency with overtones
+        // to make it sound richer than a simple pure beep.
         double sample = 0;
+        // Fundamental frequency (60% weight)
         sample += 0.6 * sin(2.0 * 3.14159265358979323846 * freq * t_note);
+        // First overtone / 2nd harmonic (30% weight)
         sample += 0.3 * sin(2.0 * 3.14159265358979323846 * freq * 2.0 * t_note);
+        // Second overtone / 3rd harmonic (10% weight)
         sample += 0.1 * sin(2.0 * 3.14159265358979323846 * freq * 3.0 * t_note);
 
         sample *= volume;
 
+        // Scale to 16-bit signed integer PCM
         int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
         writeVal16(static_cast<uint16_t>(pcmSample));
     }

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -24,6 +24,9 @@ namespace app {
 
 namespace {
 
+const double kPi = 3.14159265358979323846;
+const uint16_t kAudioFormatPCM = 1;
+
 // Helper to generate a simple WAV file in memory
 void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
@@ -65,7 +68,7 @@ void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2
     writeStr("fmt ", 4);
     uint32_t subChunk1Size = 16;
     writeVal32(subChunk1Size);
-    uint16_t audioFormat = 1; // PCM
+    uint16_t audioFormat = kAudioFormatPCM; // PCM
     writeVal16(audioFormat);
     uint16_t numChans = numChannels;
     writeVal16(numChans);
@@ -124,11 +127,11 @@ void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2
         // to make it sound richer than a simple pure beep.
         double sample = 0;
         // Fundamental frequency (60% weight)
-        sample += 0.6 * sin(2.0 * 3.14159265358979323846 * freq * t_note);
+        sample += 0.6 * sin(2.0 * kPi * freq * t_note);
         // First overtone / 2nd harmonic (30% weight)
-        sample += 0.3 * sin(2.0 * 3.14159265358979323846 * freq * 2.0 * t_note);
+        sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note);
         // Second overtone / 3rd harmonic (10% weight)
-        sample += 0.1 * sin(2.0 * 3.14159265358979323846 * freq * 3.0 * t_note);
+        sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note);
 
         sample *= volume;
 

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -37,7 +37,6 @@ namespace app {
 namespace {
 
 constexpr double kPi               = 3.14159265358979323846;
-constexpr uint16_t kAudioFormatPCM = 1;
 constexpr uint32_t kSampleRateHz   = 44100;
 
 // Custom data source read callback. This is called by miniaudio to fetch more audio frames.

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -41,35 +41,43 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
         p += len;
     };
 
-    // Helper to write trivial types
-    auto writeVal = [&](const auto & val) {
-        memcpy(p, &val, sizeof(val));
-        p += sizeof(val);
+    // Helper to write Little-Endian 16-bit values
+    auto writeVal16 = [&](uint16_t val) {
+        *p++ = static_cast<uint8_t>(val & 0xFF);
+        *p++ = static_cast<uint8_t>((val >> 8) & 0xFF);
+    };
+
+    // Helper to write Little-Endian 32-bit values
+    auto writeVal32 = [&](uint32_t val) {
+        *p++ = static_cast<uint8_t>(val & 0xFF);
+        *p++ = static_cast<uint8_t>((val >> 8) & 0xFF);
+        *p++ = static_cast<uint8_t>((val >> 16) & 0xFF);
+        *p++ = static_cast<uint8_t>((val >> 24) & 0xFF);
     };
 
     // WAV Header
     writeStr("RIFF", sizeof("RIFF") - 1);
     uint32_t chunkSize = 36 + dataSize;
-    writeVal(chunkSize);
+    writeVal32(chunkSize);
     writeStr("WAVE", sizeof("WAVE") - 1);
     writeStr("fmt ", sizeof("fmt ") - 1);
     uint32_t subChunk1Size = 16;
-    writeVal(subChunk1Size);
+    writeVal32(subChunk1Size);
     uint16_t audioFormat = 1; // PCM
-    writeVal(audioFormat);
+    writeVal16(audioFormat);
     uint16_t channels = numChannels;
-    writeVal(channels);
+    writeVal16(channels);
     uint32_t sRate = sampleRate;
-    writeVal(sRate);
+    writeVal32(sRate);
     uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-    writeVal(byteRate);
+    writeVal32(byteRate);
     uint16_t blockAlign = numChannels * (bitsPerSample / 8);
-    writeVal(blockAlign);
+    writeVal16(blockAlign);
     uint16_t bps = bitsPerSample;
-    writeVal(bps);
+    writeVal16(bps);
     writeStr("data", sizeof("data") - 1);
     uint32_t subChunk2Size = dataSize;
-    writeVal(subChunk2Size);
+    writeVal32(subChunk2Size);
 
     // Generate samples
     for (int i = 0; i < numSamples; ++i)
@@ -114,7 +122,7 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
         sample *= volume;
 
         int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
-        writeVal(pcmSample);
+        writeVal16(static_cast<uint16_t>(pcmSample));
     }
 
     ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -25,37 +25,51 @@ namespace app {
 // Helper to generate a simple WAV file in memory
 static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
-    std::stringstream file(std::ios::binary | std::ios::out);
-
     const int sampleRate    = 44100;
     const int bitsPerSample = 16;
     const int numChannels   = 1;
     const int numSamples    = static_cast<int>(duration * sampleRate);
     const int dataSize      = numSamples * numChannels * (bitsPerSample / 8);
+    const int totalSize     = 44 + dataSize;
+
+    buffer.resize(totalSize);
+    uint8_t * p = buffer.data();
+
+    // Helper to write strings
+    auto writeStr = [&](const char * str, size_t len) {
+        memcpy(p, str, len);
+        p += len;
+    };
+
+    // Helper to write trivial types
+    auto writeVal = [&](const auto & val) {
+        memcpy(p, &val, sizeof(val));
+        p += sizeof(val);
+    };
 
     // WAV Header
-    file.write("RIFF", 4);
+    writeStr("RIFF", sizeof("RIFF") - 1);
     uint32_t chunkSize = 36 + dataSize;
-    file.write(reinterpret_cast<const char *>(&chunkSize), 4);
-    file.write("WAVE", 4);
-    file.write("fmt ", 4);
+    writeVal(chunkSize);
+    writeStr("WAVE", sizeof("WAVE") - 1);
+    writeStr("fmt ", sizeof("fmt ") - 1);
     uint32_t subChunk1Size = 16;
-    file.write(reinterpret_cast<const char *>(&subChunk1Size), 4);
+    writeVal(subChunk1Size);
     uint16_t audioFormat = 1; // PCM
-    file.write(reinterpret_cast<const char *>(&audioFormat), 2);
+    writeVal(audioFormat);
     uint16_t channels = numChannels;
-    file.write(reinterpret_cast<const char *>(&channels), 2);
+    writeVal(channels);
     uint32_t sRate = sampleRate;
-    file.write(reinterpret_cast<const char *>(&sRate), 4);
+    writeVal(sRate);
     uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-    file.write(reinterpret_cast<const char *>(&byteRate), 4);
+    writeVal(byteRate);
     uint16_t blockAlign = numChannels * (bitsPerSample / 8);
-    file.write(reinterpret_cast<const char *>(&blockAlign), 2);
+    writeVal(blockAlign);
     uint16_t bps = bitsPerSample;
-    file.write(reinterpret_cast<const char *>(&bps), 2);
-    file.write("data", 4);
+    writeVal(bps);
+    writeStr("data", sizeof("data") - 1);
     uint32_t subChunk2Size = dataSize;
-    file.write(reinterpret_cast<const char *>(&subChunk2Size), 4);
+    writeVal(subChunk2Size);
 
     // Generate samples
     for (int i = 0; i < numSamples; ++i)
@@ -66,13 +80,11 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
 
         if (pulse)
         {
-            // For pulse (Ring Ring), we don't split into two notes
             freq   = freq1;
             t_note = t;
         }
         else
         {
-            // For chime (Ding Dong), we split into two notes
             if (t < duration / 2.0)
             {
                 freq   = freq1;
@@ -85,18 +97,15 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
             }
         }
 
-        // Exponential decay per note
         double volume = exp(-t_note * 4.0);
 
         if (pulse)
         {
-            // Pulse every 50ms (50ms on, 50ms off)
             bool on = (static_cast<int>(t * 20) % 2) == 0;
             if (!on)
                 volume = 0;
         }
 
-        // Additive synthesis for richer sound (Fundamental + Harmonics)
         double sample = 0;
         sample += 0.6 * sin(2.0 * 3.14159265358979323846 * freq * t_note);
         sample += 0.3 * sin(2.0 * 3.14159265358979323846 * freq * 2.0 * t_note);
@@ -105,12 +114,9 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
         sample *= volume;
 
         int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
-
-        file.write(reinterpret_cast<const char *>(&pcmSample), 2);
+        writeVal(pcmSample);
     }
 
-    std::string str = file.str();
-    buffer.assign(str.begin(), str.end());
     ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());
 }
 
@@ -120,54 +126,76 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     if (result != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize miniaudio engine: %d", result);
+        return;
     }
-    else
+
+    mEngineInitialized = true;
+    ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
+
+    mSoundResources.resize(sounds.size());
+
+    bool allSoundsInitialized = true;
+    for (size_t i = 0; i < sounds.size(); ++i)
     {
-        mEngineInitialized = true;
-        ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
+        const auto & sound = sounds[i];
+        auto & resource    = mSoundResources[i];
+        resource.id        = sound.id;
 
-        // Generate dummy sound buffers
-        GenerateWavMemory(mChime0Buffer, 880, 660, 1.0, false);  // Ding Dong
-        GenerateWavMemory(mChime1Buffer, 1000, 1000, 1.0, true); // Ring Ring
-
-        // Initialize decoders from memory
-        ma_result res0 = ma_decoder_init_memory(mChime0Buffer.data(), mChime0Buffer.size(), NULL, &mDecoder0);
-        ma_result res1 = ma_decoder_init_memory(mChime1Buffer.data(), mChime1Buffer.size(), NULL, &mDecoder1);
-
-        if (res0 == MA_SUCCESS && res1 == MA_SUCCESS)
+        // Generate sound based on ID
+        if (sound.id == 0)
         {
-            // Initialize sounds from data sources
-            res0 = ma_sound_init_from_data_source(&mEngine, &mDecoder0, 0, NULL, &mSound0);
-            res1 = ma_sound_init_from_data_source(&mEngine, &mDecoder1, 0, NULL, &mSound1);
-
-            if (res0 == MA_SUCCESS && res1 == MA_SUCCESS)
-            {
-                mSoundsInitialized = true;
-                ChipLogProgress(DeviceLayer, "In-memory sounds initialized successfully");
-            }
-            else
-            {
-                ChipLogError(DeviceLayer, "Failed to initialize sounds from data source: %d, %d", res0, res1);
-            }
+            GenerateWavMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
+        }
+        else if (sound.id == 1)
+        {
+            GenerateWavMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
         }
         else
         {
-            ChipLogError(DeviceLayer, "Failed to initialize decoders from memory: %d, %d", res0, res1);
+            GenerateWavMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
         }
+
+        // Initialize decoder from memory
+        ma_result res = ma_decoder_init_memory(resource.buffer.data(), resource.buffer.size(), NULL, &resource.decoder);
+        if (res != MA_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to initialize decoder for sound %d: %d", sound.id, res);
+            allSoundsInitialized = false;
+            continue;
+        }
+
+        // Initialize sound from data source
+        res = ma_sound_init_from_data_source(&mEngine, &resource.decoder, 0, NULL, &resource.sound);
+        if (res != MA_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
+            ma_decoder_uninit(&resource.decoder);
+            allSoundsInitialized = false;
+            continue;
+        }
+
+        resource.initialized = true;
+    }
+
+    mSoundsInitialized = allSoundsInitialized;
+    if (mSoundsInitialized)
+    {
+        ChipLogProgress(DeviceLayer, "In-memory sounds initialized successfully");
     }
 }
 
 PosixChimeDevice::~PosixChimeDevice()
 {
-    if (mSoundsInitialized)
-    {
-        ma_sound_uninit(&mSound0);
-        ma_sound_uninit(&mSound1);
-        ma_decoder_uninit(&mDecoder0);
-        ma_decoder_uninit(&mDecoder1);
-    }
     if (mEngineInitialized)
     {
+        for (auto & resource : mSoundResources)
+        {
+            if (resource.initialized)
+            {
+                ma_sound_uninit(&resource.sound);
+                ma_decoder_uninit(&resource.decoder);
+            }
+        }
         ma_engine_uninit(&mEngine);
         ChipLogProgress(DeviceLayer, "Miniaudio engine uninitialized");
     }
@@ -185,10 +213,14 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     }
 
     ma_sound * pSound = nullptr;
-    if (chimeID == 0)
-        pSound = &mSound0;
-    else if (chimeID == 1)
-        pSound = &mSound1;
+    for (auto & resource : mSoundResources)
+    {
+        if (resource.id == chimeID && resource.initialized)
+        {
+            pSound = &resource.sound;
+            break;
+        }
+    }
 
     if (pSound)
     {
@@ -202,7 +234,7 @@ Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chi
     }
     else
     {
-        ChipLogError(DeviceLayer, "PosixChimeDevice: Invalid chimeID %d", chimeID);
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Invalid or uninitialized chimeID %d", chimeID);
     }
 
     return status;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -22,8 +22,10 @@
 namespace chip {
 namespace app {
 
+namespace {
+
 // Helper to generate a simple WAV file in memory
-static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
+void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
 {
     const int sampleRate    = 44100;
     const int bitsPerSample = 16;
@@ -56,17 +58,17 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
     };
 
     // WAV Header
-    writeStr("RIFF", sizeof("RIFF") - 1);
-    uint32_t chunkSize = 36 + dataSize;
-    writeVal32(chunkSize);
-    writeStr("WAVE", sizeof("WAVE") - 1);
-    writeStr("fmt ", sizeof("fmt ") - 1);
+    writeStr("RIFF", 4);
+    uint32_t fileSize = totalSize - 8;
+    writeVal32(fileSize);
+    writeStr("WAVE", 4);
+    writeStr("fmt ", 4);
     uint32_t subChunk1Size = 16;
     writeVal32(subChunk1Size);
     uint16_t audioFormat = 1; // PCM
     writeVal16(audioFormat);
-    uint16_t channels = numChannels;
-    writeVal16(channels);
+    uint16_t numChans = numChannels;
+    writeVal16(numChans);
     uint32_t sRate = sampleRate;
     writeVal32(sRate);
     uint32_t byteRate = sampleRate * numChannels * (bitsPerSample / 8);
@@ -75,7 +77,7 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
     writeVal16(blockAlign);
     uint16_t bps = bitsPerSample;
     writeVal16(bps);
-    writeStr("data", sizeof("data") - 1);
+    writeStr("data", 4);
     uint32_t subChunk2Size = dataSize;
     writeVal32(subChunk2Size);
 
@@ -138,6 +140,47 @@ static void GenerateWavMemory(std::vector<uint8_t> & buffer, double freq1, doubl
     ChipLogProgress(DeviceLayer, "Generated WAV buffer size %zu", buffer.size());
 }
 
+bool InitializeSoundResource(ma_engine * engine, const ChimeDevice::Sound & sound, PosixChimeDevice::SoundResource & resource)
+{
+    resource.id = sound.id;
+
+    // Generate sound based on ID
+    if (sound.id == 0)
+    {
+        GenerateWavMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
+    }
+    else if (sound.id == 1)
+    {
+        GenerateWavMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
+    }
+    else
+    {
+        GenerateWavMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
+    }
+
+    // Initialize decoder from memory
+    ma_result res = ma_decoder_init_memory(resource.buffer.data(), resource.buffer.size(), NULL, &resource.decoder);
+    if (res != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize decoder for sound %d: %d", sound.id, res);
+        return false;
+    }
+
+    // Initialize sound from data source
+    res = ma_sound_init_from_data_source(engine, &resource.decoder, 0, NULL, &resource.sound);
+    if (res != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
+        ma_decoder_uninit(&resource.decoder);
+        return false;
+    }
+
+    resource.initialized = true;
+    return true;
+}
+
+} // namespace
+
 PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) : ChimeDevice(timerDelegate, sounds)
 {
     ma_result result = ma_engine_init(NULL, &mEngine);
@@ -155,44 +198,10 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     bool allSoundsInitialized = true;
     for (size_t i = 0; i < sounds.size(); ++i)
     {
-        const auto & sound = sounds[i];
-        auto & resource    = mSoundResources[i];
-        resource.id        = sound.id;
-
-        // Generate sound based on ID
-        if (sound.id == 0)
+        if (!InitializeSoundResource(&mEngine, sounds[i], mSoundResources[i]))
         {
-            GenerateWavMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
-        }
-        else if (sound.id == 1)
-        {
-            GenerateWavMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
-        }
-        else
-        {
-            GenerateWavMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
-        }
-
-        // Initialize decoder from memory
-        ma_result res = ma_decoder_init_memory(resource.buffer.data(), resource.buffer.size(), NULL, &resource.decoder);
-        if (res != MA_SUCCESS)
-        {
-            ChipLogError(DeviceLayer, "Failed to initialize decoder for sound %d: %d", sound.id, res);
             allSoundsInitialized = false;
-            continue;
         }
-
-        // Initialize sound from data source
-        res = ma_sound_init_from_data_source(&mEngine, &resource.decoder, 0, NULL, &resource.sound);
-        if (res != MA_SUCCESS)
-        {
-            ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
-            ma_decoder_uninit(&resource.decoder);
-            allSoundsInitialized = false;
-            continue;
-        }
-
-        resource.initialized = true;
     }
 
     mSoundsInitialized = allSoundsInitialized;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -19,23 +19,17 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <sstream>
 
-/**
- * @file PosixChimeDevice.cpp
- * @brief Implementation of the Chime device for POSIX platforms.
- *
- * High-Level Overview:
- * This file implements the audio playback for the Chime cluster on POSIX systems using the
- * miniaudio library. To avoid shipping large audio files or consuming significant memory with
- * pre-rendered PCM buffers, this implementation uses an "incremental synthesis" approach.
- *
- * A custom miniaudio data source (`CustomDataSource`) is defined. When miniaudio needs more
- * audio data, it calls `custom_data_source_read`, which generates the audio samples on-the-fly.
- * The sounds are synthesized using additive synthesis (combining a fundamental frequency with
- * harmonics) and an exponential decay to simulate a natural bell or chime fade-out.
- *
- * The `SoundResource` class manages the lifecycle of these miniaudio structures using RAII,
- * ensuring proper cleanup when the device is destroyed.
- */
+// This file implements the audio playback for the Chime cluster on POSIX systems using the
+// miniaudio library. To avoid shipping large audio files or consuming significant memory with
+// pre-rendered PCM buffers, this implementation uses an "incremental synthesis" approach.
+//
+// A custom miniaudio data source (`CustomDataSource`) is defined. When miniaudio needs more
+// audio data, it calls `custom_data_source_read`, which generates the audio samples on-the-fly.
+// The sounds are synthesized using additive synthesis (combining a fundamental frequency with
+// harmonics) and an exponential decay to simulate a natural bell or chime fade-out.
+//
+// The `SoundResource` class manages the lifecycle of these miniaudio structures using RAII,
+// ensuring proper cleanup when the device is destroyed.
 
 namespace chip {
 namespace app {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -26,121 +26,195 @@ namespace {
 
 const double kPi = 3.14159265358979323846;
 const uint16_t kAudioFormatPCM = 1;
+const uint32_t kSampleRate = 44100;
 
-// Helper to generate raw PCM data in memory
-void GeneratePcmMemory(std::vector<uint8_t> & buffer, double freq1, double freq2, double duration, bool pulse = false)
+// Custom data source read callback
+ma_result custom_data_source_read(ma_data_source* pDataSource, void* pFramesOut, ma_uint64 frameCount, ma_uint64* pFramesRead)
 {
-    const int sampleRate    = 44100;
-    const int bitsPerSample = 16;
-    const int numChannels   = 1;
-    const int numSamples    = static_cast<int>(duration * sampleRate);
-    const int dataSize      = numSamples * numChannels * (bitsPerSample / 8);
+    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    if (pCustomDS == NULL) return MA_INVALID_ARGS;
 
-    buffer.resize(dataSize);
-    uint8_t * p = buffer.data();
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
 
-    // Helper to write Little-Endian 16-bit values
-    auto writeVal16 = [&](uint16_t val) {
-        *p++ = static_cast<uint8_t>(val & 0xFF);
-        *p++ = static_cast<uint8_t>((val >> 8) & 0xFF);
-    };
-
-    // Generate samples
-    for (int i = 0; i < numSamples; ++i)
+    ma_uint64 framesToRead = frameCount;
+    if (pCustomDS->cursor + framesToRead > totalSamples)
     {
-        // Current time in seconds
-        double t = static_cast<double>(i) / sampleRate;
-        double freq;
-        double t_note; // Time relative to the start of the current note
+        framesToRead = totalSamples - pCustomDS->cursor;
+    }
 
-        if (pulse)
+    if (framesToRead == 0)
+    {
+        if (pFramesRead) *pFramesRead = 0;
+        return MA_AT_END;
+    }
+
+    int16_t* pOut = reinterpret_cast<int16_t*>(pFramesOut);
+
+    for (ma_uint64 i = 0; i < framesToRead; ++i)
+    {
+        ma_uint64 currentSample = pCustomDS->cursor + i;
+        double t = static_cast<double>(currentSample) / kSampleRate;
+        double freq;
+        double t_note;
+
+        if (pCustomDS->pulse)
         {
-            freq   = freq1;
+            freq = pCustomDS->freq1;
             t_note = t;
         }
         else
         {
-            // Two-tone sound: first half plays freq1, second half plays freq2
-            if (t < duration / 2.0)
+            if (t < pCustomDS->duration / 2.0)
             {
-                freq   = freq1;
+                freq = pCustomDS->freq1;
                 t_note = t;
             }
             else
             {
-                freq   = freq2;
-                t_note = t - (duration / 2.0);
+                freq = pCustomDS->freq2;
+                t_note = t - (pCustomDS->duration / 2.0);
             }
         }
 
-        // Exponential decay for a natural "bell-like" volume drop
         double volume = exp(-t_note * 4.0);
 
-        // If pulsing, toggle sound on and off at 20Hz rate
-        if (pulse)
+        if (pCustomDS->pulse)
         {
             bool on = (static_cast<int>(t * 20) % 2) == 0;
-            if (!on)
-                volume = 0;
+            if (!on) volume = 0;
         }
 
-        // Additive synthesis: combine fundamental frequency with overtones
-        // to make it sound richer than a simple pure beep.
         double sample = 0;
-        // Fundamental frequency (60% weight)
         sample += 0.6 * sin(2.0 * kPi * freq * t_note);
-        // First overtone / 2nd harmonic (30% weight)
         sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note);
-        // Second overtone / 3rd harmonic (10% weight)
         sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note);
 
         sample *= volume;
 
-        // Scale to 16-bit signed integer PCM
-        int16_t pcmSample = static_cast<int16_t>(sample * 32767.0);
-        writeVal16(static_cast<uint16_t>(pcmSample));
+        pOut[i] = static_cast<int16_t>(sample * 32767.0);
     }
 
-    ChipLogProgress(DeviceLayer, "Generated PCM buffer size %zu", buffer.size());
+    pCustomDS->cursor += framesToRead;
+    if (pFramesRead) *pFramesRead = framesToRead;
+
+    return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
 }
+
+// Custom data source seek callback
+ma_result custom_data_source_seek(ma_data_source* pDataSource, ma_uint64 frameIndex)
+{
+    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
+
+    if (frameIndex > totalSamples)
+    {
+        pCustomDS->cursor = totalSamples;
+    }
+    else
+    {
+        pCustomDS->cursor = frameIndex;
+    }
+
+    return MA_SUCCESS;
+}
+
+// Custom data source get data format callback
+ma_result custom_data_source_get_data_format(ma_data_source* pDataSource, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap)
+{
+    if (pFormat) *pFormat = ma_format_s16;
+    if (pChannels) *pChannels = 1;
+    if (pSampleRate) *pSampleRate = kSampleRate;
+    if (pChannelMap && channelMapCap > 0) *pChannelMap = MA_CHANNEL_MONO;
+
+    return MA_SUCCESS;
+}
+
+// Custom data source get cursor callback
+ma_result custom_data_source_get_cursor(ma_data_source* pDataSource, ma_uint64* pCursor)
+{
+    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+
+    if (pCursor) *pCursor = pCustomDS->cursor;
+    return MA_SUCCESS;
+}
+
+// Custom data source get length callback
+ma_result custom_data_source_get_length(ma_data_source* pDataSource, ma_uint64* pLength)
+{
+    auto* pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource*>(pDataSource);
+    if (pCustomDS == NULL) return MA_INVALID_ARGS;
+
+    if (pLength) *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRate);
+    return MA_SUCCESS;
+}
+
+// Custom data source set looping callback
+ma_result custom_data_source_set_looping(ma_data_source* pDataSource, ma_bool32 isLooping)
+{
+    // Not supported for now
+    return MA_NOT_IMPLEMENTED;
+}
+
+// Define the vtable
+static ma_data_source_vtable g_custom_data_source_vtable = {
+    custom_data_source_read,
+    custom_data_source_seek,
+    custom_data_source_get_data_format,
+    custom_data_source_get_cursor,
+    custom_data_source_get_length,
+    custom_data_source_set_looping,
+    0 // flags
+};
 
 bool InitializeSoundResource(ma_engine * engine, const ChimeDevice::Sound & sound, PosixChimeDevice::SoundResource & resource)
 {
     resource.id = sound.id;
  
-    // Generate sound based on ID
+    // Configure the custom data source based on ID
+    resource.dataSource.cursor = 0;
+ 
     if (sound.id == 0)
     {
-        GeneratePcmMemory(resource.buffer, 880, 660, 1.0, false); // Ding Dong
+        resource.dataSource.freq1 = 880;
+        resource.dataSource.freq2 = 660;
+        resource.dataSource.duration = 1.0;
+        resource.dataSource.pulse = false;
     }
     else if (sound.id == 1)
     {
-        GeneratePcmMemory(resource.buffer, 1000, 1000, 1.0, true); // Ring Ring
+        resource.dataSource.freq1 = 1000;
+        resource.dataSource.freq2 = 1000;
+        resource.dataSource.duration = 1.0;
+        resource.dataSource.pulse = true;
     }
     else
     {
-        GeneratePcmMemory(resource.buffer, 440, 440, 0.5, false); // Default beep
+        resource.dataSource.freq1 = 440;
+        resource.dataSource.freq2 = 440;
+        resource.dataSource.duration = 0.5;
+        resource.dataSource.pulse = false;
     }
  
-    // Initialize audio buffer from raw PCM memory
-    // We use 44100 Hz, 16-bit signed PCM, mono.
-    // Frames count is buffer size / 2 (since each sample is 2 bytes).
-    ma_audio_buffer_config config = ma_audio_buffer_config_init(ma_format_s16, 1, resource.buffer.size() / 2, resource.buffer.data(), NULL);
-    config.sampleRate = 44100; // Explicitly set sample rate as it's not in the init helper arguments for audio_buffer
+    // Initialize the base data source with our vtable
+    ma_data_source_config config = ma_data_source_config_init();
+    config.vtable = &g_custom_data_source_vtable;
     
-    ma_result res = ma_audio_buffer_init(&config, &resource.audioBuffer);
+    ma_result res = ma_data_source_init(&config, &resource.dataSource.base);
     if (res != MA_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "Failed to initialize audio buffer for sound %d: %d", sound.id, res);
+        ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", sound.id, res);
         return false;
     }
  
     // Initialize sound from data source
-    res = ma_sound_init_from_data_source(engine, &resource.audioBuffer, 0, NULL, &resource.sound);
+    res = ma_sound_init_from_data_source(engine, &resource.dataSource.base, 0, NULL, &resource.sound);
     if (res != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", sound.id, res);
-        ma_audio_buffer_uninit(&resource.audioBuffer);
+        ma_data_source_uninit(&resource.dataSource.base);
         return false;
     }
  
@@ -189,7 +263,7 @@ PosixChimeDevice::~PosixChimeDevice()
             if (resource.initialized)
             {
                 ma_sound_uninit(&resource.sound);
-                ma_audio_buffer_uninit(&resource.audioBuffer);
+                ma_data_source_uninit(&resource.dataSource.base);
             }
         }
         ma_engine_uninit(&mEngine);

--- a/examples/all-devices-app/posix/darwin/BUILD.gn
+++ b/examples/all-devices-app/posix/darwin/BUILD.gn
@@ -39,8 +39,8 @@ source_set("darwin") {
     "${chip_root}/src/data-model-providers/codedriven",
     "${chip_root}/src/data-model-providers/codedriven/endpoint",
     "${chip_root}/src/platform/Darwin",
-    "${chip_root}/zzz_generated/app-common/devices",
     "${chip_root}/third_party/miniaudio:miniaudio",
+    "${chip_root}/zzz_generated/app-common/devices",
   ]
 
   public_configs = [ ":includes" ]

--- a/examples/all-devices-app/posix/darwin/BUILD.gn
+++ b/examples/all-devices-app/posix/darwin/BUILD.gn
@@ -19,6 +19,7 @@ config("includes") {
   include_dirs = [
     ".",
     "../include",
+    "${chip_root}/third_party/miniaudio/repo",
   ]
 }
 

--- a/examples/all-devices-app/posix/darwin/BUILD.gn
+++ b/examples/all-devices-app/posix/darwin/BUILD.gn
@@ -19,7 +19,6 @@ config("includes") {
   include_dirs = [
     ".",
     "../include",
-    "${chip_root}/third_party/miniaudio/repo",
   ]
 }
 
@@ -41,6 +40,7 @@ source_set("darwin") {
     "${chip_root}/src/data-model-providers/codedriven/endpoint",
     "${chip_root}/src/platform/Darwin",
     "${chip_root}/zzz_generated/app-common/devices",
+    "${chip_root}/third_party/miniaudio:miniaudio",
   ]
 
   public_configs = [ ":includes" ]

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -30,7 +30,7 @@ public:
     {
         uint8_t id;
         std::vector<uint8_t> buffer;
-        ma_decoder decoder;
+        ma_audio_buffer audioBuffer;
         ma_sound sound;
         bool initialized = false;
     };

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -26,11 +26,20 @@ namespace app {
 class PosixChimeDevice : public ChimeDevice
 {
 public:
+    struct CustomDataSource
+    {
+        ma_data_source_base base;
+        double freq1;
+        double freq2;
+        double duration;
+        bool pulse;
+        ma_uint64 cursor;
+    };
+
     struct SoundResource
     {
         uint8_t id;
-        std::vector<uint8_t> buffer;
-        ma_audio_buffer audioBuffer;
+        CustomDataSource dataSource;
         ma_sound sound;
         bool initialized = false;
     };

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -26,15 +26,6 @@ namespace app {
 class PosixChimeDevice : public ChimeDevice
 {
 public:
-    PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);
-    ~PosixChimeDevice() override;
-
-    Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
-
-private:
-    ma_engine mEngine;
-    bool mEngineInitialized = false;
-
     struct SoundResource
     {
         uint8_t id;
@@ -43,6 +34,15 @@ private:
         ma_sound sound;
         bool initialized = false;
     };
+
+    PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);
+    ~PosixChimeDevice() override;
+
+    Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
+
+private:
+    ma_engine mEngine;
+    bool mEngineInitialized = false;
 
     std::vector<SoundResource> mSoundResources;
     bool mSoundsInitialized = false;

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <devices/chime/ChimeDevice.h>
+#include <miniaudio.h>
 
 namespace chip {
 namespace app {
@@ -24,8 +25,14 @@ namespace app {
 class PosixChimeDevice : public ChimeDevice
 {
 public:
-    using ChimeDevice::ChimeDevice;
+    PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);
+    ~PosixChimeDevice() override;
+
     Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
+
+private:
+    ma_engine mEngine;
+    bool mEngineInitialized = false;
 };
 
 } // namespace app

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -18,6 +18,7 @@
 
 #include <devices/chime/ChimeDevice.h>
 #include <miniaudio.h>
+#include <vector>
 
 namespace chip {
 namespace app {
@@ -33,6 +34,14 @@ public:
 private:
     ma_engine mEngine;
     bool mEngineInitialized = false;
+
+    std::vector<uint8_t> mChime0Buffer;
+    std::vector<uint8_t> mChime1Buffer;
+    ma_decoder mDecoder0;
+    ma_decoder mDecoder1;
+    ma_sound mSound0;
+    ma_sound mSound1;
+    bool mSoundsInitialized = false;
 };
 
 } // namespace app

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -24,29 +24,34 @@
 namespace chip {
 namespace app {
 
+// Platform-specific implementation of ChimeDevice for POSIX systems.
+// It uses miniaudio for audio playback and generates sounds on-the-fly (incremental synthesis).
 class PosixChimeDevice : public ChimeDevice
 {
 public:
+    // Custom data source for miniaudio to generate sound on-the-fly.
+    // This avoids loading large audio files or holding full PCM buffers in memory.
     struct CustomDataSource
     {
-        ma_data_source_base base;
-        double freq1;
-        double freq2;
-        double duration;
-        bool pulse;
-        ma_uint64 cursor;
+        ma_data_source_base base; // Base structure required by miniaudio
+        double freq1;             // Primary frequency or first tone
+        double freq2;             // Secondary frequency or second tone
+        double duration;          // Total duration of the sound in seconds
+        bool pulse;               // Whether to apply a pulse modulation effect
+        ma_uint64 cursor;         // Current playback position in samples
     };
 
+    // RAII wrapper for sound resources. Manages the lifecycle of miniaudio structures.
     class SoundResource
     {
     public:
         SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo);
         ~SoundResource();
 
-        uint8_t id;
-        CustomDataSource dataSource;
-        ma_sound sound;
-        bool mInitialized = false;
+        uint8_t id;                  // Chime ID matching the Matter spec
+        CustomDataSource dataSource; // Custom data source for this sound
+        ma_sound sound;              // Miniaudio sound object
+        bool mInitialized = false;   // Whether the resource was successfully initialized
     };
 
     PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -19,6 +19,7 @@
 #include <devices/chime/ChimeDevice.h>
 #include <miniaudio.h>
 #include <vector>
+#include <memory>
 
 namespace chip {
 namespace app {
@@ -36,12 +37,16 @@ public:
         ma_uint64 cursor;
     };
 
-    struct SoundResource
+    class SoundResource
     {
+    public:
+        SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo);
+        ~SoundResource();
+
         uint8_t id;
         CustomDataSource dataSource;
         ma_sound sound;
-        bool initialized = false;
+        bool mInitialized = false;
     };
 
     PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);
@@ -53,7 +58,7 @@ private:
     ma_engine mEngine;
     bool mEngineInitialized = false;
 
-    std::vector<SoundResource> mSoundResources;
+    std::vector<std::unique_ptr<SoundResource>> mSoundResources;
     bool mSoundsInitialized = false;
 };
 

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -35,12 +35,16 @@ private:
     ma_engine mEngine;
     bool mEngineInitialized = false;
 
-    std::vector<uint8_t> mChime0Buffer;
-    std::vector<uint8_t> mChime1Buffer;
-    ma_decoder mDecoder0;
-    ma_decoder mDecoder1;
-    ma_sound mSound0;
-    ma_sound mSound1;
+    struct SoundResource
+    {
+        uint8_t id;
+        std::vector<uint8_t> buffer;
+        ma_decoder decoder;
+        ma_sound sound;
+        bool initialized = false;
+    };
+
+    std::vector<SoundResource> mSoundResources;
     bool mSoundsInitialized = false;
 };
 

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <devices/chime/ChimeDevice.h>
+#include <memory>
 #include <miniaudio.h>
 #include <vector>
-#include <memory>
 
 namespace chip {
 namespace app {

--- a/examples/all-devices-app/posix/linux/BUILD.gn
+++ b/examples/all-devices-app/posix/linux/BUILD.gn
@@ -19,6 +19,7 @@ config("includes") {
   include_dirs = [
     ".",
     "../include",
+    "${chip_root}/third_party/miniaudio/repo",
   ]
 }
 

--- a/examples/all-devices-app/posix/linux/BUILD.gn
+++ b/examples/all-devices-app/posix/linux/BUILD.gn
@@ -19,7 +19,6 @@ config("includes") {
   include_dirs = [
     ".",
     "../include",
-    "${chip_root}/third_party/miniaudio/repo",
   ]
 }
 
@@ -41,6 +40,7 @@ source_set("linux") {
     "${chip_root}/src/data-model-providers/codedriven/endpoint",
     "${chip_root}/src/platform/Linux",
     "${chip_root}/zzz_generated/app-common/devices",
+    "${chip_root}/third_party/miniaudio:miniaudio",
   ]
 
   public_configs = [ ":includes" ]

--- a/examples/all-devices-app/posix/linux/BUILD.gn
+++ b/examples/all-devices-app/posix/linux/BUILD.gn
@@ -39,8 +39,8 @@ source_set("linux") {
     "${chip_root}/src/data-model-providers/codedriven",
     "${chip_root}/src/data-model-providers/codedriven/endpoint",
     "${chip_root}/src/platform/Linux",
-    "${chip_root}/zzz_generated/app-common/devices",
     "${chip_root}/third_party/miniaudio:miniaudio",
+    "${chip_root}/zzz_generated/app-common/devices",
   ]
 
   public_configs = [ ":includes" ]

--- a/examples/all-devices-app/posix/miniaudio.cpp
+++ b/examples/all-devices-app/posix/miniaudio.cpp
@@ -1,0 +1,2 @@
+#define MINIAUDIO_IMPLEMENTATION
+#include <miniaudio.h>

--- a/examples/all-devices-app/posix/miniaudio.cpp
+++ b/examples/all-devices-app/posix/miniaudio.cpp
@@ -1,2 +1,0 @@
-#define MINIAUDIO_IMPLEMENTATION
-#include <miniaudio.h>

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -29,8 +29,11 @@ config("boringssl_config_disable_warnings") {
   cflags = [
     "-Wno-cast-function-type-mismatch",
     "-Wno-conversion",
-    "-Wno-unterminated-string-initialization",
     "-Wno-unused-variable",
+  ]
+
+  cflags_c = [
+    "-Wno-unterminated-string-initialization",
   ]
 
   if (is_clang) {

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -32,9 +32,7 @@ config("boringssl_config_disable_warnings") {
     "-Wno-unused-variable",
   ]
 
-  cflags_c = [
-    "-Wno-unterminated-string-initialization",
-  ]
+  cflags_c = [ "-Wno-unterminated-string-initialization" ]
 
   if (is_clang) {
     cflags += [ "-Wno-shorten-64-to-32" ]

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -29,10 +29,9 @@ config("boringssl_config_disable_warnings") {
   cflags = [
     "-Wno-cast-function-type-mismatch",
     "-Wno-conversion",
+    "-Wno-unterminated-string-initialization",
     "-Wno-unused-variable",
   ]
-
-  cflags_c = [ "-Wno-unterminated-string-initialization" ]
 
   if (is_clang) {
     cflags += [ "-Wno-shorten-64-to-32" ]

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -22,4 +22,10 @@ source_set("miniaudio") {
   sources = [ "miniaudio.cpp" ]
 
   public_configs = [ ":miniaudio_config" ]
+
+  cflags = [
+    "-Wno-missing-format-attribute",
+    "-Wno-shorten-64-to-32",
+    "-Wno-implicit-fallthrough",
+  ]
 }

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("miniaudio_config") {
+  include_dirs = [ "repo" ]
+}
+
+source_set("miniaudio") {
+  sources = [ "miniaudio.cpp" ]
+
+  public_configs = [ ":miniaudio_config" ]
+}

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -21,11 +21,7 @@ config("miniaudio_config") {
   include_dirs = [ "repo" ]
 }
 
-source_set("miniaudio") {
-  sources = [ "miniaudio.cpp" ]
-
-  public_configs = [ ":miniaudio_config" ]
-
+config("miniaudio_warnings") {
   cflags = [
     "-Wno-missing-format-attribute",
     "-Wno-implicit-fallthrough",
@@ -40,4 +36,11 @@ source_set("miniaudio") {
       "-Wno-shadow",
     ]
   }
+}
+
+source_set("miniaudio") {
+  sources = [ "miniaudio.cpp" ]
+
+  public_configs = [ ":miniaudio_config" ]
+  configs += [ ":miniaudio_warnings" ]
 }

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+
+import("${build_root}/config/compiler/compiler.gni")
 
 config("miniaudio_config") {
   include_dirs = [ "repo" ]
@@ -25,7 +28,16 @@ source_set("miniaudio") {
 
   cflags = [
     "-Wno-missing-format-attribute",
-    "-Wno-shorten-64-to-32",
     "-Wno-implicit-fallthrough",
   ]
+
+  if (is_clang) {
+    cflags += [
+      "-Wno-shorten-64-to-32",
+      "-Wno-format-nonliteral",
+      "-Wno-conversion",
+      "-Wno-sign-conversion",
+      "-Wno-shadow",
+    ]
+  }
 }

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -29,6 +29,7 @@
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
 #pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
 
 #include <miniaudio.h>

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -23,19 +23,4 @@
 // duplicate symbol errors during linking.
 #define MINIAUDIO_IMPLEMENTATION
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-format-attribute"
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#pragma clang diagnostic ignored "-Wshadow"
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#pragma clang diagnostic ignored "-Wconversion"
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#endif
-
 #include <miniaudio.h>
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -30,6 +30,8 @@
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wsign-conversion"
 #endif
 
 #include <miniaudio.h>

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -22,4 +22,17 @@
 // This file should be compiled exactly once in the project to avoid
 // duplicate symbol errors during linking.
 #define MINIAUDIO_IMPLEMENTATION
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include <miniaudio.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -1,0 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// miniaudio is a header-only library.
+// This file is used to generate the implementation of the library.
+// By defining MINIAUDIO_IMPLEMENTATION before including miniaudio.h,
+// we tell the header to include the actual function definitions.
+// This file should be compiled exactly once in the project to avoid
+// duplicate symbol errors during linking.
+#define MINIAUDIO_IMPLEMENTATION
+#include <miniaudio.h>


### PR DESCRIPTION
Fixed. I have renamed freq1 and freq2 to kDefaultFreq1Hz and kDefaultFreq2Hz, and applied unit-based naming consistently. See: `https://github.com/project-chip/connectedhomeip/pull/71723/changes/fa5ae1513f40fd139736c3f7595ca36ce3c809c6`