### PR TITLE
restyled-ci: remove create PR step and store the changes as an artifact

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -29,7 +29,7 @@ jobs:
 
       - id: upload
         if: ${{ steps.restyler.outputs.git-patch }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-${{ github.event.pull_request.number }}-restyled
           path: /tmp/pr-${{ github.event.pull_request.number }}-restyled.patch

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -18,17 +18,17 @@ jobs:
 
       - id: restyler
         uses: restyled-io/actions/run@v4
-        with:
-          fail-on-differences: true
 
-      - if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+      - name: Save restyle patch
+        if: ${{ steps.restyler.outputs.git-patch }}
+        env:
+          PATCH_CONTENT: ${{ steps.restyler.outputs.git-patch }}
         run: |
-          cat >/tmp/pr-${{ github.event.pull_request.number }}-restyled.patch <<'EOM'
-          ${{ steps.restyler.outputs.git-patch }}
-          EOM
+          printf '%s\n' "$PATCH_CONTENT" > /tmp/pr-${{ github.event.pull_request.number }}-restyled.patch
+          echo "Patch saved ($(wc -l < /tmp/pr-${{ github.event.pull_request.number }}-restyled.patch) lines)"
 
       - id: upload
-        if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+        if: ${{ steps.restyler.outputs.git-patch }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-${{ github.event.pull_request.number }}-restyled
@@ -37,15 +37,10 @@ jobs:
           overwrite: true
           retention-days: 1
 
-      - if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.upload.outputs.artifact-url }}
+      - name: Fail if restyle differences found
+        if: ${{ steps.restyler.outputs.differences == 'true' }}
         run: |
-          cat >>"$GITHUB_STEP_SUMMARY" <<'EOM'
-          ## Restyled
-
-          To apply these fixes locally,
-
-          1. Download [this patch](${{ steps.upload.outputs.artifact-url }})
-          2. Unzip it: `unzip pr-${{ github.event.pull_request.number }}-restyled.zip`
-          3. Apply it: `git am < pr-${{ github.event.pull_request.number }}-restyled.patch`
-
-          EOM
+          echo "::error::Restyle differences found. Download patch: ${{ steps.upload.outputs.artifact-url }}"
+          echo ""
+          echo "To apply: unzip pr-${{ github.event.pull_request.number }}-restyled.zip && git am < pr-${{ github.event.pull_request.number }}-restyled.patch"
+          exit 1

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -21,16 +21,31 @@ jobs:
         with:
           fail-on-differences: true
 
-      - if: |
-          !cancelled() &&
-          steps.restyler.outputs.success == 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-pull-request@v8
+      - if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+        run: |
+          cat >/tmp/pr-${{ github.event.pull_request.number }}-restyled.patch <<'EOM'
+          ${{ steps.restyler.outputs.git-patch }}
+          EOM
+
+      - id: upload
+        if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+        uses: actions/upload-artifact@v4
         with:
-          base: ${{ steps.restyler.outputs.restyled-base }}
-          branch: ${{ steps.restyler.outputs.restyled-head }}
-          title: ${{ steps.restyler.outputs.restyled-title }}
-          body: ${{ steps.restyler.outputs.restyled-body }}
-          labels: "restyled"
-          reviewers: ${{ github.event.pull_request.user.login }}
-          delete-branch: true
+          name: pr-${{ github.event.pull_request.number }}-restyled
+          path: /tmp/pr-${{ github.event.pull_request.number }}-restyled.patch
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 1
+
+      - if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.upload.outputs.artifact-url }}
+        run: |
+          cat >>"$GITHUB_STEP_SUMMARY" <<'EOM'
+          ## Restyled
+
+          To apply these fixes locally,
+
+          1. Download [this patch](${{ steps.upload.outputs.artifact-url }})
+          2. Unzip it: `unzip pr-${{ github.event.pull_request.number }}-restyled.zip`
+          3. Apply it: `git am < pr-${{ github.event.pull_request.number }}-restyled.patch`
+
+          EOM

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -21,14 +21,14 @@ jobs:
         with:
           fail-on-differences: true
 
-      - if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+      - if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
         run: |
           cat >/tmp/pr-${{ github.event.pull_request.number }}-restyled.patch <<'EOM'
           ${{ steps.restyler.outputs.git-patch }}
           EOM
 
       - id: upload
-        if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
+        if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.restyler.outputs.git-patch }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-${{ github.event.pull_request.number }}-restyled
@@ -37,7 +37,7 @@ jobs:
           overwrite: true
           retention-days: 1
 
-      - if: ${{ !cancelled && steps.restyler.outputs.success == 'true' && steps.upload.outputs.artifact-url }}
+      - if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' && steps.upload.outputs.artifact-url }}
         run: |
           cat >>"$GITHUB_STEP_SUMMARY" <<'EOM'
           ## Restyled

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -17,7 +17,6 @@
 
 #include "DeviceCallbacks.h"
 
-#include "AppTask.h"
 #include "esp_log.h"
 #include <common/CHIPDeviceManager.h>
 #include <common/Esp32AppServer.h>
@@ -30,10 +29,11 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "nvs_flash.h"
+#include "AppTask.h"
 #include "shell_extension/launch.h"
 #include "shell_extension/openthread_cli_register.h"
 #include <app/server/Dnssd.h>
+#include "nvs_flash.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <platform/ESP32/ESP32Utils.h>

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -26,14 +26,14 @@
 #else
 #include "esp_spi_flash.h"
 #endif
+#include "AppTask.h"
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "AppTask.h"
+#include "nvs_flash.h"
 #include "shell_extension/launch.h"
 #include "shell_extension/openthread_cli_register.h"
 #include <app/server/Dnssd.h>
-#include "nvs_flash.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <platform/ESP32/ESP32Utils.h>

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -17,6 +17,7 @@
 
 #include "DeviceCallbacks.h"
 
+#include "AppTask.h"
 #include "esp_log.h"
 #include <common/CHIPDeviceManager.h>
 #include <common/Esp32AppServer.h>
@@ -26,7 +27,6 @@
 #else
 #include "esp_spi_flash.h"
 #endif
-#include "AppTask.h"
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"


### PR DESCRIPTION
#### Problem
- It's not convenient to copy-paste the restyled patch locally, and if it's big then it's a mess.
- On mac, the `scripts/helpers/restyle-diff.sh` script exits with some attribute error
```
Error response from daemon: lsetxattr /data/examples/lighting-app/esp32/main/main.cpp: xattr "com.apple.provenance": operation not supported
```

#### Summary
- Followed the `restyled-io/actions'` readme: https://github.com/restyled-io/actions#upload-patch-artifact

- Remove the peter-evans/create-pull-request step, it was not in use
- Upload restyle patch as a downloadable artifact (pr-<number>-restyled.patch) with 1-day retention
- Fail the job with artifact download link in the error annotation to easily find/download the patch

#### Testing
Tested in the CI
- Pushed a commit which has styling issue (012e6c7daa46ca54362942439dc4edb598992fd9) and then applied the downloaded patch (0a8fbcbc0d3a1e3face9088df1eea5ec83fe2373)


- When there is a diff, step shows artifact download link: https://github.com/project-chip/connectedhomeip/actions/runs/24667129296/job/72127611991?pr=71669
- When there is no diff: https://github.com/project-chip/connectedhomeip/actions/runs/24667224961/job/72127936397?pr=71669