### PR TITLE
[MSAN fix] FabricEntryData::Find() + UDCClientState

### DIFF
--- a/src/app/storage/FabricTableImpl.ipp
+++ b/src/app/storage/FabricTableImpl.ipp
@@ -322,9 +322,10 @@ struct FabricEntryData : public PersistableData<kFabricMaxBytes>
     }
 
     /// @brief  Finds the index where the current entry should be inserted by going through the endpoint's table and checking
-    /// whether the entry is already there. If the target is not in the table, sets idx to the first empty space
-    /// @param target_entry StorageId of entry to find
-    /// @param idx Index where target or space is found
+    /// whether the entry is already there. If the target is not in the table, sets idx to the first empty space.
+    /// If the target was not found and the table is full, sets idx to kUndefinedEntryIndex.
+    /// @param[in] target_entry StorageId of entry to find
+    /// @param[out] idx Index where target or space is found.
     /// @return CHIP_NO_ERROR if managed to find the target entry, CHIP_ERROR_NOT_FOUND if not found and space left
     ///         CHIP_ERROR_NO_MEMORY if target was not found and table is full
     CHIP_ERROR Find(const StorageId & target_entry, EntryIndex & idx)
@@ -351,7 +352,7 @@ struct FabricEntryData : public PersistableData<kFabricMaxBytes>
             idx = firstFreeIdx;
             return CHIP_ERROR_NOT_FOUND;
         }
-
+        idx = Data::kUndefinedEntryIndex;
         return CHIP_ERROR_NO_MEMORY;
     }
 
@@ -360,8 +361,8 @@ struct FabricEntryData : public PersistableData<kFabricMaxBytes>
         CHIP_ERROR err = CHIP_NO_ERROR;
         // Look for empty storage space
 
-        EntryIndex index;
-        err = this->Find(id, index);
+        EntryIndex index = Data::kUndefinedEntryIndex;
+        err              = this->Find(id, index);
 
         // C++ doesn't have const constructors; variable is declared const
         const TypedTableEntryData entry(endpoint_id, fabric_index, const_cast<StorageId &>(id), const_cast<StorageData &>(data),

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -241,8 +241,8 @@ private:
     bool mCancelPasscode            = false;
     uint8_t mPasscodeLength         = 0;
 
-    UDCClientProcessingState mUDCClientProcessingState;
-    System::Clock::Timestamp mExpirationTime = System::Clock::kZero;
+    UDCClientProcessingState mUDCClientProcessingState = UDCClientProcessingState::kNotInitialized;
+    System::Clock::Timestamp mExpirationTime           = System::Clock::kZero;
 
     uint32_t mCachedCommissionerPasscode = 0;
 };


### PR DESCRIPTION
#### Summary

- Two more fixes found through MSAN Unit Test failures
1. `TestSceneTable` + `TestScenesManagementCluster` triggered MSAN failures in testcases that fill the Fabric Table to capactity, hitting a codepath  where  the EntryIndex within `SaveEntry` was used while uninitialized  
   - Fix: make  `FabricEntryData::Find()`  return `idx=Data::kUndefinedEntryIndex` when the Table is full.
 
2. `TestUdcMessages` triggers MSAN due to `mUDCClientProcessingState` used while uninitialized

#### Related issues
- https://github.com/project-chip/connectedhomeip/issues/71500

#### Testing

- Ran msan unit tests locally
