### PR TITLE
[NXP] Add Zephyr CI trigger based on Zephyr file changes

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -169,6 +169,8 @@ jobs:
                   filters: |
                       nxp:
                         - '**/nxp/**'
+                        - '**/Zephyr/**'
+                        - '**/zephyr/**'
                       pigweed:
                         - 'src/pw_backends/**'
                         - 'third_party/pigweed/**'


### PR DESCRIPTION
#### Summary

This PR adds a CI trigger for NXP Zephyr jobs so that the CI is automatically executed when Zephyr-related files are modified.

#### Testing

No particular test required.
