### PR TITLE
fix: commodity-tariff-server null-deref in GetTariffComponent/GetDayEntry when provider lists are unavailable

### DIFF
--- a/src/app/clusters/commodity-tariff-server/commodity-tariff-server.cpp
+++ b/src/app/clusters/commodity-tariff-server/commodity-tariff-server.cpp
@@ -731,11 +731,13 @@ void Instance::HandleGetTariffComponent(HandlerContext & ctx, const Commands::Ge
     Commands::GetTariffComponentResponse::Type response;
     Status status = Status::Failure;
 
-    if (mServerTariffAttrsCtx.mTariffProvider == nullptr)
+    if (mServerTariffAttrsCtx.mTariffProvider == nullptr ||
+        mServerTariffAttrsCtx.mTariffProvider->GetTariffComponents().IsNull())
     {
         ChipLogError(AppServer, "The tariff is not available");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::Failure);
+        return;
     }
-    else
     {
         status         = Status::NotFound;
         auto component = Utils::GetListEntryById<Structs::TariffComponentStruct::Type>(
@@ -844,11 +846,13 @@ void Instance::HandleGetDayEntry(HandlerContext & ctx, const Commands::GetDayEnt
     Commands::GetDayEntryResponse::Type response;
     Status status = Status::Failure;
 
-    if (mServerTariffAttrsCtx.mTariffProvider == nullptr)
+    if (mServerTariffAttrsCtx.mTariffProvider == nullptr ||
+        mServerTariffAttrsCtx.mTariffProvider->GetDayEntries().IsNull())
     {
         ChipLogError(AppServer, "The tariff is not available");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::Failure);
+        return;
     }
-    else
     {
         status     = Status::NotFound;
         auto entry = Utils::GetListEntryById<Structs::DayEntryStruct::Type>(


### PR DESCRIPTION
## Summary
**Code Robustness Improvement.** 
`HandleGetTariffComponent` and `HandleGetDayEntry` in `src/app/clusters/commodity-tariff-server/commodity-tariff-server.cpp` do not correctly guard against null/partial provider state before calling `.Value()` on `Nullable<List<...>>` getters, leading to a null dereference / SEGV.

## Root cause

The same file already demonstrates that this state is valid in two places:

1. **Line 631** — `HandleGetCurrentDay` returns `CHIP_ERROR_NOT_FOUND` when `mTariffProvider == nullptr`, proving the author knew the provider can be unavailable.
2. **Line 282** — the day-cycle update path explicitly checks `IsNull()` on all three `Nullable<List<...>>` getters (`GetDayEntries()`, `GetTariffPeriods()`, `GetTariffComponents()`), showing the SDK's own `mDelegate` validation accepts that these lists can be null even when the outer provider is wired.

`HandleGetTariffComponent` (line 729) and `HandleGetDayEntry` (line 842) diverge from both patterns: they only check `mTariffProvider == nullptr`, log, and then fall through to `.Value()` on the inner `Nullable<List>`. When the list is `IsNull()`, the `.Value()` call is UB.

## Reachability

Any deployment where the tariff delegate's lists are not fully populated before the first `GetTariffComponent` or `GetDayEntry` Invoke. This is reachable via normal IM interaction — no special injection or crafted payload needed.

## Fix

Both handlers now:
- Check `mTariffProvider == nullptr || Get<X>().IsNull()` 
- Call `AddStatus(Failure)` and `return` early, matching the pattern at line 631

## Test plan
- [ ] Verified the patched handlers no longer SEGV on inputs that previously crashed
- [ ] No new dependencies; change is local to one file

