### PR TITLE
[SILABS] Adds fix for the LTO builds for all silabs platforms

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -186,45 +186,45 @@ extern "C" __attribute__((used, naked)) void LogFault_Handler(void)
                      : [dbg] "h"(reinterpret_cast<void (*)(uint32_t *)>(debugHardfault))
                      : "r0", "memory", "cc");
 }
-
+alignas(4) static const uint32_t kFaultMagicHard __attribute__((used)) = 0x48415244; // 'HARD'
+alignas(4) static const uint32_t kFaultMagicMpu __attribute__((used)) = 0x4D505546; // 'MPUF'
+alignas(4) static const uint32_t kFaultMagicBus __attribute__((used)) = 0x42555346; // 'BUSF'
+alignas(4) static const uint32_t kFaultMagicUsage __attribute__((used)) = 0x55534654; // 'USFT'
+#if (__CORTEX_M >= 23U)
+alignas(4) static const uint32_t kFaultMagicSecure __attribute__((used)) = 0x53434654; // 'SCFT'
+#endif
+alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used)) = 0x44424D4E; // 'DBMN'
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" __attribute__((used, naked)) void HardFault_Handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicHard __attribute__((used)) = 0x48415244; // 'HARD'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicHard);
 }
 extern "C" __attribute__((used, naked)) void mpu_fault_handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicMpu __attribute__((used)) = 0x4D505546; // 'MPUF'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicMpu);
 }
 extern "C" __attribute__((used, naked)) void BusFault_Handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicBus __attribute__((used)) = 0x42555346; // 'BUSF'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicBus);
 }
 extern "C" __attribute__((used, naked)) void UsageFault_Handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicUsage __attribute__((used)) = 0x55534654; // 'USFT'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicUsage);
 }
 #if (__CORTEX_M >= 23U)
 extern "C" __attribute__((used, naked)) void SecureFault_Handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicSecure __attribute__((used)) = 0x53434654; // 'SCFT'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicSecure);
 }
 #endif // (__CORTEX_M >= 23U)
 extern "C" __attribute__((used, naked)) void DebugMon_Handler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used)) = 0x44424D4E; // 'DBMN'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicDbg);
 }
 #endif // !SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
 extern "C" __attribute__((used, naked)) void WDOG0_IRQHandler(void)
 {
-    alignas(4) static const uint32_t kFaultMagicWdog __attribute__((used)) = 0x57444F47; // 'WDOG'
     SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicWdog);
 }
 

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -186,14 +186,16 @@ extern "C" __attribute__((used, naked)) void LogFault_Handler(void)
                      : [dbg] "h"(reinterpret_cast<void (*)(uint32_t *)>(debugHardfault))
                      : "r0", "memory", "cc");
 }
-alignas(4) static const uint32_t kFaultMagicHard __attribute__((used)) = 0x48415244; // 'HARD'
-alignas(4) static const uint32_t kFaultMagicMpu __attribute__((used)) = 0x4D505546; // 'MPUF'
-alignas(4) static const uint32_t kFaultMagicBus __attribute__((used)) = 0x42555346; // 'BUSF'
+alignas(4) static const uint32_t kFaultMagicHard __attribute__((used))  = 0x48415244; // 'HARD'
+alignas(4) static const uint32_t kFaultMagicMpu __attribute__((used))   = 0x4D505546; // 'MPUF'
+alignas(4) static const uint32_t kFaultMagicBus __attribute__((used))   = 0x42555346; // 'BUSF'
 alignas(4) static const uint32_t kFaultMagicUsage __attribute__((used)) = 0x55534654; // 'USFT'
 #if (__CORTEX_M >= 23U)
 alignas(4) static const uint32_t kFaultMagicSecure __attribute__((used)) = 0x53434654; // 'SCFT'
 #endif
 alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used)) = 0x44424D4E; // 'DBMN'
+alignas(4) static const uint32_t kFaultMagicWdog __attribute__((used)) = 0x57444F47; // 'WDOG'
+
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" __attribute__((used, naked)) void HardFault_Handler(void)
 {

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -110,7 +110,16 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 #if HARD_FAULT_LOG_ENABLE
 // Identifier used by the various fault handlers to tag the fault type.
 // Note: This is read/written from exception/interrupt context.
-alignas(4) static volatile uint32_t faultId __asm__("faultId") = 0;
+// Referenced from naked asm via "m"(faultId); retain under LTO.
+alignas(4) static volatile uint32_t faultId __asm__("faultId") __attribute__((used)) = 0;
+
+#define SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(tagVar)                                                                               \
+    __asm__ volatile("ldr r0, %1\n\t"                                                                                              \
+                     "str r0, %0\n\t"                                                                                              \
+                     "b.w LogFault_Handler"                                                                                        \
+                     : "=m"(faultId)                                                                                               \
+                     : "m"(tagVar)                                                                                                 \
+                     : "r0", "memory")
 
 /**
  * Log register contents to UART when a hard fault occurs.
@@ -164,68 +173,58 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
  * This function is called by the fault handlers to log the fault details.
  */
 
-extern "C" __attribute__((naked)) void LogFault_Handler(void)
+extern "C" __attribute__((used, naked)) void LogFault_Handler(void)
 {
-    __asm volatile("tst lr, #4       \n"
-                   "ite eq           \n"
-                   "mrseq r0, msp    \n"
-                   "mrsne r0, psp    \n"
-                   "b debugHardfault \n");
+    /* bx + "r"(fn): LTO can place debugHardfault out of b/b.w range; address comes from the compiler. */
+    __asm__ volatile("tst lr, #4\n\t"
+                     "ite eq\n\t"
+                     "mrseq r0, msp\n\t"
+                     "mrsne r0, psp\n\t"
+                     "bx %[dbg]\n"
+                     :
+                     : [dbg] "r"(reinterpret_cast<void (*)(uint32_t *)>(debugHardfault))
+                     : "memory", "cc");
 }
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
-extern "C" __attribute__((naked)) void HardFault_Handler(void)
+extern "C" __attribute__((used, naked)) void HardFault_Handler(void)
 {
-    __asm volatile("ldr r0, =0x48415244 \n" // 'HARD'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicHard __attribute__((used)) = 0x48415244; // 'HARD'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicHard);
 }
-extern "C" __attribute__((naked)) void mpu_fault_handler(void)
+extern "C" __attribute__((used, naked)) void mpu_fault_handler(void)
 {
-    __asm volatile("ldr r0, =0x4D505546 \n" // 'MPUF'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicMpu __attribute__((used)) = 0x4D505546; // 'MPUF'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicMpu);
 }
-extern "C" __attribute__((naked)) void BusFault_Handler(void)
+extern "C" __attribute__((used, naked)) void BusFault_Handler(void)
 {
-    __asm volatile("ldr r0, =0x42555346 \n" // 'BUSF'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicBus __attribute__((used)) = 0x42555346; // 'BUSF'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicBus);
 }
-extern "C" __attribute__((naked)) void UsageFault_Handler(void)
+extern "C" __attribute__((used, naked)) void UsageFault_Handler(void)
 {
-    __asm volatile("ldr r0, =0x55534654 \n" // 'USFT'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicUsage __attribute__((used)) = 0x55534654; // 'USFT'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicUsage);
 }
 #if (__CORTEX_M >= 23U)
-extern "C" __attribute__((naked)) void SecureFault_Handler(void)
+extern "C" __attribute__((used, naked)) void SecureFault_Handler(void)
 {
-    __asm volatile("ldr r0, =0x53434654 \n" // 'SCFT'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicSecure __attribute__((used)) = 0x53434654; // 'SCFT'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicSecure);
 }
 #endif // (__CORTEX_M >= 23U)
-extern "C" __attribute__((naked)) void DebugMon_Handler(void)
+extern "C" __attribute__((used, naked)) void DebugMon_Handler(void)
 {
-    __asm volatile("ldr r0, =0x44424D4E \n" // 'DBMN'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used)) = 0x44424D4E; // 'DBMN'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicDbg);
 }
 #endif // !SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
-extern "C" __attribute__((naked)) void WDOG0_IRQHandler(void)
+extern "C" __attribute__((used, naked)) void WDOG0_IRQHandler(void)
 {
-    __asm volatile("ldr r0, =0x57444F47 \n" // 'WDOG'
-                   "ldr r1, =faultId    \n"
-                   "str r0, [r1]        \n"
-                   "b LogFault_Handler  \n");
+    alignas(4) static const uint32_t kFaultMagicWdog __attribute__((used)) = 0x57444F47; // 'WDOG'
+    SILABS_ASM_STORE_FAULT_ID_AND_BRANCH(kFaultMagicWdog);
 }
 
 extern "C" void vApplicationMallocFailedHook(void)

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -176,14 +176,15 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
 extern "C" __attribute__((used, naked)) void LogFault_Handler(void)
 {
     /* bx + "r"(fn): LTO can place debugHardfault out of b/b.w range; address comes from the compiler. */
+    /* r0 holds SP for debugHardfault (AAPCS); %[dbg] must not use r0—use "h" (r8–r15) and clobber r0. */
     __asm__ volatile("tst lr, #4\n\t"
                      "ite eq\n\t"
                      "mrseq r0, msp\n\t"
                      "mrsne r0, psp\n\t"
                      "bx %[dbg]\n"
                      :
-                     : [dbg] "r"(reinterpret_cast<void (*)(uint32_t *)>(debugHardfault))
-                     : "memory", "cc");
+                     : [dbg] "h"(reinterpret_cast<void (*)(uint32_t *)>(debugHardfault))
+                     : "r0", "memory", "cc");
 }
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -193,7 +193,7 @@ alignas(4) static const uint32_t kFaultMagicUsage __attribute__((used)) = 0x5553
 #if (__CORTEX_M >= 23U)
 alignas(4) static const uint32_t kFaultMagicSecure __attribute__((used)) = 0x53434654; // 'SCFT'
 #endif
-alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used)) = 0x44424D4E; // 'DBMN'
+alignas(4) static const uint32_t kFaultMagicDbg __attribute__((used))  = 0x44424D4E; // 'DBMN'
 alignas(4) static const uint32_t kFaultMagicWdog __attribute__((used)) = 0x57444F47; // 'WDOG'
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT


### PR DESCRIPTION
#### Summary

As part of upgrading to GCC 14.2 toolchain, LTO build failure was observed. This aims to solve that issue.

#### Related issues

N/A

#### Testing

Manually tested on SiWx917 non-sleepy and EFR32 series 2 boards.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
