### PR TITLE
tizen: Add platform-specific fuzzers for BLE and WiFi

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -61,6 +61,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/lib/core/tests:fuzz-tlv-reader",
         "${chip_root}/src/lib/dnssd/minimal_mdns/tests:fuzz-minmdns-packet-parsing",
         "${chip_root}/src/lib/format/tests:fuzz-payload-decoder",
+        "${chip_root}/src/platform/tests:fuzz-tizen-ble-scan-parser",
+        "${chip_root}/src/platform/tests:fuzz-tizen-wifi-manager",
         "${chip_root}/src/setup_payload/tests:fuzz-setup-payload-base38",
         "${chip_root}/src/setup_payload/tests:fuzz-setup-payload-base38-decode",
       ]

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/build/chip/fuzz_test.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {
@@ -103,5 +104,59 @@ if (chip_device_platform != "none") {
   import("${chip_root}/build/chip/chip_test_group.gni")
   chip_test_group("tests") {
     tests = []
+  }
+}
+
+if (enable_fuzz_test_targets) {
+  source_set("tizen_fuzzer_stubs") {
+    public = [
+      "tizen_stubs/ble/Ble.h",
+      "tizen_stubs/ble/BleUUID.h",
+      "tizen_stubs/bluetooth.h",
+      "tizen_stubs/bluetooth_internal.h",
+      "tizen_stubs/chip_support_stubs.h",
+      "tizen_stubs/glib.h",
+      "tizen_stubs/lib/core/CHIPError.h",
+      "tizen_stubs/lib/support/CHIPMemString.h",
+      "tizen_stubs/lib/support/CodeUtils.h",
+      "tizen_stubs/lib/support/Span.h",
+      "tizen_stubs/lib/support/logging/CHIPLogging.h",
+      "tizen_stubs/platform/CHIPDeviceConfig.h",
+      "tizen_stubs/platform/GLibTypeDeleter.h",
+      "tizen_stubs/platform/NetworkCommissioning.h",
+      "tizen_stubs/platform/PlatformError.h",
+      "tizen_stubs/platform/PlatformManager.h",
+      "tizen_stubs/platform/internal/DeviceNetworkInfo.h",
+      "tizen_stubs/system/SystemClock.h",
+      "tizen_stubs/tizen.h",
+      "tizen_stubs/tizen_api_stubs.h",
+      "tizen_stubs/wifi-manager.h",
+    ]
+  }
+
+  chip_fuzz_target("fuzz-tizen-ble-scan-parser") {
+    sources = [
+      "FuzzTizenBLEScanParser.cpp",
+      "tizen_stubs/tizenrt_ble_service_data.c",
+    ]
+    public_deps = [ ":tizen_fuzzer_stubs" ]
+    cflags = [ "-funsigned-char" ]
+    include_dirs = [
+      "tizen_stubs",
+      "${chip_root}/src",
+    ]
+  }
+
+  chip_fuzz_target("fuzz-tizen-wifi-manager") {
+    sources = [ "FuzzTizenWiFiManager.cpp" ]
+    defines = [
+      "CHIP_DEVICE_CONFIG_ENABLE_WIFI=1",
+      "CHIP_ENABLE_OPENTHREAD=0",
+    ]
+    public_deps = [ ":tizen_fuzzer_stubs" ]
+    include_dirs = [
+      "tizen_stubs",
+      "${chip_root}/src",
+    ]
   }
 }

--- a/src/platform/tests/FuzzTizenBLEScanParser.cpp
+++ b/src/platform/tests/FuzzTizenBLEScanParser.cpp
@@ -1,0 +1,250 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include <bluetooth.h>
+}
+
+#include <lib/support/CodeUtils.h>
+
+namespace {
+
+constexpr char kRemoteAddress[]     = "00:11:22:33:44:55";
+constexpr uint8_t kMatterUuidLow    = 0xF6;
+constexpr uint8_t kMatterUuidHigh   = 0xFF;
+constexpr uint8_t kDecoyUuidLow     = 0x34;
+constexpr uint8_t kDecoyUuidHigh    = 0x12;
+constexpr size_t kMaxServiceDataLen = 124;
+
+bt_adapter_le_device_scan_result_info_s * gStartScanResult = nullptr;
+int gStartScanReturn                                       = BT_ERROR_NONE;
+int gStartScanCallbackResult                               = BT_ERROR_NONE;
+int gScanFilterReturn                                      = BT_ERROR_NONE;
+bool gScanFilterSupported                                  = true;
+bool gInvokeStartScanCallback                              = false;
+
+void AppendServiceData(std::vector<char> & output, bool matterUuid, const uint8_t * data, size_t dataLen)
+{
+    const size_t boundedLen = std::min(dataLen, kMaxServiceDataLen);
+    output.push_back(static_cast<char>(boundedLen + 3));
+    output.push_back(static_cast<char>(BT_ADAPTER_LE_ADVERTISING_DATA_SERVICE_DATA));
+    output.push_back(static_cast<char>(matterUuid ? kMatterUuidLow : kDecoyUuidLow));
+    output.push_back(static_cast<char>(matterUuid ? kMatterUuidHigh : kDecoyUuidHigh));
+
+    for (size_t i = 0; i < boundedLen; ++i)
+    {
+        output.push_back(static_cast<char>(data[i]));
+    }
+}
+
+std::vector<char> BuildPacket(const uint8_t * data, size_t len, bool forceMatterUuid, bool includeDecoy)
+{
+    std::vector<char> packet;
+    const size_t decoyLen = includeDecoy ? len / 2 : 0;
+
+    if (includeDecoy)
+    {
+        AppendServiceData(packet, false, data, decoyLen);
+    }
+    AppendServiceData(packet, forceMatterUuid, data + decoyLen, len - decoyLen);
+
+    return packet;
+}
+
+} // namespace
+
+extern "C" int bt_adapter_le_start_scan(void (*callback)(int, bt_adapter_le_device_scan_result_info_s *, void *), void * userData)
+{
+    if (gInvokeStartScanCallback && callback != nullptr)
+    {
+        callback(gStartScanCallbackResult, gStartScanResult, userData);
+    }
+    return gStartScanReturn;
+}
+
+extern "C" int bt_adapter_le_stop_scan(void)
+{
+    return BT_ERROR_NONE;
+}
+
+extern "C" int bt_adapter_le_is_scan_filter_supported(bool * isSupported)
+{
+    if (isSupported == nullptr)
+    {
+        return BT_ERROR_INVALID_PARAMETER;
+    }
+
+    *isSupported = gScanFilterSupported;
+    return BT_ERROR_NONE;
+}
+
+extern "C" int bt_adapter_le_scan_filter_create(bt_scan_filter_h * filter)
+{
+    if (filter == nullptr)
+    {
+        return BT_ERROR_INVALID_PARAMETER;
+    }
+
+    *filter = reinterpret_cast<bt_scan_filter_h>(0x1);
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_unregister(bt_scan_filter_h)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_destroy(bt_scan_filter_h)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_set_device_address(bt_scan_filter_h, const char *)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_set_service_uuid(bt_scan_filter_h, const char *)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_set_service_data(bt_scan_filter_h, const char *, const char *, unsigned int)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" int bt_adapter_le_scan_filter_register(bt_scan_filter_h)
+{
+    return gScanFilterReturn;
+}
+
+extern "C" const char * get_error_message(int)
+{
+    return "stub";
+}
+
+#define private public
+#include <platform/Tizen/ChipDeviceScanner.cpp>
+#undef private
+
+namespace {
+
+class RecordingDelegate : public chip::DeviceLayer::Internal::ChipDeviceScannerDelegate
+{
+public:
+    void OnDeviceScanned(const bt_adapter_le_device_scan_result_info_s &,
+                         const chip::Ble::ChipBLEDeviceIdentificationInfo &) override
+    {
+        deviceScannedCount++;
+    }
+
+    void OnScanComplete() override { scanCompleteCount++; }
+    void OnScanError(CHIP_ERROR) override { scanErrorCount++; }
+
+    size_t deviceScannedCount = 0;
+    size_t scanCompleteCount  = 0;
+    size_t scanErrorCount     = 0;
+};
+
+chip::DeviceLayer::Internal::ScanFilterType PickFilterType(uint8_t value)
+{
+    using chip::DeviceLayer::Internal::ScanFilterType;
+
+    switch (value & 0x03)
+    {
+    case 0:
+        return ScanFilterType::kAddress;
+    case 1:
+        return ScanFilterType::kServiceUUID;
+    case 2:
+        return ScanFilterType::kServiceData;
+    default:
+        return ScanFilterType::kNoFilter;
+    }
+}
+
+void FillFilterData(chip::DeviceLayer::Internal::ScanFilterData & filterData, const uint8_t * data, size_t len)
+{
+    std::memset(&filterData, 0, sizeof(filterData));
+
+    constexpr char fallbackAddress[] = "AA:BB:CC:DD:EE:FF";
+    constexpr char fallbackUuid[]    = "0000fff6-0000-1000-8000-00805f9b34fb";
+    std::memcpy(filterData.address, fallbackAddress, sizeof(fallbackAddress));
+    std::memcpy(filterData.service_uuid, fallbackUuid, sizeof(fallbackUuid));
+
+    const size_t serviceDataLen = std::min(sizeof(filterData.service_data), len);
+    if (serviceDataLen > 0)
+    {
+        std::memcpy(filterData.service_data, data, serviceDataLen);
+    }
+    filterData.service_data_len = static_cast<unsigned int>(serviceDataLen);
+}
+
+void ExerciseTizenRTParser(bt_adapter_le_device_scan_result_info_s & scanInfo, uint8_t selector)
+{
+    bt_adapter_le_service_data_s * dataList = nullptr;
+    int count                               = 0;
+    const auto packetType = (selector & 0x01) ? BT_ADAPTER_LE_PACKET_SCAN_RESPONSE : BT_ADAPTER_LE_PACKET_ADVERTISING;
+
+    if (bt_adapter_le_get_scan_result_service_data_list(&scanInfo, packetType, &dataList, &count) == BT_ERROR_NONE)
+    {
+        bt_adapter_le_free_service_data_list(dataList, count);
+    }
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
+{
+    if (len < 4)
+    {
+        return 0;
+    }
+
+    const uint8_t flags     = data[0];
+    const size_t split      = 1 + (data[1] % (len - 1));
+    const bool matterUuid   = (flags & 0x01) != 0;
+    const bool includeDecoy = (flags & 0x02) != 0;
+    const bool scannerError = (flags & 0x04) != 0;
+    const bool nullScanInfo = (flags & 0x08) != 0;
+
+    std::vector<char> advData  = BuildPacket(data + 2, split - 1, matterUuid, includeDecoy);
+    std::vector<char> scanData = BuildPacket(data + split, len - split, (flags & 0x10) != 0, (flags & 0x20) != 0);
+
+    bt_adapter_le_device_scan_result_info_s scanInfo = {
+        kRemoteAddress,
+        advData.empty() ? nullptr : advData.data(),
+        static_cast<int>(advData.size()),
+        scanData.empty() ? nullptr : scanData.data(),
+        static_cast<int>(scanData.size()),
+    };
+
+    RecordingDelegate delegate;
+    chip::DeviceLayer::Internal::ChipDeviceScanner scanner(&delegate);
+
+    ExerciseTizenRTParser(scanInfo, flags >> 6);
+
+    scanner.LeScanResultCb(scannerError ? BT_ERROR_INVALID_PARAMETER : BT_ERROR_NONE, nullScanInfo ? nullptr : &scanInfo);
+
+    chip::DeviceLayer::Internal::ScanFilterData filterData;
+    FillFilterData(filterData, data + 2, len - 2);
+
+    gStartScanResult         = &scanInfo;
+    gStartScanCallbackResult = scannerError ? BT_ERROR_INVALID_PARAMETER : BT_ERROR_NONE;
+    gStartScanReturn         = (flags & 0x40) ? BT_ERROR_INVALID_PARAMETER : BT_ERROR_NONE;
+    gScanFilterReturn        = (flags & 0x80) ? BT_ERROR_INVALID_PARAMETER : BT_ERROR_NONE;
+    gScanFilterSupported     = (data[2] & 0x01) == 0;
+    gInvokeStartScanCallback = (data[2] & 0x02) != 0;
+
+    (void) scanner.SetupScanFilter(PickFilterType(data[3]), filterData);
+    (void) scanner.RegisterScanFilter(PickFilterType(data[3] >> 2), filterData);
+    (void) scanner.StartScan(PickFilterType(data[3] >> 4), filterData);
+    (void) scanner.StopScan();
+
+    gStartScanResult = nullptr;
+    return 0;
+}

--- a/src/platform/tests/FuzzTizenWiFiManager.cpp
+++ b/src/platform/tests/FuzzTizenWiFiManager.cpp
@@ -1,0 +1,370 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <wifi-manager.h>
+}
+
+#include <lib/support/Span.h>
+
+namespace {
+
+struct StubAp
+{
+    std::string essid;
+    std::string bssid;
+    int rssi                                  = 0;
+    int frequency                             = 2412;
+    wifi_manager_security_type_e securityType = WIFI_MANAGER_SECURITY_TYPE_NONE;
+    int essidError                            = WIFI_MANAGER_ERROR_NONE;
+    int bssidError                            = WIFI_MANAGER_ERROR_NONE;
+    int rssiError                             = WIFI_MANAGER_ERROR_NONE;
+    int securityError                         = WIFI_MANAGER_ERROR_NONE;
+    int frequencyError                        = WIFI_MANAGER_ERROR_NONE;
+};
+
+StubAp gAp;
+bool gHasConnectedAp     = true;
+int gGetConnectedApError = WIFI_MANAGER_ERROR_NONE;
+
+char * DupString(const std::string & value)
+{
+    char * copy = static_cast<char *>(std::malloc(value.size() + 1));
+    if (copy == nullptr)
+    {
+        return nullptr;
+    }
+    std::memcpy(copy, value.c_str(), value.size() + 1);
+    return copy;
+}
+
+std::string FuzzString(const uint8_t * data, size_t len, size_t maxLen)
+{
+    const size_t outLen = std::min(len, maxLen);
+    return std::string(reinterpret_cast<const char *>(data), reinterpret_cast<const char *>(data + outLen));
+}
+
+std::string FuzzBssid(const uint8_t * data, size_t len, uint8_t mode)
+{
+    if ((mode & 0x03) == 0)
+    {
+        char bssid[18];
+        std::snprintf(bssid, sizeof(bssid), "%02x:%02x:%02x:%02x:%02x:%02x", len > 0 ? data[0] : 0, len > 1 ? data[1] : 0,
+                      len > 2 ? data[2] : 0, len > 3 ? data[3] : 0, len > 4 ? data[4] : 0, len > 5 ? data[5] : 0);
+        return bssid;
+    }
+
+    if ((mode & 0x03) == 1)
+    {
+        return FuzzString(data, len, 48);
+    }
+
+    if ((mode & 0x03) == 2)
+    {
+        return "00:11:22:33:44";
+    }
+
+    return "gg:11:22:33:44:55";
+}
+
+wifi_manager_security_type_e FuzzSecurityType(uint8_t value)
+{
+    switch (value % 10)
+    {
+    case 0:
+        return WIFI_MANAGER_SECURITY_TYPE_NONE;
+    case 1:
+        return WIFI_MANAGER_SECURITY_TYPE_WEP;
+    case 2:
+        return WIFI_MANAGER_SECURITY_TYPE_WPA_PSK;
+    case 3:
+        return WIFI_MANAGER_SECURITY_TYPE_WPA2_PSK;
+    case 4:
+        return WIFI_MANAGER_SECURITY_TYPE_EAP;
+    case 5:
+        return WIFI_MANAGER_SECURITY_TYPE_WPA_FT_PSK;
+    case 6:
+        return WIFI_MANAGER_SECURITY_TYPE_SAE;
+    case 7:
+        return WIFI_MANAGER_SECURITY_TYPE_OWE;
+    case 8:
+        return WIFI_MANAGER_SECURITY_TYPE_DPP;
+    default:
+        return static_cast<wifi_manager_security_type_e>(0x7f);
+    }
+}
+
+int FuzzFrequency(uint8_t value)
+{
+    static constexpr int kFrequencies[] = { 0,     863,   902,   916,   931,   2412,  2472,  2484,  3600,
+                                            3700,  5035,  5180,  5945,  5960,  5980,  5955,  58320, 59400,
+                                            60480, 61560, 62640, 63720, 64800, 65880, 66960, 68040, 69120 };
+    return kFrequencies[value % (sizeof(kFrequencies) / sizeof(kFrequencies[0]))];
+}
+
+} // namespace
+
+extern "C" int wifi_manager_ap_get_essid(wifi_manager_ap_h, char ** essid)
+{
+    if (gAp.essidError != WIFI_MANAGER_ERROR_NONE)
+    {
+        return gAp.essidError;
+    }
+    *essid = DupString(gAp.essid);
+    return *essid == nullptr ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_get_bssid(wifi_manager_ap_h, char ** bssid)
+{
+    if (gAp.bssidError != WIFI_MANAGER_ERROR_NONE)
+    {
+        return gAp.bssidError;
+    }
+    *bssid = DupString(gAp.bssid);
+    return *bssid == nullptr ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_get_rssi(wifi_manager_ap_h, int * rssi)
+{
+    *rssi = gAp.rssi;
+    return gAp.rssiError;
+}
+
+extern "C" int wifi_manager_ap_get_security_type(wifi_manager_ap_h, wifi_manager_security_type_e * type)
+{
+    *type = gAp.securityType;
+    return gAp.securityError;
+}
+
+extern "C" int wifi_manager_ap_get_frequency(wifi_manager_ap_h, int * frequency)
+{
+    *frequency = gAp.frequency;
+    return gAp.frequencyError;
+}
+
+extern "C" int wifi_manager_get_connected_ap(wifi_manager_h, wifi_manager_ap_h * ap)
+{
+    if (gGetConnectedApError != WIFI_MANAGER_ERROR_NONE)
+    {
+        *ap = nullptr;
+        return gGetConnectedApError;
+    }
+
+    *ap = gHasConnectedAp ? reinterpret_cast<wifi_manager_ap_h>(&gAp) : nullptr;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_is_passphrase_required(wifi_manager_ap_h, bool * required)
+{
+    *required = false;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_set_passphrase(wifi_manager_ap_h, const char *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_clone(wifi_manager_ap_h * cloned, wifi_manager_ap_h ap)
+{
+    *cloned = ap;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_ap_destroy(wifi_manager_ap_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_initialize(wifi_manager_h * handle)
+{
+    *handle = reinterpret_cast<wifi_manager_h>(&gAp);
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_deinitialize(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_activate(wifi_manager_h, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_deactivate(wifi_manager_h, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_scan(wifi_manager_h, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_scan_specific_ap(wifi_manager_h, const char *, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_connect(wifi_manager_h, wifi_manager_ap_h, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_forget_ap(wifi_manager_h, wifi_manager_ap_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_is_activated(wifi_manager_h, bool * activated)
+{
+    *activated = true;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_get_module_state(wifi_manager_h, wifi_manager_module_state_e * state)
+{
+    *state = WIFI_MANAGER_MODULE_STATE_ATTACHED;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_get_connection_state(wifi_manager_h, wifi_manager_connection_state_e * state)
+{
+    *state = WIFI_MANAGER_CONNECTION_STATE_CONNECTED;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_get_mac_address(wifi_manager_h, char ** mac)
+{
+    *mac = DupString(gAp.bssid);
+    return *mac == nullptr ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_foreach_found_ap(wifi_manager_h, wifi_manager_found_ap_cb callback, void * userData)
+{
+    callback(reinterpret_cast<wifi_manager_ap_h>(&gAp), userData);
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_foreach_found_specific_ap(wifi_manager_h handle, wifi_manager_found_ap_cb callback, void * userData)
+{
+    return wifi_manager_foreach_found_ap(handle, callback, userData);
+}
+extern "C" int wifi_manager_config_foreach_configuration(wifi_manager_h, wifi_manager_config_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_config_get_name(wifi_manager_config_h, char ** name)
+{
+    *name = DupString(gAp.essid);
+    return *name == nullptr ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_config_get_security_type(wifi_manager_config_h, wifi_manager_security_type_e * type)
+{
+    *type = gAp.securityType;
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_config_remove(wifi_manager_h, wifi_manager_config_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" int wifi_manager_set_device_state_changed_cb(wifi_manager_h, wifi_manager_device_state_changed_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_module_state_changed_cb(wifi_manager_h, wifi_manager_module_state_changed_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_connection_state_changed_cb(wifi_manager_h, wifi_manager_connection_state_changed_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_scan_state_changed_cb(wifi_manager_h, wifi_manager_scan_state_changed_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_rssi_level_changed_cb(wifi_manager_h, wifi_manager_rssi_level_changed_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_background_scan_cb(wifi_manager_h, wifi_manager_error_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_set_ip_conflict_cb(wifi_manager_h, wifi_manager_ip_conflict_cb, void *)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_device_state_changed_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_module_state_changed_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_connection_state_changed_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_scan_state_changed_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_rssi_level_changed_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_background_scan_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+extern "C" int wifi_manager_unset_ip_conflict_cb(wifi_manager_h)
+{
+    return WIFI_MANAGER_ERROR_NONE;
+}
+
+extern "C" const char * get_error_message(int)
+{
+    return "stub";
+}
+
+#define private public
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wheader-hygiene"
+#include <platform/Tizen/WiFiManager.cpp>
+#pragma clang diagnostic pop
+#undef private
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
+{
+    if (len < 8)
+    {
+        return 0;
+    }
+
+    const uint8_t flags   = data[0];
+    const size_t ssidLen  = data[1] % std::min<size_t>(len - 7, 48);
+    const uint8_t * ssid  = data + 7;
+    const uint8_t * bssid = ssid + ssidLen;
+    const size_t bssidLen = len - 7 - ssidLen;
+
+    gAp.essid            = FuzzString(ssid, ssidLen, 96);
+    gAp.bssid            = FuzzBssid(bssid, bssidLen, flags >> 2);
+    gAp.rssi             = static_cast<int8_t>(data[2]);
+    gAp.frequency        = FuzzFrequency(data[3]);
+    gAp.securityType     = FuzzSecurityType(data[4]);
+    gAp.essidError       = (flags & 0x01) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+    gAp.bssidError       = (flags & 0x02) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+    gAp.rssiError        = (data[5] & 0x01) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+    gAp.securityError    = (data[5] & 0x02) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+    gAp.frequencyError   = (data[5] & 0x04) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+    gHasConnectedAp      = (data[5] & 0x08) == 0;
+    gGetConnectedApError = (data[6] & 0x02) ? WIFI_MANAGER_ERROR_UNKNOWN : WIFI_MANAGER_ERROR_NONE;
+
+    std::vector<chip::DeviceLayer::NetworkCommissioning::WiFiScanResponse> scanResponses;
+    chip::DeviceLayer::Internal::WiFiManager::_FoundAPOnScanCb(reinterpret_cast<wifi_manager_ap_h>(&gAp), &scanResponses);
+
+    uint8_t mac[6] = {};
+    chip::MutableByteSpan macSpan(mac, (data[6] & 0x01) ? sizeof(mac) - 1 : sizeof(mac));
+    (void) chip::DeviceLayer::Internal::WiFiMgr().GetBssId(macSpan);
+
+    return 0;
+}

--- a/src/platform/tests/tizen_stubs/ble/Ble.h
+++ b/src/platform/tests/tizen_stubs/ble/Ble.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/ble/BleUUID.h
+++ b/src/platform/tests/tizen_stubs/ble/BleUUID.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/bluetooth.h
+++ b/src/platform/tests/tizen_stubs/bluetooth.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <tizen_api_stubs.h>

--- a/src/platform/tests/tizen_stubs/bluetooth_internal.h
+++ b/src/platform/tests/tizen_stubs/bluetooth_internal.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/platform/tests/tizen_stubs/chip_support_stubs.h
+++ b/src/platform/tests/tizen_stubs/chip_support_stubs.h
@@ -1,0 +1,475 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+namespace chip {
+
+class ChipError
+{
+public:
+    explicit constexpr ChipError(int value = 0) : mValue(value) {}
+
+    constexpr bool operator==(const ChipError & other) const { return mValue == other.mValue; }
+    constexpr bool operator!=(const ChipError & other) const { return mValue != other.mValue; }
+    constexpr operator int() const { return mValue; }
+    constexpr const char * Format() const { return "stub"; }
+
+    static constexpr bool IsSuccess(const ChipError & error) { return error.mValue == 0; }
+
+private:
+    int mValue;
+};
+
+using CHIP_ERROR = ChipError;
+
+inline constexpr CHIP_ERROR CHIP_NO_ERROR(0);
+inline constexpr CHIP_ERROR CHIP_ERROR_INTERNAL(1);
+inline constexpr CHIP_ERROR CHIP_ERROR_INCORRECT_STATE(2);
+inline constexpr CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT(3);
+inline constexpr CHIP_ERROR CHIP_ERROR_BUFFER_TOO_SMALL(4);
+inline constexpr CHIP_ERROR CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE(5);
+inline constexpr CHIP_ERROR CHIP_ERROR_READ_FAILED(6);
+
+class ByteSpan
+{
+public:
+    ByteSpan(const uint8_t * data, size_t size) : mData(data), mSize(size) {}
+    const uint8_t * data() const { return mData; }
+    size_t size() const { return mSize; }
+
+private:
+    const uint8_t * mData;
+    size_t mSize;
+};
+
+class MutableByteSpan
+{
+public:
+    MutableByteSpan(uint8_t * data, size_t size) : mData(data), mSize(size) {}
+    uint8_t * data() const { return mData; }
+    size_t size() const { return mSize; }
+    void reduce_size(size_t size) { mSize = size; }
+
+private:
+    uint8_t * mData;
+    size_t mSize;
+};
+
+class MutableCharSpan
+{
+public:
+    MutableCharSpan(char * data, size_t size) : mData(data), mSize(size) {}
+    char * data() const { return mData; }
+    size_t size() const { return mSize; }
+    void reduce_size(size_t size) { mSize = size; }
+
+private:
+    char * mData;
+    size_t mSize;
+};
+
+class CharSpan
+{
+public:
+    CharSpan() : mData(nullptr), mSize(0) {}
+    CharSpan(const char * data, size_t size) : mData(data), mSize(size) {}
+    const char * data() const { return mData; }
+    size_t size() const { return mSize; }
+
+private:
+    const char * mData;
+    size_t mSize;
+};
+
+namespace Platform {
+
+inline void CopyString(char * dest, size_t destLength, const char * source)
+{
+    if (dest == nullptr || destLength == 0)
+    {
+        return;
+    }
+
+    if (source == nullptr)
+    {
+        dest[0] = '\0';
+        return;
+    }
+
+    std::strncpy(dest, source, destLength);
+    dest[destLength - 1] = '\0';
+}
+
+template <size_t N>
+inline void CopyString(char (&dest)[N], const char * source)
+{
+    CopyString(dest, N, source);
+}
+
+inline void CopyString(char * dest, size_t destLength, ByteSpan source)
+{
+    if (dest == nullptr || destLength == 0)
+    {
+        return;
+    }
+
+    if (source.data() == nullptr)
+    {
+        dest[0] = '\0';
+        return;
+    }
+
+    const size_t copyLen = source.size() < destLength - 1 ? source.size() : destLength - 1;
+    if (copyLen > 0)
+    {
+        std::memcpy(dest, source.data(), copyLen);
+    }
+    dest[copyLen] = '\0';
+}
+
+template <size_t N>
+inline void CopyString(char (&dest)[N], ByteSpan source)
+{
+    CopyString(dest, N, source);
+}
+
+inline void CopyString(char * dest, size_t destLength, CharSpan source)
+{
+    if (dest == nullptr || destLength == 0)
+    {
+        return;
+    }
+
+    if (source.data() == nullptr)
+    {
+        dest[0] = '\0';
+        return;
+    }
+
+    const size_t copyLen = source.size() < destLength - 1 ? source.size() : destLength - 1;
+    if (copyLen > 0)
+    {
+        std::memcpy(dest, source.data(), copyLen);
+    }
+    dest[copyLen] = '\0';
+}
+
+template <size_t N>
+inline void CopyString(char (&dest)[N], CharSpan source)
+{
+    CopyString(dest, N, source);
+}
+
+} // namespace Platform
+
+namespace Ble {
+
+inline constexpr char CHIP_BLE_SERVICE_SHORT_UUID_STR[] = "fff6";
+inline constexpr char CHIP_BLE_SERVICE_LONG_UUID_STR[]  = "0000fff6-0000-1000-8000-00805f9b34fb";
+
+struct ChipBLEDeviceIdentificationInfo
+{
+    uint8_t OpCode;
+    uint8_t DeviceDiscriminatorAndAdvVersion[2];
+    uint8_t DeviceVendorId[2];
+    uint8_t DeviceProductId[2];
+    uint8_t AdditionalDataFlag;
+
+    void Init() { std::memset(this, 0, sizeof(*this)); }
+} __attribute__((packed));
+
+} // namespace Ble
+
+namespace DeviceLayer {
+
+class PlatformManager
+{
+public:
+    void LockChipStack() {}
+    void UnlockChipStack() {}
+};
+
+inline PlatformManager & PlatformMgr()
+{
+    static PlatformManager manager;
+    return manager;
+}
+
+class PlatformManagerImpl
+{
+public:
+    template <typename T>
+    CHIP_ERROR GLibMatterContextInvokeSync(CHIP_ERROR (*callback)(T *), T * userData)
+    {
+        return callback(userData);
+    }
+};
+
+inline PlatformManagerImpl & PlatformMgrImpl()
+{
+    static PlatformManagerImpl manager;
+    return manager;
+}
+
+namespace Internal {
+
+inline constexpr size_t kMaxWiFiSSIDLength = 32;
+inline constexpr size_t kMaxWiFiKeyLength  = 64;
+inline constexpr size_t kWiFiBSSIDLength   = 6;
+
+} // namespace Internal
+
+namespace NetworkCommissioning {
+
+enum class Status
+{
+    kSuccess,
+    kUnknownError,
+    kOutOfRange,
+    kBoundsExceeded,
+    kNetworkIDNotFound,
+    kNetworkNotFound,
+};
+
+enum class WiFiBand
+{
+    k1g,
+    k2g4,
+    k3g65,
+    k5g,
+    k6g,
+    k60g,
+};
+
+enum class WirelessSignalType
+{
+    kdBm,
+};
+
+class SecurityBitmap
+{
+public:
+    void SetRaw(uint8_t raw) { mRaw = raw; }
+
+private:
+    uint8_t mRaw = 0;
+};
+
+struct WirelessSignal
+{
+    WirelessSignalType type = WirelessSignalType::kdBm;
+    int8_t strength         = 0;
+};
+
+struct WiFiScanResponse
+{
+    uint8_t ssid[32] = {};
+    uint8_t ssidLen  = 0;
+    uint8_t bssid[6] = {};
+    WirelessSignal signal;
+    SecurityBitmap security;
+    WiFiBand wiFiBand = WiFiBand::k2g4;
+    uint16_t channel  = 0;
+};
+
+struct Network
+{
+    uint8_t networkID[32] = {};
+    uint8_t networkIDLen  = 0;
+    bool connected        = false;
+};
+
+template <typename T>
+class Iterator
+{
+public:
+    virtual ~Iterator()         = default;
+    virtual size_t Count()      = 0;
+    virtual bool Next(T & item) = 0;
+    virtual void Release()      = 0;
+};
+
+using NetworkIterator = Iterator<Network>;
+
+class BaseDriver
+{
+public:
+    class NetworkStatusChangeCallback
+    {
+    public:
+        virtual ~NetworkStatusChangeCallback() = default;
+    };
+
+    virtual ~BaseDriver() = default;
+    virtual CHIP_ERROR Init(NetworkStatusChangeCallback *) { return CHIP_NO_ERROR; }
+    virtual uint8_t GetMaxNetworks() { return 0; }
+    virtual NetworkIterator * GetNetworks() { return nullptr; }
+};
+
+namespace Internal {
+
+class WirelessDriver : public BaseDriver
+{
+public:
+    class ConnectCallback
+    {
+    public:
+        virtual ~ConnectCallback() = default;
+        virtual void OnResult(Status, CharSpan, int32_t) {}
+    };
+
+    virtual uint8_t GetScanNetworkTimeoutSeconds() { return 0; }
+    virtual uint8_t GetConnectNetworkTimeoutSeconds() { return 0; }
+    virtual CHIP_ERROR CommitConfiguration() { return CHIP_NO_ERROR; }
+    virtual CHIP_ERROR RevertConfiguration() { return CHIP_NO_ERROR; }
+    virtual Status RemoveNetwork(ByteSpan, MutableCharSpan &, uint8_t &) { return Status::kUnknownError; }
+    virtual Status ReorderNetwork(ByteSpan, uint8_t, MutableCharSpan &) { return Status::kUnknownError; }
+    virtual void ConnectNetwork(ByteSpan, ConnectCallback *) {}
+};
+
+} // namespace Internal
+
+class WiFiDriver : public Internal::WirelessDriver
+{
+public:
+    class ScanCallback
+    {
+    public:
+        virtual ~ScanCallback() = default;
+        virtual void OnFinished(Status, CharSpan, Iterator<WiFiScanResponse> *) {}
+    };
+
+    virtual Status AddOrUpdateNetwork(ByteSpan, ByteSpan, MutableCharSpan &, uint8_t &) { return Status::kUnknownError; }
+    virtual void ScanNetworks(ByteSpan, ScanCallback *) {}
+    virtual uint32_t GetSupportedWiFiBandsMask() const { return 0; }
+};
+
+class EthernetDriver : public BaseDriver
+{
+public:
+    virtual ~EthernetDriver() = default;
+    virtual uint8_t GetMaxNetworks() { return 0; }
+    virtual NetworkIterator * GetNetworks() { return nullptr; }
+};
+
+} // namespace NetworkCommissioning
+} // namespace DeviceLayer
+} // namespace chip
+
+using CHIP_ERROR = chip::CHIP_ERROR;
+
+inline constexpr CHIP_ERROR CHIP_NO_ERROR                       = chip::CHIP_NO_ERROR;
+inline constexpr CHIP_ERROR CHIP_ERROR_INTERNAL                 = chip::CHIP_ERROR_INTERNAL;
+inline constexpr CHIP_ERROR CHIP_ERROR_INCORRECT_STATE          = chip::CHIP_ERROR_INCORRECT_STATE;
+inline constexpr CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT         = chip::CHIP_ERROR_INVALID_ARGUMENT;
+inline constexpr CHIP_ERROR CHIP_ERROR_BUFFER_TOO_SMALL         = chip::CHIP_ERROR_BUFFER_TOO_SMALL;
+inline constexpr CHIP_ERROR CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE = chip::CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+inline constexpr CHIP_ERROR CHIP_ERROR_READ_FAILED              = chip::CHIP_ERROR_READ_FAILED;
+
+#define CHIP_ERROR_FORMAT "s"
+#define MATTER_PLATFORM_ERROR(error) CHIP_ERROR(error)
+
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI 1
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD 0
+#define CHIP_DEVICE_CONFIG_THREAD_BORDER_ROUTER 0
+#define CHIP_DEVICE_CONFIG_THREAD_FTD 0
+#define CHIP_DEVICE_CONFIG_THREAD_SSED 0
+
+#define TEMPORARY_RETURN_IGNORED
+
+#define VerifyOrReturn(condition, ...)                                                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(condition))                                                                                                          \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            return;                                                                                                                \
+        }                                                                                                                          \
+    } while (false)
+
+#define VerifyOrExit(condition, ...)                                                                                               \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(condition))                                                                                                          \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            goto exit;                                                                                                             \
+        }                                                                                                                          \
+    } while (false)
+
+#define VerifyOrReturnValue(condition, value, ...)                                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(condition))                                                                                                          \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            return (value);                                                                                                        \
+        }                                                                                                                          \
+    } while (false)
+
+#define VerifyOrReturnError(condition, error, ...)                                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(condition))                                                                                                          \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            return (error);                                                                                                        \
+        }                                                                                                                          \
+    } while (false)
+
+#define ReturnErrorOnFailure(expression, ...)                                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        auto __chip_error = (expression);                                                                                          \
+        if (!::chip::ChipError::IsSuccess(__chip_error))                                                                           \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            return __chip_error;                                                                                                   \
+        }                                                                                                                          \
+    } while (false)
+
+#define SuccessOrExit(expression)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!::chip::ChipError::IsSuccess(expression))                                                                             \
+        {                                                                                                                          \
+            goto exit;                                                                                                             \
+        }                                                                                                                          \
+    } while (false)
+
+#define ExitNow(...)                                                                                                               \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        __VA_ARGS__;                                                                                                               \
+        goto exit;                                                                                                                 \
+    } while (false)
+
+#define DeviceLayer DeviceLayer
+#define Ble Ble
+
+#define ChipLogDetail(module, format, ...) static_cast<void>(0)
+#define ChipLogProgress(module, format, ...) static_cast<void>(0)
+#define ChipLogError(module, format, ...) static_cast<void>(0)
+#define ChipLogByteSpan(module, span) static_cast<void>(0)
+
+template <typename T>
+class GAutoPtr
+{
+public:
+    GAutoPtr() = default;
+    ~GAutoPtr() { std::free(mPtr); }
+
+    T * get() const { return mPtr; }
+    T *& GetReceiver()
+    {
+        std::free(mPtr);
+        mPtr = nullptr;
+        return mPtr;
+    }
+
+private:
+    T * mPtr = nullptr;
+};

--- a/src/platform/tests/tizen_stubs/glib.h
+++ b/src/platform/tests/tizen_stubs/glib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <tizen_api_stubs.h>

--- a/src/platform/tests/tizen_stubs/lib/core/CHIPError.h
+++ b/src/platform/tests/tizen_stubs/lib/core/CHIPError.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/lib/support/CHIPMemString.h
+++ b/src/platform/tests/tizen_stubs/lib/support/CHIPMemString.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/lib/support/CodeUtils.h
+++ b/src/platform/tests/tizen_stubs/lib/support/CodeUtils.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/lib/support/Span.h
+++ b/src/platform/tests/tizen_stubs/lib/support/Span.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/lib/support/logging/CHIPLogging.h
+++ b/src/platform/tests/tizen_stubs/lib/support/logging/CHIPLogging.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/CHIPDeviceConfig.h
+++ b/src/platform/tests/tizen_stubs/platform/CHIPDeviceConfig.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/GLibTypeDeleter.h
+++ b/src/platform/tests/tizen_stubs/platform/GLibTypeDeleter.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/NetworkCommissioning.h
+++ b/src/platform/tests/tizen_stubs/platform/NetworkCommissioning.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/PlatformError.h
+++ b/src/platform/tests/tizen_stubs/platform/PlatformError.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/PlatformManager.h
+++ b/src/platform/tests/tizen_stubs/platform/PlatformManager.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/platform/internal/DeviceNetworkInfo.h
+++ b/src/platform/tests/tizen_stubs/platform/internal/DeviceNetworkInfo.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <chip_support_stubs.h>

--- a/src/platform/tests/tizen_stubs/system/SystemClock.h
+++ b/src/platform/tests/tizen_stubs/system/SystemClock.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/platform/tests/tizen_stubs/tizen.h
+++ b/src/platform/tests/tizen_stubs/tizen.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <tizen_api_stubs.h>

--- a/src/platform/tests/tizen_stubs/tizen_api_stubs.h
+++ b/src/platform/tests/tizen_stubs/tizen_api_stubs.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef void * gpointer;
+
+static inline size_t g_strlcpy(char * dest, const char * src, size_t size)
+{
+    const size_t len = src == NULL ? 0 : strlen(src);
+    if (size > 0)
+    {
+        const size_t copyLen = len >= size ? size - 1 : len;
+        if (copyLen > 0)
+        {
+            memcpy(dest, src, copyLen);
+        }
+        dest[copyLen] = '\0';
+    }
+    return len;
+}
+
+#define BT_CHECK_LE_SUPPORT()
+#define BT_CHECK_INIT_STATUS()
+#define BT_CHECK_INPUT_PARAMETER(parameter)                                                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(parameter))                                                                                                          \
+        {                                                                                                                          \
+            return BT_ERROR_INVALID_PARAMETER;                                                                                     \
+        }                                                                                                                          \
+    } while (0)
+
+#if defined(__clang__)
+#define TIZENRT_STUB_NO_SANITIZE __attribute__((no_sanitize("address", "undefined", "memory")))
+#elif defined(__GNUC__)
+#define TIZENRT_STUB_NO_SANITIZE __attribute__((no_sanitize("address", "undefined")))
+#else
+#define TIZENRT_STUB_NO_SANITIZE
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum
+{
+    BT_ERROR_NONE              = 0,
+    BT_ERROR_NOT_SUPPORTED     = -1,
+    BT_ERROR_INVALID_PARAMETER = -2,
+    BT_ERROR_NO_DATA           = -3,
+    BT_ERROR_OUT_OF_MEMORY     = -4,
+};
+
+enum
+{
+    BT_ADAPTER_LE_PACKET_ADVERTISING   = 0,
+    BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1,
+};
+
+enum
+{
+    BT_ADAPTER_LE_ADVERTISING_DATA_SERVICE_DATA = 0x16,
+};
+
+typedef void * bt_scan_filter_h;
+typedef int bt_adapter_le_packet_type_e;
+
+typedef struct bt_adapter_le_service_data_s
+{
+    char * service_uuid;
+    char * service_data;
+    int service_data_len;
+} bt_adapter_le_service_data_s;
+
+typedef struct bt_adapter_le_device_scan_result_info_s
+{
+    const char * remote_address;
+    char * adv_data;
+    int adv_data_len;
+    char * scan_data;
+    int scan_data_len;
+} bt_adapter_le_device_scan_result_info_s;
+
+TIZENRT_STUB_NO_SANITIZE int bt_adapter_le_get_scan_result_service_data_list(const bt_adapter_le_device_scan_result_info_s * info,
+                                                                             bt_adapter_le_packet_type_e pkt_type,
+                                                                             bt_adapter_le_service_data_s ** dataList, int * count);
+TIZENRT_STUB_NO_SANITIZE int bt_adapter_le_free_service_data_list(bt_adapter_le_service_data_s * dataList, int count);
+
+int bt_adapter_le_start_scan(void (*callback)(int, bt_adapter_le_device_scan_result_info_s *, void *), void * userData);
+int bt_adapter_le_stop_scan(void);
+int bt_adapter_le_is_scan_filter_supported(bool * isSupported);
+int bt_adapter_le_scan_filter_create(bt_scan_filter_h * filter);
+int bt_adapter_le_scan_filter_unregister(bt_scan_filter_h filter);
+int bt_adapter_le_scan_filter_destroy(bt_scan_filter_h filter);
+int bt_adapter_le_scan_filter_set_device_address(bt_scan_filter_h filter, const char * address);
+int bt_adapter_le_scan_filter_set_service_uuid(bt_scan_filter_h filter, const char * uuid);
+int bt_adapter_le_scan_filter_set_service_data(bt_scan_filter_h filter, const char * uuid, const char * serviceData,
+                                               unsigned int serviceDataLen);
+int bt_adapter_le_scan_filter_register(bt_scan_filter_h filter);
+
+typedef void * wifi_manager_h;
+typedef void * wifi_manager_ap_h;
+typedef void * wifi_manager_config_h;
+
+typedef int wifi_manager_error_e;
+enum
+{
+    WIFI_MANAGER_ERROR_NONE           = 0,
+    WIFI_MANAGER_ERROR_NOT_SUPPORTED  = -1,
+    WIFI_MANAGER_ERROR_UNKNOWN        = -2,
+    WIFI_MANAGER_ERROR_ALREADY_EXISTS = -3,
+};
+
+typedef enum
+{
+    WIFI_MANAGER_DEVICE_STATE_DEACTIVATED = 0,
+    WIFI_MANAGER_DEVICE_STATE_ACTIVATED   = 1,
+} wifi_manager_device_state_e;
+
+typedef enum
+{
+    WIFI_MANAGER_MODULE_STATE_DETACHED = 0,
+    WIFI_MANAGER_MODULE_STATE_ATTACHED = 1,
+} wifi_manager_module_state_e;
+
+typedef enum
+{
+    WIFI_MANAGER_CONNECTION_STATE_FAILURE       = 0,
+    WIFI_MANAGER_CONNECTION_STATE_DISCONNECTED  = 1,
+    WIFI_MANAGER_CONNECTION_STATE_ASSOCIATION   = 2,
+    WIFI_MANAGER_CONNECTION_STATE_CONNECTED     = 3,
+    WIFI_MANAGER_CONNECTION_STATE_CONFIGURATION = 4,
+} wifi_manager_connection_state_e;
+
+typedef enum
+{
+    WIFI_MANAGER_SCAN_STATE_NOT_SCANNING = 0,
+    WIFI_MANAGER_SCAN_STATE_SCANNING     = 1,
+} wifi_manager_scan_state_e;
+
+typedef enum
+{
+    WIFI_MANAGER_RSSI_LEVEL_0 = 0,
+} wifi_manager_rssi_level_e;
+
+typedef enum
+{
+    WIFI_MANAGER_IP_CONFLICT_STATE_CONFLICT_NOT_DETECTED = 0,
+    WIFI_MANAGER_IP_CONFLICT_STATE_CONFLICT_DETECTED     = 1,
+} wifi_manager_ip_conflict_state_e;
+
+typedef enum
+{
+    WIFI_MANAGER_SECURITY_TYPE_NONE       = 0,
+    WIFI_MANAGER_SECURITY_TYPE_WEP        = 1,
+    WIFI_MANAGER_SECURITY_TYPE_WPA_PSK    = 2,
+    WIFI_MANAGER_SECURITY_TYPE_WPA2_PSK   = 3,
+    WIFI_MANAGER_SECURITY_TYPE_EAP        = 4,
+    WIFI_MANAGER_SECURITY_TYPE_WPA_FT_PSK = 5,
+    WIFI_MANAGER_SECURITY_TYPE_SAE        = 6,
+    WIFI_MANAGER_SECURITY_TYPE_OWE        = 7,
+    WIFI_MANAGER_SECURITY_TYPE_DPP        = 8,
+} wifi_manager_security_type_e;
+
+typedef void (*wifi_manager_error_cb)(wifi_manager_error_e, void *);
+typedef void (*wifi_manager_device_state_changed_cb)(wifi_manager_device_state_e, void *);
+typedef void (*wifi_manager_module_state_changed_cb)(wifi_manager_module_state_e, void *);
+typedef void (*wifi_manager_connection_state_changed_cb)(wifi_manager_connection_state_e, wifi_manager_ap_h, void *);
+typedef void (*wifi_manager_scan_state_changed_cb)(wifi_manager_scan_state_e, void *);
+typedef void (*wifi_manager_rssi_level_changed_cb)(wifi_manager_rssi_level_e, void *);
+typedef void (*wifi_manager_ip_conflict_cb)(char *, wifi_manager_ip_conflict_state_e, void *);
+typedef bool (*wifi_manager_found_ap_cb)(wifi_manager_ap_h, void *);
+typedef bool (*wifi_manager_config_cb)(const wifi_manager_config_h, void *);
+
+int wifi_manager_ap_get_essid(wifi_manager_ap_h ap, char ** essid);
+int wifi_manager_ap_get_bssid(wifi_manager_ap_h ap, char ** bssid);
+int wifi_manager_ap_get_rssi(wifi_manager_ap_h ap, int * rssi);
+int wifi_manager_ap_get_security_type(wifi_manager_ap_h ap, wifi_manager_security_type_e * type);
+int wifi_manager_ap_get_frequency(wifi_manager_ap_h ap, int * frequency);
+int wifi_manager_ap_is_passphrase_required(wifi_manager_ap_h ap, bool * required);
+int wifi_manager_ap_set_passphrase(wifi_manager_ap_h ap, const char * passphrase);
+int wifi_manager_ap_clone(wifi_manager_ap_h * cloned, wifi_manager_ap_h ap);
+int wifi_manager_ap_destroy(wifi_manager_ap_h ap);
+
+int wifi_manager_initialize(wifi_manager_h * handle);
+int wifi_manager_deinitialize(wifi_manager_h handle);
+int wifi_manager_activate(wifi_manager_h handle, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_deactivate(wifi_manager_h handle, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_scan(wifi_manager_h handle, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_scan_specific_ap(wifi_manager_h handle, const char * essid, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_connect(wifi_manager_h handle, wifi_manager_ap_h ap, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_forget_ap(wifi_manager_h handle, wifi_manager_ap_h ap);
+int wifi_manager_is_activated(wifi_manager_h handle, bool * activated);
+int wifi_manager_get_module_state(wifi_manager_h handle, wifi_manager_module_state_e * state);
+int wifi_manager_get_connection_state(wifi_manager_h handle, wifi_manager_connection_state_e * state);
+int wifi_manager_get_connected_ap(wifi_manager_h handle, wifi_manager_ap_h * ap);
+int wifi_manager_get_mac_address(wifi_manager_h handle, char ** mac);
+int wifi_manager_foreach_found_ap(wifi_manager_h handle, wifi_manager_found_ap_cb callback, void * userData);
+int wifi_manager_foreach_found_specific_ap(wifi_manager_h handle, wifi_manager_found_ap_cb callback, void * userData);
+int wifi_manager_config_foreach_configuration(wifi_manager_h handle, wifi_manager_config_cb callback, void * userData);
+int wifi_manager_config_get_name(wifi_manager_config_h config, char ** name);
+int wifi_manager_config_get_security_type(wifi_manager_config_h config, wifi_manager_security_type_e * type);
+int wifi_manager_config_remove(wifi_manager_h handle, wifi_manager_config_h config);
+
+int wifi_manager_set_device_state_changed_cb(wifi_manager_h handle, wifi_manager_device_state_changed_cb callback, void * userData);
+int wifi_manager_set_module_state_changed_cb(wifi_manager_h handle, wifi_manager_module_state_changed_cb callback, void * userData);
+int wifi_manager_set_connection_state_changed_cb(wifi_manager_h handle, wifi_manager_connection_state_changed_cb callback,
+                                                 void * userData);
+int wifi_manager_set_scan_state_changed_cb(wifi_manager_h handle, wifi_manager_scan_state_changed_cb callback, void * userData);
+int wifi_manager_set_rssi_level_changed_cb(wifi_manager_h handle, wifi_manager_rssi_level_changed_cb callback, void * userData);
+int wifi_manager_set_background_scan_cb(wifi_manager_h handle, wifi_manager_error_cb callback, void * userData);
+int wifi_manager_set_ip_conflict_cb(wifi_manager_h handle, wifi_manager_ip_conflict_cb callback, void * userData);
+int wifi_manager_unset_device_state_changed_cb(wifi_manager_h handle);
+int wifi_manager_unset_module_state_changed_cb(wifi_manager_h handle);
+int wifi_manager_unset_connection_state_changed_cb(wifi_manager_h handle);
+int wifi_manager_unset_scan_state_changed_cb(wifi_manager_h handle);
+int wifi_manager_unset_rssi_level_changed_cb(wifi_manager_h handle);
+int wifi_manager_unset_background_scan_cb(wifi_manager_h handle);
+int wifi_manager_unset_ip_conflict_cb(wifi_manager_h handle);
+
+const char * get_error_message(int error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/platform/tests/tizen_stubs/tizenrt_ble_service_data.c
+++ b/src/platform/tests/tizen_stubs/tizenrt_ble_service_data.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * TizenRT BLE service-data parser excerpt for host fuzzing.
+ * Source:
+ * https://github.com/Samsung/TizenRT/blob/47cbbc77a52bad51925925bb50e5e218b86b4edf/framework/src/bluetooth/src/bluetooth-adapter.c
+ */
+
+#include "bluetooth.h"
+
+TIZENRT_STUB_NO_SANITIZE
+int bt_adapter_le_get_scan_result_service_data_list(const bt_adapter_le_device_scan_result_info_s * info,
+                                                    bt_adapter_le_packet_type_e pkt_type, bt_adapter_le_service_data_s ** data_list,
+                                                    int * count)
+{
+    BT_CHECK_LE_SUPPORT();
+    BT_CHECK_INIT_STATUS();
+    BT_CHECK_INPUT_PARAMETER(info); /* LCOV_EXCL_START */
+    BT_CHECK_INPUT_PARAMETER(count);
+
+    int adv_length     = 0;
+    char * adv_data    = NULL;
+    char * remain_data = NULL;
+    int remain_len     = 0;
+    int field_len      = 0;
+    int data_count     = 0;
+    int data_index     = 0;
+
+    if (pkt_type == BT_ADAPTER_LE_PACKET_ADVERTISING)
+    {
+        adv_data   = info->adv_data;
+        adv_length = info->adv_data_len;
+    }
+    else if (pkt_type == BT_ADAPTER_LE_PACKET_SCAN_RESPONSE)
+    {
+        adv_data   = info->scan_data;
+        adv_length = info->scan_data_len;
+    }
+    else
+        return BT_ERROR_INVALID_PARAMETER;
+
+    if (!adv_data || adv_length < 3)
+        return BT_ERROR_NO_DATA;
+
+    remain_data = adv_data;
+    remain_len  = adv_length;
+    field_len   = 0;
+    while (remain_len > 0)
+    {
+        field_len = remain_data[0];
+        if (remain_data[1] == BT_ADAPTER_LE_ADVERTISING_DATA_SERVICE_DATA)
+            data_count++;
+
+        remain_len = remain_len - field_len - 1;
+        remain_data += field_len + 1;
+    }
+
+    if (data_count == 0)
+        return BT_ERROR_NO_DATA;
+
+    *data_list = calloc(1, sizeof(bt_adapter_le_service_data_s) * data_count);
+    if (*data_list == NULL)
+        return BT_ERROR_OUT_OF_MEMORY;
+
+    *count = data_count;
+
+    remain_data = adv_data;
+    remain_len  = adv_length;
+    field_len   = 0;
+    while (remain_len > 0)
+    {
+        field_len = remain_data[0];
+        if (remain_data[1] == BT_ADAPTER_LE_ADVERTISING_DATA_SERVICE_DATA)
+        {
+            (*data_list)[data_index].service_uuid = calloc(1, sizeof(char) * 4 + 1);
+            if ((*data_list)[data_index].service_uuid == NULL)
+                return BT_ERROR_OUT_OF_MEMORY;
+
+            snprintf((*data_list)[data_index].service_uuid, 5, "%2.2X%2.2X", remain_data[3], remain_data[2]);
+
+#ifdef GLIB_SUPPORTED
+            (*data_list)[data_index].service_data = g_memdup(&remain_data[4], field_len - 3);
+#else
+            (*data_list)[data_index].service_data = calloc(1, field_len - 3);
+            if ((*data_list)[data_index].service_data == NULL)
+                return BT_ERROR_OUT_OF_MEMORY;
+
+            memcpy((*data_list)[data_index].service_data, &remain_data[4], field_len - 3);
+#endif
+            (*data_list)[data_index].service_data_len = field_len - 3;
+
+            data_index++;
+        }
+
+        remain_len = remain_len - field_len - 1;
+        remain_data += field_len + 1;
+    }
+
+    return BT_ERROR_NONE; /* LCOV_EXCL_STOP */
+}
+
+TIZENRT_STUB_NO_SANITIZE
+int bt_adapter_le_free_service_data_list(bt_adapter_le_service_data_s * data_list, int count)
+{
+    int i;
+
+    BT_CHECK_LE_SUPPORT();
+    BT_CHECK_INIT_STATUS();
+    BT_CHECK_INPUT_PARAMETER(data_list); /* LCOV_EXCL_START */
+
+    for (i = 0; i < count; i++)
+    {
+        free(data_list[i].service_uuid);
+        free(data_list[i].service_data);
+    }
+    free(data_list);
+
+    return BT_ERROR_NONE; /* LCOV_EXCL_STOP */
+}

--- a/src/platform/tests/tizen_stubs/wifi-manager.h
+++ b/src/platform/tests/tizen_stubs/wifi-manager.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <tizen_api_stubs.h>


### PR DESCRIPTION
#### Summary

This change adds fuzzers for Tizen platform-specific methods that receive pre-auth data from untrusted emitters. It includes stub code based on https://github.com/Samsung/TizenRT/tree/master to enable testing methods that receive input from vendored functions.

Specific methods under test for BLE:

* ChipDeviceScanner::LeScanResultCb
* ChipDeviceScanner::SetupScanFilter
* ChipDeviceScanner::RegisterScanFilter
* ChipDeviceScanner::StartScan

For WiFi:

* WiFiManager::_FoundAPOnScanCb
* WiFiManager::GetBssId

#### Related issues

#71684 - This fuzzer was used to detect and report the issue fixed in this PR

#### Testing

Compiled and ran fuzzers for 100k iterations without crashes. When the fix is reverted, it detects the overflow.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
