### PR TITLE
Remove more NOLINT bugprone-unchecked-optional-access from tests

### DIFF
--- a/src/app/clusters/actions-server/tests/TestActionsCluster.cpp
+++ b/src/app/clusters/actions-server/tests/TestActionsCluster.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/actions-server/ActionsCluster.h>
@@ -280,15 +281,13 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionSuccess)
     auto result = tester.Invoke(request);
 
     // Verify the command was successful
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_TRUE(result.status.value().IsSuccess()); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
     // Verify the delegate was called
     EXPECT_TRUE(mDelegate.mHandleInstantActionCalled);
     EXPECT_EQ(mDelegate.mLastActionId, 1);
-    // ASSERT_TRUE forces the test to stop evaluating immediately if it fails, preventing the crash
     ASSERT_TRUE(mDelegate.mLastInvokeId.HasValue());
-    EXPECT_EQ(mDelegate.mLastInvokeId.Value(), 12345u); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(mDelegate.mLastInvokeId.Value(), 12345u);
 }
 
 // Test invoking InstantAction command with invalid action ID
@@ -308,7 +307,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionNotFound)
 
     // Verify the command returned NotFound status
     ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status.value().IsSuccess()); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(result.status->IsSuccess());
 }
 
 // Test invoking InstantAction command when delegate returns failure
@@ -340,7 +339,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionDelegateFailure)
 
     // Verify the command returned the failure status from delegate
     ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status.value().IsSuccess()); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(result.status->IsSuccess());
 
     // Verify the delegate was still called
     EXPECT_TRUE(mDelegate.mHandleInstantActionCalled);
@@ -371,7 +370,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionUnsupportedCommand)
 
     // Verify the command returned InvalidCommand status
     ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status.value().IsSuccess()); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(result.status->IsSuccess());
 
     // Verify the delegate was NOT called (command was rejected before delegate)
     EXPECT_FALSE(mDelegate.mHandleInstantActionCalled);

--- a/src/app/clusters/actions-server/tests/TestActionsCluster.cpp
+++ b/src/app/clusters/actions-server/tests/TestActionsCluster.cpp
@@ -306,8 +306,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionNotFound)
     auto result = tester.Invoke(request);
 
     // Verify the command returned NotFound status
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status->IsSuccess());
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 // Test invoking InstantAction command when delegate returns failure
@@ -338,8 +337,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionDelegateFailure)
     auto result = tester.Invoke(request);
 
     // Verify the command returned the failure status from delegate
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status->IsSuccess());
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Failure));
 
     // Verify the delegate was still called
     EXPECT_TRUE(mDelegate.mHandleInstantActionCalled);
@@ -369,8 +367,7 @@ TEST_F(TestActionsCluster, TestInvokeInstantActionUnsupportedCommand)
     auto result = tester.Invoke(request);
 
     // Verify the command returned InvalidCommand status
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_FALSE(result.status->IsSuccess());
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidCommand));
 
     // Verify the delegate was NOT called (command was rejected before delegate)
     EXPECT_FALSE(mDelegate.mHandleInstantActionCalled);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -21,6 +21,7 @@
 #include <clusters/ElectricalEnergyMeasurement/Events.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/CHIPCounter.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 using namespace chip;
@@ -250,12 +251,10 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
 
         using CumulativeEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::Type;
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         EXPECT_EQ(event->eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, CumulativeEventType::GetClusterId(), CumulativeEventType::GetEventId()));
 
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::DecodableType decodedEvent;
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         ASSERT_EQ(event->GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());
@@ -293,12 +292,10 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         ASSERT_TRUE(event.has_value());
 
         using PeriodicEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::Type;
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         EXPECT_EQ(event->eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, PeriodicEventType::GetClusterId(), PeriodicEventType::GetEventId()));
 
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::DecodableType decodedEvent;
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): we asserted above for has_value
         ASSERT_EQ(event->GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -811,9 +811,7 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
         {
             data.groupID = i + 1;
             auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
             data.key.ClearValue();
         }
     }
@@ -821,17 +819,13 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
     {
         data.groupID = maxMcastAddrCount + 1;
         auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
     // Leave all groups
     {
         data.groupID = 0;
         auto result  = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
     // Join MaxMcastAddrCount PerGroup address groups
     {
@@ -841,26 +835,20 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
         {
             data.groupID = i + 1;
             auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
     }
     // Join MaxMcastAddrCount+1
     {
         data.groupID = maxMcastAddrCount + 1;
         auto result  = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ResourceExhausted);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
     }
     // Leave all groups
     {
         data.groupID = 0;
         auto result  = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
     // Join 1 IANA address plus (MaxMcastAddrCount - 1) PerGroup groups
     {
@@ -872,9 +860,7 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
             data.mcastAddrPolicy = MakeOptional((0 == i) ? app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr
                                                          : app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
             auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
     }
     // Join MaxMcastAddrCount+1
@@ -882,18 +868,14 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
         data.groupID         = maxMcastAddrCount + 1;
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
         auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
     // Join MaxMcastAddrCount+2
     {
         data.groupID         = maxMcastAddrCount + 2;
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
         auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ResourceExhausted);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
     }
     // Join MaxMcastAddrCount+1 (existing group)
     {
@@ -901,9 +883,7 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints2, MATTER_ARRAY_SIZE(kEndpoints2));
         auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 }
 
@@ -992,21 +972,15 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
         // Join group: ReplaceEndpoints
         data.replaceEndpoints = MakeOptional(true);
         result                = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
         data.replaceEndpoints = MakeOptional(false);
         result                = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
         data.replaceEndpoints.ClearValue();
         result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group: McastAddrPolicy kPerGroup without kPerGroup feature set
         data.groupID         = 2;


### PR DESCRIPTION
#### Summary

Following the pattern from #43346 this removes the remaining instances.

- ASSERT_TRUE(has_value()) is now understood to guard the dereference
- Use the GetStatusCode() helper where possible.

#### Testing

This PR only changes tests.
