### PR TITLE
[1.4.2 backport] OccupancySensing: report HoldTime on legacy *OccupiedToUnoccupiedDelay aliases

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -21,9 +21,9 @@
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
-#include <app/util/endpoint-config-api.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/endpoint-config-api.h>
 #include <lib/core/CHIPError.h>
 
 using chip::Protocols::InteractionModel::Status;

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -21,6 +21,7 @@
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
+#include <app/util/endpoint-config-api.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPError.h>
@@ -192,6 +193,20 @@ CHIP_ERROR SetHoldTime(EndpointId endpointId, uint16_t newHoldTime)
     if (previousHoldTime != newHoldTime)
     {
         MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, Attributes::HoldTime::Id);
+        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.  
+        // For each alias enabled in ZAP on this endpoint, report so legacy subscribers see the change.
+        constexpr AttributeId kAliasAttributes[] = {
+            Attributes::PIROccupiedToUnoccupiedDelay::Id,
+            Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id,
+            Attributes::PhysicalContactOccupiedToUnoccupiedDelay::Id,
+        };
+        for (AttributeId aliasId : kAliasAttributes)
+        {
+            if (emberAfContainsAttribute(endpointId, OccupancySensing::Id, aliasId))
+            {
+                MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, aliasId);
+            }
+        }
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR SetHoldTime(EndpointId endpointId, uint16_t newHoldTime)
     if (previousHoldTime != newHoldTime)
     {
         MatterReportingAttributeChangeCallback(endpointId, OccupancySensing::Id, Attributes::HoldTime::Id);
-        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.  
+        // HoldTime is aliased to the deprecated *OccupiedToUnoccupiedDelay attributes.
         // For each alias enabled in ZAP on this endpoint, report so legacy subscribers see the change.
         constexpr AttributeId kAliasAttributes[] = {
             Attributes::PIROccupiedToUnoccupiedDelay::Id,


### PR DESCRIPTION
### Summary
Backport of the alternative, ember/codegen-based fix (see [#71370](https://github.com/project-chip/connectedhomeip/pull/71370)): when HoldTime changes, report the change not only for HoldTime but for each deprecated *OccupiedToUnoccupiedDelay attribute that is present on the endpoint, so clients subscribed to those legacy attribute IDs also receive a report. Those attributes alias the same value as HoldTime.

### Related issues
Tracked by: [matter-test-scripts#766](https://github.com/project-chip/matter-test-scripts/issues/766)
Upstream / reference: [#71370](https://github.com/project-chip/connectedhomeip/pull/71370)

### Testing
Ran OCC_2_3 test to cover this change:
```
scripts/tests/run_python_test.py --factory-reset --app out/linux-x64-all-clusters/chip-all-clusters-app --app-args "--discriminator 1234 --passcode 20202021 --KVS kvs1" --script-args "--storage-path admin_storage.json --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 1 --commissioning-method on-network --bool-arg simulate_occupancy:true" --script src/python_testing/TC_OCC_2_3.py
```
No issues with running the test with the code changes made, in which this issue was found initially.