### PR TITLE
[Silabs]Fix radio configuration error causing an assert during init for MGM24 Modules

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -350,7 +350,7 @@ template("efr32_sdk") {
         defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
       }
 
-      defines += [ "MGM24" ]
+      defines += [ "MGM24", "_SILICON_LABS_MODULE=1" ]
     } else if (silabs_family == "efr32mg26") {
       _include_dirs += [
         "${efr32_sdk_root}/devices/platform/Device/SiliconLabs/EFR32MG26/Include",
@@ -1005,6 +1005,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/devices/platform/Device/SiliconLabs/EFR32MG24/Source/system_efr32mg24.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_manager/clocks/sl_device_clock_efr32xg24.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg24.c",
+        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/pa_curves_efr32.c",
       ]
     } else if (silabs_family == "mgm24") {
       sources += [
@@ -1020,6 +1021,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/devices/platform/Device/SiliconLabs/EFR32MG26/Source/system_efr32mg26.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_manager/clocks/sl_device_clock_efr32xg26.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg26.c",
+        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/pa_curves_efr32.c",
       ]
     }
 
@@ -1036,7 +1038,6 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform_core/platform/service/mpu/src/sl_mpu_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/power_manager/src/sleep_loop/sl_power_manager_hal_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_sysrtc.c",
-        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/pa_curves_efr32.c",
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_rssi/sl_rail_util_rssi.c",
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_sequencer/sl_rail_util_sequencer.c",
         "${efr32_sdk_root}/security_mbedtls/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -350,7 +350,10 @@ template("efr32_sdk") {
         defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
       }
 
-      defines += [ "MGM24", "_SILICON_LABS_MODULE=1" ]
+      defines += [
+        "MGM24",
+        "_SILICON_LABS_MODULE=1",
+      ]
     } else if (silabs_family == "efr32mg26") {
       _include_dirs += [
         "${efr32_sdk_root}/devices/platform/Device/SiliconLabs/EFR32MG26/Include",


### PR DESCRIPTION
#### Summary
Apps built with GN for MGM24 are hitting an Assert during radio init.

MGM24 products are Radio module from our EFR32MG24 Family. 
The low level radio driver configuration differ and have a strict settings.

Generic PA curves configuration apply to all Series 2 devkits bot not the modules. 
Fix is to remove `rail_library/plugin/pa-conversions/pa_curves_efr32.c` from MGM24 firmwares and to add `_SILICON_LABS_MODULE=1` define for proper configuration gating in our radio drivers.

#### Related issues
N/A

#### Testing
- Build lighting-app for BRD2704A (Sparkfun module), validate radio init completes without issue. 
- Commission and Control the Light with chip-tool