### PR TITLE
[NXP][OTBR] Add null pointer check in cas the external interface is not set

### DIFF
--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -163,7 +163,8 @@ static uint32_t mServiceListFreeIndex;
 CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {
     struct netif * extNetif = (ConnectivityManagerImpl().GetExternalInterface()).GetPlatformInterface();
-    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE, ChipLogError(DeviceLayer, "External interface not set, DNS-SD init failed"));
+    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(DeviceLayer, "External interface not set, DNS-SD init failed"));
     mNetifIndex = netif_get_index(extNetif);
 
     if (!mListIsInit)

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -164,7 +164,7 @@ CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncRet
 {
     struct netif * extNetif = (ConnectivityManagerImpl().GetExternalInterface()).GetPlatformInterface();
     VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mNetifIndex             = netif_get_index(extNetif);
+    mNetifIndex = netif_get_index(extNetif);
 
     if (!mListIsInit)
     {

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -163,6 +163,7 @@ static uint32_t mServiceListFreeIndex;
 CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {
     struct netif * extNetif = (ConnectivityManagerImpl().GetExternalInterface()).GetPlatformInterface();
+    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mNetifIndex             = netif_get_index(extNetif);
 
     if (!mListIsInit)

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -163,7 +163,7 @@ static uint32_t mServiceListFreeIndex;
 CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {
     struct netif * extNetif = (ConnectivityManagerImpl().GetExternalInterface()).GetPlatformInterface();
-    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE, ChipLogError(DeviceLayer, "External interface not set, DNS-SD init failed"));
     mNetifIndex = netif_get_index(extNetif);
 
     if (!mListIsInit)


### PR DESCRIPTION
#### Summary

After adding rt1060 MPU protection for null ptr usage, we identify null pointer usage in a OTBR scenario. To avoid this we added a check before using it.
Scenario to reproduce:
OTBR thermostat rt1060 example, ble-wifi commissioning, reboot the board after commisisoning finish, MPU detect a null pointer usage.

#### Testing

Validate that the scenario discribe bellow is no more reproduce after this commit with RT1060 evkc OTBR thermostat example.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
