### PR TITLE
Fix for TC_JFADMIN_1_2 test failure

### DIFF
--- a/src/python_testing/TC_JFADMIN_1_2.py
+++ b/src/python_testing/TC_JFADMIN_1_2.py
@@ -195,11 +195,16 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             attributes=[(self._OPERATIONAL_CREDENTIALS_ENDPOINT, Clusters.OperationalCredentials.Attributes.NOCs)],
             returnClusterObject=True)
         icac1 = response[0][Clusters.OperationalCredentials].NOCs[0].icac
-        await self.send_single_cmd(
+        resp = await self.send_single_cmd(
             dev_ctrl=self.default_controller,
             node_id=self.dut_node_id,
             endpoint=self._JOINT_FABRIC_ADMINISTRATOR_ENDPOINT,
             cmd=Clusters.JointFabricAdministrator.Commands.AddICAC(icac1))
+        self._assert_icac_response_status(
+            resp,
+            Clusters.JointFabricAdministrator.Enums.ICACResponseStatusEnum.kOk,
+            "Step 5",
+        )
 
         self.step("6")
         await self._assert_im_error(
@@ -223,11 +228,16 @@ class TC_JFADMIN_1_2(MatterBaseTest):
         await self._arm_failsafe(20)
 
         self.step("10")
-        await self.send_single_cmd(
+        resp = await self.send_single_cmd(
             dev_ctrl=self.default_controller,
             node_id=self.dut_node_id,
             endpoint=self._JOINT_FABRIC_ADMINISTRATOR_ENDPOINT,
             cmd=Clusters.JointFabricAdministrator.Commands.AddICAC(icac1))
+        self._assert_icac_response_status(
+            resp,
+            Clusters.JointFabricAdministrator.Enums.ICACResponseStatusEnum.kOk,
+            "Step 10",
+        )
 
         self.step("11")
         await self._assert_im_error(
@@ -263,14 +273,10 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             node_id=self.dut_node_id,
             endpoint=self._JOINT_FABRIC_ADMINISTRATOR_ENDPOINT,
             cmd=Clusters.JointFabricAdministrator.Commands.AddICAC(other_icac))
-        asserts.assert_true(
-            isinstance(resp, Clusters.JointFabricAdministrator.Commands.ICACResponse),
-            f"Unexpected response type: {type(resp)}",
-        )
-        asserts.assert_equal(
-            resp.statusCode,
+        self._assert_icac_response_status(
+            resp,
             Clusters.JointFabricAdministrator.Enums.ICACResponseStatusEnum.kInvalidICAC,
-            f"Expected InvalidICAC response status, but got {resp.statusCode}",
+            "Step 14",
         )
 
         self.step("15")
@@ -287,14 +293,10 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             node_id=self.dut_node_id,
             endpoint=self._JOINT_FABRIC_ADMINISTRATOR_ENDPOINT,
             cmd=Clusters.JointFabricAdministrator.Commands.AddICAC(icac_wrong_public_key.icacBytes))
-        asserts.assert_true(
-            isinstance(resp, Clusters.JointFabricAdministrator.Commands.ICACResponse),
-            f"Unexpected response type: {type(resp)}",
-        )
-        asserts.assert_equal(
-            resp.statusCode,
+        self._assert_icac_response_status(
+            resp,
             Clusters.JointFabricAdministrator.Enums.ICACResponseStatusEnum.kInvalidPublicKey,
-            f"Expected InvalidPublicKey response status, but got {resp.statusCode}",
+            "Step 15",
         )
 
         self.step("16")
@@ -324,14 +326,10 @@ class TC_JFADMIN_1_2(MatterBaseTest):
             node_id=self.dut_node_id,
             endpoint=self._JOINT_FABRIC_ADMINISTRATOR_ENDPOINT,
             cmd=Clusters.JointFabricAdministrator.Commands.AddICAC(invalid_dn_icac))
-        asserts.assert_true(
-            isinstance(resp, Clusters.JointFabricAdministrator.Commands.ICACResponse),
-            f"Unexpected response type: {type(resp)}",
-        )
-        asserts.assert_equal(
-            resp.statusCode,
+        self._assert_icac_response_status(
+            resp,
             Clusters.JointFabricAdministrator.Enums.ICACResponseStatusEnum.kInvalidICAC,
-            f"Expected InvalidICAC response status, but got {resp.statusCode}",
+            "Step 16",
         )
 
         self.step("17")
@@ -402,6 +400,17 @@ class TC_JFADMIN_1_2(MatterBaseTest):
                 expected_cluster_status,
                 f"Expected {expected_cluster_status} cluster status, but got {str(cm.exception)}",
             )
+
+    def _assert_icac_response_status(self, resp, expected_status, step_label):
+        asserts.assert_true(
+            isinstance(resp, Clusters.JointFabricAdministrator.Commands.ICACResponse),
+            f"{step_label}: Unexpected response type: {type(resp)}",
+        )
+        asserts.assert_equal(
+            resp.statusCode,
+            expected_status,
+            f"{step_label}: Expected ICACResponse status {expected_status}, but got {resp.statusCode}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary
The test script does not validate the ICACResponse in the TC_JFADMIN_1_2 test steps.

#### Related issues
https://github.com/project-chip/connectedhomeip/issues/71709

#### Testing
Test Instructions to execute TC_JFADMIN_1_2 Python Test

Build and Activate the Python Environment
```
./scripts/build_python.sh -i out/python_env

source out/python_env/bin/activate
```

Run the Test
Execute the TC_JFADMIN_1_2 Python test script with the required application paths:

```
python3 src/python_testing/TC_JFADMIN_1_2.py \
  --string-arg "jfa_server_app:/home/vijay/apps/jfa-app" \
  --string-arg "jfc_server_app:/home/vijay/apps/jfc-app"
```