### PR TITLE
Enable external DUT support for JF test cases

### DIFF
--- a/src/python_testing/TC_JFADMIN_1_1.py
+++ b/src/python_testing/TC_JFADMIN_1_1.py
@@ -106,35 +106,54 @@ class TC_JFADMIN_1_1(MatterBaseTest):
     @async_test_body
     async def test_TC_JFADMIN_1_1(self):
         self.step("1")
-        self.JFADMIN_fabric_a_passcode = random.randint(110220011, 110220999)
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
+        dut_rpc_server_port = None
+        dut_rpc_server_ip = None
+        jfadmin_fabric_a_discriminator = None
 
-        # Start Fabric A JF-Administrator App
-        self.fabric_a_admin = AppServerSubprocess(
-            self.jfa_server_app,
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=random.randint(0, 4095),
-            passcode=self.JFADMIN_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=20)
+        if self.is_pics_sdk_ci_only:
+            dut_rpc_server_ip = "127.0.0.1"
+            jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            dut_rpc_server_port = "33033"
+            # Start Fabric A JF-Administrator App
+            self.fabric_a_admin = AppServerSubprocess(
+                self.jfa_server_app,
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=jfadmin_fabric_a_discriminator,
+                passcode=jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=20)
+        else:
+            # We have a DUT that is already running, connect to it via RPC
+            dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            if not self.matter_test_config.setup_passcodes:
+                asserts.fail("JF-Administrator passcode must be specified via --passcode:<passcode>")
+            jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             "JFC-A",
-            rpc_server_port=33033,
+            rpc_server_port=dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=20)
 
         # Commission JF-ADMIN app with JF-Controller on Fabric A
         self.fabric_a_ctrl.send(
-            message=f"pairing onnetwork 1 {self.JFADMIN_fabric_a_passcode} --anchor true",
+            message=f"pairing onnetwork 1 {jfadmin_fabric_a_passcode} --anchor true",
             expected_output="[JF] Anchor Administrator (nodeId=1) commissioned with success",
             timeout=20)
 

--- a/src/python_testing/TC_JFADMIN_1_2.py
+++ b/src/python_testing/TC_JFADMIN_1_2.py
@@ -102,7 +102,8 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             self.admin_discriminator = self.matter_test_config.discriminators[0]
 
     def teardown_class(self):
-        self.jf_admin.terminate()
+        if self.jf_admin is not None:
+            self.jf_admin.terminate()
         if self.storage_directory_ecosystem_a is not None:
             self.storage_directory_ecosystem_a.cleanup()
         super().teardown_class()

--- a/src/python_testing/TC_JFADMIN_1_2.py
+++ b/src/python_testing/TC_JFADMIN_1_2.py
@@ -77,20 +77,29 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             self.fabric_storage = self.storage_directory_ecosystem_a.name
             log.info("Temporary storage directory: %s", self.fabric_storage)
 
-        self.admin_passcode = random.randint(20202021, 20202099)
-        self.admin_discriminator = random.randint(0, 4095)
+        self.admin_passcode = None
+        self.admin_discriminator = None
 
-        # Start JF-Administrator App
-        self.jf_admin = AppServerSubprocess(
-            self.jfa_server_app,
-            storage_dir=self.fabric_storage,
-            port=random.randint(5001, 5999),
-            discriminator=self.admin_discriminator,
-            passcode=self.admin_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.jf_admin.start(
-            expected_output="Server initialization complete",
-            timeout=10)
+        if self.is_pics_sdk_ci_only:
+            self.admin_passcode = random.randint(20202021, 20202099)
+            self.admin_discriminator = random.randint(0, 4095)
+            # Start JF-Administrator App
+            self.jf_admin = AppServerSubprocess(
+                self.jfa_server_app,
+                storage_dir=self.fabric_storage,
+                port=random.randint(5001, 5999),
+                discriminator=self.admin_discriminator,
+                passcode=self.admin_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
+            self.jf_admin.start(
+                expected_output="Server initialization complete",
+                timeout=10)
+        else:
+            if not self.matter_test_config.setup_passcodes or not self.matter_test_config.discriminators:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.admin_passcode = self.matter_test_config.setup_passcodes[0]
+            self.admin_discriminator = self.matter_test_config.discriminators[0]
 
     def teardown_class(self):
         self.jf_admin.terminate()

--- a/src/python_testing/TC_JFADMIN_1_4.py
+++ b/src/python_testing/TC_JFADMIN_1_4.py
@@ -173,28 +173,47 @@ class TC_JFADMIN_1_4(MatterBaseTest):
             self.storage_fabric_a = self.storage_directory_ecosystem_a
             log.info("Temporary storage directory: %s", self.storage_fabric_a)
 
-        self.jfadmin_fabric_a_passcode = random.randint(20202021, 20202099)
-        self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            self.jfadmin_fabric_a_passcode = random.randint(20202021, 20202099)
+            self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            dut_rpc_server_ip = "127.0.0.1"
+            dut_rpc_server_port = 33033
+            self.fabric_a_admin = JFAdministratorSubprocess(
+                self.jfa_server_app,
+                prefix="JFA-A",
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=self.jfadmin_fabric_a_discriminator,
+                passcode=self.jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port, "--min_commissioning_timeout", f"{self._MIN_COMMISSIONING_TIMEOUT}"])
+            self.fabric_a_admin.start(
+                expected_output="Updating services using commissioning mode 1",
+                timeout=30)
+        else:
+            dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            self.jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not self.jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.jfadmin_fabric_a_discriminator = self.matter_test_config.discriminators[0]
+            if not self.jfadmin_fabric_a_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
-
-        self.fabric_a_admin = JFAdministratorSubprocess(
-            self.jfa_server_app,
-            prefix="JFA-A",
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=self.jfadmin_fabric_a_discriminator,
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033", "--min_commissioning_timeout", f"{self._MIN_COMMISSIONING_TIMEOUT}"])
-        self.fabric_a_admin.start(
-            expected_output="Updating services using commissioning mode 1",
-            timeout=30)
-
         self.fabric_a_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             prefix="JFC-A",
-            rpc_server_port=33033,
+            rpc_server_port=dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=30)

--- a/src/python_testing/TC_JFADMIN_1_4.py
+++ b/src/python_testing/TC_JFADMIN_1_4.py
@@ -178,7 +178,7 @@ class TC_JFADMIN_1_4(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(20202021, 20202099)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             dut_rpc_server_ip = "127.0.0.1"
-            dut_rpc_server_port = 33033
+            dut_rpc_server_port = "33033"
             self.fabric_a_admin = JFAdministratorSubprocess(
                 self.jfa_server_app,
                 prefix="JFA-A",

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -29,6 +29,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -133,38 +133,58 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         _devCtrlEcoB = None
         _fabric_a_persistent_storage = None
         _fabric_b_persistent_storage = None
+        jfadmin_fabric_a_passcode = None
+        dut_rpc_server_ip = None
+        dut_rpc_server_port = None
 
         self.step("1")
-        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
 
-        # Start Fabric A JF-Administrator App (DUT)
-        self.fabric_a_admin = JFAdministratorSubprocess(
-            self.jfa_server_app,
-            prefix="JFA-A",
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=random.randint(0, 4095),
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=20)
+        # If test is executed in CI environment, start JFA app for Fabric A
+        if self.is_pics_sdk_ci_only:
+            dut_rpc_server_ip = "127.0.0.1"
+            jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            dut_rpc_server_port = "33033"
+            # Start Fabric A JF-Administrator App (DUT)
+            self.fabric_a_admin = JFAdministratorSubprocess(
+                self.jfa_server_app,
+                prefix="JFA-A",
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=random.randint(0, 4095),
+                passcode=jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=20)
+        else:
+            # We have a DUT that is already running, connect to it via RPC
+            dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             prefix="JFC-A",
-            rpc_server_port=33033,
+            rpc_server_port=dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=20)
 
         # Commission JF-ADMIN app with JF-Controller on Fabric A
         self.fabric_a_ctrl.send(
-            message=f"pairing onnetwork 1 {self.jfadmin_fabric_a_passcode} --anchor true",
+            message=f"pairing onnetwork 1 {jfadmin_fabric_a_passcode} --anchor true",
             expected_output="[JF] Anchor Administrator (nodeId=1) commissioned with success",
             timeout=20)
 
@@ -422,19 +442,29 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             asserts.fail(f'Exception {e} occured during OJCW')
 
         self.step("4")
-        log.info("Setup event on fabric_a_admin for JCM completion message")
-        self.fabric_a_admin.set_output_match("[JF] Joint Commissioning Method (nodeId=15) success")
-        self.fabric_a_admin.event.clear()
-
         self.fabric_a_ctrl.send(
             message=f"pairing onnetwork-long 15 {response.setupPinCode} {discriminator} --jcm true",
             expected_output="[CTL] Commissioning complete for node ID 0x000000000000000F: success",
             timeout=60)
 
-        log.info("Waiting for transfer of ownership from the commissioner(controller) to the administrator and completion of commissioning")
-        if self.fabric_a_admin.event.wait(30) is False:
-            raise TimeoutError("Timed out waiting for commissioning to complete")
-        log.info("JCM commissioning complete")
+        fabric_a_trusted_roots = await _devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.TrustedRootCertificates)],
+            returnClusterObject=True, fabricFiltered=False)
+
+        fabric_b_nocs = await _devCtrlEcoB.ReadAttribute(
+            nodeId=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)],
+            returnClusterObject=True, fabricFiltered=False)
+
+        rcac_data = matter.tlv.TLVReader(fabric_a_trusted_roots[0]
+                                         [Clusters.OperationalCredentials].trustedRootCertificates[1]).get()
+        icac_data = matter.tlv.TLVReader(fabric_b_nocs[0][Clusters.OperationalCredentials].NOCs[2].icac).get()
+
+        log.info("Verify the chain of trust between Ecosystem A and Ecosystem B. Issuer of ICAC for Ecosystem B should be the RCAC from Ecosystem A")
+        asserts.assert_equal(
+            dict(rcac_data.get('Any', [])).get(6),  # Tag 6 = Subject
+            dict(icac_data.get('Any', [])).get(3),  # Tag 3 = Issuer
+            "Issuer of ICAC for Ecosystem B is not the Subject of RCAC from Ecosystem A"
+        )
 
         # Shutdown the Python Controllers started at the beginning of this script
         if _devCtrlEcoA is not None:

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -236,37 +236,63 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
             catTags=[int(self.ecoACATs, 16), int('fffe0001', 16)])
 
         self.step("2")
-        self.jfadmin_fabric_b_passcode = random.randint(20202021, 20202099)
-        self.jfadmin_fabric_b_discriminator = random.randint(0, 4095)
-        self.jfctrl_fabric_b_vid = random.randint(0x0001, 0xFFF0)
 
-        # Start Fabric B JF-Administrator App
-        self.fabric_b_admin = JFAdministratorSubprocess(
-            self.jfa_server_app,
-            prefix="JFA-B",
-            storage_dir=self.storage_fabric_b,
-            port=random.randint(5001, 5999),
-            discriminator=self.jfadmin_fabric_b_discriminator,
-            passcode=self.jfadmin_fabric_b_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33055"])
-        self.fabric_b_admin.start(
-            expected_output="Updating services using commissioning mode 1",
-            timeout=30)
+        self.jfctrl_fabric_b_vid = random.randint(0x0001, 0xFFF0)
+        jfadmin_fabric_b_passcode = None
+        jfadmin_fabric_b_discriminator = None
+        dut_rpc_server_ip = None
+        dut_rpc_server_port = None
+
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            dut_rpc_server_ip = "127.0.0.1"
+            jfadmin_fabric_b_passcode = random.randint(20202021, 20202099)
+            jfadmin_fabric_b_discriminator = random.randint(0, 4095)
+            dut_rpc_server_port = "33055"
+            # Start Fabric B JF-Administrator App
+            self.fabric_b_admin = JFAdministratorSubprocess(
+                self.jfa_server_app,
+                prefix="JFA-B",
+                storage_dir=self.storage_fabric_b,
+                port=random.randint(5001, 5999),
+                discriminator=jfadmin_fabric_b_discriminator,
+                passcode=jfadmin_fabric_b_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])
+            self.fabric_b_admin.start(
+                expected_output="Updating services using commissioning mode 1",
+                timeout=30)
+        else:
+            # We have a DUT that is already running, connect to it via RPC
+            dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            jfadmin_fabric_b_passcode = self.matter_test_config.setup_passcodes[0]
+            if not jfadmin_fabric_b_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            jfadmin_fabric_b_discriminator = self.matter_test_config.discriminators[0]
+            if not jfadmin_fabric_b_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric B JF-Administrator App
         self.fabric_b_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             prefix="JFC-B",
-            rpc_server_port=33055,
+            rpc_server_port=dut_rpc_server_port,
             storage_dir=self.storage_fabric_b,
-            vendor_id=self.jfctrl_fabric_b_vid)
+            vendor_id=self.jfctrl_fabric_b_vid,
+            extra_args=["--rpc-server-ip", dut_rpc_server_ip])
         self.fabric_b_ctrl.start(
             expected_output="CHIP task running",
             timeout=30)
 
         # Commission JF-ADMIN app with JF-Controller on Fabric B
         self.fabric_b_ctrl.send(
-            message=f"pairing onnetwork-long 11 {self.jfadmin_fabric_b_passcode} {self.jfadmin_fabric_b_discriminator} --anchor true",
+            message=f"pairing onnetwork-long 11 {jfadmin_fabric_b_passcode} {jfadmin_fabric_b_discriminator} --anchor true",
             expected_output="[JF] Anchor Administrator (nodeId=11) commissioned with success",
             timeout=60)
 

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -29,6 +29,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -28,6 +28,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -97,7 +97,7 @@ class TC_JFDS_2_1(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = 33033
+            self.dut_rpc_server_port = "33033"
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -85,30 +85,53 @@ class TC_JFDS_2_1(MatterBaseTest):
         # Initialize Ecosystem A
         #
         #####################################################################################################################################
-        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
-        self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
-        self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
-        self.jfadmin_fabric_a_node_id = 1
 
-        # Start Fabric A JF-Administrator App
-        self.fabric_a_admin = AppServerSubprocess(
-            jfa_server_app,
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=self.jfadmin_fabric_a_discriminator,
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=10)
+        self.jfadmin_fabric_a_node_id = 1
+        self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
+        self.dut_rpc_server_ip = None
+        self.dut_rpc_server_port = None
+        self.fabric_a_admin = None
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            self.dut_rpc_server_ip = "127.0.0.1"
+            self.dut_rpc_server_port = 33033
+            # Start Fabric A JF-Administrator App
+            self.fabric_a_admin = AppServerSubprocess(
+                jfa_server_app,
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=self.jfadmin_fabric_a_discriminator,
+                passcode=self.jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=10)
+        else:
+            self.dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not self.dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            self.dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not self.dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            self.jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not self.jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.jfadmin_fabric_a_discriminator = self.matter_test_config.discriminators[0]
+            if not self.jfadmin_fabric_a_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             jfc_server_app,
             "JFC_A",  # Name of the controller instance, used for logging purposes in the JF-Controller app:w
-            rpc_server_port=33033,
+            rpc_server_port=self.dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", self.dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=10)

--- a/src/python_testing/TC_JFDS_2_2.py
+++ b/src/python_testing/TC_JFDS_2_2.py
@@ -28,6 +28,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_JFDS_2_2.py
+++ b/src/python_testing/TC_JFDS_2_2.py
@@ -100,7 +100,7 @@ class TC_JFDS_2_2(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = 33033
+            self.dut_rpc_server_port = "33033"
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,

--- a/src/python_testing/TC_JFDS_2_2.py
+++ b/src/python_testing/TC_JFDS_2_2.py
@@ -90,29 +90,51 @@ class TC_JFDS_2_2(MatterBaseTest):
         # Initialize Ecosystem A
         #
         #####################################################################################################################################
-        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
         self.jfadmin_fabric_a_node_id = 1
-
-        # Start Fabric A JF-Administrator App
-        self.fabric_a_admin = AppServerSubprocess(
-            jfa_server_app,
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=random.randint(0, 4095),
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=10)
+        self.fabric_a_admin = None
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            self.dut_rpc_server_ip = "127.0.0.1"
+            self.dut_rpc_server_port = 33033
+            # Start Fabric A JF-Administrator App
+            self.fabric_a_admin = AppServerSubprocess(
+                jfa_server_app,
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=self.jfadmin_fabric_a_discriminator,
+                passcode=self.jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=10)
+        else:
+            self.dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not self.dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            self.dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not self.dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            self.jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not self.jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.jfadmin_fabric_a_discriminator = self.matter_test_config.discriminators[0]
+            if not self.jfadmin_fabric_a_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             jfc_server_app,
             "JFC_A",  # Name of the controller instance, used for logging purposes in the JF-Controller app:w
-            rpc_server_port=33033,
+            rpc_server_port=self.dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", self.dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=10)

--- a/src/python_testing/TC_JFDS_2_3.py
+++ b/src/python_testing/TC_JFDS_2_3.py
@@ -28,6 +28,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_JFDS_2_3.py
+++ b/src/python_testing/TC_JFDS_2_3.py
@@ -100,7 +100,7 @@ class TC_JFDS_2_3(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = 33033
+            self.dut_rpc_server_port = "33033"
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,

--- a/src/python_testing/TC_JFDS_2_3.py
+++ b/src/python_testing/TC_JFDS_2_3.py
@@ -90,29 +90,51 @@ class TC_JFDS_2_3(MatterBaseTest):
         # Initialize Ecosystem A
         #
         #####################################################################################################################################
-        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
         self.jfadmin_fabric_a_node_id = 1
-
-        # Start Fabric A JF-Administrator App
-        self.fabric_a_admin = AppServerSubprocess(
-            jfa_server_app,
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=random.randint(0, 4095),
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=10)
+        self.fabric_a_admin = None
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            self.dut_rpc_server_ip = "127.0.0.1"
+            self.dut_rpc_server_port = 33033
+            # Start Fabric A JF-Administrator App
+            self.fabric_a_admin = AppServerSubprocess(
+                jfa_server_app,
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=self.jfadmin_fabric_a_discriminator,
+                passcode=self.jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=10)
+        else:
+            self.dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not self.dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            self.dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not self.dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            self.jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not self.jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.jfadmin_fabric_a_discriminator = self.matter_test_config.discriminators[0]
+            if not self.jfadmin_fabric_a_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             jfc_server_app,
             "JFC_A",  # Name of the controller instance, used for logging purposes in the JF-Controller app:w
-            rpc_server_port=33033,
+            rpc_server_port=self.dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", self.dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=10)

--- a/src/python_testing/TC_JFDS_2_4.py
+++ b/src/python_testing/TC_JFDS_2_4.py
@@ -28,6 +28,7 @@
 #       --string-arg jfc_server_app:${JF_CONTROL_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_JFDS_2_4.py
+++ b/src/python_testing/TC_JFDS_2_4.py
@@ -100,29 +100,50 @@ class TC_JFDS_2_4(MatterBaseTest):
         # Initialize Ecosystem A
         #
         #####################################################################################################################################
-        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
         self.jfadmin_fabric_a_node_id = 1
-
-        # Start Fabric A JF-Administrator App
-        self.fabric_a_admin = AppServerSubprocess(
-            jfa_server_app,
-            storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
-            discriminator=random.randint(0, 4095),
-            passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
-        self.fabric_a_admin.start(
-            expected_output="Server initialization complete",
-            timeout=10)
+        self.fabric_a_admin = None
+        # If test is executed in CI environment, start JFA app for Fabric B
+        if self.is_pics_sdk_ci_only:
+            self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+            self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
+            self.dut_rpc_server_ip = "127.0.0.1"
+            self.dut_rpc_server_port = 33033
+            # Start Fabric A JF-Administrator App
+            self.fabric_a_admin = AppServerSubprocess(
+                jfa_server_app,
+                storage_dir=self.storage_fabric_a,
+                port=random.randint(5001, 5999),
+                discriminator=self.jfadmin_fabric_a_discriminator,
+                passcode=self.jfadmin_fabric_a_passcode,
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])
+            self.fabric_a_admin.start(
+                expected_output="Server initialization complete",
+                timeout=10)
+        else:
+            self.dut_rpc_server_ip = self.user_params.get("dut_rpc_server_ip", None)
+            if not self.dut_rpc_server_ip:
+                asserts.fail("DUT RPC server IP must be specified via --string-arg dut_rpc_server_ip:<ip_address>")
+            self.dut_rpc_server_port = self.user_params.get("dut_rpc_server_port", None)
+            if not self.dut_rpc_server_port:
+                asserts.fail("DUT RPC server PORT must be specified via --string-arg dut_rpc_server_port:<port>")
+            self.jfadmin_fabric_a_passcode = self.matter_test_config.setup_passcodes[0]
+            if not self.jfadmin_fabric_a_passcode:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
+            self.jfadmin_fabric_a_discriminator = self.matter_test_config.discriminators[0]
+            if not self.jfadmin_fabric_a_discriminator:
+                asserts.fail(
+                    "JF-Administrator passcode and discriminator must be specified via --passcode:<passcode> --discriminator:<discriminator>")
 
         # Start Fabric A JF-Controller App
         self.fabric_a_ctrl = JFControllerSubprocess(
             jfc_server_app,
             "JFC_A",  # Name of the controller instance, used for logging purposes in the JF-Controller app:w
-            rpc_server_port=33033,
+            rpc_server_port=self.dut_rpc_server_port,
             storage_dir=self.storage_fabric_a,
-            vendor_id=self.jfctrl_fabric_a_vid)
+            vendor_id=self.jfctrl_fabric_a_vid,
+            extra_args=["--rpc-server-ip", self.dut_rpc_server_ip])
         self.fabric_a_ctrl.start(
             expected_output="CHIP task running",
             timeout=10)

--- a/src/python_testing/TC_JFDS_2_4.py
+++ b/src/python_testing/TC_JFDS_2_4.py
@@ -109,7 +109,7 @@ class TC_JFDS_2_4(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = 33033
+            self.dut_rpc_server_port = "33033"
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,


### PR DESCRIPTION
#### Summary

This PR enables the usage of an external DUT when the default PICS from SDK are not used. In order to use an external DUT the following parameters needs to be added:

    rcp_server_ip_address
    rcp_server_port
    passcode
    discriminator

The parameters don't need to be added when the CI environment is used. The script will automatically detect this and run the jfa-app locally.
#### Related issues

JF scrips doesn't allow an external DUT to be used.
#### Testing

#### Local testing
<img width="809" height="55" alt="image" src="https://github.com/user-attachments/assets/8bbb8d2f-7b2b-41ab-ae04-46c77598b71a" />
