### PR TITLE
[Silabs] Use UULP GPIO 3 for shell

### DIFF
--- a/examples/platform/silabs/Si70xxSensorWiseMcu.cpp
+++ b/examples/platform/silabs/Si70xxSensorWiseMcu.cpp
@@ -132,8 +132,6 @@ sl_status_t Init()
 sl_status_t GetSensorData(uint16_t & relativeHumidity, int16_t & temperature)
 {
     sl_status_t status      = SL_STATUS_OK;
-    int32_t tempTemperature = 0;
-    uint32_t tempHumidity   = 0;
 
 #if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED
     // Add PS requirement to keep the sensor awake
@@ -144,6 +142,8 @@ sl_status_t GetSensorData(uint16_t & relativeHumidity, int16_t & temperature)
     // Remove PS requirement to allow device to sleep (always remove, even on error)
     sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS3);
 #else
+    int32_t tempTemperature = 0;
+    uint32_t tempHumidity   = 0;
     status = sl_si91x_si70xx_measure_rh_and_temp(SI70XX_I2C_INSTANCE, SI70XX_SLAVE_ADDR, &tempHumidity, &tempTemperature);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 

--- a/examples/platform/silabs/Si70xxSensorWiseMcu.cpp
+++ b/examples/platform/silabs/Si70xxSensorWiseMcu.cpp
@@ -131,7 +131,7 @@ sl_status_t Init()
 
 sl_status_t GetSensorData(uint16_t & relativeHumidity, int16_t & temperature)
 {
-    sl_status_t status      = SL_STATUS_OK;
+    sl_status_t status = SL_STATUS_OK;
 
 #if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED
     // Add PS requirement to keep the sensor awake

--- a/src/platform/silabs/SiWx/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx/SiWxPlatformInterface.h
@@ -20,9 +20,9 @@
 #include <app/icd/server/ICDServerConfig.h>
 
 namespace {
-#if defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER && defined(RTE_UULP_GPIO_1_PIN)
+#if defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER && defined(RTE_UULP_GPIO_3_PIN)
 bool ps_requirement_added = false;
-#endif // defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER && defined(RTE_UULP_GPIO_1_PIN)
+#endif // defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER && defined(RTE_UULP_GPIO_3_PIN)
 } // namespace
 
 #ifdef __cplusplus
@@ -102,9 +102,9 @@ inline void sl_si91x_btn_event_handler()
 void sl_si91x_uart_power_requirement_handler()
 {
 #ifdef ENABLE_CHIP_SHELL
-#ifdef RTE_UULP_GPIO_1_PIN
-    // Checking the UULP PIN 1 status to reinit the UART and not allow the device to go to sleep
-    if (sl_si91x_gpio_get_uulp_npss_pin(RTE_UULP_GPIO_1_PIN))
+#ifdef RTE_UULP_GPIO_3_PIN
+    // Checking the UULP PIN 3 status to reinit the UART and not allow the device to go to sleep
+    if (sl_si91x_gpio_get_uulp_npss_pin(RTE_UULP_GPIO_3_PIN))
     {
         if (!ps_requirement_added)
         {
@@ -120,7 +120,7 @@ void sl_si91x_uart_power_requirement_handler()
             ps_requirement_added = false;
         }
     }
-#endif // RTE_UULP_GPIO_1_PIN
+#endif // RTE_UULP_GPIO_3_PIN
 #endif // ENABLE_CHIP_SHELL
 }
 


### PR DESCRIPTION
#### Summary

This is a small follow-up PR of https://github.com/project-chip/connectedhomeip/pull/71481.

On SiWx builds that enable both the Matter shell and ICD, UART activity is tied to UULP GPIO 1, which is the same pin used by the Si7021 temperature/humidity sensor on those boards, so shell wake / power handling and the sensor driver contended on one pin. So modified the logic to use UULP_GPIO_3 for shell so that it doesn't affect the temperature sensor's behavior.

#### Related issues

N/A

#### Testing

Build SiWx example with Matter shell and ICD enabled (e.g. chip_build_libshell + ICD).
Confirm Si7021 reads still work (GPIO 1 reserved for the sensor).

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
