### PR TITLE
Add missing failsafe check to HandleReorderNetwork

### DIFF
--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -703,6 +703,7 @@ NetworkCommissioningCluster::HandleReorderNetwork(CommandHandler & handler, cons
                                                   const Commands::ReorderNetwork::DecodableType & req)
 {
     MATTER_TRACE_SCOPE("HandleReorderNetwork", "NetworkCommissioning");
+    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(mClusterContext.failSafeContext, handler.GetAccessingFabricIndex());
     Commands::NetworkConfigResponse::Type response;
     DebugTextStorage debugTextBuffer;
     MutableCharSpan debugText(debugTextBuffer);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -127,4 +127,31 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+
+TEST_F(TestNetworkCommissioningCluster, TestReorderNetworkRequiresFailsafe)
+{
+    Testing::FakeWiFiDriver fakeWifiDriver;
+
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
+
+    ClusterTester tester(cluster);
+    ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
+
+    // The fail-safe is not armed (default state). ReorderNetwork should be rejected.
+    Commands::ReorderNetwork::Type request;
+    uint8_t networkId[] = { 0x01, 0x02, 0x03 };
+    request.networkID   = ByteSpan(networkId);
+    request.networkIndex = 0;
+
+    auto result = tester.Invoke(request);
+
+    // The command should fail with FailsafeRequired status
+    ASSERT_TRUE(result.status.has_value());
+    EXPECT_EQ(result.GetStatusCode(),
+              std::optional(Protocols::InteractionModel::ClusterStatusCode::Of(
+                  Protocols::InteractionModel::Status::FailsafeRequired)));
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 } // namespace

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -127,7 +127,6 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-
 TEST_F(TestNetworkCommissioningCluster, TestReorderNetworkRequiresFailsafe)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
@@ -139,17 +138,17 @@ TEST_F(TestNetworkCommissioningCluster, TestReorderNetworkRequiresFailsafe)
 
     // The fail-safe is not armed (default state). ReorderNetwork should be rejected.
     Commands::ReorderNetwork::Type request;
-    uint8_t networkId[] = { 0x01, 0x02, 0x03 };
-    request.networkID   = ByteSpan(networkId);
+    uint8_t networkId[]  = { 0x01, 0x02, 0x03 };
+    request.networkID    = ByteSpan(networkId);
     request.networkIndex = 0;
 
     auto result = tester.Invoke(request);
 
     // The command should fail with FailsafeRequired status
     ASSERT_TRUE(result.status.has_value());
-    EXPECT_EQ(result.GetStatusCode(),
-              std::optional(Protocols::InteractionModel::ClusterStatusCode::Of(
-                  Protocols::InteractionModel::Status::FailsafeRequired)));
+    EXPECT_EQ(
+        result.GetStatusCode(),
+        std::optional(Protocols::InteractionModel::ClusterStatusCode::Of(Protocols::InteractionModel::Status::FailsafeRequired)));
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -127,30 +127,4 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-TEST_F(TestNetworkCommissioningCluster, TestReorderNetworkRequiresFailsafe)
-{
-    Testing::FakeWiFiDriver fakeWifiDriver;
-
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
-
-    ClusterTester tester(cluster);
-    ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
-
-    // The fail-safe is not armed (default state). ReorderNetwork should be rejected.
-    Commands::ReorderNetwork::Type request;
-    uint8_t networkId[]  = { 0x01, 0x02, 0x03 };
-    request.networkID    = ByteSpan(networkId);
-    request.networkIndex = 0;
-
-    auto result = tester.Invoke(request);
-
-    // The command should fail with FailsafeRequired status
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_EQ(
-        result.GetStatusCode(),
-        std::optional(Protocols::InteractionModel::ClusterStatusCode::Of(Protocols::InteractionModel::Status::FailsafeRequired)));
-
-    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
-}
-
 } // namespace


### PR DESCRIPTION
## Summary
- Add `RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED` check to `HandleReorderNetwork`
- All other network config commands (AddOrUpdateWiFi, RemoveNetwork, ConnectNetwork) already have this check
- Without it, any authenticated node could reorder network priority outside commissioning, causing service disruption

### Testing

Trivial change

🤖 Generated with [Claude Code](https://claude.com/claude-code)