### PR TITLE
Fix Gemini Review Bot Regression - Add GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+Read AGENTS.md


### PR DESCRIPTION
The Gemini review bot regressed since we removed the `.gemini/styleguide` and added `AGENTS.md` in (https://github.com/project-chip/connectedhomeip/pull/71642). For example, it started commenting on formatting style (https://github.com/project-chip/connectedhomeip/pull/71919#discussion_r3190041961).

I talked to the Google team that manages the review bot and they clarified the bot looks for `.gemini/style_guide.md` or `GEMINI.md` files and suggested I write a `GEMINI.md` with a single line that says "Read AGENTS.md".

### Testing
Manually verified file creation and content. Cannot test bot behavior until PR is scanned.
