### PR TITLE
Accept NullValue on StartUpColorTemperatureMireds on TC_CC_6_5 step 1

### DIFF
--- a/src/python_testing/TC_CC_6_5.py
+++ b/src/python_testing/TC_CC_6_5.py
@@ -39,6 +39,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
 from matter.testing import matter_asserts
 from matter.testing.decorators import has_attribute, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
@@ -138,11 +139,16 @@ class TC_CC_6_5(MatterBaseTest):
             cc_cluster, cc_attributes.StartUpColorTemperatureMireds, self.TH1, endpoint=self.endpoint)
         log.info(f"Extracted startup color temperature value: {startup_color_temp_mireds}")
 
-        matter_asserts.assert_valid_uint16(startup_color_temp_mireds, "Startup mireds value should be an integer")
-        asserts.assert_greater_equal(startup_color_temp_mireds, MIN_STARTUP_COLOR_TEMP,
-                                     f"Startup color temperature {startup_color_temp_mireds} should be >= {MIN_STARTUP_COLOR_TEMP}")
-        asserts.assert_less_equal(startup_color_temp_mireds, MAX_STARTUP_COLOR_TEMP,
-                                  f"Startup color temperature {startup_color_temp_mireds} should be <= {MAX_STARTUP_COLOR_TEMP}")
+        # Verify if StartUpColorTemperatureMireds is a int(16) or NullValue
+        asserts.assert_true(matter_asserts.is_valid_uint_value(startup_color_temp_mireds, 16) or startup_color_temp_mireds is NullValue,
+                            f"Value for StartUpColorTemperatureMireds is not Null or is out of range {MIN_STARTUP_COLOR_TEMP} and {MAX_STARTUP_COLOR_TEMP}")
+
+        # If is int check the range if not just avoid this check.
+        if matter_asserts.is_valid_uint_value(startup_color_temp_mireds, 16):
+            asserts.assert_greater_equal(startup_color_temp_mireds, MIN_STARTUP_COLOR_TEMP,
+                                         f"Startup color temperature {startup_color_temp_mireds} should be >= {MIN_STARTUP_COLOR_TEMP}")
+            asserts.assert_less_equal(startup_color_temp_mireds, MAX_STARTUP_COLOR_TEMP,
+                                      f"Startup color temperature {startup_color_temp_mireds} should be <= {MAX_STARTUP_COLOR_TEMP}")
 
         self.step("2a")
         if ((colortemp_physical_max_mireds - colortemp_physical_min_mireds) // 2 + colortemp_physical_min_mireds) == color_temp_mireds:


### PR DESCRIPTION
#### Summary

This is a fix for the Step 1 to accept Null as defined in the spec.


1 to 65279 | Set the ColorTemperatureMireds attribute to this value.
-- | --
null | Set the ColorTemperatureMireds attribute to its previous value

#### Related issues

Fix: https://github.com/project-chip/certification-tool/issues/964

#### Testing

To test this I peformed the following steps:

Build the app with NullValue using the zaptool.

`./scripts/tools/zap/run_zaptool.sh examples/lighting-app-data-mode-no-unique-id/lighting-common/lighting-app.zap`

<img width="1272" height="493" alt="Screenshot 2026-04-22 at 11 44 38 a m" src="https://github.com/user-attachments/assets/9026d762-4a8d-416b-8f41-83440c447b4c" />

Generate files:
`./scripts/tools/zap/generate.py `examples/lighting-app-data-mode-no-unique-id/lighting-common/lighting-app.zap`

Build the app with the updated value:

`./scripts/build/build_examples.py --target darwin-arm64-light-data-model-no-unique-id  build`

Run the test and check it passed, also verify the attribute StartUpColorTemperatureMireds is Null:

`python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_CC_6_5.py`

Confirm NullValue is set on StartUpColorTemperatureMireds

<img width="1674" height="191" alt="Screenshot 2026-04-22 at 12 19 59 p m" src="https://github.com/user-attachments/assets/68639685-6b7c-4968-999d-4a675e4d6b14" />
