### PR TITLE
Fix logs and step skipping in TC-CHIME tests

### DIFF
--- a/src/python_testing/TC_CHIME_2_4.py
+++ b/src/python_testing/TC_CHIME_2_4.py
@@ -107,10 +107,10 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             if user_response is not None:
-                log.info(f"CHIME 2_4: response '{user_response}' received on confirmation of no chime sound")
+                log.info(f"TC-CHIME-2.4: response '{user_response}' received on confirmation of no chime sound")
                 asserts.assert_equal(user_response.lower(), "y")
             else:
-                log.info("CHIME 2_4: No response received for no chime sound played user prompt")
+                log.info("TC-CHIME-2.4: No response received for no chime sound played user prompt")
 
         self.step(4)
         await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)
@@ -122,10 +122,10 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             if user_response is not None:
-                log.info(f"CHIME 2_4: response '{user_response}' received on confirmation of chime sound")
+                log.info(f"TC-CHIME-2.4: response '{user_response}' received on confirmation of chime sound")
                 asserts.assert_equal(user_response.lower(), "y")
             else:
-                log.info("CHIME 2_4: No response received for chime sound played user prompt")
+                log.info("TC-CHIME-2.4: No response received for chime sound played user prompt")
 
         self.step(6)
         # Use the current selected chime when in CI
@@ -149,11 +149,11 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                 if not found_id:
                     asserts.assert_fail(f"Unknown ChimeID selected: {chosenChimeID}")
                 else:
-                    log.info(f"CHIME 2_4: selected chime id for longest chime: {chosenChimeID}")
+                    log.info(f"TC-CHIME-2.4: selected chime id for longest chime: {chosenChimeID}")
 
                 longestChimeDurationChime = chosenChimeID
             else:
-                log.info("CHIME 2_4: No response received for longest ChimeID user prompt")
+                log.info("TC-CHIME-2.4: No response received for longest ChimeID user prompt")
 
         await self.write_chime_attribute_expect_success(endpoint, attributes.SelectedChime, longestChimeDurationChime)
 
@@ -170,10 +170,10 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             if user_response is not None:
-                log.info(f"CHIME 2_4: response '{user_response}' received on confirmation of no more than two chime sounds")
+                log.info(f"TC-CHIME-2.4: response '{user_response}' received on confirmation of no more than two chime sounds")
                 asserts.assert_equal(user_response.lower(), "y")
             else:
-                log.info("CHIME 2_4: No response received for no more than two chime sounds played user prompt")
+                log.info("TC-CHIME-2.4: No response received for no more than two chime sounds played user prompt")
 
         self.step(8)
         myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
@@ -205,10 +205,10 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                          prompt_msg_placeholder="y",
                                                          default_value="y")
                 if user_response is not None:
-                    log.info(f"CHIME 2_4: response '{user_response}' received on confirmation of different chime sound")
+                    log.info(f"TC-CHIME-2.4: response '{user_response}' received on confirmation of different chime sound")
                     asserts.assert_equal(user_response.lower(), "y")
                 else:
-                    log.info("CHIME 2_4: No response received for different chime sound played user prompt")
+                    log.info("TC-CHIME-2.4: No response received for different chime sound played user prompt")
 
         else:
             self.skip_step(9)

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -92,8 +92,8 @@ class TC_CHIME_2_5(MatterBaseTest, CHIMETestBase):
         # Pre-condition, make sure the ClusterRevision is at least 2
         clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
         if clusterRevision < 2:
-            log.info("Chime 2.5: skipping as cluster revision is less than 2")
-            self.mark_all_remaining_steps_skipped(6)
+            log.info("TC-CHIME-2.5: skipping as cluster revision is less than 2")
+            self.mark_all_remaining_steps_skipped(1) # Skip rest of test.
             return
 
         self.step(1)  # Already done, immediately go to step 2
@@ -108,10 +108,10 @@ class TC_CHIME_2_5(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             if user_response is not None:
-                log.info(f"CHIME 2_5: response '{user_response}' received on confirmation of no chime sound")
+                log.info(f"TC-CHIME-2.5: response '{user_response}' received on confirmation of no chime sound")
                 asserts.assert_equal(user_response.lower(), "y")
             else:
-                log.info("CHIME 2_5: No response received for no chime sound played user prompt")
+                log.info("TC-CHIME-2.5: No response received for no chime sound played user prompt")
 
         self.step(4)
         await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)
@@ -134,10 +134,10 @@ class TC_CHIME_2_5(MatterBaseTest, CHIMETestBase):
                                                          prompt_msg_placeholder="y",
                                                          default_value="y")
                 if user_response is not None:
-                    log.info(f"CHIME 2_5: response '{user_response}' received on confirmation of different chime sound")
+                    log.info(f"TC-CHIME-2.5: response '{user_response}' received on confirmation of different chime sound")
                     asserts.assert_equal(user_response.lower(), "y")
                 else:
-                    log.info("CHIME 2_5: No response received for different chime sound played user prompt")
+                    log.info("TC-CHIME-2.5: No response received for different chime sound played user prompt")
             else:
                 self.skip_step(6)
 

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -93,7 +93,7 @@ class TC_CHIME_2_5(MatterBaseTest, CHIMETestBase):
         clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
         if clusterRevision < 2:
             log.info("TC-CHIME-2.5: skipping as cluster revision is less than 2")
-            self.mark_all_remaining_steps_skipped(1) # Skip rest of test.
+            self.mark_all_remaining_steps_skipped(1)  # Skip rest of test.
             return
 
         self.step(1)  # Already done, immediately go to step 2

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -94,8 +94,8 @@ class TC_CHIME_2_6(MatterBaseTest, CHIMETestBase):
         # Pre-condition, make sure the ClusterRevision is at least 2
         clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
         if clusterRevision < 2:
-            log.info("Chime 2.5: skipping as cluster revision is less than 2")
-            self.mark_all_remaining_steps_skipped(7)
+            log.info("TC-CHIME-2.6: skipping as cluster revision is less than 2")
+            self.mark_all_remaining_steps_skipped(1) # Skip rest of steps
             return
 
         self.step(1)  # Already done, immediately go to step 2
@@ -120,13 +120,13 @@ class TC_CHIME_2_6(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             if user_response is not None:
-                log.info(f"CHIME 2_6: response '{user_response}' received confirmation of chime sound")
+                log.info(f"TC-CHIME-2.6: response '{user_response}' received confirmation of chime sound")
                 asserts.assert_equal(user_response.lower(), "y")
             else:
-                log.info("CHIME 2_6: No response received for chime sound played user prompt")
+                log.info("TC-CHIME-2.6: No response received for chime sound played user prompt")
 
         self.step(6)
-        event_data = event_callback.wait_for_event_report(Clusters.Chime.Events.ChimeStartedPlaying, timeout_sec=5)
+        event_data = event_callback.wait_for_event_report(Clusters.Chime.Events.ChimeStartedPlaying, timeout_sec=30)
         log.info(f"Event data {event_data}")
 
         self.step(7)

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -95,7 +95,7 @@ class TC_CHIME_2_6(MatterBaseTest, CHIMETestBase):
         clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
         if clusterRevision < 2:
             log.info("TC-CHIME-2.6: skipping as cluster revision is less than 2")
-            self.mark_all_remaining_steps_skipped(1) # Skip rest of steps
+            self.mark_all_remaining_steps_skipped(1)  # Skip rest of steps
             return
 
         self.step(1)  # Already done, immediately go to step 2


### PR DESCRIPTION
This PR addresses several issues in Chime python tests:
- Fixed log prefixes to use the standard `TC-CHIME-X.Y` format instead of `CHIME X_Y` or `Chime X.Y`.
- Fixed `mark_all_remaining_steps_skipped` argument to `1` to correctly skip all remaining steps when the cluster revision check fails.
- Increased timeout for event reporting in `TC_CHIME_2_6.py` to 30 seconds to avoid flakiness.

Fixes #71692

### Testing
* Verified that the modified files (`TC_CHIME_2_4.py`, `TC_CHIME_2_5.py`, `TC_CHIME_2_6.py`) compile correctly without syntax errors using `py_compile`.
* CI will validate tests against `all-clusters-app` and `all-devices-app`.