### PR TITLE
[Silabs] On/Off cluster revisions reverted from 7 to 6.

### DIFF
--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -2848,7 +2848,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_extendedcolorlight = 269, version 4;
+  device type ma_extendedcolorlight = 269, version 5;
 
 
   server cluster Identify {
@@ -2890,7 +2890,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 1;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -3821,7 +3821,7 @@
         }
       ],
       "deviceVersions": [
-        4
+        5
       ],
       "deviceIdentifiers": [
         269
@@ -4370,7 +4370,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -3089,7 +3089,7 @@ endpoint 0 {
 }
 endpoint 1 {
   device type ma_powersource = 17, version 1;
-  device type ma_extendedcolorlight = 269, version 4;
+  device type ma_extendedcolorlight = 269, version 5;
 
 
   server cluster Identify {
@@ -3131,7 +3131,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 1;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -3247,7 +3247,7 @@
         }
       ],
       "deviceVersions": [
-        4,
+        5,
         1
       ],
       "deviceIdentifiers": [
@@ -3798,7 +3798,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -2410,7 +2410,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/pump-app/silabs/data_model/pump-thread-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.zap
@@ -3355,7 +3355,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -2410,7 +2410,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.zap
@@ -3355,7 +3355,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
@@ -2126,7 +2126,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
@@ -3438,7 +3438,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
@@ -2032,7 +2032,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 0x0007;
+    ram      attribute clusterRevision default = 6;
 
     handle command Off;
     handle command On;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
@@ -3343,7 +3343,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0007",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
#### Summary

A recent patch added to the  Device Conformance tests demand Group and OnOff cluster revisions to be rolled back. On Silicon Labs devices the OnOff cluster comes from the project's ZAP files, which need to be rolled back. test_TC_IDM_10_3 fails in consequence.

#### Related issues

[Hack: Fix a parsing error in the DM XML...](https://github.com/project-chip/connectedhomeip/pull/71576)

#### Testing

Previously failing TC_IDM_10_3 run successfully.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
