### PR TITLE
tizen: Improve service data handling for BLE advertisement filters

### DIFF
--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -49,6 +49,7 @@ enum chipBLEServiceDataType
  * Defines the over-the-air encoded format of the device identification information block that appears
  * within chip BLE service advertisement data.
  */
+// TODO: Support Network Recovery service data block
 struct ChipBLEDeviceIdentificationInfo
 {
     constexpr static uint16_t kDiscriminatorMask            = 0xfff;

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -940,8 +940,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    ReturnErrorOnFailure(
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
+    ReturnErrorOnFailure(PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
 
     mFlags.Set(Flags::kTizenBLELayerInitialized);
     return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -940,8 +940,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    ReturnErrorOnFailure(PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
+    ReturnErrorOnFailure(
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
 
     mFlags.Set(Flags::kTizenBLELayerInitialized);
     return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });
@@ -1262,7 +1262,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     /* Send StartScan Request to Scanner Class */
     strcpy(data.service_uuid, Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR);
-    err = mDeviceScanner.StartScan(ScanFilterType::kServiceData, data);
+    err = mDeviceScanner.StartScan(ScanFilterType::kServiceUUID, data);
     SuccessOrExitAction(err, ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = DeviceLayer::SystemLayer().StartTimer(kNewConnectionScanTimeout, HandleScanTimeout, this);

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -142,7 +142,8 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
         ChipLogProgress(DeviceLayer, "Proceeding with filterless scan");
     }
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, TEMPORARY_RETURN_IGNORED StopScan());
 
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -23,7 +23,6 @@
 
 #include "ChipDeviceScanner.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <strings.h>
@@ -72,9 +71,12 @@ static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & 
                 strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
                 __PrintLEScanData(dataList[i]);
-                memcpy(&info, dataList[i].service_data, std::min(static_cast<size_t>(dataList[i].service_data_len), sizeof(info)));
-                isChipDevice = true;
-                break;
+                if (dataList[i].service_data_len == sizeof(info))
+                {
+                    memcpy(&info, dataList[i].service_data, sizeof(info));
+                    isChipDevice = true;
+                    break;
+                }
             }
         }
     }

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -71,6 +71,7 @@ static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & 
                 strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
                 __PrintLEScanData(dataList[i]);
+                // TODO: Support Network Recovery, the service data block size is different in that case
                 if (dataList[i].service_data_len == sizeof(info))
                 {
                     memcpy(&info, dataList[i].service_data, sizeof(info));

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -23,6 +23,7 @@
 
 #include "ChipDeviceScanner.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <strings.h>
@@ -71,7 +72,7 @@ static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & 
                 strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
                 __PrintLEScanData(dataList[i]);
-                memcpy(&info, dataList[i].service_data, dataList[i].service_data_len);
+                memcpy(&info, dataList[i].service_data, std::min(static_cast<size_t>(dataList[i].service_data_len), sizeof(info)));
                 isChipDevice = true;
                 break;
             }
@@ -141,8 +142,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
         ChipLogProgress(DeviceLayer, "Proceeding with filterless scan");
     }
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, TEMPORARY_RETURN_IGNORED StopScan());
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Summary

Service data was not handled correctly when creating the BLE scan filter as well as when processing of scan results.

#### Testing

Tested connection in lab:

device: chip-all-clusters on raspberry pi 4 (ubuntu-24.04)
controller: chip-tool on raspberry pi 4 (tizen-10.0)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
