### PR TITLE
[MicrowaveOvenControl] emit PowerSetting change report on SetCookingParameters

### DIFF
--- a/src/app/clusters/microwave-oven-control-server/MicrowaveOvenControlCluster.cpp
+++ b/src/app/clusters/microwave-oven-control-server/MicrowaveOvenControlCluster.cpp
@@ -316,8 +316,18 @@ void Instance::HandleSetCookingParameters(HandlerContext & ctx, const Commands::
                 Zcl,
                 "Microwave Oven Control: Failed to set PowerSetting, PowerSetting value must be multiple of PowerStep number"));
 
+        // Snapshot PowerSetting before the delegate call so this cluster server can emit the
+        // attribute-change report when the delegate updates its internal value.  The delegate owns
+        // storage for PowerSetting, but reporting is the server's responsibility (mirrors CookTime).
+        uint8_t oldPowerSettingNum = mDelegate->GetPowerSettingNum();
+
         status = mDelegate->HandleSetCookingParametersCallback(reqCookMode, reqCookTimeSec, reqStartAfterSetting,
                                                                MakeOptional(reqPowerSettingNum), NullOptional);
+
+        if (status == Status::Success && oldPowerSettingNum != mDelegate->GetPowerSettingNum())
+        {
+            MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::PowerSetting::Id);
+        }
     }
     else
     {

--- a/src/app/clusters/microwave-oven-control-server/MicrowaveOvenControlCluster.cpp
+++ b/src/app/clusters/microwave-oven-control-server/MicrowaveOvenControlCluster.cpp
@@ -324,7 +324,7 @@ void Instance::HandleSetCookingParameters(HandlerContext & ctx, const Commands::
         status = mDelegate->HandleSetCookingParametersCallback(reqCookMode, reqCookTimeSec, reqStartAfterSetting,
                                                                MakeOptional(reqPowerSettingNum), NullOptional);
 
-        if (status == Status::Success && oldPowerSettingNum != mDelegate->GetPowerSettingNum())
+        if (oldPowerSettingNum != mDelegate->GetPowerSettingNum())
         {
             MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::PowerSetting::Id);
         }


### PR DESCRIPTION
### Summary

**Reason for Change:**
- PowerSetting on MicrowaveOvenControl was not reporting changes during TC_MWOCTRL_2_2, which showed up with the wildcard-subscription validation added in PR [43274](https://github.com/project-chip/connectedhomeip/pull/43274).
- Direct reads returned the updated value, but the subscription cache still had the old value since no MatterReportingAttributeChangeCallback was fired for PowerSetting::Id.

**Root Cause:**
- PowerSetting is owned by the delegate (mPowerSettingNum) and updated inside HandleSetCookingParametersCallback without any reporting hook. There is no Instance::Set…() wrapper, so nothing emits a change report today.
- This differs from CookTime, which is owned by Instance (mCookTimeSec). Its setter (Instance::SetCookTimeSec()) already fires the reporting callback, and both delegates route through it, so no extra handling is needed in HandleSetCookingParameters.

**Change Made:**
- In HandleSetCookingParameters (PowerAsNumber branch), snapshot mDelegate->GetPowerSettingNum() before the delegate call, then emit MatterReportingAttributeChangeCallback(..., PowerSetting::Id) after a successful call if the value changed.
- Storage remains on the delegate, while reporting is handled by the server, consistent with the existing pattern used for CookTime, adapted for delegate-owned state.

### Related issues

- Fixes: [71363](https://github.com/project-chip/connectedhomeip/issues/71363)

### Testing

- Verified with TC_MWOCTRL_2_2 in WSL against the framework wildcard-subscription logic from PR[43274](https://github.com/project-chip/connectedhomeip/pull/43274).
- Note: Also tested other MWOCTRL test modules (2_1 and 2_4) to make sure this didn't cause any unexpected issues.

- Unit test follow-up: A DefaultServerCluster-style unit test (matching the pattern in TestCameraAvSettingsUserLevelManagementCluster.cpp) can be added as a follow-up once the MicrowaveOvenControl code-driven cluster migration (part 2 of [#71444](https://github.com/project-chip/connectedhomeip/pull/71444) in [#71598](https://github.com/project-chip/connectedhomeip/pull/71598)) lands. The current legacy CommandHandlerInterface / AttributeAccessInterface Instance cannot be constructed in isolation without ember and a live InteractionModelEngine, so regression coverage for this fix is provided by TC_MWOCTRL_2_2 under the wildcard-subscription verification from PR [#43274](https://github.com/project-chip/connectedhomeip/pull/43274).