### PR TITLE
[all devices] Enable scenes support/handling for on-off and dimmable light

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/dimmable-light/DimmableLightDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/dimmable-light/DimmableLightDevice.cpp
@@ -29,9 +29,9 @@ DimmableLightDevice::DimmableLightDevice(Clusters::OnOffDelegate & onOffDelegate
                                          Clusters::LevelControlDelegate & levelControlDelegate,
                                          Clusters::OnOffEffectDelegate & effectDelegate,
                                          Clusters::IdentifyDelegate & identifyDelegate, const Context & context) :
-    SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDimmableLight, 1)),
-    mOnOffDelegate(onOffDelegate), mLevelControlDelegate(levelControlDelegate), mEffectDelegate(effectDelegate),
-    mIdentifyDelegate(identifyDelegate), mContext(context)
+    SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDimmableLight, 1)), mOnOffDelegate(onOffDelegate),
+    mLevelControlDelegate(levelControlDelegate), mEffectDelegate(effectDelegate), mIdentifyDelegate(identifyDelegate),
+    mContext(context)
 {}
 
 CHIP_ERROR DimmableLightDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointId parentId)
@@ -76,6 +76,14 @@ CHIP_ERROR DimmableLightDevice::Register(chip::EndpointId endpoint, CodeDrivenDa
                           });
     ReturnErrorOnFailure(provider.AddCluster(mGroupsCluster.Registration()));
 
+    // We have scenes enabled, so make sure handlers are registered so we can
+    // save and recall scenes.
+    {
+        Clusters::ScopedSceneTable table(mScenesTableProvider);
+        table->RegisterHandler(&mOnOffCluster.Cluster());
+        table->RegisterHandler(&mLevelControlCluster.Cluster());
+    }
+
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
@@ -91,6 +99,11 @@ void DimmableLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 
     if (mLevelControlCluster.IsConstructed())
     {
+        if (static_cast<scenes::DefaultSceneHandlerImpl &>(mLevelControlCluster.Cluster()).IsInList())
+        {
+            Clusters::ScopedSceneTable table(mScenesTableProvider);
+            table->UnregisterHandler(&mLevelControlCluster.Cluster());
+        }
         if (mOnOffCluster.IsConstructed())
         {
             mOnOffCluster.Cluster().RemoveDelegate(&mLevelControlCluster.Cluster());
@@ -101,6 +114,12 @@ void DimmableLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 
     if (mOnOffCluster.IsConstructed())
     {
+        if (mOnOffCluster.Cluster().IsInList())
+        {
+            Clusters::ScopedSceneTable table(mScenesTableProvider);
+            table->UnregisterHandler(&mOnOffCluster.Cluster());
+        }
+
         mOnOffCluster.Cluster().RemoveDelegate(&mOnOffDelegate);
         LogErrorOnFailure(provider.RemoveCluster(&mOnOffCluster.Cluster()));
         mOnOffCluster.Destroy();

--- a/examples/all-devices-app/all-devices-common/devices/dimmable-light/DimmableLightDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/dimmable-light/DimmableLightDevice.cpp
@@ -29,9 +29,9 @@ DimmableLightDevice::DimmableLightDevice(Clusters::OnOffDelegate & onOffDelegate
                                          Clusters::LevelControlDelegate & levelControlDelegate,
                                          Clusters::OnOffEffectDelegate & effectDelegate,
                                          Clusters::IdentifyDelegate & identifyDelegate, const Context & context) :
-    SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDimmableLight, 1)), mOnOffDelegate(onOffDelegate),
-    mLevelControlDelegate(levelControlDelegate), mEffectDelegate(effectDelegate), mIdentifyDelegate(identifyDelegate),
-    mContext(context)
+    SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDimmableLight, 1)),
+    mOnOffDelegate(onOffDelegate), mLevelControlDelegate(levelControlDelegate), mEffectDelegate(effectDelegate),
+    mIdentifyDelegate(identifyDelegate), mContext(context)
 {}
 
 CHIP_ERROR DimmableLightDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointId parentId)

--- a/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
@@ -167,12 +167,24 @@ CHIP_ERROR LoggingOnOffLightDevice::Register(chip::EndpointId endpoint, CodeDriv
                           });
     ReturnErrorOnFailure(provider.AddCluster(mGroupsCluster.Registration()));
 
+    // We have scenes enabled, so make sure handlers are registered so we can
+    // save and recall scenes.
+    {
+        Clusters::ScopedSceneTable table(mScenesTableProvider);
+        table->RegisterHandler(&mOnOffCluster.Cluster());
+    }
+
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
 void LoggingOnOffLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
+
+    {
+        Clusters::ScopedSceneTable table(mScenesTableProvider);
+        table->UnregisterHandler(&mOnOffCluster.Cluster());
+    }
 
     if (mGroupsCluster.IsConstructed())
     {

--- a/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
@@ -181,11 +181,6 @@ void LoggingOnOffLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
 
-    {
-        Clusters::ScopedSceneTable table(mScenesTableProvider);
-        table->UnregisterHandler(&mOnOffCluster.Cluster());
-    }
-
     if (mGroupsCluster.IsConstructed())
     {
         LogErrorOnFailure(provider.RemoveCluster(&mGroupsCluster.Cluster()));
@@ -194,6 +189,12 @@ void LoggingOnOffLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 
     if (mOnOffCluster.IsConstructed())
     {
+        if (mOnOffCluster.Cluster().IsInList())
+        {
+            Clusters::ScopedSceneTable table(mScenesTableProvider);
+            table->UnregisterHandler(&mOnOffCluster.Cluster());
+        }
+
         LogErrorOnFailure(provider.RemoveCluster(&mOnOffCluster.Cluster()));
         mOnOffCluster.Cluster().RemoveDelegate(&mOnOffDelegate);
         mOnOffCluster.Destroy();

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
@@ -66,28 +66,6 @@ constexpr Protocols::InteractionModel::Status ResponseStatus(CHIP_ERROR err)
     return StatusIB(err).mStatus;
 }
 
-/// RAII for a scenes management table provider:
-///    - does a `Take()` on a scene at creation
-///    - ensures `Release()` is called on destruction
-class ScopedSceneTable
-{
-public:
-    ScopedSceneTable(const ScopedSceneTable &)             = delete;
-    ScopedSceneTable & operator=(const ScopedSceneTable &) = delete;
-
-    ScopedSceneTable(ScenesManagementTableProvider & provider) : mProvider(provider), mTable(provider.Take()) {}
-    ~ScopedSceneTable() { mProvider.Release(mTable); }
-
-    SceneTable * operator->() { return mTable; }
-    const SceneTable * operator->() const { return mTable; }
-
-    operator bool() const { return mTable != nullptr; }
-
-private:
-    ScenesManagementTableProvider & mProvider;
-    SceneTable * mTable;
-};
-
 /// A very common pattern of:
 ///   - if error (i.e. NOT CHIP_NO_ERROR), then set response status and return response
 #define SuccessOrReturnWithFailureStatus(err_expr, response)                                                                       \

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -45,6 +45,41 @@ public:
     virtual void Release(ScenesManagementSceneTable *) = 0;
 };
 
+/// RAII for a scenes management table provider:
+///    - does a `Take()` on a scene at creation
+///    - ensures `Release()` is called on destruction
+///
+/// Use this for operating on scenes tables provided by a scene management table provider.
+/// For example to register a cluster for scene processing:
+///
+///    ScopedSceneTable  table(sceneTableProvider);
+///    table->RegisterHandler(&cluster)
+///
+/// And to unregister:
+///
+///    ScopedSceneTable  table(sceneTableProvider);
+///    table->UnregisterHandler(&cluster)
+///
+class ScopedSceneTable
+{
+public:
+    ScopedSceneTable(const ScopedSceneTable &)             = delete;
+    ScopedSceneTable & operator=(const ScopedSceneTable &) = delete;
+
+    ScopedSceneTable(ScenesManagementTableProvider & provider) : mProvider(provider), mTable(provider.Take()) {}
+    ~ScopedSceneTable() { mProvider.Release(mTable); }
+
+    ScenesManagementSceneTable * operator->() { return mTable; }
+    const ScenesManagementSceneTable * operator->() const { return mTable; }
+
+    operator bool() const { return mTable != nullptr; }
+
+private:
+    ScenesManagementTableProvider & mProvider;
+    ScenesManagementSceneTable * mTable;
+};
+
+
 class ScenesManagementCluster : public DefaultServerCluster, public FabricTable::Delegate, public scenes::ScenesIntegrationDelegate
 {
 public:

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -79,7 +79,6 @@ private:
     ScenesManagementSceneTable * mTable;
 };
 
-
 class ScenesManagementCluster : public DefaultServerCluster, public FabricTable::Delegate, public scenes::ScenesIntegrationDelegate
 {
 public:

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -70,7 +70,7 @@ public:
 
     explicit ScopedSceneTable(ScenesManagementTableProvider & provider) : mProvider(provider), mTable(provider.Take())
     {
-        /// Users of this class DO NOT expect the sene provider to fail. This is generally the case
+        /// Users of this class DO NOT expect the scene provider to fail. This is generally the case
         /// as existing implementations re-use a global static scene object.
         VerifyOrDie(mTable != nullptr);
     }

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -46,7 +46,7 @@ public:
 };
 
 /// RAII for a scenes management table provider:
-///    - does a `Take()` on a scene at creation
+///    - does a `Take()` to get a ScenesManagementSceneTable at creation
 ///    - ensures `Release()` is called on destruction
 ///
 /// Use this for operating on scenes tables provided by a scene management table provider.

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -50,6 +50,8 @@ public:
 ///    - ensures `Release()` is called on destruction
 ///
 /// Use this for operating on scenes tables provided by a scene management table provider.
+/// This objects asserts that scene provider `Take` does NOT fail with nullptr.
+///
 /// For example to register a cluster for scene processing:
 ///
 ///    ScopedSceneTable  table(sceneTableProvider);
@@ -66,7 +68,12 @@ public:
     ScopedSceneTable(const ScopedSceneTable &)             = delete;
     ScopedSceneTable & operator=(const ScopedSceneTable &) = delete;
 
-    ScopedSceneTable(ScenesManagementTableProvider & provider) : mProvider(provider), mTable(provider.Take()) {}
+    explicit ScopedSceneTable(ScenesManagementTableProvider & provider) : mProvider(provider), mTable(provider.Take())
+    {
+        /// Users of this class DO NOT expect the sene provider to fail. This is generally the case
+        /// as existing implementations re-use a global static scene object.
+        VerifyOrDie(mTable != nullptr);
+    }
     ~ScopedSceneTable() { mProvider.Release(mTable); }
 
     ScenesManagementSceneTable * operator->() { return mTable; }

--- a/src/python_testing/TC_OO_2_7.py
+++ b/src/python_testing/TC_OO_2_7.py
@@ -34,6 +34,20 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run2:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device on-off-light:1 --discriminator 1234 --KVS kvs1
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio


### PR DESCRIPTION
#### Summary

On/Off cluster needs explicit scenes association in all-devices (because code driven).

#### Testing

Manual run:

```
bash -c 'source out/pyenv/bin/activate && python3 src/python_testing/TC_OO_2_7.py --commissioning-method on-network --discriminator 1234 --passcode 20202021 --endpoint 1'
```

enabled this in TC_OO_2_7 in CI