### PR TITLE
[GroupDataProvider] Zero-initialize KeySet::epoch_keys in constructors

### DIFF
--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -171,9 +171,11 @@ public:
     {
         static constexpr size_t kEpochKeysMax = 3;
 
-        KeySet() = default;
+        KeySet() { ClearKeys(); }
         KeySet(uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(id), policy(policy_id), num_keys_used(num_keys)
-        {}
+        {
+            ClearKeys();
+        }
 
         // The actual keys for the group key set
         EpochKey epoch_keys[kEpochKeysMax];

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1652,8 +1652,8 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
                                             const KeySet & in_keyset)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(in_keyset.num_keys_used <= KeySet::kEpochKeysMax, CHIP_ERROR_INVALID_ARGUMENT);
-
+    VerifyOrReturnError(in_keyset.num_keys_used >= 1 && in_keyset.num_keys_used <= KeySet::kEpochKeysMax,
+                        CHIP_ERROR_INVALID_ARGUMENT);
     FabricData fabric(fabric_index);
     KeySetData keyset;
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1652,6 +1652,7 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
                                             const KeySet & in_keyset)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(in_keyset.num_keys_used <= KeySet::kEpochKeysMax, CHIP_ERROR_INVALID_ARGUMENT);
 
     FabricData fabric(fabric_index);
     KeySetData keyset;
@@ -1667,13 +1668,11 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     keyset.policy     = in_keyset.policy;
     keyset.keys_count = in_keyset.num_keys_used;
     memset(keyset.operational_keys, 0x00, sizeof(keyset.operational_keys));
-    keyset.operational_keys[0].start_time = in_keyset.epoch_keys[0].start_time;
-    keyset.operational_keys[1].start_time = in_keyset.epoch_keys[1].start_time;
-    keyset.operational_keys[2].start_time = in_keyset.epoch_keys[2].start_time;
 
     // Store the operational keys and hash instead of the epoch keys
     for (size_t i = 0; i < in_keyset.num_keys_used; ++i)
     {
+        keyset.operational_keys[i].start_time = in_keyset.epoch_keys[i].start_time;
         ByteSpan epoch_key(in_keyset.epoch_keys[i].key, Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES);
         ReturnErrorOnFailure(
             Crypto::DeriveGroupOperationalCredentials(epoch_key, compressed_fabric_id, keyset.operational_keys[i]));


### PR DESCRIPTION
#### Summary

- Currently  `GroupDataProvider::KeySet` constructors leave `epoch_keys `uninitialized, this was the root cause of https://github.com/project-chip/connectedhomeip/pull/71585.

- make `GroupDataProvider::KeySet` safer by ensuring that epoch keys are initialized, by calling `ClearKeys()` in all constructors.

- In addition, make sure `GroupDataProviderImpl::SetKeySet` only sets epoch keys for keys that are actually used

#### Testing
- No new tests added, I can add a unit test, but it will only be relevant in MSAN-unit test build (since most non-msan tests end up zeroing epoch keys)


