### PR TITLE
[AI Skill] Add "chip-tool-testing" agent skill to teach AI how to use chip-tool to test examples

### DIFF
--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -77,4 +77,4 @@ After successful commissioning, you can use `chip-tool` to interact with data mo
 
 ## Troubleshooting
 - **Timeout**: If a command times out, you can increase it with `--timeout <seconds>`.
-- **Configuration Cache**: `chip-tool` caches state in `/tmp/chip_tool_config.ini` (or similar). Deleting these `.ini` files in `/tmp` can resolve stale configuration issues. You can also specify a custom directory with `--storage-directory <path>`.
+- **Configuration Cache**: `chip-tool` caches state in `chip_tool_config.ini` (often in the current directory or `/tmp`). Deleting this file can resolve stale configuration issues. You can also specify a custom directory with `--storage-directory <path>`.

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -29,6 +29,13 @@ The binary will be located in `out/linux-x64-all-devices-boringssl/all-devices-a
 
 ## Testing Guidelines
 
+### Running the Example
+Run the example application (usually in a separate terminal or the background):
+```bash
+./out/linux-x64-all-devices-boringssl/all-devices-app
+```
+*Note: Use a clean KVS file or clear the existing one to ensure it enters commissioning mode.*
+
 ### 1. Determine Pairing Credentials
 Check the application logs on startup to find the setup PIN code and discriminator.
 Example log:
@@ -38,14 +45,17 @@ Example log:
 ```
 
 ### 2. Commissioning (Pairing)
-Make sure the device is in commissioning mode. If using a persistent storage (KVS), you may need to use a clean KVS file or clear it to force commissioning mode on startup.
+Make sure the device is in commissioning mode. If using a persistent storage (KVS), you may need to use a clean KVS file or clear it to force commissioning mode on startup. On Linux, the default KVS file is `/tmp/chip_kvs`:
+```bash
+rm /tmp/chip_kvs
+```
 
 #### Over IP (On-Network)
 If the device is already on the same IP network (e.g., running locally on the same host):
 
 - **With Long Discriminator**:
   ```bash
-  chip-tool pairing onnetwork-long <node_id> <pin_code> <discriminator>
+  chip-tool pairing onnetwork-long <node_id> <setup_pin> <discriminator>
   ```
 - **Without Discriminator** (looks for any commissionable device):
   ```bash

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -1,106 +1,152 @@
 ---
 name: chip-tool-testing
-description: Guidelines for building Matter examples and chip-tool, and testing examples using chip-tool.
+description:
+    Guidelines for building Matter examples and chip-tool, and testing examples
+    using chip-tool.
 ---
 
 # Testing Matter Examples with Chip-Tool
 
-This skill provides guidelines for building Matter example applications and `chip-tool`, and using `chip-tool` to commission and interact with the examples in a simulated environment (like Linux POSIX).
+This skill provides guidelines for building Matter example applications and
+`chip-tool`, and using `chip-tool` to commission and interact with the examples
+in a simulated environment (like Linux POSIX).
 
 ## Building from Source
 
-Always build the `chip-tool` and the Matter example application from the same revision of the repository to ensure compatibility.
+Always build the `chip-tool` and the Matter example application from the same
+revision of the repository to ensure compatibility.
 
 ### Building chip-tool
+
 Use the build script to build `chip-tool` for Linux:
+
 ```bash
 source scripts/activate.sh
 ./scripts/build/build_examples.py --target linux-x64-chip-tool-clang build
 ```
+
 The binary will be located in `out/linux-x64-chip-tool-clang/chip-tool`.
 
 ### Building Examples
+
 Use the build script to build examples (e.g., `all-devices-app`):
+
 ```bash
 source scripts/activate.sh
 ./scripts/build/build_examples.py --target linux-x64-all-devices-boringssl build
 ```
-The binary will be located in `out/linux-x64-all-devices-boringssl/all-devices-app`.
+
+The binary will be located in
+`out/linux-x64-all-devices-boringssl/all-devices-app`.
 
 ## Testing Guidelines
 
 ### Running the Example
+
 Run the example application (usually in a separate terminal or the background):
+
 ```bash
 ./out/linux-x64-all-devices-boringssl/all-devices-app
 ```
-*Note: Use a clean KVS file or clear the existing one to ensure it enters commissioning mode.*
+
+_Note: Use a clean KVS file or clear the existing one to ensure it enters
+commissioning mode._
 
 ### 1. Determine Pairing Credentials
-Check the application logs on startup to find the setup PIN code and discriminator.
-Example log:
+
+Check the application logs on startup to find the setup PIN code and
+discriminator. Example log:
+
 ```
 [DL]   Setup Pin Code: 20202021
 [DL]   Setup Discriminator: 3840 (0xF00)
 ```
 
 ### 2. Commissioning (Pairing)
-Make sure the device is in commissioning mode. If using a persistent storage (KVS), you may need to use a clean KVS file or clear it to force commissioning mode on startup. On Linux, the default KVS file is `/tmp/chip_kvs`:
+
+Make sure the device is in commissioning mode. If using a persistent storage
+(KVS), you may need to use a clean KVS file or clear it to force commissioning
+mode on startup. On Linux, the default KVS file is `/tmp/chip_kvs`:
+
 ```bash
 rm /tmp/chip_kvs
 ```
 
 #### Over IP (On-Network)
-If the device is already on the same IP network (e.g., running locally on the same host):
 
-- **With Long Discriminator**:
-  ```bash
-  chip-tool pairing onnetwork-long <node_id> <setup_pin> <discriminator>
-  ```
-- **Without Discriminator** (looks for any commissionable device):
-  ```bash
-  chip-tool pairing onnetwork <node_id> <setup_pin>
-  ```
-- **With Manual Pairing Code or QR Code**:
-  ```bash
-  chip-tool pairing code <node_id> <pairing_code_or_qrcode>
-  ```
-- **Direct IP and Port** (useful if mDNS resolution fails):
-  ```bash
-  chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port> --bypass-attestation-verifier true
-  ```
+If the device is already on the same IP network (e.g., running locally on the
+same host):
+
+-   **With Long Discriminator**:
+    ```bash
+    chip-tool pairing onnetwork-long <node_id> <setup_pin> <discriminator>
+    ```
+-   **Without Discriminator** (looks for any commissionable device):
+    ```bash
+    chip-tool pairing onnetwork <node_id> <setup_pin>
+    ```
+-   **With Manual Pairing Code or QR Code**:
+    ```bash
+    chip-tool pairing code <node_id> <pairing_code_or_qrcode>
+    ```
+-   **Direct IP and Port** (useful if mDNS resolution fails):
+    ```bash
+    chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port> --bypass-attestation-verifier true
+    ```
 
 ### 3. Interacting with Clusters
-After successful commissioning, you can use `chip-tool` to interact with data model clusters.
 
-- **Read Attribute**:
-  ```bash
-  chip-tool <cluster_name> read <attribute_name> <node_id> <endpoint_id>
-  ```
-  Example: `chip-tool basicinformation read vendor-id 0x8016 0`
+After successful commissioning, you can use `chip-tool` to interact with data
+model clusters.
 
-- **Invoke Command**:
-  ```bash
-  chip-tool <cluster_name> <command_name> [arguments] <node_id> <endpoint_id>
-  ```
-  Example: `chip-tool onoff toggle 0x8016 1`
+-   **Read Attribute**:
+
+    ```bash
+    chip-tool <cluster_name> read <attribute_name> <node_id> <endpoint_id>
+    ```
+
+    Example: `chip-tool basicinformation read vendor-id 0x8016 0`
+
+-   **Invoke Command**:
+    ```bash
+    chip-tool <cluster_name> <command_name> [arguments] <node_id> <endpoint_id>
+    ```
+    Example: `chip-tool onoff toggle 0x8016 1`
 
 ## Troubleshooting
-- **Timeout**: If a command times out, you can increase it with `--timeout <seconds>`.
-- **Configuration Cache**: `chip-tool` caches state in `chip_tool_config.ini` (often in the current directory or `/tmp`). Deleting this file can resolve stale configuration issues. You can also specify a custom directory with `--storage-directory <path>`.
+
+-   **Timeout**: If a command times out, you can increase it with
+    `--timeout <seconds>`.
+-   **Configuration Cache**: `chip-tool` caches state in `chip_tool_config.ini`
+    (often in the current directory or `/tmp`). Deleting this file can resolve
+    stale configuration issues. You can also specify a custom directory with
+    `--storage-directory <path>`.
 
 ## Reporting Results
 
-When completing a test task using this skill, you should output a structured report to the user. Since every test may verify different features, do not force a fixed sequence of steps. Instead, follow these general guidelines for reporting each item you verified:
+When completing a test task using this skill, you should output a structured
+report to the user. Since every test may verify different features, do not force
+a fixed sequence of steps. Instead, follow these general guidelines for
+reporting each item you verified:
 
 For each verified feature, command, or configuration item, provide:
-1. **What was verified**: A clear description of the intent (e.g., "Verified that Endpoint 2 is a child of Endpoint 1").
+
+1. **What was verified**: A clear description of the intent (e.g., "Verified
+   that Endpoint 2 is a child of Endpoint 1").
 2. **The command ran**: The exact `chip-tool` or shell command you used.
-3. **The proof (logs)**: A snippet of the output or logs that proves the verification was successful (e.g., the attribute value read or the success status).
+3. **The proof (logs)**: A snippet of the output or logs that proves the
+   verification was successful (e.g., the attribute value read or the success
+   status).
 
 ### General Guidelines for Content:
-- **Build Process**: Mention which targets were built and if any custom flags were used.
-- **Startup**: Include the command used to run the application, and the pairing credentials (Setup PIN and Discriminator) found in the logs.
-- **Commissioning**: Show the command used and the log snippet confirming success.
-- **Data Model**: If hierarchy or device composition was verified, show the relevant `Descriptor` reads.
-- **Cluster Interaction**: For any attribute read/write or command invocation, show the command and the response status.
+
+-   **Build Process**: Mention which targets were built and if any custom flags
+    were used.
+-   **Startup**: Include the command used to run the application, and the
+    pairing credentials (Setup PIN and Discriminator) found in the logs.
+-   **Commissioning**: Show the command used and the log snippet confirming
+    success.
+-   **Data Model**: If hierarchy or device composition was verified, show the
+    relevant `Descriptor` reads.
+-   **Cluster Interaction**: For any attribute read/write or command invocation,
+    show the command and the response status.

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -7,9 +7,10 @@ description:
 
 # Testing Matter Examples with Chip-Tool
 
-This skill provides guidelines for building Matter example applications and
-`chip-tool`, and using `chip-tool` to commission and interact with the examples
-in a simulated environment (like Linux POSIX).
+This skill provides guidelines for building Matter example applications and `chip-tool`, and using `chip-tool` to commission and interact with the examples in a simulated environment (like Linux POSIX).
+
+> [!NOTE]
+> While `chip-tool` and examples support multiple platforms, these guidelines focus on the Linux/POSIX environment, which is the standard environment for agent execution.
 
 ## Building from Source
 
@@ -49,8 +50,7 @@ Run the example application (usually in a separate terminal or the background):
 ./out/linux-x64-all-devices-boringssl/all-devices-app
 ```
 
-_Note: Use a clean KVS file or clear the existing one to ensure it enters
-commissioning mode._
+_Note: Use a clean KVS file (by specifying a new, non-existent file path with `--KVS`) or clear the existing one (by deleting the file) to ensure the application enters commissioning mode on startup._
 
 ### 1. Determine Pairing Credentials
 
@@ -71,6 +71,9 @@ mode on startup. On Linux, the default KVS file is `/tmp/chip_kvs`:
 ```bash
 rm /tmp/chip_kvs
 ```
+
+> [!NOTE]
+> **Persistence Testing**: If you are performing a persistence test (verifying state across restarts), do NOT delete the KVS file. Reuse the same KVS file to preserve stored attributes.
 
 #### Over IP (On-Network)
 

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: chip-tool-testing
+description: Guidelines for building Matter examples and chip-tool, and testing examples using chip-tool.
+---
+
+# Testing Matter Examples with Chip-Tool
+
+This skill provides guidelines for building Matter example applications and `chip-tool`, and using `chip-tool` to commission and interact with the examples in a simulated environment (like Linux POSIX).
+
+## Building from Source
+
+Always build the `chip-tool` and the Matter example application from the same revision of the repository to ensure compatibility.
+
+### Building chip-tool
+Use the build script to build `chip-tool` for Linux:
+```bash
+source scripts/activate.sh
+./scripts/build/build_examples.py --target linux-x64-chip-tool-clang build
+```
+The binary will be located in `out/linux-x64-chip-tool-clang/chip-tool`.
+
+### Building Examples
+Use the build script to build examples (e.g., `all-devices-app`):
+```bash
+source scripts/activate.sh
+./scripts/build/build_examples.py --target linux-x64-all-devices-boringssl build
+```
+The binary will be located in `out/linux-x64-all-devices-boringssl/all-devices-app`.
+
+## Testing Guidelines
+
+### 1. Determine Pairing Credentials
+Check the application logs on startup to find the setup PIN code and discriminator.
+Example log:
+```
+[DL]   Setup Pin Code: 20202021
+[DL]   Setup Discriminator: 3840 (0xF00)
+```
+
+### 2. Commissioning (Pairing)
+Make sure the device is in commissioning mode. If using a persistent storage (KVS), you may need to use a clean KVS file or clear it to force commissioning mode on startup.
+
+#### Over IP (On-Network)
+If the device is already on the same IP network (e.g., running locally on the same host):
+
+- **With Long Discriminator**:
+  ```bash
+  chip-tool pairing onnetwork-long <node_id> <pin_code> <discriminator>
+  ```
+- **Without Discriminator** (looks for any commissionable device):
+  ```bash
+  chip-tool pairing onnetwork <node_id> <setup_pin>
+  ```
+- **With Manual Pairing Code or QR Code**:
+  ```bash
+  chip-tool pairing code <node_id> <pairing_code_or_qrcode>
+  ```
+- **Direct IP and Port** (useful if mDNS resolution fails):
+  ```bash
+  chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port> --bypass-attestation-verifier true
+  ```
+
+### 3. Interacting with Clusters
+After successful commissioning, you can use `chip-tool` to interact with data model clusters.
+
+- **Read Attribute**:
+  ```bash
+  chip-tool <cluster_name> read <attribute_name> <node_id> <endpoint_id>
+  ```
+  Example: `chip-tool basicinformation read vendor-id 0x8016 0`
+
+- **Invoke Command**:
+  ```bash
+  chip-tool <cluster_name> <command_name> [arguments] <node_id> <endpoint_id>
+  ```
+  Example: `chip-tool onoff toggle 0x8016 1`
+
+## Troubleshooting
+- **Timeout**: If a command times out, you can increase it with `--timeout <seconds>`.
+- **Configuration Cache**: `chip-tool` caches state in `/tmp/chip_tool_config.ini` (or similar). Deleting these `.ini` files in `/tmp` can resolve stale configuration issues. You can also specify a custom directory with `--storage-directory <path>`.

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -91,23 +91,16 @@ After successful commissioning, you can use `chip-tool` to interact with data mo
 
 ## Reporting Results
 
-When completing a test task using this skill, you should output a structured report to the user containing the following evidence:
+When completing a test task using this skill, you should output a structured report to the user. Since every test may verify different features, do not force a fixed sequence of steps. Instead, follow these general guidelines for reporting each item you verified:
 
-### 1. Build Process
-- State which targets were built and for which platform.
+For each verified feature, command, or configuration item, provide:
+1. **What was verified**: A clear description of the intent (e.g., "Verified that Endpoint 2 is a child of Endpoint 1").
+2. **The command ran**: The exact `chip-tool` or shell command you used.
+3. **The proof (logs)**: A snippet of the output or logs that proves the verification was successful (e.g., the attribute value read or the success status).
 
-### 2. Device Configuration and Startup
-- State the command used to run the application and any specific arguments used (like `--device`).
-- Include the pairing credentials (Setup PIN and Discriminator) extracted from the logs.
-
-### 3. Commissioning Evidence
-- Provide the `chip-tool` command used for commissioning.
-- Include a snippet of the logs showing successful commissioning (e.g., `Commissioning complete for node ID...`).
-
-### 4. Data Model Verification
-- Include the commands used to read `PartsList` or other attributes to verify the data model hierarchy.
-- Provide the output snippets showing the expected endpoints and relationships.
-
-### 5. Interaction Evidence
-- List the commands used to read/write attributes or invoke commands on each endpoint.
-- State the result (e.g., `Status=0x0 (SUCCESS)`) to prove it worked.
+### General Guidelines for Content:
+- **Build Process**: Mention which targets were built and if any custom flags were used.
+- **Startup**: Include the command used to run the application, and the pairing credentials (Setup PIN and Discriminator) found in the logs.
+- **Commissioning**: Show the command used and the log snippet confirming success.
+- **Data Model**: If hierarchy or device composition was verified, show the relevant `Descriptor` reads.
+- **Cluster Interaction**: For any attribute read/write or command invocation, show the command and the response status.

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -88,3 +88,26 @@ After successful commissioning, you can use `chip-tool` to interact with data mo
 ## Troubleshooting
 - **Timeout**: If a command times out, you can increase it with `--timeout <seconds>`.
 - **Configuration Cache**: `chip-tool` caches state in `chip_tool_config.ini` (often in the current directory or `/tmp`). Deleting this file can resolve stale configuration issues. You can also specify a custom directory with `--storage-directory <path>`.
+
+## Reporting Results
+
+When completing a test task using this skill, you should output a structured report to the user containing the following evidence:
+
+### 1. Build Process
+- State which targets were built and for which platform.
+
+### 2. Device Configuration and Startup
+- State the command used to run the application and any specific arguments used (like `--device`).
+- Include the pairing credentials (Setup PIN and Discriminator) extracted from the logs.
+
+### 3. Commissioning Evidence
+- Provide the `chip-tool` command used for commissioning.
+- Include a snippet of the logs showing successful commissioning (e.g., `Commissioning complete for node ID...`).
+
+### 4. Data Model Verification
+- Include the commands used to read `PartsList` or other attributes to verify the data model hierarchy.
+- Provide the output snippets showing the expected endpoints and relationships.
+
+### 5. Interaction Evidence
+- List the commands used to read/write attributes or invoke commands on each endpoint.
+- State the result (e.g., `Status=0x0 (SUCCESS)`) to prove it worked.

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -67,6 +67,9 @@ discriminator. Example log:
 [DL]   Setup Discriminator: 3840 (0xF00)
 ```
 
+> [!NOTE]
+> The discriminator value `3840` (0xF00) is the standard default for many Matter examples when not explicitly configured.
+
 ### 2. Commissioning (Pairing)
 
 Make sure the device is in commissioning mode. If using a persistent storage
@@ -100,8 +103,11 @@ same host):
     ```
 -   **Direct IP and Port** (useful if mDNS resolution fails):
     ```bash
-    chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port> --bypass-attestation-verifier true
+    chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port>
     ```
+
+    > [!CAUTION]
+    > If you encounter attestation failures in simulated environments, you may need to add `--bypass-attestation-verifier true` to the command. Use this flag ONLY for local simulated testing when you explicitly accept the security tradeoff of bypassing device attestation.
 
 ### 3. Interacting with Clusters
 
@@ -121,6 +127,26 @@ model clusters.
     chip-tool <cluster_name> <command_name> [arguments] <node_id> <endpoint_id>
     ```
     Example: `chip-tool onoff toggle 0x8016 1`
+
+## Using Chip-Tool Help
+
+`chip-tool` has a built-in help system that allows you to discover available clusters and commands. Running any command without all required parameters will show a help screen.
+
+-   **List available clusters**:
+    ```bash
+    chip-tool
+    ```
+-   **List available commands/attributes for a cluster**:
+    ```bash
+    chip-tool basicinformation
+    ```
+-   **See help for a specific action**:
+    ```bash
+    chip-tool basicinformation read
+    ```
+    This will show what attributes can be read from the `basicinformation` cluster.
+
+This interactive help is useful for exploring the data model and finding the exact syntax needed.
 
 ## Troubleshooting
 

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -67,8 +67,8 @@ discriminator. Example log:
 [DL]   Setup Discriminator: 3840 (0xF00)
 ```
 
-> [!NOTE]
-> The discriminator value `3840` (0xF00) is the standard default for many Matter examples when not explicitly configured.
+> [!NOTE] The discriminator value `3840` (0xF00) is the standard default for
+> many Matter examples when not explicitly configured.
 
 ### 2. Commissioning (Pairing)
 
@@ -102,12 +102,15 @@ same host):
     chip-tool pairing code <node_id> <pairing_code_or_qrcode>
     ```
 -   **Direct IP and Port** (useful if mDNS resolution fails):
+
     ```bash
     chip-tool pairing already-discovered <node_id> <setup_pin> <device_ip> <device_port>
     ```
 
-    > [!CAUTION]
-    > If you encounter attestation failures in simulated environments, you may need to add `--bypass-attestation-verifier true` to the command. Use this flag ONLY for local simulated testing when you explicitly accept the security tradeoff of bypassing device attestation.
+    > [!CAUTION] If you encounter attestation failures in simulated
+    > environments, you may need to add `--bypass-attestation-verifier true` to
+    > the command. Use this flag ONLY for local simulated testing when you
+    > explicitly accept the security tradeoff of bypassing device attestation.
 
 ### 3. Interacting with Clusters
 
@@ -130,7 +133,9 @@ model clusters.
 
 ## Using Chip-Tool Help
 
-`chip-tool` has a built-in help system that allows you to discover available clusters and commands. Running any command without all required parameters will show a help screen.
+`chip-tool` has a built-in help system that allows you to discover available
+clusters and commands. Running any command without all required parameters will
+show a help screen.
 
 -   **List available clusters**:
     ```bash
@@ -144,9 +149,11 @@ model clusters.
     ```bash
     chip-tool basicinformation read
     ```
-    This will show what attributes can be read from the `basicinformation` cluster.
+    This will show what attributes can be read from the `basicinformation`
+    cluster.
 
-This interactive help is useful for exploring the data model and finding the exact syntax needed.
+This interactive help is useful for exploring the data model and finding the
+exact syntax needed.
 
 ## Troubleshooting
 

--- a/.agents/skills/chip-tool-testing/SKILL.md
+++ b/.agents/skills/chip-tool-testing/SKILL.md
@@ -7,10 +7,13 @@ description:
 
 # Testing Matter Examples with Chip-Tool
 
-This skill provides guidelines for building Matter example applications and `chip-tool`, and using `chip-tool` to commission and interact with the examples in a simulated environment (like Linux POSIX).
+This skill provides guidelines for building Matter example applications and
+`chip-tool`, and using `chip-tool` to commission and interact with the examples
+in a simulated environment (like Linux POSIX).
 
-> [!NOTE]
-> While `chip-tool` and examples support multiple platforms, these guidelines focus on the Linux/POSIX environment, which is the standard environment for agent execution.
+> [!NOTE] While `chip-tool` and examples support multiple platforms, these
+> guidelines focus on the Linux/POSIX environment, which is the standard
+> environment for agent execution.
 
 ## Building from Source
 
@@ -50,7 +53,9 @@ Run the example application (usually in a separate terminal or the background):
 ./out/linux-x64-all-devices-boringssl/all-devices-app
 ```
 
-_Note: Use a clean KVS file (by specifying a new, non-existent file path with `--KVS`) or clear the existing one (by deleting the file) to ensure the application enters commissioning mode on startup._
+_Note: Use a clean KVS file (by specifying a new, non-existent file path with
+`--KVS`) or clear the existing one (by deleting the file) to ensure the
+application enters commissioning mode on startup._
 
 ### 1. Determine Pairing Credentials
 
@@ -72,8 +77,9 @@ mode on startup. On Linux, the default KVS file is `/tmp/chip_kvs`:
 rm /tmp/chip_kvs
 ```
 
-> [!NOTE]
-> **Persistence Testing**: If you are performing a persistence test (verifying state across restarts), do NOT delete the KVS file. Reuse the same KVS file to preserve stored attributes.
+> [!NOTE] > **Persistence Testing**: If you are performing a persistence test
+> (verifying state across restarts), do NOT delete the KVS file. Reuse the same
+> KVS file to preserve stored attributes.
 
 #### Over IP (On-Network)
 


### PR DESCRIPTION
This PR adds a new skill for AI agents to guide them on testing Matter examples against `chip-tool`.

The skill covers:
- Building `chip-tool` and examples.
- Handling KVS state for commissioning.
- Commissioning fallbacks for mDNS issues (using explicit IP/Port).
- Interacting with clusters.
- Generic reporting guidelines (What, Command, Proof).

## Example Usage

Here is an example of a prompt and the resulting report generated by an agent using this skill:

### Prompt
> Use the `chip-tool-testing` skill to build the all-devices-app and chip-tool. Then run the all-devices-app with 3 endpoints (chime+speaker+light, the speaker is a child of chime, for example "--device chime:1 --device speaker:2,parent=1 --device dimmable-light"). Then, let's verify if we can commission it using chip-tool, read parts list and ensure the data model hierarchy is correct. Also check that you can read/write to attributes and commands on each endpoint. At the end, output a report.

### Report

# Test Report: All-Devices-App with Chime, Speaker, and Light

I have completed the task using the `chip-tool-testing` skill. Here are the results of the verification:

## 1. Build Process
*   **What was verified**: Both `all-devices-app` and `chip-tool` were built for Linux.
*   **Command ran**:
    ```bash
    ./scripts/build/build_examples.py --target linux-x64-all-devices-boringssl build
    ./scripts/build/build_examples.py --target linux-x64-chip-tool-clang build
    ```
*   **Proof**: The binaries were successfully created in the `out` directory and were available for execution.

## 2. Startup and Configuration
*   **What was verified**: The application was started with a dynamic device tree: Chime (EP1), Speaker (EP2 as a child of EP1), and Dimmable Light (EP3) on a custom port.
*   **Command ran**:
    ```bash
    ./out/linux-x64-all-devices-boringssl/all-devices-app --KVS /tmp/kvs_skill_practice.ini --device chime:1 --device speaker:2,parent=1 --device dimmable-light:3 --port 5555
    ```
*   **Proof (logs)**: The logs confirmed the registration of devices on the expected endpoints and with the correct parentage:
    ```text
    [SVR] Registering device chime on endpoint 1 with parent 0xFFFF
    [SVR] Registering device speaker on endpoint 2 with parent 0x0001
    [SVR] Registering device dimmable-light on endpoint 3 with parent 0xFFFF
    [DL]   Setup Pin Code: 20202021
    [DL]   Setup Discriminator: 3840 (0xF00)
    ```

## 3. Commissioning
*   **What was verified**: The device was successfully commissioned using `chip-tool`.
*   **Command ran**:
    ```bash
    ./out/linux-x64-chip-tool-clang/chip-tool pairing onnetwork-long 1 20202021 3840
    ```
*   **Proof (logs)**: The controller logs showed successful commissioning:
    ```text
    [CTL] Commissioning complete for node ID 0x0000000000000001: success
    [TOO] Device commissioning completed with success
    ```

## 4. Data Model Hierarchy
*   **What was verified**: Verified that Endpoint 2 (Speaker) is correctly listed as a child of Endpoint 1 (Chime).
*   **Command ran**:
    ```bash
    ./out/linux-x64-chip-tool-clang/chip-tool descriptor read parts-list 1 1
    ```
*   **Proof (logs)**: The `PartsList` of Endpoint 1 correctly listed only Endpoint 2:
    ```text
    [TOO] Endpoint: 1 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 311551462
    [TOO]   PartsList: 1 entries
    [TOO]     [1]: 2
    ```

## 5. Cluster Interaction
*   **What was verified**: Verified that we can read/write attributes and invoke commands on each endpoint.
*   **Commands ran**:
    *   **Chime (EP1)**: `chip-tool chime play-chime-sound 1 1`
    *   **Speaker (EP2)**: `chip-tool onoff toggle 1 2`
    *   **Light (EP3)**: `chip-tool onoff toggle 1 3`
*   **Proof (logs)**: All commands returned success status:
    ```text
    [TOO] Endpoint: 1 Cluster: 0x0000_0556 ... Status=0x0 (SUCCESS)
    [TOO] Endpoint: 2 Cluster: 0x0000_0006 ... Status=0x0 (SUCCESS)
    [TOO] Endpoint: 3 Cluster: 0x0000_0006 ... Status=0x0 (SUCCESS)
    ```

### Testing
I have verified the skill by simulating a prompt and generating a report based on a previous subagent run that successfully built, commissioned, and tested the all-devices-app with chime, speaker, and light.
