### PR TITLE
[debug pretty print] reduce stack usage on pretty print

### DIFF
--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -211,9 +211,7 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
         chip::Platform::ScopedMemoryBuffer<uint8_t> value_b;
         VerifyOrReturnError(!value_b.Alloc(CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE).IsNull(), CHIP_ERROR_NO_MEMORY);
 
-        uint32_t len, readerLen;
-
-        readerLen = aReader.GetLength();
+        uint32_t readerLen = aReader.GetLength();
 
         CHIP_ERROR err = aReader.GetBytes(value_b.Get(), CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         VerifyOrReturnError(err == CHIP_NO_ERROR || err == CHIP_ERROR_BUFFER_TOO_SMALL, err);
@@ -221,21 +219,13 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
         PRETTY_PRINT_SAMELINE("[");
         PRETTY_PRINT("\t\t");
 
-        if (readerLen < sizeof(value_b))
-        {
-            len = readerLen;
-        }
-        else
-        {
-            len = sizeof(value_b);
-        }
-
         if (err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
             PRETTY_PRINT_SAMELINE("... (byte string too long) ...");
         }
         else
         {
+            const uint32_t len = std::min(readerLen, static_cast<uint32_t>(CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE));
             for (size_t i = 0; i < len; i++)
             {
                 PRETTY_PRINT_SAMELINE("0x%02x, ", value_b[i]);

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -22,14 +22,18 @@
  */
 
 #include "MessageDefHelper.h"
+
 #include <algorithm>
 #include <app/AppConfig.h>
 #include <app/SpecificationDefinedRevisions.h>
 #include <app/util/basic-types.h>
-#include <inttypes.h>
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/ScopedMemoryBuffer.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <stdarg.h>
-#include <stdio.h>
+
+#include <cinttypes>
+#include <cstdarg>
+#include <cstdio>
 
 namespace chip {
 namespace app {
@@ -183,12 +187,13 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
     }
 
     case TLV::kTLVType_UTF8String: {
-        char value_s[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+        chip::Platform::ScopedMemoryBuffer<char> value_s;
+        VerifyOrReturnError(!value_s.Alloc(CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE).IsNull(), CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_DETAIL_LOGGING
         uint32_t readerLen = aReader.GetLength();
 #endif // CHIP_DETAIL_LOGGING
-        CHIP_ERROR err = aReader.GetString(value_s, sizeof(value_s));
+        CHIP_ERROR err = aReader.GetString(value_s.Get(), CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         VerifyOrReturnError(err == CHIP_NO_ERROR || err == CHIP_ERROR_BUFFER_TOO_SMALL, err);
 
         if (err == CHIP_ERROR_BUFFER_TOO_SMALL)
@@ -197,18 +202,20 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
         }
         else
         {
-            PRETTY_PRINT_SAMELINE("\"%s\" (%" PRIu32 " chars), ", value_s, readerLen);
+            PRETTY_PRINT_SAMELINE("\"%s\" (%" PRIu32 " chars), ", value_s.Get(), readerLen);
         }
         break;
     }
 
     case TLV::kTLVType_ByteString: {
-        uint8_t value_b[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+        chip::Platform::ScopedMemoryBuffer<uint8_t> value_b;
+        VerifyOrReturnError(!value_b.Alloc(CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE).IsNull(), CHIP_ERROR_NO_MEMORY);
+
         uint32_t len, readerLen;
 
         readerLen = aReader.GetLength();
 
-        CHIP_ERROR err = aReader.GetBytes(value_b, sizeof(value_b));
+        CHIP_ERROR err = aReader.GetBytes(value_b.Get(), CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         VerifyOrReturnError(err == CHIP_NO_ERROR || err == CHIP_ERROR_BUFFER_TOO_SMALL, err);
 
         PRETTY_PRINT_SAMELINE("[");

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -99,8 +99,18 @@ void DecreaseDepth()
 #endif
 
 #if CHIP_CONFIG_IM_PRETTY_PRINT
+
 CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLabel)
 {
+    // do not allow fully unbounded recursion.
+    constexpr int kMaxRecursionDepth = 100;
+
+    if (aDepth > kMaxRecursionDepth)
+    {
+        PRETTY_PRINT("!!! RECURSION LIMIT REACHED !!!");
+        return CHIP_ERROR_RECURSION_DEPTH_LIMIT;
+    }
+
     if (aDepth == 0)
     {
         PRETTY_PRINT("%s = ", aLabel);


### PR DESCRIPTION
#### Summary

Two chages for printing out overly large recursed TLV packets:
 - limit recursion to 100-level nested TLV structs (overly excessive overall: we do not have such deep nesting)
 - move printing out of strings and bytes to heap, so that individual stack frames are not that large

#### Testing

Ran a pairing for a bridge app with the new code, output was ok (saw both strings and bytes printed out).