### PR TITLE
[1.5 backport] OccupancySensing: report HoldTime on legacy *OccupiedToUnoccupiedDelay aliases

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -23,6 +23,7 @@
 #include <app/data-model/Encode.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/endpoint-config-api.h>
 #include <clusters/OccupancySensing/Metadata.h>
 #include <lib/core/CHIPError.h>
 
@@ -195,6 +196,21 @@ CHIP_ERROR SetHoldTime(EndpointId endpointId, uint16_t newHoldTime)
     if (previousHoldTime != newHoldTime)
     {
         MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, Attributes::HoldTime::Id);
+
+        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.  Notify any that are enabled in ZAP on this endpoint so subscribers to the legacy aliases also see the change.
+        // are enabled in ZAP on this endpoint so subscribers to the legacy aliases also see the change.
+        constexpr AttributeId kAliasAttributes[] = {
+            Attributes::PIROccupiedToUnoccupiedDelay::Id,
+            Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id,
+            Attributes::PhysicalContactOccupiedToUnoccupiedDelay::Id,
+        };
+        for (AttributeId aliasId : kAliasAttributes)
+        {
+            if (emberAfContainsAttribute(endpointId, OccupancySensing::Id, aliasId))
+            {
+                MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, aliasId);
+            }
+        }
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -197,8 +197,8 @@ CHIP_ERROR SetHoldTime(EndpointId endpointId, uint16_t newHoldTime)
     {
         MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, Attributes::HoldTime::Id);
 
-        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.  Notify any that are enabled in ZAP on this endpoint so subscribers to the legacy aliases also see the change.
-        // are enabled in ZAP on this endpoint so subscribers to the legacy aliases also see the change.
+        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.
+        // For each alias enabled in ZAP on this endpoint, report so legacy subscribers see the change.
         constexpr AttributeId kAliasAttributes[] = {
             Attributes::PIROccupiedToUnoccupiedDelay::Id,
             Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id,


### PR DESCRIPTION
### Summary
Backport of the alternative, ember/codegen-based fix (see [#71370](https://github.com/project-chip/connectedhomeip/pull/71370)): when HoldTime changes, report the change not only for HoldTime but for each deprecated *OccupiedToUnoccupiedDelay attribute that is present on the endpoint, so clients subscribed to those legacy attribute IDs also receive a report. Those attributes alias the same value as HoldTime.

### Related issues
Tracked by: [matter-test-scripts#766](https://github.com/project-chip/matter-test-scripts/issues/766)
Upstream / reference: [#71370](https://github.com/project-chip/connectedhomeip/pull/71370)

### Testing
Build verification (compile the occupancy sensor server in the all-clusters test app without issues):


```
scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang-test gen"
ninja -C out/linux-x64-all-clusters-clang-test obj/third_party/connectedhomeip/src/app/clusters/occupancy-sensor-server/all-clusters-common.occupancy-sensor-server.cpp.o
```

Ran OCC_2_3 test to cover this change:
```
scripts/tests/run_python_test.py --factory-reset --app out/linux-x64-all-clusters/chip-all-clusters-app --app-args "--discriminator 1234 --passcode 20202021 --KVS kvs1" --script-args "--storage-path admin_storage.json --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 1 --commissioning-method on-network --bool-arg simulate_occupancy:true" --script src/python_testing/TC_OCC_2_3.py
```
No issues with running the test with the code changes made, in which this issue was found initially.