### PR TITLE
[Ameba] add support for ConfigurationVersion and Groupcast

### DIFF
--- a/examples/air-purifier-app/ameba/main/chipinterface.cpp
+++ b/examples/air-purifier-app/ameba/main/chipinterface.cpp
@@ -22,10 +22,12 @@
 #include <CHIPDeviceManager.h>
 #include <DeviceCallbacks.h>
 
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 #include <air-purifier-manager.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#include <credentials/GroupDataProviderImpl.h>
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
 #include <app/server/TermsAndConditionsManager.h>
 #endif
@@ -140,6 +142,12 @@ static void InitServer(intptr_t context)
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
+#endif
+
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    initParams.groupDataProvider->SetGroupcastEnabled(true);
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate sGroupAuxAccessDelegate(initParams.groupDataProvider);
+    initParams.groupAuxiliaryAccessControlDelegate = &sGroupAuxAccessDelegate;
 #endif
 
     static AmebaObserver sAmebaObserver;

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -28,9 +28,11 @@
 #include <Globals.h>
 #include <LEDWidget.h>
 
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#include <credentials/GroupDataProviderImpl.h>
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
 #include <app/server/TermsAndConditionsManager.h>
 #endif
@@ -145,6 +147,12 @@ static void InitServer(intptr_t context)
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
+#endif
+
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    initParams.groupDataProvider->SetGroupcastEnabled(true);
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate sGroupAuxAccessDelegate(initParams.groupDataProvider);
+    initParams.groupAuxiliaryAccessControlDelegate = &sGroupAuxAccessDelegate;
 #endif
 
     static AmebaObserver sAmebaObserver;

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -25,9 +25,11 @@
 #include <Globals.h>
 #include <LEDWidget.h>
 
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#include <credentials/GroupDataProviderImpl.h>
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
 #include <app/server/TermsAndConditionsManager.h>
 #endif
@@ -107,13 +109,17 @@ static void InitServer(intptr_t context)
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
 #endif
 
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    initParams.groupDataProvider->SetGroupcastEnabled(true);
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate sGroupAuxAccessDelegate(initParams.groupDataProvider);
+    initParams.groupAuxiliaryAccessControlDelegate = &sGroupAuxAccessDelegate;
+#endif
+
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-
-    NetWorkCommissioningInstInit();
 
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
@@ -121,6 +127,8 @@ static void InitServer(intptr_t context)
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
     chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
+
+    NetWorkCommissioningInstInit();
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
     {

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -24,9 +24,11 @@
 #include <Globals.h>
 #include <LEDWidget.h>
 
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#include <credentials/GroupDataProviderImpl.h>
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
 #include <app/server/TermsAndConditionsManager.h>
 #endif
@@ -132,6 +134,12 @@ static void InitServer(intptr_t context)
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
+#endif
+
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    initParams.groupDataProvider->SetGroupcastEnabled(true);
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate sGroupAuxAccessDelegate(initParams.groupDataProvider);
+    initParams.groupAuxiliaryAccessControlDelegate = &sGroupAuxAccessDelegate;
 #endif
 
     static AmebaObserver sAmebaObserver;

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -77,7 +77,8 @@ const AmebaConfig::Key AmebaConfig::kConfigKey_OperationalDeviceICACerts   = { k
 const AmebaConfig::Key AmebaConfig::kConfigKey_OperationalDevicePrivateKey = { kConfigNamespace_ChipConfig, "op-device-key" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_RegulatoryLocation          = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_LocationCapability          = { kConfigNamespace_ChipConfig, "location-capability" };
-const AmebaConfig::Key AmebaConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
+const AmebaConfig::Key AmebaConfig::kConfigKey_ConfigurationVersion = { kConfigNamespace_ChipConfig, "configuration-version" };
+const AmebaConfig::Key AmebaConfig::kConfigKey_CountryCode          = { kConfigNamespace_ChipConfig, "country-code" };
 
 // Keys stored in the Chip-counters namespace
 const AmebaConfig::Key AmebaConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -62,6 +62,7 @@ public:
     static const Key kConfigKey_SetupDiscriminator;
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_LocationCapability;
+    static const Key kConfigKey_ConfigurationVersion;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -96,6 +96,11 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
+    if (!AmebaConfig::ConfigValueExists(AmebaConfig::kConfigKey_ConfigurationVersion))
+    {
+        ReturnErrorOnFailure(StoreConfigurationVersion(1));
+    }
+
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<AmebaConfig>::Init();
     SuccessOrExit(err);
@@ -149,6 +154,16 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     }
 
     return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetConfigurationVersion(uint32_t & configurationVersion)
+{
+    return ReadConfigValue(AmebaConfig::kConfigKey_ConfigurationVersion, configurationVersion);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreConfigurationVersion(uint32_t configurationVersion)
+{
+    return WriteConfigValue(AmebaConfig::kConfigKey_ConfigurationVersion, configurationVersion);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -46,6 +46,8 @@ public:
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
     CHIP_ERROR GetLocationCapability(uint8_t & locationCapability) override;
+    CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) override;
+    CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.


### PR DESCRIPTION
#### Summary

* added implementation for ConfigurationVersion.
* added code to support and initialize groupcast cluster.

#### Related issues

N/A

#### Testing

Verified with v1.6 TH. Tested using CLI-PYTHON TC-BINFO-3.2 and all CLI-PYTHON TC-GC test cases; all results passed.