### PR TITLE
[Chef] Enable Pw attribute access: switch current position and relative humidity measurement measured value

### DIFF
--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -262,7 +262,7 @@ public:
             break;
 #endif // MATTER_DM_OCCUPANCY_SENSING_CLUSTER_SERVER_ENDPOINT_COUNT > 0
 #if MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-        case Switch::Id: {
+        case Switch::Id:
             switch (path.mAttributeId)
             {
             case Switch::Attributes::CurrentPosition::Id:
@@ -287,11 +287,10 @@ public:
                 }
                 return ::pw::OkStatus();
             }
-        }
-        break;
+            break;
 #endif // MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
 #if MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-        case RelativeHumidityMeasurement::Id: {
+        case RelativeHumidityMeasurement::Id:
             switch (path.mAttributeId)
             {
             case RelativeHumidityMeasurement::Attributes::MeasuredValue::Id:
@@ -319,8 +318,7 @@ public:
                 }
                 return ::pw::OkStatus();
             }
-        }
-        break;
+            break;
 #endif // MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
         }
         return std::nullopt;

--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -262,7 +262,7 @@ public:
             break;
 #endif // MATTER_DM_OCCUPANCY_SENSING_CLUSTER_SERVER_ENDPOINT_COUNT > 0
 #if MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-        case Switch::Id:
+        case Switch::Id: {
             switch (path.mAttributeId)
             {
             case Switch::Attributes::CurrentPosition::Id:
@@ -287,10 +287,11 @@ public:
                 }
                 return ::pw::OkStatus();
             }
-            break;
+        }
+        break;
 #endif // MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
 #if MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-        case RelativeHumidityMeasurement::Id:
+        case RelativeHumidityMeasurement::Id: {
             switch (path.mAttributeId)
             {
             case RelativeHumidityMeasurement::Attributes::MeasuredValue::Id:
@@ -318,7 +319,8 @@ public:
                 }
                 return ::pw::OkStatus();
             }
-            break;
+        }
+        break;
 #endif // MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
         }
         return std::nullopt;

--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -43,6 +43,14 @@
 #include <app/clusters/occupancy-sensor-server/CodegenIntegration.h>
 #endif
 
+#if MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#include <app/clusters/switch-server/CodegenIntegration.h>
+#endif
+
+#if MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#include <app/clusters/relative-humidity-measurement-server/CodegenIntegration.h>
+#endif
+
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -253,6 +261,65 @@ public:
             }
             break;
 #endif // MATTER_DM_OCCUPANCY_SENSING_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#if MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+        case Switch::Id:
+            switch (path.mAttributeId)
+            {
+            case Switch::Attributes::CurrentPosition::Id:
+                uint8_t currentPosition;
+                CHIP_ERROR err = decoder.Decode(currentPosition);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to decode switch current position: %" CHIP_ERROR_FORMAT, err.Format());
+                    return ::pw::Status::Internal();
+                }
+                auto switchCluster = Switch::FindClusterOnEndpoint(path.mEndpointId);
+                if (switchCluster == nullptr)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to find switch cluster on endpoint: %d", path.mEndpointId);
+                    return ::pw::Status::Internal();
+                }
+                err = switchCluster->SetCurrentPosition(currentPosition);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to set switch current position: %" CHIP_ERROR_FORMAT, err.Format());
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            break;
+#endif // MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#if MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+        case RelativeHumidityMeasurement::Id:
+            switch (path.mAttributeId)
+            {
+            case RelativeHumidityMeasurement::Attributes::MeasuredValue::Id:
+                DataModel::Nullable<uint16_t> measuredValue;
+                CHIP_ERROR err = decoder.Decode(measuredValue);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to decode relative humidity measurement measured value: %" CHIP_ERROR_FORMAT,
+                                 err.Format());
+                    return ::pw::Status::Internal();
+                }
+                auto relativeHumidityMeasurementCluster = RelativeHumidityMeasurement::FindClusterOnEndpoint(path.mEndpointId);
+                if (relativeHumidityMeasurementCluster == nullptr)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to find relative humidity measurement cluster on endpoint: %d",
+                                 path.mEndpointId);
+                    return ::pw::Status::Internal();
+                }
+                err = relativeHumidityMeasurementCluster->SetMeasuredValue(measuredValue);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "[Pw] Failed to set relative humidity measurement measured value: %" CHIP_ERROR_FORMAT,
+                                 err.Format());
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            break;
+#endif // MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
         }
         return std::nullopt;
     }

--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -265,7 +265,7 @@ public:
         case Switch::Id:
             switch (path.mAttributeId)
             {
-            case Switch::Attributes::CurrentPosition::Id:
+            case Switch::Attributes::CurrentPosition::Id: {
                 uint8_t currentPosition;
                 CHIP_ERROR err = decoder.Decode(currentPosition);
                 if (err != CHIP_NO_ERROR)
@@ -287,13 +287,14 @@ public:
                 }
                 return ::pw::OkStatus();
             }
+            }
             break;
 #endif // MATTER_DM_SWITCH_CLUSTER_SERVER_ENDPOINT_COUNT > 0
 #if MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0
         case RelativeHumidityMeasurement::Id:
             switch (path.mAttributeId)
             {
-            case RelativeHumidityMeasurement::Attributes::MeasuredValue::Id:
+            case RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {
                 DataModel::Nullable<uint16_t> measuredValue;
                 CHIP_ERROR err = decoder.Decode(measuredValue);
                 if (err != CHIP_NO_ERROR)
@@ -317,6 +318,7 @@ public:
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
+            }
             }
             break;
 #endif // MATTER_DM_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0


### PR DESCRIPTION
#### Summary

Enable Pw attribute access: switch current position and relative humidity measurement measured value

#### Testing

Tested using RPc console.

```
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1,
     cluster=protos.chip.rpc.ClusterType.ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
     attribute_id=0, type=protos.chip.rpc.AttributeType.ZCL_INT16U_ATTRIBUTE_TYPE),
     data=protos.chip.rpc.AttributeData(data_uint16=5000)
```

```
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1,
     cluster=protos.chip.rpc.ClusterType.ZCL_SWITCH_CLUSTER_ID, attribute_id=1,
     type=protos.chip.rpc.AttributeType.ZCL_INT8U_ATTRIBUTE_TYPE),
     data=protos.chip.rpc.AttributeData(data_uint8=1)
```