### PR TITLE
Fix TC_ACE_1_6 When no Endpoint Specified 

### DIFF
--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -167,7 +167,7 @@ class TC_ACE_1_6(MatterBaseTest):
         else:
             # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least
             # one cluster with a command that has operate priviliege.
-            endpoint_to_search = self.get_endpoint() if (self.get_endpoint() != 0) else None
+            endpoint_to_search = self.get_endpoint() or None
             operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, endpoint_to_search)
             asserts.assert_greater(len(operate_only_command_list), 0,
                                    "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -167,7 +167,8 @@ class TC_ACE_1_6(MatterBaseTest):
         else:
             # Find "ep~1~" (not endpoint1) (non-root node endpoint) that will be used later. This is an endpoint that must have at least
             # one cluster with a command that has operate priviliege.
-            operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, self.get_endpoint())
+            endpoint_to_search = self.get_endpoint() if (self.get_endpoint() != 0) else None
+            operate_only_command_list = await get_operate_only_commands(self.default_controller, self.dut_node_id, True, endpoint_to_search)
             asserts.assert_greater(len(operate_only_command_list), 0,
                                    "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
             operate_only_command = operate_only_command_list[0]


### PR DESCRIPTION
#### Summary

When an endpoint is not specified when running the python tests, the endpoint used defaults to 0. When this happened for `TC_ACE_1_6.py` the test would fail as it was receiving conflicting arguments. The test by default tries to ignore endpoint 0 when searching for a cluster on an endpoint with an operate privilege command, as it needs one to use for group commands (and groups cannot contain endpoint 0). This PR updates the logic in the test so that all endpoints will be searched (excluding endpoint 0) when no endpoint is specified. 

#### Related Issues
- https://github.com/project-chip/certification-tool/issues/957

#### Testing

- Ran test locally without specifying an endpoint, passed as expected
- All other CI should still pass