### PR TITLE
Add data channel to camera WebRTC controller

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -256,6 +256,7 @@ void WebRTCManager::Disconnect()
     // Reset track
     mTrack.reset();
     mAudioTrack.reset();
+    mDataChannel.reset();
 
     // Clear state
     mCurrentVideoStreamId = 0;
@@ -369,6 +370,15 @@ CHIP_ERROR WebRTCManager::Connect(Controller::DeviceCommissioner & commissioner,
                    reinterpret_cast<const struct sockaddr *>(&audioAddr), sizeof(audioAddr));
         },
         nullptr);
+
+    mDataChannel = mPeerConnection->createDataChannel("data");
+    mDataChannel->onMessage([](std::variant<rtc::binary, rtc::string> message) {
+        if (std::holds_alternative<rtc::string>(message))
+        {
+            std::string message_content = std::get<rtc::string>(message);
+            ChipLogProgress(Camera, "DataChannel message: %s", message_content.c_str());
+        }
+    });
 
     // Local description generation is deferred to ProvideOffer or HandleOffer
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -121,6 +121,7 @@ private:
 
     std::shared_ptr<rtc::Track> mTrack;
     std::shared_ptr<rtc::Track> mAudioTrack;
+    std::shared_ptr<rtc::DataChannel> mDataChannel;
 
     // Callback to notify when session is established
     SessionEstablishedCallback mSessionEstablishedCallback;


### PR DESCRIPTION

#### Summary

Enhance the sample camera WebRTC controller by adding a data channel. This provides a richer testing environment using the sample WebRTC controller.

Note, during SDP exchange, the camera may reject the data channel if it does not support it.[1]

[1] https://datatracker.ietf.org/doc/html/rfc3264#section-6

#### Related issues

#### Testing

Ran camera app with camera controller and validated that WebRTC streaming works.
Validated via app logs that the data track is present in both offer and answer SDP.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
