### PR TITLE
Add wifi scan CLI command and fix NXP wifi scan issue

### DIFF
--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -32,7 +32,7 @@ using namespace chip::DeviceLayer::NetworkCommissioning;
 namespace chip {
 namespace Shell {
 
-    class ShellScanCallback : public WiFiDriver::ScanCallback
+class ShellScanCallback : public WiFiDriver::ScanCallback
 {
 public:
     void OnFinished(Status status, CharSpan debugText, WiFiScanResponseIterator * networks) override
@@ -50,9 +50,7 @@ public:
             WiFiScanResponse scanResponse;
             while (networks->Next(scanResponse))
             {
-                ChipLogProgress(Shell, "SSID: %.*s",
-                               static_cast<int>(scanResponse.ssidLen),
-                               scanResponse.ssid);
+                ChipLogProgress(Shell, "SSID: %.*s", static_cast<int>(scanResponse.ssidLen), scanResponse.ssid);
             }
             networks->Release();
         }

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -24,35 +24,38 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/NetworkCommissioning.h>
+#include <lib/support/AutoRelease.h>
 
 using chip::DeviceLayer::ConnectivityManager;
 using chip::DeviceLayer::ConnectivityMgr;
 using namespace chip::DeviceLayer::NetworkCommissioning;
 
+/// Convenience macro to auto-create a variable for you to release the given name at
+/// the exit of the current scope.
+#define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
+
 namespace chip {
 namespace Shell {
 
-class ShellScanCallback : public WiFiDriver::ScanCallback
+    class ShellScanCallback : public WiFiDriver::ScanCallback
 {
 public:
     void OnFinished(Status status, CharSpan debugText, WiFiScanResponseIterator * networks) override
-    {
-        if (status != Status::kSuccess)
-        {
-            ChipLogProgress(Shell, "WiFi scan failed");
-            return;
-        }
-
+    {   
+        DEFER_AUTO_RELEASE(networks);    
+        VerifyOrReturn(status == Status::kSuccess, ChipLogError(Shell, "WiFi scan failed with status: %d", static_cast<int>(status)));
+        
         ChipLogProgress(Shell, "WiFi scan completed");
-
+        
         if (networks != nullptr)
         {
             WiFiScanResponse scanResponse;
             while (networks->Next(scanResponse))
             {
-                ChipLogProgress(Shell, "SSID: %.*s", static_cast<int>(scanResponse.ssidLen), scanResponse.ssid);
+                ChipLogProgress(Shell, "SSID: %.*s",
+                               static_cast<int>(scanResponse.ssidLen),
+                               scanResponse.ssid);
             }
-            networks->Release();
         }
     }
 };

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -36,15 +36,15 @@ namespace Shell {
 {
 public:
     void OnFinished(Status status, CharSpan debugText, WiFiScanResponseIterator * networks) override
-    {       
+    {
         if (status != Status::kSuccess)
         {
             ChipLogProgress(Shell, "WiFi scan failed");
             return;
         }
-        
+
         ChipLogProgress(Shell, "WiFi scan completed");
-        
+
         if (networks != nullptr)
         {
             WiFiScanResponse scanResponse;

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -32,6 +32,35 @@ using namespace chip::DeviceLayer::NetworkCommissioning;
 namespace chip {
 namespace Shell {
 
+    class ShellScanCallback : public WiFiDriver::ScanCallback
+{
+public:
+    void OnFinished(Status status, CharSpan debugText, WiFiScanResponseIterator * networks) override
+    {       
+        if (status != Status::kSuccess)
+        {
+            ChipLogProgress(Shell, "WiFi scan failed");
+            return;
+        }
+        
+        ChipLogProgress(Shell, "WiFi scan completed");
+        
+        if (networks != nullptr)
+        {
+            WiFiScanResponse scanResponse;
+            while (networks->Next(scanResponse))
+            {
+                ChipLogProgress(Shell, "SSID: %.*s",
+                               static_cast<int>(scanResponse.ssidLen),
+                               scanResponse.ssid);
+            }
+            networks->Release();
+        }
+    }
+};
+
+static ShellScanCallback sScanCallback;
+
 static DeviceLayer::NetworkCommissioning::WiFiDriver * sDriver;
 
 static CHIP_ERROR PrintWiFiMode()
@@ -137,7 +166,15 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
 
     return error;
 }
+static CHIP_ERROR WiFiScanHandler(int argc, char ** argv)
+{
+    VerifyOrReturnError(GetWiFiDriver() != nullptr, CHIP_ERROR_NOT_IMPLEMENTED);
 
+    ByteSpan ssidSpan;
+    GetWiFiDriver()->ScanNetworks(ssidSpan, &sScanCallback);
+
+    return CHIP_NO_ERROR;
+}
 static CHIP_ERROR WiFiDisconnectHandler(int argc, char ** argv)
 {
     VerifyOrReturnError((argc == 0), CHIP_ERROR_INVALID_ARGUMENT);
@@ -161,6 +198,7 @@ void RegisterWiFiCommands()
         { &WiFiModeHandler, "mode", "Get/Set wifi mode. Usage: wifi mode [disable|ap|sta]" },
         { &WiFiConnectHandler, "connect", "Connect to AP. Usage: wifi connect <ssid> [<psk>]" },
         { &WiFiDisconnectHandler, "disconnect", "Disconnect device from AP. Usage: wifi disconnect" },
+        { &WiFiScanHandler, "scan", "Scan networks. Usage: wifi scan" },
     };
 
     static constexpr Command wifiCommand = { &SubShellCommand<MATTER_ARRAY_SIZE(subCommands), subCommands>, "wifi",

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -169,6 +169,7 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
 }
 static CHIP_ERROR WiFiScanHandler(int argc, char ** argv)
 {
+    VerifyOrReturnError((argc == 0), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(GetWiFiDriver() != nullptr, CHIP_ERROR_NOT_IMPLEMENTED);
 
     ByteSpan ssidSpan;

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -200,7 +200,7 @@ void RegisterWiFiCommands()
         { &WiFiModeHandler, "mode", "Get/Set wifi mode. Usage: wifi mode [disable|ap|sta]" },
         { &WiFiConnectHandler, "connect", "Connect to AP. Usage: wifi connect <ssid> [<psk>]" },
         { &WiFiDisconnectHandler, "disconnect", "Disconnect device from AP. Usage: wifi disconnect" },
-        { &WiFiScanHandler, "scan", "Scan networks. Usage: wifi scan" },
+        { &WiFiScanHandler, "scan", "Scan networks (concurrent scans are not suported). Usage: wifi scan" },
     };
 
     static constexpr Command wifiCommand = { &SubShellCommand<MATTER_ARRAY_SIZE(subCommands), subCommands>, "wifi",

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -41,12 +41,12 @@ namespace Shell {
 {
 public:
     void OnFinished(Status status, CharSpan debugText, WiFiScanResponseIterator * networks) override
-    {   
-        DEFER_AUTO_RELEASE(networks);    
+    {
+        DEFER_AUTO_RELEASE(networks);
         VerifyOrReturn(status == Status::kSuccess, ChipLogError(Shell, "WiFi scan failed with status: %d", static_cast<int>(status)));
-        
+
         ChipLogProgress(Shell, "WiFi scan completed");
-        
+
         if (networks != nullptr)
         {
             WiFiScanResponse scanResponse;

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -591,24 +591,28 @@ void ConnectivityManagerImpl::_NetifExtCallback(struct netif * netif, netif_nsc_
 
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
-    struct netif * netif = nullptr;
-    int32_t result;
-
-    LOCK_TCPIP_CORE();
-    netif = static_cast<struct netif *>(net_get_mlan_handle());
-    if (netif != nullptr)
+    if (mWifiManagerInit == false)
     {
-        memset(&ConnectivityManagerImpl::sNetifCallback, 0, sizeof(ConnectivityManagerImpl::sNetifCallback));
-        netif_add_ext_callback(&ConnectivityManagerImpl::sNetifCallback, &_NetifExtCallback);
-    }
-    UNLOCK_TCPIP_CORE();
+        struct netif * netif = nullptr;
+        int32_t result;
 
-    result = wlan_start(_WlanEventCallback);
+        LOCK_TCPIP_CORE();
+        netif = static_cast<struct netif *>(net_get_mlan_handle());
+        if (netif != nullptr)
+        {
+            memset(&ConnectivityManagerImpl::sNetifCallback, 0, sizeof(ConnectivityManagerImpl::sNetifCallback));
+            netif_add_ext_callback(&ConnectivityManagerImpl::sNetifCallback, &_NetifExtCallback);
+        }
+        UNLOCK_TCPIP_CORE();
 
-    if (result != WM_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed to start WLAN Connection Manager");
-        chipDie();
+        result = wlan_start(_WlanEventCallback);
+
+        if (result != WM_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to start WLAN Connection Manager");
+            chipDie();
+        }
+        mWifiManagerInit = true;
     }
 }
 #if CHIP_ENABLE_OPENTHREAD
@@ -683,11 +687,8 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, uint
     // Need to enable the WIFI interface here when Thread is enabled as a secondary network interface. We don't want to enable
     // WIFI from the init phase anymore and we will only do it in case the commissioner is provisioning the device with
     // the WIFI credentials.
-    if (mWifiManagerInit == false)
-    {
-        StartWiFiManagement();
-        mWifiManagerInit = true;
-    }
+    /* If already done, will do nothing */
+    StartWiFiManagement();
 
     memset(pNetworkData, 0, sizeof(struct wlan_network));
 

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -591,7 +591,7 @@ void ConnectivityManagerImpl::_NetifExtCallback(struct netif * netif, netif_nsc_
 
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
-    if (mWifiManagerInit == false)
+    if (!mWifiManagerInit)
     {
         struct netif * netif = nullptr;
         int32_t result;
@@ -687,7 +687,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, uint
     // Need to enable the WIFI interface here when Thread is enabled as a secondary network interface. We don't want to enable
     // WIFI from the init phase anymore and we will only do it in case the commissioner is provisioning the device with
     // the WIFI credentials.
-    /* If already done, will do nothing */
+    // If already done, will do nothing
     StartWiFiManagement();
 
     memset(pNetworkData, 0, sizeof(struct wlan_network));

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -324,6 +324,9 @@ CHIP_ERROR NXPWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 #endif
     }
 
+    /* If already done, will do nothing */
+    ConnectivityMgrImpl().StartWiFiManagement();
+
     int status = wlan_scan_with_opt(wlan_scan_param);
     if (status != WM_SUCCESS)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -324,7 +324,7 @@ CHIP_ERROR NXPWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 #endif
     }
 
-    /* If already done, will do nothing */
+    // If already done, will do nothing
     ConnectivityMgrImpl().StartWiFiManagement();
 
     int status = wlan_scan_with_opt(wlan_scan_param);


### PR DESCRIPTION
#### Summary
On NXP platforms, Wi‑Fi network scanning is currently not possible unless the device has already gone through commissioning. This limitation exists because StartWifiManagement is only invoked when the DUT receives Wi‑Fi credentials during commissioning (due to OTBR scenarios).
Proposal:

- Allow NXP_StartWifiManagement to be called multiple times safely.
- Invoke StartWifiManagement as part of the Wi‑Fi scan process to ensure that the Wi‑Fi manager is properly initialized before scanning.

Also implement a wifi scan cli command to validate this scenario


#### Testing

Built the RT1060 EVKC thermostat Wi‑Fi application
Executed the wifi scan CLI command
Verified that available Wi‑Fi networks are correctly discovered and printed over the Matter log UART

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
