### PR TITLE
[all-devices-app][PosixChimeDevice] Address post-merge review comments

### DIFF
--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -160,9 +160,18 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
 ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
                                              ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    *pFormat     = ma_format_s16; // 16-bit signed integer PCM
-    *pChannels   = 1;             // Mono
-    *pSampleRate = kSampleRateHz;
+    if (pFormat)
+    {
+        *pFormat = ma_format_s16; // 16-bit signed integer PCM
+    }
+    if (pChannels)
+    {
+        *pChannels = 1; // Mono
+    }
+    if (pSampleRate)
+    {
+        *pSampleRate = kSampleRateHz;
+    }
 
     if (pChannelMap && channelMapCap > 0)
     {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -48,7 +48,7 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         return MA_INVALID_ARGS;
 
     // Calculate total samples for the full duration of the sound
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
 
     ma_uint64 framesToRead = frameCount;
     // Ensure we don't read past the end of the sound
@@ -78,21 +78,21 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         if (pCustomDS->pulse)
         {
             // Pulsing sound: keep same frequency
-            freq   = pCustomDS->freq1;
+            freq   = pCustomDS->freq1_hz;
             t_note = t;
         }
         else
         {
             // Two-tone sound (Ding-Dong): switch frequency halfway
-            if (t < pCustomDS->duration / 2.0)
+            if (t < pCustomDS->duration_sec / 2.0)
             {
-                freq   = pCustomDS->freq1;
+                freq   = pCustomDS->freq1_hz;
                 t_note = t;
             }
             else
             {
-                freq   = pCustomDS->freq2;
-                t_note = t - (pCustomDS->duration / 2.0); // Reset relative time for second tone
+                freq   = pCustomDS->freq2_hz;
+                t_note = t - (pCustomDS->duration_sec / 2.0); // Reset relative time for second tone
             }
         }
 
@@ -133,7 +133,7 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
     if (pCustomDS == NULL)
         return MA_INVALID_ARGS;
 
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
 
     // Cap the cursor at the end of the sound
     if (frameIndex > totalSamples)
@@ -184,7 +184,7 @@ ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 
         return MA_INVALID_ARGS;
 
     if (pLength)
-        *pLength = static_cast<ma_uint64>(pCustomDS->duration * kSampleRateHz);
+        *pLength = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
     return MA_SUCCESS;
 }
 
@@ -220,26 +220,26 @@ PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDe
     if (soundInfo.id == 0)
     {
         // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
-        dataSource.freq1    = 880;
-        dataSource.freq2    = 660;
-        dataSource.duration = 1.0;
-        dataSource.pulse    = false;
+        dataSource.freq1_hz    = 880;
+        dataSource.freq2_hz    = 660;
+        dataSource.duration_sec = 1.0;
+        dataSource.pulse       = false;
     }
     else if (soundInfo.id == 1)
     {
         // Chime 1: Pulsing warning tone (1000Hz pulsing)
-        dataSource.freq1    = 1000;
-        dataSource.freq2    = 1000;
-        dataSource.duration = 1.0;
-        dataSource.pulse    = true;
+        dataSource.freq1_hz    = 1000;
+        dataSource.freq2_hz    = 1000;
+        dataSource.duration_sec = 1.0;
+        dataSource.pulse       = true;
     }
     else
     {
         // Chime 2 (Default): Single short tone (440Hz)
-        dataSource.freq1    = 440;
-        dataSource.freq2    = 440;
-        dataSource.duration = 0.5;
-        dataSource.pulse    = false;
+        dataSource.freq1_hz    = 440;
+        dataSource.freq2_hz    = 440;
+        dataSource.duration_sec = 0.5;
+        dataSource.pulse       = false;
     }
 
     // Initialize the base data source with our vtable mapping to the callbacks above

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -160,11 +160,18 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
 ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
                                              ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    // Note: miniaudio's ma_data_source_get_data_format guarantees that pFormat, pChannels, and pSampleRate are non-null
-    // when calling this callback, by passing addresses of local variables if the user passed NULL to the API.
-    *pFormat     = ma_format_s16; // 16-bit signed integer PCM
-    *pChannels   = 1;             // Mono
-    *pSampleRate = kSampleRateHz;
+    if (pFormat)
+    {
+        *pFormat = ma_format_s16; // 16-bit signed integer PCM
+    }
+    if (pChannels)
+    {
+        *pChannels = 1; // Mono
+    }
+    if (pSampleRate)
+    {
+        *pSampleRate = kSampleRateHz;
+    }
 
     if (pChannelMap && channelMapCap > 0)
     {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <limits>
 #include <sstream>
 
 // This file implements the audio playback for the Chime cluster on POSIX systems using the
@@ -118,7 +119,7 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         sample *= volume;
 
         // Scale to 16-bit signed PCM and store
-        pOut[i] = static_cast<int16_t>(sample * 32767.0);
+        pOut[i] = static_cast<int16_t>(sample * static_cast<double>(std::numeric_limits<int16_t>::max()));
     }
 
     pCustomDS->cursor += framesToRead;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -160,18 +160,11 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
 ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
                                              ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    if (pFormat)
-    {
-        *pFormat = ma_format_s16; // 16-bit signed integer PCM
-    }
-    if (pChannels)
-    {
-        *pChannels = 1; // Mono
-    }
-    if (pSampleRate)
-    {
-        *pSampleRate = kSampleRateHz;
-    }
+    // Note: miniaudio's ma_data_source_get_data_format guarantees that pFormat, pChannels, and pSampleRate are non-null
+    // when calling this callback, by passing addresses of local variables if the user passed NULL to the API.
+    *pFormat     = ma_format_s16; // 16-bit signed integer PCM
+    *pChannels   = 1;             // Mono
+    *pSampleRate = kSampleRateHz;
 
     if (pChannelMap && channelMapCap > 0)
     {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -61,7 +61,9 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
     if (framesToRead == 0)
     {
         if (pFramesRead)
+        {
             *pFramesRead = 0;
+        }
         return MA_AT_END;
     }
 
@@ -107,7 +109,9 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
             // Apply a square wave modulation for the pulse effect
             bool on = (static_cast<int>(t * 20) % 2) == 0;
             if (!on)
+            {
                 volume = 0;
+            }
         }
 
         // Additive synthesis: combine fundamental frequency and harmonics
@@ -124,7 +128,9 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
 
     pCustomDS->cursor += framesToRead;
     if (pFramesRead)
+    {
         *pFramesRead = framesToRead;
+    }
 
     return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
 }
@@ -159,7 +165,9 @@ ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_fo
     *pSampleRate = kSampleRateHz;
 
     if (pChannelMap && channelMapCap > 0)
+    {
         *pChannelMap = MA_CHANNEL_MONO;
+    }
 
     return MA_SUCCESS;
 }
@@ -171,7 +179,9 @@ ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 
     VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     if (pCursor)
+    {
         *pCursor = pCustomDS->cursor;
+    }
     return MA_SUCCESS;
 }
 
@@ -182,7 +192,9 @@ ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 
     VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     if (pLength)
+    {
         *pLength = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
+    }
     return MA_SUCCESS;
 }
 

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -153,12 +153,10 @@ ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameI
 ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
                                              ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
 {
-    if (pFormat)
-        *pFormat = ma_format_s16; // 16-bit signed integer PCM
-    if (pChannels)
-        *pChannels = 1; // Mono
-    if (pSampleRate)
-        *pSampleRate = kSampleRateHz;
+    *pFormat     = ma_format_s16; // 16-bit signed integer PCM
+    *pChannels   = 1;             // Mono
+    *pSampleRate = kSampleRateHz;
+
     if (pChannelMap && channelMapCap > 0)
         *pChannelMap = MA_CHANNEL_MONO;
 

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -83,7 +83,9 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
         }
         else
         {
-            // Two-tone sound (Ding-Dong): switch frequency halfway
+            // Two-tone sound (e.g., Ding-Dong): switch from freq1_hz to freq2_hz halfway through the total duration.
+            // This creates a classic two-note chime effect. We also reset the relative time (t_note) for the second
+            // tone so that the exponential decay applies to each note individually.
             if (t < pCustomDS->duration_sec / 2.0)
             {
                 freq   = pCustomDS->freq1_hz;

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -16,6 +16,7 @@
  */
 #include <PosixChimeDevice.h>
 #include <cmath>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <sstream>
 
@@ -44,8 +45,7 @@ constexpr uint32_t kSampleRateHz = 44100;
 ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL)
-        return MA_INVALID_ARGS;
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     // Calculate total samples for the full duration of the sound
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
@@ -132,8 +132,7 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
 ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL)
-        return MA_INVALID_ARGS;
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
 
@@ -170,8 +169,7 @@ ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_fo
 ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL)
-        return MA_INVALID_ARGS;
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     if (pCursor)
         *pCursor = pCustomDS->cursor;
@@ -182,8 +180,7 @@ ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 
 ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
 {
     auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    if (pCustomDS == NULL)
-        return MA_INVALID_ARGS;
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
 
     if (pLength)
         *pLength = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -219,10 +219,11 @@ static ma_data_source_vtable g_custom_data_source_vtable = {
 } // namespace
 
 // SoundResource Factory: Initializes a specific sound based on its ID.
-std::unique_ptr<PosixChimeDevice::SoundResource> PosixChimeDevice::SoundResource::Create(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
+std::unique_ptr<PosixChimeDevice::SoundResource> PosixChimeDevice::SoundResource::Create(ma_engine * engine,
+                                                                                         const ChimeDevice::Sound & soundInfo)
 {
     auto resource = std::make_unique<SoundResource>();
-    resource->id = soundInfo.id;
+    resource->id  = soundInfo.id;
 
     // Configure the custom data source parameters based on ID.
     // These hardcoded values define the characteristics of each chime.
@@ -231,26 +232,26 @@ std::unique_ptr<PosixChimeDevice::SoundResource> PosixChimeDevice::SoundResource
     if (soundInfo.id == 0)
     {
         // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
-        resource->dataSource.freq1_hz    = 880;
-        resource->dataSource.freq2_hz    = 660;
+        resource->dataSource.freq1_hz     = 880;
+        resource->dataSource.freq2_hz     = 660;
         resource->dataSource.duration_sec = 1.0;
-        resource->dataSource.pulse       = false;
+        resource->dataSource.pulse        = false;
     }
     else if (soundInfo.id == 1)
     {
         // Chime 1: Pulsing warning tone (1000Hz pulsing)
-        resource->dataSource.freq1_hz    = 1000;
-        resource->dataSource.freq2_hz    = 1000;
+        resource->dataSource.freq1_hz     = 1000;
+        resource->dataSource.freq2_hz     = 1000;
         resource->dataSource.duration_sec = 1.0;
-        resource->dataSource.pulse       = true;
+        resource->dataSource.pulse        = true;
     }
     else
     {
         // Chime 2 (Default): Single short tone (440Hz)
-        resource->dataSource.freq1_hz    = 440;
-        resource->dataSource.freq2_hz    = 440;
+        resource->dataSource.freq1_hz     = 440;
+        resource->dataSource.freq2_hz     = 440;
         resource->dataSource.duration_sec = 0.5;
-        resource->dataSource.pulse       = false;
+        resource->dataSource.pulse        = false;
     }
 
     // Initialize the base data source with our vtable mapping to the callbacks above

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -218,61 +218,63 @@ static ma_data_source_vtable g_custom_data_source_vtable = {
 
 } // namespace
 
-// SoundResource Constructor: Initializes a specific sound based on its ID.
-PosixChimeDevice::SoundResource::SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
+// SoundResource Factory: Initializes a specific sound based on its ID.
+std::unique_ptr<PosixChimeDevice::SoundResource> PosixChimeDevice::SoundResource::Create(ma_engine * engine, const ChimeDevice::Sound & soundInfo)
 {
-    id = soundInfo.id;
+    auto resource = std::make_unique<SoundResource>();
+    resource->id = soundInfo.id;
 
     // Configure the custom data source parameters based on ID.
     // These hardcoded values define the characteristics of each chime.
-    dataSource.cursor = 0;
+    resource->dataSource.cursor = 0;
 
     if (soundInfo.id == 0)
     {
         // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
-        dataSource.freq1_hz    = 880;
-        dataSource.freq2_hz    = 660;
-        dataSource.duration_sec = 1.0;
-        dataSource.pulse       = false;
+        resource->dataSource.freq1_hz    = 880;
+        resource->dataSource.freq2_hz    = 660;
+        resource->dataSource.duration_sec = 1.0;
+        resource->dataSource.pulse       = false;
     }
     else if (soundInfo.id == 1)
     {
         // Chime 1: Pulsing warning tone (1000Hz pulsing)
-        dataSource.freq1_hz    = 1000;
-        dataSource.freq2_hz    = 1000;
-        dataSource.duration_sec = 1.0;
-        dataSource.pulse       = true;
+        resource->dataSource.freq1_hz    = 1000;
+        resource->dataSource.freq2_hz    = 1000;
+        resource->dataSource.duration_sec = 1.0;
+        resource->dataSource.pulse       = true;
     }
     else
     {
         // Chime 2 (Default): Single short tone (440Hz)
-        dataSource.freq1_hz    = 440;
-        dataSource.freq2_hz    = 440;
-        dataSource.duration_sec = 0.5;
-        dataSource.pulse       = false;
+        resource->dataSource.freq1_hz    = 440;
+        resource->dataSource.freq2_hz    = 440;
+        resource->dataSource.duration_sec = 0.5;
+        resource->dataSource.pulse       = false;
     }
 
     // Initialize the base data source with our vtable mapping to the callbacks above
     ma_data_source_config config = ma_data_source_config_init();
     config.vtable                = &g_custom_data_source_vtable;
 
-    ma_result res = ma_data_source_init(&config, &dataSource.base);
+    ma_result res = ma_data_source_init(&config, &resource->dataSource.base);
     if (res != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", soundInfo.id, res);
-        return;
+        return nullptr;
     }
 
     // Initialize the sound object from the data source. Miniaudio will pull data from it during playback.
-    res = ma_sound_init_from_data_source(engine, &dataSource.base, 0, NULL, &sound);
+    res = ma_sound_init_from_data_source(engine, &resource->dataSource.base, 0, NULL, &resource->sound);
     if (res != MA_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", soundInfo.id, res);
-        ma_data_source_uninit(&dataSource.base);
-        return;
+        ma_data_source_uninit(&resource->dataSource.base);
+        return nullptr;
     }
 
-    mInitialized = true;
+    resource->mInitialized = true;
+    return resource;
 }
 
 // SoundResource Destructor: Ensures safe cleanup of miniaudio structures.
@@ -303,12 +305,15 @@ PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sou
     bool allSoundsInitialized = true;
     for (size_t i = 0; i < sounds.size(); ++i)
     {
-        auto resource = std::make_unique<SoundResource>(&mEngine, sounds[i]);
-        if (!resource->mInitialized)
+        auto resource = SoundResource::Create(&mEngine, sounds[i]);
+        if (resource)
+        {
+            mSoundResources.push_back(std::move(resource));
+        }
+        else
         {
             allSoundsInitialized = false;
         }
-        mSoundResources.push_back(std::move(resource));
     }
 
     mSoundsInitialized = allSoundsInitialized;

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -34,9 +34,9 @@ public:
     struct CustomDataSource
     {
         ma_data_source_base base; // Base structure required by miniaudio
-        double freq1_hz;             // Primary frequency or first tone in Hz
-        double freq2_hz;             // Secondary frequency or second tone in Hz
-        double duration_sec;          // Total duration of the sound in seconds
+        double freq1_hz;          // Primary frequency or first tone in Hz
+        double freq2_hz;          // Secondary frequency or second tone in Hz
+        double duration_sec;      // Total duration of the sound in seconds
         bool pulse;               // Whether to apply a pulse modulation effect
         ma_uint64 cursor;         // Current playback position in samples
     };

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -34,9 +34,9 @@ public:
     struct CustomDataSource
     {
         ma_data_source_base base; // Base structure required by miniaudio
-        double freq1;             // Primary frequency or first tone
-        double freq2;             // Secondary frequency or second tone
-        double duration;          // Total duration of the sound in seconds
+        double freq1_hz;             // Primary frequency or first tone in Hz
+        double freq2_hz;             // Secondary frequency or second tone in Hz
+        double duration_sec;          // Total duration of the sound in seconds
         bool pulse;               // Whether to apply a pulse modulation effect
         ma_uint64 cursor;         // Current playback position in samples
     };

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -47,7 +47,8 @@ public:
     class SoundResource
     {
     public:
-        SoundResource(ma_engine * engine, const ChimeDevice::Sound & soundInfo);
+        static std::unique_ptr<SoundResource> Create(ma_engine * engine, const ChimeDevice::Sound & soundInfo);
+        SoundResource() = default; // Needed for factory
         ~SoundResource();
 
         uint8_t id;                  // Chime ID matching the Matter spec

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -42,6 +42,8 @@ public:
     };
 
     // RAII wrapper for sound resources. Manages the lifecycle of miniaudio structures.
+    // A "SoundResource" represents a single chime sound, binding a Matter Chime ID to a specific
+    // audio synthesis configuration (CustomDataSource) and the associated miniaudio sound object.
     class SoundResource
     {
     public:


### PR DESCRIPTION
This PR addresses post-merge review comments for the Matter Chime audio integration on POSIX systems (PR #71644).

Key changes:
- Renamed variables to include units (e.g., `freq1` -> `freq1_hz`).
- Documented tone generation behavior.
- Clarified `SoundResource` via comments.
- Replaced manual error handling with Matter macros (`VerifyOrReturnError`).
- Removed redundant null checks for `miniaudio`.
- Replaced magic numbers with symbolic constants.
- Ensured all conditional blocks use braces.
- Refactored `SoundResource` to use factory pattern.

### Testing
- Verified build with `linux-x64-all-devices-boringssl` target.
- Verified that `all-devices-app` starts successfully and initializes `miniaudio` without errors.
