### PR TITLE
[BufferedReadCallback] double-check for nullptr before trying to deference/use the data TLV

### DIFF
--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -136,23 +136,24 @@ CHIP_ERROR BufferedReadCallback::BufferListItem(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & aData)
+CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData)
 {
 
     if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
     {
+        VerifyOrReturnError(apData != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         TLV::TLVType outerContainer;
 
-        VerifyOrReturnError(aData.GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
+        VerifyOrReturnError(apData->GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
         mBufferedList.clear();
 
-        ReturnErrorOnFailure(aData.EnterContainer(outerContainer));
+        ReturnErrorOnFailure(apData->EnterContainer(outerContainer));
 
         CHIP_ERROR err;
 
-        while ((err = aData.Next()) == CHIP_NO_ERROR)
+        while ((err = apData->Next()) == CHIP_NO_ERROR)
         {
-            ReturnErrorOnFailure(BufferListItem(aData));
+            ReturnErrorOnFailure(BufferListItem(*apData));
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -161,11 +162,12 @@ CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aP
         }
 
         ReturnErrorOnFailure(err);
-        ReturnErrorOnFailure(aData.ExitContainer(outerContainer));
+        ReturnErrorOnFailure(apData->ExitContainer(outerContainer));
     }
     else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
     {
-        ReturnErrorOnFailure(BufferListItem(aData));
+        VerifyOrReturnError(apData != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(BufferListItem(*apData));
     }
 
     return CHIP_NO_ERROR;
@@ -244,8 +246,7 @@ void BufferedReadCallback::OnAttributeData(const ConcreteDataAttributePath & aPa
     //
     if (aPath.IsListOperation() && aStatus.mStatus == Protocols::InteractionModel::Status::Success)
     {
-        VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-        err = BufferData(aPath, *apData);
+        err = BufferData(aPath, apData);
         SuccessOrExit(err);
     }
     else

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -136,23 +136,23 @@ CHIP_ERROR BufferedReadCallback::BufferListItem(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & apData)
+CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & aData)
 {
 
     if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
     {
         TLV::TLVType outerContainer;
 
-        VerifyOrReturnError(apData.GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
+        VerifyOrReturnError(aData.GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
         mBufferedList.clear();
 
-        ReturnErrorOnFailure(apData.EnterContainer(outerContainer));
+        ReturnErrorOnFailure(aData.EnterContainer(outerContainer));
 
         CHIP_ERROR err;
 
-        while ((err = apData.Next()) == CHIP_NO_ERROR)
+        while ((err = aData.Next()) == CHIP_NO_ERROR)
         {
-            ReturnErrorOnFailure(BufferListItem(apData));
+            ReturnErrorOnFailure(BufferListItem(aData));
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -161,11 +161,11 @@ CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aP
         }
 
         ReturnErrorOnFailure(err);
-        ReturnErrorOnFailure(apData.ExitContainer(outerContainer));
+        ReturnErrorOnFailure(aData.ExitContainer(outerContainer));
     }
     else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
     {
-        ReturnErrorOnFailure(BufferListItem(apData));
+        ReturnErrorOnFailure(BufferListItem(aData));
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -16,15 +16,15 @@
  *    limitations under the License.
  */
 
-#include "lib/core/TLV.h"
-#include "lib/core/TLVTags.h"
-#include "lib/core/TLVTypes.h"
-#include "protocols/interaction_model/Constants.h"
-#include "system/SystemPacketBuffer.h"
-#include "system/TLVPacketBufferBackingStore.h"
 #include <app/BufferedReadCallback.h>
 #include <app/InteractionModelEngine.h>
+#include <lib/core/TLV.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
 #include <lib/support/ScopedMemoryBuffer.h>
+#include <protocols/interaction_model/Constants.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 namespace chip {
 namespace app {
@@ -136,23 +136,23 @@ CHIP_ERROR BufferedReadCallback::BufferListItem(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData)
+CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & apData)
 {
 
     if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
     {
         TLV::TLVType outerContainer;
 
-        VerifyOrReturnError(apData->GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
+        VerifyOrReturnError(apData.GetType() == TLV::kTLVType_Array, CHIP_ERROR_INVALID_TLV_ELEMENT);
         mBufferedList.clear();
 
-        ReturnErrorOnFailure(apData->EnterContainer(outerContainer));
+        ReturnErrorOnFailure(apData.EnterContainer(outerContainer));
 
         CHIP_ERROR err;
 
-        while ((err = apData->Next()) == CHIP_NO_ERROR)
+        while ((err = apData.Next()) == CHIP_NO_ERROR)
         {
-            ReturnErrorOnFailure(BufferListItem(*apData));
+            ReturnErrorOnFailure(BufferListItem(apData));
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -161,11 +161,11 @@ CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aP
         }
 
         ReturnErrorOnFailure(err);
-        ReturnErrorOnFailure(apData->ExitContainer(outerContainer));
+        ReturnErrorOnFailure(apData.ExitContainer(outerContainer));
     }
     else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
     {
-        ReturnErrorOnFailure(BufferListItem(*apData));
+        ReturnErrorOnFailure(BufferListItem(apData));
     }
 
     return CHIP_NO_ERROR;
@@ -244,7 +244,8 @@ void BufferedReadCallback::OnAttributeData(const ConcreteDataAttributePath & aPa
     //
     if (aPath.IsListOperation() && aStatus.mStatus == Protocols::InteractionModel::Status::Success)
     {
-        err = BufferData(aPath, apData);
+        VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+        err = BufferData(aPath, *apData);
         SuccessOrExit(err);
     }
     else

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -65,7 +65,7 @@ private:
     /*
      * Buffer up list data as they arrive.
      */
-    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apReader);
+    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & apReader);
 
     //
     // ReadClient::Callback

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -65,7 +65,7 @@ private:
     /*
      * Buffer up list data as they arrive.
      */
-    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & apReader);
+    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & aData);
 
     //
     // ReadClient::Callback

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -65,7 +65,7 @@ private:
     /*
      * Buffer up list data as they arrive.
      */
-    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader *apData);
+    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData);
 
     //
     // ReadClient::Callback

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -65,7 +65,7 @@ private:
     /*
      * Buffer up list data as they arrive.
      */
-    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader & aData);
+    CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader *apData);
 
     //
     // ReadClient::Callback

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -17,16 +17,18 @@
  */
 #include <vector>
 
-#include "app-common/zap-generated/ids/Attributes.h"
-#include "lib/core/TLVTags.h"
-#include "protocols/interaction_model/Constants.h"
-#include "system/SystemPacketBuffer.h"
-#include "system/TLVPacketBufferBackingStore.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/ids/Attributes.h>
 #include <app/BufferedReadCallback.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/MessageDef/StatusIB.h>
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
+#include <lib/core/TLVTags.h>
+#include <protocols/interaction_model/Constants.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
@@ -66,6 +68,17 @@ struct ValidationInstruction
 using InstructionListType = std::vector<ValidationInstruction>;
 
 using TestBufferedReadCallback = chip::Testing::AppContext;
+
+class NooCallback : public BufferedReadCallback::Callback
+{
+public:
+    NooCallback() = default;
+
+    void OnReportBegin() override {}
+    void OnReportEnd() override {}
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override {}
+    void OnDone(ReadClient *) override {}
+};
 
 class DataSeriesValidator : public BufferedReadCallback::Callback
 {
@@ -524,6 +537,35 @@ void RunAndValidateSequence(std::vector<ValidationInstruction> instructionList)
     generator.Generate();
 
     EXPECT_EQ(validator.mCurrentInstruction, instructionList.size());
+}
+
+TEST_F(TestBufferedReadCallback, TestInvalidInput)
+{
+    NooCallback noop;
+    BufferedReadCallback reader(noop);
+    ReadClient::Callback & callback = reader; // access as a public interface
+
+    // Send a list operation, but with null data
+    //   - successfull list operations will deference the input data, so it needs validation
+    EXPECT_EQ(
+        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::AppendItem, 0 },
+                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
+        CHIP_ERROR_INVALID_ARGUMENT);
+
+    EXPECT_EQ(
+        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceAll, 0 },
+                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
+        CHIP_ERROR_INVALID_ARGUMENT);
+
+    EXPECT_EQ(
+        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::DeleteItem, 123 },
+                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
+        CHIP_ERROR_INVALID_ARGUMENT);
+
+    EXPECT_EQ(
+        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceItem, 1 },
+                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
+        CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 TEST_F(TestBufferedReadCallback, TestBufferedSequences)

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -69,10 +69,10 @@ using InstructionListType = std::vector<ValidationInstruction>;
 
 using TestBufferedReadCallback = chip::Testing::AppContext;
 
-class NooCallback : public BufferedReadCallback::Callback
+class NoopCallback : public BufferedReadCallback::Callback
 {
 public:
-    NooCallback() = default;
+    NoopCallback() = default;
 
     void OnReportBegin() override {}
     void OnReportEnd() override {}
@@ -541,7 +541,7 @@ void RunAndValidateSequence(std::vector<ValidationInstruction> instructionList)
 
 TEST_F(TestBufferedReadCallback, TestInvalidInput)
 {
-    NooCallback noop;
+    NoopCallback noop;
     BufferedReadCallback reader(noop);
     ReadClient::Callback & callback = reader; // access as a public interface
                                               //

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -544,28 +544,19 @@ TEST_F(TestBufferedReadCallback, TestInvalidInput)
     NooCallback noop;
     BufferedReadCallback reader(noop);
     ReadClient::Callback & callback = reader; // access as a public interface
+                                              //
+    // Send a list operation, but with null data, ensure no deferencing
+    callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::AppendItem, 0 }, nullptr,
+                             StatusIB{ Protocols::InteractionModel::Status::Success });
 
-    // Send a list operation, but with null data
-    //   - successfull list operations will deference the input data, so it needs validation
-    EXPECT_EQ(
-        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::AppendItem, 0 },
-                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
-        CHIP_ERROR_INVALID_ARGUMENT);
+    callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceAll, 0 }, nullptr,
+                             StatusIB{ Protocols::InteractionModel::Status::Success });
 
-    EXPECT_EQ(
-        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceAll, 0 },
-                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
-        CHIP_ERROR_INVALID_ARGUMENT);
+    callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::DeleteItem, 123 },
+                             nullptr, StatusIB{ Protocols::InteractionModel::Status::Success });
 
-    EXPECT_EQ(
-        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::DeleteItem, 123 },
-                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
-        CHIP_ERROR_INVALID_ARGUMENT);
-
-    EXPECT_EQ(
-        callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceItem, 1 },
-                                 nullptr, StatusIB{ Protocols::InteractionModel::Status::Success }),
-        CHIP_ERROR_INVALID_ARGUMENT);
+    callback.OnAttributeData(ConcreteDataAttributePath{ 1, 2, 3, ConcreteDataAttributePath::ListOperation::ReplaceItem, 1 },
+                             nullptr, StatusIB{ Protocols::InteractionModel::Status::Success });
 }
 
 TEST_F(TestBufferedReadCallback, TestBufferedSequences)


### PR DESCRIPTION
#### Summary

Changes:
 - Add extra null check for paths that can dereference the data pointer

#### Testing

Added a basic unit test of "when called with null list operation, it errors out". Slightly change-detector however figuring out an integration test/sequence to reproduce this is probably non-trivial.