### PR TITLE
[Darwin] Call private cluster decoder if regular decoder hits unknown path

### DIFF
--- a/src/darwin/Framework/CHIP/MTRAttributeTLVValueDecoder_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeTLVValueDecoder_Internal.h
@@ -32,4 +32,11 @@ id _Nullable MTRDecodeAttributeValue(const chip::app::ConcreteAttributePath & aP
 id _Nullable MTRDecodeAttributeValue(const chip::app::ConcreteAttributePath & aPath, const chip::app::ClusterStateCache & aCache,
                                      CHIP_ERROR * aError);
 
+// Decodes an attribute value for private clusters or private extensions on spec clusters.
+// Returns CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB in *aError for unknown paths, matching
+// MTRDecodeAttributeValue's convention. Call as a fallback only when MTRDecodeAttributeValue
+// has already reported CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB.
+id _Nullable MTRPrivateDecodeAttributeValue(const chip::app::ConcreteAttributePath & aPath, chip::TLV::TLVReader & aReader,
+                                            CHIP_ERROR * aError);
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -3235,8 +3235,18 @@ static bool EncodeDataValueToTLV(System::PacketBufferHandle & buffer, Platform::
     }
 
     if (errorCode == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB) {
-        LogStringAndReturnError(@"No known schema for decoding attribute value.", MTRErrorCodeUnknownSchema, error);
-        return nil;
+        decodedValue = MTRPrivateDecodeAttributeValue(attributePath, reader, &errorCode);
+        if (errorCode == CHIP_NO_ERROR) {
+            _path = path;
+            _value = decodedValue;
+            _error = nil;
+            return self;
+        }
+
+        if (errorCode == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB) {
+            LogStringAndReturnError(@"No known schema for decoding attribute value.", MTRErrorCodeUnknownSchema, error);
+            return nil;
+        }
     }
 
     // Treat all other errors as schema errors.
@@ -3470,8 +3480,11 @@ void SubscriptionCallback::OnAttributeData(
         CHIP_ERROR err;
         value = MTRDecodeAttributeValue(aPath, *apData, &err);
         if (err == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB) {
-            // We don't know this attribute; just skip it.
-            return;
+            value = MTRPrivateDecodeAttributeValue(aPath, *apData, &err);
+            if (err == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB) {
+                // We don't know this attribute; just skip it.
+                return;
+            }
         }
 
         if (err != CHIP_NO_ERROR) {


### PR DESCRIPTION
#### Summary

Currently private cluster payload decoders are generated but never called.  Call them if public cluster payload decoders indicate the cluster was not found in the public decoders.

#### Testing

Existing unit tests ensure no regression for public clusters.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
