### PR TITLE
NFC commissioning tests should check the commissioning method used

### DIFF
--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -94,7 +94,15 @@ class TC_DD_3_23(MatterBaseTest):
         self.step(2)
         payload = SetupPayload().ParseQrCode(nfc_tag_data)
         asserts.assert_true(payload.supports_nfc_commissioning, "Device does not Support NFC Commissioning")
-        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+
+        commissioning_method = self.matter_test_config.in_test_commissioning_method
+        asserts.assert_is_not_none(commissioning_method, "in_test_commissioning_method must not be None")
+        asserts.assert_true(
+            str(commissioning_method).startswith("nfc-"),
+            f"Expected in_test_commissioning_method to start with 'nfc-', got: {commissioning_method}"
+        )
+
+        self.matter_test_config.commissioning_method = commissioning_method
         commissioning_success = await self.commission_devices()
         asserts.assert_true(commissioning_success, "Device Commissioning using nfc transport has failed")
 

--- a/src/python_testing/TC_DD_3_24.py
+++ b/src/python_testing/TC_DD_3_24.py
@@ -95,7 +95,15 @@ class TC_DD_3_24(MatterBaseTest):
         self.step(2)
         payload = SetupPayload().ParseQrCode(nfc_tag_data)
         asserts.assert_true(payload.supports_nfc_commissioning, "Device does not Support NFC Commissioning")
-        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+
+        commissioning_method = self.matter_test_config.in_test_commissioning_method
+        asserts.assert_is_not_none(commissioning_method, "in_test_commissioning_method must not be None")
+        asserts.assert_true(
+            str(commissioning_method).startswith("nfc-"),
+            f"Expected in_test_commissioning_method to start with 'nfc-', got: {commissioning_method}"
+        )
+
+        self.matter_test_config.commissioning_method = commissioning_method        
 
         log.info("default_controller in test: %s (id=%s)",
                  getattr(self, "default_controller", None),

--- a/src/python_testing/TC_DD_3_24.py
+++ b/src/python_testing/TC_DD_3_24.py
@@ -103,7 +103,7 @@ class TC_DD_3_24(MatterBaseTest):
             f"Expected in_test_commissioning_method to start with 'nfc-', got: {commissioning_method}"
         )
 
-        self.matter_test_config.commissioning_method = commissioning_method        
+        self.matter_test_config.commissioning_method = commissioning_method
 
         log.info("default_controller in test: %s (id=%s)",
                  getattr(self, "default_controller", None),


### PR DESCRIPTION
#### Summary

This PR is fixing a small problem seen during SVE: The tester chose the wrong project config so he executed the test with BLE instead of NFC and the test was successful because a BLE commissioning was successfully done. This is not expected!
Added an assert to raise an error if the commissioning method is not NFC.

#### Testing

Tested that the test fails with an explicit error :)
