### PR TITLE
[Mergify] allow people to `request-backport-sve` and `request-backport-supported`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,6 +47,7 @@ pull_request_rules:
     - name: Backport to v1.6-sve-branch
       conditions:
           - merged
+          - base=master
           - label="request-backport-sve"
       actions:
           backport:
@@ -56,6 +57,7 @@ pull_request_rules:
     - name: Backport to supported branches
       conditions:
           - merged
+          - base=master
           - label="request-backport-supported"
       actions:
           backport:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,97 +1,97 @@
 pull_request_rules:
-  - name: Label conflicting pull requests
-    description: Add a label to a pull request with conflict to spot it easily
-    conditions:
-      - conflict
-      - '-closed'
-    actions:
-      label:
-        toggle:
+    - name: Label conflicting pull requests
+      description: Add a label to a pull request with conflict to spot it easily
+      conditions:
           - conflict
-  # WARNING: If the rule name below is changed, you must also update the
-  # condition `check-failure~=Automatic merge on PullApprove` to match the new name.
-  - name: Automatic merge on PullApprove
-    conditions:
-      - or:
-          - check-success=pullapprove
-          - label="fast track"
-      - '#approved-reviews-by>=1'
-      - '#review-threads-unresolved=0'
-      - '-draft'
-      - label!=docker
-      # Workaround for Mergify deadlock due to using "#check-failure=0":
-      # Mergify's own action check can appear as failed/cancelled if conditions stop matching;
-      # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
-      # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
-      # We whitelist only this self-check so merges aren't deadlocked, while all other failures still block.
-      - or:
-          - '#check-failure=0'
-          - and:
-              - '#check-failure=1'
-              # WARNING: This must match the rule name defined above.
-              # If the rule name changes, update this condition accordingly.
-              - check-failure~=Automatic merge on PullApprove
-      - '#check-pending=0'
-      - check-success~=Build
-      - or:
-          - check-success=pullapprove
-          - check-skipped=pullapprove
-          - check-neutral=pullapprove
-    actions:
-      merge:
-        method: squash
+          - "-closed"
+      actions:
+          label:
+              toggle:
+                  - conflict
+    # WARNING: If the rule name below is changed, you must also update the
+    # condition `check-failure~=Automatic merge on PullApprove` to match the new name.
+    - name: Automatic merge on PullApprove
+      conditions:
+          - or:
+                - check-success=pullapprove
+                - label="fast track"
+          - "#approved-reviews-by>=1"
+          - "#review-threads-unresolved=0"
+          - "-draft"
+          - label!=docker
+          # Workaround for Mergify deadlock due to using "#check-failure=0":
+          # Mergify's own action check can appear as failed/cancelled if conditions stop matching;
+          # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
+          # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
+          # We whitelist only this self-check so merges aren't deadlocked, while all other failures still block.
+          - or:
+                - "#check-failure=0"
+                - and:
+                      - "#check-failure=1"
+                      # WARNING: This must match the rule name defined above.
+                      # If the rule name changes, update this condition accordingly.
+                      - check-failure~=Automatic merge on PullApprove
+          - "#check-pending=0"
+          - check-success~=Build
+          - or:
+                - check-success=pullapprove
+                - check-skipped=pullapprove
+                - check-neutral=pullapprove
+      actions:
+          merge:
+              method: squash
 
-  # Backport rules - cherry-pick the squashed master commit after merge.
-  # Apply label request-backport-sve or request-backport-supported on the master PR
-  # (before or after merge) to trigger the corresponding backport.
-  - name: Backport to v1.6-sve-branch
-    conditions:
-      - merged
-      - label="request-backport-sve"
-    actions:
-      backport:
-        branches:
-          - v1.6-sve-branch
+    # Backport rules - cherry-pick the squashed master commit after merge.
+    # Apply label request-backport-sve or request-backport-supported on the master PR
+    # (before or after merge) to trigger the corresponding backport.
+    - name: Backport to v1.6-sve-branch
+      conditions:
+          - merged
+          - label="request-backport-sve"
+      actions:
+          backport:
+              branches:
+                  - v1.6-sve-branch
 
-  - name: Backport to supported branches
-    conditions:
-      - merged
-      - label="request-backport-supported"
-    actions:
-      backport:
-        branches:
-          - v1.5-branch
-          - v1.4.2-branch
+    - name: Backport to supported branches
+      conditions:
+          - merged
+          - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.5-branch
+                  - v1.4.2-branch
 
-  # Auto-merge backport PRs when CI is green and there are no conflicts.
-  # Mergify automatically labels backport PRs it creates as backport-{target-branch}.
-  # If a cherry-pick has conflicts or CI fails, the PR is left open for manual resolution.
-  # WARNING: If the rule name below is changed, you must also update the
-  # condition `check-failure~=Auto-merge clean backport PRs` to match the new name.
-  - name: Auto-merge clean backport PRs
-    conditions:
-      - or:
-          - label="backport-v1.6-sve-branch"
-          - label="backport-v1.5-branch"
-          - label="backport-v1.4.2-branch"
-      - author=mergify[bot]
-      - '-conflict'
-      - '-draft'
-      # Same deadlock workaround as above: allow exactly 1 failure if it is
-      # this rule's own self-check (which Mergify marks failed when conditions
-      # stop matching, and GitHub retains that historic failure forever).
-      - or:
-          - '#check-failure=0'
-          - and:
-              - '#check-failure=1'
-              # WARNING: This must match the rule name defined above.
-              # If the rule name changes, update this condition accordingly.
-              - check-failure~=Auto-merge clean backport PRs
-      - '#check-pending=0'
-      - check-success~=Build
-    actions:
-      merge:
-        method: squash
+    # Auto-merge backport PRs when CI is green and there are no conflicts.
+    # Mergify automatically labels backport PRs it creates as backport-{target-branch}.
+    # If a cherry-pick has conflicts or CI fails, the PR is left open for manual resolution.
+    # WARNING: If the rule name below is changed, you must also update the
+    # condition `check-failure~=Auto-merge clean backport PRs` to match the new name.
+    - name: Auto-merge clean backport PRs
+      conditions:
+          - or:
+                - label="backport-v1.6-sve-branch"
+                - label="backport-v1.5-branch"
+                - label="backport-v1.4.2-branch"
+          - author=mergify[bot]
+          - "-conflict"
+          - "-draft"
+          # Same deadlock workaround as above: allow exactly 1 failure if it is
+          # this rule's own self-check (which Mergify marks failed when conditions
+          # stop matching, and GitHub retains that historic failure forever).
+          - or:
+                - "#check-failure=0"
+                - and:
+                      - "#check-failure=1"
+                      # WARNING: This must match the rule name defined above.
+                      # If the rule name changes, update this condition accordingly.
+                      - check-failure~=Auto-merge clean backport PRs
+          - "#check-pending=0"
+          - check-success~=Build
+      actions:
+          merge:
+              method: squash
 
 merge_protections_settings:
-  reporting_method: check-runs
+    reporting_method: check-runs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,10 +20,10 @@ pull_request_rules:
       - '-draft'
       - label!=docker
       # Workaround for Mergify deadlock due to using "#check-failure=0":
-      # Mergify’s own action check can appear as failed/cancelled if conditions stop matching;
+      # Mergify's own action check can appear as failed/cancelled if conditions stop matching;
       # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
       # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
-      # We whitelist only this self-check so merges aren’t deadlocked, while all other failures still block.
+      # We whitelist only this self-check so merges aren't deadlocked, while all other failures still block.
       - or:
           - '#check-failure=0'
           - and:
@@ -40,5 +40,57 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+
+  # Backport rules - cherry-pick the squashed master commit after merge.
+  # Apply label request-backport-sve or request-backport-supported on the master PR
+  # (before or after merge) to trigger the corresponding backport.
+  - name: Backport to v1.6-sve-branch
+    conditions:
+      - merged
+      - label="request-backport-sve"
+    actions:
+      backport:
+        branches:
+          - v1.6-sve-branch
+
+  - name: Backport to supported branches
+    conditions:
+      - merged
+      - label="request-backport-supported"
+    actions:
+      backport:
+        branches:
+          - v1.5-branch
+          - v1.4.2-branch
+
+  # Auto-merge backport PRs when CI is green and there are no conflicts.
+  # Mergify automatically labels backport PRs it creates as backport-{target-branch}.
+  # If a cherry-pick has conflicts or CI fails, the PR is left open for manual resolution.
+  # WARNING: If the rule name below is changed, you must also update the
+  # condition `check-failure~=Auto-merge clean backport PRs` to match the new name.
+  - name: Auto-merge clean backport PRs
+    conditions:
+      - or:
+          - label="backport-v1.6-sve-branch"
+          - label="backport-v1.5-branch"
+          - label="backport-v1.4.2-branch"
+      - '-conflict'
+      - '-draft'
+      # Same deadlock workaround as above: allow exactly 1 failure if it is
+      # this rule's own self-check (which Mergify marks failed when conditions
+      # stop matching, and GitHub retains that historic failure forever).
+      - or:
+          - '#check-failure=0'
+          - and:
+              - '#check-failure=1'
+              # WARNING: This must match the rule name defined above.
+              # If the rule name changes, update this condition accordingly.
+              - check-failure~=Auto-merge clean backport PRs
+      - '#check-pending=0'
+      - check-success~=Build
+    actions:
+      merge:
+        method: squash
+
 merge_protections_settings:
   reporting_method: check-runs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -74,6 +74,7 @@ pull_request_rules:
           - label="backport-v1.6-sve-branch"
           - label="backport-v1.5-branch"
           - label="backport-v1.4.2-branch"
+      - author=mergify[bot]
       - '-conflict'
       - '-draft'
       # Same deadlock workaround as above: allow exactly 1 failure if it is


### PR DESCRIPTION
#### Summary

  Adds two cherry-pick workflows to .mergify.yml so maintainers can trigger backports by adding a label to any merged master PR, with fully automated merging when CI is clean.

  Labels to use on master PRs:
  - request-backport-sve — cherry-picks to v1.6-sve-branch (SVE test harness fixes)
  - request-backport-supported — cherry-picks to both v1.5-branch and v1.4.2-branch (security/important fixes for actively supported releases)

  Behavior:
  - Backport PRs are created only after the master PR merges
  - If the cherry-pick is clean and CI passes, the backport PR is auto-merged (squash) with no human review required
  - If there are conflicts or CI failures, the PR is left open for manual resolution
  - Auto-merge is restricted to PRs authored by mergify[bot] to prevent accidentally auto-merging manually opened PRs on release branches that happen to have backport labels

#### Testing

Rules should be clean. We will test it when using them.