### PR TITLE
[1.5 cherrypick] [Groups] add a bounds check for session decryption

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1037,6 +1037,11 @@ static bool GroupKeyDecryptAttempt(const PacketHeader & partialPacketHeader, Pac
         // Perform privacy deobfuscation, if applicable.
         uint8_t * privacyHeader = partialPacketHeader.PrivacyHeader(msgCopy->Start());
         size_t privacyLength    = partialPacketHeader.PrivacyHeaderLength();
+
+        // Bounds check: we decrypt in place a privacy header located inside the packet.
+        // Validate that we are still within the packet as the length is based on header flags.
+        VerifyOrReturnValue(privacyHeader + privacyLength <= msgCopy->Start() + msgCopy->DataLength(), false);
+
         if (CHIP_NO_ERROR != context.PrivacyDecrypt(privacyHeader, privacyLength, privacyHeader, partialPacketHeader, mac))
         {
             return false;

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -365,6 +365,36 @@ struct MessageTestEntry theMessageTestVector[] = {
 
         .expectedMessageCount = 0,
     },
+    {
+        // Buffer is truncated to exactly 16 bytes (the MIC size), so it passes
+        // the MIC extraction check but is far too short to hold the privacy header.
+        //
+        // msgFlags  = 0x06: version=0, kSourceNodeIdPresent (0x04), kDestinationGroupIdPresent (0x02)
+        // sessionId = 0xdb7d (matches the group key set up by the epoch key below)
+        // secFlags  = 0x81: kPrivacyFlag (0x80) | kGroupSession (0x01)
+        //
+        // PrivacyHeaderLength() = 4 (min) + 8 (source NodeId) + 2 (dest GroupId) = 14
+        // Required buffer for privacy region: offset 4 + length 14 = 18 bytes > 16 bytes → OOB
+        .name     = "private group message (privacy header exceeds buffer length)",
+        .peerAddr = "::1",
+
+        .payload = "",
+        .plain   = "",
+        .privacy = "\x06\x7d\xdb\x81\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+
+        .payloadLength = 0,
+        .plainLength   = 0,
+        .privacyLength = 16,
+
+        .epochKey = "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+
+        .sessionId    = 0xdb7d, // 56189
+        .peerNodeId   = 0x0000000000000000ULL,
+        .groupId      = 2,
+        .sourceNodeId = 0x0000000000000002ULL,
+
+        .expectedMessageCount = 0,
+    },
 #if CHIP_CONFIG_PRIVACY_ACCEPT_NONSPEC_SVE2
     // =======================================
     // Test early-SVE2 workaround


### PR DESCRIPTION
#### Summary

Cherrypick #71842 to 1.5

#### Testing

Clean CP