### PR TITLE
[BoringSSL] Move -Wno-unterminated-string-initialization to cflags_c

### DIFF
--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -29,9 +29,10 @@ config("boringssl_config_disable_warnings") {
   cflags = [
     "-Wno-cast-function-type-mismatch",
     "-Wno-conversion",
-    "-Wno-unterminated-string-initialization",
     "-Wno-unused-variable",
   ]
+
+  cflags_c = [ "-Wno-unterminated-string-initialization" ]
 
   if (is_clang) {
     cflags += [ "-Wno-shorten-64-to-32" ]


### PR DESCRIPTION
This PR moves the `-Wno-unterminated-string-initialization` warning suppression flag from `cflags` to `cflags_c` in `third_party/boringssl/repo/BUILD.gn`.

This flag is specific to C and causes warnings/errors when applied to C++ files with some compilers. Moving it to `cflags_c` ensures it is only applied to C source files.

### Testing
I verified that the project still builds successfully locally with this change for the `linux-x64-all-devices-boringssl` target.
