### PR TITLE
[ICD minmdns] Avoid a reference of a data pointer before size check.

### DIFF
--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <inttypes.h>
 #include <limits>
+#include <optional>
 #include <stdlib.h>
 #include <string.h>
 
@@ -110,12 +111,11 @@ bool MakeBoolFromAsciiDecimal(const ByteSpan & val)
 
 std::optional<bool> MakeOptionalBoolFromAsciiDecimal(const ByteSpan & val)
 {
+    VerifyOrReturnValue(val.size() == 1, std::nullopt); // need to be a valid boolean (single char)
+
     char character = static_cast<char>(*val.data());
-    if (val.size() == 1 && ((character == '1') || (character == '0')))
-    {
-        return std::make_optional(character == '1');
-    }
-    return std::nullopt;
+    VerifyOrReturnValue((character == '1') || (character == '0'), std::nullopt); // need to be a valid boolean (single char)
+    return std::make_optional(character == '1');
 }
 
 size_t GetPlusSignIdx(const ByteSpan & value)

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -802,6 +802,17 @@ void DiscoveredTxtFieldICDoperatesAsLIT()
     strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_FALSE(nodeData.Get<NodeData>().isICDOperatingAsLIT.has_value());
+
+    // Invalid value, empty
+    strcpy(key, "ICD");
+    strcpy(val, "");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
+    EXPECT_FALSE(nodeData.Get<NodeData>().isICDOperatingAsLIT.has_value());
+
+    // Invalid value: missing
+    strcpy(key, "ICD");
+    FillNodeDataFromTxt(GetSpan(key), {}, resolutionData);
+    EXPECT_FALSE(nodeData.Get<NodeData>().isICDOperatingAsLIT.has_value());
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRI


### PR DESCRIPTION
#### Summary

MakeOptionalBoolFromAsciiDecimal was grabbing the value before checking the buffer size. If buffer size is 0, the dereference is invalid.

#### Testing

Trivial change, but also added extra unit tests.