### PR TITLE
Fix microwave oven control cmake file

### DIFF
--- a/src/app/clusters/microwave-oven-control-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/microwave-oven-control-server/app_config_dependent_sources.cmake
@@ -18,6 +18,6 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
-    "${CLUSTER_DIR}/Delegate.h",
+    "${CLUSTER_DIR}/Delegate.h"
     "${CLUSTER_DIR}/microwave-oven-control-server.h"
 )


### PR DESCRIPTION
#### Summary

Fix: Remove extra comma from cmake file.

#### Testing

