### PR TITLE
[Realtek] Add InitGpio overload with LED PWM parameter support

### DIFF
--- a/examples/platform/realtek/util/LEDWidget.cpp
+++ b/examples/platform/realtek/util/LEDWidget.cpp
@@ -44,6 +44,11 @@ void LEDWidget::InitGpio()
     matter_led_init(kLedPwmParam, kLedPinNum);
 }
 
+void LEDWidget::InitGpio(T_LED_PWM_PARAM * ledPwmList, uint8_t ledPwmNum)
+{
+    matter_led_init(ledPwmList, ledPwmNum);
+}
+
 void LEDWidget::Init(uint8_t gpioNum)
 {
     mLEDHandle = matter_led_create(gpioNum, false, 0);

--- a/examples/platform/realtek/util/LEDWidget.h
+++ b/examples/platform/realtek/util/LEDWidget.h
@@ -29,6 +29,7 @@ public:
     LEDWidget() : mLEDHandle(NULL) {}
 
     static void InitGpio();
+    static void InitGpio(T_LED_PWM_PARAM * ledPwmList, uint8_t ledPwmNum);
     void Init(uint8_t gpioNum);
     void Set(bool state);
     void Invert(void);


### PR DESCRIPTION
#### Summary

 The change adds useful flexibility for LED configuration without breaking existing functionality.

#### Related issues

NA

#### Testing

1. Manually tested on Realtek platform
2. LED parameter can be configured from upper layer