### PR TITLE
[CI Fix] use the correct stdbuf in CI darwin tests

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -66,8 +66,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Environment
-        # coreutils for stdbuf
-        run: brew install coreutils
+        # coreutils for stdbuf; gnubin is needed because newer coreutils only exposes 'stdbuf' under libexec/gnubin
+        run: |
+          brew install coreutils
+          echo "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
       - name: Try to ensure the directories for core dumping and diagnostic
           log collection exist and we can write them.
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -636,8 +636,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
             - name: Setup Environment
-              # coreutils for stdbuf
-              run: brew install coreutils
+              # coreutils for stdbuf; gnubin is needed because newer coreutils only exposes 'stdbuf' under libexec/gnubin
+              run: |
+                brew install coreutils
+                echo "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
             - name: Install ccache
               run: |
                 brew install ccache
@@ -1362,8 +1364,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
             - name: Setup Environment
-              # coreutils for stdbuf
-              run: brew install coreutils
+              # coreutils for stdbuf; gnubin is needed because newer coreutils only exposes 'stdbuf' under libexec/gnubin
+              run: |
+                brew install coreutils
+                echo "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
             - name: Try to ensure the directories for core dumping and diagnostic
                   log collection exist and we can write them.
               run: |

--- a/scripts/tests/chiptest/darwin.py
+++ b/scripts/tests/chiptest/darwin.py
@@ -12,18 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
 from typing import IO, Any
 
 from .runner import Executor, LogPipe, SubprocessInfo
-
-# Older Homebrew coreutils installed 'stdbuf' directly on $PATH; newer versions only expose it as 'gstdbuf',
-# with the unprefixed name installed only in libexec/gnubin (not on $PATH by default). Use whichever is available.
-_STDBUF = shutil.which('stdbuf') or shutil.which('gstdbuf')
 
 
 class DarwinExecutor(Executor):
     def run(self, subproc: SubprocessInfo, stdin: IO[Any] | None = None, stdout: IO[Any] | LogPipe | None = None, stderr: IO[Any] | LogPipe | None = None):
         # Try harder to avoid any stdout buffering in our tests
-        wrapped = subproc.wrap_with(_STDBUF, '-o0', '-i0') if _STDBUF else subproc
+        wrapped = subproc.wrap_with('stdbuf', '-o0', '-i0')
         return super().run(wrapped, stdin, stdout, stderr)

--- a/scripts/tests/chiptest/darwin.py
+++ b/scripts/tests/chiptest/darwin.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 from typing import IO, Any
 
 from .runner import Executor, LogPipe, SubprocessInfo
+
+# Older Homebrew coreutils installed 'stdbuf' directly on $PATH; newer versions only expose it as 'gstdbuf',
+# with the unprefixed name installed only in libexec/gnubin (not on $PATH by default). Use whichever is available.
+_STDBUF = shutil.which('stdbuf') or shutil.which('gstdbuf')
 
 
 class DarwinExecutor(Executor):
     def run(self, subproc: SubprocessInfo, stdin: IO[Any] | None = None, stdout: IO[Any] | LogPipe | None = None, stderr: IO[Any] | LogPipe | None = None):
         # Try harder to avoid any stdout buffering in our tests
-        wrapped = subproc.wrap_with('stdbuf', '-o0', '-i0')
+        wrapped = subproc.wrap_with(_STDBUF, '-o0', '-i0') if _STDBUF else subproc
         return super().run(wrapped, stdin, stdout, stderr)


### PR DESCRIPTION
#### Summary

- Darwin CI started failing with `FileNotFoundError: [Errno 2] No such file or directory: 'stdbuf'` after the `macos-26-arm64` runner image was updated yesterday.
- inside it Homebrew coreutils was bumped from 9.10 to 9.11; and apparently it now enforces that everything is prefixed with a `g`
- Fix: add gnubin to path as recommended by homebrew
<img width="1036" height="251" alt="image" src="https://github.com/user-attachments/assets/d1d5e8ab-0ac9-4d72-9d7e-c4842b668856" />






#### Testing
 - CI will test this