### PR TITLE
[Darwin] Fix use-after-free in MTRDeviceConnectivityMonitor linger timer

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
@@ -50,6 +50,10 @@ static os_unfair_lock sConnectivityMonitorLock = OS_UNFAIR_LOCK_INIT;
 // Tracks number of currently active monitors. When this drops to zero, triggers timer
 // to cleanup sSharedResolverConnection after kSharedConnectionLingerIntervalSeconds.
 static NSUInteger sConnectivityMonitorCount;
+// Incremented each time a monitor starts; linger timers capture the current value and
+// only fire if it hasn't changed, preventing stale timers from freeing the shared
+// connection while newer child resolvers are still pending cleanup.
+static NSUInteger sSharedResolverLingerGeneration;
 static DNSServiceRef sSharedResolverConnection;
 static dispatch_queue_t sSharedResolverQueue;
 
@@ -318,6 +322,7 @@ static void ResolveCallback(
 
         if (_resolvers.size() != 0) {
             sConnectivityMonitorCount++;
+            sSharedResolverLingerGeneration++;
             result = YES;
             return;
         }
@@ -347,9 +352,10 @@ static void ResolveCallback(
         // Check if we should do linger cleanup
         std::lock_guard lock(sConnectivityMonitorLock);
         if (!sConnectivityMonitorCount) {
+            NSUInteger generationAtSchedule = sSharedResolverLingerGeneration;
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kSharedConnectionLingerIntervalSeconds * NSEC_PER_SEC), sSharedResolverQueue, ^{
                 std::lock_guard lock(sConnectivityMonitorLock);
-                if (!sConnectivityMonitorCount && sSharedResolverConnection) {
+                if (!sConnectivityMonitorCount && sSharedResolverConnection && sSharedResolverLingerGeneration == generationAtSchedule) {
                     MTR_LOG("MTRDeviceConnectivityMonitor: Closing shared resolver connection");
                     DNSServiceRefDeallocate(sSharedResolverConnection);
                     sSharedResolverConnection = NULL;


### PR DESCRIPTION
#### Summary

A queued linger timer can tear down the shared connection while other resolver cleanup blocks are still queued.  Add a generation counter that linger timer cleanup blocks capture at schedule time and check before cleaning up - if the generation increased, other monitors have used the shared connection since; no-op the cleanup.

#### Related issues

N/A

#### Testing

No new functionality.  Practically testing this would require mocking DNSServiceRef and dispatch queues.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase