### PR TITLE
[NXP] fix random BLE adv issue due tasks execution timing/order

### DIFF
--- a/examples/lock-app/nxp/common/main/AppTask.cpp
+++ b/examples/lock-app/nxp/common/main/AppTask.cpp
@@ -116,9 +116,6 @@ exit:
 void LockApp::AppTask::PreInitMatterStack()
 {
     ChipLogProgress(DeviceLayer, "Welcome to NXP Lock Demo App");
-
-    /* BLEApplicationManager implemented per platform or left blank */
-    chip::NXP::App::BleAppMgr().Init();
 }
 
 void LockApp::AppTask::PostInitMatterStack()

--- a/examples/platform/nxp/common/app_ble/include/BLEApplicationManager.h
+++ b/examples/platform/nxp/common/app_ble/include/BLEApplicationManager.h
@@ -31,7 +31,8 @@ namespace chip::NXP::App {
 class BLEApplicationManager
 {
 public:
-    void Init();
+    void BLEApplicationManager_PreMatterStackInit();
+    void BLEApplicationManager_PostMatterStackInit();
     void EnableMultipleConnectionsHandler();
     void FactoryReset();
 

--- a/examples/platform/nxp/common/app_ble/include/BLEApplicationManager.h
+++ b/examples/platform/nxp/common/app_ble/include/BLEApplicationManager.h
@@ -31,8 +31,8 @@ namespace chip::NXP::App {
 class BLEApplicationManager
 {
 public:
-    void BLEApplicationManager_PreMatterStackInit();
-    void BLEApplicationManager_PostMatterStackInit();
+    void PreMatterStackInit();
+    void PostMatterStackInit();
     void EnableMultipleConnectionsHandler();
     void FactoryReset();
 

--- a/examples/platform/nxp/common/app_ble/source/BLEApplicationManagerEmpty.cpp
+++ b/examples/platform/nxp/common/app_ble/source/BLEApplicationManagerEmpty.cpp
@@ -23,12 +23,12 @@ using namespace ::chip::NXP::App;
 
 BLEApplicationManager BLEApplicationManager::sInstance;
 
-void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
+void BLEApplicationManager::PreMatterStackInit(void)
 {
     /*Empty implementation. Intentionally left blank */
 }
 
-void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
+void BLEApplicationManager::PostMatterStackInit(void)
 {
     /*Empty implementation. Intentionally left blank */
 }

--- a/examples/platform/nxp/common/app_ble/source/BLEApplicationManagerEmpty.cpp
+++ b/examples/platform/nxp/common/app_ble/source/BLEApplicationManagerEmpty.cpp
@@ -23,7 +23,12 @@ using namespace ::chip::NXP::App;
 
 BLEApplicationManager BLEApplicationManager::sInstance;
 
-void BLEApplicationManager::Init(void)
+void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
+{
+    /*Empty implementation. Intentionally left blank */
+}
+
+void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
 {
     /*Empty implementation. Intentionally left blank */
 }

--- a/examples/platform/nxp/common/app_ble/source/BleZephyrManagerApp.cpp
+++ b/examples/platform/nxp/common/app_ble/source/BleZephyrManagerApp.cpp
@@ -53,8 +53,14 @@ uint8_t manuf_data[ADV_LEN] = {
 
 bt_uuid_16 UUID16_CHIPoBLEService = BT_UUID_INIT_16(0xFFF6);
 
+
+void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
+{
+    /* Nothing to do */
+}
+
 /**
- * @brief Init BLE application manager
+ * @brief Set Custom BLE advertising parameters
  *
  * In this example, the application manager is used to customize BLE advertising
  * parameters. This example is provided for platforms with Zephyr BLE manager support.
@@ -79,8 +85,9 @@ bt_uuid_16 UUID16_CHIPoBLEService = BT_UUID_INIT_16(0xFFF6);
  * could be called. If InsertRequest API is called several time, only the request with the
  * higher priority will be advertise.
  *
+ * @note This function have to be called after Matter init to be able to get correct factory data values.
  */
-void BLEApplicationManager::Init(void)
+void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
 {
     /* Register Matter adv data + custom adv data */
     static_assert(sizeof(serviceData) == 10, "Unexpected size of BLE advertising data!");

--- a/examples/platform/nxp/common/app_ble/source/BleZephyrManagerApp.cpp
+++ b/examples/platform/nxp/common/app_ble/source/BleZephyrManagerApp.cpp
@@ -54,7 +54,7 @@ uint8_t manuf_data[ADV_LEN] = {
 bt_uuid_16 UUID16_CHIPoBLEService = BT_UUID_INIT_16(0xFFF6);
 
 
-void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
+void BLEApplicationManager::PreMatterStackInit(void)
 {
     /* Nothing to do */
 }
@@ -87,7 +87,7 @@ void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
  *
  * @note This function have to be called after Matter init to be able to get correct factory data values.
  */
-void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
+void BLEApplicationManager::PostMatterStackInit(void)
 {
     /* Register Matter adv data + custom adv data */
     static_assert(sizeof(serviceData) == 10, "Unexpected size of BLE advertising data!");

--- a/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
+++ b/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
@@ -54,7 +54,7 @@ void app_gatt_callback(deviceId_t id, gattServerEvent_t * event)
     }
 }
 
-void BLEApplicationManager::Init(void)
+void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     auto * bleManager = &chip::DeviceLayer::Internal::BLEMgrImpl();
@@ -71,6 +71,12 @@ void BLEApplicationManager::Init(void)
     btSettingsInit();
 #endif
 }
+
+void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
+{
+    /*Empty implementation. Intentionally left blank */
+}
+
 
 void BLEApplicationManager::EnableMultipleConnectionsHandler(void)
 {

--- a/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
+++ b/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
@@ -55,7 +55,7 @@ void app_gatt_callback(deviceId_t id, gattServerEvent_t * event)
 }
 
 /* This function have to be called before Matter init in order to register callbacks */
-void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
+void BLEApplicationManager::PreMatterStackInit(void)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     auto * bleManager = &chip::DeviceLayer::Internal::BLEMgrImpl();
@@ -73,7 +73,7 @@ void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
 #endif
 }
 
-void BLEApplicationManager::BLEApplicationManager_PostMatterStackInit(void)
+void BLEApplicationManager::PostMatterStackInit(void)
 {
     /*Empty implementation. Intentionally left blank */
 }

--- a/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
+++ b/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
@@ -54,6 +54,7 @@ void app_gatt_callback(deviceId_t id, gattServerEvent_t * event)
     }
 }
 
+/* This function have to be called before Matter init in order to register callbacks */
 void BLEApplicationManager::BLEApplicationManager_PreMatterStackInit(void)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -277,7 +277,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     /* BLEApplicationManager implemented per platform or left blank */
-    chip::NXP::App::BleAppMgr().BLEApplicationManager_PreMatterStackInit();
+    chip::NXP::App::BleAppMgr().PreMatterStackInit();
 #endif
 
     /*
@@ -355,7 +355,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     /* BLEApplicationManager implemented per platform or left blank */
-    chip::NXP::App::BleAppMgr().BLEApplicationManager_PostMatterStackInit();
+    chip::NXP::App::BleAppMgr().PostMatterStackInit();
 #endif
 
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -265,6 +265,11 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     TEMPORARY_RETURN_IGNORED chip::NXP::App::LowPower::Init();
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+    /* BLEApplicationManager implemented per platform or left blank */
+    chip::NXP::App::BleAppMgr().BLEApplicationManager_PreMatterStackInit();
+#endif
+
     /* Initialize Matter factory data before initializing the Matter stack */
     err = AppFactoryData_PreMatterStackInit();
 
@@ -345,6 +350,11 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
 #if CONFIG_CHIP_SE05X
     err = chip::NXP::App::Se05x::Init();
     SuccessOrExit(err);
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+    /* BLEApplicationManager implemented per platform or left blank */
+    chip::NXP::App::BleAppMgr().BLEApplicationManager_PostMatterStackInit();
 #endif
 
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -265,19 +265,20 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     TEMPORARY_RETURN_IGNORED chip::NXP::App::LowPower::Init();
 #endif
 
-#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    /* BLEApplicationManager implemented per platform or left blank */
-    chip::NXP::App::BleAppMgr().BLEApplicationManager_PreMatterStackInit();
-#endif
-
     /* Initialize Matter factory data before initializing the Matter stack */
     err = AppFactoryData_PreMatterStackInit();
+
 
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Pre Factory Data Provider init failed");
         goto exit;
     }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+    /* BLEApplicationManager implemented per platform or left blank */
+    chip::NXP::App::BleAppMgr().BLEApplicationManager_PreMatterStackInit();
+#endif
 
     /*
      * Initialize the CHIP stack.

--- a/examples/thermostat/nxp/common/main/AppTask.cpp
+++ b/examples/thermostat/nxp/common/main/AppTask.cpp
@@ -24,10 +24,6 @@
 #include <app/InteractionModelEngine.h>
 #include <app/util/attribute-storage.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-#include "BLEApplicationManager.h"
-#endif
-
 using namespace chip;
 
 void ThermostatApp::AppTask::PreInitMatterStack()
@@ -37,10 +33,6 @@ void ThermostatApp::AppTask::PreInitMatterStack()
 
 void ThermostatApp::AppTask::PostInitMatterStack()
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    /* BLEApplicationManager implemented per platform or left blank */
-    chip::NXP::App::BleAppMgr().Init();
-#endif
     chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&chip::NXP::App::GetICDUtil());
 }
 


### PR DESCRIPTION
#### Summary

fix random BLE adv issue due to tasks execution timing/order.
Issue:
Randomly Matter start ble advertising before the application set custom ble adv data. Due to that the advertising failed (depending on time execution and task priority).

Proposal:

Introduce explicit BLE pre-initialization and post-Matter-initialization functions.
BLE advertising data customization is moved to the pre-initialization phase, ensuring it is fully configured before Matter starts BLE advertising.
This change guarantees that application-specific BLE customization is executed at the correct time, eliminating the observed race condition and preventing random BLE advertising init failures.


#### Testing

BLE-wifi commisioning with nxp rt1060 thermostat example, validate commissioning is passing the set custom ble adv data is done before matter start ble advertising

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
