### PR TITLE
 Remove unnecessary mutex lock to fix deadlock and code cleanup

### DIFF
--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -111,25 +111,6 @@ PushAVClipRecorder::~PushAVClipRecorder()
         ChipLogProgress(Camera, "Worker thread completed for connection %u", mConnectionID);
     }
 
-    {
-        std::lock_guard<std::mutex> lock(mQueueMutex);
-        while (!mVideoQueue.empty())
-        {
-            AVPacket * packet = mVideoQueue.front();
-            mVideoQueue.pop();
-            av_packet_free(&packet);
-        }
-        while (!mAudioQueue.empty())
-        {
-            AVPacket * packet = mAudioQueue.front();
-            mAudioQueue.pop();
-            av_packet_free(&packet);
-        }
-    }
-
-    // Clean up FFmpeg resources
-    CleanupOutput();
-
     std::filesystem::path mpdPath = mUploadFileBasePath / "index.mpd";
     if (IsFileReadyForUpload(mpdPath))
     {
@@ -413,6 +394,23 @@ void PushAVClipRecorder::Stop()
                 chip::DeviceLayer::PlatformMgr().UnlockChipStack();
                 ChipLogProgress(Camera, "Async thread: NotifyTransportStopped completed for connection %u", connectionID);
             }).detach();
+        }
+        else
+        {
+            ChipLogError(Camera, "PushAVClipRecorder::Stop - Cluster server reference is null for connection %u", mConnectionID);
+        }
+
+        while (!mVideoQueue.empty())
+        {
+            AVPacket * packet = mVideoQueue.front();
+            mVideoQueue.pop();
+            av_packet_free(&packet);
+        }
+        while (!mAudioQueue.empty())
+        {
+            AVPacket * packet = mAudioQueue.front();
+            mAudioQueue.pop();
+            av_packet_free(&packet);
         }
     }
     else

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -348,10 +348,7 @@ bool PushAVTransport::HandleTriggerDetected()
     if (!mPreviousActivationByManualTrigger && !mCurrentActivationByManualTrigger &&
         InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS, now))
     {
-        ChipLogError(Camera,
-                     "PushAVTransport command/motion transport trigger received but ignored due to blind period. Clip duration "
-                     "[%d seconds]",
-                     mRecorder->mClipInfo.mMotionDetectedDurationS);
+        ChipLogError(Camera, "PushAVTransport command/motion transport trigger received but ignored due to blind period");
         return false;
     }
 
@@ -394,7 +391,7 @@ bool PushAVTransport::HandleTriggerDetected()
     mBlindStartTime = mClipInfo.mActivationTime + std::chrono::seconds(mClipInfo.mMotionDetectedDurationS);
 
     {
-        // std::lock_guard<std::mutex> lock(mRecorderMutex);
+        std::lock_guard<std::mutex> lock(mRecorderMutex);
         if (mRecorder.get() != nullptr)
         {
             mRecorder->mClipInfo.mMotionDetectedDurationS = mClipInfo.mMotionDetectedDurationS;
@@ -604,8 +601,8 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
             mUploader->Start();
         }
         {
-            InitializeRecorder();
-            std::lock_guard<std::mutex> lock(mRecorderMutex);
+          std::lock_guard<std::mutex> lock(mRecorderMutex);
+          InitializeRecorder();
         }
         if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
         {

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -270,7 +270,6 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
 
 void PushAVTransport::InitializeRecorder()
 {
-    std::lock_guard<std::mutex> lock(mRecorderMutex);
     if (mRecorder.get() == nullptr)
     {
         mSessionStartedTimestamp = std::chrono::system_clock::time_point();
@@ -394,22 +393,20 @@ bool PushAVTransport::HandleTriggerDetected()
     // Use the current motion detected duration which represents when this recording session will end
     mBlindStartTime = mClipInfo.mActivationTime + std::chrono::seconds(mClipInfo.mMotionDetectedDurationS);
 
-    if (mRecorder.get() == nullptr && mTransportStatus == TransportStatusEnum::kActive)
     {
-        InitializeRecorder();
-    }
-
-    if (mRecorder.get() != nullptr)
-    {
-        mRecorder->mClipInfo.mMotionDetectedDurationS = mClipInfo.mMotionDetectedDurationS;
-        if (!mRecorder->GetRecorderStatus())
+        // std::lock_guard<std::mutex> lock(mRecorderMutex);
+        if (mRecorder.get() != nullptr)
         {
-            mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType, mActivationReason);
-            // Initiate recording if the recorder is not currently recording
-            StartRecordingAndStreaming();
+            mRecorder->mClipInfo.mMotionDetectedDurationS = mClipInfo.mMotionDetectedDurationS;
+            if (!mRecorder->GetRecorderStatus())
+            {
+                mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType, mActivationReason);
+                // Initiate recording if the recorder is not currently recording
+                StartRecordingAndStreaming();
+            }
         }
+        return true;
     }
-    return true;
 }
 
 void PushAVTransport::StartRecordingAndStreaming()
@@ -606,8 +603,10 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
             mUploader->setCertificatePath(mCertPath);
             mUploader->Start();
         }
-        InitializeRecorder();
-
+        {
+            InitializeRecorder();
+            std::lock_guard<std::mutex> lock(mRecorderMutex);
+        }
         if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
         {
             mClipInfo.mMotionDetectedDurationS = 0;
@@ -690,6 +689,7 @@ bool PushAVTransport::CanSendPacketsToRecorder()
     {
         ChipLogProgress(Camera, "Current clip is completed, Next clip will start on trigger");
         mRecorder.reset(); // Redundant cleanup to make sure no dangling pointer left
+        InitializeRecorder();
         mStreaming = false;
         UpdateSendFlags();
         return false;
@@ -780,8 +780,8 @@ CHIP_ERROR PushAVTransport::ModifyPushTransport(const TransportOptionsStorage & 
         {
             std::lock_guard<std::mutex> lock(mRecorderMutex);
             mRecorder.reset();
+            InitializeRecorder();
         }
-        InitializeRecorder();
     }
     return CHIP_NO_ERROR;
 }
@@ -823,9 +823,8 @@ void PushAVTransport::CheckAndUpdateSession()
         {
             std::lock_guard<std::mutex> lock(mRecorderMutex);
             mRecorder.reset();
+            InitializeRecorder();
         }
-
-        InitializeRecorder();
         auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
                                                                                mRecorder->mClipInfo.mActivationTime)
                                   .count();

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -601,8 +601,8 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
             mUploader->Start();
         }
         {
-          std::lock_guard<std::mutex> lock(mRecorderMutex);
-          InitializeRecorder();
+            std::lock_guard<std::mutex> lock(mRecorderMutex);
+            InitializeRecorder();
         }
         if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
         {

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,10 +171,6 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
-    - name: TC_PAVST_2_13.py
-      reason:
-          Used to be flaky, now it seems to deadlock and tests are cancelled.
-          https://github.com/project-chip/connectedhomeip/issues/71808
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary
A deadlock was observed in the camera‑app example when the transport layer attempted to acquire a mutex that was already held by the recorder component. The lock was redundant – the protected resources are already accessed in a thread‑safe manner. Removing the unnecessary lock eliminates the deadlock and simplifies the code path.

#### Related issues

Fixes #71808 
Fixes #72028

#### Testing

Local Testing and CI