### PR TITLE
[SILABS] Add force transmit of log during Init phase

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -93,6 +93,10 @@ static chip::DeviceLayer::Internal::Efr32PsaOperationalKeystore gOperationalKeys
 #include <performance_test_commands.h>
 #endif
 
+#if SILABS_LOG_OUT_UART
+#include "uart.h"
+#endif // SILABS_LOG_OUT_UART
+
 #include <AppTask.h>
 
 #include <DeviceInfoProviderImpl.h>
@@ -210,6 +214,9 @@ void ApplicationStart(void * unused)
         appError(err);
 
     VerifyOrDie(osThreadTerminate(sMainTaskHandle) == osOK); // Deleting the main task should never fail.
+#if SILABS_LOG_OUT_UART
+    sendLogImmediately(false);
+#endif // SILABS_LOG_OUT_UART
     sMainTaskHandle = nullptr;
 }
 } // namespace

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -213,10 +213,10 @@ void ApplicationStart(void * unused)
     if (err != CHIP_NO_ERROR)
         appError(err);
 
-    VerifyOrDie(osThreadTerminate(sMainTaskHandle) == osOK); // Deleting the main task should never fail.
 #if SILABS_LOG_OUT_UART
     sendLogImmediately(false);
-#endif // SILABS_LOG_OUT_UART
+#endif                                                       // SILABS_LOG_OUT_UART
+    VerifyOrDie(osThreadTerminate(sMainTaskHandle) == osOK); // Deleting the main task should never fail.
     sMainTaskHandle = nullptr;
 }
 } // namespace

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -210,6 +210,18 @@ constexpr osMessageQueueAttr_t kUartTxQueueAttr = { .cb_mem  = &sUartTxQueueStru
 static uint8_t sRxFifoBuffer[MAX_BUFFER_SIZE];
 static Fifo_t sReceiveFifo;
 
+// Force transmit logs by default during the Init sequence
+static bool sSendLogImmediately = true;
+
+void sendLogImmediately(bool force)
+{
+    taskENTER_CRITICAL();
+    sSendLogImmediately = force;
+    taskEXIT_CRITICAL();
+}
+
+static int16_t formatAndSendLog(UartTxStruct_t & logStruct, bool forceTransmit);
+
 #if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 0
 static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t * data, UARTDRV_Count_t transferCount);
 #endif // SLI_SI91X_MCU_INTERFACE == 0
@@ -528,6 +540,11 @@ int16_t uartLogWrite(const char * log, uint8_t length, uint8_t category, uint64_
     workBuffer.category  = SilabsCoreLogs::LogCategory(category);
     workBuffer.timestamp = timestamp;
 
+    if (sSendLogImmediately)
+    {
+        return formatAndSendLog(workBuffer, true);
+    }
+
     // Don't wait when queue is full. Drop the log and return UART_CONSOLE_ERR
     if (osMessageQueuePut(sUartTxQueue, &workBuffer, osPriorityNormal, 0) == osOK)
     {
@@ -573,16 +590,41 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
     return (int16_t) RetrieveFromFifo(&sReceiveFifo, (uint8_t *) Buf, NbBytesToRead);
 }
 
-void uartMainLoop(void * args)
+static int16_t formatAndSendLog(UartTxStruct_t & logStruct, bool forceTransmit)
 {
-    UartTxStruct_t workBuffer;
 #if defined(SILABS_LOG_ENABLED) && SILABS_LOG_ENABLED
     uint8_t timeStampString[SilabsCoreLogs::kTimeStampStringSize];
     uint8_t logWorkBuffer[kHeaderSize + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen +
                           UART_TX_MAX_BUF_LEN + kEndOfLineSize +
                           kFooterSize]; // Header + Timestamp + Category + Data + \r\n + Footer
-#endif                                  // SILABS_LOG_ENABLED
+    SilabsCoreLogs::FormatTimestamp(reinterpret_cast<char *>(timeStampString), sizeof(timeStampString), logStruct.timestamp);
+    int32_t len =
+        snprintf(reinterpret_cast<char *>(logWorkBuffer), sizeof(logWorkBuffer), "%c%s%s%.*s\r\n%c", kLogHeader, timeStampString,
+                 SilabsCoreLogs::GetCategoryString(logStruct.category), logStruct.length, logStruct.data, kLogFooter);
+    if (len > 0)
+    {
+        if (forceTransmit)
+        {
+#if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE
+            Board_UARTPutSTR(logWorkBuffer);
+#else
+            UARTDRV_ForceTransmit(vcom_handle, logWorkBuffer, static_cast<uint16_t>(len));
+#endif
+        }
+        else
+        {
+            uartSendBytes(logWorkBuffer, static_cast<uint16_t>(len));
+        }
+    }
+    return static_cast<int16_t>(len);
+#else
+    return 0;
+#endif // SILABS_LOG_ENABLED
+}
 
+void uartMainLoop(void * args)
+{
+    UartTxStruct_t workBuffer;
     while (1)
     {
         osStatus_t eventReceived = osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, osWaitForever);
@@ -591,15 +633,7 @@ void uartMainLoop(void * args)
             if (workBuffer.isLog)
             {
 #if defined(SILABS_LOG_ENABLED) && SILABS_LOG_ENABLED
-                SilabsCoreLogs::FormatTimestamp(reinterpret_cast<char *>(timeStampString), sizeof(timeStampString),
-                                                workBuffer.timestamp);
-                int32_t len = snprintf(reinterpret_cast<char *>(logWorkBuffer), sizeof(logWorkBuffer), "%c%s%s%.*s\r\n%c",
-                                       kLogHeader, timeStampString, SilabsCoreLogs::GetCategoryString(workBuffer.category),
-                                       workBuffer.length, workBuffer.data, kLogFooter);
-                if (len > 0)
-                {
-                    uartSendBytes(logWorkBuffer, static_cast<uint16_t>(len));
-                }
+                formatAndSendLog(workBuffer, false);
 #endif // SILABS_LOG_ENABLED
             }
             else

--- a/examples/platform/silabs/uart.h
+++ b/examples/platform/silabs/uart.h
@@ -39,6 +39,8 @@ void uartForceTransmit(const char * data, uint16_t length);
 
 void uartMainLoop(void * args);
 
+void sendLogImmediately(bool sendNow);
+
 // Implemented by in openthread code
 #ifndef PW_RPC_ENABLED
 extern void otPlatUartReceived(const uint8_t * aBuf, uint16_t aBufLength);


### PR DESCRIPTION
#### Summary
Check if we are still in the Init task, if so push the log directly to prevent filling up the queue as the UART task don't have a priority higher than the Init task.

#### Related issues
None, but prevent loosing logs during the init sequence

#### Testing
Tested with a MG24

#### Readability checklist


