### PR TITLE
Remove endpoint assertion from TC_OO_2_7.py

### DIFF
--- a/src/python_testing/TC_OO_2_7.py
+++ b/src/python_testing/TC_OO_2_7.py
@@ -135,7 +135,6 @@ class TC_OO_2_7(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.Groups.Commands.RemoveAllGroups())
 
         self.step("1a")
-        asserts.assert_equal(1, self.matter_test_config.endpoint, "Endpoint should be 1")
         if self.groupcast_enabled:
             await self.TH1.SendCommand(self.dut_node_id, 0, Clusters.Groupcast.Commands.JoinGroup(
                 groupID=self.kGroup1,


### PR DESCRIPTION
#### Summary

Remove assert statement for endpoint check.



cherry pick of https://github.com/project-chip/connectedhomeip/pull/71683/changes/38a841c25ffdddb0f4e6f7c87e3dbe50cb482168


#### Related issues

addresses project-chip/certification-tool#958

#### Testing

this is a test

