### PR TITLE
Remove references to the basic information cluster from the OTA requestor cluster.

### DIFF
--- a/src/app/clusters/ota-requestor/BUILD.gn
+++ b/src/app/clusters/ota-requestor/BUILD.gn
@@ -29,7 +29,7 @@ source_set("ota-requestor") {
   public_deps = [
     ":interface",
     "${chip_root}/src/app:user-consent",
-    "${chip_root}/src/app/clusters/basic-information",
+    "${chip_root}/src/app/server-cluster",
     "${chip_root}/src/controller:interactions",
   ]
 }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -20,7 +20,6 @@
  * OTA Requestor logic is contained in this class.
  */
 
-#include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/clusters/ota-requestor/CodegenIntegrationInternal.h>
 #include <controller/CHIPCluster.h>
 #include <lib/core/CHIPEncoding.h>


### PR DESCRIPTION
#### Summary
The OTA requestor cluster used to refer to the basic information cluster for some information, but as of #42355 it gets that information from the platform's DeviceInstanceInfoProvider. This PR removes the stale references to the basic information cluster.

#### Related issues
No related issues.

#### Testing
Built the Linux OTA requestor example app to verify that it still compiled.
```
./scripts/build/build_examples.py --target linux-x64-ota-requestor-ipv6only-no-ble-no-wifi-clang build
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
