### PR TITLE
[1.4.2] Backport subscription report fix for MWOCTRL.PowerSetting

### DIFF
--- a/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+++ b/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
@@ -312,8 +312,18 @@ void Instance::HandleSetCookingParameters(HandlerContext & ctx, const Commands::
                 Zcl,
                 "Microwave Oven Control: Failed to set PowerSetting, PowerSetting value must be multiple of PowerStep number"));
 
+        // Snapshot PowerSetting before the delegate call so this cluster server can emit the
+        // attribute-change report when the delegate updates its internal value.  The delegate owns
+        // storage for PowerSetting, but reporting is the server's responsibility (mirrors CookTime).
+        uint8_t oldPowerSettingNum = mDelegate->GetPowerSettingNum();
+
         status = mDelegate->HandleSetCookingParametersCallback(reqCookMode, reqCookTimeSec, reqStartAfterSetting,
                                                                MakeOptional(reqPowerSettingNum), NullOptional);
+
+        if (oldPowerSettingNum != mDelegate->GetPowerSettingNum())
+        {
+            MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::PowerSetting::Id);
+        }
     }
     else
     {


### PR DESCRIPTION
#### Summary

This PR backports subscription report fixes from master to the v1.4.2 branch.

Cherry-picked commits:

- https://github.com/project-chip/connectedhomeip/commit/592f6f7af7bea1706653ec4abeaf065eac1ce24b Fix MWOCTRL PowerSetting not reporting on SetCookingParameters (https://github.com/project-chip/connectedhomeip/pull/71646)

The above fix was identified via the wildcard subscription validation framework (PR [43274](https://github.com/project-chip/connectedhomeip/pull/43274))

Note: This is a minimal, low-risk fix intended to align reporting behavior with master.

Unable to cherry-pick following commits due to features not being available at this point for Thermostat or AVSM clusters and respective tests where these issues were found not being created yet:

- https://github.com/project-chip/connectedhomeip/commit/6579e95f8e27a5f04dc09ba58c2ca5bd9dbeb378 Fix AVSM referenceCount not reporting
- https://github.com/project-chip/connectedhomeip/commit/e2bb4a3f41e2b6fc42f1a41c97cdadb971734de1 Fix Thermostat suggestion reporting issue

#### Testing