### PR TITLE
[all-devices-app] Support parent/child endpoint relationships via command line

### DIFF
--- a/examples/BUILD.gn
+++ b/examples/BUILD.gn
@@ -29,6 +29,7 @@ if (chip_build_tests) {
     if (chip_device_platform == "linux" && current_os == "linux") {
       tests += [ "${chip_root}/examples/evse-app/evse-common/tests" ]
     }
+    tests += [ "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests" ]
 
     # TV Casting app tests (platform-independent)
     tests +=

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -94,9 +94,12 @@ Build the application using the following command:
 
 ## Running the Application
 
-To run the application, specify the device type using the `--device` flag. The format is `type:endpoint[:parent]`, where the optional `parent` field allows establishing parent/child endpoint relationships for logical grouping.
+To run the application, specify the device type using the `--device` flag. The
+format is `type:endpoint[:parent]`, where the optional `parent` field allows
+establishing parent/child endpoint relationships for logical grouping.
 
-The application supports running multiple devices simultaneously by specifying the flag multiple times.
+The application supports running multiple devices simultaneously by specifying
+the flag multiple times.
 
 ```bash
 # Clean up KVS storage if needed

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -94,16 +94,16 @@ Build the application using the following command:
 
 ## Running the Application
 
-To run the application, specify the device type using the `--device` flag. The
-application supports running multiple devices simultaneously by specifying the
-flag multiple times.
+To run the application, specify the device type using the `--device` flag. The format is `type:endpoint[:parent]`, where the optional `parent` field allows establishing parent/child endpoint relationships for logical grouping.
+
+The application supports running multiple devices simultaneously by specifying the flag multiple times.
 
 ```bash
 # Clean up KVS storage if needed
 rm -rf /tmp/chip_*
 
-# Run a chime on endpoint 1 and a speaker on endpoint 2
-./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2
+# Run a chime on endpoint 1, a speaker on endpoint 2 (child of endpoint 1), and a dimmable light on endpoint 3
+./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2:1 --device dimmable-light:3
 ```
 
 ## Testing with chip-tool

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -92,8 +92,9 @@ Build the application using the following command:
 ## Running the Application
 
 To run the application, specify the device type using the `--device` flag. The
-format is `type:endpoint` or `type:endpoint,parent=parentId`, where the optional `parent` option allows
-establishing parent/child endpoint relationships for logical grouping.
+format is `type:endpoint` or `type:endpoint,parent=parentId`, where the optional
+`parent` option allows establishing parent/child endpoint relationships for
+logical grouping.
 
 The application supports running multiple devices simultaneously by specifying
 the flag multiple times.

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -67,12 +67,9 @@ Usage: ./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app
 PROGRAM OPTIONS
 
   --device <chime|contact-sensor|dimmable-light|occupancy-sensor|on-off-light|soil-sensor|speaker|water-leak-detector>
-       Select the device to start up. Format: 'type' or 'type:endpoint'
+       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'
        Can be specified multiple times for multi-endpoint devices.
-       Example: --device chime:1 --device speaker:2
-
-  --endpoint <endpoint-number>
-       Define the endpoint for the preceding device (default 1)
+       Example: --device chime:1 --device speaker:2,parent=1
 
   --wifi
        Enable wifi support for commissioning
@@ -95,7 +92,7 @@ Build the application using the following command:
 ## Running the Application
 
 To run the application, specify the device type using the `--device` flag. The
-format is `type:endpoint[:parent]`, where the optional `parent` field allows
+format is `type:endpoint` or `type:endpoint,parent=parentId`, where the optional `parent` option allows
 establishing parent/child endpoint relationships for logical grouping.
 
 The application supports running multiple devices simultaneously by specifying
@@ -106,7 +103,7 @@ the flag multiple times.
 rm -rf /tmp/chip_*
 
 # Run a chime on endpoint 1, a speaker on endpoint 2 (child of endpoint 1), and a dimmable light on endpoint 3
-./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2:1 --device dimmable-light:3
+./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2,parent=1 --device dimmable-light:3
 ```
 
 ## Testing with chip-tool

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
@@ -26,9 +26,7 @@ source_set("device-type-parser") {
     "DeviceTypeParser.h",
   ]
 
-  public_deps = [
-    "${chip_root}/src/lib",
-  ]
+  public_deps = [ "${chip_root}/src/lib" ]
 
   public_configs = [
     "${chip_root}/src:includes",

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
@@ -34,20 +34,4 @@ source_set("device-type-parser") {
   ]
 }
 
-if (chip_build_tests) {
-  import("${chip_root}/build/chip/chip_test_suite.gni")
 
-  chip_test_suite("tests") {
-    output_name = "TestDeviceTypeParser"
-
-    test_sources = [ "TestDeviceTypeParser.cpp" ]
-
-    cflags = [ "-Wconversion" ]
-
-    public_deps = [
-      ":device-type-parser",
-      "${chip_root}/src/lib/support:testing",
-      "${chip_root}/src/platform",
-    ]
-  }
-}

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,29 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-config("option-includes") {
-  include_dirs = [ ".." ]
+import("${chip_root}/build/chip/tests.gni")
+
+config("device-type-parser-includes") {
+  include_dirs = [ "../.." ]
 }
 
-source_set("app-options") {
+source_set("device-type-parser") {
   sources = [
-    "AppOptions.cpp",
-    "AppOptions.h",
+    "DeviceTypeParser.cpp",
+    "DeviceTypeParser.h",
   ]
 
   public_deps = [
-    "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-type-parser",
-    "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-factory",
-    "${chip_root}/examples/common/tracing:commandline",
-    "${chip_root}/examples/platform/linux:app-options",
     "${chip_root}/src/lib",
   ]
 
   public_configs = [
     "${chip_root}/src:includes",
-    ":option-includes",
+    ":device-type-parser-includes",
   ]
+}
+
+if (chip_build_tests) {
+  import("${chip_root}/build/chip/chip_test_suite.gni")
+
+  chip_test_suite("tests") {
+    output_name = "TestDeviceTypeParser"
+
+    test_sources = [ "TestDeviceTypeParser.cpp" ]
+
+    cflags = [ "-Wconversion" ]
+
+    public_deps = [
+      ":device-type-parser",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform",
+    ]
+  }
 }

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/BUILD.gn
@@ -33,5 +33,3 @@ source_set("device-type-parser") {
     ":device-type-parser-includes",
   ]
 }
-
-

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -83,9 +83,9 @@ bool DeviceTypeParser::ParseDeviceTypeEntry(const char * value, Entry & entry)
     // Parse options: "parent=parentId"
     if (comma != nullptr)
     {
-        const char * optionsStr = comma + 1;
+        const char * optionsStr   = comma + 1;
         const char * parentPrefix = "parent=";
-        const char * parentPtr = strstr(optionsStr, parentPrefix);
+        const char * parentPtr    = strstr(optionsStr, parentPrefix);
         if (parentPtr != nullptr)
         {
             const char * parentValStr = parentPtr + strlen(parentPrefix);

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -1,0 +1,123 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceTypeParser.h"
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <cstdlib>
+#include <cstring>
+
+bool DeviceTypeParser::ParseEndpointId(const char * str, chip::EndpointId & endpoint)
+{
+    char * endptr;
+    long val = strtol(str, &endptr, 10);
+
+    if (endptr == str || *endptr != '\0' || val < 0 || val > UINT16_MAX)
+    {
+        return false;
+    }
+
+    endpoint = static_cast<chip::EndpointId>(val);
+    return true;
+}
+
+bool DeviceTypeParser::ParseDeviceTypeEntry(const char * value, Entry & entry)
+{
+    VerifyOrReturnValue(value != nullptr, false);
+
+    // Set default values for optional fields
+    entry.endpoint = 1;
+    entry.parentId = chip::kInvalidEndpointId;
+
+    // Find the comma to separate main config from options
+    const char * comma = strchr(value, ',');
+
+    std::string mainConfig;
+    if (comma != nullptr)
+    {
+        mainConfig.assign(value, static_cast<size_t>(comma - value));
+    }
+    else
+    {
+        mainConfig = value;
+    }
+
+    // Parse main config: "type" or "type:endpoint"
+    const char * colon = strchr(mainConfig.c_str(), ':');
+    if (colon == nullptr)
+    {
+        entry.type = mainConfig;
+    }
+    else
+    {
+        entry.type.assign(mainConfig.c_str(), static_cast<size_t>(colon - mainConfig.c_str()));
+        if (!ParseEndpointId(colon + 1, entry.endpoint))
+        {
+            ChipLogError(Support, "Invalid endpoint ID in device config: %s\n", value);
+            return false;
+        }
+    }
+
+    if (entry.type.empty())
+    {
+        ChipLogError(Support, "Invalid empty device type in config: %s\n", value);
+        return false;
+    }
+
+    // Parse options: "parent=parentId"
+    if (comma != nullptr)
+    {
+        const char * optionsStr = comma + 1;
+        const char * parentPrefix = "parent=";
+        const char * parentPtr = strstr(optionsStr, parentPrefix);
+        if (parentPtr != nullptr)
+        {
+            const char * parentValStr = parentPtr + strlen(parentPrefix);
+            if (!ParseEndpointId(parentValStr, entry.parentId))
+            {
+                ChipLogError(Support, "Invalid parent endpoint ID in device config: %s\n", value);
+                return false;
+            }
+        }
+        else
+        {
+            ChipLogError(Support, "Unknown option in device config: %s\n", value);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+CHIP_ERROR DeviceTypeParser::ParseSingleDeviceString(const char * value)
+{
+    Entry entry;
+    if (!ParseDeviceTypeEntry(value, entry))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mDeviceConfigs.push_back(std::move(entry));
+    return CHIP_NO_ERROR;
+}
+
+const std::vector<DeviceTypeParser::Entry> & DeviceTypeParser::GetDeviceTypeEntries()
+{
+    return mDeviceConfigs;
+}

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
@@ -33,11 +33,11 @@ public:
         chip::EndpointId parentId = chip::kInvalidEndpointId;
     };
 
-    DeviceTypeParser() = default;
+    DeviceTypeParser()  = default;
     ~DeviceTypeParser() = default;
-    
+
     // Disable copy and assignment to be safe, though not strictly necessary if only one instance is used.
-    DeviceTypeParser(const DeviceTypeParser &) = delete;
+    DeviceTypeParser(const DeviceTypeParser &)             = delete;
     DeviceTypeParser & operator=(const DeviceTypeParser &) = delete;
 
     /**

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
+#include <string>
+#include <vector>
+
+class DeviceTypeParser
+{
+public:
+    struct Entry
+    {
+        std::string type;
+        chip::EndpointId endpoint;
+        chip::EndpointId parentId = chip::kInvalidEndpointId;
+    };
+
+    DeviceTypeParser() = default;
+    ~DeviceTypeParser() = default;
+    
+    // Disable copy and assignment to be safe, though not strictly necessary if only one instance is used.
+    DeviceTypeParser(const DeviceTypeParser &) = delete;
+    DeviceTypeParser & operator=(const DeviceTypeParser &) = delete;
+
+    /**
+     * Parses a device configuration string in the format "type" or "type:endpoint" or "type:endpoint,parent=parentId"
+     * and adds it to the list of device configs.
+     *
+     * @param value The string to parse.
+     * @return CHIP_NO_ERROR on success, or a CHIP_ERROR on failure.
+     */
+    CHIP_ERROR ParseSingleDeviceString(const char * value);
+
+    /**
+     * Gets the list of parsed device configurations.
+     * If no devices were parsed, returns a default list (e.g. contact-sensor on endpoint 1).
+     */
+    const std::vector<Entry> & GetDeviceTypeEntries();
+
+    /**
+     * Clears the list of parsed device configurations.
+     */
+    void Clear() { mDeviceConfigs.clear(); }
+
+private:
+    bool ParseDeviceTypeEntry(const char * value, Entry & entry);
+    static bool ParseEndpointId(const char * str, chip::EndpointId & endpoint);
+
+    std::vector<Entry> mDeviceConfigs;
+};

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/BUILD.gn
@@ -14,8 +14,8 @@
 
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/tests.gni")
 
 if (chip_build_tests) {
   chip_test_suite("tests") {

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("${chip_root}/config/recommended.gni")
-import("${chip_root}/src/platform/device.gni")
-import("${chip_root}/src/system/system.gni")
 
-declare_args() {
-  # Build controller (set to false for a device)
-  chip_support_commissioning_in_controller = true
+import("${chip_root}/build/chip/tests.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
 
-  # Build controller with webrtc python bindings
-  chip_support_webrtc_python_bindings = false
-}
+if (chip_build_tests) {
+  chip_test_suite("tests") {
+    output_name = "TestDeviceTypeParser"
 
-declare_args() {
-  # Disable Thread MeshCoP if cross-compiling because of missing libevent.
-  chip_support_thread_meshcop = false
+    test_sources = [ "TestDeviceTypeParser.cpp" ]
+
+    cflags = [ "-Wconversion" ]
+
+    public_deps = [
+      "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-type-parser",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform",
+    ]
+  }
 }

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -86,15 +86,13 @@ TEST_F(TestDeviceTypeParser, AccumulateDevices)
 {
     EXPECT_EQ(mParser.ParseSingleDeviceString("chime:1"), CHIP_NO_ERROR);
     EXPECT_EQ(mParser.ParseSingleDeviceString("speaker:2,parent=1"), CHIP_NO_ERROR);
-    
+
     const auto & configs = mParser.GetDeviceTypeEntries();
     EXPECT_EQ(configs.size(), 2U);
     EXPECT_EQ(configs[0].type, "chime");
     EXPECT_EQ(configs[0].endpoint, 1);
-    
+
     EXPECT_EQ(configs[1].type, "speaker");
     EXPECT_EQ(configs[1].endpoint, 2);
     EXPECT_EQ(configs[1].parentId, 1);
 }
-
-

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -1,0 +1,100 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <devices/device-type-parser/DeviceTypeParser.h>
+#include <pw_unit_test/framework.h>
+
+using namespace chip;
+
+class TestDeviceTypeParser : public ::testing::Test
+{
+protected:
+    DeviceTypeParser mParser;
+};
+
+TEST_F(TestDeviceTypeParser, Parse_ValidTypeOnly)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("chime"), CHIP_NO_ERROR);
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 1U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    EXPECT_EQ(configs[0].parentId, kInvalidEndpointId);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_ValidTypeAndEndpoint)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("speaker:2"), CHIP_NO_ERROR);
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 1U);
+    EXPECT_EQ(configs[0].type, "speaker");
+    EXPECT_EQ(configs[0].endpoint, 2);
+    EXPECT_EQ(configs[0].parentId, kInvalidEndpointId);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_ValidTypeEndpointAndParent)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("light:1,parent=2"), CHIP_NO_ERROR);
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 1U);
+    EXPECT_EQ(configs[0].type, "light");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    EXPECT_EQ(configs[0].parentId, 2);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_InvalidEndpoint)
+{
+    EXPECT_NE(mParser.ParseSingleDeviceString("light:abc"), CHIP_NO_ERROR);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_InvalidParent)
+{
+    EXPECT_NE(mParser.ParseSingleDeviceString("light:1,parent=abc"), CHIP_NO_ERROR);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_UnknownOption)
+{
+    EXPECT_NE(mParser.ParseSingleDeviceString("light:1,vendor=123"), CHIP_NO_ERROR);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_MissingParentValue)
+{
+    EXPECT_NE(mParser.ParseSingleDeviceString("light:1,parent="), CHIP_NO_ERROR);
+}
+
+TEST_F(TestDeviceTypeParser, Parse_EmptyString)
+{
+    EXPECT_NE(mParser.ParseSingleDeviceString(""), CHIP_NO_ERROR);
+}
+
+TEST_F(TestDeviceTypeParser, AccumulateDevices)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("chime:1"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("speaker:2,parent=1"), CHIP_NO_ERROR);
+    
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 2U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 2);
+    EXPECT_EQ(configs[1].parentId, 1);
+}
+
+

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -78,7 +78,7 @@ bool AppOptions::ParseDeviceConfig(const char * value, DeviceConfig & config)
 
     // Find the first colon to separate type from endpoint
     const char * firstColon = strchr(value, ':');
-    
+
     // Case 1: No colon present. The entire value is treated as the device type.
     // Example: "chime" -> type="chime", endpoint=1, parentId=invalid
     if (firstColon == nullptr)
@@ -92,14 +92,14 @@ bool AppOptions::ParseDeviceConfig(const char * value, DeviceConfig & config)
 
     // Find the second colon to separate endpoint from parent
     const char * secondColon = strchr(firstColon + 1, ':');
-    
+
     // The endpoint ID starts immediately after the first colon
     const char * endpointStart = firstColon + 1;
-    
+
     // If a second colon exists, the endpoint ID is between the colons.
     // Otherwise, it extends to the end of the string.
     size_t endpointLen = secondColon ? static_cast<size_t>(secondColon - endpointStart) : strlen(endpointStart);
-    
+
     // Extract and parse the endpoint ID
     std::string endpointStr(endpointStart, endpointLen);
     if (!ParseEndpointId(endpointStr.c_str(), config.endpoint))

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -29,98 +29,17 @@ using namespace chip::ArgParser;
 
 // App custom argument handling
 constexpr uint16_t kOptionDeviceType = 0xffd0;
-constexpr uint16_t kOptionEndpoint   = 0xffd1;
 constexpr uint16_t kOptionWiFi       = 0xffd2;
 
-std::vector<AppOptions::DeviceConfig> AppOptions::mDeviceConfigs;
+DeviceTypeParser AppOptions::sParser;
 bool AppOptions::mEnableWiFi = false;
 
-const std::vector<AppOptions::DeviceConfig> & AppOptions::GetDeviceConfigs()
+const std::vector<DeviceTypeParser::Entry> & AppOptions::GetDeviceTypeEntries()
 {
-    if (mDeviceConfigs.empty())
-    {
-        static const std::vector<DeviceConfig> kDefault = { { "contact-sensor", 1 } };
-        return kDefault;
-    }
-    return mDeviceConfigs;
+    return sParser.GetDeviceTypeEntries();
 }
 
-bool AppOptions::ParseEndpointId(const char * str, chip::EndpointId & endpoint)
-{
-    char * endptr;
-    long val = strtol(str, &endptr, 10);
 
-    if (endptr == str || *endptr != '\0' || val < 0 || val > UINT16_MAX)
-    {
-        return false;
-    }
-
-    endpoint = static_cast<chip::EndpointId>(val);
-    return true;
-}
-
-/**
- * Parses a device configuration string in the format "type" or "type:endpoint".
- *
- * Example: "speaker:2" -> type="speaker", endpoint=2
- *
- * @param value The string to parse.
- * @param config The DeviceConfig structure to populate.
- * @return true on success, false on failure (e.g. invalid format or endpoint ID).
- */
-bool AppOptions::ParseDeviceConfig(const char * value, DeviceConfig & config)
-{
-    VerifyOrReturnValue(value != nullptr, false);
-
-    // Set default values for optional fields
-    config.endpoint = 1;
-    config.parentId = chip::kInvalidEndpointId;
-
-    // Find the first colon to separate type from endpoint
-    const char * firstColon = strchr(value, ':');
-
-    // Case 1: No colon present. The entire value is treated as the device type.
-    // Example: "chime" -> type="chime", endpoint=1, parentId=invalid
-    if (firstColon == nullptr)
-    {
-        config.type = value;
-        return true;
-    }
-
-    // Extract the type (all characters before the first colon)
-    config.type.assign(value, static_cast<size_t>(firstColon - value));
-
-    // Find the second colon to separate endpoint from parent
-    const char * secondColon = strchr(firstColon + 1, ':');
-
-    // The endpoint ID starts immediately after the first colon
-    const char * endpointStart = firstColon + 1;
-
-    // If a second colon exists, the endpoint ID is between the colons.
-    // Otherwise, it extends to the end of the string.
-    size_t endpointLen = secondColon ? static_cast<size_t>(secondColon - endpointStart) : strlen(endpointStart);
-
-    // Extract and parse the endpoint ID
-    std::string endpointStr(endpointStart, endpointLen);
-    if (!ParseEndpointId(endpointStr.c_str(), config.endpoint))
-    {
-        ChipLogError(Support, "Invalid endpoint ID in device config: %s\n", value);
-        return false;
-    }
-
-    // Case 2: Two colons present (format: type:endpoint:parent)
-    // Extract and parse the parent ID after the second colon.
-    if (secondColon != nullptr)
-    {
-        if (!ParseEndpointId(secondColon + 1, config.parentId))
-        {
-            ChipLogError(Support, "Invalid parent endpoint ID in device config: %s\n", value);
-            return false;
-        }
-    }
-
-    return true;
-}
 
 bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * options, int identifier, const char * name,
                                             const char * value)
@@ -128,36 +47,9 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
     switch (identifier)
     {
     case kOptionDeviceType: {
-        DeviceConfig config;
-        if (!ParseDeviceConfig(value, config))
+        if (sParser.ParseSingleDeviceString(value) != CHIP_NO_ERROR)
         {
             return false;
-        }
-
-        ChipLogProgress(AppServer, "Adding device type %s on endpoint %d", config.type.c_str(), config.endpoint);
-        mDeviceConfigs.push_back(std::move(config));
-        return true;
-    }
-    case kOptionEndpoint: {
-        chip::EndpointId ep;
-        if (value == nullptr || !ParseEndpointId(value, ep))
-        {
-            ChipLogError(Support, "Invalid endpoint ID: %s\n", value ? value : "(null)");
-            return false;
-        }
-
-        if (mDeviceConfigs.empty())
-        {
-            ChipLogError(Support, "Warning: --endpoint specified before --device. Creating default 'contact-sensor'.");
-            DeviceConfig config;
-            config.type     = "contact-sensor";
-            config.endpoint = ep;
-            mDeviceConfigs.push_back(std::move(config));
-        }
-        else
-        {
-            mDeviceConfigs.back().endpoint = ep;
-            ChipLogProgress(AppServer, "Updated last device to endpoint %d", ep);
         }
         return true;
     }
@@ -177,7 +69,6 @@ OptionSet * AppOptions::GetOptions()
 {
     static OptionDef sAllDevicesAppOptionDefs[] = {
         { "device", kArgumentRequired, kOptionDeviceType },
-        { "endpoint", kArgumentRequired, kOptionEndpoint },
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
         { "wifi", kNoArgument, kOptionWiFi },
 #endif
@@ -194,13 +85,9 @@ OptionSet * AppOptions::GetOptions()
         }
         result.replace(result.length() - 1, 1, ">");
         result += "\n";
-        result += "       Select the device to start up. Format: 'type' or 'type:endpoint'\n";
+        result += "       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'\n";
         result += "       Can be specified multiple times for multi-endpoint devices.\n";
-        result += "       Example: --device chime:1 --device speaker:2\n\n";
-
-        // rest of the help
-        result += "  --endpoint <endpoint-number>\n";
-        result += "       Define the endpoint for the preceding device (default 1)\n\n";
+        result += "       Example: --device chime:1 --device speaker:2,parent=1\n\n";
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
         result += "  --wifi\n";

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -39,8 +39,6 @@ const std::vector<DeviceTypeParser::Entry> & AppOptions::GetDeviceTypeEntries()
     return sParser.GetDeviceTypeEntries();
 }
 
-
-
 bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * options, int identifier, const char * name,
                                             const char * value)
 {

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -72,23 +72,53 @@ bool AppOptions::ParseDeviceConfig(const char * value, DeviceConfig & config)
 {
     VerifyOrReturnValue(value != nullptr, false);
 
-    config.endpoint = 1; // Default to endpoint 1
+    // Set default values for optional fields
+    config.endpoint = 1;
+    config.parentId = chip::kInvalidEndpointId;
 
-    const char * colonPos = strchr(value, ':');
-    if (colonPos != nullptr)
+    // Find the first colon to separate type from endpoint
+    const char * firstColon = strchr(value, ':');
+    
+    // Case 1: No colon present. The entire value is treated as the device type.
+    // Example: "chime" -> type="chime", endpoint=1, parentId=invalid
+    if (firstColon == nullptr)
     {
-        config.type.assign(value, static_cast<size_t>(colonPos - value));
+        config.type = value;
+        return true;
+    }
 
-        if (!ParseEndpointId(colonPos + 1, config.endpoint))
+    // Extract the type (all characters before the first colon)
+    config.type.assign(value, static_cast<size_t>(firstColon - value));
+
+    // Find the second colon to separate endpoint from parent
+    const char * secondColon = strchr(firstColon + 1, ':');
+    
+    // The endpoint ID starts immediately after the first colon
+    const char * endpointStart = firstColon + 1;
+    
+    // If a second colon exists, the endpoint ID is between the colons.
+    // Otherwise, it extends to the end of the string.
+    size_t endpointLen = secondColon ? static_cast<size_t>(secondColon - endpointStart) : strlen(endpointStart);
+    
+    // Extract and parse the endpoint ID
+    std::string endpointStr(endpointStart, endpointLen);
+    if (!ParseEndpointId(endpointStr.c_str(), config.endpoint))
+    {
+        ChipLogError(Support, "Invalid endpoint ID in device config: %s\n", value);
+        return false;
+    }
+
+    // Case 2: Two colons present (format: type:endpoint:parent)
+    // Extract and parse the parent ID after the second colon.
+    if (secondColon != nullptr)
+    {
+        if (!ParseEndpointId(secondColon + 1, config.parentId))
         {
-            ChipLogError(Support, "Invalid endpoint ID in device config: %s\n", value);
+            ChipLogError(Support, "Invalid parent endpoint ID in device config: %s\n", value);
             return false;
         }
     }
-    else
-    {
-        config.type = value;
-    }
+
     return true;
 }
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -36,7 +36,13 @@ bool AppOptions::mEnableWiFi = false;
 
 const std::vector<DeviceTypeParser::Entry> & AppOptions::GetDeviceTypeEntries()
 {
-    return sParser.GetDeviceTypeEntries();
+    const auto & entries = sParser.GetDeviceTypeEntries();
+    if (entries.empty())
+    {
+        static const std::vector<DeviceTypeParser::Entry> kDefault = { { "contact-sensor", 1, kInvalidEndpointId } };
+        return kDefault;
+    }
+    return entries;
 }
 
 bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * options, int identifier, const char * name,

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -19,9 +19,9 @@
 #pragma once
 
 #include <Options.h>
+#include <devices/device-type-parser/DeviceTypeParser.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/CHIPDeviceConfig.h>
-#include <devices/device-type-parser/DeviceTypeParser.h>
 
 #include <string>
 #include <vector>

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -21,6 +21,7 @@
 #include <Options.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/CHIPDeviceConfig.h>
+#include <devices/device-type-parser/DeviceTypeParser.h>
 
 #include <string>
 #include <vector>
@@ -28,36 +29,16 @@
 class AppOptions
 {
 public:
-    /**
-     * @brief Configuration for a single device instance.
-     *
-     * This structure holds the device type string (e.g. "on-off-light") and the
-     * endpoint ID where this device should be instantiated.
-     */
-    struct DeviceConfig
-    {
-        std::string type;
-        chip::EndpointId endpoint;
-        chip::EndpointId parentId = chip::kInvalidEndpointId;
-    };
-
     static chip::ArgParser::OptionSet * GetOptions();
 
-    static const std::vector<DeviceConfig> & GetDeviceConfigs();
-
-    static const char * GetDeviceType() { return GetDeviceConfigs().front().type.c_str(); }
-
-    static chip::EndpointId GetDeviceEndpoint() { return GetDeviceConfigs().front().endpoint; }
-
     static bool EnableWiFi() { return mEnableWiFi; }
+
+    static const std::vector<DeviceTypeParser::Entry> & GetDeviceTypeEntries();
 
 private:
     static bool AllDevicesAppOptionHandler(const char * program, chip::ArgParser::OptionSet * options, int identifier,
                                            const char * name, const char * value);
 
-    static bool ParseEndpointId(const char * str, chip::EndpointId & endpoint);
-    static bool ParseDeviceConfig(const char * value, DeviceConfig & config);
-
-    static std::vector<DeviceConfig> mDeviceConfigs;
+    static DeviceTypeParser sParser;
     static bool mEnableWiFi;
 };

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -38,6 +38,7 @@ public:
     {
         std::string type;
         chip::EndpointId endpoint;
+        chip::EndpointId parentId = chip::kInvalidEndpointId;
     };
 
     static chip::ArgParser::OptionSet * GetOptions();

--- a/examples/all-devices-app/posix/app_options/BUILD.gn
+++ b/examples/all-devices-app/posix/app_options/BUILD.gn
@@ -26,8 +26,8 @@ source_set("app-options") {
   ]
 
   public_deps = [
-    "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-type-parser",
     "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-factory",
+    "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-type-parser",
     "${chip_root}/examples/common/tracing:commandline",
     "${chip_root}/examples/platform/linux:app-options",
     "${chip_root}/src/lib",

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -153,7 +153,8 @@ public:
         {
             auto device = DeviceFactory::GetInstance().Create(config.type);
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ChipLogProgress(AppServer, "Registering device %s on endpoint %d with parent %d", config.type.c_str(), config.endpoint, config.parentId);
+            ChipLogProgress(AppServer, "Registering device %s on endpoint %d with parent %d", config.type.c_str(), config.endpoint,
+                            config.parentId);
             ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
             mConstructedDevices.push_back(std::move(device));
         }

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -153,7 +153,8 @@ public:
         {
             auto device = DeviceFactory::GetInstance().Create(config.type);
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, kInvalidEndpointId));
+            ChipLogProgress(AppServer, "Registering device %s on endpoint %d with parent %d", config.type.c_str(), config.endpoint, config.parentId);
+            ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
             mConstructedDevices.push_back(std::move(device));
         }
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -153,14 +153,7 @@ public:
         {
             auto device = DeviceFactory::GetInstance().Create(config.type);
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            if (config.parentId == chip::kInvalidEndpointId)
-            {
-                ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent None", config.type.c_str(), config.endpoint);
-            }
-            else
-            {
-                ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent %u", config.type.c_str(), config.endpoint, config.parentId);
-            }
+            ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", config.type.c_str(), config.endpoint, config.parentId);
             ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
             mConstructedDevices.push_back(std::move(device));
         }

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -150,16 +150,6 @@ public:
         ReturnErrorOnFailure(mAttributePersistence.Init(&mContext.storageDelegate));
         ReturnErrorOnFailure(mRootNode.RootDevice().Register(kRootEndpointId, mDataModelProvider, kInvalidEndpointId));
 
-        if (AppOptions::GetDeviceTypeEntries().empty())
-        {
-            ChipLogProgress(AppServer, "No devices specified. Creating default contact-sensor on endpoint 1");
-            auto device = DeviceFactory::GetInstance().Create("contact-sensor");
-            VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ReturnErrorOnFailure(device->Register(1, mDataModelProvider, kInvalidEndpointId));
-            mConstructedDevices.push_back(std::move(device));
-            return CHIP_NO_ERROR;
-        }
-
         for (const auto & entry : AppOptions::GetDeviceTypeEntries())
         {
             auto device = DeviceFactory::GetInstance().Create(entry.type);

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -153,8 +153,14 @@ public:
         {
             auto device = DeviceFactory::GetInstance().Create(config.type);
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ChipLogProgress(AppServer, "Registering device %s on endpoint %d with parent %d", config.type.c_str(), config.endpoint,
-                            config.parentId);
+            if (config.parentId == chip::kInvalidEndpointId)
+            {
+                ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent None", config.type.c_str(), config.endpoint);
+            }
+            else
+            {
+                ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent %u", config.type.c_str(), config.endpoint, config.parentId);
+            }
             ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
             mConstructedDevices.push_back(std::move(device));
         }

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -153,7 +153,8 @@ public:
         {
             auto device = DeviceFactory::GetInstance().Create(config.type);
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", config.type.c_str(), config.endpoint, config.parentId);
+            ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", config.type.c_str(),
+                            config.endpoint, config.parentId);
             ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
             mConstructedDevices.push_back(std::move(device));
         }

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -34,6 +34,7 @@
 #include <app/server/Server.h>
 #include <app_options/AppOptions.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <devices/device-type-parser/DeviceTypeParser.h>
 #include <devices/device-factory/DeviceFactory.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -149,13 +150,23 @@ public:
         ReturnErrorOnFailure(mAttributePersistence.Init(&mContext.storageDelegate));
         ReturnErrorOnFailure(mRootNode.RootDevice().Register(kRootEndpointId, mDataModelProvider, kInvalidEndpointId));
 
-        for (const auto & config : AppOptions::GetDeviceConfigs())
+        if (AppOptions::GetDeviceTypeEntries().empty())
         {
-            auto device = DeviceFactory::GetInstance().Create(config.type);
+            ChipLogProgress(AppServer, "No devices specified. Creating default contact-sensor on endpoint 1");
+            auto device = DeviceFactory::GetInstance().Create("contact-sensor");
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
-            ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", config.type.c_str(),
-                            config.endpoint, config.parentId);
-            ReturnErrorOnFailure(device->Register(config.endpoint, mDataModelProvider, config.parentId));
+            ReturnErrorOnFailure(device->Register(1, mDataModelProvider, kInvalidEndpointId));
+            mConstructedDevices.push_back(std::move(device));
+            return CHIP_NO_ERROR;
+        }
+
+        for (const auto & entry : AppOptions::GetDeviceTypeEntries())
+        {
+            auto device = DeviceFactory::GetInstance().Create(entry.type);
+            VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
+            ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", entry.type.c_str(),
+                            entry.endpoint, entry.parentId);
+            ReturnErrorOnFailure(device->Register(entry.endpoint, mDataModelProvider, entry.parentId));
             mConstructedDevices.push_back(std::move(device));
         }
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -34,8 +34,8 @@
 #include <app/server/Server.h>
 #include <app_options/AppOptions.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <devices/device-type-parser/DeviceTypeParser.h>
 #include <devices/device-factory/DeviceFactory.h>
+#include <devices/device-type-parser/DeviceTypeParser.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/PlatformManager.h>

--- a/src/controller/flags.gni
+++ b/src/controller/flags.gni
@@ -27,5 +27,9 @@ declare_args() {
 
 declare_args() {
   # Disable Thread MeshCoP if cross-compiling because of missing libevent.
-  chip_support_thread_meshcop = false
+  chip_support_thread_meshcop =
+      matter_enable_recommended && chip_device_platform == "linux" &&
+      !chip_system_config_use_openthread_inet_endpoints &&
+      current_cpu == host_cpu && current_os == host_os &&
+      chip_support_commissioning_in_controller
 }


### PR DESCRIPTION
This PR implements support for specifying a parent endpoint ID when registering devices via the command line in `all-devices-app`, and refactors the parsing logic to be more robust and reusable.

## Key Changes

### Parent Endpoint Support
-   Added support for specifying a parent endpoint when creating devices.
-   Updated the registration loop in `main.cpp` to pass the parsed `parentId` to the `Register` API.
-   This allows use cases like grouping a Speaker device under a Chime device for logical grouping in controller UIs.

### Extracted `DeviceTypeParser`
-   Moved the parsing logic from `AppOptions` (POSIX specific) to a platform-independent `DeviceTypeParser` class in `all-devices-common`.
-   This allows reusing the parsing logic in other platforms (e.g., embedded devices with UART input) without duplicating code.
-   The class is non-singleton and stateful.

### Updated CLI Syntax
-   Changed the syntax for specifying parent endpoints from positional colons (`type:endpoint:parent`) to explicit comma-separated options (`type:endpoint,parent=parentId`).
-   This makes the syntax clearer and less prone to confusion.
-   Example: `--device chime:1 --device speaker:2,parent=1`

### Cleaned up `AppOptions`
-   Removed all device configuration state and getters from `AppOptions`.
-   Removed the redundant `--endpoint` option.
-   `AppOptions` now strictly handles the CLI options and forwards them to the `DeviceTypeParser` instance it owns.
-   Handled the default device policy in `AppOptions::GetDeviceTypeEntries()`, returning a default `"contact-sensor"` on endpoint 1 if no devices were specified.

### Tests
-   Added comprehensive unit tests for the new `DeviceTypeParser` in `all-devices-common/devices/device-type-parser/tests/`.

### Documentation
-   Updated help text in `AppOptions.cpp` and usage examples in `README.md` to reflect the new syntax.

### Testing
-   Verified by running the application with the new syntax: `--device chime:1 --device speaker:2,parent=1 --device dimmable-light:3`.
-   Confirmed through logs that parent/child relationships are registered correctly.
-   Ran the new unit tests: `ninja -C out/linux-x64-tests-clang examples/all-devices-app/all-devices-common/devices/device-type-parser/tests:TestDeviceTypeParser.run`
-   Verified build of the application: `./scripts/build/build_examples.py --target linux-x64-all-devices build`
-   Verified hierarchy via `chip-tool`: read `parts-list` on endpoint 1 and confirmed it contains endpoint 2.
