### PR TITLE
[miniaudio] Fix build warnings propagation for all compiler targets

### DIFF
--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -18,23 +18,23 @@ import("//build_overrides/chip.gni")
 import("${build_root}/config/compiler/compiler.gni")
 
 config("miniaudio_config") {
-  include_dirs = [ "repo" ]
+  # Use -isystem instead of include_dirs to treat miniaudio.h as a system header
+  # and suppress warnings originating from it for dependents.
+  cflags = [ "-isystem" + rebase_path("repo", root_build_dir) ]
 }
 
 config("miniaudio_warnings") {
   cflags = [
     "-Wno-missing-format-attribute",
     "-Wno-implicit-fallthrough",
+    "-Wno-format-nonliteral",
+    "-Wno-conversion",
+    "-Wno-sign-conversion",
+    "-Wno-shadow",
   ]
 
   if (is_clang) {
-    cflags += [
-      "-Wno-shorten-64-to-32",
-      "-Wno-format-nonliteral",
-      "-Wno-conversion",
-      "-Wno-sign-conversion",
-      "-Wno-shadow",
-    ]
+    cflags += [ "-Wno-shorten-64-to-32" ]
   }
 }
 


### PR DESCRIPTION
## Summary

This pull request ensures that compiler warnings originating from the third-party `miniaudio` library are suppressed for all targets that include it, without leaking those warning suppressions to the rest of the translation unit of dependent files. This fixes an issue when building `all-devices-app` for `darwin`.

### Problem
`miniaudio` is a single-header library. When application code (such as `PosixChimeDevice.h` in the `all-devices-app`) includes `miniaudio.h` directly, it may trigger compiler warnings (e.g., `-Wconversion`, `-Wshadow`) that fail the build under strict warning settings (`-Werror`). Disabling these warnings globally or via `public_configs` is undesirable as it can mask real bugs in application code.

### Solution
Instead of propagating warning suppressions via `public_configs`, this PR updates the include path for `miniaudio` to use `-isystem` instead of a standard include directory. This instructs the compiler to treat `miniaudio.h` as a system header, which automatically suppresses warnings originating from it for any file that includes it, while preserving strict warning checks for the rest of the source file.

## Changes
- **`third_party/miniaudio/BUILD.gn`**:
  - Updated `miniaudio_config` to use `-isystem` for the `repo` directory.
  - Kept `miniaudio_warnings` private to the `miniaudio` target.

### Testing
- [x] Verified that `all-devices-app` builds cleanly without warnings from `miniaudio.h` on both linux and darwin.