### PR TITLE
[Fix] Fix webOS's bluetooth overflow problem

### DIFF
--- a/src/platform/webos/wbs/WbsDeviceScanner.cpp
+++ b/src/platform/webos/wbs/WbsDeviceScanner.cpp
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
+#include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
@@ -46,22 +47,26 @@ namespace Internal {
 
 namespace {
 
-static bool _HexToBytes(std::string octetString, uint8_t * dataBytes)
+static bool _HexToBytes(const std::string & octetString, chip::MutableByteSpan & outBuffer)
 {
-    chip::Platform::ScopedMemoryBuffer<uint8_t> buffer;
-    size_t argLen = octetString.length();
-    if (!buffer.Calloc(argLen))
+    if (octetString.empty() || outBuffer.empty())
     {
         return false;
     }
 
-    size_t octetCount = chip::Encoding::HexToBytes(octetString.c_str(), argLen, buffer.Get(), argLen);
-
-    if (octetCount == 0)
+    if (octetString.length() > outBuffer.size() * 2)
     {
         return false;
     }
-    memcpy(dataBytes, buffer.Get(), octetCount);
+
+    size_t decodedSize = chip::Encoding::HexToBytes(octetString.c_str(), octetString.length(), outBuffer.data(), outBuffer.size());
+
+    if (decodedSize == 0)
+    {
+        return false;
+    }
+
+    outBuffer.reduce_size(decodedSize);
 
     return true;
 }
@@ -69,7 +74,7 @@ static bool _HexToBytes(std::string octetString, uint8_t * dataBytes)
 /// Retrieve CHIP device identification info from the device advertising data
 bool WbsGetChipDeviceInfo(const pbnjson::JValue & aDevice, chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
 {
-    VerifyOrReturnError(aDevice.hasKey("serviceData") == true, false);
+    VerifyOrReturnError(aDevice.hasKey("serviceData"), false);
     bool bChipDevice = false;
 
     if (aDevice.hasKey("serviceUuid") == true)
@@ -92,10 +97,11 @@ bool WbsGetChipDeviceInfo(const pbnjson::JValue & aDevice, chip::Ble::ChipBLEDev
         }
     }
 
-    VerifyOrReturnError(bChipDevice == true, false);
-    VerifyOrReturnError(_HexToBytes(aDevice["serviceData"].asString(), reinterpret_cast<uint8_t *>(&aDeviceInfo)) == true, false);
+    VerifyOrReturnError(bChipDevice, false);
+    chip::MutableByteSpan deviceInfoSpan(reinterpret_cast<uint8_t *>(&aDeviceInfo),
+                                         sizeof(chip::Ble::ChipBLEDeviceIdentificationInfo));
 
-    return bChipDevice;
+    return _HexToBytes(aDevice["serviceData"].asString(), deviceInfoSpan);
 }
 
 } // namespace

--- a/src/platform/webos/wbs/WbsDeviceScanner.cpp
+++ b/src/platform/webos/wbs/WbsDeviceScanner.cpp
@@ -54,19 +54,17 @@ static bool _HexToBytes(const std::string & octetString, chip::MutableByteSpan &
         return false;
     }
 
-    if (octetString.length() > outBuffer.size() * 2)
+    if (octetString.length() != outBuffer.size() * 2)
     {
         return false;
     }
 
     size_t decodedSize = chip::Encoding::HexToBytes(octetString.c_str(), octetString.length(), outBuffer.data(), outBuffer.size());
 
-    if (decodedSize == 0)
+    if (decodedSize != outBuffer.size())
     {
         return false;
     }
-
-    outBuffer.reduce_size(decodedSize);
 
     return true;
 }
@@ -101,10 +99,16 @@ bool WbsGetChipDeviceInfo(const pbnjson::JValue & aDevice, chip::Ble::ChipBLEDev
     chip::MutableByteSpan deviceInfoSpan(reinterpret_cast<uint8_t *>(&aDeviceInfo),
                                          sizeof(chip::Ble::ChipBLEDeviceIdentificationInfo));
 
-    return _HexToBytes(aDevice["serviceData"].asString(), deviceInfoSpan);
-}
 
-} // namespace
+    bool success = _HexToBytes(aDevice["serviceData"].asString(), deviceInfoSpan);
+
+    if (!success)
+    {
+        return false;
+    }
+
+    return true;
+}
 
 CHIP_ERROR WbsDeviceScanner::Init(WbsDeviceScannerDelegate * delegate)
 {


### PR DESCRIPTION
### Summary

- Fix potential stack buffer overflow in webOS BLE scanner when parsing oversized Matter advertisement data.The _HexToBytes() function did not properly validate the length of attacker-controlled serviceData, which could lead to out-of-bounds stack write.

### Related issues

Fixes #71760

### Testing

Manually verified rejection of oversized serviceData and confirmed normal Matter BLE advertisements are still parsed correctly.

### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:
 - PR title is descriptive
 - Apply the “When in Rome…” rule (coding style)
 - PR size is short
 - Try to avoid "squashing" and "force-update" in commit history
 - CI time didn't increase

