### PR TITLE
Add a command-line parameter `--camera-framerate` to the Linux camera app to allow overriding the default frame rate.

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -897,29 +897,10 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
-    uint16_t framerate = k30fpsVideoFrameRate; // Default to 30 fps
-    if (LinuxDeviceOptions::GetInstance().cameraFramerate.HasValue())
-    {
-        framerate = LinuxDeviceOptions::GetInstance().cameraFramerate.Value();
-    }
-    else
-    {
-        if (framerate < allocatedStream.minFrameRate)
-        {
-            framerate = allocatedStream.minFrameRate;
-        }
-        else if (framerate > allocatedStream.maxFrameRate)
-        {
-            framerate = allocatedStream.maxFrameRate;
-        }
-    }
-
-    if (framerate < allocatedStream.minFrameRate || framerate > allocatedStream.maxFrameRate)
-    {
-        ChipLogError(Camera, "Requested frame rate %u is out of range [%u, %u]", framerate, allocatedStream.minFrameRate,
-                     allocatedStream.maxFrameRate);
-        return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
-    }
+    const uint16_t framerate = std::clamp(
+        LinuxDeviceOptions::GetInstance().cameraFramerate.ValueOr(k30fpsVideoFrameRate),
+        allocatedStream.minFrameRate,
+        allocatedStream.maxFrameRate);
 
     mCurrentVideoFrameRate = framerate;
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -905,7 +905,8 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
 
     if (framerate < allocatedStream.minFrameRate || framerate > allocatedStream.maxFrameRate)
     {
-        ChipLogError(Camera, "Requested frame rate %u is out of range [%u, %u]", framerate, allocatedStream.minFrameRate, allocatedStream.maxFrameRate);
+        ChipLogError(Camera, "Requested frame rate %u is out of range [%u, %u]", framerate, allocatedStream.minFrameRate,
+                     allocatedStream.maxFrameRate);
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -897,10 +897,8 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
-    const uint16_t framerate = std::clamp(
-        LinuxDeviceOptions::GetInstance().cameraFramerate.ValueOr(k30fpsVideoFrameRate),
-        allocatedStream.minFrameRate,
-        allocatedStream.maxFrameRate);
+    const uint16_t framerate = std::clamp(LinuxDeviceOptions::GetInstance().cameraFramerate.ValueOr(k30fpsVideoFrameRate),
+                                          allocatedStream.minFrameRate, allocatedStream.maxFrameRate);
 
     mCurrentVideoFrameRate = framerate;
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -897,7 +897,7 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
-    uint16_t framerate = 30; // Default to 30 fps
+    uint16_t framerate = k30fpsVideoFrameRate; // Default to 30 fps
     if (LinuxDeviceOptions::GetInstance().cameraFramerate.HasValue())
     {
         framerate = LinuxDeviceOptions::GetInstance().cameraFramerate.Value();

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -897,10 +897,22 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
+    uint16_t framerate = 30; // Default to 30 fps
+    if (LinuxDeviceOptions::GetInstance().cameraFramerate.HasValue())
+    {
+        framerate = LinuxDeviceOptions::GetInstance().cameraFramerate.Value();
+    }
+
+    if (framerate < allocatedStream.minFrameRate || framerate > allocatedStream.maxFrameRate)
+    {
+        ChipLogError(Camera, "Requested frame rate %u is out of range [%u, %u]", framerate, allocatedStream.minFrameRate, allocatedStream.maxFrameRate);
+        return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
+    }
+
     // Create Gstreamer video pipeline using the final allocated stream parameters
     CameraError error          = CameraError::SUCCESS;
     GstElement * videoPipeline = CreateVideoPipeline(mVideoDevicePath, allocatedStream.minResolution.width,
-                                                     allocatedStream.minResolution.height, allocatedStream.minFrameRate, error);
+                                                     allocatedStream.minResolution.height, framerate, error);
     if (videoPipeline == nullptr)
     {
         ChipLogError(Camera, "Failed to create video pipeline.");

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -902,6 +902,17 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
     {
         framerate = LinuxDeviceOptions::GetInstance().cameraFramerate.Value();
     }
+    else
+    {
+        if (framerate < allocatedStream.minFrameRate)
+        {
+            framerate = allocatedStream.minFrameRate;
+        }
+        else if (framerate > allocatedStream.maxFrameRate)
+        {
+            framerate = allocatedStream.maxFrameRate;
+        }
+    }
 
     if (framerate < allocatedStream.minFrameRate || framerate > allocatedStream.maxFrameRate)
     {
@@ -909,6 +920,8 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
                      allocatedStream.maxFrameRate);
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
+
+    mCurrentVideoFrameRate = framerate;
 
     // Create Gstreamer video pipeline using the final allocated stream parameters
     CameraError error          = CameraError::SUCCESS;
@@ -932,7 +945,7 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
     }
 
     ChipLogProgress(Camera, "Starting video stream (id=%u): %u×%u @ %ufps", streamID, allocatedStream.minResolution.width,
-                    allocatedStream.minResolution.height, allocatedStream.minFrameRate);
+                    allocatedStream.minResolution.height, framerate);
 
     // Start the pipeline
     ChipLogProgress(Camera, "Requesting PLAYING …");

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -1005,8 +1005,13 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         break;
     }
     case kDeviceOption_Camera_Framerate: {
-        uint16_t value = static_cast<uint16_t>(strtoul(aValue, nullptr, 0));
-        LinuxDeviceOptions::GetInstance().cameraFramerate.SetValue(value);
+        unsigned long value = strtoul(aValue, nullptr, 0);
+        if (value > UINT16_MAX)
+        {
+            PrintArgError("%s: Invalid camera framerate: %s\n", aProgram, aValue);
+            return false;
+        }
+        LinuxDeviceOptions::GetInstance().cameraFramerate.SetValue(static_cast<uint16_t>(value));
         break;
     }
 #endif

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -155,6 +155,7 @@ enum
     kDeviceOption_Camera_TestAudiosrc,
     kDeviceOption_Camera_AudioPlayback,
     kDeviceOption_Camera_VideoDevice,
+    kDeviceOption_Camera_Framerate,
 #endif
     kDeviceOption_VendorName,
     kDeviceOption_ProductName,
@@ -264,6 +265,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "camera-test-audiosrc", kNoArgument, kDeviceOption_Camera_TestAudiosrc },
     { "camera-audio-playback", kNoArgument, kDeviceOption_Camera_AudioPlayback },
     { "camera-video-device", kArgumentRequired, kDeviceOption_Camera_VideoDevice },
+    { "camera-framerate", kArgumentRequired, kDeviceOption_Camera_Framerate },
 #endif
     {}
 };
@@ -490,6 +492,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --camera-audio-playback\n"
     "       Enables audio playback gstreamer pipeline to play the audio received from remote peer.\n"
+    "\n"
+    "  --camera-framerate <fps>\n"
+    "       Framerate for video streaming (default: 30).\n"
     "\n"
 #endif
     "\n";
@@ -997,6 +1002,11 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     }
     case kDeviceOption_Camera_VideoDevice: {
         LinuxDeviceOptions::GetInstance().cameraVideoDevice.SetValue(aValue);
+        break;
+    }
+    case kDeviceOption_Camera_Framerate: {
+        uint16_t value = static_cast<uint16_t>(strtoul(aValue, nullptr, 0));
+        LinuxDeviceOptions::GetInstance().cameraFramerate.SetValue(value);
         break;
     }
 #endif

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -1009,7 +1009,8 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         if (value > UINT16_MAX)
         {
             PrintArgError("%s: Invalid camera framerate: %s\n", aProgram, aValue);
-            return false;
+            retval = false;
+            break;
         }
         LinuxDeviceOptions::GetInstance().cameraFramerate.SetValue(static_cast<uint16_t>(value));
         break;

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -69,6 +69,7 @@ struct LinuxDeviceOptions
     bool cameraTestAudiosrc  = false;
     bool cameraAudioPlayback = false;
     chip::Optional<std::string> cameraVideoDevice;
+    chip::Optional<uint16_t> cameraFramerate;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     bool mWiFiPAF                = false;
     const char * mWiFiPAFExtCmds = nullptr;


### PR DESCRIPTION
#### Summary
Fixes https://github.com/project-chip/certification-tool/issues/945

    - Default to 30 fps if the parameter is not provided.
    - Validate that the specified frame rate is within the allowed range of the allocated stream in `CameraDevice::StartVideoStream`.
    - Return an error if the validation fails.

#### Related issues

#### Testing
Test scripts and CI sanity

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
