### PR TITLE
[crypto] Add define to enable x509 usage

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -160,6 +160,7 @@ matter_add_gn_arg_bool  ("chip_mdns_minimal"                      CONFIG_WIFI_NR
 matter_add_gn_arg_bool  ("chip_config_enable_groupcast"           CONFIG_CHIP_ENABLE_GROUPCAST)
 matter_add_gn_arg_bool  ("chip_mdns_platform"                     CONFIG_OPENTHREAD)
 matter_add_gn_arg_bool  ("enable_im_pretty_print"                 CONFIG_CHIP_IM_PRETTY_PRINT)
+matter_add_gn_arg_bool  ("chip_crypto_use_x509"                   CONFIG_CHIP_CRYPTO_USE_X509)
 
 matter_add_gn_arg_bool  ("chip_system_config_use_sockets"                   NOT CONFIG_CHIP_USE_OPENTHREAD_ENDPOINT)
 matter_add_gn_arg_bool  ("chip_system_config_use_openthread_inet_endpoints" CONFIG_CHIP_USE_OPENTHREAD_ENDPOINT)

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -472,4 +472,11 @@ config CHIP_QSPI_NOR_POWER_MANAGEMENT_SUPPORT
 	  Enables management of nRF QSPI NOR external flash power state
 	  transitions during Matter operations.
 
+config CHIP_CRYPTO_USE_X509
+	bool "X.509 certificate support"
+	default n if CHIP_CRYPTO_PSA
+	default y if MBEDTLS_X509_LIBRARY # We still need it to be enabled if we use mbedTLS as the crypto backend
+	help
+	  Enables X.509 certificate support for Matter.
+
 endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -474,9 +474,12 @@ config CHIP_QSPI_NOR_POWER_MANAGEMENT_SUPPORT
 
 config CHIP_CRYPTO_USE_X509
 	bool "X.509 certificate support"
+	depends on MBEDTLS_X509_LIBRARY || MBEDTLS
+	default y if CHIP_BUILD_TESTS
 	default n if CHIP_CRYPTO_PSA
-	default y if MBEDTLS_X509_LIBRARY # We still need it to be enabled if we use mbedTLS as the crypto backend
+	default y if MBEDTLS_X509_LIBRARY
 	help
-	  Enables X.509 certificate support for Matter.
+	  Controls compilation of X.509-related crypto functionality in Matter.
+	  Disable to reduce code footprint if your device does not need X.509 certificate parsing/validation.
 
 endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -1,17 +1,17 @@
 #
-#   Copyright (c) 2021 Project CHIP Authors
+#Copyright(c) 2021 Project CHIP Authors
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+#Licensed under the Apache License, Version 2.0(the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
 #
-#       http://www.apache.org/licenses/LICENSE-2.0
+#http: // www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 #
 
 rsource "../../zephyr/Kconfig"
@@ -34,11 +34,11 @@ config CHIP_NRF_PLATFORM
 	  what can be used to conditionally deviate from Zephyr generic configuration
 	  for nRF platform related purposes.
 
-# See config/zephyr/Kconfig for full definition
+#See config / zephyr / Kconfig for full definition
 config CHIP_DEVICE_VENDOR_NAME
 	default "Nordic Semiconductor ASA"
 
-# See config/common/cmake/Kconfig for full definition
+#See config / common / cmake / Kconfig for full definition
 config CHIP_NFC_ONBOARDING_PAYLOAD
 	default n
 	imply NFC_T2T_NRFXLIB
@@ -65,11 +65,11 @@ endchoice
 
 config CHIP_DFU_LIBRARY_MCUMGR
 	bool "Use mcumgr library for Matter DFU purposes"
-	# MCUBOOT
+#MCUBOOT
 	select MCUMGR_GRP_IMG if CHIP_BOOTLOADER_MCUBOOT
 	select MCUMGR_GRP_OS if CHIP_BOOTLOADER_MCUBOOT
 	select MCUMGR_GRP_IMG_STATUS_HOOKS if CHIP_BOOTLOADER_MCUBOOT
-	# COMMON
+#COMMON
 	select MCUMGR
 	imply STREAM_FLASH
 	imply STREAM_FLASH_ERASE
@@ -77,14 +77,14 @@ config CHIP_DFU_LIBRARY_MCUMGR
 config CHIP_DFU_LIBRARY_DFU_TARGET
 	bool "Use dfu target library for Matter DFU purposes"
 	imply DFU_MULTI_IMAGE
-	# COMMON
+#COMMON
 	imply DFU_TARGET
 	imply STREAM_FLASH
 	imply STREAM_FLASH_ERASE
 	select ZCBOR
 	select ZCBOR_CANONICAL
 
-# See config/zephyr/Kconfig for full definition
+#See config / zephyr / Kconfig for full definition
 config CHIP_OTA_REQUESTOR
 	bool
 	imply DFU_MULTI_IMAGE
@@ -197,7 +197,7 @@ config CHIP_FACTORY_DATA_WRITE_PROTECT
 
 if CHIP_FACTORY_DATA_BUILD
 
-# Factory data definitions
+#Factory data definitions
 config CHIP_FACTORY_DATA_MERGE_WITH_FIRMWARE
 	bool "Merge generated factory data with merged.hex output build file"
 	default y
@@ -216,7 +216,7 @@ config CHIP_FACTORY_DATA_GENERATE_ONBOARDING_CODES
 	  onboarding codes a Matter controller to commission a device to a Matter 
 	  network.
 
-# Select source of the certificates
+#Select source of the certificates
 choice CHIP_FACTORY_DATA_CERT_SOURCE
 	prompt "Attestation certificate file source"
 	default CHIP_FACTORY_DATA_USE_DEFAULT_CERTS
@@ -268,7 +268,7 @@ config CHIP_FACTORY_DATA_USER_CERTS_PAI_CERT
 
 endif # CHIP_FACTORY_DATA_CERT_SOURCE_USER
 
-# Configs for SPAKE2+ generation
+#Configs for SPAKE2 + generation
 config CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER
 	bool "Generate SPAKE2+ verifier"
 	default y
@@ -286,7 +286,7 @@ endif # CHIP_FACTORY_DATA_BUILD
 
 endif # CHIP_FACTORY_DATA_NRFCONNECT_BACKEND
 
-# See config/zephyr/Kconfig for full definition
+#See config / zephyr / Kconfig for full definition
 config CHIP_FACTORY_RESET_ERASE_SETTINGS
 	default y
 	depends on NVS || ZMS
@@ -476,10 +476,13 @@ config CHIP_CRYPTO_USE_X509
 	bool "X.509 certificate support"
 	depends on MBEDTLS_X509_LIBRARY || MBEDTLS
 	default y if CHIP_BUILD_TESTS
-	default n if CHIP_CRYPTO_PSA
-	default y if MBEDTLS_X509_LIBRARY
+	default y if !CHIP_CRYPTO_PSA
+	default n
 	help
-	  Controls compilation of X.509-related crypto functionality in Matter.
-	  Disable to reduce code footprint if your device does not need X.509 certificate parsing/validation.
+	  Controls compilation of X.509-related crypto functionality in the
+	  mbedTLS CryptoPAL (certificate parsing/validation and, on the mbedTLS
+	  crypto backend, operational CSR generation during commissioning).
+	  Must remain enabled when using the mbedTLS crypto backend for standard
+	  Matter commissioning (OperationalCredentials CSRRequest).
 
 endif # CHIP

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -49,6 +49,7 @@ buildconfig_header("crypto_buildconfig") {
     "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
     "CHIP_CRYPTO_PLATFORM=${chip_crypto_platform}",
     "CHIP_OP_KEYSTORE_ELE=${chip_with_imx_ele}",
+    "CHIP_CRYPTO_USE_X509=${chip_crypto_use_x509}",
   ]
 }
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -783,7 +783,7 @@ P256Keypair::~P256Keypair()
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
-#if defined(MBEDTLS_X509_CSR_WRITE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     size_t out_length;
@@ -834,7 +834,7 @@ exit:
 #else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif
+#endif // CHIP_CRYPTO_USE_X509
 }
 
 typedef struct Spake2p_Context

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -783,7 +783,7 @@ P256Keypair::~P256Keypair()
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_WRITE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     size_t out_length;
@@ -834,7 +834,7 @@ exit:
 #else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_WRITE_C)
 }
 
 typedef struct Spake2p_Context

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -783,7 +783,7 @@ P256Keypair::~P256Keypair()
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_WRITE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     size_t out_length;
@@ -832,9 +832,13 @@ exit:
     _log_mbedTLS_error(result);
     return error;
 #else
+#if !CHIP_CRYPTO_USE_X509
+    ChipLogError(Crypto, "X.509 support is not enabled. CSR cannot be created");
+#else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
+#endif
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_WRITE_C)
 }
 
 typedef struct Spake2p_Context

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -837,7 +837,7 @@ exit:
 #else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
 #endif
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_WRITE_C)
 }
 

--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -40,16 +40,16 @@
 
 #include <mbedtls/x509_csr.h>
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
 #include <mbedtls/x509_crt.h>
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
 namespace chip {
 namespace Crypto {
 
 CHIP_ERROR VerifyCertificateSigningRequest(const uint8_t * csr_buf, size_t csr_length, P256PublicKey & pubkey)
 {
-#if defined(MBEDTLS_X509_CSR_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     ReturnErrorOnFailure(VerifyCertificateSigningRequestFormat(csr_buf, csr_length));
 
     // TODO: For some embedded targets, mbedTLS library doesn't have mbedtls_x509_csr_parse_der, and mbedtls_x509_csr_parse_free.
@@ -137,7 +137,7 @@ exit:
 
 namespace {
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
 bool IsTimeGreaterThanEqual(const mbedtls_x509_time * const timeA, const mbedtls_x509_time * const timeB)
 {
 
@@ -215,13 +215,13 @@ constexpr uint8_t sOID_Extension_CRLDistributionPoint[]   = { 0x55, 0x1D, 0x1F }
      (sizeof(oid) == (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) &&                                                                \
      (memcmp((oid), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(p), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) == 0))
 
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
 } // anonymous namespace
 
 CHIP_ERROR VerifyAttestationCertificateFormat(const ByteSpan & cert, AttestationCertType certType)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     mbedtls_x509_crt mbed_cert;
@@ -383,7 +383,7 @@ exit:
     (void) cert;
     (void) certType;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -392,7 +392,7 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
                                     size_t caCertificateLen, const uint8_t * leafCertificate, size_t leafCertificateLen,
                                     CertificateChainValidationResult & result)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt certChain;
     mbedtls_x509_crt rootCert;
@@ -459,14 +459,14 @@ exit:
     (void) leafCertificateLen;
     (void) result;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtIssuance(const ByteSpan & candidateCertificate, const ByteSpan & issuerCertificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCandidateCertificate;
     mbedtls_x509_crt mbedIssuerCertificate;
@@ -497,14 +497,14 @@ exit:
     (void) candidateCertificate;
     (void) issuerCertificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtCurrentTime(const ByteSpan & certificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCertificate;
     int result;
@@ -531,14 +531,14 @@ exit:
 #else
     (void) certificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractPubkeyFromX509Cert(const ByteSpan & certificate, Crypto::P256PublicKey & pubkey)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     size_t pubkey_size = 0;
@@ -593,7 +593,7 @@ exit:
     (void) certificate;
     (void) pubkey;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -602,7 +602,7 @@ namespace {
 
 CHIP_ERROR ExtractKIDFromX509Cert(bool extractSKID, const ByteSpan & certificate, MutableByteSpan & kid)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -679,7 +679,7 @@ exit:
     (void) certificate;
     (void) kid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -698,7 +698,7 @@ CHIP_ERROR ExtractAKIDFromX509Cert(const ByteSpan & certificate, MutableByteSpan
 
 CHIP_ERROR ExtractCRLDistributionPointURIFromX509Cert(const ByteSpan & certificate, MutableCharSpan & cdpurl)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -818,14 +818,14 @@ exit:
     (void) certificate;
     (void) cdpurl;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractCDPExtensionCRLIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSpan & crlIssuer)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -934,14 +934,14 @@ exit:
     (void) certificate;
     (void) crlIssuer;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractSerialNumberFromX509Cert(const ByteSpan & certificate, MutableByteSpan & serialNumber)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -968,14 +968,14 @@ exit:
     (void) certificate;
     (void) serialNumber;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCertVidPid & vidpid)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     mbedtls_asn1_named_data * dnIterator = nullptr;
@@ -1024,7 +1024,7 @@ exit:
     (void) certificate;
     (void) vidpid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -1032,7 +1032,7 @@ exit:
 namespace {
 CHIP_ERROR ExtractRawDNFromX509Cert(bool extractSubject, const ByteSpan & certificate, MutableByteSpan & dn)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -1068,7 +1068,7 @@ exit:
     (void) certificate;
     (void) dn;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -1087,7 +1087,7 @@ CHIP_ERROR ExtractIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSp
 CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate, const ByteSpan * candidateCertificates,
                                           size_t candidateCertificatesCount, ByteSpan & outCertificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     uint8_t referenceSubjectBuf[kMaxCertificateDistinguishedNameLength];
     uint8_t referenceSKIDBuf[kSubjectKeyIdentifierLength];
     MutableByteSpan referenceSubject(referenceSubjectBuf);
@@ -1125,7 +1125,7 @@ CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate,
     (void) candidateCertificatesCount;
     (void) outCertificate;
     return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 }
 
 } // namespace Crypto

--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -38,8 +38,6 @@
 #include <psa/crypto.h>
 #endif // (MBEDTLS_VERSION_NUMBER >= 0x04000000)
 
-#include <mbedtls/x509_csr.h>
-
 #if CHIP_CRYPTO_USE_X509
 #include <mbedtls/x509_crt.h>
 #endif // CHIP_CRYPTO_USE_X509

--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -48,16 +48,16 @@
 
 #include <mbedtls/x509_csr.h>
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
 #include <mbedtls/x509_crt.h>
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
 namespace chip {
 namespace Crypto {
 
 CHIP_ERROR VerifyCertificateSigningRequest(const uint8_t * csr_buf, size_t csr_length, P256PublicKey & pubkey)
 {
-#if defined(MBEDTLS_X509_CSR_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     ReturnErrorOnFailure(VerifyCertificateSigningRequestFormat(csr_buf, csr_length));
 
     // TODO: For some embedded targets, mbedTLS library doesn't have mbedtls_x509_csr_parse_der, and mbedtls_x509_csr_parse_free.
@@ -146,7 +146,7 @@ exit:
 
 namespace {
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
 bool IsTimeGreaterThanEqual(const mbedtls_x509_time * const timeA, const mbedtls_x509_time * const timeB)
 {
 
@@ -224,13 +224,13 @@ constexpr uint8_t sOID_Extension_CRLDistributionPoint[]   = { 0x55, 0x1D, 0x1F }
      (sizeof(oid) == (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) &&                                                                \
      (memcmp((oid), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(p), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) == 0))
 
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
 } // anonymous namespace
 
 CHIP_ERROR VerifyAttestationCertificateFormat(const ByteSpan & cert, AttestationCertType certType)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     mbedtls_x509_crt mbed_cert;
@@ -392,7 +392,7 @@ exit:
     (void) cert;
     (void) certType;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -401,7 +401,7 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
                                     size_t caCertificateLen, const uint8_t * leafCertificate, size_t leafCertificateLen,
                                     CertificateChainValidationResult & result)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt certChain;
     mbedtls_x509_crt rootCert;
@@ -468,14 +468,14 @@ exit:
     (void) leafCertificateLen;
     (void) result;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtIssuance(const ByteSpan & candidateCertificate, const ByteSpan & issuerCertificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCandidateCertificate;
     mbedtls_x509_crt mbedIssuerCertificate;
@@ -506,14 +506,14 @@ exit:
     (void) candidateCertificate;
     (void) issuerCertificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtCurrentTime(const ByteSpan & certificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCertificate;
     int result;
@@ -540,14 +540,14 @@ exit:
 #else
     (void) certificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractPubkeyFromX509Cert(const ByteSpan & certificate, Crypto::P256PublicKey & pubkey)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     size_t pubkey_size = 0;
@@ -602,7 +602,7 @@ exit:
     (void) certificate;
     (void) pubkey;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -611,7 +611,7 @@ namespace {
 
 CHIP_ERROR ExtractKIDFromX509Cert(bool extractSKID, const ByteSpan & certificate, MutableByteSpan & kid)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -688,7 +688,7 @@ exit:
     (void) certificate;
     (void) kid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -707,7 +707,7 @@ CHIP_ERROR ExtractAKIDFromX509Cert(const ByteSpan & certificate, MutableByteSpan
 
 CHIP_ERROR ExtractCRLDistributionPointURIFromX509Cert(const ByteSpan & certificate, MutableCharSpan & cdpurl)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -827,14 +827,14 @@ exit:
     (void) certificate;
     (void) cdpurl;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractCDPExtensionCRLIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSpan & crlIssuer)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -943,14 +943,14 @@ exit:
     (void) certificate;
     (void) crlIssuer;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractSerialNumberFromX509Cert(const ByteSpan & certificate, MutableByteSpan & serialNumber)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -977,14 +977,14 @@ exit:
     (void) certificate;
     (void) serialNumber;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
 
 CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCertVidPid & vidpid)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     mbedtls_asn1_named_data * dnIterator = nullptr;
@@ -1033,7 +1033,7 @@ exit:
     (void) certificate;
     (void) vidpid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -1041,7 +1041,7 @@ exit:
 namespace {
 CHIP_ERROR ExtractRawDNFromX509Cert(bool extractSubject, const ByteSpan & certificate, MutableByteSpan & dn)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -1077,7 +1077,7 @@ exit:
     (void) certificate;
     (void) dn;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 
     return error;
 }
@@ -1096,7 +1096,7 @@ CHIP_ERROR ExtractIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSp
 CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate, const ByteSpan * candidateCertificates,
                                           size_t candidateCertificatesCount, ByteSpan & outCertificate)
 {
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if CHIP_CRYPTO_USE_X509
     uint8_t referenceSubjectBuf[kMaxCertificateDistinguishedNameLength];
     uint8_t referenceSKIDBuf[kSubjectKeyIdentifierLength];
     MutableByteSpan referenceSubject(referenceSubjectBuf);
@@ -1134,7 +1134,7 @@ CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate,
     (void) candidateCertificatesCount;
     (void) outCertificate;
     return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#endif // CHIP_CRYPTO_USE_X509
 }
 
 } // namespace Crypto

--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -46,18 +46,20 @@
 #include <mbedtls/ecp.h>
 #endif // (MBEDTLS_VERSION_NUMBER >= 0x04000000)
 
-#include <mbedtls/x509_csr.h>
-
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 #include <mbedtls/x509_crt.h>
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
+
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_PARSE_C)
+#include <mbedtls/x509_csr.h>
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_PARSE_C)
 
 namespace chip {
 namespace Crypto {
 
 CHIP_ERROR VerifyCertificateSigningRequest(const uint8_t * csr_buf, size_t csr_length, P256PublicKey & pubkey)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_PARSE_C)
     ReturnErrorOnFailure(VerifyCertificateSigningRequestFormat(csr_buf, csr_length));
 
     // TODO: For some embedded targets, mbedTLS library doesn't have mbedtls_x509_csr_parse_der, and mbedtls_x509_csr_parse_free.
@@ -139,14 +141,18 @@ exit:
     _log_mbedTLS_error(result);
     return error;
 #else
+#if !CHIP_CRYPTO_USE_X509
+    ChipLogError(Crypto, "X.509 support is not enabled. CSR cannot be parsed");
+#else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_PARSE_C is not enabled. CSR cannot be parsed");
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_PARSE_C)
 }
 
 namespace {
 
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 bool IsTimeGreaterThanEqual(const mbedtls_x509_time * const timeA, const mbedtls_x509_time * const timeB)
 {
 
@@ -224,13 +230,13 @@ constexpr uint8_t sOID_Extension_CRLDistributionPoint[]   = { 0x55, 0x1D, 0x1F }
      (sizeof(oid) == (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) &&                                                                \
      (memcmp((oid), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(p), (oidBuf).CHIP_CRYPTO_PAL_PRIVATE_X509(len)) == 0))
 
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
 } // anonymous namespace
 
 CHIP_ERROR VerifyAttestationCertificateFormat(const ByteSpan & cert, AttestationCertType certType)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     mbedtls_x509_crt mbed_cert;
@@ -391,8 +397,13 @@ exit:
 #else
     (void) cert;
     (void) certType;
-    CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#if !CHIP_CRYPTO_USE_X509
+    ChipLogError(Crypto, "X.509 support is not enabled. Attestation certificate format cannot be verified");
+#else
+    ChipLogError(Crypto, "MBEDTLS_X509_CRT_PARSE_C is not enabled. Attestation certificate format cannot be verified");
+#endif
+    CHIP_ERROR error = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
@@ -401,7 +412,7 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
                                     size_t caCertificateLen, const uint8_t * leafCertificate, size_t leafCertificateLen,
                                     CertificateChainValidationResult & result)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt certChain;
     mbedtls_x509_crt rootCert;
@@ -468,14 +479,14 @@ exit:
     (void) leafCertificateLen;
     (void) result;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtIssuance(const ByteSpan & candidateCertificate, const ByteSpan & issuerCertificate)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCandidateCertificate;
     mbedtls_x509_crt mbedIssuerCertificate;
@@ -506,14 +517,14 @@ exit:
     (void) candidateCertificate;
     (void) issuerCertificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR IsCertificateValidAtCurrentTime(const ByteSpan & certificate)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbedCertificate;
     int result;
@@ -540,14 +551,14 @@ exit:
 #else
     (void) certificate;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR ExtractPubkeyFromX509Cert(const ByteSpan & certificate, Crypto::P256PublicKey & pubkey)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     size_t pubkey_size = 0;
@@ -602,7 +613,7 @@ exit:
     (void) certificate;
     (void) pubkey;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
@@ -611,7 +622,7 @@ namespace {
 
 CHIP_ERROR ExtractKIDFromX509Cert(bool extractSKID, const ByteSpan & certificate, MutableByteSpan & kid)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -688,7 +699,7 @@ exit:
     (void) certificate;
     (void) kid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
@@ -707,7 +718,7 @@ CHIP_ERROR ExtractAKIDFromX509Cert(const ByteSpan & certificate, MutableByteSpan
 
 CHIP_ERROR ExtractCRLDistributionPointURIFromX509Cert(const ByteSpan & certificate, MutableCharSpan & cdpurl)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -827,14 +838,14 @@ exit:
     (void) certificate;
     (void) cdpurl;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR ExtractCDPExtensionCRLIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSpan & crlIssuer)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_ERROR_NOT_FOUND;
     mbedtls_x509_crt mbed_cert;
     unsigned char * p         = nullptr;
@@ -943,14 +954,14 @@ exit:
     (void) certificate;
     (void) crlIssuer;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR ExtractSerialNumberFromX509Cert(const ByteSpan & certificate, MutableByteSpan & serialNumber)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -977,14 +988,14 @@ exit:
     (void) certificate;
     (void) serialNumber;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
 
 CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCertVidPid & vidpid)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     mbedtls_x509_crt mbed_cert;
     mbedtls_asn1_named_data * dnIterator = nullptr;
@@ -1033,7 +1044,7 @@ exit:
     (void) certificate;
     (void) vidpid;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
@@ -1041,7 +1052,7 @@ exit:
 namespace {
 CHIP_ERROR ExtractRawDNFromX509Cert(bool extractSubject, const ByteSpan & certificate, MutableByteSpan & dn)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     uint8_t * p      = nullptr;
@@ -1077,7 +1088,7 @@ exit:
     (void) certificate;
     (void) dn;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;
 }
@@ -1096,7 +1107,7 @@ CHIP_ERROR ExtractIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSp
 CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate, const ByteSpan * candidateCertificates,
                                           size_t candidateCertificatesCount, ByteSpan & outCertificate)
 {
-#if CHIP_CRYPTO_USE_X509
+#if CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
     uint8_t referenceSubjectBuf[kMaxCertificateDistinguishedNameLength];
     uint8_t referenceSKIDBuf[kSubjectKeyIdentifierLength];
     MutableByteSpan referenceSubject(referenceSubjectBuf);
@@ -1134,7 +1145,7 @@ CHIP_ERROR ReplaceCertIfResignedCertFound(const ByteSpan & referenceCertificate,
     (void) candidateCertificatesCount;
     (void) outCertificate;
     return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CRYPTO_USE_X509
+#endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 }
 
 } // namespace Crypto

--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -146,7 +146,7 @@ exit:
 #else
     ChipLogError(Crypto, "MBEDTLS_X509_CSR_PARSE_C is not enabled. CSR cannot be parsed");
 #endif
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CSR_PARSE_C)
 }
 
@@ -402,7 +402,7 @@ exit:
 #else
     ChipLogError(Crypto, "MBEDTLS_X509_CRT_PARSE_C is not enabled. Attestation certificate format cannot be verified");
 #endif
-    CHIP_ERROR error = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_CRYPTO_USE_X509 && defined(MBEDTLS_X509_CRT_PARSE_C)
 
     return error;

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -46,6 +46,11 @@ declare_args() {
   # see https://www.nxp.com/products/nxp-product-information/nxp-product-programs/edgelock-secure-enclave:EDGELOCK-SECURE-ENCLAVE
   # to get more information.
   chip_with_imx_ele = false
+
+  # Enable support for x509 certificates.
+  # Disable this argument to reduce the code footprint if your device does not
+  # need to manage the x509 certificates.
+  chip_crypto_use_x509 = true
 }
 
 if (chip_crypto == "") {

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -47,10 +47,10 @@ declare_args() {
   # to get more information.
   chip_with_imx_ele = false
 
-  # Enable support for x509 certificates.
-  # Disable this argument to reduce the code footprint if your device does not
-  # need to manage the x509 certificates.
-  chip_crypto_use_x509 = true
+  # Enable mbedTLS CryptoPAL X.509 support (cert parsing/validation and, on the
+  # mbedTLS crypto backend, operational CSR generation). Defaults to false for
+  # footprint; see chip_crypto_use_x509_required below for auto-enable cases.
+  chip_crypto_use_x509 = false
 }
 
 if (chip_crypto == "") {
@@ -70,6 +70,20 @@ assert(
         chip_crypto == "openssl" || chip_crypto == "boringssl" ||
         chip_crypto == "platform",
     "Please select a valid crypto implementation: mbedtls, psa, openssl, boringssl, platform")
+
+# mbedTLS backend operational CSR generation requires X509 PAL support.
+# Host-side tests (non-PSA) exercise X509 PAL code paths. PSA products keep
+# X509 disabled by default; see TestX509Disabled_* in TestChipCryptoPAL.
+_chip_build_tests = defined(chip_build_tests) && chip_build_tests
+chip_crypto_use_x509_required = chip_crypto == "mbedtls" ||
+                                (_chip_build_tests && chip_crypto != "psa")
+
+if (chip_crypto_use_x509_required) {
+  chip_crypto_use_x509 = true
+}
+
+assert(!chip_crypto_use_x509_required || chip_crypto_use_x509,
+       "chip_crypto_use_x509 must be enabled when required for the selected crypto backend")
 
 if (chip_crypto_keystore == "") {
   if (chip_crypto == "psa") {

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -40,6 +40,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <crypto/CHIPCryptoPAL.h>
+#include <crypto/CryptoBuildConfig.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/StringBuilderAdapters.h>
@@ -321,6 +322,11 @@ static void TestAES_CTR_128_Decrypt(const AesCtrTestEntry * vector)
     {
         printf("\n Test failed due to mismatching plaintext\n");
     }
+}
+
+bool IsX509PalFeatureUnavailable(CHIP_ERROR err)
+{
+    return err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE || err == CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 struct TestChipCryptoPAL : public ::testing::Test
@@ -1732,7 +1738,7 @@ TEST_F(TestChipCryptoPAL, TestCSR_Verify)
         err = VerifyCertificateSigningRequest(&kBadTrailingGarbageCsr[0], sizeof(kBadTrailingGarbageCsr), pubKey);
 
         // On first test case, check if CSRs are supported at all, and skip test if they are not.
-        if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+        if (IsX509PalFeatureUnavailable(err))
         {
             ChipLogError(Crypto, "The current platform does not support CSR parsing.");
             return;
@@ -1895,7 +1901,7 @@ TEST_F(TestChipCryptoPAL, TestCSR_GenDirect)
     P256PublicKey pubkey;
 
     CHIP_ERROR err = VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), pubkey);
-    if (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    if (!IsX509PalFeatureUnavailable(err))
     {
         EXPECT_EQ(err, CHIP_NO_ERROR);
         EXPECT_EQ(pubkey.Length(), kP256_PublicKey_Length);
@@ -1927,7 +1933,7 @@ TEST_F(TestChipCryptoPAL, TestCSR_GenByKeypair)
 
     P256PublicKey pubkey;
     CHIP_ERROR err = VerifyCertificateSigningRequest(csr, length, pubkey);
-    if (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    if (!IsX509PalFeatureUnavailable(err))
     {
         ASSERT_EQ(err, CHIP_NO_ERROR);
         EXPECT_EQ(pubkey.Length(), kP256_PublicKey_Length);
@@ -2452,6 +2458,8 @@ TEST_F(TestChipCryptoPAL, TestCompressedFabricIdentifier)
     error = GenerateCompressedFabricId(invalid_root_public_key, kFabricId, compressed_fabric_id_span);
     EXPECT_EQ(error, CHIP_ERROR_INVALID_ARGUMENT);
 }
+
+#if CHIP_CRYPTO_USE_X509
 
 TEST_F(TestChipCryptoPAL, TestPubkey_x509Extraction)
 {
@@ -3295,6 +3303,8 @@ TEST_F(TestChipCryptoPAL, TestX509_ReplaceCertIfResignedCertFound)
     }
 }
 
+#endif // CHIP_CRYPTO_USE_X509
+
 static const uint8_t kCompressedFabricId[] = { 0x29, 0x06, 0xC9, 0x08, 0xD1, 0x15, 0xD3, 0x62 };
 
 const uint8_t kEpochKeyBuffer1[Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
@@ -3822,3 +3832,88 @@ TEST_F(TestChipCryptoPAL, TestHazardousOperationLoadKeypairFromRaw)
     // Verify again with that instance
     EXPECT_EQ(pubkey.ECDSA_validate_msg_signature(reinterpret_cast<const uint8_t *>(msg), msg_len, signature), CHIP_NO_ERROR);
 }
+
+#if !CHIP_CRYPTO_USE_X509
+
+TEST_F(TestChipCryptoPAL, TestX509Disabled_CertParsingUnavailable)
+{
+    using namespace TestCerts;
+
+    HeapChecker heapChecker;
+
+    P256PublicKey publicKey;
+    CertificateChainValidationResult chainValidationResult;
+    AttestationCertVidPid vidpid;
+    ByteSpan outCert;
+    ByteSpan candidateCerts[] = { sTestCert_PAA_FFF1_Cert };
+    uint8_t skidBuf[kSubjectKeyIdentifierLength];
+    MutableByteSpan skidOut(skidBuf);
+    uint8_t akidBuf[kAuthorityKeyIdentifierLength];
+    MutableByteSpan akidOut(akidBuf);
+    char cdpBuf[kMaxCRLDistributionPointURLLength] = { '\0' };
+    MutableCharSpan cdp(cdpBuf);
+    uint8_t crlIssuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
+    MutableByteSpan crlIssuer(crlIssuerBuf);
+    uint8_t serialNumberBuf[kMaxCertificateSerialNumberLength] = { 0 };
+    MutableByteSpan serialNumber(serialNumberBuf);
+    uint8_t dnBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
+    MutableByteSpan dn(dnBuf);
+
+    EXPECT_EQ(VerifyAttestationCertificateFormat(sTestCert_PAA_FFF1_Cert, AttestationCertType::kPAA),
+              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ValidateCertificateChain(sTestCert_PAA_FFF1_Cert.data(), sTestCert_PAA_FFF1_Cert.size(),
+                                       sTestCert_PAI_FFF1_8000_Cert.data(), sTestCert_PAI_FFF1_8000_Cert.size(),
+                                       sTestCert_DAC_FFF1_8000_0000_Cert.data(), sTestCert_DAC_FFF1_8000_0000_Cert.size(),
+                                       chainValidationResult),
+              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(IsCertificateValidAtIssuance(sTestCert_DAC_FFF1_8000_0000_Cert, sTestCert_PAA_FFF1_Cert),
+              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(IsCertificateValidAtCurrentTime(sTestCert_PAA_FFF1_Cert), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractPubkeyFromX509Cert(sTestCert_PAA_FFF1_Cert, publicKey), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractSKIDFromX509Cert(sTestCert_PAA_FFF1_Cert, skidOut), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractAKIDFromX509Cert(sTestCert_PAA_FFF1_Cert, akidOut), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractCRLDistributionPointURIFromX509Cert(sTestCert_PAA_FFF1_Cert, cdp), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractCDPExtensionCRLIssuerFromX509Cert(sTestCert_PAA_FFF1_Cert, crlIssuer), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractSerialNumberFromX509Cert(sTestCert_PAA_FFF1_Cert, serialNumber), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractSubjectFromX509Cert(sTestCert_PAA_FFF1_Cert, dn), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractIssuerFromX509Cert(sTestCert_PAA_FFF1_Cert, dn), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(VerifyCertificateSigningRequest(sTestCert_PAA_FFF1_Cert.data(), sTestCert_PAA_FFF1_Cert.size(), publicKey),
+              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ReplaceCertIfResignedCertFound(sTestCert_PAI_FFF1_8000_Cert, candidateCerts, MATTER_ARRAY_SIZE(candidateCerts),
+                                               outCert),
+              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(ExtractVIDPIDFromX509Cert(sTestCert_PAI_FFF1_8000_Cert, vidpid), CHIP_ERROR_NOT_IMPLEMENTED);
+}
+
+TEST_F(TestChipCryptoPAL, TestX509Disabled_PsaOperationalCsrGeneration)
+{
+#if !CHIP_CRYPTO_PSA
+    GTEST_SKIP() << "PSA backend only";
+#endif
+
+    HeapChecker heapChecker;
+
+    uint8_t csr[kMIN_CSR_Buffer_Size];
+    size_t length = sizeof(csr);
+
+    Test_P256Keypair keypair;
+    ASSERT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
+    ASSERT_EQ(keypair.NewCertificateSigningRequest(csr, length), CHIP_NO_ERROR);
+    ASSERT_GT(length, 2u);
+
+    uint8_t csrBuf[kMIN_CSR_Buffer_Size];
+    ClearSecretData(csrBuf);
+    MutableByteSpan csrSpan(csrBuf);
+    ASSERT_EQ(GenerateCertificateSigningRequest(&keypair, csrSpan), CHIP_NO_ERROR);
+
+    // CSR generation uses the ASN.1 path and remains available without X509 PAL support.
+    EXPECT_EQ(VerifyCertificateSigningRequestFormat(csr, length), CHIP_NO_ERROR);
+    EXPECT_EQ(VerifyCertificateSigningRequestFormat(csrSpan.data(), csrSpan.size()), CHIP_NO_ERROR);
+
+    // Signature verification still requires X509 PAL parsing.
+    P256PublicKey pubkey;
+    EXPECT_EQ(VerifyCertificateSigningRequest(csr, length, pubkey), CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), pubkey), CHIP_ERROR_NOT_IMPLEMENTED);
+}
+
+#endif // !CHIP_CRYPTO_USE_X509

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -3859,15 +3859,13 @@ TEST_F(TestChipCryptoPAL, TestX509Disabled_CertParsingUnavailable)
     uint8_t dnBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
     MutableByteSpan dn(dnBuf);
 
-    EXPECT_EQ(VerifyAttestationCertificateFormat(sTestCert_PAA_FFF1_Cert, AttestationCertType::kPAA),
-              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(VerifyAttestationCertificateFormat(sTestCert_PAA_FFF1_Cert, AttestationCertType::kPAA), CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(ValidateCertificateChain(sTestCert_PAA_FFF1_Cert.data(), sTestCert_PAA_FFF1_Cert.size(),
                                        sTestCert_PAI_FFF1_8000_Cert.data(), sTestCert_PAI_FFF1_8000_Cert.size(),
                                        sTestCert_DAC_FFF1_8000_0000_Cert.data(), sTestCert_DAC_FFF1_8000_0000_Cert.size(),
                                        chainValidationResult),
               CHIP_ERROR_NOT_IMPLEMENTED);
-    EXPECT_EQ(IsCertificateValidAtIssuance(sTestCert_DAC_FFF1_8000_0000_Cert, sTestCert_PAA_FFF1_Cert),
-              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(IsCertificateValidAtIssuance(sTestCert_DAC_FFF1_8000_0000_Cert, sTestCert_PAA_FFF1_Cert), CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(IsCertificateValidAtCurrentTime(sTestCert_PAA_FFF1_Cert), CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(ExtractPubkeyFromX509Cert(sTestCert_PAA_FFF1_Cert, publicKey), CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(ExtractSKIDFromX509Cert(sTestCert_PAA_FFF1_Cert, skidOut), CHIP_ERROR_NOT_IMPLEMENTED);
@@ -3879,9 +3877,9 @@ TEST_F(TestChipCryptoPAL, TestX509Disabled_CertParsingUnavailable)
     EXPECT_EQ(ExtractIssuerFromX509Cert(sTestCert_PAA_FFF1_Cert, dn), CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(VerifyCertificateSigningRequest(sTestCert_PAA_FFF1_Cert.data(), sTestCert_PAA_FFF1_Cert.size(), publicKey),
               CHIP_ERROR_NOT_IMPLEMENTED);
-    EXPECT_EQ(ReplaceCertIfResignedCertFound(sTestCert_PAI_FFF1_8000_Cert, candidateCerts, MATTER_ARRAY_SIZE(candidateCerts),
-                                               outCert),
-              CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(
+        ReplaceCertIfResignedCertFound(sTestCert_PAI_FFF1_8000_Cert, candidateCerts, MATTER_ARRAY_SIZE(candidateCerts), outCert),
+        CHIP_ERROR_NOT_IMPLEMENTED);
     EXPECT_EQ(ExtractVIDPIDFromX509Cert(sTestCert_PAI_FFF1_8000_Cert, vidpid), CHIP_ERROR_NOT_IMPLEMENTED);
 }
 

--- a/src/test_driver/nrfconnect/main/include/app_mbedtls_config.h
+++ b/src/test_driver/nrfconnect/main/include/app_mbedtls_config.h
@@ -18,5 +18,6 @@
 
 // Enable cryptographic functions needed by CHIP which can't be enabled via Kconfig
 #define MBEDTLS_X509_CREATE_C
+#define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_CSR_PARSE_C
 #define MBEDTLS_X509_CSR_WRITE_C

--- a/src/test_driver/nrfconnect/prj.conf
+++ b/src/test_driver/nrfconnect/prj.conf
@@ -97,3 +97,6 @@ CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL=200
 
 # Enable system I/O module
 CONFIG_PIGWEED_SYS_IO=y
+
+# Enable X.509 certificate support
+CONFIG_CHIP_CRYPTO_USE_X509=y

--- a/src/test_driver/nrfconnect/prj.conf
+++ b/src/test_driver/nrfconnect/prj.conf
@@ -98,5 +98,5 @@ CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL=200
 # Enable system I/O module
 CONFIG_PIGWEED_SYS_IO=y
 
-# Enable X.509 certificate support
+# Enable X.509 certificate support (required by crypto unit tests)
 CONFIG_CHIP_CRYPTO_USE_X509=y


### PR DESCRIPTION
#### Summary

In some cases, we do not want to use x509 for Matter purposes, but it can be used for different use cases. In order to allow doing that and reducing the Matter footprint added the chip_crypto_use_x509 define that can control when the
X509-related functions are added to the compilation.

#### Testing

Existing crypto tests, nrfconnect posix workflow.
