### PR TITLE
Don't shadow built-in Python symbols in src/{controller,lib,setup_payload,test_driver,tools}

### DIFF
--- a/src/controller/python/matter/ChipBleUtility.py
+++ b/src/controller/python/matter/ChipBleUtility.py
@@ -46,9 +46,9 @@ FAKE_CONN_OBJ_VALUE = 12121212
 SERVICE_DATA_LEN = 8
 
 
-def VoidPtrToUUIDString(ptr, len):
+def VoidPtrToUUIDString(ptr, length):
     try:
-        ptr = ChipUtility.VoidPtrToByteArray(ptr, len)
+        ptr = ChipUtility.VoidPtrToByteArray(ptr, length)
         ptr = ChipUtility.Hexlify(ptr)
         ptr = (
             ptr[:8]

--- a/src/controller/python/matter/ChipBluezMgr.py
+++ b/src/controller/python/matter/ChipBluezMgr.py
@@ -83,8 +83,8 @@ def get_bluez_objects(bluez, bus, interface, prefix_path):
             continue
         if item[0].startswith(prefix_path):
             results.append({
-              "object": bus.get_object(BLUEZ_NAME, item[0]),
-              "path": item[0]
+                "object": bus.get_object(BLUEZ_NAME, item[0]),
+                "path": item[0]
             })
     return results
 

--- a/src/controller/python/matter/ChipBluezMgr.py
+++ b/src/controller/python/matter/ChipBluezMgr.py
@@ -81,11 +81,11 @@ def get_bluez_objects(bluez, bus, interface, prefix_path):
         delegates = item[1].get(interface)
         if not delegates:
             continue
-        slice = {}
         if item[0].startswith(prefix_path):
-            slice["object"] = bus.get_object(BLUEZ_NAME, item[0])
-            slice["path"] = item[0]
-            results.append(slice)
+            results.append({
+              "object": bus.get_object(BLUEZ_NAME, item[0]),
+              "path": item[0]
+            })
     return results
 
 
@@ -206,9 +206,9 @@ class BluezDbusAdapter:
             LOGGER.debug(traceback.format_exc())
             return None
 
-    def SetDiscoveryFilter(self, dict):
+    def SetDiscoveryFilter(self, f: dict):
         try:
-            self.adapter.SetDiscoveryFilter(dict)
+            self.adapter.SetDiscoveryFilter(f)
         except dbus.exceptions.DBusException as ex:
             LOGGER.debug(str(ex))
         except Exception:

--- a/src/controller/python/matter/ChipCoreBluetoothMgr.py
+++ b/src/controller/python/matter/ChipCoreBluetoothMgr.py
@@ -72,9 +72,9 @@ CHROMECAST_SETUP_SERVICE = CBUUID.UUIDWithString_(
 CHROMECAST_SETUP_SERVICE_SHORT = CBUUID.UUIDWithString_(u"FEA0")
 
 
-def _VoidPtrToCBUUID(ptr, len):
+def _VoidPtrToCBUUID(ptr, length):
     try:
-        ptr = ChipUtility.VoidPtrToByteArray(ptr, len)
+        ptr = ChipUtility.VoidPtrToByteArray(ptr, length)
         ptr = ChipUtility.Hexlify(ptr)
         ptr = (
             ptr[:8]
@@ -415,14 +415,14 @@ class CoreBluetoothManager(ChipBleBase):
         """Called by CoreBluetooth via runloop when a new characteristic value is received for a
         characteristic to which this device has subscribed."""
         # len = characteristic.value().length()
-        bytes = bytearray(characteristic.value().bytes().tobytes())
+        buf = bytearray(characteristic.value().bytes().tobytes())
         charId = bytearray(characteristic.UUID().data().bytes().tobytes())
         svcId = bytearray(CHIP_SERVICE.data().bytes().tobytes())
 
         # Kick Chip thread to retrieve the saved packet.
         if self.devCtrl:
             # Save buffer, length, service UUID and characteristic UUID
-            rxEvent = BleRxEvent(charId=charId, svcId=svcId, buffer=bytes)
+            rxEvent = BleRxEvent(charId=charId, svcId=svcId, buffer=buf)
             self.chip_queue.put(rxEvent)
             self.devCtrl.DriveBleIO()
 
@@ -531,6 +531,6 @@ class CoreBluetoothManager(ChipBleBase):
 
         return True
 
-    def updateCharacteristic(self, bytes, svcId, charId):
+    def updateCharacteristic(self, buf, svcId, charId):
         # TODO: implement this for Peripheral support.
         return False

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1194,8 +1194,10 @@ class ChipDeviceControllerBase():
         # Intentionally return None instead of raising exceptions on error
         return (address.value.decode(), port.value) if error == 0 else None
 
-    async def DiscoverCommissionableNodes(self, filterType: discovery.FilterType = discovery.FilterType.NONE, filter: typing.Any = None,
-                                          stopOnFirst: bool = False, timeoutSecond: int = 5) -> typing.Union[None, CommissionableNode, typing.List[CommissionableNode]]:
+    async def DiscoverCommissionableNodes(self,
+                                            filterType: discovery.FilterType = discovery.FilterType.NONE,
+                                            filter: typing.Any = None,  # noqa: A002
+                                            stopOnFirst: bool = False, timeoutSecond: int = 5) -> typing.Union[None, CommissionableNode, typing.List[CommissionableNode]]:
         '''
         Discover commissionable nodes via DNS-SD with specified filters.
         Supported filters are:
@@ -1219,7 +1221,7 @@ class ChipDeviceControllerBase():
         self.CheckIsActive()
 
         if isinstance(filter, int):
-            filter = str(filter)
+            filter = str(filter)  # noqa: A001
 
         # Discovery is also used during commissioning. Make sure this manual discovery
         # and commissioning attempts do not interfere with each other.
@@ -3313,7 +3315,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
 
     async def CommissionOnNetwork(self, nodeId: int, setupPinCode: int,
                                   filterType: DiscoveryFilterType = DiscoveryFilterType.NONE,
-                                  filter: typing.Any = None,
+                                  filter: typing.Any = None,  # noqa: A002
                                   discoveryTimeoutMsec: int = 30000) -> int:
         '''
         Does the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
@@ -3341,7 +3343,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
 
         # Convert numerical filters to string for passing down to binding.
         if isinstance(filter, int):
-            filter = str(filter)
+            filter = str(filter)  # noqa: A001
 
         async with self._commissioning_context as ctx:
             self._enablePairingCompleteCallback(True)

--- a/src/controller/python/matter/ChipUtility.py
+++ b/src/controller/python/matter/ChipUtility.py
@@ -33,10 +33,10 @@ class ChipUtility(object):
         return binascii.hexlify(val).decode()
 
     @staticmethod
-    def VoidPtrToByteArray(ptr, len):
+    def VoidPtrToByteArray(ptr, length):
         if ptr:
-            v = bytearray(len)
-            memmove((c_byte * len).from_buffer(v), ptr, len)
+            v = bytearray(length)
+            memmove((c_byte * length).from_buffer(v), ptr, length)
             return v
         return None
 

--- a/src/controller/python/matter/clusters/Attribute.py
+++ b/src/controller/python/matter/clusters/Attribute.py
@@ -934,16 +934,16 @@ _OnReportEndCallbackFunct = CFUNCTYPE(
 
 
 @_OnReadAttributeDataCallbackFunct
-def _OnReadAttributeDataCallback(closure, dataVersion: int, endpoint: int, cluster: int, attribute: int, status, data, len):
-    dataBytes = ctypes.string_at(data, len)
+def _OnReadAttributeDataCallback(closure, dataVersion: int, endpoint: int, cluster: int, attribute: int, status, data, length):
+    dataBytes = ctypes.string_at(data, length)
     closure.handleAttributeData(AttributePath(
         EndpointId=endpoint, ClusterId=cluster, AttributeId=attribute), dataVersion, status, dataBytes[:])
 
 
 @_OnReadEventDataCallbackFunct
 def _OnReadEventDataCallback(closure, endpoint: int, cluster: int, event: c_uint64,
-                             number: int, priority: int, timestamp: int, timestampType: int, data, len, status):
-    dataBytes = ctypes.string_at(data, len)
+                             number: int, priority: int, timestamp: int, timestampType: int, data, length, status):
+    dataBytes = ctypes.string_at(data, length)
     path = EventPath(ClusterId=cluster, EventId=event)
 
     # EventHeader is valid only when successful
@@ -1174,27 +1174,26 @@ def Read(transaction: AsyncReadTransaction, device,
         dataVersionFiltersForCffiArrayType = c_void_p * numberOfDataVersionFilters
         dataVersionFiltersForCffi = dataVersionFiltersForCffiArrayType()
         for idx, f in enumerate(dataVersionFilters):
-            filter = DataVersionFilterIBstruct.parse(
+            flt = DataVersionFilterIBstruct.parse(
                 b'\xff' * DataVersionFilterIBstruct.sizeof())
             if f.EndpointId is not None:
-                filter.EndpointId = f.EndpointId
+                flt.EndpointId = f.EndpointId
             else:
                 raise ValueError(
                     "DataVersionFilter must provide EndpointId.")
             if f.ClusterId is not None:
-                filter.ClusterId = f.ClusterId
+                flt.ClusterId = f.ClusterId
             else:
                 raise ValueError(
                     "DataVersionFilter must provide ClusterId.")
             if f.DataVersion is not None:
-                filter.DataVersion = f.DataVersion
+                flt.DataVersion = f.DataVersion
             else:
                 raise ValueError(
                     "DataVersionFilter must provide DataVersion.")
-            filter = DataVersionFilterIBstruct.build(
-                filter)
+            flt = DataVersionFilterIBstruct.build(flt)
             dataVersionFiltersForCffi[idx] = cast(
-                ctypes.c_char_p(filter), c_void_p)
+                ctypes.c_char_p(flt), c_void_p)
 
     eventPathsForCffi = None
     if events is not None:

--- a/src/controller/python/matter/commissioning/pase.py
+++ b/src/controller/python/matter/commissioning/pase.py
@@ -38,7 +38,7 @@ class ContextManager:
             node_id=self.node_id,
             device=self.devCtrl.GetConnectedDeviceSync(self.node_id, allowPASE=True, timeoutMs=1000))
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.devCtrl.MarkSessionDefunct(self.node_id)
         if self.is_ble:
             self.devCtrl.CloseBLEConnection(self.is_ble)

--- a/src/controller/python/matter/native/__init__.py
+++ b/src/controller/python/matter/native/__init__.py
@@ -33,15 +33,15 @@ class Library(enum.Enum):
     SERVER = "_ChipServer.so"
 
 
-def _AllDirsToRoot(dir):
+def _AllDirsToRoot(p):
     """Return all parent paths of a directory."""
-    dir = os.path.abspath(dir)
+    p = os.path.abspath(p)
     while True:
-        yield dir
-        parent = os.path.dirname(dir)
-        if parent == "" or parent == dir:
+        yield p
+        parent = os.path.dirname(p)
+        if parent == "" or parent == p:
             break
-        dir = parent
+        p = parent
 
 
 class ErrorRange(enum.IntEnum):
@@ -199,8 +199,8 @@ def FindNativeLibraryPath(library: Library) -> str:
         "src/controller/python/.libs",
         library.value,
     )
-    for dir in _AllDirsToRoot(scriptDir):
-        dmDLLPathGlob = os.path.join(dir, relDMDLLPathGlob)
+    for p in _AllDirsToRoot(scriptDir):
+        dmDLLPathGlob = os.path.join(p, relDMDLLPathGlob)
         for dmDLLPath in glob.glob(dmDLLPathGlob):
             if os.path.exists(dmDLLPath):
                 return dmDLLPath

--- a/src/controller/python/matter/tlv/__init__.py
+++ b/src/controller/python/matter/tlv/__init__.py
@@ -242,16 +242,16 @@ class TLVWriter(object):
     def putSignedInt(self, tag, val):
         """Write a value as a TLV signed integer with the specified TLV tag."""
         if val >= INT8_MIN and val <= INT8_MAX:
-            format = "<b"
+            fmt = "<b"
         elif val >= INT16_MIN and val <= INT16_MAX:
-            format = "<h"
+            fmt = "<h"
         elif val >= INT32_MIN and val <= INT32_MAX:
-            format = "<l"
+            fmt = "<l"
         elif val >= INT64_MIN and val <= INT64_MAX:
-            format = "<q"
+            fmt = "<q"
         else:
             raise ValueError("Integer value out of range")
-        val = struct.pack(format, val)
+        val = struct.pack(fmt, val)
         controlAndTag = self._encodeControlAndTag(
             TLV_TYPE_SIGNED_INTEGER, tag, lenOfLenOrVal=len(val)
         )
@@ -309,10 +309,10 @@ class TLVWriter(object):
     def putBool(self, tag, val):
         """Write a value as a TLV boolean with the specified TLV tag."""
         if val:
-            type = TLVBoolean_True
+            tlv_type = TLVBoolean_True
         else:
-            type = TLVBoolean_False
-        controlAndTag = self._encodeControlAndTag(type, tag)
+            tlv_type = TLVBoolean_False
+        controlAndTag = self._encodeControlAndTag(tlv_type, tag)
         self._encoding.extend(controlAndTag)
 
     def putNull(self, tag):
@@ -349,8 +349,8 @@ class TLVWriter(object):
         controlAndTag = self._encodeControlAndTag(TLVEndOfContainer, None)
         self._encoding.extend(controlAndTag)
 
-    def _encodeControlAndTag(self, type, tag, lenOfLenOrVal=0):
-        controlByte = type
+    def _encodeControlAndTag(self, ctl, tag, lenOfLenOrVal=0):
+        controlByte = ctl
         if lenOfLenOrVal == 2:
             controlByte |= 1
         elif lenOfLenOrVal == 4:
@@ -359,7 +359,7 @@ class TLVWriter(object):
             controlByte |= 3
         if tag is None:
             if (
-                type != TLVEndOfContainer
+                ctl != TLVEndOfContainer
                 and len(self._containerStack) != 0
                 and self._containerStack[0] == TLV_TYPE_STRUCTURE
             ):
@@ -425,16 +425,16 @@ class TLVWriter(object):
         if val < 0:
             raise ValueError("Integer value out of range")
         if val <= UINT8_MAX:
-            format = "<B"
+            fmt = "<B"
         elif val <= UINT16_MAX:
-            format = "<H"
+            fmt = "<H"
         elif val <= UINT32_MAX:
-            format = "<L"
+            fmt = "<L"
         elif val <= UINT64_MAX:
-            format = "<Q"
+            fmt = "<Q"
         else:
             raise ValueError("Integer value out of range")
-        return struct.pack(format, val)
+        return struct.pack(fmt, val)
 
     @staticmethod
     def _verifyValidContainerType(containerType):

--- a/src/controller/python/matter/tlv/tlvlist.py
+++ b/src/controller/python/matter/tlv/tlvlist.py
@@ -102,8 +102,8 @@ class TLVList:
         Tag = 1
 
     class Iterator:
-        def __init__(self, iter: Iterator):
-            self._iterator = iter
+        def __init__(self, i: Iterator):
+            self._iterator = i
 
         def __iter__(self):
             return self

--- a/src/controller/python/matter/tracing/__init__.py
+++ b/src/controller/python/matter/tracing/__init__.py
@@ -117,5 +117,5 @@ class TracingContext:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         StopTracing()

--- a/src/controller/python/matter/webrtc/browser_peer_connection.py
+++ b/src/controller/python/matter/webrtc/browser_peer_connection.py
@@ -301,9 +301,9 @@ class BrowserPeerConnection(BrowserWebRTCClient):
             return
         self._local_events[Events.ICE_CANDIDATE].put(IceCandidate(candidate=candidate, sdpMid=mid, sdpMLineIndex=index))
 
-    def on_local_description_cb(self, sdp: str, type: str) -> None:
+    def on_local_description_cb(self, sdp: str, event_type: str) -> None:
         """Callback function called when a local SDP description is received."""
-        event = Events.OFFER if type.lower() == "offer" else Events.ANSWER
+        event = Events.OFFER if event_type.lower() == "offer" else Events.ANSWER
         self._local_events[event].put(sdp)
 
     def on_gathering_complete_cb(self) -> None:

--- a/src/controller/python/matter/webrtc/browser_webrtc_client.py
+++ b/src/controller/python/matter/webrtc/browser_webrtc_client.py
@@ -23,13 +23,13 @@ from .types import WebSocketMessage
 
 
 class BrowserWebRTCClient:
-    def __init__(self, ws_client: AsyncWebSocketClient, id: int):
+    def __init__(self, ws_client: AsyncWebSocketClient, id: int):  # noqa: A002
         self.event_callbacks: dict[str, Callable] = {}
         self.ws_client = ws_client
         self.pending_cmd_responses: dict[str, asyncio.Future] = {}
         self.event_loop = asyncio.get_running_loop()
         self._event_callbacks_without_parameter = ("GATHERING_STATE_COMPLETE",)
-        self.id = id
+        self.id = id  # noqa: A001
 
     async def create_peer_connection(self, media_direction: dict[str, str]):
         event = "CREATE_PEER_CONNECTION"
@@ -51,8 +51,8 @@ class BrowserWebRTCClient:
         self.event_callbacks["ANSWER"](answer_sdp)
         return answer_sdp
 
-    async def set_remote_description(self, sdp: str, type: str):
-        event = f"SET_REMOTE_{type.upper()}"
+    async def set_remote_description(self, sdp: str, event_type: str):
+        event = f"SET_REMOTE_{event_type.upper()}"
         return await self.send_message(event, sdp)
 
     async def set_remote_icecandidates(self, candidates):

--- a/src/controller/python/matter/webrtc/libdatachannel_peer_connection.py
+++ b/src/controller/python/matter/webrtc/libdatachannel_peer_connection.py
@@ -309,9 +309,9 @@ class LibdatachannelPeerConnection(LibdatachannelWebRTCClient):
         """Callback function called when a local ICE candidate is received."""
         self._local_events[Events.ICE_CANDIDATE].put(IceCandidate(candidate=candidate, sdpMid=mid))
 
-    def on_local_description_cb(self, sdp: str, type: str) -> None:
+    def on_local_description_cb(self, sdp: str, event_type: str) -> None:
         """Callback function called when a local SDP description is received."""
-        event = Events.OFFER if type.lower() == "offer" else Events.ANSWER
+        event = Events.OFFER if event_type.lower() == "offer" else Events.ANSWER
         self._local_events[event].put(sdp)
 
     def on_gathering_complete_cb(self) -> None:

--- a/src/controller/python/matter/webrtc/libdatachannel_webrtc_client.py
+++ b/src/controller/python/matter/webrtc/libdatachannel_webrtc_client.py
@@ -49,8 +49,8 @@ class LibdatachannelWebRTCClient:
         self._lib.pychip_webrtc_client_add_ice_candidate(self._handle, candidate.encode("utf-8"), mid.encode("utf-8"))
 
     def on_local_description(self, callback):
-        def c_callback(sdp, type, user_data):
-            callback(sdp.decode("utf-8"), type.decode("utf-8"))
+        def c_callback(sdp, event_type, user_data):
+            callback(sdp.decode("utf-8"), event_type.decode("utf-8"))
 
         self._local_desc_cb = LocalDescriptionCallbackType(c_callback)
         self._lib.pychip_webrtc_client_set_local_description_callback(self._handle, self._local_desc_cb, None)

--- a/src/controller/python/matter/yaml/data_model_lookup.py
+++ b/src/controller/python/matter/yaml/data_model_lookup.py
@@ -20,10 +20,10 @@ from abc import ABC, abstractmethod
 from .. import clusters as Clusters
 
 
-def _case_insensitive_getattr(object, attr_name, default):
-    for attr in dir(object):
+def _case_insensitive_getattr(obj, attr_name, default):
+    for attr in dir(obj):
         if attr.lower() == attr_name.lower():
-            return getattr(object, attr)
+            return getattr(obj, attr)
     return default
 
 

--- a/src/controller/python/matter/yaml/format_converter.py
+++ b/src/controller/python/matter/yaml/format_converter.py
@@ -32,10 +32,10 @@ class _TargetTypeInfo:
     is_fabric_scoped: bool
 
 
-def _case_insensitive_getattr(object, attr_name, default):
-    for attr in dir(object):
+def _case_insensitive_getattr(obj, attr_name, default):
+    for attr in dir(obj):
         if attr.lower() == attr_name.lower():
-            return getattr(object, attr)
+            return getattr(obj, attr)
     return default
 
 

--- a/src/controller/python/matter/yaml/runner.py
+++ b/src/controller/python/matter/yaml/runner.py
@@ -689,19 +689,19 @@ class DiscoveryCommandAction(BaseAction):
         args = test_step.arguments['values']
         request_data_as_dict = Converter.convert_list_of_name_value_pair_to_dict(args)
 
-        filter = request_data_as_dict['value']
+        flt = request_data_as_dict['value']
 
         if test_step.command == 'FindCommissionableByDeviceType':
-            return discovery.FilterType.DEVICE_TYPE, filter
+            return discovery.FilterType.DEVICE_TYPE, flt
 
         if test_step.command == 'FindCommissionableByLongDiscriminator':
-            return discovery.FilterType.LONG_DISCRIMINATOR, filter
+            return discovery.FilterType.LONG_DISCRIMINATOR, flt
 
         if test_step.command == 'FindCommissionableByShortDiscriminator':
-            return discovery.FilterType.SHORT_DISCRIMINATOR, filter
+            return discovery.FilterType.SHORT_DISCRIMINATOR, flt
 
         if test_step.command == 'FindCommissionableByVendorId':
-            return discovery.FilterType.VENDOR_ID, filter
+            return discovery.FilterType.VENDOR_ID, flt
 
         raise UnexpectedActionCreationError(f'Invalid command: {test_step.command}')
 
@@ -992,8 +992,8 @@ class ReplTestRunner:
 
         return decoded_response
 
-    def _get_fabric_id(self, id):
-        return _TestFabricId[id.upper()].value
+    def _get_fabric_id(self, _id):
+        return _TestFabricId[_id.upper()].value
 
     def _get_dev_ctrl(self, action: BaseAction):
         if action.identity is not None:

--- a/src/controller/python/tests/test_cluster_objects.py
+++ b/src/controller/python/tests/test_cluster_objects.py
@@ -23,8 +23,8 @@ def _encode_and_then_decode_to_native(data: ClusterObjects.ClusterObject):
     return TLVReader(tlv).get()['Any']
 
 
-def _encode_attribute_and_then_decode_to_native(data, type: ClusterObjects.ClusterAttributeDescriptor):
-    return TLVReader(type.ToTLV(None, data)).get()['Any']
+def _encode_attribute_and_then_decode_to_native(data, data_type: ClusterObjects.ClusterAttributeDescriptor):
+    return TLVReader(data_type.ToTLV(None, data)).get()['Any']
 
 
 def _encode_from_native_and_then_decode(data,

--- a/src/controller/python/tests/test_tlv.py
+++ b/src/controller/python/tests/test_tlv.py
@@ -132,8 +132,8 @@ class TestTLVWriter(unittest.TestCase):
 
 
 class TestTLVReader(unittest.TestCase):
-    def _read_case(self, input, answer):
-        decoded = TLVReader(bytearray(input)).get()["Any"]
+    def _read_case(self, data, answer):
+        decoded = TLVReader(bytearray(data)).get()["Any"]
         self.assertEqual(type(decoded), type(answer))
         self.assertEqual(decoded, answer)
 

--- a/src/lib/support/verhoeff/Verhoeff.py
+++ b/src/lib/support/verhoeff/Verhoeff.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import, print_function
 
 import sys
 
-from six.moves import range
+from six.moves import range  # noqa: A004
 
 __all__ = ['ComputeCheckChar',   'VerifyCheckChar',
            'ComputeCheckChar16', 'VerifyCheckChar16',
@@ -78,11 +78,11 @@ def Permute(val, permTable, iterCount):
     return Permute(permTable[val], permTable, iterCount - 1)
 
 
-def _ComputeCheckChar(str, strLen, polygonSize, permTable, charSet):
-    str = str.upper()
+def _ComputeCheckChar(s, strLen, polygonSize, permTable, charSet):
+    s = s.upper()
     c = 0
     for i in range(1, strLen+1):
-        ch = str[strLen - i]
+        ch = s[strLen - i]
         val = charSet.index(ch)
         p = Permute(val, permTable, i)
         c = DihedralMultiply(c, p, polygonSize)
@@ -90,44 +90,40 @@ def _ComputeCheckChar(str, strLen, polygonSize, permTable, charSet):
     return charSet[c]
 
 
-def ComputeCheckChar(str, charSet=CharSet_Base10):
-    return _ComputeCheckChar(str, len(str), polygonSize=5, permTable=PermTable_Base10, charSet=charSet)
+def ComputeCheckChar(s, charSet=CharSet_Base10):
+    return _ComputeCheckChar(s, len(s), polygonSize=5, permTable=PermTable_Base10, charSet=charSet)
 
 
-def VerifyCheckChar(str, charSet=CharSet_Base10):
-    expectedCheckCh = _ComputeCheckChar(str, len(
-        str)-1, polygonSize=5, permTable=PermTable_Base10, charSet=CharSet_Base10)
-    return str[-1] == expectedCheckCh
+def VerifyCheckChar(s, charSet=CharSet_Base10):
+    expectedCheckCh = _ComputeCheckChar(s, len(s)-1, polygonSize=5, permTable=PermTable_Base10, charSet=CharSet_Base10)
+    return s[-1] == expectedCheckCh
 
 
-def ComputeCheckChar16(str, charSet=CharSet_Base16):
-    return _ComputeCheckChar(str, len(str), polygonSize=8, permTable=PermTable_Base16, charSet=charSet)
+def ComputeCheckChar16(s, charSet=CharSet_Base16):
+    return _ComputeCheckChar(s, len(s), polygonSize=8, permTable=PermTable_Base16, charSet=charSet)
 
 
-def VerifyCheckChar16(str, charSet=CharSet_Base16):
-    expectedCheckCh = _ComputeCheckChar(
-        str, len(str)-1, polygonSize=8, permTable=PermTable_Base16, charSet=charSet)
-    return str[-1] == expectedCheckCh
+def VerifyCheckChar16(s, charSet=CharSet_Base16):
+    expectedCheckCh = _ComputeCheckChar(s, len(s)-1, polygonSize=8, permTable=PermTable_Base16, charSet=charSet)
+    return s[-1] == expectedCheckCh
 
 
-def ComputeCheckChar32(str, charSet=CharSet_Base32):
-    return _ComputeCheckChar(str, len(str), polygonSize=16, permTable=PermTable_Base32, charSet=charSet)
+def ComputeCheckChar32(s, charSet=CharSet_Base32):
+    return _ComputeCheckChar(s, len(s), polygonSize=16, permTable=PermTable_Base32, charSet=charSet)
 
 
-def VerifyCheckChar32(str, charSet=CharSet_Base32):
-    expectedCheckCh = _ComputeCheckChar(
-        str, len(str)-1, polygonSize=16, permTable=PermTable_Base32, charSet=charSet)
-    return str[-1] == expectedCheckCh
+def VerifyCheckChar32(s, charSet=CharSet_Base32):
+    expectedCheckCh = _ComputeCheckChar(s, len(s)-1, polygonSize=16, permTable=PermTable_Base32, charSet=charSet)
+    return s[-1] == expectedCheckCh
 
 
-def ComputeCheckChar36(str, charSet=CharSet_Base36):
-    return _ComputeCheckChar(str, len(str), polygonSize=18, permTable=PermTable_Base36, charSet=charSet)
+def ComputeCheckChar36(s, charSet=CharSet_Base36):
+    return _ComputeCheckChar(s, len(s), polygonSize=18, permTable=PermTable_Base36, charSet=charSet)
 
 
-def VerifyCheckChar36(str, charSet=CharSet_Base36):
-    expectedCheckCh = _ComputeCheckChar(
-        str, len(str)-1, polygonSize=18, permTable=PermTable_Base36, charSet=charSet)
-    return str[-1] == expectedCheckCh
+def VerifyCheckChar36(s, charSet=CharSet_Base36):
+    expectedCheckCh = _ComputeCheckChar(s, len(s)-1, polygonSize=18, permTable=PermTable_Base36, charSet=charSet)
+    return s[-1] == expectedCheckCh
 
 
 if __name__ == "__main__":

--- a/src/setup_payload/python/Base38.py
+++ b/src/setup_payload/python/Base38.py
@@ -27,8 +27,8 @@ MAX_BYTES_IN_CHUNK = 3
 MAX_ENCODED_BYTES_IN_CHUNK = 5
 
 
-def encode(bytes):
-    total_bytes = len(bytes)
+def encode(data):
+    total_bytes = len(data)
     qrcode = ''
 
     for i in range(0, total_bytes, MAX_BYTES_IN_CHUNK):
@@ -39,7 +39,7 @@ def encode(bytes):
 
         value = 0
         for j in range(i, i + bytes_in_chunk):
-            value = value + (bytes[j] << (8 * (j - i)))
+            value = value + (data[j] << (8 * (j - i)))
 
         base38_chars_needed = BASE38_CHARS_NEEDED_IN_CHUNK[bytes_in_chunk - 1]
         while base38_chars_needed > 0:

--- a/src/setup_payload/python/SetupPayload.py
+++ b/src/setup_payload/python/SetupPayload.py
@@ -116,9 +116,9 @@ class SetupPayload:
         CHUNK3_START = CHUNK2_START + CHUNK2_LEN
         CHUNK3_LEN = 13
 
-        bytes = manualcode_format.build(self.manualcode_dict())
+        data = manualcode_format.build(self.manualcode_dict())
         bits = bitarray()
-        bits.frombytes(bytes)
+        bits.frombytes(data)
 
         chunk1 = str(int(bits[CHUNK1_START:CHUNK1_START + CHUNK1_LEN].to01(), 2)).zfill(1)
         chunk2 = str(int(bits[CHUNK2_START:CHUNK2_START + CHUNK2_LEN].to01(), 2)).zfill(5)

--- a/src/test_driver/linux-cirque/EchoOverTcpTest.py
+++ b/src/test_driver/linux-cirque/EchoOverTcpTest.py
@@ -81,9 +81,9 @@ class TestEchoOverTCP(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        for id in resp_ids:
+        for _id in resp_ids:
             self.execute_device_cmd(
-                id,
+                _id,
                 "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex run -ex bt --args {}".format(
                     os.path.join(CHIP_REPO, "out/debug/linux_x64_gcc/chip-echo-responder --tcp")))
 

--- a/src/test_driver/linux-cirque/EchoTest.py
+++ b/src/test_driver/linux-cirque/EchoTest.py
@@ -81,8 +81,8 @@ class TestEcho(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        for id in resp_ids:
-            self.execute_device_cmd(id, "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex run -ex bt {}".format(
+        for _id in resp_ids:
+            self.execute_device_cmd(_id, "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex run -ex bt {}".format(
                 os.path.join(CHIP_REPO, "out/debug/linux_x64_gcc/chip-echo-responder")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args " + \

--- a/src/test_driver/linux-cirque/InteractionModelTest.py
+++ b/src/test_driver/linux-cirque/InteractionModelTest.py
@@ -81,8 +81,8 @@ class TestInteractionModel(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        for id in resp_ids:
-            self.execute_device_cmd(id, "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex run -ex bt {}".format(
+        for _id in resp_ids:
+            self.execute_device_cmd(_id, "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex run -ex bt {}".format(
                 os.path.join(CHIP_REPO, "out/debug/linux_x64_gcc/chip-im-responder")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args " + \

--- a/src/tools/chip-cert/dacs.py
+++ b/src/tools/chip-cert/dacs.py
@@ -30,12 +30,12 @@ copyrightNotice = """/*
 """
 
 
-def bytes_from_hex(hex: str) -> bytes:
-    """Converts any `hex` string representation including `01:ab:cd` to bytes
+def bytes_from_hex(s: str) -> bytes:
+    """Converts any `s` string representation including `01:ab:cd` to bytes
 
     Handles any whitespace including newlines, which are all stripped.
     """
-    return unhexlify("".join(hex.replace(":", "").split()))
+    return unhexlify("".join(s.replace(":", "").split()))
 
 
 def make_c_array(byte_string: bytes, name: str, linelen: int) -> str:

--- a/src/tools/push_av_server/src/api.py
+++ b/src/tools/push_av_server/src/api.py
@@ -228,11 +228,11 @@ class PushAvServer:
     def certificate_details(self, hierarchy: str, name: str):
         """Get certificate details."""
         data = pathlib.Path(self.stream_service.wd.path("certs", hierarchy, name)).read_bytes()
-        type = "key" if name.endswith(".key") else "cert"
+        pem_type = "key" if name.endswith(".key") else "cert"
         key = None
         cert = None
 
-        if type == "key":
+        if pem_type == "key":
             key = serialization.load_pem_private_key(data, None)
             key = {
                 "key_size": key.key_size,
@@ -258,7 +258,7 @@ class PushAvServer:
                 "extensions": [str(ext) for ext in cert.extensions]
             }
 
-        return {"type": type, "key": key, "cert": cert}
+        return {"type": pem_type, "key": key, "cert": cert}
 
     def create_client_keypair(self, name: str, override: bool = True):
         """Create a client keypair."""


### PR DESCRIPTION
#### Summary

This is the second stage in implementing changes to align our Python codebase for ruff's `A` ruleset. Everything inside `src/**` has been refactored with the exception of `src/python_testing`.

#### Testing

Before:
```
$ ruff check --statistics --output-format=concise --select=A src/{controller,lib,setup_payload,test_driver,tools} 
35	A002	builtin-argument-shadowing
26	A001	builtin-variable-shadowing
 1	A004	builtin-import-shadowing
Found 62 errors.
```

After:

```
$ ruff check --output-format=concise --select=A src/{controller,lib,setup_payload,test_driver,tools}
All checks passed!
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
