### PR TITLE
[Telink] Increase BT_RX_STACK_SIZE for W91

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -190,7 +190,7 @@ config BT_GATT_CACHING
 
 config BT_RX_STACK_SIZE
     default 1352 if BT_B9X || BT_TLX
-    default 1024 if BT_W91
+    default 1200 if BT_W91
 
 config BT_HCI_TX_STACK_SIZE
     default 664 if BT_B9X || BT_TLX


### PR DESCRIPTION
#### Summary

Increase W91 BT_RX_STACK_SIZE to fix unpair stress test instability.

#### Testing

Tested by internal Telink jenkins tests:
- Factory reset and commissioning lighting-app stress test (W91) 
- Unpair and commissioning lighting-app stress test (W91)