### PR TITLE
[crosscompile docker] Add armhf (32-bit arm) sysroot to docker images

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-193 : [Tizen] Update installer script for Tizen 10.0
+194 : [crosscompile] Add armhf sysroot, update aarch64 sysroot to build-2026.05.07

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -15,22 +15,17 @@ WORKDIR /opt
 # Unpack the sysroots, while also removing some rather large items in them that
 # are generally not required for compilation
 RUN set -x \
+  && SYSROOT_VERSION="build-2026.05.07" \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && printf 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2026.05.07\nexperimental/matter/sysroot/ubuntu-24.04-armhf version:build-2026.05.07\n' > ensure_file.txt \
+  && echo "experimental/matter/sysroot/ubuntu-24.04-aarch64 version:${SYSROOT_VERSION}" > ensure_file.txt \
+  && echo "experimental/matter/sysroot/ubuntu-24.04-armhf version:${SYSROOT_VERSION}" >> ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/modules \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/modules \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/modules \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/modules \
+  && for arch in aarch64 armhf; do \
+       for d in usr/lib/firmware usr/lib/git-core usr/lib/modules lib/firmware lib/git-core lib/modules; do \
+         rm -rf "/opt/ubuntu-24.04-${arch}-sysroot/${d}"; \
+       done; \
+     done \
   && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -12,12 +12,12 @@ RUN set -x \
   && : # last line
 
 WORKDIR /opt
-# Unpack the sysroot, while also removing some rather large items in it that
+# Unpack the sysroots, while also removing some rather large items in them that
 # are generally not required for compilation
 RUN set -x \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2026.01.28' > ensure_file.txt \
+  && printf 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2026.05.07\nexperimental/matter/sysroot/ubuntu-24.04-armhf version:build-2026.05.07\n' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \
@@ -25,11 +25,19 @@ RUN set -x \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/git-core \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/modules \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/firmware \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/git-core \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/usr/lib/modules \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/firmware \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/git-core \
+  && rm -rf /opt/ubuntu-24.04-armhf-sysroot/lib/modules \
   && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
 COPY --from=build /opt/ubuntu-24.04-aarch64-sysroot/ /opt/ubuntu-24.04-aarch64-sysroot/
+COPY --from=build /opt/ubuntu-24.04-armhf-sysroot/ /opt/ubuntu-24.04-armhf-sysroot/
 
 ENV SYSROOT_AARCH64=/opt/ubuntu-24.04-aarch64-sysroot
+ENV SYSROOT_ARMHF=/opt/ubuntu-24.04-armhf-sysroot

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=telink /opt/telink/zephyr-sdk-0.17.0 /opt/telink/zephyr-sdk-0.17.0
 COPY --from=tizen /opt/tizen-sdk /opt/tizen-sdk
 
 COPY --from=crosscompile /opt/ubuntu-24.04-aarch64-sysroot /opt/ubuntu-24.04-aarch64-sysroot
+COPY --from=crosscompile /opt/ubuntu-24.04-armhf-sysroot /opt/ubuntu-24.04-armhf-sysroot
 
 COPY --from=ameba /opt/ameba /opt/ameba
 
@@ -115,6 +116,7 @@ ENV OPENOCD_PATH=/opt/openocd/
 ENV QEMU_ESP32=/opt/espressif/qemu/qemu-system-xtensa
 ENV QEMU_ESP32_DIR=/opt/espressif/qemu
 ENV SYSROOT_AARCH64=/opt/ubuntu-24.04-aarch64-sysroot
+ENV SYSROOT_ARMHF=/opt/ubuntu-24.04-armhf-sysroot
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr
 ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.17.0
 ENV TI_SYSCONFIG_ROOT=/opt/ti/sysconfig_1.22.0


### PR DESCRIPTION
#### Summary

This relies on sysroots that #71968 can create, however those already exist in https://chrome-infra-packages.appspot.com/p/experimental/matter/sysroot/ 

Intent is to get #71867 to compile

#### Testing

Docker image changes, should be clean. 

Manually ran:

```
docker build --network=host --build-arg VERSION=193 \
    -t ghcr.io/project-chip/chip-build-crosscompile:test \
    integrations/docker/images/stage-1/chip-build-crosscompile/
```