### PR TITLE
Fixed groupcast steps in TC-SC-5.3 and TC-SM-1.1 for SVE

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_3.yaml
@@ -439,7 +439,7 @@ tests:
           [1775758228.012] [2754009:2754011] [TOO] Sending cluster (0x00000006) command (0x00000002) on Group 1
           [1775758228.012] [2754009:2754011] [DMG] ICR moving to [AddingComm]
           [1775758228.012] [2754009:2754011] [DMG] ICR moving to [AddedComma]
-          [1775758228.012] [2754009:2754011] [EM] <<< [E:14931i S:1 M:157645958] (G) Msg TX from 000000000001B669 to 1:FFFFFFFFFFFF0001 [CAE0] [UDP:[ff35:40:ff05::fa]:5540] --- Type 0001:08 (IM:InvokeCommandRequest) (B:66)
+          [1775758228.012] [2754009:2754011] [EM] <<< [E:14931i S:1 M:157645958] (G) Msg TX from 000000000001B669 to 1:FFFFFFFFFFFF0001 [CAE0] [UDP:[ff05::fa]:5540] --- Type 0001:08 (IM:InvokeCommandRequest) (B:66)
           [1775758228.013] [2754009:2754011] [IN] Interface wlan0 has a link local address
           [1775758228.013] [2754009:2754011] [IN] Successfully send Multicast message on interface wlan0
       disabled: true

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -340,9 +340,12 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
                                   problem=f'Root node does not contain required cluster {c}', spec_location="Root node device type")
                 self.fail_current_test()
 
-        self.print_step(6, "Verify that the specification version is 1.6 or above for the next steps")
+        # NOTE: This was provisional in 1.6.0, but due to issues with reaching the finish line,
+        #       this step was punted to a later release to reduce friction for SVE participants.
+        self.print_step(6, "Verify that the specification version is above 1.6.0 for the next steps")
         specification_version = root[Clusters.BasicInformation].get(Clusters.BasicInformation.Attributes.SpecificationVersion, 0)
-        if specification_version >= 0x01060000:
+        # Gate Groupcast requirements on Matter > 1.6.0
+        if specification_version > 0x01060000:
             groupcast_feature_map = 0
             if Clusters.Groupcast in root:
                 groupcast_feature_map = root[Clusters.Groupcast][Clusters.Groupcast.Attributes.FeatureMap]


### PR DESCRIPTION
#### Summary
- Make the verification step correct for IP address in TC-SC-5.3 (it was wrong in the manual verification steps).
- Punt the conditions checks on Root Node in TC-SM-1.1 to post-1.6 to derisk needless failures.
- Fixes #71635

#### Testing

- CI still passes
- 1.6 DUT does not fail the conditions if missing group cast.