### PR TITLE
Remove duplicated clusters in CHI and SCI config file.

### DIFF
--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -34,7 +34,6 @@ CommandHandlerInterfaceOnlyClusters:
     - Laundry Washer Mode
     - Microwave Oven Control
     - Network Commissioning
-    - Network Identity Management
     - Operational State
     - Oven Cavity Operational State
     - Oven Mode
@@ -43,11 +42,8 @@ CommandHandlerInterfaceOnlyClusters:
     - RVC Run Mode
     - Refrigerator And Temperature Controlled Cabinet Mode
     - Sample MEI
-    - Scenes Management
     - Service Area
     - Soil Measurement
-    - TLS Certificate Management
-    - TLS Client Management
     - Thread Border Router Management
     - Thread Network Directory
     - Water Heater Management


### PR DESCRIPTION
#### Summary

There seems to be some duplicated clusters in the CHI and SCI lists inside the `config-data.yaml` file of the project.

In theory, a code driven cluster (using SCI) should not use CommandHandlerInterface, so having then listed in both parts can be confusing.

At some point it was needed to add the code driven clusters to the CHI list to avoid ember generated code for commands, but this was changed so adding them in the code driven list also stops this generation.

#### Related issues

NA

#### Testing

The CI should confirm that no ember generated code was added after removing those entries.
