### PR TITLE
[FLAKY TEST QUARANTINE] quarantine mcorefs 1.4 and pavst 2.13 due to excessive flakyness

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,7 +171,7 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
-    - name: TC_PAVST_2_13.py 
+    - name: TC_PAVST_2_13.py
       reason:
           Used to be flaky, now it seems to deadlock and tests are cancelled.
           https://github.com/project-chip/connectedhomeip/issues/71808

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,8 +171,9 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
-    - name: TC_PAVST_2_13.py
-          Used to be flaky, now it seems to deadlock and tests are cancelled.
+    - name:
+          TC_PAVST_2_13.py Used to be flaky, now it seems to deadlock and tests
+          are cancelled.
           https://github.com/project-chip/connectedhomeip/issues/71808
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -166,6 +166,11 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GC_common.py
       reason: Shared code for TC_GC, not a standalone test.
+    # Items below MUST be fixed eventually.
+    - name: TC_MCORE_FS_1_4.py
+      reason:
+          Very flaky in CI.
+          https://github.com/project-chip/connectedhomeip/issues/71932
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,9 +171,9 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
-    - name:
-          TC_PAVST_2_13.py Used to be flaky, now it seems to deadlock and tests
-          are cancelled.
+    - name: TC_PAVST_2_13.py 
+      reason:
+          Used to be flaky, now it seems to deadlock and tests are cancelled.
           https://github.com/project-chip/connectedhomeip/issues/71808
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,6 +171,9 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
+    - name: TC_PAVST_2_13.py
+          Used to be flaky, now it seems to deadlock and tests are cancelled.
+          https://github.com/project-chip/connectedhomeip/issues/71808
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

I opened #71932 for this for now, however I see no maintainer picking this up, so quarantining the test until someone has bandwidth to fix it.

Also quarantined TC_PAVST_2.13 since the fix in #71470 did not seem to fix the flake: it moved it to a "timeout/cancel" flake instead and it seems to still happen quite frequently.

In parallel looking to get feedback from SC on sideffects/risks and how to mitigate when these things happen - a test that stops running will bitrot.

#### Testing

Clear disabling of test.