### PR TITLE
TC-BOOL-2.2: Remove manual PICS

### DIFF
--- a/src/python_testing/TC_BOOL_2_2.py
+++ b/src/python_testing/TC_BOOL_2_2.py
@@ -108,7 +108,6 @@ class TC_BOOL_2_2(MatterBaseTest):
     def pics_TC_BOOL_2_2(self) -> list[str]:
         return [
             "BOOL.S",
-            "BOOL.S.M.ManuallyControlled",
         ]
 
     def _feature_map_has_chgevent(self, feature_map: int) -> bool:


### PR DESCRIPTION
#### Summary

These PICS don't tend to be filled out well so it's reasonable to expect that this test could be accidentally skipped if someone didn't fill out the PICS correctly.

A boolean state cluster does nothing but go true and false. I don't think it's unreasonable to say that an operator needs a way to change the state in order to pass certification.

#### Related issues

See
https://github.com/CHIP-Specifications/chip-test-plans/pull/6040

#### Testing

Runs in CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
