### PR TITLE
Python Testing: Introduce ergonomic alternatives to steps_, desc_ and pics_ methods

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1199,6 +1199,7 @@ jobs:
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingNamespace.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingSelection.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingSupport.py'
+                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestStepExtractor.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestTestMetadata.py'
                   scripts/run_in_python_env.sh out/venv 'scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/test_testing/TestFactoryResetRequests.py'
                   scripts/run_in_python_env.sh out/venv 'PYTHONPATH=src/python_testing:$PYTHONPATH python3 -m unittest discover -s src/python_testing/mdns_discovery/tests -p "test_*.py"'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1199,6 +1199,7 @@ jobs:
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingNamespace.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingSelection.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestSpecParsingSupport.py'
+                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestTestMetadata.py'
                   scripts/run_in_python_env.sh out/venv 'scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/test_testing/TestFactoryResetRequests.py'
                   scripts/run_in_python_env.sh out/venv 'PYTHONPATH=src/python_testing:$PYTHONPATH python3 -m unittest discover -s src/python_testing/mdns_discovery/tests -p "test_*.py"'
             - name: Run Tests (individual)

--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2023 Project CHIP Authors
+#    Copyright (c) 2023-2026 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,34 +34,23 @@
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.decorators import async_test_body
+from matter.testing.decorators import async_test_body, pics
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.runner import default_matter_test_main
 
 
 class TC_ACL_2_2(MatterBaseTest):
 
-    def desc_TC_ACL_2_2(self) -> str:
-        return "[TC-ACL-2.2] Cluster endpoint"
-
-    def pics_TC_ACL_2_2(self) -> list[str]:
-        return ['ACL.S']
-
-    def steps_TC_ACL_2_2(self) -> list[TestStep]:
-        return [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep(2, "TH1 reads DUT Descriptor cluster ServerList attribute from Endpoint 0"),
-            TestStep(3, "TH1 reads DUT Descriptor cluster ServerList attribute from every Endpoint except 0"),
-        ]
-
+    @pics('ACL.S')
     @async_test_body
     async def test_TC_ACL_2_2(self):
-        self.step(1)
-        self.step(2)
+        """[TC-ACL-2.2] Cluster endpoint"""
+        self.step(1, "Commissioning, already done", is_commissioning=True)
+        self.step(2, "TH1 reads DUT Descriptor cluster ServerList attribute from Endpoint 0")
         data = await self.default_controller.ReadAttribute(nodeId=self.dut_node_id, attributes=[(Clusters.Descriptor.Attributes.ServerList)])
         asserts.assert_true(Clusters.AccessControl.id in data[0][Clusters.Descriptor]
                             [Clusters.Descriptor.Attributes.ServerList], "ACL cluster not on EP0")
-        self.step(3)
+        self.step(3, "TH1 reads DUT Descriptor cluster ServerList attribute from every Endpoint except 0")
         for endpoint, ep_data in data.items():
             if endpoint == 0:
                 continue

--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -73,6 +73,7 @@ pw_python_package("matter-testing-module") {
     "matter/testing/problem_notices.py",
     "matter/testing/runner.py",
     "matter/testing/spec_parsing.py",
+    "matter/testing/step_extractor.py",
     "matter/testing/taglist_and_topology_test.py",
     "matter/testing/tasks.py",
     "matter/testing/timeoperations.py",

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/decorators.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/decorators.py
@@ -372,3 +372,21 @@ def run_if_endpoint_matches(accept_function: EndpointCheckFunction):
                 body(test_instance, *args, **kwargs), timeout=timeout))
         return per_endpoint_runner
     return run_if_endpoint_matches_internal
+
+
+def pics(*pics_list):
+    """Decorator to declare PICS codes required for a test method.
+
+    Provides an alternative to defining a separate pics_* method.
+    The pics_* method takes precedence if both are defined.
+
+    Usage:
+        @pics("OO.S", "S.S")
+        @async_test_body
+        async def test_TC_OO_2_1(self):
+            ...
+    """
+    def decorator(fn):
+        fn._pics = list(pics_list)
+        return fn
+    return decorator

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/decorators.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/decorators.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2025 Project CHIP Authors
+#    Copyright (c) 2026 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ and endpoint matching.
 import asyncio
 import logging
 from enum import IntFlag
-from functools import partial
+from functools import partial, wraps
 from typing import TYPE_CHECKING, Callable, Type
 
 from mobly import asserts
@@ -261,6 +261,7 @@ def async_test_body(body):
     a asyncio-run synchronous method. This decorator does the wrapping.
     """
 
+    @wraps(body)
     def async_runner(self: "MatterBaseTest", *args, **kwargs):
         return _async_runner(body, self, *args, **kwargs)
     return async_runner
@@ -294,6 +295,7 @@ def run_on_singleton_matching_endpoint(accept_function: EndpointCheckFunction):
         Note that currently this test is limited to devices with a SINGLE matching endpoint.
     """
     def run_on_singleton_matching_endpoint_internal(body):
+        @wraps(body)
         def matching_runner(self: "MatterBaseTest", *args, **kwargs):
             # Import locally to avoid circular dependency
             from matter.testing.matter_testing import MatterBaseTest
@@ -351,6 +353,7 @@ def run_if_endpoint_matches(accept_function: EndpointCheckFunction):
         PICS values internally.
     """
     def run_if_endpoint_matches_internal(body):
+        @wraps(body)
         def per_endpoint_runner(test_instance, *args, **kwargs):
             runner_with_timeout = asyncio.wait_for(
                 should_run_test_on_endpoint(test_instance, accept_function), timeout=60)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2022-2025 Project CHIP Authors
+#    Copyright (c) 2022-2026 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -651,20 +651,20 @@ class MatterBaseTest(base_test.BaseTestClass):
         return [] if pics is None else pics
 
     def _get_defined_pics(self, test: str) -> Optional[list[str]]:
-        """Retrieve PICS list from a 'pics_*' function if it exists.
+        """Retrieve PICS list from a 'pics_*' function or @pics decorator.
+
+        The pics_* method takes precedence over the @pics decorator.
 
         Args:
             test: Name of the test to get PICS for.
 
         Returns:
-            List of PICS strings if pics function exists, None otherwise.
+            List of PICS strings if pics function or decorator exists, None otherwise.
         """
-        steps_name = f'pics_{test.removeprefix("test_")}'
-        try:
-            fn = getattr(self, steps_name)
-            return fn()
-        except AttributeError:
-            return None
+        if pics_method := getattr(self, 'pics_' + test.removeprefix('test_'), None):
+            return pics_method()
+        test_method = getattr(self, test)
+        return getattr(test_method, '_pics', None)  # set by @pics
 
     def get_test_desc(self, test: str) -> str:
         ''' Returns a description of this test

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -669,9 +669,9 @@ class MatterBaseTest(base_test.BaseTestClass):
     def get_test_desc(self, test: str) -> str:
         ''' Returns a description of this test
 
-            Test description is defined in the function called desc_<functionname>.
-            ex for test test_TC_TEST_1_1, the steps are in a function called
-            desc_TC_TEST_1_1.
+            Test description is defined in the function called desc_<functionname>,
+            or as a docstring on the test method itself.
+            The desc_* method takes precedence if both are defined.
 
             Format:
             <Test plan reference> [<test plan number>] <test plan name>
@@ -679,12 +679,12 @@ class MatterBaseTest(base_test.BaseTestClass):
             ex:
             133.1.1. [TC-ACL-1.1] Global attributes
         '''
-        desc_name = f'desc_{test.removeprefix("test_")}'
-        try:
-            fn = getattr(self, desc_name)
-            return fn()
-        except AttributeError:
-            return test
+        if desc_method := getattr(self, 'desc_' + test.removeprefix('test_'), None):
+            return desc_method()
+        test_method = getattr(self, test)
+        if doc := test_method.__doc__:
+            return doc.strip()
+        return test
 
     #
     # Matter Test API - Step Management & Execution

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -620,18 +620,26 @@ class MatterBaseTest(base_test.BaseTestClass):
         return [TestStep(1, "Run entire test")] if steps is None else steps
 
     def get_defined_test_steps(self, test: str) -> Optional[list[TestStep]]:
-        """Retrieves test steps from a 'steps_*' function, using a cache."""
-        steps_name = f'steps_{test.removeprefix("test_")}'
+        """Retrieves test steps from a 'steps_*' function or AST extraction, using a cache.
+
+        Checks for an explicit steps_* method first. If none exists, falls back to
+        extracting steps from self.step() calls in the test method's source code.
+
+        Returns None if no steps are defined by either mechanism.
+        """
         if test in self.cached_steps:
             return self.cached_steps[test]
 
-        try:
-            fn = getattr(self, steps_name)
-            steps = fn()
-            self.cached_steps[test] = steps
-            return fn()
-        except AttributeError:
-            return None
+        steps = None
+        if steps_method := getattr(self, 'steps_' + test.removeprefix('test_'), None):
+            steps = steps_method()
+        else:
+            test_method = getattr(self, test)
+            from matter.testing.step_extractor import extract_steps_from_method
+            steps = extract_steps_from_method(test_method) or None
+
+        self.cached_steps[test] = steps
+        return steps
 
     def get_restart_flag_file(self) -> Optional[str]:
         if self.matter_test_config.restart_flag_file is None:
@@ -692,17 +700,24 @@ class MatterBaseTest(base_test.BaseTestClass):
     # These methods are used to mark test progress for the test harness and logs, to help with test
     # debugging, issue creation and log analysis by the test labs.
 
-    def step(self, step: typing.Union[int, str]):
+    def step(self, step: typing.Union[int, str], description: str = "", *,
+             is_commissioning: bool = False, expectation: str = ""):
         """Execute a test step and manage step progression.
 
         Validates step order, prints step information, and notifies runner hooks.
 
         Args:
             step: The step number or identifier to execute.
+            description: Step description for inline step definitions.
+            is_commissioning: Mark this step as the commissioning step (keyword-only).
+            expectation: Expected outcome for test plan generation (keyword-only).
 
         Raises:
             AssertionError: If steps are called out of order or step doesn't exist.
         """
+        # description, is_commissioning, and expectation are not used at runtime.
+        # They exist so the AST step extractor can read them from source code to
+        # build the step list without needing a separate steps_* method.
         test_name = self.current_test_info.name
         steps = self.get_test_steps(test_name)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/step_extractor.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/step_extractor.py
@@ -1,0 +1,152 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+"""
+AST-based extraction of TestStep objects from test method source code.
+
+When a test class does not define an explicit steps_* method, this module
+extracts step information by parsing the test method's source code. It finds
+all self.step() and self.skip_step() calls and returns them as TestStep objects.
+
+Step numbers and descriptions must be constants (string or int literals).
+Dynamic step numbers (e.g. self.step(variable)) will raise a ValueError,
+since the extracted plan would be silently incomplete. Tests that need
+dynamic steps should define an explicit steps_* method instead.
+"""
+
+
+import ast
+import inspect
+import textwrap
+from typing import Optional
+
+from matter.testing.runner import TestStep
+
+
+class _StepExtractorVisitor(ast.NodeVisitor):
+    """
+    Walks the AST finding self.step() and self.skip_step() calls.
+
+    When the same step number appears in multiple branches of an if/else,
+    the merge logic deduplicates them (keeping the first description found).
+    """
+
+    def __init__(self):
+        self.steps: list[dict] = []
+
+    def _is_step_call(self, node: ast.Call) -> bool:
+        return (isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr in ("step", "skip_step"))
+
+    def _extract_step_data(self, node: ast.Call) -> Optional[dict]:
+        if not node.args:
+            return None
+
+        # Step number must be a constant (int or str literal)
+        num_node = node.args[0]
+        if not isinstance(num_node, ast.Constant):
+            raise ValueError(f"self.step() at line {node.lineno} has a dynamic step number. "
+                             "AST step extraction requires constant step numbers. "
+                             "Define an explicit steps_* method for tests with dynamic steps.")
+        number = num_node.value
+
+        # Description is optional; must be a constant if provided
+        description = ""
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            description = str(node.args[1].value)
+
+        # Extract keyword-only arguments
+        kw_values: dict[str, object] = {}
+        for kw in node.keywords:
+            if isinstance(kw.value, ast.Constant):
+                kw_values[kw.arg] = kw.value.value
+        if not description:
+            description = str(kw_values.get("description", ""))
+
+        is_commissioning = bool(kw_values.get("is_commissioning", False))
+        expectation = str(kw_values.get("expectation", ""))
+
+        return {
+            "number": number,
+            "description": description,
+            "is_commissioning": is_commissioning,
+            "expectation": expectation,
+        }
+
+    def visit_Call(self, node: ast.Call):
+        if self._is_step_call(node):
+            data = self._extract_step_data(node)
+            if data:
+                self.steps.append(data)
+        self.generic_visit(node)
+
+
+def _merge_duplicate_steps(steps: list[dict]) -> list[dict]:
+    """Deduplicate steps with the same number (e.g. from if/else branches)."""
+    seen: dict = {}
+    order: list = []
+    for s in steps:
+        key = str(s["number"])
+        if key not in seen:
+            seen[key] = s
+            order.append(key)
+        else:
+            existing = seen[key]
+            if not existing["description"] and s["description"]:
+                existing["description"] = s["description"]
+    return [seen[k] for k in order]
+
+
+def _extract_steps_from_ast(tree: ast.AST) -> list[TestStep]:
+    visitor = _StepExtractorVisitor()
+    visitor.visit(tree)
+    if not visitor.steps:
+        return []
+    merged = _merge_duplicate_steps(visitor.steps)
+    return [TestStep(
+        test_plan_number=s["number"],
+        description=s["description"],
+        is_commissioning=s.get("is_commissioning", False),
+        expectation=s.get("expectation", ""),
+    ) for s in merged]
+
+
+def extract_steps_from_method(method) -> list[TestStep]:
+    """Extract a TestStep list from a test method using AST analysis."""
+    name = getattr(method, '__name__', repr(method))
+    try:
+        source = textwrap.dedent(inspect.getsource(method))
+    except (OSError, TypeError) as e:
+        raise ValueError(
+            f"Failed to get source for {name}: {e}. "
+            "Define an explicit steps_* method for tests whose source is not available.") from e
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as e:
+        raise ValueError(
+            f"Failed to parse source for {name}: {e}. "
+            "Define an explicit steps_* method if AST extraction cannot handle the source.") from e
+
+    return _extract_steps_from_ast(tree)
+
+
+def extract_steps_from_source(source: str) -> list[TestStep]:
+    """Extract TestStep list from a source code string (convenience for testing)."""
+    return _extract_steps_from_ast(ast.parse(textwrap.dedent(source)))

--- a/src/python_testing/test_testing/TestStepExtractor.py
+++ b/src/python_testing/test_testing/TestStepExtractor.py
@@ -1,0 +1,252 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+"""Unit tests for the AST step extractor module."""
+
+import sys
+
+from matter.testing.runner import TestStep
+from matter.testing.step_extractor import extract_steps_from_method, extract_steps_from_source
+
+
+def test_simple_sequential_steps():
+    source = '''
+    def test_foo(self):
+        self.step(1, "First step")
+        self.step(2, "Second step")
+        self.step(3, "Third step")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+    assert steps[0] == TestStep(test_plan_number=1, description="First step")
+    assert steps[1] == TestStep(test_plan_number=2, description="Second step")
+    assert steps[2] == TestStep(test_plan_number=3, description="Third step")
+
+
+def test_string_step_numbers():
+    source = '''
+    def test_foo(self):
+        self.step("4a", "Sub-step a")
+        self.step("4b", "Sub-step b")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 2
+    assert steps[0].test_plan_number == "4a"
+    assert steps[1].test_plan_number == "4b"
+
+
+def test_skip_step():
+    source = '''
+    def test_foo(self):
+        self.step(1, "Do something")
+        self.skip_step(2)
+        self.step(3, "Do something else")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+    assert steps[1].test_plan_number == 2
+    assert steps[1].description == ""
+
+
+def test_conditional_if_step():
+    source = '''
+    def test_foo(self):
+        self.step(1, "Always")
+        if self.step(2, "Conditional"):
+            pass
+        self.step(3, "Always again")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+
+
+def test_duplicate_steps_in_if_else():
+    source = '''
+    def test_foo(self):
+        if condition:
+            self.step(1, "Branch A")
+        else:
+            self.step(1, "Branch B")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 1
+    assert steps[0].test_plan_number == 1
+    assert steps[0].description == "Branch A"
+
+
+def test_duplicate_prefers_description():
+    source = '''
+    def test_foo(self):
+        if condition:
+            self.skip_step(1)
+        else:
+            self.step(1, "Has description")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 1
+    assert steps[0].description == "Has description"
+
+
+def test_no_description():
+    source = '''
+    def test_foo(self):
+        self.step(1)
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 1
+    assert steps[0].description == ""
+
+
+def test_dynamic_step_number_raises():
+    source = '''
+    def test_foo(self):
+        self.step(1, "Static")
+        self.step(step_var, "Dynamic")
+        self.step(3, "Static again")
+    '''
+    try:
+        extract_steps_from_source(source)
+        assert False, "Expected ValueError for dynamic step number"
+    except ValueError as e:
+        assert "dynamic step number" in str(e).lower()
+
+
+def test_keyword_description():
+    source = '''
+    def test_foo(self):
+        self.step(1, description="Keyword desc")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 1
+    assert steps[0].description == "Keyword desc"
+
+
+def test_nested_for_loop():
+    source = '''
+    def test_foo(self):
+        self.step(1, "Before loop")
+        for i in range(3):
+            self.step(2, "In loop")
+        self.step(3, "After loop")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+
+
+def test_empty_method():
+    source = '''
+    def test_foo(self):
+        pass
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 0
+
+
+def test_extract_from_live_method():
+    class FakeTest:
+        def test_example(self):
+            self.step(1, "Live step")
+            self.step(2, "Another live step")
+
+    steps = extract_steps_from_method(FakeTest.test_example)
+    assert len(steps) == 2
+    assert steps[0] == TestStep(test_plan_number=1, description="Live step")
+
+
+def test_current_style_no_description():
+    source = '''
+    def test_foo(self):
+        self.step(0)
+        self.step(1)
+        self.step(2)
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+    assert all(s.description == "" for s in steps)
+
+
+def test_sc_5_1_pattern():
+    source = '''
+    def test_TC_SC_5_1(self):
+        self.step("0", "Commissioning")
+        self.step("1", "TH writes ACL")
+        if groupcast_enabled:
+            self.skip_step("3")
+            self.skip_step("4")
+        else:
+            self.step("3", "Bind GroupId")
+            self.step("4", "RemoveAllGroups")
+        self.step("10", "KeySetRead")
+    '''
+    steps = extract_steps_from_source(source)
+    numbers = [s.test_plan_number for s in steps]
+    assert numbers == ["0", "1", "3", "4", "10"]
+
+
+def test_keyword_only_args():
+    source = '''
+    def test_foo(self):
+        self.step(1, "Commissioning", is_commissioning=True)
+        self.step(2, "Do something", expectation="Verify success")
+        self.step(3, "Plain step")
+    '''
+    steps = extract_steps_from_source(source)
+    assert len(steps) == 3
+    assert steps[0].is_commissioning is True
+    assert steps[1].expectation == "Verify success"
+    assert steps[1].is_commissioning is False
+    assert steps[2].expectation == ""
+
+
+def main():
+    failures = []
+
+    test_functions = [
+        test_simple_sequential_steps,
+        test_string_step_numbers,
+        test_skip_step,
+        test_conditional_if_step,
+        test_duplicate_steps_in_if_else,
+        test_duplicate_prefers_description,
+        test_no_description,
+        test_dynamic_step_number_raises,
+        test_keyword_description,
+        test_nested_for_loop,
+        test_empty_method,
+        test_extract_from_live_method,
+        test_current_style_no_description,
+        test_sc_5_1_pattern,
+        test_keyword_only_args,
+    ]
+
+    for test_fn in test_functions:
+        try:
+            test_fn()
+            print(f"  PASS: {test_fn.__name__}")
+        except Exception as e:
+            print(f"  FAIL: {test_fn.__name__}: {e}")
+            failures.append(test_fn.__name__)
+
+    print(f"\nTest of StepExtractor: {len(failures)} failures out of {len(test_functions)} tests")
+    for f in failures:
+        print(f"  FAILED: {f}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python_testing/test_testing/TestTestMetadata.py
+++ b/src/python_testing/test_testing/TestTestMetadata.py
@@ -22,7 +22,7 @@ import sys
 from matter.testing.decorators import async_test_body, pics
 from matter.testing.matter_test_config import MatterTestConfig
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import generate_mobly_test_config
+from matter.testing.runner import TestStep, generate_mobly_test_config
 
 
 def _make_test_instance(test_class):
@@ -146,6 +146,87 @@ def test_desc_falls_back_to_method_name():
     assert result == "test_TC_FOO_1_1", f"Unexpected desc: {result}"
 
 
+def test_steps_from_explicit_method():
+    """Explicit steps_* method is used when defined."""
+
+    class MyTest(MatterBaseTest):
+        def steps_TC_FOO_1_1(self):
+            return [TestStep(1, "Explicit step")]
+
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            self.step(1, "Inline step")
+
+    inst = _make_test_instance(MyTest)
+    steps = inst.get_defined_test_steps("test_TC_FOO_1_1")
+    assert len(steps) == 1
+    assert steps[0].description == "Explicit step", f"Expected explicit method to win, got: {steps[0].description}"
+
+
+def test_steps_from_ast_fallback():
+    """AST extraction is used when no steps_* method exists."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            self.step(1, "First inline step")
+            self.step(2, "Second inline step")
+
+    inst = _make_test_instance(MyTest)
+    steps = inst.get_defined_test_steps("test_TC_FOO_1_1")
+    assert steps is not None, "Expected AST fallback to find steps"
+    assert len(steps) == 2
+    assert steps[0].test_plan_number == 1
+    assert steps[0].description == "First inline step"
+    assert steps[1].test_plan_number == 2
+    assert steps[1].description == "Second inline step"
+
+
+def test_steps_inline_runtime_validation():
+    """Inline step descriptions work end-to-end with step validation."""
+    from types import SimpleNamespace
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            self.step(1, "First step")
+            self.step(2, "Second step")
+
+    inst = _make_test_instance(MyTest)
+    # Manually set up the per-test state that Mobly normally initializes
+    # before each test method. We can't call setup_test() because it
+    # requires the full Mobly test runner lifecycle and chip stack.
+    inst.current_test_info = SimpleNamespace(name="test_TC_FOO_1_1")
+    inst.current_step_index = 0
+    inst.step_skipped = False
+    inst.step_start_time = None
+
+    # These should succeed — steps match the AST-extracted plan
+    inst.step(1, "First step")
+    inst.step(2, "Second step")
+
+    # Calling a step out of order should fail
+    inst.current_step_index = 0
+    try:
+        inst.step(2, "Wrong order")
+        assert False, "Expected AssertionError for out-of-order step"
+    except Exception:
+        pass
+
+
+def test_steps_none_when_no_steps():
+    """No steps_* and no self.step() calls returns None."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    steps = inst.get_defined_test_steps("test_TC_FOO_1_1")
+    assert steps is None, f"Expected None, got: {steps}"
+
+
 def main():
     failures = []
 
@@ -158,6 +239,10 @@ def main():
         test_desc_from_docstring,
         test_desc_method_takes_precedence,
         test_desc_falls_back_to_method_name,
+        test_steps_from_explicit_method,
+        test_steps_from_ast_fallback,
+        test_steps_inline_runtime_validation,
+        test_steps_none_when_no_steps,
     ]
 
     for test_fn in test_functions:

--- a/src/python_testing/test_testing/TestTestMetadata.py
+++ b/src/python_testing/test_testing/TestTestMetadata.py
@@ -1,0 +1,132 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+"""Unit tests for MatterBaseTest metadata extraction"""
+
+import sys
+
+from matter.testing.decorators import async_test_body, pics
+from matter.testing.matter_test_config import MatterTestConfig
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import generate_mobly_test_config
+
+
+def _make_test_instance(test_class):
+    config = generate_mobly_test_config(MatterTestConfig())
+    return test_class(config)
+
+
+def test_pics_decorator_only():
+    """@pics decorator is used when no pics_* method exists."""
+
+    class MyTest(MatterBaseTest):
+        @pics("OO.S", "S.S")
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_pics("test_TC_FOO_1_1")
+    assert result == ["OO.S", "S.S"], f"Expected ['OO.S', 'S.S'], got {result}"
+
+
+def test_pics_method_takes_precedence():
+    """Explicit pics_* method takes precedence over @pics decorator."""
+
+    class MyTest(MatterBaseTest):
+        def pics_TC_FOO_1_1(self):
+            return ["FROM.METHOD"]
+
+        @pics("FROM.DECORATOR")
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_pics("test_TC_FOO_1_1")
+    assert result == ["FROM.METHOD"], f"Expected ['FROM.METHOD'], got {result}"
+
+
+def test_no_pics_at_all():
+    """No pics_* method and no @pics decorator returns empty list."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_pics("test_TC_FOO_1_1")
+    assert result == [], f"Expected [], got {result}"
+
+
+def test_pics_decorator_below_async_test_body():
+    """@pics works when placed below @async_test_body (wraps propagates __dict__)."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        @pics("OO.S")
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_pics("test_TC_FOO_1_1")
+    assert result == ["OO.S"], f"Expected ['OO.S'], got {result}"
+
+
+def test_pics_decorator_single_code():
+    """@pics with a single PICS code."""
+
+    class MyTest(MatterBaseTest):
+        @pics("GRPKEY.S")
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_pics("test_TC_FOO_1_1")
+    assert result == ["GRPKEY.S"], f"Expected ['GRPKEY.S'], got {result}"
+
+
+def main():
+    failures = []
+
+    test_functions = [
+        test_pics_decorator_only,
+        test_pics_method_takes_precedence,
+        test_no_pics_at_all,
+        test_pics_decorator_below_async_test_body,
+        test_pics_decorator_single_code,
+    ]
+
+    for test_fn in test_functions:
+        try:
+            test_fn()
+            print(f"  PASS: {test_fn.__name__}")
+        except Exception as e:
+            print(f"  FAIL: {test_fn.__name__}: {e}")
+            failures.append(test_fn.__name__)
+
+    print(f"\nTestTestMetadata: {len(failures)} failures out of {len(test_functions)} tests")
+    for f in failures:
+        print(f"  FAILED: {f}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python_testing/test_testing/TestTestMetadata.py
+++ b/src/python_testing/test_testing/TestTestMetadata.py
@@ -102,6 +102,50 @@ def test_pics_decorator_single_code():
     assert result == ["GRPKEY.S"], f"Expected ['GRPKEY.S'], got {result}"
 
 
+def test_desc_from_docstring():
+    """Docstring is used as description when no desc_* method exists."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            """4.2.4. [TC-FOO-1.1] Scenes Management Cluster Interaction"""
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_desc("test_TC_FOO_1_1")
+    assert result == "4.2.4. [TC-FOO-1.1] Scenes Management Cluster Interaction", f"Unexpected desc: {result}"
+
+
+def test_desc_method_takes_precedence():
+    """Explicit desc_* method takes precedence over docstring."""
+
+    class MyTest(MatterBaseTest):
+        def desc_TC_FOO_1_1(self):
+            return "From method"
+
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            """From docstring"""
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_desc("test_TC_FOO_1_1")
+    assert result == "From method", f"Unexpected desc: {result}"
+
+
+def test_desc_falls_back_to_method_name():
+    """No desc_* and no docstring falls back to method name."""
+
+    class MyTest(MatterBaseTest):
+        @async_test_body
+        async def test_TC_FOO_1_1(self):
+            pass
+
+    inst = _make_test_instance(MyTest)
+    result = inst.get_test_desc("test_TC_FOO_1_1")
+    assert result == "test_TC_FOO_1_1", f"Unexpected desc: {result}"
+
+
 def main():
     failures = []
 
@@ -111,6 +155,9 @@ def main():
         test_no_pics_at_all,
         test_pics_decorator_below_async_test_body,
         test_pics_decorator_single_code,
+        test_desc_from_docstring,
+        test_desc_method_takes_precedence,
+        test_desc_falls_back_to_method_name,
     ]
 
     for test_fn in test_functions:


### PR DESCRIPTION
#### Summary

- Handle docstring as an alternative for `desc_*` methods
- Add `@pics` decorator as an alternative to `pics_*` methods
- Add AST step extractor as an alternative to `steps_*` methods
   
  it extracts TestStep objects from `self.step()` calls in test method source code
  using an AST visitor. The step() method signature is extended to take description,
  is_commissioning, and expectation arguments that are picked up by the extractor.
  (They are currently ignored at runtime.)

In all cases the existing methods (`desc_*`, `pics_*`, `steps_*`) take precedence if they do exist.

Also add `@functools.wraps` to test framework decorators.
This ensures attributes propagate correctly through the decoration chain.

Converted `TC_ACL_2_2.py` to use these new mechanisms as a proof of concept.

#### Testing

Added new TestTestMetadata and TestStepExtractor tests.
Validated that `test_plan_table_generator.py` still produces the same output for `TC_ACL_2_2.py`.