### PR TITLE
[Tests] Fix status thread cancellation flow

### DIFF
--- a/scripts/tests/chiptest/log_config.py
+++ b/scripts/tests/chiptest/log_config.py
@@ -89,7 +89,6 @@ class LogMessageCounter:
         """Context manager to register a user of this counter."""
         with self._users_cond:
             self._users_counter.value += 1
-            self._users_cond.notify_all()
 
         try:
             yield self

--- a/scripts/tests/chiptest/log_config.py
+++ b/scripts/tests/chiptest/log_config.py
@@ -17,13 +17,14 @@
 import contextlib
 import dataclasses
 import logging
-import threading
 from collections.abc import Iterator
-from multiprocessing.managers import SyncManager, ValueProxy
+from multiprocessing.managers import SyncManager
 from types import TracebackType
 from typing import Self
 
 import coloredlogs
+
+log = logging.getLogger(__name__)
 
 LOG_LEVELS = tuple(coloredlogs.find_defined_levels().keys())
 """Possible log levels for coloredlogs."""
@@ -39,19 +40,18 @@ _FIELD_STYLES = coloredlogs.DEFAULT_FIELD_STYLES | {
 
 
 class LogMessageCounter:
-    """Cross-thread or cross-process cancellable counter for printed log messages."""
+    """Cross-process cancellable counter for printed log messages."""
 
-    _counter: int | ValueProxy
+    USER_CANCEL_TIMEOUT_SEC = 1.0
 
-    def __init__(self, mp_manager: SyncManager | None = None) -> None:
-        if mp_manager is None:
-            self._cond = threading.Condition()
-            self._counter = 0
-            self._cancelled = threading.Event()
-        else:
-            self._cond = mp_manager.Condition()
-            self._counter = mp_manager.Value('i', 0)
-            self._cancelled = mp_manager.Event()
+    def __init__(self, mp_manager: SyncManager) -> None:
+        self._cond = mp_manager.Condition()
+        self._counter = mp_manager.Value('i', 0)
+        self._cancelled = mp_manager.Event()
+
+        # Usage counter of this counter.
+        self._users_cond = mp_manager.Condition()
+        self._users_counter = mp_manager.Value('i', 0)
 
     def increment(self) -> None:
         """Atomically increment the shared message count."""
@@ -59,10 +59,7 @@ class LogMessageCounter:
             if self.cancelled:
                 return
 
-            if isinstance(self._counter, int):
-                self._counter += 1
-            else:
-                self._counter.value += 1
+            self._counter.value += 1
             self._cond.notify_all()
 
     def cancel(self) -> None:
@@ -80,18 +77,35 @@ class LogMessageCounter:
     def total(self) -> int:
         """Return total number of printed messages."""
         with self._cond:
-            return self._counter if isinstance(self._counter, int) else self._counter.value
+            return self._counter.value
 
     def wait_for_count_or_cancel(self, count: int, timeout: float | None = None) -> bool:
         """Wait until the total message count reaches at least the specified count or until cancelled."""
         with self._cond:
             return self._cond.wait_for(lambda: self.total >= count or self.cancelled, timeout=timeout)
 
+    @contextlib.contextmanager
+    def register_user(self) -> Iterator[Self]:
+        """Context manager to register a user of this counter."""
+        with self._users_cond:
+            self._users_counter.value += 1
+            self._users_cond.notify_all()
+
+        try:
+            yield self
+        finally:
+            with self._users_cond:
+                self._users_counter.value -= 1
+                self._users_cond.notify_all()
+
     def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
         self.cancel()
+        with self._users_cond:
+            if not self._users_cond.wait_for(lambda: self._users_counter.value == 0, timeout=self.USER_CANCEL_TIMEOUT_SEC):
+                log.warning("Log message counter still has %d users after waiting for cancellation", self._users_counter.value)
 
 
 class ProcessThreadTaskFilter(logging.Filter):

--- a/scripts/tests/chiptest/log_config.py
+++ b/scripts/tests/chiptest/log_config.py
@@ -82,7 +82,7 @@ class LogMessageCounter:
     def wait_for_count_or_cancel(self, count: int, timeout: float | None = None) -> bool:
         """Wait until the total message count reaches at least the specified count or until cancelled."""
         with self._cond:
-            return self._cond.wait_for(lambda: self.total >= count or self.cancelled, timeout=timeout)
+            return self._cond.wait_for(lambda: self._counter.value >= count or self.cancelled, timeout=timeout)
 
     @contextlib.contextmanager
     def register_user(self) -> Iterator[Self]:

--- a/scripts/tests/chiptest/status.py
+++ b/scripts/tests/chiptest/status.py
@@ -43,31 +43,32 @@ class PeriodicStatusThread(threading.Thread):
             return
 
         log.debug("Starting periodic status overview thread with periodicity of %i log lines", self.periodicity)
-        target_count = self.log_counter.total
-        while not self.log_counter.cancelled:
-            target_count += self.periodicity
-            self.log_counter.wait_for_count_or_cancel(target_count)
-            # We want to print the status one more time after cancellation to show the final result before termination.
+        with self.log_counter.register_user() as log_counter:
+            target_count = log_counter.total
+            while not log_counter.cancelled:
+                target_count += self.periodicity
+                log_counter.wait_for_count_or_cancel(target_count)
+                # We want to print the status one more time after cancellation to show the final result before termination.
 
-            with self.run_summary:
-                current_iteration = self.run_summary.current_iteration
-                iterations = self.run_summary.iterations
-                successful_tests = self.run_summary.passed
-                failed_tests = self.run_summary.failed
-                expected_test_count = self.run_summary.expected_test_count
+                with self.run_summary:
+                    current_iteration = self.run_summary.current_iteration
+                    iterations = self.run_summary.iterations
+                    successful_tests = self.run_summary.passed
+                    failed_tests = self.run_summary.failed
+                    expected_test_count = self.run_summary.expected_test_count
 
-            test_status: list[str] = []
-            if successful_tests > 0:
-                test_status.append(f"{successful_tests} successful")
-            if failed_tests > 0:
-                test_status.append(f"{failed_tests} failed")
-            if not test_status:
-                test_status.append("no tests completed")
+                test_status: list[str] = []
+                if successful_tests > 0:
+                    test_status.append(f"{successful_tests} successful")
+                if failed_tests > 0:
+                    test_status.append(f"{failed_tests} failed")
+                if not test_status:
+                    test_status.append("no tests completed")
 
-            status_message = (
-                f"Iteration {current_iteration}/{iterations}: "
-                f"{successful_tests + failed_tests}/{expected_test_count} tests ({', '.join(test_status)})"
-            )
-            log.info("", extra={"status": status_message, "count": False})
+                status_message = (
+                    f"Iteration {current_iteration}/{iterations}: "
+                    f"{successful_tests + failed_tests}/{expected_test_count} tests ({', '.join(test_status)})"
+                )
+                log.info("", extra={"status": status_message, "count": False})
 
         log.debug("Status overview thread has stopped")


### PR DESCRIPTION
#### Summary

Before, the log counter didn't wait for the status thread to finish operation, which resulted in a frequent broken pipe error at the end of test execution.

Also, since the log counter is not used in multi-thread context, and only in multi-process, I removed the redundant bifurcation for threading and processing data structures.

#### Related issues

Fixing issue introduced with https://github.com/project-chip/connectedhomeip/pull/71560

#### Testing

Local tests with `run_test_suite.py`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
