### PR TITLE
docker: Drop executables (usr/bin/*) from the Ubuntu cross-compile sysroots

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-194 : [crosscompile] Add armhf sysroot, update aarch64 sysroot to build-2026.05.07
+195 : [crosscompile] Remove executables from armhf and aarch64 sysroots

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -14,6 +14,7 @@ RUN set -x \
 WORKDIR /opt
 # Unpack the sysroots, while also removing some rather large items in them that
 # are generally not required for compilation
+# Executables are also removed as those confuse cmake. It tries to run `make` from the sysrot and fails.
 RUN set -x \
   && SYSROOT_VERSION="build-2026.05.07" \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
@@ -22,7 +23,7 @@ RUN set -x \
   && echo "experimental/matter/sysroot/ubuntu-24.04-armhf version:${SYSROOT_VERSION}" >> ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && for arch in aarch64 armhf; do \
-       for d in usr/lib/firmware usr/lib/git-core usr/lib/modules lib/firmware lib/git-core lib/modules; do \
+       for d in usr/bin usr/lib/firmware usr/lib/git-core usr/lib/modules lib/firmware lib/git-core lib/modules; do \
          rm -rf "/opt/ubuntu-24.04-${arch}-sysroot/${d}"; \
        done; \
      done \

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 WORKDIR /opt
 # Unpack the sysroots, while also removing some rather large items in them that
 # are generally not required for compilation
-# Executables are also removed as those confuse cmake. It tries to run `make` from the sysrot and fails.
+# Executables are also removed as those confuse cmake. It tries to run `make` from the sysroot and fails.
 RUN set -x \
   && SYSROOT_VERSION="build-2026.05.07" \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/create_sysroot.py
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/create_sysroot.py
@@ -207,6 +207,7 @@ def cleanup_sysroot(sysroot_dir):
                 os.unlink(path)
 
     # Clean up large unneeded subdirectories inside usr/lib to save space
+    # Remove executables as we don't need them for the build and they just confuse `cmake`
     excludes = [
         "usr/lib/*/dri",
         "usr/lib/firmware",
@@ -214,6 +215,9 @@ def cleanup_sysroot(sysroot_dir):
         "usr/lib/modules",
         "usr/lib/ssl/private",
         "usr/lib/systemd",
+
+        "usr/bin",
+        "usr/sbin"
     ]
     for pattern in excludes:
         full_pattern = os.path.join(sysroot_dir, pattern)


### PR DESCRIPTION
#### Summary

The new cross-compile sysroots introduced in https://github.com/project-chip/connectedhomeip/pull/71968 broke cross-compiling libdatachannel. The new sysroot contains executables which confuses cmake as it tries to run tooling from the sysroot's `usr/bin`. Example:

```shell
$ scripts/build/build_examples.py --target linux-arm64-all-clusters-webrtc-clang build
[…]
2026-05-12 13:59:00.700 INFO    Command ['bash', '-c', '\nPKG_CONFIG_PATH="/opt/ubuntu-24.04-aarch64-sysroot/lib/aarch64-linux-gnu/pkgconfig" \\\n gn gen --check --fail-on-unused-args \'--add-export-compile-commands=*\' --root=/workspaces/connectedhomeip/examples/all-clusters-app/linux \'--args=pw_command_launcher="ccache" is_clang=true chip_support_webrtc_python_bindings=true target_cpu="arm64" sysroot="/opt/ubuntu-24.04-aarch64-sysroot"\' /workspaces/connectedhomeip/out/linux-arm64-all-clusters-webrtc-clang'] completed
[…]
2026-05-12 13:59:01.166 INFO    python ../../examples/all-clusters-app/linux/third_party/connectedhomeip/third_party/libdatachannel/scripts/build_libdatachannel.py --build-dir obj/third_party/connectedhomeip/third_party/libdatachannel/arm64-clang --clang --cross-compile-cpu-type=arm64
2026-05-12 13:59:01.166 INFO    -- The CXX compiler identification is Clang 23.0.0
2026-05-12 13:59:01.166 INFO    -- Detecting CXX compiler ABI info
2026-05-12 13:59:01.166 INFO    -- Detecting CXX compiler ABI info - failed
2026-05-12 13:59:01.166 INFO    -- Check for working CXX compiler: /workspaces/connectedhomeip/.environment-vscode/cipd/packages/pigweed/bin/clang++
2026-05-12 13:59:01.166 INFO    -- Check for working CXX compiler: /workspaces/connectedhomeip/.environment-vscode/cipd/packages/pigweed/bin/clang++ - broken
2026-05-12 13:59:01.166 INFO    CMake Error at /usr/share/cmake-3.28/Modules/CMakeTestCXXCompiler.cmake:60 (message):
2026-05-12 13:59:01.166 INFO      The C++ compiler
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO        "/workspaces/connectedhomeip/.environment-vscode/cipd/packages/pigweed/bin/clang++"
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO      is not able to compile a simple test program.
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO      It fails with the following output:
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO        Change Dir: '/workspaces/connectedhomeip/out/linux-arm64-all-clusters-webrtc-clang/obj/third_party/connectedhomeip/third_party/libdatachannel/arm64-clang/CMakeFiles/CMakeScratch/TryCompile-dcybpa'
2026-05-12 13:59:01.166 INFO        
2026-05-12 13:59:01.166 INFO        Run Build Command(s): /usr/bin/cmake -E env VERBOSE=1 /opt/ubuntu-24.04-aarch64-sysroot/usr/bin/gmake -f Makefile cmTC_85324/fast
2026-05-12 13:59:01.166 INFO        aarch64-binfmt-P: Could not open '/lib/ld-linux-aarch64.so.1': No such file or directory
2026-05-12 13:59:01.166 INFO        
2026-05-12 13:59:01.166 INFO        
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO      
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO      CMake will not be able to correctly generate this project.
2026-05-12 13:59:01.166 INFO    Call Stack (most recent call first):
2026-05-12 13:59:01.166 INFO      CMakeLists.txt:2 (project)
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO    
2026-05-12 13:59:01.166 INFO    -- Configuring incomplete, errors occurred!
2026-05-12 13:59:01.166 INFO    Running: cmake -S /workspaces/connectedhomeip/third_party/libdatachannel/repo -B obj/third_party/connectedhomeip/third_party/libdatachannel/arm64-clang -DUSE_GNUTLS=0 -DUSE_NICE=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-Wno-shadow -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DNO_EXAMPLES=ON -DNO_TESTS=ON -DCMAKE_SYSROOT=/opt/ubuntu-24.04-aarch64-sysroot -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
```

Indeed `/opt/ubuntu-24.04-aarch64-sysroot/usr/bin/gmake` is not runnable on the build host without qemu userspace emulation:

```shell
$ /opt/ubuntu-24.04-aarch64-sysroot/usr/bin/gmake
aarch64-binfmt-P: Could not open '/lib/ld-linux-aarch64.so.1': No such file or directory
$ file /opt/ubuntu-24.04-aarch64-sysroot/usr/bin/gmake
/opt/ubuntu-24.04-aarch64-sysroot/usr/bin/gmake: symbolic link to make
$ file /opt/ubuntu-24.04-aarch64-sysroot/usr/bin/make
/opt/ubuntu-24.04-aarch64-sysroot/usr/bin/make: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=a41c4213e92a946d08ed1fe891fa857f0c8c9d41, for GNU/Linux 3.7.0, stripped
```

After removing the executables:

```shell
$ sudo rm -r /opt/ubuntu-24.04-aarch64-sysroot/usr/bin
$ scripts/build/build_examples.py --target linux-arm64-all-clusters-webrtc-clang build
[…]
2026-05-12 14:19:08.579 INFO    Command ['bash', '-c', '\nPKG_CONFIG_PATH="/opt/ubuntu-24.04-aarch64-sysroot/lib/aarch64-linux-gnu/pkgconfig" \\\n ninja -C /workspaces/connectedhomeip/out/linux-arm64-all-clusters-webrtc-clang'] completed
2026-05-12 14:19:08.579 INFO    Build Time Summary:
2026-05-12 14:19:08.579 INFO      - linux-arm64-all-clusters-webrtc-clang: 1m48s
2026-05-12 14:19:08.579 INFO    Total build time: 1m48s
```

The executables were not present before in the sysroot extracted from a VM therefore I assume they are not required for us:

```shell
$ docker run -it --rm ghcr.io/project-chip/chip-build-vscode:190
root@48a4ecd35953:/# ls -l /opt/ubuntu-24.04-aarch64-sysroot/
total 4
lrwxrwxrwx 1 root root  7 Feb  5 20:44 lib -> usr/lib
drwxr-xr-x 1 root root 20 Feb  5 20:44 usr
root@48a4ecd35953:/# ls -l /opt/ubuntu-24.04-aarch64-sysroot/usr/
total 0
drwxr-xr-x 1 root root 3948 Feb  5 20:44 include
drwxr-xr-x 1 root root 1604 Feb  5 20:44 lib
root@48a4ecd35953:/# 
```

Plus they consume ~100MB of space so it would save space to get rid of them. If we want to leave the executables in the sysroot there is a workaround variable which we can set in cmake to not look for programs (ie. `make`) in sysroots.

#### Testing

See above for results of local builds before and after the change.


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
