### PR TITLE
[ReadClient] skip spec-violating AttributeStatusIB(Success) in attribute reports

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -825,6 +825,20 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
 
             ReturnErrorOnFailure(status.GetErrorStatus(&errorStatus));
             ReturnErrorOnFailure(errorStatus.DecodeStatusIB(statusIB));
+            // Per Matter IM spec, an AttributeStatusIB inside an AttributeReportIB always carries an
+            // error status (Success is only valid for AttributeStatusIBs in WriteResponses). A peer
+            // sending Status::Success here is spec-violating; passing it to OnAttributeData with
+            // apData == nullptr breaks the documented callback contract and has caused null derefs
+            // in consumers. Skip the IB instead, mirroring the out-of-range-ID handling above.
+            if (statusIB.IsSuccess())
+            {
+                ChipLogError(DataManagement,
+                             "Skipping AttributeStatusIB with Success status (spec violation): (%d, " ChipLogFormatMEI
+                             ", " ChipLogFormatMEI ")",
+                             attributePath.mEndpointId, ChipLogValueMEI(attributePath.mClusterId),
+                             ChipLogValueMEI(attributePath.mAttributeId));
+                continue;
+            }
             NoteReportingData();
             mpCallback.OnAttributeData(attributePath, nullptr, statusIB);
         }

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -430,7 +430,9 @@ void TimeSynchronizationCluster::OnDeviceConnectionFailureFn()
 void TimeSynchronizationCluster::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
                                                  const StatusIB & aStatus)
 {
-    if (aPath.mClusterId != Id || aStatus.IsFailure())
+    // Defense-in-depth: ReadClient::ProcessAttributeReportIBs already rejects spec-violating
+    // AttributeStatusIB(Success), but keep the local nullptr check in case that invariant is ever loosened.
+    if (aPath.mClusterId != Id || aStatus.IsFailure() || apData == nullptr)
     {
         return;
     }

--- a/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
@@ -16,6 +16,9 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include <app/ConcreteAttributePath.h>
+#include <app/MessageDef/StatusIB.h>
+#include <app/ReadClient.h>
 #include <app/clusters/time-synchronization-server/TimeSynchronizationCluster.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
@@ -26,6 +29,7 @@
 #include <clusters/TimeSynchronization/Enums.h>
 #include <clusters/TimeSynchronization/Metadata.h>
 #include <clusters/TimeSynchronization/Structs.h>
+#include <protocols/interaction_model/Constants.h>
 
 namespace {
 
@@ -53,6 +57,29 @@ struct TestTimeSynchronizationCluster : public ::testing::Test
 };
 
 } // namespace
+
+// Defense-in-depth: ReadClient::ProcessAttributeReportIBs already rejects AttributeStatusIB(Success),
+// but verify the cluster's early-return guard handles apData == nullptr in case that invariant
+// is ever loosened.
+TEST_F(TestTimeSynchronizationCluster, OnAttributeDataToleratesNullData)
+{
+    const BitFlags<Feature> features{ Feature::kTimeSyncClient };
+    TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features, TimeSynchronizationCluster::OptionalAttributeSet(),
+                                                   TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate },
+                                                   context);
+    ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    ReadClient::Callback & callback = timeSynchronization;
+    const StatusIB success{ Protocols::InteractionModel::Status::Success };
+    const StatusIB failure{ Protocols::InteractionModel::Status::Failure };
+
+    callback.OnAttributeData(ConcreteDataAttributePath{ kRootEndpointId, Id, UTCTime::Id }, nullptr, success);
+    callback.OnAttributeData(ConcreteDataAttributePath{ kRootEndpointId, Id, Granularity::Id }, nullptr, success);
+    callback.OnAttributeData(ConcreteDataAttributePath{ kRootEndpointId, Id, UTCTime::Id }, nullptr, failure);
+    callback.OnAttributeData(ConcreteDataAttributePath{ kRootEndpointId, Id, ClusterRevision::Id }, nullptr, success);
+
+    timeSynchronization.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
 
 TEST_F(TestTimeSynchronizationCluster, AttributeTest)
 {

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -541,6 +541,7 @@ public:
     void TestReadClientGenerateInvalidAttributePathList();
     void TestReadClientGenerateOneEventPaths();
     void TestReadClientGenerateTwoEventPaths();
+    void TestReadClientAttributeStatusIBWithSuccess();
     void TestReadClientInvalidAttributeId();
     void TestReadClientInvalidReport();
     void TestReadClientReceiveInvalidMessage();
@@ -590,6 +591,7 @@ public:
         kValid,
         kInvalidNoAttributeId,
         kInvalidOutOfRangeAttributeId,
+        kAttributeStatusIBWithSuccess,
     };
 
     static void GenerateReportData(System::PacketBufferHandle & aPayload, ReportType aReportType, bool aSuppressResponse,
@@ -630,6 +632,34 @@ void TestReadInteraction::GenerateReportData(System::PacketBufferHandle & aPaylo
 
     AttributeReportIB::Builder & attributeReportIBBuilder = attributeReportIBsBuilder.CreateAttributeReport();
     EXPECT_EQ(attributeReportIBsBuilder.GetError(), CHIP_NO_ERROR);
+
+    if (aReportType == ReportType::kAttributeStatusIBWithSuccess)
+    {
+        // Spec-violating: AttributeStatusIB inside an AttributeReportIB must carry a failure status
+        // (AttributeDataIB is used to convey successful reads). The parser must skip this without
+        // dispatching to the callback.
+        AttributeStatusIB::Builder & attributeStatusIBBuilder = attributeReportIBBuilder.CreateAttributeStatus();
+        EXPECT_EQ(attributeReportIBBuilder.GetError(), CHIP_NO_ERROR);
+
+        AttributePathIB::Builder & attributePathBuilder = attributeStatusIBBuilder.CreatePath();
+        EXPECT_EQ(attributeStatusIBBuilder.GetError(), CHIP_NO_ERROR);
+        EXPECT_SUCCESS(attributePathBuilder.Endpoint(2).Cluster(3).Attribute(4).EndOfAttributePathIB());
+        EXPECT_EQ(attributePathBuilder.GetError(), CHIP_NO_ERROR);
+
+        StatusIB::Builder & errorStatusBuilder = attributeStatusIBBuilder.CreateErrorStatus();
+        EXPECT_EQ(attributeStatusIBBuilder.GetError(), CHIP_NO_ERROR);
+        errorStatusBuilder.EncodeStatusIB(StatusIB(Protocols::InteractionModel::Status::Success));
+        EXPECT_EQ(errorStatusBuilder.GetError(), CHIP_NO_ERROR);
+
+        EXPECT_SUCCESS(attributeStatusIBBuilder.EndOfAttributeStatusIB());
+        EXPECT_SUCCESS(attributeReportIBBuilder.EndOfAttributeReportIB());
+        EXPECT_SUCCESS(attributeReportIBsBuilder.EndOfAttributeReportIBs());
+        reportDataMessageBuilder.MoreChunkedMessages(false);
+        reportDataMessageBuilder.SuppressResponse(aSuppressResponse);
+        EXPECT_SUCCESS(reportDataMessageBuilder.EndOfReportDataMessage());
+        EXPECT_EQ(writer.Finalize(&aPayload), CHIP_NO_ERROR);
+        return;
+    }
 
     AttributeDataIB::Builder & attributeDataIBBuilder = attributeReportIBBuilder.CreateAttributeData();
     EXPECT_EQ(attributeReportIBBuilder.GetError(), CHIP_NO_ERROR);
@@ -1013,6 +1043,37 @@ void TestReadInteraction::TestReadClientInvalidAttributeId()
     EXPECT_EQ(readClient.ProcessReportData(std::move(buf), ReadClient::ReportType::kContinuingTransaction), CHIP_NO_ERROR);
 
     // We should not have gotten any attribute reports or errors.
+    EXPECT_FALSE(delegate.mGotEventResponse);
+    EXPECT_EQ(delegate.mNumAttributeResponse, 0);
+    EXPECT_FALSE(delegate.mGotReport);
+    EXPECT_FALSE(delegate.mReadError);
+}
+
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteraction, TestReadClientAttributeStatusIBWithSuccess)
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteractionSync, TestReadClientAttributeStatusIBWithSuccess)
+void TestReadInteraction::TestReadClientAttributeStatusIBWithSuccess()
+{
+    MockInteractionModelApp delegate;
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+
+    app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), delegate,
+                               chip::app::ReadClient::InteractionType::Read);
+
+    ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+    EXPECT_EQ(readClient.SendRequest(readPrepareParams), CHIP_NO_ERROR);
+
+    GetLoopback().mNumMessagesToDrop = 1;
+    DrainAndServiceIO();
+
+    GenerateReportData(buf, ReportType::kAttributeStatusIBWithSuccess, true /* aSuppressResponse*/);
+
+    // Per Matter IM spec, an AttributeStatusIB inside an AttributeReportIB only carries failure
+    // statuses; AttributeDataIB conveys successful reads. The parser must skip a Success-bearing
+    // AttributeStatusIB without dispatching to OnAttributeData, where apData == nullptr would
+    // otherwise break the documented callback contract.
+    EXPECT_EQ(readClient.ProcessReportData(std::move(buf), ReadClient::ReportType::kContinuingTransaction), CHIP_NO_ERROR);
+
     EXPECT_FALSE(delegate.mGotEventResponse);
     EXPECT_EQ(delegate.mNumAttributeResponse, 0);
     EXPECT_FALSE(delegate.mGotReport);


### PR DESCRIPTION
#### Summary

- Per the spec, an `AttributeStatusIB` inside an `AttributeReportIB` always carries a failure status. `AttributeDataIB` is the IB that conveys successful reads; SUCCESS in an AttributeStatusIB is only valid in WriteResponses.

- Without parser-level enforcement, a spec-violating peer sending `Status::Success` reaches `OnAttributeData` with `apData == nullptr`, which can null-deref consumers that follow the documented API contract ("apData is nullptr if status is not Success"). 
  - one such consumer (BufferedReadCallback) was patched in PR; #71928
  - this enforces the invariant at the parser so every consumer is covered. 

#### Fix 
-  `ReadClient::ProcessAttributeReportIBs` now skips AttributeStatusIB with Success status.

- Also added a defensive `apData == nullptr` check in `TimeSynchronizationCluster::OnAttributeData` although the parser fix already covers this site; similar defensive fix as #71928.
#### Testing

- Added a Unit Test case that creates a `ReportData` carrying an `AttributeStatusIB(Success)` and ensures ProcessAttributeReportIBs skips it

