### PR TITLE
[1.5] Backport subscription report fixes (MWOCTRL / AVSM / Thermostat)

### DIFF
--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -434,8 +434,7 @@ CHIP_ERROR ThermostatDelegate::ReEvaluateCurrentSuggestion()
     Seconds32 currentMatterEpochTimestamp = Seconds32(currentMatterEpochTimestampInSeconds);
 
     // For the reference thermostat app, we will always choose a suggestion with the earliest effective time.
-    mIndexOfCurrentSuggestion = GetThermostatSuggestionIndexWithEarliestEffectiveTime(currentMatterEpochTimestamp);
-    SetCurrentThermostatSuggestion(mIndexOfCurrentSuggestion);
+    SetCurrentThermostatSuggestion(GetThermostatSuggestionIndexWithEarliestEffectiveTime(currentMatterEpochTimestamp));
 
     DataModel::Nullable<ThermostatSuggestionStructWithOwnedMembers> nullableCurrentThermostatSuggestion;
     GetCurrentThermostatSuggestion(nullableCurrentThermostatSuggestion);

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -499,10 +499,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateVideoStreamRefCount(uint16_t v
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedVideoStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement)
@@ -517,10 +523,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateAudioStreamRefCount(uint16_t a
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedAudioStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement)
@@ -536,10 +548,16 @@ CHIP_ERROR CameraAVStreamManagementCluster::UpdateSnapshotStreamRefCount(uint16_
 
     if (shouldIncrement)
     {
-        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+        VerifyOrReturnError(it->referenceCount < UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount++;
+    }
+    else
+    {
+        VerifyOrReturnError(it->referenceCount > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        it->referenceCount--;
     }
 
-    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
+    return PersistAndNotify<Attributes::AllocatedSnapshotStreams::Id>();
 }
 
 DataModel::ActionReturnStatus CameraAVStreamManagementCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -653,4 +653,152 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReadStatusLightBrightness)
     EXPECT_EQ(statusLightBrightness, Globals::ThreeLevelAutoEnum::kMedium);
 }
 
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateVideoStreamRefCount)
+{
+    using AllocateRequest  = Commands::VideoStreamAllocate::Type;
+    using AllocateResponse = Commands::VideoStreamAllocateResponse::DecodableType;
+
+    mVideoStreams.clear();
+
+    // First, allocate a stream
+    AllocateRequest allocRequest;
+    allocRequest.streamUsage      = StreamUsageEnum::kLiveView;
+    allocRequest.videoCodec       = VideoCodecEnum::kH264;
+    allocRequest.minFrameRate     = 30;
+    allocRequest.maxFrameRate     = 120;
+    allocRequest.minResolution    = { 640, 480 };
+    allocRequest.maxResolution    = { 1280, 720 };
+    allocRequest.minBitRate       = 10000;
+    allocRequest.maxBitRate       = 10000;
+    allocRequest.keyFrameInterval = 4;
+    allocRequest.watermarkEnabled = chip::MakeOptional(false);
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->videoStreamID;
+    EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
+
+    // Read initial referenceCount
+    Attributes::AllocatedVideoStreams::TypeInfo::DecodableType allocatedVideoStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    auto it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    // Increment
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    // Decrement back
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+    it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent stream ID
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+
+    // Already back at zero after the round-trip, so decrement should fail
+    EXPECT_EQ(mServer.UpdateVideoStreamRefCount(streamId, false), CHIP_ERROR_INVALID_INTEGER_VALUE);
+}
+
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateAudioStreamRefCount)
+{
+    using AllocateRequest  = Commands::AudioStreamAllocate::Type;
+    using AllocateResponse = Commands::AudioStreamAllocateResponse::DecodableType;
+
+    mAudioStreams.clear();
+
+    AllocateRequest allocRequest;
+    allocRequest.streamUsage  = StreamUsageEnum::kLiveView;
+    allocRequest.audioCodec   = AudioCodecEnum::kOpus;
+    allocRequest.channelCount = 2;
+    allocRequest.sampleRate   = 48000;
+    allocRequest.bitRate      = 128000;
+    allocRequest.bitDepth     = 24;
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->audioStreamID;
+    EXPECT_EQ(mServer.GetAllocatedAudioStreams().size(), 1u);
+
+    Attributes::AllocatedAudioStreams::TypeInfo::DecodableType allocatedAudioStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    auto it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    // Increment and verify
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    // Decrement and verify
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedAudioStreams::Id, allocatedAudioStreams), CHIP_NO_ERROR);
+    it = allocatedAudioStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent stream
+    EXPECT_EQ(mServer.UpdateAudioStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+}
+
+TEST_F(TestCameraAVStreamManagementCluster, TestUpdateSnapshotStreamRefCount)
+{
+    using AllocateRequest  = Commands::SnapshotStreamAllocate::Type;
+    using AllocateResponse = Commands::SnapshotStreamAllocateResponse::DecodableType;
+
+    mSnapshotStreams.clear();
+
+    AllocateRequest allocRequest;
+    allocRequest.imageCodec       = ImageCodecEnum::kJpeg;
+    allocRequest.maxFrameRate     = 30;
+    allocRequest.minResolution    = { 640, 480 };
+    allocRequest.maxResolution    = { 1280, 720 };
+    allocRequest.quality          = 80;
+    allocRequest.watermarkEnabled = chip::MakeOptional(false);
+
+    auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
+    ASSERT_TRUE(allocResult.IsSuccess());
+    ASSERT_TRUE(allocResult.response.has_value());
+    uint16_t streamId = allocResult.response->snapshotStreamID;
+    EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
+
+    Attributes::AllocatedSnapshotStreams::TypeInfo::DecodableType allocatedSnapshotStreams;
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    auto it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    uint8_t initialRefCount = it.GetValue().referenceCount;
+
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(streamId, true), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, static_cast<uint8_t>(initialRefCount + 1));
+
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(streamId, false), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
+    it = allocatedSnapshotStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, initialRefCount);
+
+    // Non-existent ID
+    EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
+}
+
 } // namespace

--- a/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+++ b/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
@@ -316,8 +316,18 @@ void Instance::HandleSetCookingParameters(HandlerContext & ctx, const Commands::
                 Zcl,
                 "Microwave Oven Control: Failed to set PowerSetting, PowerSetting value must be multiple of PowerStep number"));
 
+        // Snapshot PowerSetting before the delegate call so this cluster server can emit the
+        // attribute-change report when the delegate updates its internal value.  The delegate owns
+        // storage for PowerSetting, but reporting is the server's responsibility (mirrors CookTime).
+        uint8_t oldPowerSettingNum = mDelegate->GetPowerSettingNum();
+
         status = mDelegate->HandleSetCookingParametersCallback(reqCookMode, reqCookTimeSec, reqStartAfterSetting,
                                                                MakeOptional(reqPowerSettingNum), NullOptional);
+
+        if (oldPowerSettingNum != mDelegate->GetPowerSettingNum())
+        {
+            MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::PowerSetting::Id);
+        }
     }
     else
     {


### PR DESCRIPTION
#### Summary

This PR backports subscription report fixes from master to the v1.5 branch.

Cherry-picked commits:
- 592f6f7af7bea1706653ec4abeaf065eac1ce24b  Fix MWOCTRL PowerSetting not reporting on SetCookingParameters (#71646)
- 6579e95f8e27a5f04dc09ba58c2ca5bd9dbeb378 Fix AVSM referenceCount not reporting
- e2bb4a3f41e2b6fc42f1a41c97cdadb971734de1 Fix Thermostat suggestion reporting issue

These fixes were identified via the wildcard subscription validation framework (PR #43274) 

Note: These are minimal, low-risk fixes intended to align reporting behavior with master.

#### Testing

