### PR TITLE
Add Cleanup Step to TC_GC_2_6 and TC_GC_2_7

### DIFF
--- a/src/python_testing/TC_GC_2_6.py
+++ b/src/python_testing/TC_GC_2_6.py
@@ -69,6 +69,7 @@ class TC_GC_2_6(MatterBaseTest):
             TestStep(7, "On F2, join group G1 generating a new key. TH2 sends command JoinGroup (GroupID=G1, Endpoints='see notes', KeySetID=K1, Key=InputKey1)"),
             TestStep(8, "On F2, iteratively Join groups using a new GroupId and assigning KeySetID K1 every time until the total group count combining all DUT groups on both fabrics = M_max. TH2 sends command JoinGroup (GroupID=Gi, Endpoints='see notes', KeySetID=K1)"),
             TestStep(9, "On F2, attempt to join 1 additional group. TH2 sends command JoinGroup (GroupID=Gi+1, Endpoints='see notes', KeySetID=K1)"),
+            TestStep(10, "Cleanup: Remove F2"),
         ]
 
     def pics_TC_GC_2_6(self) -> list[str]:
@@ -93,7 +94,8 @@ class TC_GC_2_6(MatterBaseTest):
         self.discriminatorTH2 = random.randint(0, 4095)
         # Create TH2 controller
         th2_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
-        th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=self.th1.fabricId + 1)
+        fabric_index_2 = self.th1.fabricId + 1
+        th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=fabric_index_2)
         self.th2 = th2_fabric_admin.NewController(nodeId=2, useTestCommissioner=True)
 
         # Open commissioning window on TH1
@@ -205,6 +207,13 @@ class TC_GC_2_6(MatterBaseTest):
             asserts.assert_equal(e.status, Status.ResourceExhausted,
                                  f"Send JoinGroup command error should be {Status.ResourceExhausted} instead of {e.status}")
 
+        self.step(10)
+        # Use TH1 to remove TH2's fabric
+        logger.info(f"Cleaning up: Removing TH2 fabric index {fabric_index_2}")
+        await self.send_single_cmd(
+            dev_ctrl=self.th1,
+            cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
+        )
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_GC_2_6.py
+++ b/src/python_testing/TC_GC_2_6.py
@@ -209,7 +209,7 @@ class TC_GC_2_6(MatterBaseTest):
 
         self.step(10)
         # Use TH1 to remove TH2's fabric
-        logger.info(f"Cleaning up: Removing TH2 fabric index {self.th2.fabricId}")
+        logger.info(f"Cleaning up: Removing TH2 fabric at index {self.th2.fabricId}")
         await self.th1.SendCommand(
             nodeId=self.dut_node_id,
             endpoint=0,

--- a/src/python_testing/TC_GC_2_6.py
+++ b/src/python_testing/TC_GC_2_6.py
@@ -209,10 +209,11 @@ class TC_GC_2_6(MatterBaseTest):
 
         self.step(10)
         # Use TH1 to remove TH2's fabric
-        logger.info(f"Cleaning up: Removing TH2 fabric index {fabric_index_2}")
-        await self.send_single_cmd(
-            dev_ctrl=self.th1,
-            cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
+        logger.info(f"Cleaning up: Removing TH2 fabric index {self.th2.fabricId}")
+        await self.th1.SendCommand(
+            nodeId=self.dut_node_id,
+            endpoint=0,
+            payload=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=self.th2.fabricId)
         )
 
 

--- a/src/python_testing/TC_GC_2_6.py
+++ b/src/python_testing/TC_GC_2_6.py
@@ -215,5 +215,6 @@ class TC_GC_2_6(MatterBaseTest):
             cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
         )
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_GC_2_7.py
+++ b/src/python_testing/TC_GC_2_7.py
@@ -275,10 +275,11 @@ class TC_GC_2_7(MatterBaseTest):
         else:
             self.step(11)
             # Use TH1 to remove TH2's fabric
-            logger.info(f"Cleaning up: Removing TH2 fabric index {fabric_index_2}")
-            await self.send_single_cmd(
-                dev_ctrl=self.th1,
-                cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
+            logger.info(f"Cleaning up: Removing TH2 fabric index {self.th2.fabricId}")
+            await self.th1.SendCommand(
+                nodeId=self.dut_node_id,
+                endpoint=0,
+                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=self.th2.fabricId)
             )
 
 

--- a/src/python_testing/TC_GC_2_7.py
+++ b/src/python_testing/TC_GC_2_7.py
@@ -79,6 +79,7 @@ class TC_GC_2_7(MatterBaseTest):
             TestStep(8, "On F1, iteratively Join additional PerGroup groups using a new GroupID every time until A_max groups have been joined. JoinGroup (GroupID=Gn, Endpoints='see notes', KeySetID=K1, McastAddrPolicy=PerGroup)"),
             TestStep(9, "TH awaits subscription report of new UsedMcastAddrCount within max interval. (value == A_max)"),
             TestStep(10, "Attempt to join 1 additional PerGroup group beyond A_max"),
+            TestStep(11, "Cleanup: Remove F2"),
         ]
 
     def pics_TC_GC_2_7(self) -> list[str]:
@@ -184,6 +185,7 @@ class TC_GC_2_7(MatterBaseTest):
 
         f2_current_group_count = 0
         self.step("6a")
+        fabric_index_2 = None
         if A_max < math.floor(M_max / 2):
             self.mark_step_range_skipped("6b", "7b")
         else:
@@ -192,7 +194,8 @@ class TC_GC_2_7(MatterBaseTest):
             self.discriminatorTH2 = random.randint(0, 4095)
             # Create TH2 controller
             th2_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
-            th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=self.th1.fabricId + 1)
+            fabric_index_2 = self.th1.fabricId + 1
+            th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=fabric_index_2)
             self.th2 = th2_fabric_admin.NewController(nodeId=2, useTestCommissioner=True)
 
             # Open commissioning window on TH1
@@ -266,7 +269,17 @@ class TC_GC_2_7(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.ResourceExhausted,
                                  f"Send JoinGroup command error should be {Status.ResourceExhausted} instead of {e.status}")
-
+            
+        if fabric_index_2 is None:
+            self.skip_step(11)
+        else:
+            self.step(11)
+            # Use TH1 to remove TH2's fabric
+            logger.info(f"Cleaning up: Removing TH2 fabric index {fabric_index_2}")
+            await self.send_single_cmd(
+                dev_ctrl=self.th1,
+                cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
+            )
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_GC_2_7.py
+++ b/src/python_testing/TC_GC_2_7.py
@@ -269,7 +269,7 @@ class TC_GC_2_7(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.ResourceExhausted,
                                  f"Send JoinGroup command error should be {Status.ResourceExhausted} instead of {e.status}")
-            
+
         if fabric_index_2 is None:
             self.skip_step(11)
         else:

--- a/src/python_testing/TC_GC_2_7.py
+++ b/src/python_testing/TC_GC_2_7.py
@@ -275,7 +275,7 @@ class TC_GC_2_7(MatterBaseTest):
         else:
             self.step(11)
             # Use TH1 to remove TH2's fabric
-            logger.info(f"Cleaning up: Removing TH2 fabric index {self.th2.fabricId}")
+            logger.info(f"Cleaning up: Removing TH2 fabric at index {self.th2.fabricId}")
             await self.th1.SendCommand(
                 nodeId=self.dut_node_id,
                 endpoint=0,

--- a/src/python_testing/TC_GC_2_7.py
+++ b/src/python_testing/TC_GC_2_7.py
@@ -281,5 +281,6 @@ class TC_GC_2_7(MatterBaseTest):
                 cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index_2)
             )
 
+
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
#### Summary

A bug was found where if TC_GC_2_6 and TC_GC_2_7 were ran in succession without resetting the commissioning window, they would fail. This was because both tests establish a second fabric which is used for some group commands. The fabrics are never cleaned up and so the results of doing the commands in these tests are interfering with each other on certain steps. This PR is adding a cleanup step at the end of each test to mitigate this.

#### Related issues

- https://github.com/project-chip/certification-tool/issues/952

#### Testing

- Ran both tests in succession locally (on same commission, in either order). Both passed in each case
- All other CI should still pass