### PR TITLE
Switch instanceName used in FindCommissionableNode

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1975,7 +1975,7 @@ CHIP_ERROR DeviceCommissioner::SetUdcListenPort(uint16_t listenPort)
     return CHIP_NO_ERROR;
 }
 
-void DeviceCommissioner::FindCommissionableNode(char * instanceName)
+void DeviceCommissioner::FindCommissionableNode(const char * instanceName)
 {
     Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kInstanceName, instanceName);
     TEMPORARY_RETURN_IGNORED DiscoverCommissionableNodes(filter);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -798,7 +798,7 @@ public:
      * @param instanceName DNS-SD instance name for the client requesting commissioning
      *
      */
-    void FindCommissionableNode(char * instanceName) override;
+    void FindCommissionableNode(const char * instanceName) override;
 
     /**
      * @brief

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -461,7 +461,7 @@ public:
      * @param instanceName DNS-SD instance name for the client requesting commissioning
      *
      */
-    virtual void FindCommissionableNode(char * instanceName) = 0;
+    virtual void FindCommissionableNode(const char * instanceName) = 0;
 
     virtual ~InstanceNameResolver() = default;
 };

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -120,7 +120,7 @@ void UserDirectedCommissioningServer::HandleNewUDC(const Transport::PeerAddress 
         // Call the registered InstanceNameResolver, if any.
         if (mInstanceNameResolver != nullptr)
         {
-            mInstanceNameResolver->FindCommissionableNode(instanceName);
+            mInstanceNameResolver->FindCommissionableNode(client->GetInstanceName());
         }
         else
         {

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -48,7 +48,7 @@ public:
 
     void OnCommissionerPasscodeReady(UDCClientState state) {}
 
-    void FindCommissionableNode(char * instanceName)
+    void FindCommissionableNode(const char * instanceName)
     {
         mFindCommissionableNodeCalled = true;
         mInstanceName                 = instanceName;
@@ -56,7 +56,7 @@ public:
 
     // virtual ~UserConfirmationProvider() = default;
     UDCClientState mState;
-    char * mInstanceName;
+    const char * mInstanceName;
 
     bool mOnUserDirectedCommissioningRequestCalled = false;
     bool mFindCommissionableNodeCalled             = false;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -56,7 +56,7 @@ public:
 
     // virtual ~UserConfirmationProvider() = default;
     UDCClientState mState;
-    const char * mInstanceName;
+    const char * mInstanceName = nullptr;
 
     bool mOnUserDirectedCommissioningRequestCalled = false;
     bool mFindCommissionableNodeCalled             = false;


### PR DESCRIPTION
#### Summary

##### Changes Made

This PR updates `UserDirectedCommissioningServer::HandleNewUDC` so that the registered `InstanceNameResolver` is given a pointer to the `UDCClientState`'s `instanceName` instead of the `IdentificationDeclaration`'s `instanceName`. The `UDCClientState`'s instance name is owned and persists long enough to prevent the flake from occurring. 

`UDCClientState::GetInstanceName` returns a `const char *`, so we also update `FindCommissionableNode` to use const as well. This doesn't affect any callsites in the repo, but the change did need to be propagated across InstanceNameResolver subclasses.

##### Background

JFADMIN 2.2 seems to require User-Directed Commissioning because each controller needs to initiate commissioning to get onto the corresponding administrator's fabric.

ASan reports a stack-use-after-return when doing a string compare on the following line inside `ActiveResolveAttempts::MarkPending`: 

https://github.com/project-chip/connectedhomeip/blob/e6863fcd9de6b703b26f7a823cc36be2123c1f2e/src/lib/dnssd/ActiveResolveAttempts.cpp#L140

This code runs as part of `UserDirectedCommissioningServer::OnMessageReceived`. It seems like an entry in `ActiveResolveAttempts`' `mRetryQueue` has a dangling pointer to the instanceName of an IdentificationDeclaration from an earlier `OnMessageReceived`. The variable is stack-allocated here:

https://github.com/project-chip/connectedhomeip/blob/e6863fcd9de6b703b26f7a823cc36be2123c1f2e/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp#L63

This is a rare flake because the UDC Server must receive a retransmission of the commissionee's identity declaration BEFORE mDNS completes and clears the RetryQueue. Retransmission occurs after 500 or more milliseconds, which is usually plenty of time for mDNS outside of CI.

Outside of ASan, this is probably a silent error because the string comparison just fails and a duplicate entry is added to the retry queue. 

Here is a minimal test case showing the failure. If you add this to `TestActiveResolveAttempts.cpp`, compile with `is_asan=true chip_mdns="minimal"`, and run the test, it will crash. 
```
TEST(TestActiveResolveAttempts, TestInstanceNameFilterNoDanglingPointer)
{
    System::Clock::Internal::MockClock mockClock;
    mdns::Minimal::ActiveResolveAttempts attempts(&mockClock);

    // This test passes under ASan if these curly braces are removed, since instanceName will remain in scope for the second MarkPending.
    {
        char instanceName[] = "ABCDEF1234567890"; // 16 chars + NUL <= kInstanceNameMaxLength
        Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kInstanceName, instanceName);
        attempts.MarkPending(filter, Dnssd::DiscoveryType::kCommissionableNode);
    }

    char instanceName2[] = "1234567890ABCDEF";
    Dnssd::DiscoveryFilter filter2(Dnssd::DiscoveryFilterType::kInstanceName, instanceName2);
    attempts.MarkPending(filter2, Dnssd::DiscoveryType::kCommissionableNode);
}
```

Disclaimer: I used AI to help troubleshoot and write the test, but everything written here is my own words from my own manual investigation of the failure/relevant code.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/71404
^ Can't say with confidence this will be fixed, so I won't mark it to automatically close.

#### Testing

Ran TestUdcMessages and JFADMIN 2.2, both passed. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
