### PR TITLE
[ESP32] Fix delta OTA build errors

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -487,6 +487,10 @@ if (CONFIG_ENABLE_ENCRYPTED_OTA)
     list(APPEND matter_requires espressif__esp_encrypted_img)
 endif()
 
+if (CONFIG_ENABLE_DELTA_OTA)
+    list(APPEND matter_requires espressif__esp_delta_ota)
+endif()
+
 add_prebuilt_library(matterlib "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a"
                      REQUIRES ${matter_requires})
 

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -261,6 +261,7 @@ esp_err_t OTAImageProcessorImpl::DeltaOTAWriteCallback(const uint8_t * buf, size
             esp_image_header_t * header = (esp_image_header_t *) headerData;
             if (!VerifyChipId(header->chip_id))
             {
+                headerDataRead = 0;
                 return ESP_ERR_INVALID_VERSION;
             }
             imageProcessor->chipIdVerified = true;

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -322,7 +322,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     if (imageProcessor->mDeltaOTAUpdateHandle == NULL)
     {
         ChipLogError(SoftwareUpdate, "esp_delta_ota_init failed");
-        imageProcessor->mDownloader->OnPreparedForDownload(CHIP_ERROR_INTERNAL);
+        LogErrorOnFailure(imageProcessor->mDownloader->OnPreparedForDownload(CHIP_ERROR_INTERNAL));
         return;
     }
 #endif // CONFIG_ENABLE_DELTA_OTA
@@ -332,7 +332,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     if (chipError != CHIP_NO_ERROR)
     {
         ChipLogError(SoftwareUpdate, "Failed to start decryption process, err:%" CHIP_ERROR_FORMAT, chipError.Format());
-        imageProcessor->mDownloader->OnPreparedForDownload(chipError);
+        LogErrorOnFailure(imageProcessor->mDownloader->OnPreparedForDownload(chipError));
         return;
     }
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
@@ -360,7 +360,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     {
         ChipLogError(SoftwareUpdate, "Failed to end pre encrypted OTA");
         esp_ota_abort(imageProcessor->mOTAUpdateHandle);
-        imageProcessor->ReleaseBlock();
+        LogErrorOnFailure(imageProcessor->ReleaseBlock());
         PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
         return;
     }
@@ -372,7 +372,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     {
         ESP_LOGE(TAG, "esp_delta_ota_finalize() failed (%s)!", esp_err_to_name(err));
         esp_ota_abort(imageProcessor->mOTAUpdateHandle);
-        imageProcessor->ReleaseBlock();
+        LogErrorOnFailure(imageProcessor->ReleaseBlock());
         PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
     }
 
@@ -381,7 +381,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     {
         ESP_LOGE(TAG, "esp_delta_ota_deinit() failed (%s)!", esp_err_to_name(err));
         esp_ota_abort(imageProcessor->mOTAUpdateHandle);
-        imageProcessor->ReleaseBlock();
+        LogErrorOnFailure(imageProcessor->ReleaseBlock());
         PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
     }
 

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -187,10 +187,10 @@ esp_err_t OTAImageProcessorImpl::VerifyHeaderData(const uint8_t * buf, size_t si
             memcpy(patchHeader + headerDataRead, buf, *index);
             if (!VerifyPatchHeader(patchHeader))
             {
+                headerDataRead = 0;
                 return ESP_ERR_INVALID_VERSION;
             }
             headerDataRead      = 0;
-            *index              = PATCH_HEADER_SIZE;
             patchHeaderVerified = true;
         }
     }
@@ -264,9 +264,15 @@ esp_err_t OTAImageProcessorImpl::DeltaOTAWriteCallback(const uint8_t * buf, size
                 return ESP_ERR_INVALID_VERSION;
             }
             imageProcessor->chipIdVerified = true;
+            headerDataRead                 = 0;
 
             // Write data in headerData buffer.
-            return esp_ota_write(imageProcessor->mOTAUpdateHandle, headerData, IMG_HEADER_LEN);
+            esp_err_t err = esp_ota_write(imageProcessor->mOTAUpdateHandle, headerData, IMG_HEADER_LEN);
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "esp_ota_write failed (%s)!", esp_err_to_name(err));
+                return err;
+            }
         }
     }
 


### PR DESCRIPTION
 #### Summary                                                                                                                                                                                                          
                  
  Fixes build failures when `CONFIG_ENABLE_DELTA_OTA=y` is enabled:                                                                                                                                                  

  Fixes espressif/esp-matter#1753.                                                                                                                                                                           
                  
  #### Testing

  - Built esp-matter/examples/light with `CONFIG_ENABLE_DELTA_OTA=y` build succeeds, no link errors, no warnings.                                                                                                   
  - Default build (CONFIG_ENABLE_DELTA_OTA=n) unaffected.
  - Tested complete flow of the delta OTA and it succeed with this fix.
