### PR TITLE
Docs: Update skill file with class Config and builder pattern

### DIFF
--- a/.agents/skills/code-driven-cluster-development/SKILL.md
+++ b/.agents/skills/code-driven-cluster-development/SKILL.md
@@ -97,15 +97,15 @@ public:
     class Config
     {
     public:
-        Config & WithMinValue(DataModel::Nullable<int16_t> min) { minValue = min; return *this; }
-        Config & WithMaxValue(DataModel::Nullable<int16_t> max) { maxValue = max; return *this; }
-        Config & WithOptionalAttributes(OptionalAttributeSet attrs) { optionalAttributes = attrs; return *this; }
+        Config & WithMinValue(DataModel::Nullable<int16_t> min) { mMinValue = min; return *this; }
+        Config & WithMaxValue(DataModel::Nullable<int16_t> max) { mMaxValue = max; return *this; }
+        Config & WithOptionalAttributes(OptionalAttributeSet attrs) { mOptionalAttributes = attrs; return *this; }
 
     private:
         friend class FooCluster;
-        DataModel::Nullable<int16_t> minValue{};
-        DataModel::Nullable<int16_t> maxValue{};
-        OptionalAttributeSet optionalAttributes{};
+        DataModel::Nullable<int16_t> mMinValue{};
+        DataModel::Nullable<int16_t> mMaxValue{};
+        OptionalAttributeSet mOptionalAttributes{};
     };
 
     FooCluster(EndpointId endpointId, const Config & config = {});
@@ -136,8 +136,7 @@ Key points:
     base constructor.
 -   Declare `OptionalAttributeSet` as a `using` alias so callers can refer to it
     via `FooCluster::OptionalAttributeSet`.
--   Use a `Config` struct (not a long constructor parameter list) when there are
-    optional or defaulted configuration fields.
+-   **Use a `Config` type:** For constructor arguments that may be optional or have defaults. Prefer a `class` with private members and builder-style `.WithXxx()` setters in non-trivial cases, and use a `struct` only for simple passive configuration bundles.
 -   **Store Separate Variables:** Extract fields from the `Config` object into separate member variables in the cluster class. This allows marking immutable fields as `const` and prevents accidental runtime modification.
 -   Validate constructor arguments with `VerifyOrDie` (programming errors that
     indicate a logic bug at call site, not a recoverable runtime error).

--- a/.agents/skills/code-driven-cluster-development/SKILL.md
+++ b/.agents/skills/code-driven-cluster-development/SKILL.md
@@ -90,11 +90,20 @@ public:
         Foo::Attributes::SomeOptional::Id,
         Foo::Attributes::AnotherOptional::Id>;
 
-    // Use a Config/StartupConfiguration struct for constructor arguments that
-    // may be optional or have defaults.  Builder-style .WithXxx() setters are
-    // common for optional fields.
-    struct Config
+    // Use a Config/StartupConfiguration class (or struct for simple cases) for
+    // constructor arguments that may be optional or have defaults. Use a class
+    // with private members and builder-style .WithXxx() setters to prevent
+    // misconfiguration in non-trivial cases.
+    class Config
     {
+    public:
+        Config() = default;
+        Config & WithMinValue(DataModel::Nullable<int16_t> min) { minValue = min; return *this; }
+        Config & WithMaxValue(DataModel::Nullable<int16_t> max) { maxValue = max; return *this; }
+        Config & WithOptionalAttributes(OptionalAttributeSet attrs) { optionalAttributes = attrs; return *this; }
+
+    private:
+        friend class FooCluster;
         DataModel::Nullable<int16_t> minValue{};
         DataModel::Nullable<int16_t> maxValue{};
         OptionalAttributeSet optionalAttributes{};

--- a/.agents/skills/code-driven-cluster-development/SKILL.md
+++ b/.agents/skills/code-driven-cluster-development/SKILL.md
@@ -136,8 +136,13 @@ Key points:
     base constructor.
 -   Declare `OptionalAttributeSet` as a `using` alias so callers can refer to it
     via `FooCluster::OptionalAttributeSet`.
--   **Use a `Config` type:** For constructor arguments that may be optional or have defaults. Prefer a `class` with private members and builder-style `.WithXxx()` setters in non-trivial cases, and use a `struct` only for simple passive configuration bundles.
--   **Store Separate Variables:** Extract fields from the `Config` object into separate member variables in the cluster class. This allows marking immutable fields as `const` and prevents accidental runtime modification.
+-   **Use a `Config` type:** For constructor arguments that may be optional or
+    have defaults. Prefer a `class` with private members and builder-style
+    `.WithXxx()` setters in non-trivial cases, and use a `struct` only for
+    simple passive configuration bundles.
+-   **Store Separate Variables:** Extract fields from the `Config` object into
+    separate member variables in the cluster class. This allows marking
+    immutable fields as `const` and prevents accidental runtime modification.
 -   Validate constructor arguments with `VerifyOrDie` (programming errors that
     indicate a logic bug at call site, not a recoverable runtime error).
 -   Expose application-facing setters/getters; keep attribute storage in

--- a/.agents/skills/code-driven-cluster-development/SKILL.md
+++ b/.agents/skills/code-driven-cluster-development/SKILL.md
@@ -97,7 +97,6 @@ public:
     class Config
     {
     public:
-        Config() = default;
         Config & WithMinValue(DataModel::Nullable<int16_t> min) { minValue = min; return *this; }
         Config & WithMaxValue(DataModel::Nullable<int16_t> max) { maxValue = max; return *this; }
         Config & WithOptionalAttributes(OptionalAttributeSet attrs) { optionalAttributes = attrs; return *this; }

--- a/.agents/skills/code-driven-cluster-development/SKILL.md
+++ b/.agents/skills/code-driven-cluster-development/SKILL.md
@@ -122,7 +122,7 @@ public:
     DataModel::Nullable<int16_t> GetMeasuredValue() const { return mMeasuredValue; }
 
 protected:
-    BitFlags<Foo::Feature> mFeatureMap;
+    const BitFlags<Foo::Feature> mFeatureMap;
     OptionalAttributeSet mOptionalAttributeSet;
     DataModel::Nullable<int16_t> mMeasuredValue{};
     // ... other member variables
@@ -139,6 +139,7 @@ Key points:
     via `FooCluster::OptionalAttributeSet`.
 -   Use a `Config` struct (not a long constructor parameter list) when there are
     optional or defaulted configuration fields.
+-   **Store Separate Variables:** Extract fields from the `Config` object into separate member variables in the cluster class. This allows marking immutable fields as `const` and prevents accidental runtime modification.
 -   Validate constructor arguments with `VerifyOrDie` (programming errors that
     indicate a logic bug at call site, not a recoverable runtime error).
 -   Expose application-facing setters/getters; keep attribute storage in

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -128,6 +128,11 @@ is the primary reference for this implementation pattern.
     constructor directly, not stored in the `Config` object. This allows the
     same `Config` instance to be reused across multiple cluster instances on
     different endpoints.
+-   **Separate Member Variables:** Extract configuration values from the
+    `Config` object into separate member variables within the cluster class,
+    rather than storing the `Config` object itself. This allows making
+    immutable configuration values `const` (enhancing safety) and reduces
+    coupling.
 
 **Example Implementation (from LevelControlCluster):**
 
@@ -175,7 +180,10 @@ public:
     LevelControlCluster(EndpointId endpoint, const Config & config);
 };
 ```
+<<<<<<< HEAD
 
+=======
+>>>>>>> 9dadbdba57 (Docs: Add separate variables principle to writing_clusters.md)
 ### Design Principles
 
 When designing and implementing a cluster, adhere to the following principles to

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -180,10 +180,8 @@ public:
     LevelControlCluster(EndpointId endpoint, const Config & config);
 };
 ```
-<<<<<<< HEAD
 
-=======
->>>>>>> 9dadbdba57 (Docs: Add separate variables principle to writing_clusters.md)
+
 ### Design Principles
 
 When designing and implementing a cluster, adhere to the following principles to

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -130,9 +130,8 @@ is the primary reference for this implementation pattern.
     different endpoints.
 -   **Separate Member Variables:** Extract configuration values from the
     `Config` object into separate member variables within the cluster class,
-    rather than storing the `Config` object itself. This allows making
-    immutable configuration values `const` (enhancing safety) and reduces
-    coupling.
+    rather than storing the `Config` object itself. This allows making immutable
+    configuration values `const` (enhancing safety) and reduces coupling.
 
 **Example Implementation (from LevelControlCluster):**
 
@@ -180,7 +179,6 @@ public:
     LevelControlCluster(EndpointId endpoint, const Config & config);
 };
 ```
-
 
 ### Design Principles
 


### PR DESCRIPTION
This PR updates the skill file to document the config/builder pattern for code-driven clusters as agreed in the team sync.

### Testing
Documentation only change. Verified visually.