### PR TITLE
Don't shadow builtin Python symbols in scripts/*

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(MATTER_BASE / "docs" / "_extensions"))
 # -- Project information -----------------------------------------------------
 
 project = "Matter"
-copyright = "2020-2025, Matter Contributors"
+project_copyright = "2020-2025, Matter Contributors"
 author = "Matter Contributors"
 version = "1.0.0"
 

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -205,7 +205,7 @@ def cmd_generate(context):
     'targets',
     help=('Lists the targets that can be used with the build and gen commands'))
 @click.option(
-    '--format',
+    '--format', 'format_type',
     default='summary',
     type=click.Choice(['summary', 'expanded', 'json', 'completion'], case_sensitive=False),
     help="""
@@ -219,15 +219,15 @@ def cmd_generate(context):
         """)
 @click.argument('COMPLETION-PREFIX', default='')
 @click.pass_context
-def cmd_targets(context, format, completion_prefix):
-    if format == 'expanded':
+def cmd_targets(context, format_type, completion_prefix):
+    if format_type == 'expanded':
         build.target.report_rejected_parts = False
         for target in build.targets.BUILD_TARGETS:
             for s in target.AllVariants():
                 print(s)
-    elif format == 'json':
+    elif format_type == 'json':
         print(json.dumps([target.ToDict() for target in build.targets.BUILD_TARGETS], indent=4))
-    elif format == 'completion':
+    elif format_type == 'completion':
         build.target.report_rejected_parts = False
         for target in build.targets.BUILD_TARGETS:
             for s in target.CompletionStrings(completion_prefix):

--- a/scripts/codepregen.py
+++ b/scripts/codepregen.py
@@ -115,14 +115,14 @@ def main(log_level, parallel, dry_run, generator, input_glob, sdk_root, external
     else:
         runner = DryRunner()
 
-    filter = TargetFilter(path_glob=input_glob)
+    target_filter = TargetFilter(path_glob=input_glob)
 
     if generator == 'zap':
-        filter.file_type = IdlFileType.ZAP
+        target_filter.file_type = IdlFileType.ZAP
     elif generator == 'codegen':
-        filter.file_type = IdlFileType.MATTER
+        target_filter.file_type = IdlFileType.MATTER
 
-    targets = FindPregenerationTargets(sdk_root, external_root, filter, runner)
+    targets = FindPregenerationTargets(sdk_root, external_root, target_filter, runner)
 
     runner.ensure_directory_exists(output_dir)
     if parallel:

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -32,10 +32,10 @@ def download(url, dest):
 
 def download_and_extract_zip(url, dest_dir, *member_names):
     file, *_ = urllib.request.urlretrieve(url)
-    with zipfile.ZipFile(file) as zip:
-        for member in zip.infolist():
+    with zipfile.ZipFile(file) as zip_file:
+        for member in zip_file.infolist():
             if member.filename in member_names:
-                zip.extract(member, dest_dir)
+                zip_file.extract(member, dest_dir)
 
 
 def process_project_args(gn_args_json_file, *params):
@@ -159,11 +159,11 @@ class ProjectArgProcessor:
         self.add_env_arg('target_cc', 'CC', 'cc')
         self.add_env_arg('target_cxx', 'CXX', 'cxx')
         self.add_env_arg('target_ar', 'AR', 'ar')
-        self.add_env_arg('target_cflags', 'CPPFLAGS', list=True)
-        self.add_env_arg('target_cflags_c', 'CFLAGS', list=True)
-        self.add_env_arg('target_cflags_cc', 'CXXFLAGS', list=True)
-        self.add_env_arg('target_cflags_objc', 'OBJCFLAGS', list=True)
-        self.add_env_arg('target_ldflags', 'LDFLAGS', list=True)
+        self.add_env_arg('target_cflags', 'CPPFLAGS', is_list=True)
+        self.add_env_arg('target_cflags_c', 'CFLAGS', is_list=True)
+        self.add_env_arg('target_cflags_cc', 'CXXFLAGS', is_list=True)
+        self.add_env_arg('target_cflags_objc', 'OBJCFLAGS', is_list=True)
+        self.add_env_arg('target_ldflags', 'LDFLAGS', is_list=True)
 
     def add_arg(self, nameOrArg, value, required=True):
         if arg := self.gn_args.get(nameOrArg, None) if isinstance(nameOrArg, str) else nameOrArg:
@@ -172,7 +172,7 @@ class ProjectArgProcessor:
         elif required:
             fail("Project has no build arg '%s'" % nameOrArg)
 
-    def add_env_arg(self, name, envvar, default=None, list=False):
+    def add_env_arg(self, name, envvar, default=None, is_list=False):
         """Add an argument from an environment variable"""
         if not (value := os.environ.get(envvar, default)):
             return
@@ -180,7 +180,7 @@ class ProjectArgProcessor:
             info("Warning: Not propagating %s, project has no build arg '%s'" % (envvar, name))
             return
         # bypass add_arg() to handle list splitting / formatting directly
-        self.args[arg.name] = json.dumps(value if arg.type != '[' else value.split() if list else [value])
+        self.args[arg.name] = json.dumps(value if arg.type != '[' else value.split() if is_list else [value])
 
     def process_triplet_parameter(self, name, value):
         if value is None:

--- a/scripts/dm_xml_ci_change_enforcement.py
+++ b/scripts/dm_xml_ci_change_enforcement.py
@@ -21,12 +21,12 @@ import click
 
 
 @click.command()
-@click.argument('dir', nargs=1, type=click.Path(exists=True))
-def check_dm_directory(dir):
-    clusters = os.path.join(dir, 'clusters')
-    device_types = os.path.join(dir, 'device_types')
+@click.argument('directory', nargs=1, type=click.Path(exists=True))
+def check_dm_directory(directory):
+    clusters = os.path.join(directory, 'clusters')
+    device_types = os.path.join(directory, 'device_types')
     if not os.path.isdir(clusters) or not os.path.isdir(device_types):
-        print(f"Invalid data model directory {dir}")
+        print(f"Invalid data model directory {directory}")
         sys.exit(1)
 
     # We are operating in a VM, and although there is a checkout, it is working in a scratch directory
@@ -34,17 +34,17 @@ def check_dm_directory(dir):
     # Adding an exception for this directory so that git can function properly.
     subprocess.run("git config --global --add safe.directory '*'", shell=True)
 
-    def check_dir(dir):
-        cmd = f'git diff HEAD^..HEAD --name-only -- {dir}'
+    def check_dir(path):
+        cmd = f'git diff HEAD^..HEAD --name-only -- {path}'
         output = subprocess.check_output(cmd, shell=True).decode()
         if output and 'spec_sha' not in output and 'scraper_version' not in output:
-            print(f'Data model directory {dir} had changes to the following files without a corresponding update to the spec SHA')
+            print(f'Data model directory {path} had changes to the following files without a corresponding update to the spec SHA')
             print(output)
-            print("Note that the data_model directory files are automatically updated by a spec scraper and should not be manually updated.")
+            print("Note that the data model directory files are automatically updated by a spec scraper and should not be manually updated.")
             return 1
         return 0
 
-    def check_dm_scraper_script_updates(dir):
+    def check_dm_scraper_script_updates(path):
         # Run the scraper script, but don't actually scrape from the spec right now
         # because we don't have a spec checkout. This will ensure the script is
         # working, and that any script-applied updates are applied correctly.
@@ -55,19 +55,19 @@ def check_dm_directory(dir):
         generate_file = os.path.join(scripts_dir, 'spec_xml', 'generate_spec_xml.py')
         # we're not using the scraper or spec, so it doesn't matter here
         cmd_list = ['python3', generate_file, '--scraper', 'x', '--spec-root', 'x',
-                    '--output-dir', dir, '--include-in-progress', 'None', '--skip-scrape']
+                    '--output-dir', path, '--include-in-progress', 'None', '--skip-scrape']
         subprocess.run(cmd_list, check=True)
-        cmd_list = ['git', 'diff', 'HEAD', '--name-only', '--', dir]
+        cmd_list = ['git', 'diff', 'HEAD', '--name-only', '--', path]
         output = subprocess.check_output(cmd_list).decode()
         if output:
-            print(f"Data model directory {dir} files do not match DM generation script output")
+            print(f"Data model directory {path} files do not match DM generation script output")
             print(output)
             print("Note that the data_model directory files are automatically updated by a spec scraper and should not be manually updated.")
             return 1
         return 0
 
-    ret_check_dir = check_dir(dir)
-    ret_check_scraper = check_dm_scraper_script_updates(dir)
+    ret_check_dir = check_dir(directory)
+    ret_check_scraper = check_dm_scraper_script_updates(directory)
     sys.exit(ret_check_dir+ret_check_scraper)
 
 

--- a/scripts/examples/conformance_report.py
+++ b/scripts/examples/conformance_report.py
@@ -67,11 +67,11 @@ def find_executables(dirs):
       A list of paths to the first executable found in each directory.
     """
     executables = []
-    for dir in dirs:
-        if not os.path.isdir(dir):
+    for directory in dirs:
+        if not os.path.isdir(directory):
             continue
-        for filename in os.listdir(dir):
-            filepath = os.path.join(dir, filename)
+        for filename in os.listdir(directory):
+            filepath = os.path.join(directory, filename)
             if os.path.isfile(filepath) and os.access(filepath, os.X_OK):
                 executables.append(filepath)
                 break  # Move to the next directory

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -236,7 +236,7 @@ class CustomGenerator(CodeGenerator):
             self.internal_render_one_output(
                 template_path="matter_cluster_proto.jinja",
                 output_file_name=filename,
-                vars={
+                template_vars={
                     'cluster': cluster,
                     'package': self.package,
                 }

--- a/scripts/py_matter_idl/matter/idl/generators/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/__init__.py
@@ -84,7 +84,7 @@ class CodeGenerator:
         """
         raise NotImplementedError("Method should be implemented by subclasses")
 
-    def internal_render_one_output(self, template_path: str, output_file_name: str, vars: Dict):
+    def internal_render_one_output(self, template_path: str, output_file_name: str, template_vars: Dict):
         """
         Method to be called by subclasses to mark that a template is to be generated.
 
@@ -106,7 +106,7 @@ class CodeGenerator:
             return
 
         log.info("Template path: '%s', CWD: '%s'", template_path, os.getcwd())
-        rendered = self.jinja_env.get_template(template_path).render(vars)
+        rendered = self.jinja_env.get_template(template_path).render(template_vars)
 
         # Report regardless if it has changed or not. This is because even if
         # files are unchanged, validation of what the correct output is should

--- a/scripts/py_matter_idl/matter/idl/generators/cpp/application/application_generator.py
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/application/application_generator.py
@@ -164,7 +164,7 @@ class CppApplicationGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="PluginApplicationCallbacksHeader.jinja",
             output_file_name="app/PluginApplicationCallbacks.h",
-            vars={"clusters": server_side_clusters(self.idl)},
+            template_vars={"clusters": server_side_clusters(self.idl)},
         )
 
         # Source for __attribute__(weak) implementations of all cluster
@@ -172,13 +172,13 @@ class CppApplicationGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="CallbackStubSource.jinja",
             output_file_name="app/callback-stub.cpp",
-            vars={"clusters": server_side_clusters(self.idl)},
+            template_vars={"clusters": server_side_clusters(self.idl)},
         )
 
         self.internal_render_one_output(
             template_path="ClusterCallbacksSource.jinja",
             output_file_name="app/cluster-callbacks.cpp",
-            vars={
+            template_vars={
                 'clusters': server_side_clusters(self.idl)
             }
         )
@@ -201,7 +201,7 @@ class CppApplicationGenerator(CodeGenerator):
             self.internal_render_one_output(
                 template_path="ServerClusterConfig.jinja",
                 output_file_name=f"app/static-cluster-config/{name}.h",
-                vars={
+                template_vars={
                     "cluster_name": name,
                     "config": config,
                     "input_name": self.idl.parse_file_name,

--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/sdk_generator.py
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/sdk_generator.py
@@ -116,7 +116,7 @@ class SdkGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="AllItemsBuild.jinja",
             output_file_name="BUILD.gn",
-            vars={
+            template_vars={
                 "clusters": self.idl.clusters,
                 "input_name": self.idl.parse_file_name,
             },
@@ -125,7 +125,7 @@ class SdkGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="MetadataQuery.h.jinja",
             output_file_name="MetadataQuery.h",
-            vars={
+            template_vars={
                 "clusters": self.idl.clusters,
                 "input_name": self.idl.parse_file_name,
             },
@@ -152,7 +152,7 @@ class SdkGenerator(CodeGenerator):
                 self.internal_render_one_output(
                     template_path=template_path,
                     output_file_name=f"{cluster.name}/{output_file}",
-                    vars={
+                    template_vars={
                         "cluster": cluster,
                         "input_name": self.idl.parse_file_name,
                     },

--- a/scripts/py_matter_idl/matter/idl/generators/cpp/tlvmeta/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/tlvmeta/__init__.py
@@ -293,7 +293,7 @@ class TLVMetaDataGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="TLVMetaData_cpp.jinja",
             output_file_name=f"tlv/meta/{self.table_name}.cpp",
-            vars={
+            template_vars={
                 'clusters': self.idl.clusters,
                 'table_name': self.table_name,
                 'sub_tables': tables,
@@ -303,7 +303,7 @@ class TLVMetaDataGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="TLVMetaData_h.jinja",
             output_file_name=f"tlv/meta/{self.table_name}.h",
-            vars={
+            template_vars={
                 'clusters': self.idl.clusters,
                 'table_name': self.table_name,
                 'sub_tables': tables,

--- a/scripts/py_matter_idl/matter/idl/generators/idl/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/idl/__init__.py
@@ -195,7 +195,7 @@ class IdlGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="MatterIdl.jinja",
             output_file_name="idl.matter",
-            vars={
+            template_vars={
                 'idl': self.idl
             }
         )

--- a/scripts/py_matter_idl/matter/idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/java/__init__.py
@@ -744,7 +744,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ClusterReadMapping.jinja",
             output_file_name="java/chip/devicecontroller/ClusterReadMapping.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -753,7 +753,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ClusterWriteMapping.jinja",
             output_file_name="java/chip/devicecontroller/ClusterWriteMapping.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -762,7 +762,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ClusterIDMapping.jinja",
             output_file_name="java/chip/devicecontroller/ClusterIDMapping.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -771,7 +771,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ChipClusters_java.jinja",
             output_file_name="java/chip/devicecontroller/ChipClusters.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -780,7 +780,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ChipStructs_java.jinja",
             output_file_name="java/chip/devicecontroller/ChipStructs.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -789,7 +789,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ChipEventStructs_java.jinja",
             output_file_name="java/chip/devicecontroller/ChipEventStructs.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -798,7 +798,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ClusterInfoMapping_java.jinja",
             output_file_name="java/chip/devicecontroller/ClusterInfoMapping.java",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -807,7 +807,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         self.internal_render_one_output(
             template_path="ChipStructFiles_gni.jinja",
             output_file_name="java/chip/devicecontroller/cluster/files.gni",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -826,7 +826,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
                     output_file_name=output_name.format(
                         cluster_name=cluster.name,
                         struct_name=struct.name),
-                    vars={
+                    template_vars={
                         'cluster': cluster,
                         'struct': struct,
                         'typeLookup': TypeLookupContext(self.idl, cluster),
@@ -843,7 +843,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
                     output_file_name=output_name.format(
                         cluster_name=cluster.name,
                         event_name=event.name),
-                    vars={
+                    template_vars={
                         'cluster': cluster,
                         'event': event,
                         'typeLookup': TypeLookupContext(self.idl, cluster),

--- a/scripts/py_matter_idl/matter/idl/generators/kotlin/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/kotlin/__init__.py
@@ -649,7 +649,7 @@ class KotlinClassGenerator(__KotlinCodeGenerator):
         self.internal_render_one_output(
             template_path="MatterFiles_gni.jinja",
             output_file_name="java/matter/controller/cluster/files.gni",
-            vars={
+            template_vars={
                 'idl': self.idl,
                 'clientClusters': clientClusters,
             }
@@ -661,7 +661,7 @@ class KotlinClassGenerator(__KotlinCodeGenerator):
             self.internal_render_one_output(
                 template_path="MatterClusters.jinja",
                 output_file_name=output_name,
-                vars={
+                template_vars={
                     'idl': self.idl,
                     'cluster': cluster,
                 }
@@ -680,7 +680,7 @@ class KotlinClassGenerator(__KotlinCodeGenerator):
                     output_file_name=output_name.format(
                         cluster_name=cluster.name,
                         struct_name=struct.name),
-                    vars={
+                    template_vars={
                         'cluster': cluster,
                         'struct': struct,
                         'typeLookup': TypeLookupContext(self.idl, cluster),
@@ -697,7 +697,7 @@ class KotlinClassGenerator(__KotlinCodeGenerator):
                     output_file_name=output_name.format(
                         cluster_name=cluster.name,
                         event_name=event.name),
-                    vars={
+                    template_vars={
                         'cluster': cluster,
                         'event': event,
                         'typeLookup': TypeLookupContext(self.idl, cluster),

--- a/scripts/py_matter_idl/matter/idl/generators/markdown/__init__.py
+++ b/scripts/py_matter_idl/matter/idl/generators/markdown/__init__.py
@@ -31,7 +31,7 @@ class SummaryMarkdownGenerator(CodeGenerator):
         self.internal_render_one_output(
             template_path="clusters_markdown.jinja",
             output_file_name="zap_clusters.md",
-            vars={
+            template_vars={
                 'idl': self.idl,
             }
         )

--- a/scripts/py_matter_idl/matter/idl/lint/lint_rules_parser.py
+++ b/scripts/py_matter_idl/matter/idl/lint/lint_rules_parser.py
@@ -349,12 +349,12 @@ class LintRulesTransformer(Transformer):
         return Discard
 
     @v_args(inline=True)
-    def required_server_cluster(self, id):
-        return ServerClusterRequirement(ClusterActionEnum.REQUIRE, id)
+    def required_server_cluster(self, cluster_id):
+        return ServerClusterRequirement(ClusterActionEnum.REQUIRE, cluster_id)
 
     @v_args(inline=True)
-    def rejected_server_cluster(self, id):
-        return ServerClusterRequirement(ClusterActionEnum.REJECT, id)
+    def rejected_server_cluster(self, cluster_id):
+        return ServerClusterRequirement(ClusterActionEnum.REJECT, cluster_id)
 
     @v_args(inline=True)
     def denylist_cluster_attribute(self, cluster_id, attribute_id):

--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -218,25 +218,25 @@ class MatterIdlTransformer(Transformer):
         raise Exception("Unexpected size for data type")
 
     @v_args(meta=True, inline=True)
-    def constant_entry(self, meta, api_maturity, id, number, spec_name):
+    def constant_entry(self, meta, api_maturity, constant_id, number, spec_name):
         if api_maturity is None:
             api_maturity = ApiMaturity.STABLE
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return ConstantEntry(name=id, code=number, api_maturity=api_maturity, specification_name=spec_name, parse_meta=meta)
+        return ConstantEntry(name=constant_id, code=number, api_maturity=api_maturity, specification_name=spec_name, parse_meta=meta)
 
     @v_args(meta=True, inline=True)
-    def enum(self, meta, shared, id, type, *entries):
+    def enum(self, meta, shared, enum_id, enum_type, *entries):
         if shared is None:
             shared = False
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return Enum(name=id, base_type=type, entries=list(entries), is_shared=shared, parse_meta=meta)
+        return Enum(name=enum_id, base_type=enum_type, entries=list(entries), is_shared=shared, parse_meta=meta)
 
     @v_args(meta=True, inline=True)
-    def bitmap(self, meta, shared, id, type, *entries):
+    def bitmap(self, meta, shared, bitmap_id, bitmap_type, *entries):
         if shared is None:
             shared = False
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return Bitmap(name=id, base_type=type, entries=list(entries), is_shared=shared, parse_meta=meta)
+        return Bitmap(name=bitmap_id, base_type=bitmap_type, entries=list(entries), is_shared=shared, parse_meta=meta)
 
     @v_args(meta=True)
     def field(self, meta, args):
@@ -423,19 +423,19 @@ class MatterIdlTransformer(Transformer):
         return AttributeStorage.CALLBACK
 
     @v_args(meta=True, inline=True)
-    def endpoint_attribute_instantiation(self, meta, storage, id, default=None):
+    def endpoint_attribute_instantiation(self, meta, storage, attribute_id, default=None):
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return AttributeInstantiation(parse_meta=meta, name=id, storage=storage, default=default)
+        return AttributeInstantiation(parse_meta=meta, name=attribute_id, storage=storage, default=default)
 
     @v_args(meta=True, inline=True)
-    def endpoint_command_instantiation(self, meta, id):
+    def endpoint_command_instantiation(self, meta, command_id):
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return CommandInstantiation(parse_meta=meta, name=id)
+        return CommandInstantiation(parse_meta=meta, name=command_id)
 
     @v_args(meta=True, inline=True)
-    def endpoint_emitted_event(self, meta, id):
+    def endpoint_emitted_event(self, meta, event_id):
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return id
+        return event_id
 
     def ESCAPED_STRING(self, s):
         # handle escapes, skip the start and end quotes
@@ -455,11 +455,11 @@ class MatterIdlTransformer(Transformer):
         return Attribute(definition=definition, qualities=qualities, **acl)
 
     @v_args(meta=True, inline=True)
-    def struct(self, meta, shared, qualities, id, *fields):
+    def struct(self, meta, shared, qualities, struct_id, *fields):
         if shared is None:
             shared = False
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return Struct(name=id, qualities=qualities, fields=list(fields), is_shared=shared, parse_meta=meta)
+        return Struct(name=struct_id, qualities=qualities, fields=list(fields), is_shared=shared, parse_meta=meta)
 
     @v_args(inline=True)
     def request_struct(self, value):
@@ -467,9 +467,9 @@ class MatterIdlTransformer(Transformer):
         return value
 
     @v_args(meta=True, inline=True)
-    def response_struct(self, meta, id, code, *fields):
+    def response_struct(self, meta, struct_id, code, *fields):
         meta = None if self.skip_meta else ParseMetaData(meta)
-        return Struct(name=id, tag=StructTag.RESPONSE, code=code, fields=list(fields), parse_meta=meta)
+        return Struct(name=struct_id, tag=StructTag.RESPONSE, code=code, fields=list(fields), parse_meta=meta)
 
     @v_args(inline=True)
     def endpoint(self, number, *transforms):
@@ -485,11 +485,11 @@ class MatterIdlTransformer(Transformer):
         return AddDeviceTypeToEndpointTransform(DeviceType(name=name, code=code, version=version))
 
     @v_args(inline=True)
-    def endpoint_cluster_binding(self, id):
-        return AddBindingToEndpointTransform(id)
+    def endpoint_cluster_binding(self, cluster_id):
+        return AddBindingToEndpointTransform(cluster_id)
 
     @v_args(meta=True, inline=True)
-    def endpoint_server_cluster(self, meta, id, *content):
+    def endpoint_server_cluster(self, meta, cluster_id, *content):
         meta = None if self.skip_meta else ParseMetaData(meta)
 
         attributes = []
@@ -504,7 +504,7 @@ class MatterIdlTransformer(Transformer):
             else:
                 events.add(item)
         return AddServerClusterToEndpointTransform(
-            ServerClusterInstantiation(parse_meta=meta, name=id, attributes=attributes, events_emitted=events, commands=commands))
+            ServerClusterInstantiation(parse_meta=meta, name=cluster_id, attributes=attributes, events_emitted=events, commands=commands))
 
     @v_args(inline=True)
     def cluster_content(self, api_maturity, element):

--- a/scripts/py_matter_yamltests/generate_yaml_doc_tables.py
+++ b/scripts/py_matter_yamltests/generate_yaml_doc_tables.py
@@ -47,8 +47,8 @@ def get_type_list_and_vars(typetuple) -> (list[type], bool):
 def print_tree(f: TextIO, indent: str, tree: SchemaTree) -> None:
     for tag, typetuple in tree.schema.items():
         vars_str = ""
-        typelist, vars = get_type_list_and_vars(typetuple)
-        vars_str = "Y" if vars else ""
+        typelist, variables = get_type_list_and_vars(typetuple)
+        vars_str = "Y" if variables else ""
         typestr = ','.join([t.__name__ for t in typelist])
 
         try:

--- a/scripts/py_matter_yamltests/matter/yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/constraints.py
@@ -247,9 +247,9 @@ class _ConstraintHasValue(BaseConstraint):
 
 
 class _ConstraintType(BaseConstraint):
-    def __init__(self, context, type):
+    def __init__(self, context, _type):
         super().__init__(context, types=[], is_null_allowed=True)
-        self._type = type
+        self._type = _type
 
     def check_response(self, value, value_type_name) -> bool:
         success = False

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -40,8 +40,8 @@ def include_package(package: dict) -> bool:
     return True
 
 
-def generate_new_cipd_package_json(input, output, extra):
-    with open(input) as ins:
+def generate_new_cipd_package_json(input_file, output, extra):
+    with open(input_file) as ins:
         packages = json.load(ins)
 
         file_packages = packages.get('packages')
@@ -81,7 +81,7 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        '--input', '-i', required=True
+        '--input', '-i', dest='input_file', required=True
     )
     parser.add_argument(
         '--output', '-o', required=True

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -380,7 +380,7 @@ def dump_json_ids(output_dir):
     device_types, _ = build_xml_device_types(Path(device_types_output_dir))
 
     def write_json(elements: dict, path: str) -> None:
-        json_dict = {id: c.name for id, c in sorted(elements.items())}
+        json_dict = {element_id: c.name for element_id, c in sorted(elements.items())}
 
         with open(path, "wt+") as outfile:
             json.dump(json_dict, outfile, indent=4)
@@ -407,45 +407,45 @@ def dump_ids_from_data_model_dirs():
     data_model_dirs = [d for d in os.listdir(data_model_path) if os.path.isdir(os.path.join(data_model_path, d))]
     # Don't include master right now - it's in progress, not official
     data_model_dirs = sorted([d for d in data_model_dirs if 'master' not in d])
-    for dir in data_model_dirs:
-        clusters, _ = build_xml_clusters(Path(os.path.join(data_model_path, dir, 'clusters')))
-        device_types, _ = build_xml_device_types(Path(os.path.join(data_model_path, dir, 'device_types')))
+    for data_model_dir in data_model_dirs:
+        clusters, _ = build_xml_clusters(Path(os.path.join(data_model_path, data_model_dir, 'clusters')))
+        device_types, _ = build_xml_device_types(Path(os.path.join(data_model_path, data_model_dir, 'device_types')))
 
         def cluster_support_str(c):
             return "P" if c.is_provisional else "C"
 
-        version_clusters[dir] = {id: cluster_support_str(c) for id, c in clusters.items()}
+        version_clusters[data_model_dir] = {k: cluster_support_str(c) for k, c in clusters.items()}
 
         # Update the PICS Codes
-        for id, c in clusters.items():
-            if id not in pics_code_clusters:
-                pics_code_clusters[id] = c.pics
-            elif pics_code_clusters[id] != c.pics:
-                log.warning("PICS Code is inconsistent among different versions of the spec for cluster ID #%s!", id)
+        for k, c in clusters.items():
+            if k not in pics_code_clusters:
+                pics_code_clusters[k] = c.pics
+            elif pics_code_clusters[k] != c.pics:
+                log.warning("PICS Code is inconsistent among different versions of the spec for cluster ID #%s!", k)
 
         # Device types don't currently have provisional markings in the spec
         # But a device type can't be certified if it has mandatory clusters that are provisional
         # TODO: create provisional
 
         def device_type_support_str(d):
-            log.info("checking device type for '%s' for '%s'", d.name, dir)
-            dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
+            log.info("checking device type for '%s' for '%s'", d.name, data_model_dir)
+            dt_server_mandatory = [k for k, requirement in d.server_clusters.items() if requirement.conformance(
                 EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
-            dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
+            dt_client_mandatory = [k for k, requirement in d.client_clusters.items(
             ) if requirement.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 log.info("Found provisional mandatory clusters server:'%s' "
                          "client: '%s' in device type '%s' for revision '%s'",
-                         server_provisional, client_provisional, d.name, dir)
+                         server_provisional, client_provisional, d.name, data_model_dir)
                 return "P"
             return "C"
 
-        version_device_types[dir] = {id: device_type_support_str(d) for id, d in device_types.items()}
+        version_device_types[data_model_dir] = {k: device_type_support_str(d) for k, d in device_types.items()}
 
-        all_clusters.update({id: c.name for id, c in clusters.items()})
-        all_device_types.update({id: d.name for id, d in device_types.items()})
+        all_clusters.update({k: c.name for k, c in clusters.items()})
+        all_device_types.update({k: d.name for k, d in device_types.items()})
 
     def print_out_ids(filename: Path,
                       spec_section: str,
@@ -493,32 +493,32 @@ def dump_ids_from_data_model_dirs():
             hashes += f'{"-" * pics_code_len}|'
 
         version_len: dict[str, int] = {}
-        for dir in supported:
-            tag_path = os.path.join(paths.get_data_model_path(), dir, 'spec_tag')
+        for version_dir in supported:
+            tag_path = os.path.join(paths.get_data_model_path(), version_dir, 'spec_tag')
             try:
                 with open(tag_path, "r") as tag_file:
                     version = tag_file.read().strip()
             except FileNotFoundError:
-                version = dir
+                version = version_dir
             title += f'{version}|'
-            version_len[dir] = len(version)
-            hashes += f'{"-" * version_len[dir]}|'
+            version_len[version_dir] = len(version)
+            hashes += f'{"-" * version_len[version_dir]}|'
         table_header = f'{title}\n{hashes}\n'
 
         lines = []
-        for id, name in sorted(id_to_name.items()):
-            hex_id = f'0x{id:04X}'
-            line = f'|{id:<{dec_len}}|{hex_id:<{hex_len}}|{name:<{name_len}}|'
+        for element_id, name in sorted(id_to_name.items()):
+            hex_id = f'0x{element_id:04X}'
+            line = f'|{element_id:<{dec_len}}|{hex_id:<{hex_len}}|{name:<{name_len}}|'
 
             # Add PICS code (only for clusters)
             if pics_codes is not None:
-                line += f'{pics_codes[id]:<{pics_code_len}}|'
+                line += f'{pics_codes[element_id]:<{pics_code_len}}|'
 
-            for dir in supported:
+            for version_dir in supported:
                 try:
-                    line += f'{supported[dir][id]:<{version_len[dir]}}|'
+                    line += f'{supported[version_dir][element_id]:<{version_len[version_dir]}}|'
                 except KeyError:
-                    line += f'{" " * version_len[dir]}|'
+                    line += f'{" " * version_len[version_dir]}|'
             lines.append(line)
 
         with open(filename, 'w') as fout:

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -27,8 +27,8 @@ from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_cl
 
 
 def get_changes(old, new):
-    added = [e.name for id, e in new.items() if id not in old]
-    removed = [e.name for id, e in old.items() if id not in new]
+    added = [e.name for k, e in new.items() if k not in old]
+    removed = [e.name for k, e in old.items() if k not in new]
     same_ids = set(new.keys()).intersection(set(old.keys()))
 
     return added, removed, same_ids
@@ -45,17 +45,17 @@ def str_changes(element, added, removed, change_ids, old, new):
         ret.append(f'\t{element} removed: {removed}')
     if change_ids:
         ret.append(f'\t{element} changed:')
-    for id in change_ids:
-        name = old[id].name if old[id].name == new[id].name else f'{new[id].name} (previously {old[id].name})'
+    for change_id in change_ids:
+        name = old[change_id].name if old[change_id].name == new[change_id].name else f'{new[change_id].name} (previously {old[change_id].name})'
         ret.append(f'\t\t{name}')
-        ret.append(f'\t\t\t{old[id]}')
-        ret.append(f'\t\t\t{new[id]}')
+        ret.append(f'\t\t\t{old[change_id]}')
+        ret.append(f'\t\t\t{new[change_id]}')
     return ret
 
 
 def str_element_changes(element, old, new):
     added, removed, same_ids = get_changes(old, new)
-    change_ids = [id for id in same_ids if old[id] != new[id] or str(old[id].conformance) != str(new[id].conformance)]
+    change_ids = [change_id for change_id in same_ids if old[change_id] != new[change_id] or str(old[change_id].conformance) != str(new[change_id].conformance)]
     return str_changes(element, added, removed, change_ids, old, new)
 
 
@@ -143,10 +143,10 @@ def get_provisional_diff(rev1: PrebuiltDataModelDirectory, rev2: PrebuiltDataMod
     print(f'\n\nProvisional clusters in {rev2.dirname} not in {rev1.dirname}')
     print(f'\t{sorted(rev2_additional_provisional_clusters)}')
 
-    for id, c2 in clusters_rev2.items():
-        if id not in clusters_rev1:
+    for k, c2 in clusters_rev2.items():
+        if k not in clusters_rev1:
             continue
-        c1 = clusters_rev1[id]
+        c1 = clusters_rev1[k]
         rev2_provisional_features = _get_provisional(c2.features.values())
         rev1_provisional_features = _get_provisional(c1.features.values())
         features = rev2_provisional_features - rev1_provisional_features

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -46,7 +46,8 @@ def str_changes(element, added, removed, change_ids, old, new):
     if change_ids:
         ret.append(f'\t{element} changed:')
     for change_id in change_ids:
-        name = old[change_id].name if old[change_id].name == new[change_id].name else f'{new[change_id].name} (previously {old[change_id].name})'
+        name = old[change_id].name if old[change_id].name == new[
+            change_id].name else f'{new[change_id].name} (previously {old[change_id].name})'
         ret.append(f'\t\t{name}')
         ret.append(f'\t\t\t{old[change_id]}')
         ret.append(f'\t\t\t{new[change_id]}')
@@ -55,7 +56,8 @@ def str_changes(element, added, removed, change_ids, old, new):
 
 def str_element_changes(element, old, new):
     added, removed, same_ids = get_changes(old, new)
-    change_ids = [change_id for change_id in same_ids if old[change_id] != new[change_id] or str(old[change_id].conformance) != str(new[change_id].conformance)]
+    change_ids = [change_id for change_id in same_ids if old[change_id] != new[change_id]
+                  or str(old[change_id].conformance) != str(new[change_id].conformance)]
     return str_changes(element, added, removed, change_ids, old, new)
 
 

--- a/scripts/tests/chipyaml/tests_finder.py
+++ b/scripts/tests/chipyaml/tests_finder.py
@@ -90,7 +90,7 @@ class TestsFinder:
         paths = []
 
         for name in test_names:
-            for root, dir, files in os.walk(self.__test_directory):
+            for root, _, files in os.walk(self.__test_directory):
                 if name in files:
                     paths.append(os.path.join(root, name))
                 elif (name + _YAML_FILE_EXTENSION) in files:

--- a/scripts/tests/chipyaml/tests_logger.py
+++ b/scripts/tests/chipyaml/tests_logger.py
@@ -27,8 +27,8 @@ from matter.yamltests.hooks import TestParserHooks, TestRunnerHooks, WebSocketRu
 from matter.yamltests.parser import TestStep
 
 
-def _strikethrough(str):
-    return '\u0336'.join(str[i:i+1] for i in range(0, len(str), 1))
+def _strikethrough(s):
+    return '\u0336'.join(s[i:i+1] for i in range(0, len(s), 1))
 
 
 _SUCCESS = click.style(u'\N{check mark}', fg='green')

--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -299,10 +299,10 @@ def run_script_in_interactive_mode():
     return context
 
 
-def run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, help):
+def run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, show_help):
     fuzz_tests = list_fuzz_test_binaries()
 
-    if help or not fuzz_test:
+    if show_help or not fuzz_test:
         log.info("\nAVAILABLE FUZZTEST BINARIES in 'out' directory (each Binary can have multiple FUZZ_TESTs/TestCases): \n")
         previous_build_target_dir = ""
         for test in fuzz_tests:
@@ -362,9 +362,9 @@ def run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, help):
 @click.option("--test-case", help="Specific test case to run in continuous mode OR add '--test-case all' to run all Testcases for a few seconds.")
 @click.option("--list-test-cases", is_flag=True, help="List available test cases for the given FuzzTest binary and exit.")
 @click.option("--interactive", is_flag=True, help="Run Script in Interactive Mode (automatically lists FuzzTests, TestCases and allows choosing easily).")
-@click.option('--help', is_flag=True, help="Show this message and exit.")
+@click.option('--help', 'show_help', is_flag=True, help="Show this message and exit.")
 @click.option("--output", help="Optional directory for coverage report (auto-generated if not provided).")
-def main(fuzz_test, test_case, list_test_cases, interactive, output, help):
+def main(fuzz_test, test_case, list_test_cases, interactive, output, show_help):
 
     coloredlogs.install(
         level="DEBUG",
@@ -376,7 +376,7 @@ def main(fuzz_test, test_case, list_test_cases, interactive, output, help):
         },
     )
 
-    if help or not fuzz_test:
+    if show_help or not fuzz_test:
         log.info("\nThis Script:")
         log.info("1. Runs Google FuzzTests in CONTINUOUS_FUZZ_MODE or UNIT_TEST_MODE")
         log.info("2. Automatically generates HTML Coverage Report if FuzzTest is coverage-instrumented.\n")
@@ -392,7 +392,7 @@ def main(fuzz_test, test_case, list_test_cases, interactive, output, help):
         if interactive:
             context = run_script_in_interactive_mode()
         else:
-            context = run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, help)
+            context = run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, show_help)
 
     except Exception as e:
         log.exception(e)

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -448,11 +448,11 @@ def main():
             raise Exception("chip-cert should be built before and is specified.")
         log.info("chip-cert path: '%s'", args.chip_cert)
 
-    def to_bytes(input):
-        if isinstance(input, str):
-            return bytearray.fromhex(input)
-        if isinstance(input, bytes):
-            return input
+    def to_bytes(data):
+        if isinstance(data, str):
+            return bytearray.fromhex(data)
+        if isinstance(data, bytes):
+            return data
         return None
 
     def hex_to_int(hex_string):

--- a/scripts/tools/cancel_workflows_for_pr.py
+++ b/scripts/tools/cancel_workflows_for_pr.py
@@ -121,8 +121,8 @@ class Canceller:
             log.info("No critical failures found")
             return
 
-        for id in in_progress_workflows:
-            workflow = self.repo.get_workflow_run(id)
+        for workflow_id in in_progress_workflows:
+            workflow = self.repo.get_workflow_run(workflow_id)
             if self.dry_run:
                 log.warning("DRY RUN: Will not stop '%s'", workflow.name)
             else:

--- a/scripts/tools/compile_flags_from_compile_commands.py
+++ b/scripts/tools/compile_flags_from_compile_commands.py
@@ -60,10 +60,10 @@ __LOG_LEVELS__ = logging.getLevelNamesMapping()
 
 
 class CompileCommand:
-    def __init__(self, dir, file, command):
+    def __init__(self, directory, file, command):
         args = shlex.split(command)
 
-        self.dir = dir
+        self.directory = directory
         self.file = file
         self.compiler = args[0]
         self.args = []
@@ -87,7 +87,7 @@ class CompileCommand:
                 if arg.startswith(p + "/"):
                     continue
                 path = arg[len(p):]  # full path
-                path = os.path.abspath(os.path.join(self.dir, path))
+                path = os.path.abspath(os.path.join(self.directory, path))
                 arg = f"{p}{path}"
                 break
 
@@ -105,7 +105,7 @@ class CompileCommand:
 
     def __str__(self):
         prefix = "\n      "  # have all args on newlines with an indent
-        return f"[{self.dir}: {self.file}] -> {prefix}{prefix.join(self.args)}"
+        return f"[{self.directory}: {self.file}] -> {prefix}{prefix.join(self.args)}"
 
 
 class ParsedCommands:

--- a/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
+++ b/scripts/tools/nrfconnect/nrfconnect_generate_partition.py
@@ -40,13 +40,13 @@ class PartitionCreator:
 
     """
 
-    def __init__(self, offset: int, length: int, input: str, output: str) -> None:
+    def __init__(self, offset: int, length: int, input_file: str, output: str) -> None:
         self._ih = IntelHex()
         self._length = length
         self._offset = offset
         self._data_ready = False
         self._output = output
-        self._input = input
+        self._input_file = input_file
         try:
             self.__data_to_save = self._convert_to_dict(self._load_json())
         except IOError:
@@ -118,10 +118,10 @@ class PartitionCreator:
         :raises IOError: if provided JSON file can not be read out.
         """
         try:
-            with open(self._input, "rb") as json_file:
+            with open(self._input_file, "rb") as json_file:
                 return json.loads(json_file.read())
         except IOError as e:
-            log.error("Can not read Json file '%s'", self._input)
+            log.error("Can not read Json file '%s'", self._input_file)
             raise e
 
 

--- a/scripts/tools/silabs/FactoryDataProvider.py
+++ b/scripts/tools/silabs/FactoryDataProvider.py
@@ -72,7 +72,7 @@ class FactoryDataWriter:
         return generation_results["Verifier"]
 
     # Populates numberOfBits starting from LSB of input into bits, which is assumed to be zero-initialized
-    def WriteBits(self, bits, offset, input, numberOfBits, totalPayloadSizeInBits):
+    def WriteBits(self, bits, offset, input_data, numberOfBits, totalPayloadSizeInBits):
         if ((offset + numberOfBits) > totalPayloadSizeInBits):
             print("THIS IS NOT VALID")
             return None
@@ -80,11 +80,11 @@ class FactoryDataWriter:
 
         index = offset
         offset += numberOfBits
-        while (input != 0):
-            if (input & 1):
+        while (input_data != 0):
+            if (input_data & 1):
                 bits[int(index / 8)] |= (1 << (index % 8))
             index += 1
-            input >>= 1
+            input_data >>= 1
 
         return offset
 

--- a/scripts/tools/summarize_fail.py
+++ b/scripts/tools/summarize_fail.py
@@ -30,7 +30,7 @@ def pass_fail_rate(workflow):
         log.info("This workflow has already been processed.")
 
 
-def process_fail(id, pr, start_time, workflow):
+def process_fail(workflow_id, pr, start_time, workflow):
     log.info("Processing failure in PR '%s', workflow '%s' that started at '%s'", pr, workflow, start_time)
 
     log.info("Building output file structure.")
@@ -38,7 +38,7 @@ def process_fail(id, pr, start_time, workflow):
     os.makedirs(output_path)
 
     log.info("Gathering raw fail logs.")
-    subprocess.run(f"gh run view -R project-chip/connectedhomeip {id} --log-failed > {output_path}/fail_log.txt", shell=True)
+    subprocess.run(f"gh run view -R project-chip/connectedhomeip {workflow_id} --log-failed > {output_path}/fail_log.txt", shell=True)
 
     # Eventually turn this into a catalog of error messages per workflow
     log.info("Collecting info on likely cause of failure.")

--- a/scripts/tools/summarize_fail.py
+++ b/scripts/tools/summarize_fail.py
@@ -38,7 +38,8 @@ def process_fail(workflow_id, pr, start_time, workflow):
     os.makedirs(output_path)
 
     log.info("Gathering raw fail logs.")
-    subprocess.run(f"gh run view -R project-chip/connectedhomeip {workflow_id} --log-failed > {output_path}/fail_log.txt", shell=True)
+    subprocess.run(
+        f"gh run view -R project-chip/connectedhomeip {workflow_id} --log-failed > {output_path}/fail_log.txt", shell=True)
 
     # Eventually turn this into a catalog of error messages per workflow
     log.info("Collecting info on likely cause of failure.")

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -95,8 +95,8 @@ class ZapTool:
             print('*'*80)
             sys.exit(1)
 
-        def parse_version_string(str):
-            return [int(component) for component in str.split('.')]
+        def parse_version_string(s):
+            return [int(component) for component in s.split('.')]
 
         if parse_version_string(version) < parse_version_string(MIN_ZAP_VERSION):
             print(f"Checking ZAP from {self.zap_start}:")

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -411,19 +411,19 @@ def getSpecificTemplatesTargets():
     return targets
 
 
-def getTargets(type):
+def getTargets(target_type):
     targets = []
 
-    if type & TargetType.GLOBAL:
+    if target_type & TargetType.GLOBAL:
         targets.extend(getGlobalTemplatesTargets())
 
-    if type & TargetType.SPECIFIC:
+    if target_type & TargetType.SPECIFIC:
         targets.extend(getSpecificTemplatesTargets())
 
-    if type & TargetType.IDL_CODEGEN:
+    if target_type & TargetType.IDL_CODEGEN:
         targets.extend(getCodegenTemplates())
 
-    if type & TargetType.GOLDEN_TEST_IMAGES:
+    if target_type & TargetType.GOLDEN_TEST_IMAGES:
         targets.extend(getGoldenTestImageTargets())
 
     log.info("Targets to be generated:")


### PR DESCRIPTION
#### Summary

A part of a larger effort to increase coverage of useful `ruff` rules in our codebase, in particular the `A` ruleset which flags symbols shadowing builtins. Fixes restricted to the `scripts/` directory for easier reviewing. 

There are ~300 locations which need to be changed in total, more PRs focused on other directories will follow with the final PR enabling the `A` ruleset in `pyproject.toml`.

#### Testing

Local builds in devcontainer.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
