### PR TITLE
Clarify Naming Convention in Chef Example Stubs

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -172,6 +172,7 @@ const Clusters::Descriptor::Structs::SemanticTagStruct::Type kTopTagList[] = { P
 const Clusters::Descriptor::Structs::SemanticTagStruct::Type kBottomTagList[] = { PostionSemanticTag::kBottom,
                                                                                   NumberSemanticTag::kTwo };
 // These are representative tags.
+//  We usually prefer "example" or similar, but this is kept for matching real products more closely.
 namespace BilresaRotary {
 const Clusters::Descriptor::Structs::SemanticTagStruct::Type kRotaryTagList[] = {
     { .namespaceID = 0x08, .tag = 0x06, .label = MakeOptional(Nullable<Span<const char>>("1"_span)) },

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -172,7 +172,7 @@ const Clusters::Descriptor::Structs::SemanticTagStruct::Type kTopTagList[] = { P
 const Clusters::Descriptor::Structs::SemanticTagStruct::Type kBottomTagList[] = { PostionSemanticTag::kBottom,
                                                                                   NumberSemanticTag::kTwo };
 // These are representative tags.
-//  We usually prefer "example" or similar, but this is kept for matching real products more closely.
+// Note: this tries to emulate data as seen in a real product, hence using the namespace.
 namespace BilresaRotary {
 const Clusters::Descriptor::Structs::SemanticTagStruct::Type kRotaryTagList[] = {
     { .namespaceID = 0x08, .tag = 0x06, .label = MakeOptional(Nullable<Span<const char>>("1"_span)) },


### PR DESCRIPTION
#### Summary

Added a comment to examples/chef/common/stubs.cpp to provide context on namespace: The comment explains that this specific naming is used within the example for improved fidelity to real-world product representations.

#### Testing

PR only adds a comment.