### PR TITLE
[BDXTransfer] Initialize pointers to nullptr by default

### DIFF
--- a/src/protocols/bdx/BdxTransferServer.h
+++ b/src/protocols/bdx/BdxTransferServer.h
@@ -51,7 +51,7 @@ protected:
     void OnExchangeCreationFailed(Messaging::ExchangeDelegate * delegate) override;
 
 private:
-    System::Layer * mSystemLayer = nullptr;
+    System::Layer * mSystemLayer              = nullptr;
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
     BDXTransferServerDelegate * mDelegate = nullptr;

--- a/src/protocols/bdx/BdxTransferServer.h
+++ b/src/protocols/bdx/BdxTransferServer.h
@@ -33,7 +33,7 @@ class BdxTransferDiagnosticLog;
 class BDXTransferServer : public Messaging::UnsolicitedMessageHandler
 {
 public:
-    BDXTransferServer(){};
+    BDXTransferServer() = default;
 
     ~BDXTransferServer() { Shutdown(); };
 
@@ -51,10 +51,10 @@ protected:
     void OnExchangeCreationFailed(Messaging::ExchangeDelegate * delegate) override;
 
 private:
-    System::Layer * mSystemLayer;
-    Messaging::ExchangeManager * mExchangeMgr;
+    System::Layer * mSystemLayer = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
-    BDXTransferServerDelegate * mDelegate;
+    BDXTransferServerDelegate * mDelegate = nullptr;
     BdxTransferDiagnosticLogPool<CHIP_CONFIG_MAX_BDX_LOG_TRANSFERS> mPoolDelegate;
 };
 


### PR DESCRIPTION
#### Summary

Defensive programming seems to make sense here: we initialize these in init, but other methods use them (e.g. shutdown which is called in the destructor), so we should have them nullptr by default.

#### Testing

Trivial change.