### PR TITLE
[NXP][config][zephyr] Update IMU task priority to cooperative instead of preemptible to prevent its starvation

### DIFF
--- a/config/zephyr/chip-module/CMakeLists.txt
+++ b/config/zephyr/chip-module/CMakeLists.txt
@@ -76,6 +76,15 @@ if(CONFIG_CHIP)
         endif()
     endif()
 
+    
+    # IMU task has no Kconfig for priority; on RW platforms it is critical infrastructure,
+    # so its priority is forced to cooperative to prevent starvation.
+    if(CONFIG_SOC_FAMILY_NXP_RW)
+        if(DEFINED CONFIG_NUM_COOP_PRIORITIES AND CONFIG_NUM_COOP_PRIORITIES GREATER 0)
+            zephyr_compile_definitions(IMU_TASK_PRIORITY=-1)
+        endif()
+    endif()
+
     zephyr_get_compile_flags(ZEPHYR_CFLAGS_C C)
     matter_add_cflags("${ZEPHYR_CFLAGS_C}")
     zephyr_get_compile_flags(ZEPHYR_CFLAGS_CC CXX)


### PR DESCRIPTION

#### Summary

Update the IMU task to run at a cooperative priority on NXP RW platform to avoid starvation under load and better align Zephyr behavior with the existing FreeRTOS scheduling model.

#### Background

On NXP RW platforms, the IMU task is critical inter‑core infrastructure, and its timely execution is critical. In the current Zephyr configuration, the IMU task uses a preemptive priority (default: 3). Under load, this allows it to be starved by cooperative networking and system threads, which differs from the FreeRTOS execution model used on the same platforms, where IMU runs at a higher priority than application logic.

#### Change Description

- Set the IMU task to run at cooperative priority -1 on NXP RW platforms. This ensures IMU cannot be starved by application or CHIP threads.
- The change is gated on CONFIG_SOC_FAMILY_NXP_RW and only applied when cooperative priorities are enabled.

#### Testing

Tested by building and running Matter Thermostat application on RW612 platform with commissioning successful.
Build command used: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr"
