### PR TITLE
apply ClearSecretData and SensitiveDataFixedBuffer consistently

### DIFF
--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -672,7 +672,7 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
     {
         policy     = GroupDataProvider::SecurityPolicy::kCacheAndSync;
         keys_count = 0;
-        memset(operational_keys, 0x00, sizeof(operational_keys));
+        Crypto::ClearSecretData(reinterpret_cast<uint8_t *>(operational_keys), sizeof(operational_keys));
         next = kInvalidKeysetId;
     }
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -574,8 +574,8 @@ CHIP_ERROR Spake2pVerifier::Deserialize(const ByteSpan & inSerialized)
 
 CHIP_ERROR Spake2pVerifier::Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin)
 {
-    uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
-    ReturnErrorOnFailure(ComputeWS(pbkdf2IterCount, salt, setupPin, serializedWS, sizeof(serializedWS)));
+    SensitiveDataFixedBuffer<kSpake2p_WS_Length * 2> serializedWS;
+    ReturnErrorOnFailure(ComputeWS(pbkdf2IterCount, salt, setupPin, serializedWS.Bytes(), serializedWS.Capacity()));
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t len;
@@ -587,12 +587,12 @@ CHIP_ERROR Spake2pVerifier::Generate(uint32_t pbkdf2IterCount, const ByteSpan & 
 
     // Compute w0
     len = sizeof(mW0);
-    SuccessOrExit(err = spake2p.ComputeW0(mW0, &len, &serializedWS[0], kSpake2p_WS_Length));
+    SuccessOrExit(err = spake2p.ComputeW0(mW0, &len, serializedWS.Bytes(), kSpake2p_WS_Length));
     VerifyOrExit(len == sizeof(mW0), err = CHIP_ERROR_INTERNAL);
 
     // Compute L
     len = sizeof(mL);
-    SuccessOrExit(err = spake2p.ComputeL(mL, &len, &serializedWS[kSpake2p_WS_Length], kSpake2p_WS_Length));
+    SuccessOrExit(err = spake2p.ComputeL(mL, &len, serializedWS.Bytes() + kSpake2p_WS_Length, kSpake2p_WS_Length));
     VerifyOrExit(len == sizeof(mL), err = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -604,15 +604,15 @@ CHIP_ERROR Spake2pVerifier::ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan &
                                       uint32_t ws_len)
 {
     PBKDF2_sha256 pbkdf2;
-    uint8_t littleEndianSetupPINCode[sizeof(uint32_t)];
-    Encoding::LittleEndian::Put32(littleEndianSetupPINCode, setupPin);
+    SensitiveDataFixedBuffer<sizeof(uint32_t)> littleEndianSetupPINCode;
+    Encoding::LittleEndian::Put32(littleEndianSetupPINCode.Bytes(), setupPin);
 
     VerifyOrReturnError(salt.size() >= kSpake2p_Min_PBKDF_Salt_Length && salt.size() <= kSpake2p_Max_PBKDF_Salt_Length,
                         CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(pbkdf2IterCount >= kSpake2p_Min_PBKDF_Iterations && pbkdf2IterCount <= kSpake2p_Max_PBKDF_Iterations,
                         CHIP_ERROR_INVALID_ARGUMENT);
 
-    return pbkdf2.pbkdf2_sha256(littleEndianSetupPINCode, sizeof(littleEndianSetupPINCode), salt.data(), salt.size(),
+    return pbkdf2.pbkdf2_sha256(littleEndianSetupPINCode.Bytes(), littleEndianSetupPINCode.Capacity(), salt.data(), salt.size(),
                                 pbkdf2IterCount, ws_len, ws);
 }
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1032,6 +1032,9 @@ void Spake2p_P256_SHA256_HKDF_HMAC::Clear()
     free_bn(tempbn);
     free_bn(order);
 
+    ClearSecretData(Kcab);
+    ClearSecretData(Kae);
+
     state = CHIP_SPAKE2P_STATE::PREINIT;
 }
 

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -928,7 +928,7 @@ void P256Keypair::Clear()
     {
         PsaP256KeypairContext & context = ToPsaContext(mKeypair);
         psa_destroy_key(context.key_id);
-        memset(&context, 0, sizeof(context));
+        ClearSecretData(reinterpret_cast<uint8_t *>(&context), sizeof(context));
         mInitialized = false;
     }
 }
@@ -1047,6 +1047,10 @@ void Spake2p_P256_SHA256_HKDF_HMAC::Clear()
     mbedtls_mpi_free(&context->tempbn);
 
     mbedtls_ecp_group_free(&context->curve);
+
+    ClearSecretData(Kcab);
+    ClearSecretData(Kae);
+
     state = CHIP_SPAKE2P_STATE::PREINIT;
 }
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -928,6 +928,10 @@ void Spake2p_P256_SHA256_HKDF_HMAC::Clear()
     mbedtls_mpi_free(&context->tempbn);
 
     mbedtls_ecp_group_free(&context->curve);
+
+    ClearSecretData(Kcab);
+    ClearSecretData(Kae);
+
     state = CHIP_SPAKE2P_STATE::PREINIT;
 }
 

--- a/src/crypto/RawKeySessionKeystore.cpp
+++ b/src/crypto/RawKeySessionKeystore.cpp
@@ -73,12 +73,12 @@ CHIP_ERROR RawKeySessionKeystore::DeriveSessionKeys(const ByteSpan & secret, con
                                                     AttestationChallenge & attestationChallenge)
 {
     HKDF_sha hkdf;
-    uint8_t keyMaterial[2 * sizeof(Symmetric128BitsKeyByteArray) + AttestationChallenge::Capacity()];
+    SensitiveDataFixedBuffer<2 * sizeof(Symmetric128BitsKeyByteArray) + AttestationChallenge::Capacity()> keyMaterial;
 
     ReturnErrorOnFailure(hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
-                                          keyMaterial, sizeof(keyMaterial)));
+                                          keyMaterial.Bytes(), keyMaterial.Capacity()));
 
-    Encoding::LittleEndian::Reader reader(keyMaterial, sizeof(keyMaterial));
+    Encoding::LittleEndian::Reader reader(keyMaterial.Bytes(), keyMaterial.Capacity());
 
     return reader.ReadBytes(i2rKey.AsMutable<Symmetric128BitsKeyByteArray>(), sizeof(Symmetric128BitsKeyByteArray))
         .ReadBytes(r2iKey.AsMutable<Symmetric128BitsKeyByteArray>(), sizeof(Symmetric128BitsKeyByteArray))

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -23,14 +23,6 @@
 #include <cstring>
 
 namespace chip {
-namespace Crypto {
-// Forward declaration: implementation lives in src/crypto/, linked at final binary.
-// Avoids a header dependency from src/lib/support/ on src/crypto/.
-void ClearSecretData(uint8_t * buf, size_t len);
-} // namespace Crypto
-} // namespace chip
-
-namespace chip {
 namespace Thread {
 
 /**
@@ -507,7 +499,7 @@ CHIP_ERROR OperationalDataset::SetDelayTimer(uint32_t aDelayMillis)
 
 void OperationalDataset::Clear()
 {
-    Crypto::ClearSecretData(mBuffer, sizeof(mBuffer));
+    memset(mBuffer, 0, sizeof(mBuffer));
     mData = ByteSpan(mBuffer, 0);
 }
 

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -23,6 +23,14 @@
 #include <cstring>
 
 namespace chip {
+namespace Crypto {
+// Forward declaration: implementation lives in src/crypto/, linked at final binary.
+// Avoids a header dependency from src/lib/support/ on src/crypto/.
+void ClearSecretData(uint8_t * buf, size_t len);
+} // namespace Crypto
+} // namespace chip
+
+namespace chip {
 namespace Thread {
 
 /**
@@ -495,6 +503,12 @@ CHIP_ERROR OperationalDataset::SetDelayTimer(uint32_t aDelayMillis)
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
     tlv->Set32(aDelayMillis);
     return CHIP_NO_ERROR;
+}
+
+void OperationalDataset::Clear()
+{
+    Crypto::ClearSecretData(mBuffer, sizeof(mBuffer));
+    mData = ByteSpan(mBuffer, 0);
 }
 
 } // namespace Thread

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -394,7 +394,7 @@ public:
     /**
      * This method clears all data stored in the dataset.
      */
-    void Clear() { mData = ByteSpan(mBuffer, 0); }
+    void Clear();
 
     /**
      * Returns a ByteSpan view of the current state of the dataset.

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -643,7 +643,7 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session)
 CHIP_ERROR CASESession::RecoverInitiatorIpk()
 {
     Credentials::GroupDataProvider::KeySet ipkKeySet;
-    auto wipeIpkKeySet = ScopeExit([&] { ipkKeySet.ClearKeys(); });
+    auto ipkKeySetWiperOnScopeExit = ScopeExit([&] { ipkKeySet.ClearKeys(); });
 
     CHIP_ERROR err = mGroupDataProvider->GetIpkKeySet(mFabricIndex, ipkKeySet);
 
@@ -962,8 +962,8 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestinationId(const ByteSpan & destinat
 
         // Get IPK operational group key set for current candidate fabric
         GroupDataProvider::KeySet ipkKeySet;
-        auto wipeIpkKeySet = ScopeExit([&] { ipkKeySet.ClearKeys(); });
-        CHIP_ERROR err     = mGroupDataProvider->GetIpkKeySet(fabricInfo.GetFabricIndex(), ipkKeySet);
+        auto ipkKeySetWiperOnScopeExit = ScopeExit([&] { ipkKeySet.ClearKeys(); });
+        CHIP_ERROR err                 = mGroupDataProvider->GetIpkKeySet(fabricInfo.GetFabricIndex(), ipkKeySet);
         if ((err != CHIP_NO_ERROR) ||
             ((ipkKeySet.num_keys_used == 0) || (ipkKeySet.num_keys_used > Credentials::GroupDataProvider::KeySet::kEpochKeysMax)))
         {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -602,10 +602,10 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session)
     switch (mState)
     {
     case State::kFinished: {
-        std::array<uint8_t, sizeof(mIPK) + kSHA256_Hash_Length> msg_salt;
+        SensitiveDataFixedBuffer<sizeof(mIPK) + kSHA256_Hash_Length> msg_salt;
 
         {
-            Encoding::LittleEndian::BufferWriter bbuf(msg_salt);
+            Encoding::LittleEndian::BufferWriter bbuf(msg_salt.Bytes(), msg_salt.Capacity());
             bbuf.Put(mIPK, sizeof(mIPK));
             bbuf.Put(mMessageDigest, sizeof(mMessageDigest));
 
@@ -613,16 +613,16 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session)
         }
 
         ReturnErrorOnFailure(session.InitFromSecret(*mSessionManager->GetSessionKeystore(), mSharedSecret.Span(),
-                                                    ByteSpan(msg_salt), CryptoContext::SessionInfoType::kSessionEstablishment,
-                                                    mRole));
+                                                    ByteSpan(msg_salt.ConstBytes(), msg_salt.Capacity()),
+                                                    CryptoContext::SessionInfoType::kSessionEstablishment, mRole));
 
         return CHIP_NO_ERROR;
     }
     case State::kFinishedViaResume: {
-        std::array<uint8_t, sizeof(mInitiatorRandom) + decltype(mResumeResumptionId)().size()> msg_salt;
+        SensitiveDataFixedBuffer<sizeof(mInitiatorRandom) + decltype(mResumeResumptionId)().size()> msg_salt;
 
         {
-            Encoding::LittleEndian::BufferWriter bbuf(msg_salt);
+            Encoding::LittleEndian::BufferWriter bbuf(msg_salt.Bytes(), msg_salt.Capacity());
             bbuf.Put(mInitiatorRandom, sizeof(mInitiatorRandom));
             bbuf.Put(mResumeResumptionId.data(), mResumeResumptionId.size());
 
@@ -630,7 +630,8 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session)
         }
 
         ReturnErrorOnFailure(session.InitFromSecret(*mSessionManager->GetSessionKeystore(), mSharedSecret.Span(),
-                                                    ByteSpan(msg_salt), CryptoContext::SessionInfoType::kSessionResumption, mRole));
+                                                    ByteSpan(msg_salt.ConstBytes(), msg_salt.Capacity()),
+                                                    CryptoContext::SessionInfoType::kSessionResumption, mRole));
 
         return CHIP_NO_ERROR;
     }
@@ -642,6 +643,7 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session)
 CHIP_ERROR CASESession::RecoverInitiatorIpk()
 {
     Credentials::GroupDataProvider::KeySet ipkKeySet;
+    auto wipeIpkKeySet = ScopeExit([&] { ipkKeySet.ClearKeys(); });
 
     CHIP_ERROR err = mGroupDataProvider->GetIpkKeySet(mFabricIndex, ipkKeySet);
 
@@ -960,7 +962,8 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestinationId(const ByteSpan & destinat
 
         // Get IPK operational group key set for current candidate fabric
         GroupDataProvider::KeySet ipkKeySet;
-        CHIP_ERROR err = mGroupDataProvider->GetIpkKeySet(fabricInfo.GetFabricIndex(), ipkKeySet);
+        auto wipeIpkKeySet = ScopeExit([&] { ipkKeySet.ClearKeys(); });
+        CHIP_ERROR err     = mGroupDataProvider->GetIpkKeySet(fabricInfo.GetFabricIndex(), ipkKeySet);
         if ((err != CHIP_NO_ERROR) ||
             ((ipkKeySet.num_keys_used == 0) || (ipkKeySet.num_keys_used > Credentials::GroupDataProvider::KeySet::kEpochKeysMax)))
         {
@@ -1197,9 +1200,9 @@ CHIP_ERROR CASESession::PrepareSigma2(EncodeSigma2Inputs & outSigma2Data)
     // Generate a Shared Secret
     ReturnErrorOnFailure(mEphemeralKey->ECDH_derive_secret(mRemotePubKey, mSharedSecret));
 
-    uint8_t msgSalt[kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length];
+    SensitiveDataFixedBuffer<kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length> msgSalt;
 
-    MutableByteSpan saltSpan(msgSalt);
+    MutableByteSpan saltSpan(msgSalt.Bytes(), msgSalt.Capacity());
     ReturnErrorOnFailure(
         ConstructSaltSigma2(ByteSpan(outSigma2Data.responderRandom), mEphemeralKey->Pubkey(), ByteSpan(mIPK), saltSpan));
 
@@ -1498,8 +1501,8 @@ CHIP_ERROR CASESession::HandleSigma2(System::PacketBufferHandle && msg)
     // Generate the S2K key
     AutoReleaseSessionKey sr2k(*mSessionManager->GetSessionKeystore());
     {
-        uint8_t msg_salt[kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length];
-        MutableByteSpan saltSpan(msg_salt);
+        SensitiveDataFixedBuffer<kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length> msg_salt;
+        MutableByteSpan saltSpan(msg_salt.Bytes(), msg_salt.Capacity());
         ReturnErrorOnFailure(ConstructSaltSigma2(parsedSigma2.responderRandom, mRemotePubKey, ByteSpan(mIPK), saltSpan));
         ReturnErrorOnFailure(DeriveSigmaKey(saltSpan, ByteSpan(kKDFSR2Info), sr2k));
     }
@@ -1826,7 +1829,7 @@ CHIP_ERROR CASESession::SendSigma3c(SendSigma3Data & data, CHIP_ERROR status)
     System::PacketBufferHandle msg_R3;
     size_t data_len;
 
-    uint8_t msg_salt[kIPKSize + kSHA256_Hash_Length];
+    SensitiveDataFixedBuffer<kIPKSize + kSHA256_Hash_Length> msg_salt;
 
     AutoReleaseSessionKey sr3k(*mSessionManager->GetSessionKeystore());
 
@@ -1836,7 +1839,7 @@ CHIP_ERROR CASESession::SendSigma3c(SendSigma3Data & data, CHIP_ERROR status)
 
     // Generate S3K key
     {
-        MutableByteSpan saltSpan(msg_salt);
+        MutableByteSpan saltSpan(msg_salt.Bytes(), msg_salt.Capacity());
         SuccessOrExit(err = ConstructSaltSigma3(ByteSpan(mIPK), saltSpan));
         SuccessOrExit(err = DeriveSigmaKey(saltSpan, ByteSpan(kKDFSR3Info), sr3k));
     }
@@ -1915,7 +1918,7 @@ CHIP_ERROR CASESession::HandleSigma3a(System::PacketBufferHandle && msg)
 
     AutoReleaseSessionKey sr3k(*mSessionManager->GetSessionKeystore());
 
-    uint8_t msg_salt[kIPKSize + kSHA256_Hash_Length];
+    SensitiveDataFixedBuffer<kIPKSize + kSHA256_Hash_Length> msg_salt;
 
     ChipLogProgress(SecureChannel, "Received Sigma3 msg");
     MATTER_TRACE_COUNTER("Sigma3");
@@ -1947,7 +1950,7 @@ CHIP_ERROR CASESession::HandleSigma3a(System::PacketBufferHandle && msg)
             SuccessOrExit(err = ParseSigma3(tlvReader, msgR3Encrypted, msgR3EncryptedPayload, msgR3MIC));
 
             // Generate the S3K key
-            MutableByteSpan saltSpan(msg_salt);
+            MutableByteSpan saltSpan(msg_salt.Bytes(), msg_salt.Capacity());
             SuccessOrExit(err = ConstructSaltSigma3(ByteSpan(mIPK), saltSpan));
             SuccessOrExit(err = DeriveSigmaKey(saltSpan, ByteSpan(kKDFSR3Info), sr3k));
 

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -146,8 +146,8 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
     Encoding::LittleEndian::Put32(counterBuffer, counter);
 
     chip::Crypto::HMAC_sha shaHandler;
-    ReturnErrorOnFailure(
-        shaHandler.HMAC_SHA256(hmacKeyHandle, counterBuffer, sizeof(CounterType), hashWorkBuffer.Bytes(), hashWorkBuffer.Capacity()));
+    ReturnErrorOnFailure(shaHandler.HMAC_SHA256(hmacKeyHandle, counterBuffer, sizeof(CounterType), hashWorkBuffer.Bytes(),
+                                                hashWorkBuffer.Capacity()));
 
     writer.Put(hashWorkBuffer.Bytes(), CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES);
     VerifyOrReturnError(writer.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
 {
     VerifyOrReturnError(writer.Available() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    uint8_t hashWorkBuffer[CHIP_CRYPTO_HASH_LEN_BYTES] = { 0 };
+    Crypto::SensitiveDataFixedBuffer<CHIP_CRYPTO_HASH_LEN_BYTES> hashWorkBuffer;
     uint8_t counterBuffer[sizeof(CounterType)];
 
     // validate that Check-In counter is a uint32_t
@@ -147,9 +147,9 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
 
     chip::Crypto::HMAC_sha shaHandler;
     ReturnErrorOnFailure(
-        shaHandler.HMAC_SHA256(hmacKeyHandle, counterBuffer, sizeof(CounterType), hashWorkBuffer, CHIP_CRYPTO_HASH_LEN_BYTES));
+        shaHandler.HMAC_SHA256(hmacKeyHandle, counterBuffer, sizeof(CounterType), hashWorkBuffer.Bytes(), hashWorkBuffer.Capacity()));
 
-    writer.Put(hashWorkBuffer, CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES);
+    writer.Put(hashWorkBuffer.Bytes(), CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES);
     VerifyOrReturnError(writer.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -140,19 +140,20 @@ void PASESession::Clear()
     MATTER_TRACE_SCOPE("Clear", "PASESession");
     // This function zeroes out and resets the memory used by the object.
     // It's done so that no security related information will be leaked.
-    memset(&mPASEVerifier, 0, sizeof(mPASEVerifier));
+    ClearSecretData(reinterpret_cast<uint8_t *>(&mPASEVerifier), sizeof(mPASEVerifier));
     mNextExpectedMsg.ClearValue();
 
     mSpake2p.Clear();
     mCommissioningHash.Clear();
 
     mIterationCount = 0;
-    mSaltLength     = 0;
     if (mSalt != nullptr)
     {
+        ClearSecretData(mSalt, mSaltLength);
         chip::Platform::MemoryFree(mSalt);
         mSalt = nullptr;
     }
+    mSaltLength      = 0;
     mPairingComplete = false;
     PairingSession::Clear();
 }
@@ -534,7 +535,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     uint8_t random[kPBKDFParamRandomNumberSize];
 
     ByteSpan salt;
-    uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
+    SensitiveDataFixedBuffer<kSpake2p_WS_Length * 2> serializedWS;
 
     ChipLogDetail(SecureChannel, "Received PBKDF param response");
 
@@ -603,11 +604,11 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     err = SetupSpake2p();
     SuccessOrExit(err);
 
-    err = Spake2pVerifier::ComputeWS(mIterationCount, salt, mSetupPINCode, serializedWS, sizeof(serializedWS));
+    err = Spake2pVerifier::ComputeWS(mIterationCount, salt, mSetupPINCode, serializedWS.Bytes(), serializedWS.Capacity());
     SuccessOrExit(err);
 
-    err = mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length, &serializedWS[kSpake2p_WS_Length],
-                               kSpake2p_WS_Length);
+    err = mSpake2p.BeginProver(nullptr, 0, nullptr, 0, serializedWS.Bytes(), kSpake2p_WS_Length,
+                               serializedWS.Bytes() + kSpake2p_WS_Length, kSpake2p_WS_Length);
     SuccessOrExit(err);
 
     err = SendMsg1();
@@ -660,7 +661,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
     uint8_t Y[kMAX_Point_Length];
     size_t Y_len = sizeof(Y);
 
-    uint8_t verifier[kMAX_Hash_Length];
+    SensitiveDataFixedBuffer<kMAX_Hash_Length> verifier;
     size_t verifier_len = kMAX_Hash_Length;
 
     ChipLogDetail(SecureChannel, "Received spake2p msg1");
@@ -688,7 +689,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
 
     SuccessOrExit(err = mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len));
     VerifyOrReturnError(Y_len == sizeof(Y), CHIP_ERROR_INTERNAL);
-    SuccessOrExit(err = mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len));
+    SuccessOrExit(err = mSpake2p.ComputeRoundTwo(X, X_len, verifier.Bytes(), &verifier_len));
     msg1 = nullptr;
 
     {
@@ -703,7 +704,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.Put(AsTlvContextTag(Pake2Tags::kPb), ByteSpan(Y)));
-        SuccessOrExit(err = tlvWriter.Put(AsTlvContextTag(Pake2Tags::kCb), ByteSpan(verifier, verifier_len)));
+        SuccessOrExit(err = tlvWriter.Put(AsTlvContextTag(Pake2Tags::kCb), ByteSpan(verifier.Bytes(), verifier_len)));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize(&msg2));
 
@@ -731,7 +732,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
     MATTER_TRACE_SCOPE("HandleMsg2_and_SendMsg3", "PASESession");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    uint8_t verifier[kMAX_Hash_Length];
+    SensitiveDataFixedBuffer<kMAX_Hash_Length> verifier;
     size_t verifier_len = kMAX_Hash_Length;
 
     System::PacketBufferHandle resp;
@@ -767,7 +768,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
     // ExitContainer() will return CHIP_END_OF_TLV if the EndOfContainer TLV element terminator is missing.
     SuccessOrExit(err = tlvReader.ExitContainer(containerType));
 
-    SuccessOrExit(err = mSpake2p.ComputeRoundTwo(Y, Y_len, verifier, &verifier_len));
+    SuccessOrExit(err = mSpake2p.ComputeRoundTwo(Y, Y_len, verifier.Bytes(), &verifier_len));
 
     SuccessOrExit(err = mSpake2p.KeyConfirm(peer_verifier, peer_verifier_len));
     msg2 = nullptr;
@@ -783,7 +784,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
 
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
-        SuccessOrExit(err = tlvWriter.Put(AsTlvContextTag(Pake3Tags::kCa), ByteSpan(verifier, verifier_len)));
+        SuccessOrExit(err = tlvWriter.Put(AsTlvContextTag(Pake3Tags::kCa), ByteSpan(verifier.Bytes(), verifier_len)));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize(&msg3));
 
@@ -796,7 +797,6 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
     ChipLogDetail(SecureChannel, "Sent spake2p msg3");
 
 exit:
-
     if (err != CHIP_NO_ERROR)
     {
         SendStatusReport(mExchangeCtxt, kProtocolCodeInvalidParam);

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -193,9 +193,9 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveState(const ScopedNodeId & node, 
                                                      const Crypto::P256ECDHDerivedSecret & sharedSecret, const CATValues & peerCATs)
 {
     // Save session state into key: /f/<fabricIndex>/s/<nodeId>
-    std::array<uint8_t, MaxStateSize()> buf;
+    Crypto::SensitiveDataFixedBuffer<MaxStateSize()> buf;
     TLV::TLVWriter writer;
-    writer.Init(buf);
+    writer.Init(buf.Bytes(), buf.Capacity());
 
     TLV::TLVType outerType;
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
@@ -213,20 +213,20 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveState(const ScopedNodeId & node, 
     const auto len = writer.GetLengthWritten();
     VerifyOrDie(CanCastTo<uint16_t>(len));
 
-    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(node).KeyName(), buf.data(), static_cast<uint16_t>(len)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(node).KeyName(), buf.Bytes(), static_cast<uint16_t>(len)));
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SimpleSessionResumptionStorage::LoadState(const ScopedNodeId & node, ResumptionIdStorage & resumptionId,
                                                      Crypto::P256ECDHDerivedSecret & sharedSecret, CATValues & peerCATs)
 {
-    std::array<uint8_t, MaxStateSize()> buf;
-    uint16_t len = static_cast<uint16_t>(buf.size());
+    Crypto::SensitiveDataFixedBuffer<MaxStateSize()> buf;
+    uint16_t len = static_cast<uint16_t>(buf.Capacity());
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(node).KeyName(), buf.data(), len));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(node).KeyName(), buf.Bytes(), len));
 
     TLV::ContiguousBufferTLVReader reader;
-    reader.Init(buf.data(), len);
+    reader.Init(buf.Bytes(), len);
 
     ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
     TLV::TLVType containerType;


### PR DESCRIPTION
#### Summary
- apply ClearSecretData and SensitiveDataFixedBuffer consistently for secret buffers

#### Testing

CI

