### PR TITLE
[Scenes] TC-CC-10-1 & TC-LVL-9-1 timing fix

### DIFF
--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -36,15 +36,16 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.testing.runner import TestStep, default_matter_test_main
-from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.decorators import async_test_body
-from matter.interaction_model import Status
-import matter.clusters as Clusters
-from TC_GC_common import is_groupcast_on_root_node
-from mobly import asserts
 from typing import List
 
+from mobly import asserts
+from TC_GC_common import is_groupcast_on_root_node
+
+import matter.clusters as Clusters
+from matter.interaction_model import Status
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
 kTempTolerance = 0.15

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -36,17 +36,18 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.decorators import async_test_body
+from matter.interaction_model import Status
+import matter.clusters as Clusters
+from TC_GC_common import is_groupcast_on_root_node
+from mobly import asserts
 import asyncio
+import time
+from typing import Tuple
 from typing import List
 
-from mobly import asserts
-from TC_GC_common import is_groupcast_on_root_node
-
-import matter.clusters as Clusters
-from matter.interaction_model import Status
-from matter.testing.decorators import async_test_body
-from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
 kTempTolerance = 0.15
@@ -69,6 +70,26 @@ class TC_CC_10_1(MatterBaseTest):
             clusterID=Clusters.Objects.ColorControl.id,
             attributeValueList=efs_attribute_value_list
         )
+
+    async def _wait_for_attributes_within_boundaries(self, cluster, attributes: List[Tuple[int, int, int]], timeout_sec: int = 1):
+        """Wait for attributes to be within boundaries.
+
+        Args:
+            cluster: cluster to read the attribute from
+            attributes: list of (attribute_id, min_value, max_value) tuples
+            timeout_sec: timeout in seconds
+        """
+        for attribute in attributes:
+            start_time = time.time()
+
+            value = await self.read_single_attribute_check_success(cluster, attribute[0])
+            while value < attribute[1] or value > attribute[2]:
+                remaining = timeout_sec - (time.time() - start_time)
+                if remaining <= 0:
+                    raise Exception(
+                        f"Timeout waiting for attribute {attribute[0]} to be within boundaries: {attribute[1]} - {attribute[2]}")
+                await asyncio.sleep(0.1)
+                value = await self.read_single_attribute_check_success(cluster, attribute[0])
 
     def desc_TC_CC_10_1(self) -> str:
         """Returns a description of this test"""
@@ -217,19 +238,10 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("2a")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToHueAndSaturation(200, 50, 0, 1, 1))
-            await asyncio.sleep(1)
 
         self.step("2b")
         if self.pics_guard(self.check_pics("CC.S.F00")):
-            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.CurrentHue), (self.matter_test_config.endpoint, attributes.CurrentSaturation)])
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentHue], 230, "CurrentHue is not less than or equal to 230")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.CurrentHue], 170,
-                                         "CurrentHue is not greater than or equal to 170")
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentSaturation], 58, "CurrentSaturation is not less than or equal 58")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentSaturation], 42, "CurrentSaturation is not greater than or equal 42")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentHue, 170, 230), (attributes.CurrentSaturation, 42, 58)])
 
         self.step("2c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
@@ -257,19 +269,10 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("3a")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColor(32768, 19660, 0, 1, 1))
-            await asyncio.sleep(1)
 
         self.step("3b")
         if self.pics_guard(self.check_pics("CC.S.F03")):
-            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.CurrentX), (self.matter_test_config.endpoint, attributes.CurrentY)])
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentX], 35000, "CurrentX is not less than or equal to 35000")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.CurrentX], 31000,
-                                         "CurrentX is not greater than or equal to 31000")
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentY], 21000, "CurrentY is not less than or equal to 21000")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.CurrentY], 17000,
-                                         "CurrentY is not greater than or equal to 17000")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentX, 31000, 35000), (attributes.CurrentY, 17000, 21000)])
 
         self.step("3c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
@@ -302,20 +305,12 @@ class TC_CC_10_1(MatterBaseTest):
         if self.pics_guard(self.check_pics("CC.S.F04")):
             CTtarget = round((ColorTempPhysicalMinMiredsValue + ColorTempPhysicalMaxMiredsValue) / 2)
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColorTemperature(CTtarget, 0, 1, 1))
-            await asyncio.sleep(1)
 
         self.step("4b")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             CTmax = round(CTtarget * (1 + kTempTolerance))
             CTmin = round(CTtarget * (1 - kTempTolerance))
-            ct_mireds = await self.read_single_attribute_check_success(
-                cluster=cluster,
-                attribute=attributes.ColorTemperatureMireds,
-                endpoint=self.matter_test_config.endpoint)
-            asserts.assert_less_equal(ct_mireds, CTmax,
-                                      "ColorTemperatureMireds is not less than or equal to %d" % CTmax)
-            asserts.assert_greater_equal(ct_mireds, CTmin,
-                                         "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorTemperatureMireds, CTmin, CTmax)])
         self.step("4c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             result = await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.StoreScene(self.kGroup1, 0x01))
@@ -344,19 +339,10 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("5a")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.EnhancedMoveToHueAndSaturation(20000, 50, 0, 1, 1))
-            await asyncio.sleep(1)
 
         self.step("5b")
         if self.pics_guard(self.check_pics("CC.S.F01")):
-            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.EnhancedCurrentHue), (self.matter_test_config.endpoint, attributes.CurrentSaturation)])
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.EnhancedCurrentHue], 21800,
-                                      "EnhancedCurrentHue is not less than or equal to 21800")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.EnhancedCurrentHue], 18200,
-                                         "EnhancedCurrentHue is not greater than or equal to 18200")
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentSaturation], 58, "CurrentSaturation is not 58")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentSaturation], 42, "CurrentSaturation is not 42")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.EnhancedCurrentHue, 18200, 21800), (attributes.CurrentSaturation, 42, 58)])
 
         self.step("5c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
@@ -408,13 +394,9 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("6b")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
-            # delay between recall scene and attribute read
-            await asyncio.sleep(1)
         self.step("6c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
-            CurrentSaturation = await self.read_single_attribute_check_success(cluster, attributes.CurrentSaturation)
-            asserts.assert_less_equal(CurrentSaturation, 0xE8, "CurrentSaturation is above limit")
-            asserts.assert_greater_equal(CurrentSaturation, 0xD8, "CurrentSaturation is below limit")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8)])
 
         self.step("7a")
         if self.pics_guard(self.check_pics("CC.S.F03")):
@@ -446,19 +428,9 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("7b")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x03))
-            # delay between recall scene and attribute read
-            await asyncio.sleep(1)
         self.step("7c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
-            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.CurrentX), (self.matter_test_config.endpoint, attributes.CurrentY)])
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentX], 18000, "CurrentX is above limit")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentX], 14000, "CurrentX is below limit")
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentY], 15000, "CurrentY is above limit")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentY], 11000, "CurrentY is below limit")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentX, 14000, 18000), (attributes.CurrentY, 11000, 15000)])
 
         self.step("8a")
         if self.pics_guard(self.check_pics("CC.S.F04")):
@@ -487,15 +459,9 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("8b")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x04))
-            # delay between recall scene and attribute read
-            await asyncio.sleep(1)
         self.step("8c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
-            ColorTemperatureMireds = await self.read_single_attribute_check_success(cluster, attributes.ColorTemperatureMireds)
-            asserts.assert_less_equal(ColorTemperatureMireds,
-                                      ColorTempPhysicalMaxMiredsValue, "ColorTemperatureMireds is above limit")
-            asserts.assert_greater_equal(ColorTemperatureMireds,
-                                         ColorTempPhysicalMinMiredsValue, "ColorTemperatureMireds is below limit")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorTemperatureMireds, ColorTempPhysicalMinMiredsValue, ColorTempPhysicalMaxMiredsValue)])
 
         self.step("9a")
         if self.pics_guard(self.check_pics("CC.S.F01")):
@@ -526,19 +492,9 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("9b")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x05))
-            # delay between recall scene and attribute read
-            await asyncio.sleep(1)
         self.step("9c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
-            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.EnhancedCurrentHue), (self.matter_test_config.endpoint, attributes.CurrentSaturation)])
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.EnhancedCurrentHue], 13800, "EnhancedCurrentHue is above limit")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.EnhancedCurrentHue],
-                                         10200, "EnhancedCurrentHue is below limit")
-            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentSaturation], 78, "CurrentSaturation is above limit")
-            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentSaturation], 62, "CurrentSaturation is below limit")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.EnhancedCurrentHue, 10200, 13800), (attributes.CurrentSaturation, 62, 78)])
 
         self.step("10a")
         if self.pics_guard(self.check_pics("CC.S.F02")):
@@ -568,12 +524,9 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("10b")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x06))
-            # delay between recall scene and attribute read
-            await asyncio.sleep(1)
         self.step("10c")
         if self.pics_guard(self.check_pics("CC.S.F02")):
-            ColorLoopActive = await self.read_single_attribute_check_success(cluster, attributes.ColorLoopActive)
-            asserts.assert_equal(ColorLoopActive, 1, "ColorLoopActive is not 1")
+            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorLoopActive, 1, 1)])
 
         self.step("10d")
         if self.pics_guard(self.check_pics("CC.S.F02")):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -43,7 +43,7 @@ from matter.interaction_model import Status
 import matter.clusters as Clusters
 from TC_GC_common import is_groupcast_on_root_node
 from mobly import asserts
-from typing import List, Tuple
+from typing import List
 
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -408,7 +408,8 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("6b")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
-
+            # delay between recall scene and attribute read
+            await asyncio.sleep(1)
         self.step("6c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             CurrentSaturation = await self.read_single_attribute_check_success(cluster, attributes.CurrentSaturation)
@@ -445,7 +446,8 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("7b")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x03))
-
+            # delay between recall scene and attribute read
+            await asyncio.sleep(1)
         self.step("7c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.CurrentX), (self.matter_test_config.endpoint, attributes.CurrentY)])
@@ -485,7 +487,8 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("8b")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x04))
-
+            # delay between recall scene and attribute read
+            await asyncio.sleep(1)
         self.step("8c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             ColorTemperatureMireds = await self.read_single_attribute_check_success(cluster, attributes.ColorTemperatureMireds)
@@ -523,7 +526,8 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("9b")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x05))
-
+            # delay between recall scene and attribute read
+            await asyncio.sleep(1)
         self.step("9c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.EnhancedCurrentHue), (self.matter_test_config.endpoint, attributes.CurrentSaturation)])
@@ -564,7 +568,8 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("10b")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x06))
-
+            # delay between recall scene and attribute read
+            await asyncio.sleep(1)
         self.step("10c")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             ColorLoopActive = await self.read_single_attribute_check_success(cluster, attributes.ColorLoopActive)

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -43,10 +43,7 @@ from matter.interaction_model import Status
 import matter.clusters as Clusters
 from TC_GC_common import is_groupcast_on_root_node
 from mobly import asserts
-import asyncio
-import time
-from typing import Tuple
-from typing import List
+from typing import List, Tuple
 
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
@@ -70,26 +67,6 @@ class TC_CC_10_1(MatterBaseTest):
             clusterID=Clusters.Objects.ColorControl.id,
             attributeValueList=efs_attribute_value_list
         )
-
-    async def _wait_for_attributes_within_boundaries(self, cluster, attributes: List[Tuple[int, int, int]], timeout_sec: int = 1):
-        """Wait for attributes to be within boundaries.
-
-        Args:
-            cluster: cluster to read the attribute from
-            attributes: list of (attribute_id, min_value, max_value) tuples
-            timeout_sec: timeout in seconds
-        """
-        for attribute in attributes:
-            start_time = time.time()
-
-            value = await self.read_single_attribute_check_success(cluster, attribute[0])
-            while value < attribute[1] or value > attribute[2]:
-                remaining = timeout_sec - (time.time() - start_time)
-                if remaining <= 0:
-                    raise Exception(
-                        f"Timeout waiting for attribute {attribute[0]} to be within boundaries: {attribute[1]} - {attribute[2]}")
-                await asyncio.sleep(0.1)
-                value = await self.read_single_attribute_check_success(cluster, attribute[0])
 
     def desc_TC_CC_10_1(self) -> str:
         """Returns a description of this test"""
@@ -241,7 +218,7 @@ class TC_CC_10_1(MatterBaseTest):
 
         self.step("2b")
         if self.pics_guard(self.check_pics("CC.S.F00")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentHue, 170, 230), (attributes.CurrentSaturation, 42, 58)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentHue, 170, 230), (attributes.CurrentSaturation, 42, 58)])
 
         self.step("2c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
@@ -272,7 +249,7 @@ class TC_CC_10_1(MatterBaseTest):
 
         self.step("3b")
         if self.pics_guard(self.check_pics("CC.S.F03")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentX, 31000, 35000), (attributes.CurrentY, 17000, 21000)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentX, 31000, 35000), (attributes.CurrentY, 17000, 21000)])
 
         self.step("3c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
@@ -310,7 +287,7 @@ class TC_CC_10_1(MatterBaseTest):
         if self.pics_guard(self.check_pics("CC.S.F04")):
             CTmax = round(CTtarget * (1 + kTempTolerance))
             CTmin = round(CTtarget * (1 - kTempTolerance))
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorTemperatureMireds, CTmin, CTmax)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.ColorTemperatureMireds, CTmin, CTmax)])
         self.step("4c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             result = await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.StoreScene(self.kGroup1, 0x01))
@@ -342,7 +319,7 @@ class TC_CC_10_1(MatterBaseTest):
 
         self.step("5b")
         if self.pics_guard(self.check_pics("CC.S.F01")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.EnhancedCurrentHue, 18200, 21800), (attributes.CurrentSaturation, 42, 58)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.EnhancedCurrentHue, 18200, 21800), (attributes.CurrentSaturation, 42, 58)])
 
         self.step("5c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
@@ -396,7 +373,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
         self.step("6c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8)])
 
         self.step("7a")
         if self.pics_guard(self.check_pics("CC.S.F03")):
@@ -430,7 +407,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x03))
         self.step("7c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.CurrentX, 14000, 18000), (attributes.CurrentY, 11000, 15000)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentX, 14000, 18000), (attributes.CurrentY, 11000, 15000)])
 
         self.step("8a")
         if self.pics_guard(self.check_pics("CC.S.F04")):
@@ -461,7 +438,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x04))
         self.step("8c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorTemperatureMireds, ColorTempPhysicalMinMiredsValue, ColorTempPhysicalMaxMiredsValue)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.ColorTemperatureMireds, ColorTempPhysicalMinMiredsValue, ColorTempPhysicalMaxMiredsValue)])
 
         self.step("9a")
         if self.pics_guard(self.check_pics("CC.S.F01")):
@@ -494,7 +471,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x05))
         self.step("9c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.EnhancedCurrentHue, 10200, 13800), (attributes.CurrentSaturation, 62, 78)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.EnhancedCurrentHue, 10200, 13800), (attributes.CurrentSaturation, 62, 78)])
 
         self.step("10a")
         if self.pics_guard(self.check_pics("CC.S.F02")):
@@ -526,7 +503,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x06))
         self.step("10c")
         if self.pics_guard(self.check_pics("CC.S.F02")):
-            await self._wait_for_attributes_within_boundaries(cluster, [(attributes.ColorLoopActive, 1, 1)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.ColorLoopActive, 1, 1)])
 
         self.step("10d")
         if self.pics_guard(self.check_pics("CC.S.F02")):

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -36,6 +36,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 from mobly import asserts
 from TC_GC_common import is_groupcast_on_root_node
 
@@ -195,6 +196,8 @@ class TC_LVL_9_1(MatterBaseTest):
 
         self.step("5a")
         await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
+        # delay between recall scene and attribute read
+        await asyncio.sleep(1)
 
         self.step("5b")
         current_level = await self.read_single_attribute_check_success(cluster, attributes.CurrentLevel)
@@ -202,7 +205,8 @@ class TC_LVL_9_1(MatterBaseTest):
 
         self.step("6a")
         await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x01))
-
+        # delay between recall scene and attribute read
+        await asyncio.sleep(1)
         self.step("6b")
         current_level = await self.read_single_attribute_check_success(cluster, attributes.CurrentLevel)
         asserts.assert_equal(current_level, min_level, "CurrentLevel should equal MinLevel after RecallScene 0x01")

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -197,21 +197,12 @@ class TC_LVL_9_1(MatterBaseTest):
 
         self.step("5a")
         await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
-        # delay between recall scene and attribute read
-        await asyncio.sleep(1)
 
         self.step("5b")
-        current_level = await self.read_single_attribute_check_success(cluster, attributes.CurrentLevel)
-        asserts.assert_equal(current_level, 0x64, "CurrentLevel should be 0x64 after RecallScene 0x02")
+        await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentLevel, 0x64, 0x64)])
 
         self.step("6a")
         await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x01))
-        # delay between recall scene and attribute read
-        await asyncio.sleep(1)
+
         self.step("6b")
-        current_level = await self.read_single_attribute_check_success(cluster, attributes.CurrentLevel)
-        asserts.assert_equal(current_level, min_level, "CurrentLevel should equal MinLevel after RecallScene 0x01")
-
-
-if __name__ == "__main__":
-    default_matter_test_main()
+        await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentLevel, min_level, min_level)])

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -43,7 +43,7 @@ import matter.clusters as Clusters
 from matter.interaction_model import Status
 from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.runner import TestStep
 
 
 class TC_LVL_9_1(MatterBaseTest):

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -37,6 +37,7 @@
 # === END CI TEST ARGUMENTS ===
 
 import asyncio
+
 from mobly import asserts
 from TC_GC_common import is_groupcast_on_root_node
 

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -36,8 +36,6 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import asyncio
-
 from mobly import asserts
 from TC_GC_common import is_groupcast_on_root_node
 
@@ -45,7 +43,7 @@ import matter.clusters as Clusters
 from matter.interaction_model import Status
 from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.runner import TestStep
 
 
 class TC_LVL_9_1(MatterBaseTest):

--- a/src/python_testing/TC_LVL_9_1.py
+++ b/src/python_testing/TC_LVL_9_1.py
@@ -43,7 +43,7 @@ import matter.clusters as Clusters
 from matter.interaction_model import Status
 from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep
+from matter.testing.runner import TestStep, default_matter_test_main
 
 
 class TC_LVL_9_1(MatterBaseTest):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -33,7 +33,7 @@ import typing
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from enum import IntFlag
-from typing import Any, Callable, List, Optional, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 import matter.testing.matchers as matchers
 
@@ -1066,6 +1066,30 @@ class MatterBaseTest(base_test.BaseTestClass):
                 self.record_error(test_name=test_name, location=location, problem=type_err_msg)
                 return None
         return attr_ret
+
+    async def poll_until_attributes_in_range(
+            self, cluster: ClusterObjects.Cluster,
+            attribute_bounds: List[Tuple[Type[ClusterObjects.ClusterAttributeDescriptor], int, int]],
+            timeout_sec: int = 1) -> None:
+        """Poll attributes until each value falls within [min_value, max_value].
+
+        Args:
+            cluster: Cluster to read attributes from.
+            attribute_bounds: List of (attribute, min_value, max_value) tuples.
+            timeout_sec: Maximum time to wait for all attributes to be in range.
+
+        Raises:
+            TimeoutError: If any attribute does not reach its expected range before timeout.
+        """
+        for attribute, min_value, max_value in attribute_bounds:
+            deadline = time.time() + timeout_sec
+            value = await self.read_single_attribute_check_success(cluster, attribute)
+            while value < min_value or value > max_value:  # type: ignore[operator]
+                if time.time() >= deadline:
+                    raise TimeoutError(
+                        f"Timeout waiting for {attribute} to be in range [{min_value}, {max_value}], last value: {value}")
+                await asyncio.sleep(0.1)
+                value = await self.read_single_attribute_check_success(cluster, attribute)
 
     async def read_single_attribute_expect_error(
             self, cluster: ClusterObjects.Cluster, attribute: Type[ClusterObjects.ClusterAttributeDescriptor],

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -1076,16 +1076,16 @@ class MatterBaseTest(base_test.BaseTestClass):
         Args:
             cluster: Cluster to read attributes from.
             attribute_bounds: List of (attribute, min_value, max_value) tuples.
-            timeout_sec: Maximum time to wait for all attributes to be in range.
+            timeout_sec: Maximum time to wait for each attribute to be in range.
 
         Raises:
             TimeoutError: If any attribute does not reach its expected range before timeout.
         """
         for attribute, min_value, max_value in attribute_bounds:
-            deadline = time.time() + timeout_sec
+            deadline = time.monotonic() + timeout_sec
             value = await self.read_single_attribute_check_success(cluster, attribute)
             while value < min_value or value > max_value:  # type: ignore[operator]
-                if time.time() >= deadline:
+                if time.monotonic() >= deadline:
                     raise TimeoutError(
                         f"Timeout waiting for {attribute} to be in range [{min_value}, {max_value}], last value: {value}")
                 await asyncio.sleep(0.1)


### PR DESCRIPTION
#### Summary

Added a retry mechanism between Recall Scenes and Attribute Reads in TC-CC-10-1 and TC-LVL-9-1
to actively poll the attributes expected to change after a recall scene call.

This was causing failures when the TH was ran on an RPi 5 since the delay between commands was of 4ms on the pi5.
Compared to 16ms on the pi4.

1s delay should be plenty enough for this test.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/71679

#### Testing

This is just adding 1 seconds delay, the CI will ensure nothing fails.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
