### PR TITLE
[Realtek] Fix factorydata build error

### DIFF
--- a/src/platform/realtek/freertos/FactoryDataProvider.cpp
+++ b/src/platform/realtek/freertos/FactoryDataProvider.cpp
@@ -292,7 +292,7 @@ CHIP_ERROR FactoryDataProvider::GetVendorName(char * buf, size_t bufSize)
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(bufSize >= sFactoryData.dii.vendor_name.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(sFactoryData.dii.vendor_name.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(sFactoryData.dii.vendor_name.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     memcpy(buf, sFactoryData.dii.vendor_name.value, sFactoryData.dii.vendor_name.len);
     buf[sFactoryData.dii.vendor_name.len] = 0;
     err                                   = CHIP_NO_ERROR;
@@ -325,7 +325,7 @@ CHIP_ERROR FactoryDataProvider::GetProductName(char * buf, size_t bufSize)
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(bufSize >= sFactoryData.dii.product_name.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(sFactoryData.dii.product_name.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(sFactoryData.dii.product_name.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     memcpy(buf, sFactoryData.dii.product_name.value, sFactoryData.dii.product_name.len);
     buf[sFactoryData.dii.product_name.len] = 0;
     err                                    = CHIP_NO_ERROR;
@@ -374,7 +374,7 @@ CHIP_ERROR FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(bufSize >= sFactoryData.dii.serial_num.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(sFactoryData.dii.serial_num.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(sFactoryData.dii.serial_num.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     memcpy(buf, sFactoryData.dii.serial_num.value, sFactoryData.dii.serial_num.len);
     buf[sFactoryData.dii.serial_num.len] = 0;
     err                                  = CHIP_NO_ERROR;
@@ -470,7 +470,7 @@ CHIP_ERROR FactoryDataProvider::GetHardwareVersionString(char * buf, size_t bufS
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(bufSize >= sFactoryData.dii.hw_ver_string.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(sFactoryData.dii.hw_ver_string.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(sFactoryData.dii.hw_ver_string.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     memcpy(buf, sFactoryData.dii.hw_ver_string.value, sFactoryData.dii.hw_ver_string.len);
     buf[sFactoryData.dii.hw_ver_string.len] = 0;
     err                                     = CHIP_NO_ERROR;
@@ -489,7 +489,7 @@ CHIP_ERROR FactoryDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & un
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(uniqueIdSpan.size() >= sFactoryData.dii.rd_id_uid.len, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(sFactoryData.dii.rd_id_uid.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(sFactoryData.dii.rd_id_uid.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     memcpy(uniqueIdSpan.data(), sFactoryData.dii.rd_id_uid.value, sFactoryData.dii.rd_id_uid.len);
     err = CHIP_NO_ERROR;
 #else

--- a/src/platform/realtek/freertos/RTK/RTKDACVendorProvider.cpp
+++ b/src/platform/realtek/freertos/RTK/RTKDACVendorProvider.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR RTKDACVendorProvider::GetCertificationDeclaration(MutableByteSpan & o
     err                                   = CopySpanToMutableSpan(ByteSpan{ kCdForAllExamples }, outBuffer);
 #elif CONFIG_FACTORY_DATA
     VerifyOrReturnError(outBuffer.size() >= pFactoryData->dac.cd.len, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(pFactoryData->dac.cd.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.cd.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     memcpy(outBuffer.data(), pFactoryData->dac.cd.value, pFactoryData->dac.cd.len);
 
@@ -100,7 +100,7 @@ CHIP_ERROR RTKDACVendorProvider::GetDeviceAttestationCert(MutableByteSpan & outB
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(outBuffer.size() >= pFactoryData->dac.dac_cert.len, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(pFactoryData->dac.dac_cert.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.dac_cert.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     memcpy(outBuffer.data(), pFactoryData->dac.dac_cert.value, pFactoryData->dac.dac_cert.len);
 
@@ -147,7 +147,7 @@ CHIP_ERROR RTKDACVendorProvider::GetProductAttestationIntermediateCert(MutableBy
 
 #if CONFIG_FACTORY_DATA
     VerifyOrReturnError(outBuffer.size() >= pFactoryData->dac.pai_cert.len, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(pFactoryData->dac.pai_cert.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.pai_cert.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     memcpy(outBuffer.data(), pFactoryData->dac.pai_cert.value, pFactoryData->dac.pai_cert.len);
 
@@ -190,8 +190,8 @@ CHIP_ERROR RTKDACVendorProvider::GetProductAttestationIntermediateCert(MutableBy
 #if FEATURE_TRUSTZONE_ENABLE && CONFIG_DAC_KEY_ENC
 CHIP_ERROR RTKDACVendorProvider::ImportDACKey()
 {
-    VerifyOrReturnError(pFactoryData->dac.dac_cert.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    VerifyOrReturnError(pFactoryData->dac.dac_key.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.dac_cert.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.dac_key.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     ByteSpan dacCertSpan{ pFactoryData->dac.dac_cert.value, pFactoryData->dac.dac_cert.len };
     chip::Crypto::P256PublicKey dacPublicKey;
     ReturnErrorOnFailure(chip::Crypto::ExtractPubkeyFromX509Cert(dacCertSpan, dacPublicKey));
@@ -252,8 +252,8 @@ CHIP_ERROR RTKDACVendorProvider::SignWithDeviceAttestationKey(const ByteSpan & m
 
     return CopySpanToMutableSpan(ByteSpan{ sig_tmp_buf, static_cast<size_t>(param.sig_len) }, outSignBuffer);
 #else
-    VerifyOrReturnError(pFactoryData->dac.dac_cert.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    VerifyOrReturnError(pFactoryData->dac.dac_key.value, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.dac_cert.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrReturnError(pFactoryData->dac.dac_key.len > 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     // Extract public key from DAC cert.
     ByteSpan dacCertSpan{ pFactoryData->dac.dac_cert.value, pFactoryData->dac.dac_cert.len };
     chip::Crypto::P256PublicKey dacPublicKey;


### PR DESCRIPTION
  #### Summary    
  
  Fix factorydata build errors on the Realtek platform. This change addresses compilation failures in                     
  FactoryDataProvider.cpp and RTKDACVendorProvider.cpp by fixing the code logic to ensure FactoryData builds correctly.   
   
  #### Related issues                                                                                                     
  
N/A             
                                                                                                                          
  #### Testing                                                                                                            
  
  - Manually tested on Realtek platform
  - All above operations complete successfully
  - No unexpected error logs or regressions observed in console output