### PR TITLE
Add regression tests for legacy chunked ACL write path-cache behavior

### DIFF
--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -709,8 +709,7 @@ namespace {
 // callables that wrap them rather than living on the fixture class itself.
 template <typename SessionFn, typename DrainFn>
 void RunCacheRevokedTwoIBWrite(SessionFn && sessionFn, DrainFn && drainFn, const AttributePathParams & firstPath,
-                               const AttributePathParams & secondPath,
-                               Protocols::InteractionModel::Status expectedSecondStatus)
+                               const AttributePathParams & secondPath, Protocols::InteractionModel::Status expectedSecondStatus)
 {
     using namespace Protocols::InteractionModel;
 
@@ -759,7 +758,7 @@ void RunCacheRevokedTwoIBWrite(SessionFn && sessionFn, DrainFn && drainFn, const
 TEST_F(TestAclAttribute, WriteCacheReusesGrantWhenSamePathRevokedMidMessage)
 {
     AttributePathParams path(kTestEndpointId, kTestClusterId, kTestAttributeId);
-    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, path, path,
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [] { DrainAndServiceIO(); }, path, path,
                               Protocols::InteractionModel::Status::Success);
 }
 
@@ -771,7 +770,7 @@ TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentEndpoint)
 {
     AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
     AttributePathParams secondPath(kTestDeniedEndpointId, kTestClusterId, kTestAttributeId);
-    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [] { DrainAndServiceIO(); }, firstPath,
                               secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
 }
 
@@ -782,7 +781,7 @@ TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentCluster)
 {
     AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
     AttributePathParams secondPath(kTestEndpointId, kTestDeniedClusterId2, kTestAttributeId);
-    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [] { DrainAndServiceIO(); }, firstPath,
                               secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
 }
 
@@ -794,7 +793,7 @@ TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentAttribute)
 {
     AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
     AttributePathParams secondPath(kTestEndpointId, kTestClusterId, static_cast<AttributeId>(1));
-    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [] { DrainAndServiceIO(); }, firstPath,
                               secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
 }
 

--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -16,6 +16,8 @@
  *    limitations under the License.
  */
 
+#include <vector>
+
 #include <lib/core/StringBuilderAdapters.h>
 #include <pw_unit_test/framework.h>
 
@@ -664,6 +666,136 @@ TEST_F(TestAclAttribute, LegacyEncodingCacheReuseDuringWrite)
     EXPECT_TRUE(aclDelegate.mWriterRevoked);
 
     Access::GetAccessControl().Finish();
+}
+
+namespace {
+
+// WriteClient callback that records the Status of every AttributeStatusIB in order, so a
+// multi-AttributeDataIB write can be asserted IB-by-IB rather than only on the last response.
+class RecordingWriteClientCallback : public WriteClient::Callback
+{
+public:
+    void OnResponse(const WriteClient *, const ConcreteDataAttributePath &, StatusIB status) override
+    {
+        mStatuses.push_back(status.mStatus);
+    }
+    void OnError(const WriteClient *, CHIP_ERROR chipError) override { mError = chipError; }
+    void OnDone(WriteClient *) override { mOnDoneCalled++; }
+
+    std::vector<Protocols::InteractionModel::Status> mStatuses;
+    int mOnDoneCalled = 0;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
+};
+
+} // namespace
+
+namespace {
+
+// Drives one "cache-revoked two-IB write" scenario, used by the four tests below.
+// Caller provides the two AttributeDataIB paths and the expected status for IB #2; this helper
+// installs WriterRevokedAfterFirstAttributeDataIBDelegate (grants the two Check() calls for IB #1
+// then revokes), encodes both IBs into one WriteRequestMessage, drains, and asserts:
+//
+//   * IB #1 must succeed (ACL still granting; the write populates mLastSuccessfullyWrittenPath)
+//   * IB #2 status == expectedSecondStatus
+//   * delegate Check() count == 2 (when IB #2 hits the cache) or 3 (when it misses — IB #1's
+//     two calls plus IB #2's kView pre-check that the revoked delegate denies)
+//
+// So if IB #2 hits the path cache, its two CheckWriteAccess calls bypass the delegate and IB #2
+// succeeds. If it misses, the live ACL re-check denies and IB #2 returns UnsupportedAccess. This
+// shape is calibrated via mutation testing — see the per-test header comments.
+//
+// The helper requires fixture access (GetSessionBobToAlice / DrainAndServiceIO), so it takes the
+// callables that wrap them rather than living on the fixture class itself.
+template <typename SessionFn, typename DrainFn>
+void RunCacheRevokedTwoIBWrite(SessionFn && sessionFn, DrainFn && drainFn, const AttributePathParams & firstPath,
+                               const AttributePathParams & secondPath,
+                               Protocols::InteractionModel::Status expectedSecondStatus)
+{
+    using namespace Protocols::InteractionModel;
+
+    WriterRevokedAfterFirstAttributeDataIBDelegate aclDelegate;
+    Access::GetAccessControl().Finish();
+    EXPECT_SUCCESS(Access::GetAccessControl().Init(&aclDelegate, gDeviceTypeResolver));
+
+    auto * engine = InteractionModelEngine::GetInstance();
+
+    RecordingWriteClientCallback callback;
+    WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+
+    EXPECT_SUCCESS(writeClient.EncodeAttribute(firstPath, static_cast<uint8_t>(1)));
+    EXPECT_SUCCESS(writeClient.EncodeAttribute(secondPath, static_cast<uint8_t>(2)));
+
+    EXPECT_SUCCESS(writeClient.SendWriteRequest(sessionFn()));
+    drainFn();
+
+    EXPECT_EQ(callback.mOnDoneCalled, 1);
+    ASSERT_EQ(callback.mStatuses.size(), 2u);
+
+    // IB #1 must succeed: ACL is still granting; the write populates the cache.
+    EXPECT_EQ(callback.mStatuses[0], Status::Success);
+
+    // IB #2 outcome is the cache-behavior assertion.
+    EXPECT_EQ(callback.mStatuses[1], expectedSecondStatus);
+
+    // Hit-cache => 2 Check() calls total (only IB #1's). Miss-cache => 3: IB #1 made 2 (kView
+    // pre-check + actual privilege), and IB #2's kView pre-check makes the 3rd, which the
+    // revoked delegate denies — short-circuiting the rest of ProcessAttributeDataIB so the
+    // would-be 4th call (IB #2's actual-privilege re-check) never runs.
+    EXPECT_EQ(aclDelegate.mCheckCount, (expectedSecondStatus == Status::Success) ? 2 : 3);
+    EXPECT_TRUE(aclDelegate.mWriterRevoked);
+
+    Access::GetAccessControl().Finish();
+}
+
+} // namespace
+
+// Same-path positive guard: with ACL revoked between IB #1 and IB #2 but both IBs targeting the
+// SAME (endpoint, cluster, attribute), the WriteHandler path cache must short-circuit IB #2's
+// re-check and IB #2 must succeed. Mutation-calibrated: removing the cache (forcing checkAcl =
+// true) makes IB #2's live re-check return CHIP_ERROR_ACCESS_DENIED and this test fails. Generic-
+// attribute counterpart of LegacyEncodingCacheReuseDuringWrite (which exercises the same property
+// via the ACL list legacy-encoding ReplaceAll+AppendItem path).
+TEST_F(TestAclAttribute, WriteCacheReusesGrantWhenSamePathRevokedMidMessage)
+{
+    AttributePathParams path(kTestEndpointId, kTestClusterId, kTestAttributeId);
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, path, path,
+                              Protocols::InteractionModel::Status::Success);
+}
+
+// Endpoint-only differs: IB #1 (E1, C, A) caches; IB #2 (E2, C, A) must NOT reuse the cached
+// grant because endpoints differ. Mutation-calibrated: dropping the endpoint field from the
+// cache-key comparison in CheckWriteAccess would wrongly let IB #2 hit the cache and succeed,
+// failing this test.
+TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentEndpoint)
+{
+    AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
+    AttributePathParams secondPath(kTestDeniedEndpointId, kTestClusterId, kTestAttributeId);
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+                              secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
+}
+
+// Cluster-only differs: IB #1 (E, C1, A) caches; IB #2 (E, C2, A) must NOT reuse the cached
+// grant because clusters differ. Mutation-calibrated: dropping the cluster field from the
+// cache-key comparison would wrongly let IB #2 hit the cache and succeed, failing this test.
+TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentCluster)
+{
+    AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
+    AttributePathParams secondPath(kTestEndpointId, kTestDeniedClusterId2, kTestAttributeId);
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+                              secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
+}
+
+// Attribute-only differs: IB #1 (E, C, A1) caches; IB #2 (E, C, A2) must NOT reuse the cached
+// grant because attributes differ. Mutation-calibrated: dropping the attribute field from the
+// cache-key comparison would wrongly let IB #2 hit the cache and succeed, failing this test.
+// (Attribute id 1 is registered on (kTestEndpointId, kTestClusterId) by TestMockNodeConfig.)
+TEST_F(TestAclAttribute, WriteCacheDoesNotLeakAcrossDifferentAttribute)
+{
+    AttributePathParams firstPath(kTestEndpointId, kTestClusterId, kTestAttributeId);
+    AttributePathParams secondPath(kTestEndpointId, kTestClusterId, static_cast<AttributeId>(1));
+    RunCacheRevokedTwoIBWrite([this]() -> auto { return GetSessionBobToAlice(); }, [this] { DrainAndServiceIO(); }, firstPath,
+                              secondPath, Protocols::InteractionModel::Status::UnsupportedAccess);
 }
 
 } // namespace app


### PR DESCRIPTION
## Summary

Adds regression test coverage for the `WriteHandler` ACL-decision path cache (`mLastSuccessfullyWrittenPath`) and documents the legacy chunked ACL write behavior it supports. **No production behavior changes** — `WriteHandler.cpp`/`.h` are unchanged from `master`.

### Background

`WriteHandler` keeps a single-slot "last successfully written path" cache so that, within one `WriteRequestMessage`, a repeated write to the **same** `ConcreteAttributePath` can skip a redundant ACL re-check. This exists specifically to support the legacy-encoded ACL list write, which `WriteClient` emits as two `AttributeDataIB`s on the `AccessControl::Acl` attribute path:

1. `ReplaceAll([])` — empties the ACL, removing the writer's own admin entry.
2. `AppendItem(item)` — same path; without the cache its ACL re-check would now be **denied**, because IB #1 already cleared the granting entry.

The cache lets IB #2 reuse IB #1's decision so a legitimate admin can rewrite its own fabric's ACL in the legacy encoding without self-denying mid-transaction. This is an intentional, spec-aware divergence for the chunked ACL case (Matter Core spec §6.6.4 describes ACL updates taking immediate effect; the chunked legacy write is the explicit exception, since transactional ACL replacement is not otherwise expressible in the IB-by-IB model).

### On the originally-reported "privilege bypass"

The earlier framing of this PR (removing the cache to fix a "privilege escalation") was incorrect. The cache is **not** an exploitable bypass:

- It is keyed on the full `ConcreteAttributePath` (endpoint, cluster, attribute), so it never leaks a decision across different paths.
- It is only populated **after** a fully access-checked successful write.
- It is reset at the start of every `WriteRequestMessage`, so no state crosses exchanges.

Removing it would break legitimate legacy chunked ACL writes (new devices working with old controllers), which is why the original code was added on purpose. The production change has been reverted; the prior test edits (which had been adjusted to assert the regressed behavior) and the Python TC_ACL scaffolding have been reverted to `master`.

### Testing

Each test below is calibrated via mutation testing — for each, the indicated mutation to `WriteHandler::CheckWriteAccess` is verified to make the test fail, ensuring it actually covers the property it claims.

- **`LegacyEncodingCacheReuseDuringWrite`** (restored to `master`, asserts `Success`) — guards the same-path reuse the legacy ACL write depends on. Mutation: forcing `checkAcl = true` (i.e. removing the cache) makes this test fail.
- **`WriteCacheReusesGrantWhenSamePathRevokedMidMessage`** (new) — generic-attribute counterpart of the legacy test: two IBs to the **same** path with the ACL delegate revoking access between IBs. IB #2 must succeed because the path cache short-circuits its re-check. Same mutation as above makes this test fail.
- **`WriteCacheDoesNotLeakAcrossDifferentEndpoint`** / **`WriteCacheDoesNotLeakAcrossDifferentCluster`** / **`WriteCacheDoesNotLeakAcrossDifferentAttribute`** (new) — IB #1 grants on path P, access is revoked, IB #2 differs only in the named field. IB #2 must be denied (`UnsupportedAccess`) because the cache must miss. Each test fails if the corresponding field is dropped from the cache-key comparison in `CheckWriteAccess`, proving all three fields are load-bearing.

The previous revision of this PR added a single `WriteCacheDoesNotLeakAcrossDifferentPath` test; mutation testing by @Alami-Amine showed it did not actually exercise the path-cache short-circuit (the two IBs targeted different paths from the start, so the cache lookup missed regardless of whether the cache existed). It has been replaced with the four tests above.

Net diff: four new C++ unit tests; no production or Python-test changes versus `master`.

*(Edited by Claude on behalf of woody-apple)*
