### PR TITLE
[Crypto PSA][Bugfix] return the actual error on failure in HMAC_SHA256 and pbkdf2_sha256

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -554,7 +554,7 @@ exit:
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 CHIP_ERROR HMAC_sha::HMAC_SHA256(const Hmac128KeyHandle & key, const uint8_t * message, size_t message_length, uint8_t * out_buffer,
@@ -664,7 +664,7 @@ exit:
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 CHIP_ERROR add_entropy_source(entropy_source /* fn_source */, void * /* p_source */, size_t /* threshold */)

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -1147,6 +1147,28 @@ TEST_F(TestChipCryptoPAL, TestHMAC_SHA256_RawKey)
     EXPECT_EQ(numOfTestsExecuted, numOfTestCases);
 }
 
+#if CHIP_CRYPTO_PSA
+// Regression test for a bug where HMAC_SHA256 returned CHIP_NO_ERROR even when the underlying PSA call failed.
+// Fault Injection: A key larger than PSA_MAX_KEY_BITS makes the PAL's internal psa_import_key() return
+// PSA_ERROR_NOT_SUPPORTED; the PAL must return a non-success CHIP_ERROR.
+TEST_F(TestChipCryptoPAL, TestHMAC_SHA256_RawKey_PsaFailurePropagates)
+{
+    constexpr size_t kOversizedKeyBytes = PSA_BITS_TO_BYTES(PSA_MAX_KEY_BITS) + 1;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> oversizedKey;
+    oversizedKey.Alloc(kOversizedKeyBytes);
+    ASSERT_TRUE(oversizedKey);
+    memset(oversizedKey.Get(), 0, kOversizedKeyBytes);
+
+    const uint8_t msg[8]                          = {};
+    uint8_t mac[PSA_HASH_LENGTH(PSA_ALG_SHA_256)] = {};
+
+    TestHMAC_sha mHMAC;
+    CHIP_ERROR err = mHMAC.HMAC_SHA256(oversizedKey.Get(), kOversizedKeyBytes, msg, sizeof(msg), mac, sizeof(mac));
+
+    EXPECT_NE(err, CHIP_NO_ERROR);
+}
+#endif
+
 #if !(CHIP_CRYPTO_KEYSTORE_APP)
 TEST_F(TestChipCryptoPAL, TestHMAC_SHA256_KeyHandle)
 {
@@ -1565,6 +1587,28 @@ TEST_F(TestChipCryptoPAL, TestPBKDF2_SHA256_TestVectors)
     }
     EXPECT_GT(numOfTestsRan, 0);
 }
+
+#if CHIP_CRYPTO_PSA
+// Regression test for a bug where pbkdf2_sha256 returned CHIP_NO_ERROR even when the underlying PSA call failed.
+// Fault Injection: A password larger than PSA_MAX_KEY_BITS makes the PAL's internal psa_import_key() return
+// PSA_ERROR_NOT_SUPPORTED; the PAL must return a non-success CHIP_ERROR.
+TEST_F(TestChipCryptoPAL, TestPBKDF2_SHA256_PsaFailurePropagates)
+{
+    constexpr size_t kOversizedPassBytes = PSA_BITS_TO_BYTES(PSA_MAX_KEY_BITS) + 1;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> oversizedPass;
+    oversizedPass.Alloc(kOversizedPassBytes);
+    ASSERT_TRUE(oversizedPass);
+    memset(oversizedPass.Get(), 0, kOversizedPassBytes);
+
+    const uint8_t salt[16] = {};
+    uint8_t outKey[32]     = {};
+
+    TestPBKDF2_sha256 pbkdf;
+    CHIP_ERROR err = pbkdf.pbkdf2_sha256(oversizedPass.Get(), kOversizedPassBytes, salt, sizeof(salt), 1, sizeof(outKey), outKey);
+
+    EXPECT_NE(err, CHIP_NO_ERROR);
+}
+#endif
 
 TEST_F(TestChipCryptoPAL, TestP256_Keygen)
 {


### PR DESCRIPTION
#### Summary

return the actual error on failure in HMAC_SHA256 and pbkdf2_sha256


#### Testing

- Nordic CI has a job that runs PSA Unit Tests on Zephyr's native_posix_64
- We need to start Unit Testing PSA backend on linux, issue created: https://github.com/project-chip/connectedhomeip/issues/71721
