### PR TITLE
[Silabs] Fixing the build for the boards which doesn't support the button

### DIFF
--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -118,8 +118,6 @@ namespace Silabs {
 
 SilabsPlatform SilabsPlatform::sSilabsPlatformAbstractionManager;
 
-SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
-
 CHIP_ERROR SilabsPlatform::Init(void)
 {
     TEMPORARY_RETURN_IGNORED NvmInit();
@@ -281,6 +279,7 @@ CHIP_ERROR SilabsPlatform::GetLedColor(uint8_t led, uint16_t & r, uint16_t & g, 
 #endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
+SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 extern "C" void sl_button_on_change(const sl_button_t * handle)
 {
     if (Silabs::GetPlatform().mButtonCallback == nullptr)
@@ -306,11 +305,6 @@ uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 #ifdef SL_ICD_ENABLED
 void SilabsPlatform::SleepButtonActionHandler() {}
 #endif // SL_ICD_ENABLED
-#else
-uint8_t SilabsPlatform::GetButtonState(uint8_t button)
-{
-    return 0;
-}
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -303,6 +303,9 @@ uint8_t SilabsPlatform::GetButtonState(uint8_t button)
     const sl_button_t * handle = SL_SIMPLE_BUTTON_INSTANCE(button);
     return nullptr == handle ? 0 : sl_button_get_state(handle);
 }
+#ifdef SL_ICD_ENABLED
+void SilabsPlatform::SleepButtonActionHandler() {}
+#endif // SL_ICD_ENABLED
 #else
 uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 {

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -310,11 +310,6 @@ uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 }
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
-// Sleep Button Action Handler does nothing for now, but it is here to be overridden by the platform if needed.
-#ifdef SL_ICD_ENABLED
-void SilabsPlatform::SleepButtonActionHandler() {}
-#endif // SL_ICD_ENABLED
-
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
 sl_status_t SilabsPlatform::EnableSi70xxSensorGpio()
 {

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -303,15 +303,17 @@ uint8_t SilabsPlatform::GetButtonState(uint8_t button)
     const sl_button_t * handle = SL_SIMPLE_BUTTON_INSTANCE(button);
     return nullptr == handle ? 0 : sl_button_get_state(handle);
 }
-#ifdef SL_ICD_ENABLED
-void SilabsPlatform::SleepButtonActionHandler() {}
-#endif // SL_ICD_ENABLED
 #else
 uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 {
     return 0;
 }
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
+
+// Sleep Button Action Handler does nothing for now, but it is here to be overridden by the platform if needed.
+#ifdef SL_ICD_ENABLED
+void SilabsPlatform::SleepButtonActionHandler() {}
+#endif // SL_ICD_ENABLED
 
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
 sl_status_t SilabsPlatform::EnableSi70xxSensorGpio()

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -50,12 +50,14 @@ public:
 #endif
 
     // Buttons
+#if defined(SL_CATALOG_SIMPLE_BUTTON_PRESENT)
     inline void SetButtonsCb(SilabsButtonCb callback) override { mButtonCallback = callback; }
     static SilabsButtonCb mButtonCallback;
     uint8_t GetButtonState(uint8_t button) override;
-#if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1 && defined(SL_CATALOG_SIMPLE_BUTTON_PRESENT)
+#if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1
     void SleepButtonActionHandler(void) override;
-#endif // defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1 && defined(SL_ICD_SLEEP_BUTTON_ENABLE)
+#endif // defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1
+#endif // defined(SL_CATALOG_SIMPLE_BUTTON_PRESENT)
 
 #if defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
     void StartScheduler(void) override;

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
+#include "sl_component_catalog.h"
 #include <platform/silabs/platformAbstraction/SilabsPlatformBase.h>
 #include <stdint.h>
 #include <stdio.h>
-#include "sl_component_catalog.h"
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -20,6 +20,7 @@
 #include <platform/silabs/platformAbstraction/SilabsPlatformBase.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "sl_component_catalog.h"
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -52,9 +52,9 @@ public:
     inline void SetButtonsCb(SilabsButtonCb callback) override { mButtonCallback = callback; }
     static SilabsButtonCb mButtonCallback;
     uint8_t GetButtonState(uint8_t button) override;
-#ifdef SL_ICD_ENABLED
+#if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1 && defined(SL_CATALOG_SIMPLE_BUTTON_PRESENT)
     void SleepButtonActionHandler(void) override;
-#endif // SL_ICD_ENABLED
+#endif // defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1 && defined(SL_ICD_SLEEP_BUTTON_ENABLE)
 
 #if defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
     void StartScheduler(void) override;

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -141,12 +141,9 @@ int soc_pll_config(void)
 } // namespace
 
 SilabsPlatform SilabsPlatform::sSilabsPlatformAbstractionManager;
-SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 
 CHIP_ERROR SilabsPlatform::Init(void)
 {
-    mButtonCallback = nullptr;
-
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
     // Configuration the clock rate
     soc_pll_config();
@@ -232,6 +229,7 @@ CHIP_ERROR SilabsPlatform::GetLedColor(uint8_t led, uint16_t & r, uint16_t & g, 
 #endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
+SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 extern "C" void sl_button_on_change(uint8_t btn, uint8_t btnAction)
 {
 #if SL_ICD_ENABLED
@@ -335,11 +333,6 @@ void SilabsPlatform::SleepButtonActionHandler()
     sl_button_on_change(SL_BUTTON_BTN0_NUMBER, btnAction);
 }
 #endif // SL_ICD_ENABLED
-#else
-uint8_t SilabsPlatform::GetButtonState(uint8_t button)
-{
-    return 0;
-}
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
 void SilabsPlatform::SoftwareReset()


### PR DESCRIPTION
#### Summary
From the refactor PR:https://github.com/project-chip/connectedhomeip/pull/71458
The SleepButtonActionHandler was throwing undefined error when the board without any button was build since the API was overriden but there was no defination, hence throwing undefined error.

Adding it outside the button condition and since it is just an empty function no point of adding to the btn define.

#### Related issues
NA

#### Testing
Build with the BRD2704A