### PR TITLE
Remove Kotlin and Java controllers from Android builder

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -416,10 +416,6 @@ def BuildAndroidTarget():
         TargetPart('chip-test', app=AndroidApp.CHIP_TEST),
         TargetPart('tv-server', app=AndroidApp.TV_SERVER),
         TargetPart('tv-casting-app', app=AndroidApp.TV_CASTING_APP),
-        TargetPart('java-matter-controller',
-                   app=AndroidApp.JAVA_MATTER_CONTROLLER),
-        TargetPart('kotlin-matter-controller',
-                   app=AndroidApp.KOTLIN_MATTER_CONTROLLER),
         TargetPart('virtual-device-app',
                    app=AndroidApp.VIRTUAL_DEVICE_APP),
     ])

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -66,8 +66,6 @@ class AndroidApp(Enum):
     CHIP_TEST = auto()
     TV_SERVER = auto()
     TV_CASTING_APP = auto()
-    JAVA_MATTER_CONTROLLER = auto()
-    KOTLIN_MATTER_CONTROLLER = auto()
     VIRTUAL_DEVICE_APP = auto()
 
     def AppName(self):

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,6 +1,6 @@
 ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 asr-{asr550x,asr582x,asr595x}-{all-clusters,all-clusters-minimal,bridge,dishwasher,light-switch,lighting,lock,ota-requestor,refrigerator,temperature-measurement,thermostat}[-factory][-no_logging][-ota][-rio][-rotating_id][-shell]
-android-{androidstudio-arm,androidstudio-arm64,androidstudio-x64,androidstudio-x86,arm,arm64,x64,x86}-{chip-test,chip-tool,java-matter-controller,kotlin-matter-controller,tv-casting-app,tv-server,virtual-device-app}[-size-optimized]
+android-{androidstudio-arm,androidstudio-arm64,androidstudio-x64,androidstudio-x86,arm,arm64,x64,x86}-{chip-test,chip-tool,tv-casting-app,tv-server,virtual-device-app}[-size-optimized]
 bouffalolab-{bl602-night-light,bl602dk,bl616dk,bl704ldk,bl706-night-light,bl706dk}-{contact-sensor,light}-{ethernet,thread,thread-ftd,thread-mtd,wifi}-{easyflash,littlefs}[-cdc][-coredump][-memmonitor][-mfd][-mot][-rotating_device_id][-rpc][-shell]
 cc32xx-{air-purifier,lock}
 ti-cc13x4_26x4-{lighting,lock,pump,pump-controller}[-ftd][-mtd]


### PR DESCRIPTION
#### Summary

There is no support for building `java-matter-controller` and `kotlin-matter-controller` for Android. Keeping these targets in Android builder makes them pop up in the `andoird-xxx-` auto-completion:

```console
$ scripts/build/build_examples.py --target android-arm64-<TAB>
android-arm64-chip-test   android-arm64-java-matter-controller    android-arm64-tv-casting-app  android-arm64-virtual-device-app
android-arm64-chip-tool   android-arm64-kotlin-matter-controller  android-arm64-tv-server
```

```console
$ scripts/build/build_examples.py --target android-arm64-java-matter-controller build
...
  File ".../connectedhomeip/scripts/build/builders/android.py", line 84, in AppName
    raise Exception("Unknown app type: %r" % self)
Exception: Unknown app type: <AndroidApp.JAVA_MATTER_CONTROLLER: 5>
```

#### Testing

Now autocompletion works as expected.