### PR TITLE
Decoupling case logic from CNET 4_23

### DIFF
--- a/src/python_testing/TC_CNET_4_23_2.py
+++ b/src/python_testing/TC_CNET_4_23_2.py
@@ -15,8 +15,7 @@
 #    limitations under the License.
 #
 # TC_CNET_4_23_2.py — continuation of TC-CNET-4.23: Network Commissioning on a second
-# Wi-Fi profile over an operational (CASE) session. Maps to test plan steps 17–22;
-# this script uses harness steps 1–6. Intended to follow TC_CNET_4_23; with default
+# Wi-Fi profile over an operational (CASE) session. Maps to test plan steps 17–22. Intended to follow TC_CNET_4_23; with default
 # harness behaviour the DUT is commissioned before this test runs when
 # commissioning_method is configured.
 #
@@ -150,6 +149,8 @@ class TC_CNET_4_23_2(MatterBaseTest):
         )
         asserts.assert_true(isinstance(afs, cgen.Commands.ArmFailSafeResponse),
                             "Expected ArmFailSafeResponse in CASE phase")
+        asserts.assert_equal(afs.errorCode, cgen.Enums.CommissioningErrorEnum.kOk,
+                             f"ArmFailSafe (arm) failed with errorCode={afs.errorCode}")
 
         self.step(2)
         logger.info(" --- CASE phase: AddOrUpdateWiFiNetwork with WRONG password")
@@ -216,11 +217,15 @@ class TC_CNET_4_23_2(MatterBaseTest):
         )
 
         logger.info(" --- CASE phase: disarming failsafe")
-        await self.send_single_cmd(
+        afs_disarm = await self.send_single_cmd(
             endpoint=endpoint,
             cmd=cgen.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=105),
             timedRequestTimeoutMs=TIMED_REQUEST_TIMEOUT_MS
         )
+        asserts.assert_true(isinstance(afs_disarm, cgen.Commands.ArmFailSafeResponse),
+                            "Expected ArmFailSafeResponse when disarming fail-safe")
+        asserts.assert_equal(afs_disarm.errorCode, cgen.Enums.CommissioningErrorEnum.kOk,
+                             f"ArmFailSafe (disarm) failed with errorCode={afs_disarm.errorCode}")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_CNET_4_23_2.py
+++ b/src/python_testing/TC_CNET_4_23_2.py
@@ -1,0 +1,227 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# TC_CNET_4_23_2.py — continuation of TC-CNET-4.23: Network Commissioning on a second
+# Wi-Fi profile over an operational (CASE) session. Maps to test plan steps 17–22;
+# this script uses harness steps 1–6. Intended to follow TC_CNET_4_23; with default
+# harness behaviour the DUT is commissioned before this test runs when
+# commissioning_method is configured.
+#
+
+import asyncio
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.commissioning import ROOT_ENDPOINT_ID
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+logger = logging.getLogger(__name__)
+
+TIMED_REQUEST_TIMEOUT_MS = 5000
+CONNECT_NETWORK_TIMEOUT_MS = 30000
+NETWORK_STATUS_UPDATE_DELAY = 3
+TIMEOUT = 180
+
+cnet = Clusters.NetworkCommissioning
+cgen = Clusters.GeneralCommissioning
+
+
+class TC_CNET_4_23_2(MatterBaseTest):
+
+    async def _validate_network_config_response(
+        self,
+        response: cnet.Commands.NetworkConfigResponse,
+        expected_status: cnet.Enums.NetworkCommissioningStatusEnum = None
+    ) -> None:
+        expected_status = expected_status or cnet.Enums.NetworkCommissioningStatusEnum.kSuccess
+        asserts.assert_true(isinstance(response, cnet.Commands.NetworkConfigResponse),
+                            "Unexpected response type from NetworkConfig command")
+        asserts.assert_equal(response.networkingStatus, expected_status,
+                             f"Expected NetworkingStatus {expected_status}, got {response.networkingStatus}")
+        if response.debugText:
+            asserts.assert_less_equal(len(response.debugText), 512,
+                                      f"debugText too long: {len(response.debugText)} bytes")
+
+    async def _validate_connect_network_response(
+        self,
+        response: cnet.Commands.ConnectNetworkResponse,
+        expect_success: bool = True
+    ) -> None:
+        asserts.assert_true(isinstance(response, cnet.Commands.ConnectNetworkResponse),
+                            "Unexpected response type from ConnectNetwork command")
+        if expect_success:
+            asserts.assert_equal(response.networkingStatus,
+                                 cnet.Enums.NetworkCommissioningStatusEnum.kSuccess,
+                                 f"Expected success, got {response.networkingStatus}")
+        else:
+            asserts.assert_not_equal(response.networkingStatus,
+                                     cnet.Enums.NetworkCommissioningStatusEnum.kSuccess,
+                                     "Expected failure, got success")
+        if response.debugText:
+            asserts.assert_less_equal(len(response.debugText), 512,
+                                      f"debugText too long: {len(response.debugText)} bytes")
+
+    async def _read_last_networking_status(
+        self,
+        endpoint: int,
+        expected_status: cnet.Enums.NetworkCommissioningStatusEnum = None,
+        valid_statuses: list = None
+    ) -> cnet.Enums.NetworkCommissioningStatusEnum:
+        status = await self.read_single_attribute(
+            dev_ctrl=self.default_controller,
+            node_id=self.dut_node_id,
+            endpoint=endpoint,
+            attribute=cnet.Attributes.LastNetworkingStatus,
+        )
+        logger.info(f" --- LastNetworkingStatus = {status}")
+        if expected_status is not None:
+            asserts.assert_equal(status, expected_status,
+                                 f"Expected {expected_status}, got {status}")
+        elif valid_statuses is not None:
+            asserts.assert_in(status, valid_statuses,
+                              f"Expected one of {valid_statuses}, got {status}")
+        return status
+
+    @property
+    def default_timeout(self) -> int:
+        return TIMEOUT
+
+    def steps_TC_CNET_4_23_2(self):
+        return [
+            TestStep(1, "ArmFailSafe in operational to allow NC commands", ""),
+            TestStep(2, "AddOrUpdateWiFiNetwork with WRONG password", ""),
+            TestStep(3, "ConnectNetwork should FAIL", ""),
+            TestStep(4, "check LastNetworkingStatus again", ""),
+            TestStep(5, "AddOrUpdateWiFiNetwork with CORRECT password", ""),
+            TestStep(6, "ConnectNetwork should SUCCEED", ""),
+        ]
+
+    def desc_TC_CNET_4_23_2(self):
+        return ("[TC-CNET-4.23] [Wi-Fi] Second SSID commissioning (harness steps 1–6; "
+                "test plan 17–22, CASE) [DUT-Server]")
+
+    @async_test_body
+    async def test_TC_CNET_4_23_2(self):
+        endpoint = ROOT_ENDPOINT_ID
+
+        second_ssid = self.user_params.get("second_ssid")
+        second_password = self.user_params.get("second_password")
+        asserts.assert_is_not_none(second_ssid, "user_params.second_ssid is required")
+        asserts.assert_is_not_none(second_password, "user_params.second_password is required")
+
+        correct_ssid_case = second_ssid.encode("utf-8")
+        correct_password_case = second_password.encode("utf-8")
+        incorrect_password = b"IncorrectPassword123"
+
+        feature_map = await self.read_single_attribute(
+            dev_ctrl=self.default_controller,
+            node_id=self.dut_node_id,
+            endpoint=endpoint,
+            attribute=cnet.Attributes.FeatureMap,
+        )
+        if not (feature_map & cnet.Bitmaps.Feature.kWiFiNetworkInterface):
+            logger.info(" --- Device does not support WiFi on endpoint 0, skipping remaining steps")
+            self.mark_all_remaining_steps_skipped(1)
+            return
+
+        self.step(1)
+        logger.info(" --- CASE phase: arming failsafe for operational network commands...")
+        afs = await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cgen.Commands.ArmFailSafe(expiryLengthSeconds=120, breadcrumb=100),
+            timedRequestTimeoutMs=TIMED_REQUEST_TIMEOUT_MS
+        )
+        asserts.assert_true(isinstance(afs, cgen.Commands.ArmFailSafeResponse),
+                            "Expected ArmFailSafeResponse in CASE phase")
+
+        self.step(2)
+        logger.info(" --- CASE phase: AddOrUpdateWiFiNetwork with WRONG password")
+        resp = await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cnet.Commands.AddOrUpdateWiFiNetwork(
+                ssid=correct_ssid_case,
+                credentials=incorrect_password,
+                breadcrumb=101
+            ),
+            timedRequestTimeoutMs=TIMED_REQUEST_TIMEOUT_MS
+        )
+        await self._validate_network_config_response(resp)
+
+        self.step(3)
+        logger.info(" --- CASE phase: ConnectNetwork with WRONG password (expect fail)")
+        resp = await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cnet.Commands.ConnectNetwork(networkID=correct_ssid_case, breadcrumb=102),
+            timedRequestTimeoutMs=CONNECT_NETWORK_TIMEOUT_MS
+        )
+        await self._validate_connect_network_response(resp, expect_success=False)
+
+        await asyncio.sleep(NETWORK_STATUS_UPDATE_DELAY)
+
+        self.step(4)
+        await self._read_last_networking_status(
+            endpoint,
+            valid_statuses=[
+                cnet.Enums.NetworkCommissioningStatusEnum.kAuthFailure,
+                cnet.Enums.NetworkCommissioningStatusEnum.kOtherConnectionFailure
+            ]
+        )
+
+        self.step(5)
+        logger.info(" --- CASE phase: AddOrUpdateWiFiNetwork with CORRECT password")
+        resp = await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cnet.Commands.AddOrUpdateWiFiNetwork(
+                ssid=correct_ssid_case,
+                credentials=correct_password_case,
+                breadcrumb=103
+            ),
+            timedRequestTimeoutMs=TIMED_REQUEST_TIMEOUT_MS
+        )
+        await self._validate_network_config_response(resp)
+
+        await asyncio.sleep(NETWORK_STATUS_UPDATE_DELAY)
+
+        self.step(6)
+        logger.info(" --- CASE phase: ConnectNetwork with CORRECT password (expect success)")
+        resp = await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cnet.Commands.ConnectNetwork(networkID=correct_ssid_case, breadcrumb=104),
+            timedRequestTimeoutMs=CONNECT_NETWORK_TIMEOUT_MS
+        )
+        await self._validate_connect_network_response(resp, expect_success=True)
+
+        await asyncio.sleep(NETWORK_STATUS_UPDATE_DELAY)
+
+        await self._read_last_networking_status(
+            endpoint,
+            expected_status=cnet.Enums.NetworkCommissioningStatusEnum.kSuccess
+        )
+
+        logger.info(" --- CASE phase: disarming failsafe")
+        await self.send_single_cmd(
+            endpoint=endpoint,
+            cmd=cgen.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=105),
+            timedRequestTimeoutMs=TIMED_REQUEST_TIMEOUT_MS
+        )
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -35,8 +35,6 @@ not_automated:
       reason: Can not run thread CNET tests in CI
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
-    - name: TC_CNET_4_23.py
-      reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_23_2.py
       reason: It has no CI execution block, is not executed in CI
     - name: TC_DGGEN_3_2.py

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -81,16 +81,6 @@ not_automated:
       reason: Shared code for TC_SETRF, not a standalone test
     - name: TC_SUTestBase.py
       reason: Shared code for TC_SU, not a standalone test
-    - name: TC_SU_2_2.py
-      reason: Test takes around 10 minutes, skipped in CI. Works on CI if added.
-    - name: TC_SU_2_5.py
-      reason:
-          Test is skipped as it takes around 25 minutes to complete. Works on CI
-          if added.
-    - name: TC_SU_2_7.py
-      reason:
-          Test is skipped as it takes around 15 minutes to complete. Works on CI
-          if added.
     - name: TC_COMMTR_TestBase.py
       reason: Shared code for TC_COMMTR, not a standalone test
     - name: TC_MTRIDTestBase.py
@@ -178,12 +168,6 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GC_common.py
       reason: Shared code for TC_GC, not a standalone test.
-    - name: TC_GC_2_2.py
-      reason:
-          Test fails in REPL Tests - Linux CI environment because report
-          chunking is not enabled.
-    - name: TC_GC_2_7.py
-      reason: Does not currently pass.
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially
@@ -191,12 +175,10 @@ not_automated:
 slow_tests:
     - { name: mobile-device-test.py, duration: 3 minutes }
     - { name: TC_AccessChecker.py, duration: 15 minutes }
-    - { name: TC_BRBINFO_4_1.py, duration: 2 minutes }
     - { name: TC_CADMIN_1_3_4.py, duration: 4 minutes }
     - { name: TC_CADMIN_1_19.py, duration: 30 seconds }
     - { name: TC_CADMIN_1_22_24.py, duration: 3 minutes }
     - { name: TC_CADMIN_1_9.py, duration: 40 seconds }
-    - { name: TC_CC_2_2.py, duration: 1.5 minutes }
     - { name: TC_CLCTRL_4_1.py, duration: 45 seconds }
     - { name: TC_DEM_2_10.py, duration: 40 seconds }
     - { name: TC_DeviceBasicComposition.py, duration: 9 minutes }
@@ -204,7 +186,6 @@ slow_tests:
     - { name: TC_DRLK_2_3.py, duration: 30 seconds }
     - { name: TC_EEVSE_2_6.py, duration: 30 seconds }
     - { name: TC_FAN_3_1.py, duration: 15 seconds }
-    - { name: TC_JFPKI_2_4.py, duration: 5 minutes }
     - { name: TC_MCORE_FS_1_4.py, duration: 20 seconds }
     - { name: TC_OPSTATE_2_5.py, duration: 1.25 minutes }
     - { name: TC_OPSTATE_2_6.py, duration: 35 seconds }
@@ -217,5 +198,12 @@ slow_tests:
     - { name: TC_TIMESYNC_2_12.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_7.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_8.py, duration: 1.5 minutes }
-    - { name: TC_CADMIN_1_27.py, duration: 30 seconds }
-    - { name: TC_CADMIN_1_28.py, duration: 30 seconds }
+    - { name: TC_JFADMIN_2_1.py, duration: 30 seconds }
+    - { name: TC_JFADMIN_2_2.py, duration: 30 seconds }
+nightly:
+    - { name: TC_SU_2_2.py, duration: 10 minutes }
+    - { name: TC_SU_2_5.py, duration: 20 minutes }
+    - { name: TC_SU_2_7.py, duration: 25 minutes }
+    - { name: TC_CC_2_2.py, duration: 2.5 minutes }
+    - { name: TC_BRBINFO_4_1.py, duration: 5 minutes }
+    - { name: TC_JFADMIN_1_4.py, duration: 5 minutes }

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -35,6 +35,10 @@ not_automated:
       reason: Can not run thread CNET tests in CI
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
+    - name: TC_CNET_4_23.py
+      reason: It has no CI execution block, is not executed in CI
+    - name: TC_CNET_4_23_2.py
+      reason: It has no CI execution block, is not executed in CI
     - name: TC_DGGEN_3_2.py
       reason:
           src/python_testing/test_testing/test_TC_DGGEN_3_2.py is the Unit test
@@ -77,6 +81,16 @@ not_automated:
       reason: Shared code for TC_SETRF, not a standalone test
     - name: TC_SUTestBase.py
       reason: Shared code for TC_SU, not a standalone test
+    - name: TC_SU_2_2.py
+      reason: Test takes around 10 minutes, skipped in CI. Works on CI if added.
+    - name: TC_SU_2_5.py
+      reason:
+          Test is skipped as it takes around 25 minutes to complete. Works on CI
+          if added.
+    - name: TC_SU_2_7.py
+      reason:
+          Test is skipped as it takes around 15 minutes to complete. Works on CI
+          if added.
     - name: TC_COMMTR_TestBase.py
       reason: Shared code for TC_COMMTR, not a standalone test
     - name: TC_MTRIDTestBase.py
@@ -164,6 +178,12 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GC_common.py
       reason: Shared code for TC_GC, not a standalone test.
+    - name: TC_GC_2_2.py
+      reason:
+          Test fails in REPL Tests - Linux CI environment because report
+          chunking is not enabled.
+    - name: TC_GC_2_7.py
+      reason: Does not currently pass.
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially
@@ -171,10 +191,12 @@ not_automated:
 slow_tests:
     - { name: mobile-device-test.py, duration: 3 minutes }
     - { name: TC_AccessChecker.py, duration: 15 minutes }
+    - { name: TC_BRBINFO_4_1.py, duration: 2 minutes }
     - { name: TC_CADMIN_1_3_4.py, duration: 4 minutes }
     - { name: TC_CADMIN_1_19.py, duration: 30 seconds }
     - { name: TC_CADMIN_1_22_24.py, duration: 3 minutes }
     - { name: TC_CADMIN_1_9.py, duration: 40 seconds }
+    - { name: TC_CC_2_2.py, duration: 1.5 minutes }
     - { name: TC_CLCTRL_4_1.py, duration: 45 seconds }
     - { name: TC_DEM_2_10.py, duration: 40 seconds }
     - { name: TC_DeviceBasicComposition.py, duration: 9 minutes }
@@ -182,6 +204,7 @@ slow_tests:
     - { name: TC_DRLK_2_3.py, duration: 30 seconds }
     - { name: TC_EEVSE_2_6.py, duration: 30 seconds }
     - { name: TC_FAN_3_1.py, duration: 15 seconds }
+    - { name: TC_JFPKI_2_4.py, duration: 5 minutes }
     - { name: TC_MCORE_FS_1_4.py, duration: 20 seconds }
     - { name: TC_OPSTATE_2_5.py, duration: 1.25 minutes }
     - { name: TC_OPSTATE_2_6.py, duration: 35 seconds }
@@ -194,12 +217,5 @@ slow_tests:
     - { name: TC_TIMESYNC_2_12.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_7.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_8.py, duration: 1.5 minutes }
-    - { name: TC_JFADMIN_2_1.py, duration: 30 seconds }
-    - { name: TC_JFADMIN_2_2.py, duration: 30 seconds }
-nightly:
-    - { name: TC_SU_2_2.py, duration: 10 minutes }
-    - { name: TC_SU_2_5.py, duration: 20 minutes }
-    - { name: TC_SU_2_7.py, duration: 25 minutes }
-    - { name: TC_CC_2_2.py, duration: 2.5 minutes }
-    - { name: TC_BRBINFO_4_1.py, duration: 5 minutes }
-    - { name: TC_JFADMIN_1_4.py, duration: 5 minutes }
+    - { name: TC_CADMIN_1_27.py, duration: 30 seconds }
+    - { name: TC_CADMIN_1_28.py, duration: 30 seconds }


### PR DESCRIPTION
### Summary
Adds `TC_CNET_4_23_2.py` for TC-CNET-4.23 test plan steps 17–22 (Network Commissioning on a second Wi-Fi profile over an operational / CASE session). The harness exposes this as steps 1–6 in this script.

This complements [#42069](https://github.com/project-chip/connectedhomeip/pull/42069), which covers steps 0–16 (PASE commissioning through CommissioningComplete) in `TC_CNET_4_23.py`.

### Required configuration
In addition to the usual commissioning / Wi-Fi CLI setup, the test requires **`user_params`** (or equivalent harness wiring):

`second_ssid `— SSID of the secondary network
`second_password `— passphrase for that network

From the CLI this is typically passed as:

`--string-arg second_ssid:<SECONDARY_SSID> --string-arg second_password:<SECONDARY_PASSPHRASE>`

### Testing
This PR is linked to issue #41791, which is linked to issue #4046.

Test Spec created with PR [#5711](https://github.com/CHIP-Specifications/chip-test-plans/pull/5711)

Fixes https://github.com/project-chip/connectedhomeip/issues/41791

Same class of setup as for `TC_CNET_4_23.py` (ESP32 + Wi-Fi, or TH on Raspberry Pi as documented for that PR). This script is not run in CI unless a CI execution block is added later; if needed, add an entry under `not_automated ` in `src/python_testing/test_metadata.yaml` with the same pattern as other `TC_CNET_4_*.py` scripts.

Testing: Since this is a Wi-Fi test, to reproduce test steps there are some physical devices needed. For more information check https://github.com/project-chip/connectedhomeip/pull/42069

To run this test first you need to commission and then run the actual test

To commission you can run another test:
```
python3 src/python_testing/TC_CNET_4_9.py --commissioning-method ble-wifi --discriminator 3840 --passcode 20202021 --wifi-ssid <SSID> --wifi-passphrase <PASSWORD>--endpoint 0
```

Run actual test:
```
python3 src/python_testing/TC_CNET_4_23_2.py --string-arg second_ssid:<SECOND_SSID> --string-arg second_password:<SECOND_PASSWORD>
```

### Links
Issue: [connectedhomeip#41791](https://github.com/project-chip/connectedhomeip/issues/41791)
Test plan: [chip-test-plans#4046](https://github.com/CHIP-Specifications/chip-test-plans/issues/4046)
Spec PR: [chip-test-plans#5711](https://github.com/CHIP-Specifications/chip-test-plans/pull/5711)