### PR TITLE
[CI] suppress error from step that publishes test result to github actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -336,6 +336,7 @@ jobs:
                   report_paths: junit-results/**/*.xml
                   detailed_summary: true
                   require_tests: false
+                  annotate_only: true
 
             - name: Checkout gh-pages for Allure history
               uses: actions/checkout@v6.0.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1307,6 +1307,7 @@ jobs:
                 report_paths: junit-results/**/*.xml
                 detailed_summary: true
                 require_tests: false
+                annotate_only: true
 
           - name: Checkout gh-pages for Allure history
             uses: actions/checkout@v6.0.2


### PR DESCRIPTION

#### Summary

[CI] suppress error from step that publishes test result to github actions

- The idea is to stop having the error that shows up when PRs are run, as in screenshot
- 
<img width="2443" height="985" alt="image" src="https://github.com/user-attachments/assets/80269401-39a1-4ea4-8d0f-d5829aaf245a" />



#### Testing

CI will test
