### PR TITLE
configure script: Improve argument handling

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2023-2025 Project CHIP Authors
+# Copyright (c) 2023-2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ function gn_generate() { # [project options]
     info "Configuring gn build arguments (see $BUILD_DIR/build-args.txt for supported arguments)"
     touch "${BUILD_DIR}/build.ninja"
     "${gn[@]}" -q args "$BUILD_DIR" \
-        --args="$(cat "${CHIP_ROOT}/scripts/configure.preargs.gn")" \
+        --args='import("//build_overrides/chip.gni") import("${chip_root}/scripts/configure.preargs.gni")' \
         --list --json >"${BUILD_DIR}/build-args.json"
     call_impl describe_args "${BUILD_DIR}/build-args.json" >"${BUILD_DIR}/build-args.txt"
     {

--- a/scripts/configure
+++ b/scripts/configure
@@ -54,9 +54,9 @@ function usage() { # status
     info "Project options (mapped to GN build args):"
     info "  --enable-<ARG>[=no]   Enables (or disables with '=no') a bool build arg"
     info "  --<ARG>=<VALUE>       Sets a (non-bool) build arg to the given value"
-    info "  GN argument names can be specified with '-' instead of '_' and prefixes"
-    info "  like 'chip_' can be omitted from names. For the full list of available"
-    info "  build arguments, see the generated args.configured file."
+    info "  GN argument names are specified in lower-kebab-case ('-' instead of '_');"
+    info "  prefixes like 'chip_' or 'matter_' can be omitted from names. For the full"
+    info "  list of build arguments, see the generated build-args.txt file."
     info ""
     info "  By default, the toolchain for the GN build will be configured from the usual"
     info "  environment variables (CC, CXX, AR, CFLAGS, CXXFLAGS, ...), falling back to"
@@ -214,18 +214,24 @@ function gn_generate() { # [project options]
     # Pass --script-executable to all `gn` calls so scripts run in our venv
     local gn=(gn --script-executable="${BUILD_ENV_DIR}/bin/python" --root="${PROJECT_PATH}")
 
-    # Run gn gen with an empty args.gn first so we can list all arguments
-    info "Configuring gn build arguments (see $BUILD_DIR/args.configured for full list)"
+    # Run `gn args` so we know available arguments. The list will drive the
+    # mapping of our command line options to GN args. Ostensibly `gn args`
+    # requires an existing build directory, but in fact it actually executes
+    # the full setup internally anyway (including running things like
+    # pkg-config via exec_script). The 'preargs' we pass are chosen to minimize
+    # those external dependencies during this pass.
+    info "Configuring gn build arguments (see $BUILD_DIR/build-args.txt for supported arguments)"
+    touch "${BUILD_DIR}/build.ninja"
+    "${gn[@]}" -q args "$BUILD_DIR" \
+        --args="$(cat "${CHIP_ROOT}/scripts/configure.preargs.gn")" \
+        --list --json >"${BUILD_DIR}/build-args.json"
+    call_impl describe_args "${BUILD_DIR}/build-args.json" >"${BUILD_DIR}/build-args.txt"
     {
         echo "# ${CONFIGURE_MARKER}"
         echo "# project root: ${PROJECT_PATH}"
         echo "import(\"//build_overrides/chip.gni\")"
+        call_impl process_project_args "${BUILD_DIR}/build-args.json" "$@"
     } >"${BUILD_DIR}/args.gn"
-    "${gn[@]}" -q gen "$BUILD_DIR"
-
-    # Use the argument list to drive the mapping of our command line options to GN args
-    call_impl process_project_args <("${gn[@]}" args "$BUILD_DIR" --list --json) "$@" >>"${BUILD_DIR}/args.gn"
-    "${gn[@]}" args "$BUILD_DIR" --list >"${BUILD_DIR}/args.configured"
 
     # Now gn gen with the arguments we have configured.
     info "Running gn gen to generate ninja files"

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -177,7 +177,7 @@ class ProjectArgProcessor:
         if not (arg := self.gn_args.get(name, None)):
             info("Warning: Not propagating %s, project has no build arg '%s'" % (envvar, name))
             return
-        # by-pass add_arg() to handle list splitting / formatting directly
+        # bypass add_arg() to handle list splitting / formatting directly
         self.args[arg.name] = json.dumps(value if arg.type != '[' else value.split() if list else [value])
 
     def process_triplet_parameter(self, name, value):

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -14,6 +14,8 @@
 
 # This file contains private utilities for use by the `configure` script.
 # It is self-contained and depends only on the Python 3 standard library.
+#
+# Some unit tests that can be run manually are in configure.impl.test.py.
 
 import collections
 import json
@@ -240,7 +242,8 @@ def fail(message):
     sys.exit(1)
 
 
-# `configure` invokes the top-level functions in this file by
-# passing the function name and arguments on the command line.
-[_, func, *args] = sys.argv
-globals()[func](*args)
+if __name__ == "__main__":
+    # `configure` invokes the top-level functions in this file by
+    # passing the function name and arguments on the command line.
+    [_, func, *args] = sys.argv
+    globals()[func](*args)

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -110,7 +110,7 @@ class ProjectArgProcessor:
                              'matter_enable_', 'matter_use_', 'matter_config_', 'matter_', '')
         GENERIC_ARG_PREFIXES = ('chip_config_', 'chip_', 'matter_config_', 'matter_', '')
 
-        ARG_TYPE_TRANS = str.maketrans('"tf0123456789', 'sbbiiiiiiiiii')
+        ARG_TYPE_TRANS = str.maketrans('"tf0123456789-', 'sbbiiiiiiiiiii')
         DASH_TRANS = str.maketrans('_', '-')
 
         def __init__(self, data):

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -45,27 +45,115 @@ def process_project_args(gn_args_json_file, *params):
         print("%s = %s" % (arg, value))
 
 
-class ProjectArgProcessor:
-    # Prefixes to try when mapping parameters to GN arguments
-    BOOL_ARG_PREFIXES = ('is_', 'enable_', 'use_',
-                         'chip_', 'chip_enable_', 'chip_use_', 'chip_config_',
-                         'matter_', 'matter_enable_', 'matter_use_', 'matter_config_')
-    GENERIC_ARG_PREFIXES = ('chip_', 'chip_config_', 'matter_', 'matter_config_')
+def describe_args(gn_args_json_file):
+    processor = ProjectArgProcessor(gn_args_json_file)
 
-    gn_args = {}  # GN arg -> type ('s'tring, 'b'ool, 'i'integer, '[' list, '{' struct)
-    args = collections.OrderedDict()  # collected arguments
+    # Header / Built-ins handled by process_triplet_parameter
+    print("Available configure options and default values:\n"
+          "\n"
+          "### Target Options\n"
+          "\n"
+          "--build=...\n"
+          "  # host_cpu, host_os: GN built-in\n"
+          "  # The system on which the software is being built, as cpu-os or cpu-vendor-os[-abi]\n"
+          "\n"
+          "--host=...\n"
+          "--target=...\n"
+          "  # target_cpu, target_os: GN built-in\n"
+          "  # The system on which the software will run, as cpu-os or cpu-vendor-os[-abi]\n"
+          )
+
+    def describe_group(group, heading):
+        if not group:
+            return
+        print(f"### {heading}\n")
+        for arg in sorted(group, key=lambda a: a.alias):
+            if arg.type == 'b':
+                print(f"--enable-{arg.alias}{'=no' if arg.default == 'false' else ''}")
+            else:
+                # Abbreviate long list / structs
+                default = arg.default if len(arg.default) <= 40 \
+                    else '[...]' if arg.type == '[' \
+                    else '{...}' if arg.type == '{' \
+                    else arg.default
+                print(f"--{arg.alias}={default}")
+            if arg.source:
+                print(f"  # {arg.name}: {arg.source}")
+            if arg.comment:
+                print("  #", arg.comment.replace("\n", "\n  # "))
+            print()
+
+    project, sdk, third_party, overrides = [], [], [], []
+    for arg in processor.gn_args.values():
+        if (source := arg.source) and arg.alias:
+            group = third_party if source.startswith('//third_party/connectedhomeip/third_party/') \
+                else sdk if source.startswith('//third_party/connectedhomeip/') \
+                else third_party if source.startswith('//third_party/') \
+                else overrides if source.startswith('//build_overrides/') \
+                else project
+            group.append(arg)
+
+    describe_group(project, "Project Options")
+    describe_group(sdk, "Matter SDK Options")
+    describe_group(overrides, "Build Override Paths")
+    describe_group(third_party, "Third-Party Options")
+
+
+class ProjectArgProcessor:
+
+    class GnArg:
+        # Prefixes for mapping between configure parameters and GN arguments (longer prefixes first)
+        BOOL_ARG_PREFIXES = ('is_', 'enable_', 'use_',
+                             'chip_enable_', 'chip_use_', 'chip_config_', 'chip_',
+                             'matter_enable_', 'matter_use_', 'matter_config_', 'matter_', '')
+        GENERIC_ARG_PREFIXES = ('chip_config_', 'chip_', 'matter_config_', 'matter_', '')
+
+        ARG_TYPE_TRANS = str.maketrans('"tf0123456789', 'sbbiiiiiiiiii')
+        DASH_TRANS = str.maketrans('_', '-')
+
+        def __init__(self, data):
+            self.name = str(data['name'])
+            self.alias = None  # will be set below
+            self.default = str(data['default']['value'])
+            self.type = self.default[0].translate(self.ARG_TYPE_TRANS)  # 's'tring, 'b'ool, 'i'integer, '[' list, '{' struct
+            file = data['default'].get('file', None)
+            self.source = '%s:%d' % (file, data['default']['line']) if file else None
+            self.comment = str(data.get('comment', '')).strip()
+
+        def alias_candidates(self):
+            prefixes = self.BOOL_ARG_PREFIXES if self.type == 'b' else self.GENERIC_ARG_PREFIXES
+            return (self.name.removeprefix(p).lower().translate(self.DASH_TRANS) for p in prefixes if self.name.startswith(p))
+
+        def __str__(self):
+            return self.name
+
+    args: collections.OrderedDict  # collected arguments
+    gn_args: dict[str, GnArg]  # by GN name
+    options: dict[str, GnArg]  # by all unique option aliases
 
     def __init__(self, gn_args_json_file):
-        # Parse `gn args --list --json` output and derive arg types from default values
-        argtype = str.maketrans('"tf0123456789', 'sbbiiiiiiiiii')
+        self.args = collections.OrderedDict()
+
+        # Parse `gn args --list --json` output into gn_args
         with open(gn_args_json_file) as fh:
-            for arg in json.load(fh):
-                self.gn_args[arg['name']] = arg['default']['value'][0].translate(argtype)
+            self.gn_args = {arg.name: arg for arg in (self.GnArg(rec) for rec in json.load(fh))}
+
+        # Count collisions first then index options by all unique aliases
+        counts = collections.defaultdict(int)
+        for arg in self.gn_args.values():
+            for alias in arg.alias_candidates():
+                counts[alias] += 1
+        self.options = {}
+        for arg in self.gn_args.values():
+            for alias in arg.alias_candidates():
+                if counts[alias] <= 1:
+                    self.options[alias] = arg
+                    arg.alias = arg.alias or alias  # canonical (shortest unique) alias
 
     def process_env(self):
         self.add_env_arg('chip_code_pre_generated_directory', 'CHIP_PREGEN_DIR')
 
-        self.add_default('custom_toolchain', 'custom')
+        self.add_arg('custom_toolchain', 'custom', required=False)
         self.add_env_arg('target_cc', 'CC', 'cc')
         self.add_env_arg('target_cxx', 'CXX', 'cxx')
         self.add_env_arg('target_ar', 'AR', 'ar')
@@ -75,80 +163,71 @@ class ProjectArgProcessor:
         self.add_env_arg('target_cflags_objc', 'OBJCFLAGS', list=True)
         self.add_env_arg('target_ldflags', 'LDFLAGS', list=True)
 
-    def add_arg(self, arg, value):
-        # format strings and booleans as JSON, otherwise pass through as is
-        self.args[arg] = (json.dumps(value) if self.gn_args.get(arg, 's') in 'sb' else value)
+    def add_arg(self, nameOrArg, value, required=True):
+        if arg := self.gn_args.get(nameOrArg, None) if isinstance(nameOrArg, str) else nameOrArg:
+            # format strings and booleans as JSON, otherwise pass through as is
+            self.args[arg.name] = (json.dumps(value) if arg.type in 'sb' else value)
+        elif required:
+            fail("Project has no build arg '%s'" % nameOrArg)
 
-    def add_default(self, arg, value):
-        """Add an argument, if supported by the GN build"""
-        if arg in self.gn_args:
-            self.add_arg(arg, value)
-
-    def add_env_arg(self, arg, envvar, default=None, list=False):
+    def add_env_arg(self, name, envvar, default=None, list=False):
         """Add an argument from an environment variable"""
-        value = os.environ.get(envvar, default)
-        if not value:
+        if not (value := os.environ.get(envvar, default)):
             return
-        type = self.gn_args.get(arg, None)
-        if not type:
-            info("Warning: Not propagating %s, project has no build arg '%s'" % (envvar, arg))
+        if not (arg := self.gn_args.get(name, None)):
+            info("Warning: Not propagating %s, project has no build arg '%s'" % (envvar, name))
             return
-        self.args[arg] = json.dumps(value if type != '[' else value.split() if list else [value])
-
-    def gn_arg(self, name, prefixes=(), type=None):
-        """Finds the GN argument corresponding to a parameter name"""
-        arg = name.translate(str.maketrans('-', '_'))
-        candidates = [p + arg for p in (('',) + prefixes) if (p + arg) in self.gn_args]
-        preferred = [c for c in candidates if self.gn_args[c] == type] if type else []
-        match = next(iter(preferred + candidates), None)
-        if not match:
-            info("Warning: Project has no build arg '%s'" % arg)
-        return match
+        # by-pass add_arg() to handle list splitting / formatting directly
+        self.args[arg.name] = json.dumps(value if arg.type != '[' else value.split() if list else [value])
 
     def process_triplet_parameter(self, name, value):
         if value is None:
             fail("Project option --%s requires an argument" % name)
         triplet = value.split('-')
         if len(triplet) not in (2, 3, 4):
-            fail("Project option --%s argument must be a cpu-vendor-os[-abi] triplet" % name)
+            fail("Project option --%s argument must be a cpu-os pair or cpu-vendor-os[-abi] triplet" % name)
         prefix = 'host_' if name == 'build' else 'target_'  # "host" has different meanings in GNU and GN!
         self.add_arg(prefix + 'cpu', triplet[0])
         self.add_arg(prefix + 'os', triplet[1 if len(triplet) == 2 else 2])
 
-    def process_enable_parameter(self, name, value):
-        arg = self.gn_arg(name[len('enable-'):], self.BOOL_ARG_PREFIXES, 'b')
-        if not arg:
+    def option(self, option):
+        """Returns the GnArg for the given option name, or None"""
+        if not (arg := self.options.get(option, None)):
+            info("Warning: Project has no build option '%s'" % option)
+        return arg
+
+    def process_enable_parameter(self, option, value):
+        if not (arg := self.option(option.removeprefix('enable-'))):
             return
-        if self.gn_args[arg] != 'b':
+        if arg.type != 'b':
             fail("Project build arg '%s' is not a boolean" % arg)
         if value != 'no' and value is not None:
-            fail("Invalid argument for --%s, must be absent or 'no'" % name)
+            fail("Invalid argument for --%s, must be absent or 'no'" % option)
         self.add_arg(arg, value is None)
 
-    def process_generic_parameter(self, name, value):
-        arg = self.gn_arg(name, self.GENERIC_ARG_PREFIXES)
-        if not arg:
+    def process_generic_parameter(self, option, value):
+        if not (arg := self.option(option)):
             return
-        if self.gn_args[arg] == 'b':
+        if arg.type == 'b':
             fail("Project build arg '%s' is a boolean, use --enable-..." % arg)
         if value is None:
-            fail("Project option --%s requires an argument" % name)
+            fail("Project option --%s requires an argument" % option)
         self.add_arg(arg, value)
 
-    def process_parameter(self, name, value):
-        if name in ('build', 'host', 'target'):
-            self.process_triplet_parameter(name, value)
-        elif name.startswith('enable-'):
-            self.process_enable_parameter(name, value)
+    def process_parameter(self, option, value):
+        if option in ('build', 'host', 'target'):
+            self.process_triplet_parameter(option, value)
+        elif option.startswith('enable-'):
+            self.process_enable_parameter(option, value)
         else:
-            self.process_generic_parameter(name, value)
+            self.process_generic_parameter(option, value)
 
-    def process_parameters(self, args):
+    def process_parameters(self, params):
         """Process GNU-style configure command line parameters"""
-        for arg in args:
-            match = re.fullmatch(r'--([a-z][a-z0-9-]*)(?:=(.*))?', arg)
+        for param in params:
+            match = re.fullmatch(r'--([a-z][a-z0-9-]*)(?:=(.*))?', param)
             if not match:
-                fail("Invalid argument: '%s'" % arg)
+                fail("Invalid argument: '%s'" % param)
             self.process_parameter(match.group(1), match.group(2))
 
 

--- a/scripts/configure.impl.test.py
+++ b/scripts/configure.impl.test.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import json
 import os
 import tempfile
 import unittest
 
 # configure.impl uses a non-package filename; import it by path
-import importlib.util
 _spec = importlib.util.spec_from_file_location("configure_impl", os.path.join(os.path.dirname(__file__), "configure.impl.py"))
 impl = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(impl)

--- a/scripts/configure.impl.test.py
+++ b/scripts/configure.impl.test.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import tempfile
+import unittest
+
+# configure.impl uses a non-package filename; import it by path
+import importlib.util
+_spec = importlib.util.spec_from_file_location("configure_impl", os.path.join(os.path.dirname(__file__), "configure.impl.py"))
+impl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(impl)
+
+
+# A small fixture modeled on real `gn args --list --json` output.
+# Includes: bool (default true/false), string, integer, list, and a
+# collision where stripping prefixes from two args yields the same alias.
+FIXTURE = [
+    {"name": "chip_enable_wifi", "comment": "Enable wifi.", "default": {
+        "file": "//third_party/connectedhomeip/src/platform/device.gni", "line": 69, "value": "false"}},
+    {"name": "chip_automation_logging", "default": {
+        "file": "//third_party/connectedhomeip/src/lib/support/logging.gni", "line": 10, "value": "true"}},
+    {"name": "chip_crypto", "comment": "Crypto implementation.", "default": {
+        "file": "//third_party/connectedhomeip/src/crypto/crypto.gni", "line": 17, "value": "\"\""}},
+    {"name": "chip_log_message_max_size", "default": {
+        "file": "//third_party/connectedhomeip/src/lib/support/logging.gni", "line": 5, "value": "134"}},
+    {"name": "chip_project_config_include_dirs", "comment": "Extra include dirs.", "default": {
+        "file": "//third_party/connectedhomeip/src/system/BUILD.gn", "line": 39, "value": "[]"}},
+    # Collision: both reduce to alias "debug" when chip_ prefix is stripped
+    {"name": "chip_use_debug", "default": {"file": "//third_party/connectedhomeip/BUILD.gn", "line": 1, "value": "false"}},
+    {"name": "chip_config_debug", "default": {"file": "//third_party/connectedhomeip/BUILD.gn", "line": 2, "value": "false"}},
+    # A project-level arg (not under //third_party/connectedhomeip/)
+    {"name": "project_foo", "default": {"file": "//src/args.gni", "line": 1, "value": "\"bar\""}},
+    # GN built-ins needed for triplet tests (no source file)
+    {"name": "target_cpu", "default": {"value": "\"\""}},
+    {"name": "target_os", "default": {"value": "\"\""}},
+    {"name": "host_cpu", "default": {"value": "\"\""}},
+    {"name": "host_os", "default": {"value": "\"\""}},
+]
+
+
+def make_processor(fixture=FIXTURE):
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(fixture, f)
+        f.flush()
+        try:
+            return impl.ProjectArgProcessor(f.name)
+        finally:
+            os.unlink(f.name)
+
+
+class TestProjectArgProcessor(unittest.TestCase):
+
+    def test_arg_types(self):
+        p = make_processor()
+        self.assertEqual(p.gn_args['chip_enable_wifi'].type, 'b')
+        self.assertEqual(p.gn_args['chip_automation_logging'].type, 'b')
+        self.assertEqual(p.gn_args['chip_crypto'].type, 's')
+        self.assertEqual(p.gn_args['chip_log_message_max_size'].type, 'i')
+        self.assertEqual(p.gn_args['chip_project_config_include_dirs'].type, '[')
+
+    def test_aliases(self):
+        p = make_processor()
+        # chip_enable_wifi -> shortest unique alias is "wifi"
+        self.assertEqual(p.gn_args['chip_enable_wifi'].alias, 'wifi')
+        self.assertIs(p.options['wifi'], p.gn_args['chip_enable_wifi'])
+        # longer aliases work too
+        self.assertIs(p.options['enable-wifi'], p.gn_args['chip_enable_wifi'])
+        self.assertIs(p.options['chip-enable-wifi'], p.gn_args['chip_enable_wifi'])
+        # chip_crypto -> "crypto"
+        self.assertEqual(p.gn_args['chip_crypto'].alias, 'crypto')
+        # chip_log_message_max_size -> "log-message-max-size"
+        self.assertEqual(p.gn_args['chip_log_message_max_size'].alias, 'log-message-max-size')
+
+    def test_collision_excludes_ambiguous_alias(self):
+        p = make_processor()
+        # Both chip_use_debug and chip_config_debug would map to "debug"
+        self.assertNotIn('debug', p.options)
+        # But they get longer unique aliases
+        self.assertEqual(p.gn_args['chip_use_debug'].alias, 'use-debug')
+        self.assertEqual(p.gn_args['chip_config_debug'].alias, 'config-debug')
+
+    def test_process_enable_parameter(self):
+        p = make_processor()
+        p.process_parameters(['--enable-wifi'])
+        self.assertEqual(p.args['chip_enable_wifi'], 'true')
+
+    def test_process_enable_parameter_disable(self):
+        p = make_processor()
+        p.process_parameters(['--enable-wifi=no'])
+        self.assertEqual(p.args['chip_enable_wifi'], 'false')
+
+    def test_process_enable_rejects_non_bool(self):
+        p = make_processor()
+        with self.assertRaises(SystemExit):
+            p.process_parameters(['--enable-crypto'])
+
+    def test_process_string_parameter(self):
+        p = make_processor()
+        p.process_parameters(['--crypto=openssl'])
+        self.assertEqual(p.args['chip_crypto'], '"openssl"')
+
+    def test_process_integer_parameter(self):
+        p = make_processor()
+        p.process_parameters(['--log-message-max-size=256'])
+        self.assertEqual(p.args['chip_log_message_max_size'], '256')
+
+    def test_process_triplet(self):
+        p = make_processor()
+        p.process_parameters(['--target=aarch64-linux'])
+        self.assertEqual(p.args['target_cpu'], '"aarch64"')
+        self.assertEqual(p.args['target_os'], '"linux"')
+
+    def test_process_triplet_with_vendor(self):
+        p = make_processor()
+        p.process_parameters(['--build=arm-unknown-linux-gnueabihf'])
+        self.assertEqual(p.args['host_cpu'], '"arm"')
+        self.assertEqual(p.args['host_os'], '"linux"')
+
+    def test_bool_arg_rejects_generic_parameter(self):
+        p = make_processor()
+        self.assertEqual(p.options['wifi'].type, 'b')
+        with self.assertRaises(SystemExit):
+            p.process_parameters(['--wifi=yes'])
+
+    def test_unknown_option_warns(self):
+        p = make_processor()
+        # Unknown options produce a warning but don't fail
+        p.process_parameters(['--enable-nonexistent'])
+        self.assertEqual(len(p.args), 0)
+
+    def test_invalid_argument_format(self):
+        p = make_processor()
+        with self.assertRaises(SystemExit):
+            p.process_parameters(['not-an-option'])
+
+    def test_multiple_parameters(self):
+        p = make_processor()
+        p.process_parameters(['--enable-wifi', '--crypto=boringssl', '--log-message-max-size=512'])
+        self.assertEqual(p.args['chip_enable_wifi'], 'true')
+        self.assertEqual(p.args['chip_crypto'], '"boringssl"')
+        self.assertEqual(p.args['chip_log_message_max_size'], '512')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/configure.impl.test.py
+++ b/scripts/configure.impl.test.py
@@ -35,7 +35,7 @@ FIXTURE = [
     {"name": "chip_crypto", "comment": "Crypto implementation.", "default": {
         "file": "//third_party/connectedhomeip/src/crypto/crypto.gni", "line": 17, "value": "\"\""}},
     {"name": "chip_log_message_max_size", "default": {
-        "file": "//third_party/connectedhomeip/src/lib/support/logging.gni", "line": 5, "value": "134"}},
+        "file": "//third_party/connectedhomeip/src/lib/support/logging.gni", "line": 5, "value": "-1"}},
     {"name": "chip_project_config_include_dirs", "comment": "Extra include dirs.", "default": {
         "file": "//third_party/connectedhomeip/src/system/BUILD.gn", "line": 39, "value": "[]"}},
     # Collision: both reduce to alias "debug" when chip_ prefix is stripped

--- a/scripts/configure.preargs.gn
+++ b/scripts/configure.preargs.gn
@@ -1,3 +1,0 @@
-chip_crypto = "platform"
-chip_device_platform = "none"
-chip_mdns = "none"

--- a/scripts/configure.preargs.gn
+++ b/scripts/configure.preargs.gn
@@ -1,0 +1,3 @@
+chip_crypto = "platform"
+chip_device_platform = "none"
+chip_mdns = "none"

--- a/scripts/configure.preargs.gni
+++ b/scripts/configure.preargs.gni
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These settings are passed to an in initial `gn args` pass used by the
+# configure script to discover available build arguments. Because this
+# actually executes all the GN files (including exec_script calls to
+# things like pkg-config), we need to pass some non-default settings to
+# avoid external dependencies that can cause GN to fail.
+
+chip_crypto = "platform"
+chip_device_platform = "none"
+chip_mdns = "none"

--- a/scripts/configure.preargs.gni
+++ b/scripts/configure.preargs.gni
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# These settings are passed to an in initial `gn args` pass used by the
+# These settings are passed to an initial `gn args` pass used by the
 # configure script to discover available build arguments. Because this
 # actually executes all the GN files (including exec_script calls to
 # things like pkg-config), we need to pass some non-default settings to
 # avoid external dependencies that can cause GN to fail.
 
 chip_crypto = "platform"
-chip_device_platform = "none"
 chip_mdns = "none"


### PR DESCRIPTION
#### Summary

- Pass a few default arguments to the initial gn pass (where user supplied arguments are not included yet) to avoid pkg-config failures due to default dependencies like OpenSSL. This is a little crude, but sadly GN does not provide a way to collect declare_args() without executing everything.
- Reduce the number of gn passes from 4 (gen args args gen) to 2 (args gen)
- Produce a build-args.txt file with the actual configure options (rather than just raw GN args) that are available, in a more readable format than the dump produced by gn --list. This replaces the args.configured file.
- Refactor how the available GN args are represented and mapped internally.

#### Testing

Existing CI builds and some manual testing; verified this fixes the build issue I was hitting on OpenWrt due to pkgconfig not finding OpenSSL during the pre-generation pass.
