### PR TITLE
tizen: Improve service data handling for BLE advertisement filters (#71684)

### DIFF
--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -49,6 +49,7 @@ enum chipBLEServiceDataType
  * Defines the over-the-air encoded format of the device identification information block that appears
  * within chip BLE service advertisement data.
  */
+// TODO: Support Network Recovery service data block
 struct ChipBLEDeviceIdentificationInfo
 {
     constexpr static uint16_t kDiscriminatorMask            = 0xfff;

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -1287,8 +1287,8 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     /* Send StartScan Request to Scanner Class */
     strcpy(data.service_uuid, Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR);
-    err = mDeviceScanner.StartScan(ScanFilterType::kServiceData, data);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
+    err = mDeviceScanner.StartScan(ScanFilterType::kServiceUUID, data);
+    SuccessOrExitAction(err, ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = DeviceLayer::SystemLayer().StartTimer(kNewConnectionScanTimeout, HandleScanTimeout, this);
     VerifyOrExit(err == CHIP_NO_ERROR, mDeviceScanner.StopScan();

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -72,9 +72,13 @@ static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & 
                 strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
                 __PrintLEScanData(dataList[i]);
-                memcpy(&info, dataList[i].service_data, dataList[i].service_data_len);
-                isChipDevice = true;
-                break;
+                // TODO: Support Network Recovery, the service data block size is different in that case
+                if (dataList[i].service_data_len == sizeof(info))
+                {
+                    memcpy(&info, dataList[i].service_data, sizeof(info));
+                    isChipDevice = true;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary

Backport:

* tizen: Improve service data handling for BLE advertisement filters
* tizen: Only accept a BLE device when service data length matches exactly what we expect
* Add TODO for missing support for Network Recovery

#### Testing

Tested on master.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
