### PR TITLE
Refactor MakeDefer usages to use ScopeExit

### DIFF
--- a/examples/ota-provider-app/linux/OtaProviderAppCommandDelegate.cpp
+++ b/examples/ota-provider-app/linux/OtaProviderAppCommandDelegate.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "OtaProviderAppCommandDelegate.h"
-#include <lib/support/Defer.h>
+#include <lib/support/CodeUtils.h>
 #include <platform/PlatformManager.h>
 
 using namespace chip;
@@ -91,7 +91,7 @@ void OtaProviderAppCommandHandler::HandleCommand(intptr_t context)
         return;
     }
 
-    auto cleanup = MakeDefer([&]() { Platform::Delete(self); });
+    auto cleanup = ScopeExit([&]() { Platform::Delete(self); });
 
     std::string name;
     std::string cluster;

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -32,7 +32,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/CHIPKeyIds.h>
-#include <lib/support/Defer.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ApplicationExchangeDispatch.h>
@@ -515,7 +515,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
     bool isStandaloneAck = payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck);
     bool isDuplicate     = msgFlags.Has(MessageFlagValues::kDuplicateMessage);
 
-    auto deferred = MakeDefer([&]() {
+    auto deferred = ScopeExit([&]() {
         // Duplicates and standalone acks are not application-level messages, so they should generally not lead to any state
         // changes.  The one exception to that is that if we have a null mDelegate then our lifetime is not application-defined,
         // since we don't interact with the application at that point.  That can happen when we are already closed (in which case

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -25,7 +25,6 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/Defer.h>
 #include <messaging/ErrorCategory.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>

--- a/src/transport/SecureSessionTable.cpp
+++ b/src/transport/SecureSessionTable.cpp
@@ -14,11 +14,10 @@
  *    limitations under the License.
  */
 
-#include "lib/support/CHIPMem.h"
-#include "lib/support/CodeUtils.h"
-#include "lib/support/ScopedMemoryBuffer.h"
 #include <access/AuthMode.h>
-#include <lib/support/Defer.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/ScopedMemoryBuffer.h>
 #include <transport/SecureSession.h>
 #include <transport/SecureSessionTable.h>
 
@@ -97,7 +96,7 @@ SecureSession * SecureSessionTable::EvictAndAllocate(uint16_t localSessionId, Se
 
     mRunningEvictionLogic = true;
 
-    auto cleanup = MakeDefer([this]() { mRunningEvictionLogic = false; });
+    auto cleanup = ScopeExit([this]() { mRunningEvictionLogic = false; });
 
     ChipLogProgress(SecureChannel, "Evicting a slot for session with LSID: %d, type: %u", localSessionId,
                     (uint8_t) secureSessionType);


### PR DESCRIPTION

#### Summary

Refactor MakeDefer usages to use ScopeExit.
They do similar things but ScopeExit is more general because it supports release()

Defer.h could be removed now.

#### Testing

Existing CI tests.