### PR TITLE
[Build] Add option to parallelize example builder

### DIFF
--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -72,7 +72,7 @@ class Context:
         self.concurrent_generation = concurrent_generation
         self.concurrent_builders = concurrent_builders
         if concurrent_builders > 1 and (ninja_jobs is None or ninja_jobs == 0):
-            self.ninja_jobs = math.floor(multiprocessing.cpu_count() / concurrent_builders)
+            self.ninja_jobs = max(1, math.floor(multiprocessing.cpu_count() / concurrent_builders))
         else:
             self.ninja_jobs = ninja_jobs
         self.completed_steps = set()

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -1,11 +1,15 @@
 import logging
+import math
+import multiprocessing
 import os
 import shutil
 import time
 from enum import Enum, auto
+from concurrent.futures import ThreadPoolExecutor
 from typing import Sequence
 
-from builders.builder import BuilderOptions
+from builders.builder import BuilderOptions, Builder, OutDirLock
+from runner.runner import Runner
 
 from .targets import BUILD_TARGETS
 
@@ -22,14 +26,18 @@ class BuildTimer:
         self._total_end_time = None
         self._build_times = {}
 
-    def time_builds(self, builders):
-        self._total_start_time = time.time()
-        for builder in builders:
+    def time_builds(self, builders: list[Builder], concurrency: int) -> None:
+
+        def _single_build(builder: Builder):
             start_time = time.time()
             builder.build()
-            end_time = time.time()
-            self._build_times[builder.identifier] = end_time - start_time
-        self._total_end_time = time.time()
+            return builder.identifier, time.time() - start_time
+
+        with ThreadPoolExecutor(thread_name_prefix="Builder", max_workers=concurrency) as pool:
+            self._total_start_time = time.time()
+            for identifier, build_time in pool.map(_single_build, builders):
+                self._build_times[identifier] = build_time
+            self._total_end_time = time.time()
 
     def print_timing_report(self):
         total_time = self._total_end_time - self._total_start_time
@@ -52,14 +60,21 @@ class Context:
          to generate make/ninja instructions and to compile.
       """
 
-    def __init__(self, runner, repository_path: str, output_prefix: str, verbose: bool, quiet: bool, ninja_jobs: int):
-        self.builders = []
+    def __init__(self, runner: Runner, repository_path: str, output_prefix: str, verbose: bool, quiet: bool, ninja_jobs: int,
+                 concurrent_generation: int, concurrent_builders: int):
+        self.builders: list[Builder] = []
         self.runner = runner
         self.repository_path = repository_path
         self.output_prefix = output_prefix
         self.verbose = verbose
         self.quiet = quiet
-        self.ninja_jobs = ninja_jobs
+        self.out_dir_lock = OutDirLock()
+        self.concurrent_generation = concurrent_generation
+        self.concurrent_builders = concurrent_builders
+        if concurrent_builders > 1 and (ninja_jobs is None or ninja_jobs == 0):
+            self.ninja_jobs = math.floor(multiprocessing.cpu_count() / concurrent_builders)
+        else:
+            self.ninja_jobs = ninja_jobs
         self.completed_steps = set()
 
     def SetupBuilders(self, targets: Sequence[str], options: BuilderOptions):
@@ -73,9 +88,8 @@ class Context:
         for target in targets:
             found_choice = None
             for choice in BUILD_TARGETS:
-                builder = choice.Create(target, self.runner, self.repository_path,
-                                        self.output_prefix, self.verbose, self.quiet, self.ninja_jobs,
-                                        options)
+                builder = choice.Create(target, self.runner, self.repository_path, self.output_prefix, self.verbose, self.quiet,
+                                        self.ninja_jobs, options, self.out_dir_lock)
                 if builder:
                     self.builders.append(builder)
                     found_choice = choice
@@ -110,10 +124,14 @@ class Context:
 
         self.runner.StartCommandExecution()
 
-        for builder in self.builders:
+        def _single_generate(builder: Builder):
             if not builder.quiet:
                 log.info('Generating %s', builder.output_dir)
             builder.generate()
+
+        max_workers = self.concurrent_generation if self.concurrent_generation > 0 else multiprocessing.cpu_count()
+        with ThreadPoolExecutor(thread_name_prefix="Generator", max_workers=max_workers) as pool:
+            list(pool.map(_single_generate, self.builders))
 
         self.completed_steps.add(BuildSteps.GENERATED)
 
@@ -121,7 +139,7 @@ class Context:
         self.Generate()
 
         timer = BuildTimer()
-        timer.time_builds(self.builders)
+        timer.time_builds(self.builders, self.concurrent_builders)
         if not self.quiet:
             timer.print_timing_report()
 

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -45,7 +45,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
-from builders.builder import BuilderOptions, BuildProfile
+from builders.builder import Builder, BuilderOptions, BuildProfile, OutDirLock
+from runner.runner import Runner
 
 log = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ def _StringIntoParts(full_input: str, remaining_input: str, fixed_targets: List[
 
 class BuildTarget:
 
-    def __init__(self, name, builder_class, **kwargs):
+    def __init__(self, name: str, builder_class: type[Builder], **kwargs):
         """ Sets up a new build target starting with the given builder class
             and initial arguments
         """
@@ -448,8 +449,8 @@ class BuildTarget:
 
         return _StringIntoParts(value, suffix, self.fixed_targets, self.modifiers)
 
-    def Create(self, name: str, runner, repository_path: str, output_prefix: str,
-               verbose: bool, quiet: bool, ninja_jobs: int, builder_options: BuilderOptions):
+    def Create(self, name: str, runner: Runner, repository_path: str, output_prefix: str, verbose: bool, quiet: bool,
+               ninja_jobs: int, builder_options: BuilderOptions, output_dir_lock: OutDirLock):
 
         parts = self.StringIntoTargetParts(name)
 
@@ -464,6 +465,7 @@ class BuildTarget:
             log.info("Preparing builder '%s'" % (name,))
 
         builder = self.builder_class(repository_path, runner=runner, **kargs)
+        builder.output_dir_lock = output_dir_lock
         builder.target = self
         builder.identifier = name
         if self.isUnifiedBuild(parts):

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -464,8 +464,7 @@ class BuildTarget:
         if not quiet:
             log.info("Preparing builder '%s'" % (name,))
 
-        builder = self.builder_class(repository_path, runner=runner, **kargs)
-        builder.output_dir_lock = output_dir_lock
+        builder = self.builder_class(repository_path, runner=runner, output_dir_lock=output_dir_lock, **kargs)
         builder.target = self
         builder.identifier = name
         if self.isUnifiedBuild(parts):

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -186,6 +186,14 @@ before running this script.
 
     if dry_run:
         runner = PrintOnlyRunner(dry_run_output, root=repo)
+
+        if concurrent_generation != 1:
+            log.warning(
+                "Concurrent generation is set to %d, but dry-run mode is enabled. "
+                "Ignoring concurrent generation and running in single-threaded mode.",
+                concurrent_generation)
+            concurrent_generation = 1
+
         if concurrent_builders > 1:
             log.warning(
                 "Concurrent builders is set to %d, but dry-run mode is enabled. "

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -170,7 +170,10 @@ def main(context, log_level, verbose, quiet, target, build_profile, enable_link_
          concurrent_generation: int, concurrent_builders: int, pregen_dir, clean, dry_run, dry_run_output, enable_flashbundle,
          log_timestamps, pw_command_launcher):
     # Ensures somewhat pretty logging of what is going on
-    log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(threadName)s: %(message)s' if log_timestamps else '%(levelname)-7s %(message)s'
+    if log_timestamps:
+        log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(threadName)s: %(message)s'
+    else:
+        log_fmt = '%(levelname)-7s %(threadName)s: %(message)s'
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
     if 'PW_PROJECT_ROOT' not in os.environ:

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -126,6 +126,16 @@ def ValidateTargetNames(context, parameter, values):
     default=None,
     help='Number of ninja jobs')
 @click.option(
+    '--concurrent-generation',
+    type=click.IntRange(min=0),
+    default=0,
+    help='Number of concurrent generation jobs. If 0, use number of CPU cores.')
+@click.option(
+    '--concurrent-builders',
+    type=click.IntRange(min=1),
+    default=1,
+    help='Number of concurrent builders. If greater than 1, count of Ninja jobs are scaled down accordingly')
+@click.option(
     '--pregen-dir',
     default=None,
     type=click.Path(file_okay=False, resolve_path=True),
@@ -156,11 +166,11 @@ def ValidateTargetNames(context, parameter, values):
         'Set pigweed command launcher. E.g.: "--pw-command-launcher=ccache" '
         'for using ccache when building examples.'))
 @click.pass_context
-def main(context, log_level, verbose, quiet, target, build_profile, enable_link_map_file, repo,
-         out_prefix, ninja_jobs, pregen_dir, clean, dry_run, dry_run_output,
-         enable_flashbundle, log_timestamps, pw_command_launcher):
+def main(context, log_level, verbose, quiet, target, build_profile, enable_link_map_file, repo, out_prefix, ninja_jobs,
+         concurrent_generation: int, concurrent_builders: int, pregen_dir, clean, dry_run, dry_run_output, enable_flashbundle,
+         log_timestamps, pw_command_launcher):
     # Ensures somewhat pretty logging of what is going on
-    log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(message)s' if log_timestamps else '%(levelname)-7s %(message)s'
+    log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(threadName)s: %(message)s' if log_timestamps else '%(levelname)-7s %(message)s'
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
     if 'PW_PROJECT_ROOT' not in os.environ:
@@ -177,8 +187,8 @@ before running this script.
         runner = ShellRunner(root=repo)
 
     context.obj = build.Context(
-        repository_path=repo, output_prefix=out_prefix, verbose=verbose, quiet=quiet,
-        ninja_jobs=ninja_jobs, runner=runner
+        repository_path=repo, output_prefix=out_prefix, verbose=verbose, quiet=quiet, ninja_jobs=ninja_jobs,
+        concurrent_generation=concurrent_generation, concurrent_builders=concurrent_builders, runner=runner
     )
 
     requested_targets = {t.lower() for t in target}

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -134,7 +134,7 @@ def ValidateTargetNames(context, parameter, values):
     '--concurrent-builders',
     type=click.IntRange(min=1),
     default=1,
-    help='Number of concurrent builders. If greater than 1, count of Ninja jobs are scaled down accordingly')
+    help='Number of concurrent builders. If greater than 1, count of Ninja jobs is scaled down accordingly')
 @click.option(
     '--pregen-dir',
     default=None,

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -186,6 +186,12 @@ before running this script.
 
     if dry_run:
         runner = PrintOnlyRunner(dry_run_output, root=repo)
+        if concurrent_builders > 1:
+            log.warning(
+                "Concurrent builders is set to %d, but dry-run mode is enabled. "
+                "Ignoring concurrent builders and running in single-threaded mode.",
+                concurrent_builders)
+            concurrent_builders = 1
     else:
         runner = ShellRunner(root=repo)
 

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -187,7 +187,7 @@ before running this script.
     if dry_run:
         runner = PrintOnlyRunner(dry_run_output, root=repo)
 
-        if concurrent_generation != 1:
+        if concurrent_generation > 1:
             log.warning(
                 "Concurrent generation is set to %d, but dry-run mode is enabled. "
                 "Ignoring concurrent generation and running in single-threaded mode.",

--- a/scripts/build/builders/ameba.py
+++ b/scripts/build/builders/ameba.py
@@ -15,7 +15,8 @@
 import os
 from enum import Enum, auto
 
-from .builder import Builder, BuilderOutput
+from runner.runner import Runner
+from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
 
 
 class AmebaBoard(Enum):
@@ -61,14 +62,16 @@ class AmebaApp(Enum):
 class AmebaBuilder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  board: AmebaBoard = AmebaBoard.AMEBAD,
                  app: AmebaApp = AmebaApp.ALL_CLUSTERS):
-        super(AmebaBuilder, self).__init__(root, runner)
+        super(AmebaBuilder, self).__init__(root, runner, output_dir_lock)
         self.board = board
         self.app = app
 
+    @lock_output_dir
     def generate(self):
         cmd = '$AMEBA_PATH/project/realtek_amebaD_va0_example/GCC-RELEASE/build.sh '
         if self.app.ExampleName == 'pigweed-app':
@@ -82,6 +85,7 @@ class AmebaBuilder(Builder):
         self._Execute(['bash', '-c', cmd],
                       title='Generating ' + self.identifier)
 
+    @lock_output_dir
     def _build(self):
         cmd = ['ninja', '-C', self.output_dir]
 
@@ -90,6 +94,7 @@ class AmebaBuilder(Builder):
 
         self._Execute(cmd, title='Building ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         yield BuilderOutput(
             os.path.join(self.output_dir, 'asdk', 'target_image2.axf'),

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -17,7 +17,9 @@ import os
 import shlex
 from enum import Enum, auto
 
-from .builder import Builder, BuilderOutput, BuildProfile
+from runner.runner import Runner
+
+from .builder import Builder, BuilderOutput, BuildProfile, OutDirLock, lock_output_dir
 
 log = logging.getLogger(__name__)
 
@@ -119,12 +121,11 @@ class AndroidApp(Enum):
 
 class AndroidBuilder(Builder):
     def __init__(self,
-                 root,
-                 runner,
-                 board: AndroidBoard,
-                 app: AndroidApp,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock, board: AndroidBoard, app: AndroidApp,
                  optimize_size: bool = False):
-        super(AndroidBuilder, self).__init__(root, runner)
+        super(AndroidBuilder, self).__init__(root, runner, output_dir_lock)
         self.board = board
         self.app = app
         self.optimize_size = optimize_size
@@ -391,6 +392,7 @@ class AndroidBuilder(Builder):
                 title="Building Example " + self.identifier,
             )
 
+    @lock_output_dir
     def generate(self):
         self._Execute(
             ["python3", "third_party/android_deps/set_up_android_deps.py"],
@@ -508,6 +510,7 @@ class AndroidBuilder(Builder):
             # Handle SDK manager license acceptance
             self._handle_sdk_license_acceptance()
 
+    @lock_output_dir
     def stripSymbols(self):
         output_libs_dir = os.path.join(
             self.output_dir,
@@ -524,6 +527,7 @@ class AndroidBuilder(Builder):
                     "Stripping symbols from " + lib
                 )
 
+    @lock_output_dir
     def _build(self):
         if self.board.IsIde():
             # App compilation IDE
@@ -656,6 +660,7 @@ class AndroidBuilder(Builder):
             if self.options.build_profile in [BuildProfile.RELEASE, BuildProfile.RELEASE_SIZE] or self.optimize_size:
                 self.stripSymbols()
 
+    @lock_output_dir
     def build_outputs(self):
         if self.board.IsIde():
             yield BuilderOutput(

--- a/scripts/build/builders/asr.py
+++ b/scripts/build/builders/asr.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -104,8 +106,9 @@ class ASRBoard(Enum):
 class ASRBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: ASRApp = ASRApp.LIGHT,
                  board: ASRBoard = ASRBoard.ASR582X,
                  chip_build_libshell: bool = False,
@@ -116,7 +119,8 @@ class ASRBuilder(GnBuilder):
                  enable_lwip_ip6_hook: bool = False):
         super(ASRBuilder, self).__init__(
             root=app.BuildRoot(root),
-            runner=runner)
+            runner=runner,
+            output_dir_lock=output_dir_lock)
 
         self.board = board
         self.app = app
@@ -177,6 +181,7 @@ class ASRBuilder(GnBuilder):
         args.extend(self.extra_gn_options)
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["out"]
         if self.options.enable_link_map_file:

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -18,7 +18,9 @@ import re
 import time
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 log = logging.getLogger(__name__)
@@ -77,8 +79,9 @@ class BouffalolabThreadType(Enum):
 class BouffalolabBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: BouffalolabApp = BouffalolabApp.LIGHT,
                  board: BouffalolabBoard = BouffalolabBoard.BL616DK,
                  enable_rpcs: bool = False,
@@ -114,7 +117,8 @@ class BouffalolabBuilder(GnBuilder):
         super(BouffalolabBuilder, self).__init__(
             root=os.path.join(root, 'examples',
                               app.ExampleName(), 'bouffalolab', bouffalo_chip),
-            runner=runner
+            runner=runner,
+            output_dir_lock=output_dir_lock
         )
 
         self.argsOpt = []
@@ -288,6 +292,7 @@ class BouffalolabBuilder(GnBuilder):
         args.extend(self.argsOpt)
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["out"]
         if self.options.enable_link_map_file:
@@ -296,12 +301,14 @@ class BouffalolabBuilder(GnBuilder):
             name = f"{self.app.AppNamePrefix(self.chip_name)}.{ext}"
             yield BuilderOutput(os.path.join(self.output_dir, name), name)
 
+    @lock_output_dir
     def PreBuildCommand(self):
         os.system("rm -rf {}/config".format(self.output_dir))
         os.system("rm -rf {}/ota_images".format(self.output_dir))
         os.system("rm -rf {}".format(os.path.join(self.output_dir, 'boot2*.bin')))
         os.system("rm -rf {}".format(os.path.join(self.output_dir, '%s*' % self.app.AppNamePrefix(self.chip_name))))
 
+    @lock_output_dir
     def PostBuildCommand(self):
 
         if self.chip_name in ["bl616"]:

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -98,6 +98,7 @@ def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenat
 
     return wrapper
 
+
 class Builder(ABC):
     """Generic builder base class for CHIP.
 

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from collections.abc import Iterator
 import contextlib
 import functools
 import threading
@@ -23,7 +24,7 @@ import tarfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Callable, Concatenate, Iterator, ParamSpec, TypeVar
+from typing import Callable, Concatenate, ParamSpec, TypeVar
 
 from runner.runner import Runner
 

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -86,11 +86,11 @@ P = ParamSpec('P')
 R = TypeVar('R')
 
 
-def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenate[S, P], R]:
+def lock_output_dir(func: Callable[Concatenate[S, P], R | Iterator[R]]) -> Callable[Concatenate[S, P], R | Iterator[R]]:
     """Decorator to wrap build steps with output directory lock."""
 
     @functools.wraps(func)
-    def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R | Iterator[R]:
         if self.output_dir_lock is None:
             return func(self, *args, **kwargs)
         with self.output_dir_lock.lock_dir(self.output_dir):
@@ -98,7 +98,11 @@ def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenat
             # This is needed for build_outputs and bundle_outputs which are generators that yield BuilderOutput objects.
             result = func(self, *args, **kwargs)
             if isinstance(result, Iterator):
-                return (yield from result)
+                def generator_with_lock():
+                    yield from result
+
+                return generator_with_lock()
+
             return result
 
     return wrapper

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -61,7 +61,7 @@ class BuilderOutput:
 
 
 class OutDirLock:
-    """Lock to provide mutual exclusion for oprations on output directories."""
+    """Lock to provide mutual exclusion for operations on output directories."""
 
     def __init__(self) -> None:
         self._dir_locks: dict[str, threading.RLock] = defaultdict(threading.RLock)

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -93,17 +93,17 @@ def lock_output_dir(func: Callable[Concatenate[S, P], R | Iterator[R]]) -> Calla
     def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R | Iterator[R]:
         if self.output_dir_lock is None:
             return func(self, *args, **kwargs)
-        with self.output_dir_lock.lock_dir(self.output_dir):
-            # Check if func returns a generator, and if so, we need to keep the lock acquired until the generator is exhausted.
-            # This is needed for build_outputs and bundle_outputs which are generators that yield BuilderOutput objects.
-            result = func(self, *args, **kwargs)
-            if isinstance(result, Iterator):
-                def generator_with_lock():
-                    yield from result
 
-                return generator_with_lock()
+        output_dir_lock = self.output_dir_lock
 
-            return result
+        # Keep the lock held while an iterator result is consumed. This is needed for build_outputs and bundle_outputs which are
+        # generators yielding BuilderOutput objects.
+        def iterator_with_lock(result: Iterator[R]) -> Iterator[R]:
+            with output_dir_lock.lock_dir(self.output_dir):
+                yield from result
+
+        with output_dir_lock.lock_dir(self.output_dir):
+            return iterator_with_lock(result) if isinstance(result := func(self, *args, **kwargs), Iterator) else result
 
     return wrapper
 

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
+import contextlib
+import functools
+import threading
 import logging
 import os
 import shutil
@@ -19,6 +23,9 @@ import tarfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Callable, Concatenate, Iterator, ParamSpec, TypeVar
+
+from runner.runner import Runner
 
 
 class BuildProfile(StrEnum):
@@ -53,6 +60,42 @@ class BuilderOutput:
     target: str  # Target file to be copied to
 
 
+class OutDirLock:
+    """Lock to provide mutual exclusion for oprations on output directories."""
+
+    def __init__(self) -> None:
+        self._dir_locks: dict[str, threading.RLock] = defaultdict(threading.RLock)
+        self._dict_lock: threading.Lock = threading.Lock()
+
+    @contextlib.contextmanager
+    def lock_dir(self, dir_path: str | None) -> Iterator[None]:
+        # No directory to lock, just yield
+        if dir_path is None:
+            yield
+            return
+
+        with self._dict_lock:
+            dir_lock = self._dir_locks[dir_path]
+
+        with dir_lock:
+            yield
+
+
+S = TypeVar('S', bound='Builder')
+P = ParamSpec('P')
+R = TypeVar('R')
+
+
+def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenate[S, P], R]:
+    """Decorator to wrap build steps with output directory lock."""
+
+    @functools.wraps(func)
+    def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
+        with self.output_dir_lock.lock_dir(self.output_dir):
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
 class Builder(ABC):
     """Generic builder base class for CHIP.
 
@@ -61,9 +104,10 @@ class Builder(ABC):
 
     """
 
-    def __init__(self, root, runner):
+    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock):
         self.root = os.path.abspath(root)
         self._runner = runner
+        self.output_dir_lock = output_dir_lock
 
         # Set post-init once actual build target is known
         self.identifier = None

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -94,7 +94,12 @@ def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenat
         if self.output_dir_lock is None:
             return func(self, *args, **kwargs)
         with self.output_dir_lock.lock_dir(self.output_dir):
-            return func(self, *args, **kwargs)
+            # Check if func returns a generator, and if so, we need to keep the lock acquired until the generator is exhausted.
+            # This is needed for build_outputs and bundle_outputs which are generators that yield BuilderOutput objects.
+            result = func(self, *args, **kwargs)
+            if isinstance(result, Iterator):
+                return (yield from result)
+            return result
 
     return wrapper
 

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -91,6 +91,8 @@ def lock_output_dir(func: Callable[Concatenate[S, P], R]) -> Callable[Concatenat
 
     @functools.wraps(func)
     def wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> R:
+        if self.output_dir_lock is None:
+            return func(self, *args, **kwargs)
         with self.output_dir_lock.lock_dir(self.output_dir):
             return func(self, *args, **kwargs)
 
@@ -104,7 +106,7 @@ class Builder(ABC):
 
     """
 
-    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock):
+    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock | None = None):
         self.root = os.path.abspath(root)
         self._runner = runner
         self.output_dir_lock = output_dir_lock

--- a/scripts/build/builders/cc32xx.py
+++ b/scripts/build/builders/cc32xx.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -44,12 +46,11 @@ class cc32xxApp(Enum):
 class cc32xxBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: cc32xxApp = cc32xxApp.LOCK):
-        super(cc32xxBuilder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+        super(cc32xxBuilder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
         self.code_root = root
         self.app = app
 
@@ -65,6 +66,7 @@ class cc32xxBuilder(GnBuilder):
         args.append(f'ti_sysconfig_root="{sysconfig_root}"')
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         if (self.app == cc32xxApp.LOCK):
             extensions = ["out", "bin"]

--- a/scripts/build/builders/cyw30739.py
+++ b/scripts/build/builders/cyw30739.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -67,14 +69,14 @@ class Cyw30739Board(Enum):
 class Cyw30739Builder(GnBuilder):
     def __init__(
         self,
-        root,
-        runner,
+        root: str,
+        runner: Runner,
+        output_dir_lock: OutDirLock,
         app: Cyw30739App = Cyw30739App.LIGHT,
         board: Cyw30739Board = Cyw30739Board.CYW30739B2_P5_EVK_01,
         release: bool = False,
     ):
-        super(Cyw30739Builder, self).__init__(
-            root=app.BuildRoot(root), runner=runner)
+        super(Cyw30739Builder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
         self.app = app
         self.board = board
         self.release = release
@@ -98,6 +100,7 @@ class Cyw30739Builder(GnBuilder):
             args.append('is_debug=false')
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["elf"]
         if self.options.enable_link_map_file:

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -19,7 +19,9 @@ import shlex
 import subprocess
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 log = logging.getLogger(__name__)
@@ -184,8 +186,9 @@ class Efr32Board(Enum):
 class Efr32Builder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: Efr32App = Efr32App.LIGHT,
                  board: Efr32Board = Efr32Board.BRD4187C,
                  chip_build_libshell: bool = False,
@@ -209,9 +212,7 @@ class Efr32Builder(GnBuilder):
                  enable_917_soc: bool = False,
                  use_rps_extension: bool = True
                  ):
-        super(Efr32Builder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+        super(Efr32Builder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
         self.app = app
         self.extra_gn_options = ['silabs_board="%s"' % board.GnArgName()]
         self.dotfile = ''
@@ -303,6 +304,7 @@ class Efr32Builder(GnBuilder):
         args.extend(self.extra_gn_options)
         return args
 
+    @lock_output_dir
     def _bundle(self):
         # Only unit-test needs to generate the flashbundle here.  All other examples will generate a flashbundle via the silabs_executable template.
         if self.app == Efr32App.UNIT_TEST:
@@ -325,6 +327,7 @@ class Efr32Builder(GnBuilder):
             with open(flash_bundle_path, 'w') as bundle_file:
                 bundle_file.write("\n".join(files))
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["out", "hex"]
         if self.options.enable_link_map_file:
@@ -350,6 +353,7 @@ class Efr32Builder(GnBuilder):
                         os.path.join(root, file),
                         os.path.join("chip_pw_test_runner_wheels", file))
 
+    @lock_output_dir
     def bundle_outputs(self):
         # If flashbundle creation is enabled, the outputs will include the s37 and flash.py files, plus the two firmware utils scripts that support flash.py.
         # For the unit-test example, there will be a s37 and flash.py file for each unit test source.
@@ -363,6 +367,7 @@ class Efr32Builder(GnBuilder):
                     sourcepath,
                     os.path.join("flashbundle", name))
 
+    @lock_output_dir
     def generate(self, dedup=False):
         cmd = [
             'gn', 'gen', '--check', '--fail-on-unused-args',

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -18,7 +18,9 @@ import shlex
 from enum import Enum, auto
 from typing import Optional
 
-from .builder import Builder, BuilderOutput
+from runner.runner import Runner
+
+from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
 
 log = logging.getLogger(__name__)
 
@@ -163,8 +165,9 @@ def DefaultsFileName(board: Esp32Board, app: Esp32App, enable_rpcs: bool):
 class Esp32Builder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  board: Esp32Board = Esp32Board.M5Stack,
                  app: Esp32App = Esp32App.ALL_CLUSTERS,
                  enable_rpcs: bool = False,
@@ -172,7 +175,7 @@ class Esp32Builder(Builder):
                  enable_insights_trace: bool = False,
                  all_devices_enabled_devices=None,
                  ):
-        super(Esp32Builder, self).__init__(root, runner)
+        super(Esp32Builder, self).__init__(root, runner, output_dir_lock)
         self.board = board
         self.app = app
         self.enable_rpcs = enable_rpcs
@@ -210,6 +213,7 @@ class Esp32Builder(Builder):
     def ExamplePath(self):
         return os.path.join(self.app.ExamplePath, 'esp32')
 
+    @lock_output_dir
     def generate(self):
         if os.path.exists(os.path.join(self.output_dir, 'build.ninja')):
             return
@@ -270,6 +274,7 @@ class Esp32Builder(Builder):
         # This will do a 'cmake reconfigure' which will create ninja files without rebuilding
         self._IdfEnvExecute(cmd)
 
+    @lock_output_dir
     def _build(self):
         log.info('Compiling Esp32 at %s', self.output_dir)
 
@@ -298,6 +303,7 @@ class Esp32Builder(Builder):
             return 'example-device-app'
         return 'all-devices-app'
 
+    @lock_output_dir
     def build_outputs(self):
         if self.app == Esp32App.TESTS:
             # Include the runnable image names as artifacts
@@ -314,6 +320,7 @@ class Esp32Builder(Builder):
             name = f"{app_name}.{ext}"
             yield BuilderOutput(os.path.join(self.output_dir, name), name)
 
+    @lock_output_dir
     def bundle_outputs(self):
         flash_bundle_name = self.app.FlashBundleName(self.all_devices_enabled_devices)
         if not flash_bundle_name:

--- a/scripts/build/builders/genio.py
+++ b/scripts/build/builders/genio.py
@@ -1,7 +1,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -36,15 +38,11 @@ class GenioApp(Enum):
 
 class GenioBuilder(GnBuilder):
 
-    def __init__(self,
-                 root,
-                 runner,
-                 app: GenioApp = GenioApp.LIGHT):
-        super(GenioBuilder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock, app: GenioApp = GenioApp.LIGHT):
+        super(GenioBuilder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
         self.app = app
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ['out', 'bin']
         if self.options.enable_link_map_file:

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -14,19 +14,22 @@
 
 import shlex
 
-from .builder import Builder, BuildProfile
+from runner.runner import Runner
+
+from .builder import Builder, BuildProfile, OutDirLock, lock_output_dir
 
 
 class GnBuilder(Builder):
 
-    def __init__(self, root, runner):
+    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock):
         """Creates  a generic ninja builder.
 
         Args:
            root: the root where to run GN into
            runner: what to use to execute shell commands
+           output_dir_lock: lock for the output directory
         """
-        super(GnBuilder, self).__init__(root, runner)
+        super(GnBuilder, self).__init__(root, runner, output_dir_lock)
 
         self.build_command = None
 
@@ -64,6 +67,7 @@ class GnBuilder(Builder):
         """Extra steps to run after 'build'"""
         pass
 
+    @lock_output_dir
     def generate(self, dedup=False):
         cmd = [
             'gn', 'gen', '--check', '--fail-on-unused-args',
@@ -91,6 +95,7 @@ class GnBuilder(Builder):
 
         self._Execute(cmd, title=f"Generating {self.identifier}", dedup=dedup)
 
+    @lock_output_dir
     def _build(self):
         self.PreBuildCommand()
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -18,7 +18,9 @@ from enum import Enum, auto
 from platform import uname
 from typing import Optional
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -400,7 +402,7 @@ class HostBoard(Enum):
 
 class HostBuilder(GnBuilder):
 
-    def __init__(self, root, runner, app: HostApp, board=HostBoard.NATIVE,
+    def __init__(self, root: str, runner: Runner, output_dir_lock: OutDirLock, app: HostApp, board=HostBoard.NATIVE,
                  enable_ipv4=True, enable_ble=True, enable_wifi=True, enable_wifipaf=True,
                  enable_groupcast=True, enable_thread=True, use_tsan=False, use_asan=False, use_ubsan=False,
                  separate_event_loop=True, fuzzing_type: HostFuzzingType = HostFuzzingType.NONE, use_clang=False,
@@ -432,7 +434,7 @@ class HostBuilder(GnBuilder):
         if not unified:
             root = os.path.join(root, 'examples', app.ExamplePath())
 
-        super(HostBuilder, self).__init__(root=root, runner=runner)
+        super(HostBuilder, self).__init__(root=root, runner=runner, output_dir_lock=output_dir_lock)
 
         self.app = app
         self.board = board
@@ -669,6 +671,7 @@ class HostBuilder(GnBuilder):
                 ])
         return args
 
+    @lock_output_dir
     def createJavaExecutable(self, java_program):
         self._Execute(
             [
@@ -697,6 +700,7 @@ class HostBuilder(GnBuilder):
             raise Exception('Missing environment variable "%s"' % name)
         return os.environ[name]
 
+    @lock_output_dir
     def generate(self):
         super(HostBuilder, self).generate(dedup=self.unified)
         if 'JAVA_HOME' in os.environ:
@@ -729,6 +733,7 @@ class HostBuilder(GnBuilder):
             self.coverage_dir = os.path.join(self.output_dir, 'coverage')
             self._Execute(['mkdir', '-p', self.coverage_dir], title="Create coverage output location")
 
+    @lock_output_dir
     def PreBuildCommand(self):
         if self.app == HostApp.TESTS and self.use_coverage and not self.use_clang:
             cmd = ['ninja', '-C', self.output_dir]
@@ -747,6 +752,7 @@ class HostBuilder(GnBuilder):
                            '--exclude', '/usr/include/*',
                            '--output-file', os.path.join(self.coverage_dir, 'lcov_base.info')], title="Initial coverage baseline")
 
+    @lock_output_dir
     def PostBuildCommand(self):
         # TODO: CLANG coverage is not yet implemented, requires different tooling
         if self.app == HostApp.TESTS and self.use_coverage and not self.use_clang:
@@ -847,6 +853,7 @@ class HostBuilder(GnBuilder):
             return 'example-device-app'
         return 'all-devices-app'
 
+    @lock_output_dir
     def build_outputs(self):
         if self.app == HostApp.ALL_DEVICES_APP:
             base = self._AllDevicesOutputName()

--- a/scripts/build/builders/imx.py
+++ b/scripts/build/builders/imx.py
@@ -17,7 +17,9 @@ import re
 import shlex
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -68,15 +70,17 @@ class IMXApp(Enum):
 class IMXBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: IMXApp,
                  release: bool = False,
                  trusty: bool = False,
                  ele: bool = False):
         super(IMXBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
-            runner=runner)
+            runner=runner,
+            output_dir_lock=output_dir_lock)
         self.release = release
         self.trusty = trusty
         self.ele = ele
@@ -192,6 +196,7 @@ class IMXBuilder(GnBuilder):
             raise Exception('Missing environment variable "%s"' % name)
         return os.environ[name]
 
+    @lock_output_dir
     def build_outputs(self):
         for name in self.app.OutputNames():
             if not self.options.enable_link_map_file and name.endswith(".map"):

--- a/scripts/build/builders/infineon.py
+++ b/scripts/build/builders/infineon.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -74,16 +76,15 @@ class InfineonBoard(Enum):
 class InfineonBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: InfineonApp = InfineonApp.LOCK,
                  board: InfineonBoard = InfineonBoard.PSOC6BOARD,
                  enable_ota_requestor: bool = False,
                  update_image: bool = False,
                  enable_trustm: bool = False):
-        super(InfineonBuilder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+        super(InfineonBuilder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
 
         self.app = app
         self.extra_gn_options = ['psoc6_board="%s"' % board.GnArgName()]
@@ -102,6 +103,7 @@ class InfineonBuilder(GnBuilder):
         args.extend(self.extra_gn_options)
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ['out']
         if self.options.enable_link_map_file:
@@ -110,6 +112,7 @@ class InfineonBuilder(GnBuilder):
             name = f"{self.app.AppNamePrefix()}.{ext}"
             yield BuilderOutput(os.path.join(self.output_dir, name), name)
 
+    @lock_output_dir
     def bundle_outputs(self):
         with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
             for line in filter(None, [x.strip() for x in f.readlines()]):

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -17,7 +17,9 @@ import os
 import shlex
 from enum import Enum, auto
 
-from .builder import Builder, BuilderOutput
+from runner.runner import Runner
+
+from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
 
 log = logging.getLogger(__name__)
 
@@ -133,13 +135,14 @@ class NrfBoard(Enum):
 class NrfConnectBuilder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: NrfApp = NrfApp.LIGHT,
                  board: NrfBoard = NrfBoard.NRF52840DK,
                  enable_rpcs: bool = False,
                  ):
-        super(NrfConnectBuilder, self).__init__(root, runner)
+        super(NrfConnectBuilder, self).__init__(root, runner, output_dir_lock)
         self.app = app
         self.board = board
         self.enable_rpcs = enable_rpcs
@@ -173,6 +176,7 @@ class NrfConnectBuilder(Builder):
 
         return " -- " + " ".join(flags) if len(flags) > 0 else ""
 
+    @lock_output_dir
     def generate(self):
         if not os.path.exists(self.output_dir):
             if not self._runner.dry_run:
@@ -199,6 +203,7 @@ class NrfConnectBuilder(Builder):
             self._Execute(['bash', '-c', cmd.strip()],
                           title='Generating ' + self.identifier)
 
+    @lock_output_dir
     def _build(self):
         log.info('Compiling NrfConnect at %s', self.output_dir)
 
@@ -217,12 +222,14 @@ class NrfConnectBuilder(Builder):
             self._Execute(['ctest', '--build-nocmake', '-V', '--output-on-failure', '--test-dir', os.path.join(self.output_dir, 'nrfconnect'), '--no-tests=error'],
                           title='Run Tests ' + self.identifier)
 
+    @lock_output_dir
     def _bundle(self):
         log.info(f'Generating flashbundle at {self.output_dir}')
 
         self._Execute(['ninja', '-C', os.path.join(self.output_dir, 'nrfconnect'), 'flashing_script'],
                       title='Generating flashable files of ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         yield BuilderOutput(
             os.path.join(self.output_dir, 'nrfconnect', 'zephyr', 'zephyr.elf'),
@@ -232,6 +239,7 @@ class NrfConnectBuilder(Builder):
                 os.path.join(self.output_dir, 'nrfconnect', 'zephyr', 'zephyr.map'),
                 '%s.map' % self.app.AppNamePrefix())
 
+    @lock_output_dir
     def bundle_outputs(self):
         if self.app == NrfApp.UNIT_TESTS:
             return

--- a/scripts/build/builders/nuttx.py
+++ b/scripts/build/builders/nuttx.py
@@ -16,7 +16,9 @@ import logging
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import Builder
 
 log = logging.getLogger(__name__)
@@ -49,8 +51,9 @@ class NuttXBoard(Enum):
 class NuttXBuilder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: NuttXApp = NuttXApp.LIGHT,
                  board: NuttXBoard = NuttXBoard.SIM,
                  ):
@@ -60,13 +63,15 @@ class NuttXBuilder(Builder):
         super(NuttXBuilder, self).__init__(
             root=os.path.join(root, 'examples',
                               app.ExampleName(), nuttx_chip),
-            runner=runner
+            runner=runner,
+            output_dir_lock=output_dir_lock
         )
 
         self.chip_name = nuttx_chip
         self.app = app
         self.board = board
 
+    @lock_output_dir
     def generate(self):
         self._Execute(['mkdir', '-p', self.output_dir], title='Preparing output directory for ' + self.identifier)
         nuttx_dir = os.path.join(os.sep, 'opt', 'nuttx', 'nuttx')
@@ -78,11 +83,13 @@ class NuttXBuilder(Builder):
                        '-GNinja'],
                       title='Configuring ' + self.identifier)
 
+    @lock_output_dir
     def _build(self):
         log.info('Compiling NuttX %s at %s, ',
                  self.board.board_config, self.output_dir)
         self._Execute(['cmake', '--build', self.output_dir])
 
+    @lock_output_dir
     def build_outputs(self):
         log.info('Compiling outputs NuttX at %s', self.output_dir)
         extensions = ["out"]

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -18,7 +18,9 @@ import os
 import shlex
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 log = logging.getLogger(__name__)
@@ -153,8 +155,9 @@ class NxpLogLevel(Enum):
 class NxpBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: NxpApp = NxpApp.LIGHTING,
                  board: NxpBoard = NxpBoard.MCXW72,
                  board_variant: NxpBoardVariant = None,
@@ -185,7 +188,8 @@ class NxpBuilder(GnBuilder):
                  ):
         super(NxpBuilder, self).__init__(
             root=app.BuildRoot(root, board, os_env, build_system),
-            runner=runner)
+            runner=runner,
+            output_dir_lock=output_dir_lock)
         self.code_root = root
         self.app = app
         self.board = board
@@ -391,6 +395,7 @@ class NxpBuilder(GnBuilder):
             return prj_file
         raise Exception("Configuration not supported, no conf file available: %s" % prj_file_abs_path)
 
+    @lock_output_dir
     def generate(self):
         if self.build_system is NxpBuildSystem.CMAKE:
             build_flags = self.CmakeBuildFlags()
@@ -445,6 +450,7 @@ class NxpBuilder(GnBuilder):
                 build_flags=build_flags)
             self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         name = 'chip-%s-%s' % (self.board.Name(self.os_env), self.app.NameSuffix())
         if self.os_env == NxpOsUsed.ZEPHYR:

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -87,16 +89,14 @@ class QpgBoard(Enum):
 class QpgBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: QpgApp = QpgApp.LIGHT,
                  board: QpgBoard = QpgBoard.QPG6200,
                  enable_rpcs: bool = False,
-                 update_image: bool = False,
-                 ):
-        super(QpgBuilder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+                 update_image: bool = False):
+        super(QpgBuilder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
         self.app = app
         self.board = board
         self.enable_rpcs = enable_rpcs
@@ -111,6 +111,7 @@ class QpgBuilder(GnBuilder):
             args.append('matter_ota_test_image=true')
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["out", "out.hex"]
         if self.options.enable_link_map_file:

--- a/scripts/build/builders/realtek.py
+++ b/scripts/build/builders/realtek.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import Builder, BuilderOutput
+from runner.runner import Runner
+
+from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
 
 
 class RtkOsUsed(Enum):
@@ -110,14 +112,15 @@ class RealtekApp(Enum):
 class RealtekBuilder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  board: RealtekBoard = RealtekBoard.RTL8777G,
                  app: RealtekApp = RealtekApp.LIGHT,
                  enable_cli: bool = False,
                  enable_rpc: bool = False,
                  enable_shell: bool = False):
-        super(RealtekBuilder, self).__init__(root, runner)
+        super(RealtekBuilder, self).__init__(root, runner, output_dir_lock)
         self.board = board
         self.app = app
         self.enable_cli = enable_cli
@@ -169,6 +172,7 @@ class RealtekBuilder(Builder):
 
         return cmd
 
+    @lock_output_dir
     def generate(self):
         if self.os_env != RtkOsUsed.FREERTOS:
             # For freertos, app.ld needs to be precompiled with gcc
@@ -183,6 +187,7 @@ class RealtekBuilder(Builder):
             out_folder=self.output_dir)
         self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
 
+    @lock_output_dir
     def _build(self):
         if self.os_env == RtkOsUsed.FREERTOS:
             cmd = ['ninja', '-C', self.output_dir]
@@ -200,6 +205,7 @@ class RealtekBuilder(Builder):
                 example_folder=os.path.join(self.root, 'examples', self.app.ExampleName, 'realtek', 'zephyr'))
             self._Execute(['bash', '-c', cmd], title='Building ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         if self.os_env == RtkOsUsed.FREERTOS:
             yield BuilderOutput(

--- a/scripts/build/builders/stm32.py
+++ b/scripts/build/builders/stm32.py
@@ -15,7 +15,9 @@
 import os
 from enum import Enum, auto
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -53,13 +55,12 @@ class stm32Board(Enum):
 class stm32Builder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: stm32App = stm32App.LIGHT,
                  board: stm32Board = stm32Board.STM32WB55XX):
-        super(stm32Builder, self).__init__(
-            root=app.BuildRoot(root),
-            runner=runner)
+        super(stm32Builder, self).__init__(root=app.BuildRoot(root), runner=runner, output_dir_lock=output_dir_lock)
 
         self.board = board
         self.app = app
@@ -75,6 +76,7 @@ class stm32Builder(GnBuilder):
         args.extend(self.extra_gn_options)
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         extensions = ["bin", "elf"]
         if self.options.enable_link_map_file:

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -17,7 +17,9 @@ import os
 import shlex
 from enum import Enum, auto
 
-from .builder import Builder, BuilderOutput
+from runner.runner import Runner
+
+from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
 
 log = logging.getLogger(__name__)
 
@@ -163,8 +165,9 @@ class TelinkBoard(Enum):
 class TelinkBuilder(Builder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: TelinkApp = TelinkApp,
                  board: TelinkBoard = TelinkBoard,
                  enable_ota: bool = False,
@@ -182,7 +185,7 @@ class TelinkBuilder(Builder):
                  chip_enable_nfc_onboarding_payload: bool = False,
                  log_level: TelinkLogLevel = TelinkLogLevel.DEFAULT,
                  ):
-        super(TelinkBuilder, self).__init__(root, runner)
+        super(TelinkBuilder, self).__init__(root, runner, output_dir_lock)
         self.app = app
         self.board = board
         self.enable_ota = enable_ota
@@ -214,6 +217,7 @@ class TelinkBuilder(Builder):
 
         return cmd
 
+    @lock_output_dir
     def generate(self):
         os.makedirs(self.output_dir, exist_ok=True)
 
@@ -287,6 +291,7 @@ class TelinkBuilder(Builder):
         self._Execute(['bash', '-c', cmd],
                       title='Generating ' + self.identifier)
 
+    @lock_output_dir
     def _build(self):
         log.info('Compiling Telink at %s', self.output_dir)
 
@@ -297,6 +302,7 @@ class TelinkBuilder(Builder):
 
         self._Execute(['bash', '-c', cmd], title='Building ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         yield BuilderOutput(
             os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),

--- a/scripts/build/builders/ti.py
+++ b/scripts/build/builders/ti.py
@@ -16,7 +16,9 @@ import os
 from enum import Enum, auto
 from typing import Optional
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 
@@ -74,14 +76,13 @@ class TIBoard(Enum):
 class TIBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  board=TIBoard.LP_EM_CC1354P10_6,
                  app: TIApp = TIApp.LOCK,
                  openthread_ftd: Optional[bool] = None):
-        super(TIBuilder, self).__init__(
-            root=app.BuildRoot(root, board),
-            runner=runner)
+        super(TIBuilder, self).__init__(root=app.BuildRoot(root, board), runner=runner, output_dir_lock=output_dir_lock)
         self.code_root = root
         self.app = app
         self.board = board
@@ -105,6 +106,7 @@ class TIBuilder(GnBuilder):
 
         return args
 
+    @lock_output_dir
     def build_outputs(self):
         if self.board == TIBoard.LP_EM_CC1354P10_6:
             if self.app in [TIApp.LOCK,

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -19,7 +19,9 @@ from collections import namedtuple
 from enum import Enum
 from xml.etree import ElementTree as ET
 
-from .builder import BuilderOutput
+from runner.runner import Runner
+
+from .builder import BuilderOutput, OutDirLock, lock_output_dir
 from .gn import GnBuilder
 
 log = logging.getLogger(__name__)
@@ -83,8 +85,9 @@ class TizenApp(Enum):
 class TizenBuilder(GnBuilder):
 
     def __init__(self,
-                 root,
-                 runner,
+                 root: str,
+                 runner: Runner,
+                 output_dir_lock: OutDirLock,
                  app: TizenApp = TizenApp.LIGHT,
                  board: TizenBoard = TizenBoard.ARM,
                  enable_ble: bool = True,
@@ -98,7 +101,8 @@ class TizenBuilder(GnBuilder):
                  ):
         super(TizenBuilder, self).__init__(
             root=os.path.join(root, app.value.source),
-            runner=runner)
+            runner=runner,
+            output_dir_lock=output_dir_lock)
 
         self.app = app
         self.board = board
@@ -139,12 +143,14 @@ class TizenBuilder(GnBuilder):
         if with_ui:
             self.extra_gn_options.append('chip_examples_enable_ui=true')
 
+    @lock_output_dir
     def generate(self):
         super(TizenBuilder, self).generate()
         if self.app == TizenApp.TESTS and self.use_coverage:
             self.coverage_dir = os.path.join(self.output_dir, 'coverage')
             self._Execute(['mkdir', '-p', self.coverage_dir], title="Create coverage output location")
 
+    @lock_output_dir
     def lcov_args(self):
         gcov = os.path.join(os.environ['TIZEN_SDK_TOOLCHAIN'], 'bin/arm-linux-gnueabi-gcov')
         return [
@@ -156,6 +162,7 @@ class TizenBuilder(GnBuilder):
             '--exclude', '/opt/*',
         ]
 
+    @lock_output_dir
     def PreBuildCommand(self):
         if self.app == TizenApp.TESTS and self.use_coverage:
             cmd = ['ninja', '-C', self.output_dir]
@@ -224,12 +231,14 @@ class TizenBuilder(GnBuilder):
         ])
         return args
 
+    @lock_output_dir
     def _bundle(self):
         if self.app.is_tpk:
             log.info('Packaging %s', self.output_dir)
             cmd = ['ninja', '-C', self.output_dir, self.app.value.name + ':tpk']
             self._Execute(cmd, title='Packaging ' + self.identifier)
 
+    @lock_output_dir
     def build_outputs(self):
         for name in self.app.value.outputs:
             if not self.options.enable_link_map_file and name.endswith(".map"):
@@ -238,6 +247,7 @@ class TizenBuilder(GnBuilder):
                 os.path.join(self.output_dir, name),
                 name)
 
+    @lock_output_dir
     def bundle_outputs(self):
         if not self.app.is_tpk:
             return

--- a/scripts/build/runner/command_dedup.py
+++ b/scripts/build/runner/command_dedup.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 import shlex
+import threading
 
 
 class CommandDedup:
     def __init__(self):
         self.commands = set()
+        self._lock = threading.Lock()
 
     def is_duplicate(self, cmd: list) -> bool:
         s = " ".join([shlex.quote(part) for part in cmd])
-        if s in self.commands:
-            return True
-        self.commands.add(s)
+        with self._lock:
+            if s in self.commands:
+                return True
+            self.commands.add(s)
         return False

--- a/scripts/build/runner/printonly.py
+++ b/scripts/build/runner/printonly.py
@@ -14,10 +14,11 @@
 
 import shlex
 
+from .runner import Runner
 from .command_dedup import CommandDedup
 
 
-class PrintOnlyRunner:
+class PrintOnlyRunner(Runner):
     def __init__(self, output_file, root: str):
         self.output_file = output_file
         self.dry_run = True
@@ -29,7 +30,7 @@ class PrintOnlyRunner:
             "# Commands will be run in CHIP project root.\n")
         self.output_file.write('cd "%s"\n\n' % self.root)
 
-    def Run(self, cmd, title=None, dedup=False, quiet=False):
+    def Run(self, cmd: list[str], title: str | None = None, dedup: bool = False, quiet: bool = False):
         if title and not quiet:
             self.output_file.write("# " + title + "\n")
 

--- a/scripts/build/runner/runner.py
+++ b/scripts/build/runner/runner.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+
+
+class Runner(ABC):
+    """Generic runner base class."""
+
+    @abstractmethod
+    def StartCommandExecution(self):
+        """Perform any setup needed before executing commands."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def Run(self, cmd: list[str], title: str | None = None, dedup: bool = False, quiet: bool = False):
+        """Execute the given command.
+
+        Args:
+            cmd: the command to execute, as a list of strings (e.g. ['ninja', '-C', 'out/'])
+            title: an optional title to log before executing the command
+            dedup: whether to attempt to deduplicate this command with previous ones (if supported by the runner)
+            quiet: whether to suppress logging output from this command (if supported by the runner)
+        """
+        raise NotImplementedError

--- a/scripts/build/runner/shell.py
+++ b/scripts/build/runner/shell.py
@@ -37,7 +37,7 @@ class LogPipe(threading.Thread):
 
             and start the thread
             """
-        threading.Thread.__init__(self, name=title if title else self.__class__.__name__)
+        threading.Thread.__init__(self, name=title or self.__class__.__name__)
         self.daemon = False
         self.level = level
         self.fd_read, self.fd_write = os.pipe()

--- a/scripts/build/runner/shell.py
+++ b/scripts/build/runner/shell.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import threading
 
+from .runner import Runner
 from .command_dedup import CommandDedup
 
 log = logging.getLogger(__name__)
@@ -31,12 +32,12 @@ class SubcommandException(Exception):
 
 class LogPipe(threading.Thread):
 
-    def __init__(self, level):
+    def __init__(self, level: int, title: str | None = None):
         """Setup the object with a logger and a loglevel
 
             and start the thread
             """
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, name=title if title else self.__class__.__name__)
         self.daemon = False
         self.level = level
         self.fd_read, self.fd_write = os.pipe()
@@ -59,7 +60,7 @@ class LogPipe(threading.Thread):
         os.close(self.fd_write)
 
 
-class ShellRunner:
+class ShellRunner(Runner):
 
     def __init__(self, root: str):
         self.dry_run = False
@@ -69,7 +70,7 @@ class ShellRunner:
     def StartCommandExecution(self):
         pass
 
-    def Run(self, cmd, title=None, dedup=False, quiet=False):
+    def Run(self, cmd: list[str], title: str | None = None, dedup: bool = False, quiet: bool = False):
 
         if title and not quiet:
             log.info(title)
@@ -79,8 +80,8 @@ class ShellRunner:
                 log.info("Skipping duplicate command...")
             return
 
-        outpipe = LogPipe(logging.INFO)
-        errpipe = LogPipe(logging.WARNING)
+        outpipe = LogPipe(logging.INFO, title=title)
+        errpipe = LogPipe(logging.WARNING, title=title)
 
         with subprocess.Popen(cmd, cwd=self.root_dir,
                               stdout=outpipe, stderr=errpipe) as s:


### PR DESCRIPTION
#### Summary

Two new options have been added to `build_examples.py`:

* `--concurrent-generation` – parallelizes target generation. Defaults to the CPU core count.
* `--concurrent-builders` – parallelizes builder execution. Defaults to 1, as before. When set to a value greater than 1, and `--ninja-jobs` is not set, the number of Ninja jobs is scaled down accordingly. For example, on a CPU with 44 threads, `--concurrent-builders=4` scales Ninja jobs down to 11. This limits oversubscription and keeps RAM usage within a reasonable range, roughly the same as it would be with `--concurrent-builders=1`.

Both options respect ownership of the output directory. If two tasks need to access the same output directory, one waits until the other finishes (it is the case for `unified` build).

This optimization significantly speeds up example builds, especially on CPUs with a relatively large number of cores. It helps keep the concurrent job count near CPU saturation, which is particularly useful during final linker stages that can take some time while using only a single core.

In addition to the main functionality, I also added some type hints to help navigate the code.

#### Related issues

None

#### Testing

The following command tests parallel generators, and 4 concurrent builders, including the case with the same output directory (`unified` targets):

```
./scripts/run_in_build_env.sh \
  "./scripts/build/build_examples.py \
    --concurrent-builders 4 \
    --pw-command-launcher=ccache \
    --target linux-x64-bridge-clang-unified \
    --target linux-x64-lock-clang-unified \
    --target linux-x64-microwave-oven-clang-unified \
    --target linux-x64-rvc-clang-unified \
    --target linux-x64-ota-provider-clang-unified \
    --target linux-x64-chip-tool-clang \
    --target linux-x64-all-clusters-clang \
    --target linux-x64-all-clusters-no-wifi-openthread-endpoint-clang \
    --target linux-x64-all-clusters-no-wifi-no-ble-openthread-endpoint-clang \
    --target linux-x64-ota-requestor-clang \
    --target linux-x64-tv-app-clang \
    --target linux-x64-lit-icd-clang \
    --target linux-x64-network-manager-clang \
    --target linux-x64-energy-gateway-clang \
    --target linux-x64-all-devices-clang \
    --target linux-x64-evse-clang \
    --target linux-x64-water-heater-clang \
    build \
    --copy-artifacts-to objdir-clone \
  "
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
