### PR TITLE
Session Resumption: Use URL-safe base64 for storage key path

### DIFF
--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -43,7 +43,7 @@ StorageKeyName SimpleSessionResumptionStorage::GetStorageKey(const ScopedNodeId 
 StorageKeyName SimpleSessionResumptionStorage::GetStorageKey(ConstResumptionIdView resumptionId)
 {
     char resumptionIdBase64[BASE64_ENCODED_LEN(resumptionId.size()) + 1];
-    auto len                = Base64Encode(resumptionId.data(), resumptionId.size(), resumptionIdBase64);
+    auto len                = Base64URLEncode(resumptionId.data(), resumptionId.size(), resumptionIdBase64);
     resumptionIdBase64[len] = '\0';
     return DefaultStorageKeyAllocator::SessionResumption(resumptionIdBase64);
 }


### PR DESCRIPTION
#### Summary
Session resumption generates a temporary storage key based on the 16 byte resumption ID, by base64 encoding the raw value. This creates a file path that can include forward slashes. This may or may not be handled gracefully by the underlying `PersistentStorageDelegate` - but the behavior seems undefined. In any case, it seems improper since `DefaultStorageKeyAllocator` uses forward slashes as a directory separator.

As a simple fix, use the existing Base64 URL encoding to avoid putting slashes in these filenames.

#### Related issues
No existing issues known - this manifested to us because the slashes were being turned into filesystem folders on our system, which created extra effort to generate the new folder structure for resumption IDs, when in reality a flat structure should have been used. I reviewed other areas where Base64Encode is used and did not find indication that existing file names are generated using this strategy, so it is an isolated change.

#### Testing
Manually tested by creating new sessions in chip-tool and verifying the generated files did not produce directories or undesirable characters. For example, when reading chip-tool's `chip_tool_config.ini`, you may see:
```
g/s/e8W0duSWeKK8vVZ0/gyBcw\x3d\x3d=FSQBASQCARg=
```
which implies a directory `g/s/e8W0duSWeKK8vVZ0` exists. With the new encoding, this will instead be:
```
g/s/e8W0duSWeKK8vVZ0_gyBcw\x3d\x3d=FSQBASQCARg=
```
eliminating the extraneous directory.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
