### PR TITLE
[ACL] Add Unit Test to ensure LegacyEncoding for ACL stays valid

### DIFF
--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -216,6 +216,8 @@ private:
     Optional<AttributeAccessToken> mACLCheckCache = NullOptional;
 
     DataModel::Provider * mDataModelProvider = nullptr;
+
+    // Required for legacy-encoded ACL list writes; lets CheckWriteAccess skip the re-check on repeated same-path writes
     std::optional<ConcreteAttributePath> mLastSuccessfullyWrittenPath;
 
     // This may be a "fake" pointer or a real delegate pointer, depending

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -218,6 +218,10 @@ private:
     DataModel::Provider * mDataModelProvider = nullptr;
 
     // Required for legacy-encoded ACL list writes; lets CheckWriteAccess skip the re-check on repeated same-path writes
+    // Legacy-encoded ACL list write produces, in one WriteRequestMessage:
+    //   #1 ReplaceAll([])  — empties ACL, removing the writer's own admin entry
+    //   #2 AppendItem(item) — same path; its ACL re-check would be denied if not for
+    //                          mLastSuccessfullyWrittenPath cache.
     std::optional<ConcreteAttributePath> mLastSuccessfullyWrittenPath;
 
     // This may be a "fake" pointer or a real delegate pointer, depending

--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -28,7 +28,6 @@
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/EventDataIB.h>
 #include <app/MessageDef/StatusIB.h>
-#include <app/MessageDef/WriteResponseMessage.h>
 #include <app/WriteClient.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
@@ -582,20 +581,20 @@ namespace {
 // Simulates the writer losing privilege between the ReplaceAll and AppendItem AttributeDataIBs of a legacy-encoded ACL list write:
 // allows the first two Check() calls (kView pre-check + actual write privilege for the first AttributeDataIB), then revokes the
 // writer's privilege.
-class WriterRevokedAfterFirstWriteDelegate : public AccessControl::Delegate
+class WriterRevokedAfterFirstAttributeDataIBDelegate : public AccessControl::Delegate
 {
 public:
     CHIP_ERROR Check(const SubjectDescriptor &, const chip::Access::RequestPath &, Privilege) override
     {
         static constexpr uint8_t kChecksPerWrite = 2;
 
+        mCheckCount++;
         if (mWriterRevoked)
         {
             return CHIP_ERROR_ACCESS_DENIED;
         }
 
-        mAllowedChecks++;
-        if (mAllowedChecks == kChecksPerWrite)
+        if (mCheckCount == kChecksPerWrite)
         {
             // First AttributeDataIB has been fully checked; simulate writer losing privilege that the following call to
             // WriteHandler::CheckWriteAccess (without the WriteHandler cache) would deny.
@@ -604,8 +603,8 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    uint8_t mAllowedChecks = 0;
-    bool mWriterRevoked    = false;
+    uint8_t mCheckCount = 0;
+    bool mWriterRevoked = false;
 };
 
 } // namespace
@@ -620,12 +619,11 @@ TEST_F(TestAclAttribute, LegacyEncodingCacheReuseDuringWrite)
 {
     using namespace Protocols::InteractionModel;
 
-    WriterRevokedAfterFirstWriteDelegate aclDelegate;
+    WriterRevokedAfterFirstAttributeDataIBDelegate aclDelegate;
     Access::GetAccessControl().Finish();
     EXPECT_SUCCESS(Access::GetAccessControl().Init(&aclDelegate, gDeviceTypeResolver));
 
     auto * engine = InteractionModelEngine::GetInstance();
-    EXPECT_SUCCESS(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()));
 
     TestWriteClientCallback callback;
     WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
@@ -662,7 +660,7 @@ TEST_F(TestAclAttribute, LegacyEncodingCacheReuseDuringWrite)
     // Last AttributeStatusIB is the AppendItem; cache (mLastSuccessfullyWrittenPath) makes its re-check pass.
     EXPECT_EQ(callback.mStatus.mStatus, Status::Success);
 
-    EXPECT_EQ(aclDelegate.mAllowedChecks, 2);
+    EXPECT_EQ(aclDelegate.mCheckCount, 2);
     EXPECT_TRUE(aclDelegate.mWriterRevoked);
 
     Access::GetAccessControl().Finish();

--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -19,12 +19,17 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <pw_unit_test/framework.h>
 
+#include <access/AccessControl.h>
 #include <access/examples/PermissiveAccessControlDelegate.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteEventPath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/EventDataIB.h>
+#include <app/MessageDef/StatusIB.h>
+#include <app/MessageDef/WriteResponseMessage.h>
+#include <app/WriteClient.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
 #include <app/tests/test-interaction-model-api.h>
@@ -58,6 +63,12 @@ const MockNodeConfig & TestMockNodeConfig()
 
     // clang-format off
     static const MockNodeConfig config({
+        MockEndpointConfig(kRootEndpointId, {
+            MockClusterConfig(chip::app::Clusters::AccessControl::Id, {
+                ClusterRevision::Id, FeatureMap::Id,
+                chip::app::Clusters::AccessControl::Attributes::Acl::Id,
+            }),
+        }),
         MockEndpointConfig(kTestEndpointId, {
             MockClusterConfig(kTestClusterId, {
                 ClusterRevision::Id, FeatureMap::Id, 1, 2, kTestAttributeId
@@ -564,6 +575,97 @@ TEST_F(TestAclAttribute, AccessDeniedPrecedenceOverUnsupportedAttribute_Write)
 
         engine->Shutdown();
     }
+}
+
+namespace {
+
+// Simulates the writer losing privilege between the ReplaceAll and AppendItem AttributeDataIBs of a legacy-encoded ACL list write:
+// allows the first two Check() calls (kView pre-check + actual write privilege for the first AttributeDataIB), then revokes the
+// writer's privilege.
+class WriterRevokedAfterFirstWriteDelegate : public AccessControl::Delegate
+{
+public:
+    CHIP_ERROR Check(const SubjectDescriptor &, const chip::Access::RequestPath &, Privilege) override
+    {
+        static constexpr uint8_t kChecksPerWrite = 2;
+
+        if (mWriterRevoked)
+        {
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
+        mAllowedChecks++;
+        if (mAllowedChecks == kChecksPerWrite)
+        {
+            // First AttributeDataIB has been fully checked; simulate writer losing privilege that the following call to
+            // WriteHandler::CheckWriteAccess (without the WriteHandler cache) would deny.
+            mWriterRevoked = true;
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    uint8_t mAllowedChecks = 0;
+    bool mWriterRevoked    = false;
+};
+
+} // namespace
+
+// Legacy-encoded ACL list write produces, in one WriteRequestMessage:
+//   #1 ReplaceAll([])  — empties ACL, removing the writer's own admin entry
+//   #2 AppendItem(item) — same path; its ACL re-check would be denied if not for
+//                         the WriteHandler mLastSuccessfullyWrittenPath cache.
+// This test asserts mStatus.mStatus == Success to guard the cache: if anyone removes
+// it, this test fails and signals that legacy-encoded ACL writes are broken.
+TEST_F(TestAclAttribute, LegacyEncodingCacheReuseDuringWrite)
+{
+    using namespace Protocols::InteractionModel;
+
+    WriterRevokedAfterFirstWriteDelegate aclDelegate;
+    Access::GetAccessControl().Finish();
+    EXPECT_SUCCESS(Access::GetAccessControl().Init(&aclDelegate, gDeviceTypeResolver));
+
+    auto * engine = InteractionModelEngine::GetInstance();
+    EXPECT_SUCCESS(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()));
+
+    TestWriteClientCallback callback;
+    WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+
+    // Encode Attribute
+    uint8_t tlvBuf[64];
+    TLV::TLVWriter tlvWriter;
+    tlvWriter.Init(tlvBuf, sizeof(tlvBuf));
+    TLV::TLVType arrayType;
+    EXPECT_SUCCESS(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType));
+    {
+        TLV::TLVType structType;
+        EXPECT_SUCCESS(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, structType));
+        EXPECT_SUCCESS(tlvWriter.EndContainer(structType));
+    }
+    EXPECT_SUCCESS(tlvWriter.EndContainer(arrayType));
+    EXPECT_SUCCESS(tlvWriter.Finalize());
+
+    // Send Write Request
+    TLV::TLVReader tlvReader;
+    tlvReader.Init(tlvBuf, tlvWriter.GetLengthWritten());
+    EXPECT_SUCCESS(tlvReader.Next());
+    ConcreteDataAttributePath aclPath(kRootEndpointId, Clusters::AccessControl::Id, Clusters::AccessControl::Attributes::Acl::Id);
+    EXPECT_SUCCESS(
+        writeClient.PutPreencodedAttribute(aclPath, tlvReader, WriteClient::TestListEncodingOverride::kForceLegacyEncoding));
+    EXPECT_SUCCESS(writeClient.SendWriteRequest(GetSessionBobToAlice()));
+    DrainAndServiceIO();
+
+    EXPECT_EQ(callback.mOnDoneCalled, 1);
+
+    // Two calls to OnResponse: one for the ReplaceAll, one for the AppendItem.
+    EXPECT_EQ(callback.mOnSuccessCalled, 2);
+
+    // Last AttributeStatusIB is the AppendItem; cache (mLastSuccessfullyWrittenPath) makes its re-check pass.
+    EXPECT_EQ(callback.mStatus.mStatus, Status::Success);
+
+    EXPECT_EQ(aclDelegate.mAllowedChecks, 2);
+    EXPECT_TRUE(aclDelegate.mWriterRevoked);
+
+    Access::GetAccessControl().Finish();
 }
 
 } // namespace app


### PR DESCRIPTION
#### Summary

- Add Unit Test to ensure LegacyEncoding for ACL stays valid.
- This is important in the event that `mLastSuccessfullyWrittenPath` is removed.

#### Related issues

- `mLastSuccessfullyWrittenPath` was introduced in https://github.com/project-chip/connectedhomeip/pull/34754

#### Testing

- This is a unit test

