### PR TITLE
Enhance WebRTCManager state safety

### DIFF
--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
@@ -32,7 +32,7 @@ namespace webrtc {
 CHIP_ERROR ConnectCommand::RunCommand()
 {
     ChipLogProgress(Camera, "Run ConnectCommand");
-    return WebRTCManager::Instance().Connnect(CurrentCommissioner(), mPeerNodeId, mPeerEndpointId);
+    return WebRTCManager::Instance().Connect(CurrentCommissioner(), mPeerNodeId, mPeerEndpointId);
 }
 
 CHIP_ERROR ProvideOfferCommand::RunCommand()

--- a/examples/camera-controller/device-manager/DeviceManager.cpp
+++ b/examples/camera-controller/device-manager/DeviceManager.cpp
@@ -190,7 +190,7 @@ void DeviceManager::InitiateWebRTCSession(uint16_t videoStreamId)
     ChipLogProgress(Camera, "DeviceManager: Initiating WebRTC session for node=0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
     // Connect to the WebRTC transport provider on the device
-    CHIP_ERROR err = WebRTCManager::Instance().Connnect(*mCommissioner, mNodeId, kCameraEndpointId);
+    CHIP_ERROR err = WebRTCManager::Instance().Connect(*mCommissioner, mNodeId, kCameraEndpointId);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "Failed to connect WebRTC manager. Error: %" CHIP_ERROR_FORMAT, err.Format());

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -177,13 +177,8 @@ CHIP_ERROR WebRTCManager::HandleAnswer(const WebRTCSessionStruct & session, cons
     mPendingSdpContext.sessionId = session.id;
 
     // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
-    SuccessOrDie(DeviceLayer::SystemLayer().StartTimer(
-        chip::System::Clock::Milliseconds32(300),
-        [](chip::System::Layer * systemLayer, void * appState) {
-            auto * self = static_cast<WebRTCManager *>(appState);
-            LogErrorOnFailure(self->ProvideICECandidates(self->mPendingSdpContext.sessionId));
-        },
-        this));
+    SuccessOrDie(
+        DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(300), OnDelayedProvideICECandidates, this));
 
     return CHIP_NO_ERROR;
 }
@@ -244,6 +239,9 @@ void WebRTCManager::CloseRTPSockets()
 void WebRTCManager::Disconnect()
 {
     ChipLogProgress(Camera, "Disconnecting WebRTC session");
+
+    // Cancel any pending ProvideICECandidates timer
+    DeviceLayer::SystemLayer().CancelTimer(OnDelayedProvideICECandidates, this);
 
     // Close the peer connection
     if (mPeerConnection)
@@ -594,4 +592,11 @@ void WebRTCManager::OnGatheringStateChanged(const std::shared_ptr<rtc::PeerConne
         return;
     }
     ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
+}
+
+void WebRTCManager::OnDelayedProvideICECandidates(chip::System::Layer * systemLayer, void * appState)
+{
+    auto * self = static_cast<WebRTCManager *>(appState);
+    VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDelayedProvideICECandidates: appState is null"));
+    LogErrorOnFailure(self->ProvideICECandidates(self->mPendingSdpContext.sessionId));
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -157,13 +157,13 @@ CHIP_ERROR WebRTCManager::HandleAnswer(const WebRTCSessionStruct & session, cons
     mPendingSdpContext.sessionId = session.id;
 
     // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(
+    SuccessOrDie(DeviceLayer::SystemLayer().StartTimer(
         chip::System::Clock::Milliseconds32(300),
         [](chip::System::Layer * systemLayer, void * appState) {
             auto * self = static_cast<WebRTCManager *>(appState);
-            TEMPORARY_RETURN_IGNORED self->ProvideICECandidates(self->mPendingSdpContext.sessionId);
+            LogErrorOnFailure(self->ProvideICECandidates(self->mPendingSdpContext.sessionId));
         },
-        this);
+        this));
 
     return CHIP_NO_ERROR;
 }
@@ -274,23 +274,23 @@ CHIP_ERROR WebRTCManager::Connect(Controller::DeviceCommissioner & commissioner,
 
     mPeerConnection->onLocalDescription([this](rtc::Description desc) {
         auto * descPtr = new rtc::Description(desc);
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, descPtr]() {
+        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, descPtr]() {
             std::unique_ptr<rtc::Description> guard(descPtr);
             OnLocalDescriptionGenerated(*descPtr);
-        });
+        }));
     });
     mPeerConnection->onLocalCandidate([this](rtc::Candidate candidate) {
         auto * candidatePtr = new rtc::Candidate(candidate);
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, candidatePtr]() {
+        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, candidatePtr]() {
             std::unique_ptr<rtc::Candidate> guard(candidatePtr);
             OnLocalCandidateGathered(*candidatePtr);
-        });
+        }));
     });
     mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnConnectionStateChanged(state); });
+        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnConnectionStateChanged(state); }));
     });
     mPeerConnection->onGatheringStateChange([this](rtc::PeerConnection::GatheringState state) {
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnGatheringStateChanged(state); });
+        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnGatheringStateChanged(state); }));
     });
 
     // Create UDP socket for RTP forwarding
@@ -490,7 +490,7 @@ void WebRTCManager::OnLocalDescriptionGenerated(const rtc::Description & desc)
     {
         uint16_t sessionId = mPendingSdpContext.sessionId;
         mPendingSdpContext.Reset();
-        TEMPORARY_RETURN_IGNORED ProvideAnswer(sessionId, sdpStr);
+        LogErrorOnFailure(ProvideAnswer(sessionId, sdpStr));
     }
     else if (mPendingSdpContext.state == LocalSdpState::PendingOffer)
     {

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -173,12 +173,15 @@ CHIP_ERROR WebRTCManager::HandleAnswer(const WebRTCSessionStruct & session, cons
     rtc::Description answerDesc(sdp, rtc::Description::Type::Answer);
     mPeerConnection->setRemoteDescription(answerDesc);
 
-    // Store sessionId for the delayed callback
-    mPendingSdpContext.sessionId = session.id;
+    // Schedule ProvideICECandidates() to run in a subsequent event loop iteration.
+    // Since the transport is TCP, this guarantees that the StatusResponse for the Answer command
+    // is transmitted and processed by the peer before the ProvideICECandidates command is received.
+    SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this]() {
+        if (!mPeerConnection)
+            return;
 
-    // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
-    SuccessOrDie(
-        DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(300), OnDelayedProvideICECandidates, this));
+        LogErrorOnFailure(ProvideICECandidates(mPendingSdpContext.sessionId));
+    }));
 
     return CHIP_NO_ERROR;
 }
@@ -239,9 +242,6 @@ void WebRTCManager::CloseRTPSockets()
 void WebRTCManager::Disconnect()
 {
     ChipLogProgress(Camera, "Disconnecting WebRTC session");
-
-    // Cancel any pending ProvideICECandidates timer
-    DeviceLayer::SystemLayer().CancelTimer(OnDelayedProvideICECandidates, this);
 
     // Close the peer connection
     if (mPeerConnection)
@@ -592,11 +592,4 @@ void WebRTCManager::OnGatheringStateChanged(const std::shared_ptr<rtc::PeerConne
         return;
     }
     ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
-}
-
-void WebRTCManager::OnDelayedProvideICECandidates(chip::System::Layer * systemLayer, void * appState)
-{
-    auto * self = static_cast<WebRTCManager *>(appState);
-    VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDelayedProvideICECandidates: appState is null"));
-    LogErrorOnFailure(self->ProvideICECandidates(self->mPendingSdpContext.sessionId));
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -90,6 +90,26 @@ const char * GetGatheringStateStr(rtc::PeerConnection::GatheringState state)
     return "N/A";
 }
 
+void ScheduleOnMatterThread(const std::weak_ptr<rtc::PeerConnection> & weakPeerConnection,
+                            std::function<void(const std::shared_ptr<rtc::PeerConnection> &)> && callback)
+{
+    struct CallbackState
+    {
+        std::weak_ptr<rtc::PeerConnection> weakPeerConnection;
+        std::function<void(const std::shared_ptr<rtc::PeerConnection> &)> callback;
+    };
+
+    auto * callbackState = new CallbackState{ weakPeerConnection, std::move(callback) };
+    SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([callbackState]() {
+        std::unique_ptr<CallbackState> guard(callbackState);
+        auto peerConnection = guard->weakPeerConnection.lock();
+        if (peerConnection)
+        {
+            guard->callback(peerConnection);
+        }
+    }));
+}
+
 } // namespace
 
 WebRTCManager::WebRTCManager() {}
@@ -272,25 +292,26 @@ CHIP_ERROR WebRTCManager::Connect(Controller::DeviceCommissioner & commissioner,
     config.iceServers.emplace_back("stun:stun.l.google.com:19302");
     mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
 
-    mPeerConnection->onLocalDescription([this](rtc::Description desc) {
-        auto * descPtr = new rtc::Description(desc);
-        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, descPtr]() {
-            std::unique_ptr<rtc::Description> guard(descPtr);
-            OnLocalDescriptionGenerated(*descPtr);
-        }));
+    std::weak_ptr<rtc::PeerConnection> weakPeerConnection = mPeerConnection;
+    mPeerConnection->onLocalDescription([this, weakPeerConnection](rtc::Description desc) {
+        ScheduleOnMatterThread(weakPeerConnection, [this, desc](const std::shared_ptr<rtc::PeerConnection> & connection) {
+            OnLocalDescriptionGenerated(connection, desc);
+        });
     });
-    mPeerConnection->onLocalCandidate([this](rtc::Candidate candidate) {
-        auto * candidatePtr = new rtc::Candidate(candidate);
-        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, candidatePtr]() {
-            std::unique_ptr<rtc::Candidate> guard(candidatePtr);
-            OnLocalCandidateGathered(*candidatePtr);
-        }));
+    mPeerConnection->onLocalCandidate([this, weakPeerConnection](rtc::Candidate candidate) {
+        ScheduleOnMatterThread(weakPeerConnection, [this, candidate](const std::shared_ptr<rtc::PeerConnection> & connection) {
+            OnLocalCandidateGathered(connection, candidate);
+        });
     });
-    mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
-        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnConnectionStateChanged(state); }));
+    mPeerConnection->onStateChange([this, weakPeerConnection](rtc::PeerConnection::State state) {
+        ScheduleOnMatterThread(weakPeerConnection, [this, state](const std::shared_ptr<rtc::PeerConnection> & connection) {
+            OnConnectionStateChanged(connection, state);
+        });
     });
-    mPeerConnection->onGatheringStateChange([this](rtc::PeerConnection::GatheringState state) {
-        SuccessOrDie(DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnGatheringStateChanged(state); }));
+    mPeerConnection->onGatheringStateChange([this, weakPeerConnection](rtc::PeerConnection::GatheringState state) {
+        ScheduleOnMatterThread(weakPeerConnection, [this, state](const std::shared_ptr<rtc::PeerConnection> & connection) {
+            OnGatheringStateChanged(connection, state);
+        });
     });
 
     // Create UDP socket for RTP forwarding
@@ -459,10 +480,12 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     return err;
 }
 
-void WebRTCManager::OnLocalDescriptionGenerated(const rtc::Description & desc)
+void WebRTCManager::OnLocalDescriptionGenerated(const std::shared_ptr<rtc::PeerConnection> & connection,
+                                                const rtc::Description & desc)
 {
-    if (!mPeerConnection)
+    if (connection != mPeerConnection)
     {
+        ChipLogDetail(Camera, "OnLocalDescriptionGenerated: ignoring stale callback for previous WebRTC session");
         return;
     }
 
@@ -514,10 +537,12 @@ void WebRTCManager::OnLocalDescriptionGenerated(const rtc::Description & desc)
     }
 }
 
-void WebRTCManager::OnLocalCandidateGathered(const rtc::Candidate & candidate)
+void WebRTCManager::OnLocalCandidateGathered(const std::shared_ptr<rtc::PeerConnection> & connection,
+                                             const rtc::Candidate & candidate)
 {
-    if (!mPeerConnection)
+    if (connection != mPeerConnection)
     {
+        ChipLogDetail(Camera, "OnLocalCandidateGathered: ignoring stale callback for previous WebRTC session");
         return;
     }
 
@@ -533,10 +558,12 @@ void WebRTCManager::OnLocalCandidateGathered(const rtc::Candidate & candidate)
     mLocalCandidates.push_back(candidateInfo);
 }
 
-void WebRTCManager::OnConnectionStateChanged(rtc::PeerConnection::State state)
+void WebRTCManager::OnConnectionStateChanged(const std::shared_ptr<rtc::PeerConnection> & connection,
+                                             rtc::PeerConnection::State state)
 {
-    if (!mPeerConnection)
+    if (connection != mPeerConnection)
     {
+        ChipLogDetail(Camera, "OnConnectionStateChanged: ignoring stale callback for previous WebRTC session");
         return;
     }
 
@@ -558,7 +585,13 @@ void WebRTCManager::OnConnectionStateChanged(rtc::PeerConnection::State state)
     }
 }
 
-void WebRTCManager::OnGatheringStateChanged(rtc::PeerConnection::GatheringState state)
+void WebRTCManager::OnGatheringStateChanged(const std::shared_ptr<rtc::PeerConnection> & connection,
+                                            rtc::PeerConnection::GatheringState state)
 {
+    if (connection != mPeerConnection)
+    {
+        ChipLogDetail(Camera, "OnGatheringStateChanged: ignoring stale callback for previous WebRTC session");
+        return;
+    }
     ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -26,6 +26,7 @@
 
 #include <arpa/inet.h>
 #include <cstdio>
+#include <memory>
 #include <netinet/in.h>
 #include <string>
 #include <sys/socket.h>
@@ -123,25 +124,14 @@ CHIP_ERROR WebRTCManager::HandleOffer(const WebRTCSessionStruct & session, const
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    VerifyOrReturnError(mPendingSdpContext.state == LocalSdpState::Idle, CHIP_ERROR_INCORRECT_STATE);
+
+    // Store session context for the listener callback
+    mPendingSdpContext.sessionId = session.id;
+    mPendingSdpContext.state     = LocalSdpState::PendingAnswer;
+
     mPeerConnection->setRemoteDescription(rtc::Description{ args.sdp, "offer" });
-
-    if (mLocalDescription.empty())
-    {
-        ChipLogError(Camera, "No local SDP to send");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    // Store sessionId for the delayed callback
-    mPendingSessionId = session.id;
-
-    // Schedule the ProvideAnswer() call to run with a small delay to ensure the response is sent first
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(
-        chip::System::Clock::Milliseconds32(300),
-        [](chip::System::Layer * systemLayer, void * appState) {
-            auto * self = static_cast<WebRTCManager *>(appState);
-            TEMPORARY_RETURN_IGNORED self->ProvideAnswer(self->mPendingSessionId, self->mLocalDescription);
-        },
-        this);
+    mPeerConnection->setLocalDescription();
 
     return CHIP_NO_ERROR;
 }
@@ -158,18 +148,20 @@ CHIP_ERROR WebRTCManager::HandleAnswer(const WebRTCSessionStruct & session, cons
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    VerifyOrReturnError(mPendingSdpContext.state == LocalSdpState::Idle, CHIP_ERROR_INCORRECT_STATE);
+
     rtc::Description answerDesc(sdp, rtc::Description::Type::Answer);
     mPeerConnection->setRemoteDescription(answerDesc);
 
     // Store sessionId for the delayed callback
-    mPendingSessionId = session.id;
+    mPendingSdpContext.sessionId = session.id;
 
     // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
     TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(
         chip::System::Clock::Milliseconds32(300),
         [](chip::System::Layer * systemLayer, void * appState) {
             auto * self = static_cast<WebRTCManager *>(appState);
-            TEMPORARY_RETURN_IGNORED self->ProvideICECandidates(self->mPendingSessionId);
+            TEMPORARY_RETURN_IGNORED self->ProvideICECandidates(self->mPendingSdpContext.sessionId);
         },
         this);
 
@@ -213,13 +205,19 @@ CHIP_ERROR WebRTCManager::HandleICECandidates(const WebRTCSessionStruct & sessio
     return CHIP_NO_ERROR;
 }
 
-void WebRTCManager::CloseRTPSocket()
+void WebRTCManager::CloseRTPSockets()
 {
     if (mRTPSocket != -1)
     {
         ChipLogProgress(Camera, "Closing RTP socket");
         close(mRTPSocket);
         mRTPSocket = -1;
+    }
+    if (mAudioRTPSocket != -1)
+    {
+        ChipLogProgress(Camera, "Closing RTP Audio socket");
+        close(mAudioRTPSocket);
+        mAudioRTPSocket = -1;
     }
 }
 
@@ -235,7 +233,7 @@ void WebRTCManager::Disconnect()
     }
 
     // Close the RTP socket
-    CloseRTPSocket();
+    CloseRTPSockets();
 
     // Reset track
     mTrack.reset();
@@ -243,12 +241,11 @@ void WebRTCManager::Disconnect()
 
     // Clear state
     mCurrentVideoStreamId = 0;
-    mPendingSessionId     = 0;
-    mLocalDescription.clear();
+    mPendingSdpContext.Reset();
     mLocalCandidates.clear();
 }
 
-CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner, NodeId nodeId, EndpointId endpointId)
+CHIP_ERROR WebRTCManager::Connect(Controller::DeviceCommissioner & commissioner, NodeId nodeId, EndpointId endpointId)
 {
     ChipLogProgress(Camera, "Attempting to establish WebRTC connection to node 0x" ChipLogFormatX64 " on endpoint 0x%x",
                     ChipLogValueX64(nodeId), endpointId);
@@ -271,68 +268,29 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
 
     // Create the peer connection
     rtc::Configuration config;
+    config.disableAutoNegotiation = true;
     config.iceServers.emplace_back("stun:stun.l.google.com:19302");
     mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
 
     mPeerConnection->onLocalDescription([this](rtc::Description desc) {
-        mLocalDescription = std::string(desc);
-        ChipLogProgress(Camera, "Local Description:");
-        ChipLogProgress(Camera, "%s", mLocalDescription.c_str());
-
-        // Extract any candidates embedded in the SDP description
-        std::vector<rtc::Candidate> candidates = desc.candidates();
-        ChipLogProgress(Camera, "Extracted %zu candidates from SDP description", candidates.size());
-
-        for (const auto & candidate : candidates)
-        {
-            ICECandidateInfo candidateInfo;
-            candidateInfo.candidate  = std::string(candidate);
-            candidateInfo.mid        = candidate.mid();
-            candidateInfo.mlineIndex = -1; // libdatachannel doesn't provide mlineIndex
-
-            ChipLogProgress(Camera, "[From SDP] Candidate: %s, mid: %s", candidateInfo.candidate.c_str(),
-                            candidateInfo.mid.c_str());
-
-            mLocalCandidates.push_back(candidateInfo);
-        }
+        auto * descPtr = new rtc::Description(desc);
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, descPtr]() {
+            std::unique_ptr<rtc::Description> guard(descPtr);
+            OnLocalDescriptionGenerated(*descPtr);
+        });
     });
-
     mPeerConnection->onLocalCandidate([this](rtc::Candidate candidate) {
-        ICECandidateInfo candidateInfo;
-        candidateInfo.candidate = std::string(candidate);
-        candidateInfo.mid       = candidate.mid();
-
-        // Note: libdatachannel doesn't directly provide mlineIndex, so we use -1 to indicate it is not present.
-        candidateInfo.mlineIndex = -1;
-
-        ChipLogProgress(Camera, "Local Candidate:");
-        ChipLogProgress(Camera, "%s", candidateInfo.candidate.c_str());
-        ChipLogProgress(Camera, "  mid: %s, mlineIndex: %d", candidateInfo.mid.c_str(), candidateInfo.mlineIndex);
-
-        mLocalCandidates.push_back(candidateInfo);
+        auto * candidatePtr = new rtc::Candidate(candidate);
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, candidatePtr]() {
+            std::unique_ptr<rtc::Candidate> guard(candidatePtr);
+            OnLocalCandidateGathered(*candidatePtr);
+        });
     });
-
     mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
-        ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
-
-        // Check if the session is now established (connected)
-        if (state == rtc::PeerConnection::State::Connected)
-        {
-            // Call the callback to notify DeviceManager
-            if (mSessionEstablishedCallback && mCurrentVideoStreamId != 0)
-            {
-                mSessionEstablishedCallback(mCurrentVideoStreamId);
-            }
-        }
-        else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed)
-        {
-            // Limit the clearup to Failed and Closed only to avoid prematurely ending sessions.
-            Disconnect();
-        }
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnConnectionStateChanged(state); });
     });
-
-    mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
-        ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
+    mPeerConnection->onGatheringStateChange([this](rtc::PeerConnection::GatheringState state) {
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, state]() { OnGatheringStateChanged(state); });
     });
 
     // Create UDP socket for RTP forwarding
@@ -393,8 +351,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
         },
         nullptr);
 
-    ChipLogProgress(Camera, "Generate and set the SDP");
-    mPeerConnection->setLocalDescription();
+    // Local description generation is deferred to ProvideOffer or HandleOffer
 
     return CHIP_NO_ERROR;
 }
@@ -405,16 +362,18 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId, 
 {
     ChipLogProgress(Camera, "Sending ProvideOffer command to the peer device");
 
-    if (mLocalDescription.empty())
+    if (!mPeerConnection)
     {
-        ChipLogError(Camera, "No local SDP to send");
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        ChipLogError(Camera, "Cannot set local description: mPeerConnection is null");
+        return CHIP_ERROR_INCORRECT_STATE;
     }
+
+    VerifyOrReturnError(mPendingSdpContext.state == LocalSdpState::Idle, CHIP_ERROR_INCORRECT_STATE);
 
     // At least one of Video Stream ID and Audio Stream ID has to be present
     if (!videoStreamId.HasValue() && !audioStreamId.HasValue())
     {
-        ChipLogError(Zcl, "One of VideoStreamID or AudioStreamID must be present");
+        ChipLogError(Camera, "One of VideoStreamID or AudioStreamID must be present");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -425,15 +384,17 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId, 
         ChipLogProgress(Camera, "Tracking stream ID %u for WebRTC session", mCurrentVideoStreamId);
     }
 
-    CHIP_ERROR err = mWebRTCProviderClient.ProvideOffer(sessionId, mLocalDescription, streamUsage,
-                                                        kWebRTCRequesterDynamicEndpointId, videoStreamId, audioStreamId);
+    // Store context for the listener callback
+    mPendingSdpContext.nullableSessionId = sessionId;
+    mPendingSdpContext.streamUsage       = streamUsage;
+    mPendingSdpContext.videoStreamId     = videoStreamId;
+    mPendingSdpContext.audioStreamId     = audioStreamId;
+    mPendingSdpContext.state             = LocalSdpState::PendingOffer;
 
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Camera, "Failed to send ProvideOffer: %" CHIP_ERROR_FORMAT, err.Format());
-    }
+    ChipLogProgress(Camera, "Generate and set the local SDP Offer");
+    mPeerConnection->setLocalDescription();
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WebRTCManager::SolicitOffer(StreamUsageEnum streamUsage, Optional<app::DataModel::Nullable<uint16_t>> videoStreamId,
@@ -444,7 +405,7 @@ CHIP_ERROR WebRTCManager::SolicitOffer(StreamUsageEnum streamUsage, Optional<app
     // At least one of Video Stream ID and Audio Stream ID has to be present
     if (!videoStreamId.HasValue() && !audioStreamId.HasValue())
     {
-        ChipLogError(Zcl, "One of VideoStreamID or AudioStreamID must be present");
+        ChipLogError(Camera, "One of VideoStreamID or AudioStreamID must be present");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -483,12 +444,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    // Make a copy of candidates to send to avoid race condition with onLocalCandidate callback
-    // which can asynchronously add new candidates while we're sending
-    std::vector<ICECandidateInfo> candidatesToSend = mLocalCandidates;
-    size_t candidateCount                          = candidatesToSend.size();
-
-    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(sessionId, candidatesToSend);
+    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(sessionId, mLocalCandidates);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -496,25 +452,113 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     }
     else
     {
-        ChipLogProgress(Camera, "Sent %zu ICE candidate(s)", candidateCount);
-
-        // Remove only the candidates that were successfully sent
-        // New candidates may have arrived during transmission, so we remove from the front
-        if (mLocalCandidates.size() > candidateCount)
-        {
-            mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + candidateCount);
-            if (!mLocalCandidates.empty())
-            {
-                ChipLogProgress(Camera, "%zu new candidate(s) arrived during transmission, keeping for next batch",
-                                mLocalCandidates.size());
-            }
-        }
-        else
-        {
-            ChipLogProgress(Camera, "Sent %zu ICE candidate(s), clearing list", mLocalCandidates.size());
-            mLocalCandidates.clear();
-        }
+        ChipLogProgress(Camera, "Sent %zu ICE candidate(s), clearing list", mLocalCandidates.size());
+        mLocalCandidates.clear();
     }
 
     return err;
+}
+
+void WebRTCManager::OnLocalDescriptionGenerated(const rtc::Description & desc)
+{
+    if (!mPeerConnection)
+    {
+        return;
+    }
+
+    std::string sdpStr = std::string(desc);
+    ChipLogProgress(Camera, "Local Description:");
+    ChipLogProgress(Camera, "%s", sdpStr.c_str());
+
+    // Extract any candidates embedded in the SDP description directly on the main thread
+    std::vector<rtc::Candidate> candidates = desc.candidates();
+    ChipLogProgress(Camera, "Extracted %zu candidates from SDP description", candidates.size());
+
+    for (const auto & candidate : candidates)
+    {
+        ICECandidateInfo candidateInfo;
+        candidateInfo.candidate  = std::string(candidate);
+        candidateInfo.mid        = candidate.mid();
+        candidateInfo.mlineIndex = -1; // libdatachannel doesn't provide mlineIndex
+
+        ChipLogProgress(Camera, "[From SDP] Candidate: %s, mid: %s", candidateInfo.candidate.c_str(), candidateInfo.mid.c_str());
+
+        mLocalCandidates.push_back(candidateInfo);
+    }
+
+    if (mPendingSdpContext.state == LocalSdpState::PendingAnswer)
+    {
+        uint16_t sessionId = mPendingSdpContext.sessionId;
+        mPendingSdpContext.Reset();
+        TEMPORARY_RETURN_IGNORED ProvideAnswer(sessionId, sdpStr);
+    }
+    else if (mPendingSdpContext.state == LocalSdpState::PendingOffer)
+    {
+        // Cache local copies before resetting context
+        auto nullableSessionId = mPendingSdpContext.nullableSessionId;
+        auto streamUsage       = mPendingSdpContext.streamUsage;
+        auto videoStreamId     = mPendingSdpContext.videoStreamId;
+        auto audioStreamId     = mPendingSdpContext.audioStreamId;
+        mPendingSdpContext.Reset();
+
+        CHIP_ERROR err = mWebRTCProviderClient.ProvideOffer(nullableSessionId, sdpStr, streamUsage,
+                                                            kWebRTCRequesterDynamicEndpointId, videoStreamId, audioStreamId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Camera, "Failed to send ProvideOffer: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+    }
+    else
+    {
+        ChipLogError(Camera, "OnLocalDescriptionGenerated called while in LocalSdpState::Idle");
+    }
+}
+
+void WebRTCManager::OnLocalCandidateGathered(const rtc::Candidate & candidate)
+{
+    if (!mPeerConnection)
+    {
+        return;
+    }
+
+    ICECandidateInfo candidateInfo;
+    candidateInfo.candidate  = std::string(candidate);
+    candidateInfo.mid        = candidate.mid();
+    candidateInfo.mlineIndex = -1;
+
+    ChipLogProgress(Camera, "Local Candidate:");
+    ChipLogProgress(Camera, "%s", candidateInfo.candidate.c_str());
+    ChipLogProgress(Camera, "  mid: %s, mlineIndex: %d", candidateInfo.mid.c_str(), candidateInfo.mlineIndex);
+
+    mLocalCandidates.push_back(candidateInfo);
+}
+
+void WebRTCManager::OnConnectionStateChanged(rtc::PeerConnection::State state)
+{
+    if (!mPeerConnection)
+    {
+        return;
+    }
+
+    ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
+
+    // Check if the session is now established (connected)
+    if (state == rtc::PeerConnection::State::Connected)
+    {
+        // Call the callback to notify DeviceManager
+        if (mSessionEstablishedCallback && mCurrentVideoStreamId != 0)
+        {
+            mSessionEstablishedCallback(mCurrentVideoStreamId);
+        }
+    }
+    else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed)
+    {
+        // Limit the clearup to Failed and Closed only to avoid prematurely ending sessions.
+        Disconnect();
+    }
+}
+
+void WebRTCManager::OnGatheringStateChanged(rtc::PeerConnection::GatheringState state)
+{
+    ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -85,8 +85,6 @@ private:
     WebRTCManager();
     ~WebRTCManager();
 
-    static void OnDelayedProvideICECandidates(chip::System::Layer * systemLayer, void * appState);
-
     // Close and reset the RTP sockets
     void CloseRTPSockets();
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -62,7 +62,7 @@ public:
 
     CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session, const std::vector<ICECandidateStruct> & candidates);
 
-    CHIP_ERROR Connnect(chip::Controller::DeviceCommissioner & commissioner, chip::NodeId nodeId, chip::EndpointId endpointId);
+    CHIP_ERROR Connect(chip::Controller::DeviceCommissioner & commissioner, chip::NodeId nodeId, chip::EndpointId endpointId);
 
     CHIP_ERROR ProvideOffer(chip::app::DataModel::Nullable<uint16_t> sessionId, StreamUsageEnum streamUsage,
                             chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
@@ -70,6 +70,7 @@ public:
 
     CHIP_ERROR SolicitOffer(StreamUsageEnum streamUsage, chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
                             chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId);
+
     CHIP_ERROR ProvideAnswer(uint16_t sessionId, const std::string & sdp);
 
     CHIP_ERROR ProvideICECandidates(uint16_t sessionId);
@@ -84,6 +85,15 @@ private:
     WebRTCManager();
     ~WebRTCManager();
 
+    // Close and reset the RTP sockets
+    void CloseRTPSockets();
+
+    // PeerConnection callback handlers
+    void OnLocalDescriptionGenerated(const rtc::Description & desc);
+    void OnLocalCandidateGathered(const rtc::Candidate & candidate);
+    void OnConnectionStateChanged(rtc::PeerConnection::State state);
+    void OnGatheringStateChanged(rtc::PeerConnection::GatheringState state);
+
     chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster>
         mWebRTCRegisteredServerCluster;
 
@@ -92,8 +102,25 @@ private:
 
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
 
-    uint16_t mPendingSessionId = 0;
-    std::string mLocalDescription;
+    enum class LocalSdpState
+    {
+        Idle,
+        PendingOffer,
+        PendingAnswer
+    };
+
+    struct PendingSdpContext
+    {
+        LocalSdpState state = LocalSdpState::Idle;
+        uint16_t sessionId  = 0;
+        chip::app::DataModel::Nullable<uint16_t> nullableSessionId;
+        StreamUsageEnum streamUsage = {};
+        chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId;
+        chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId;
+
+        void Reset() { *this = PendingSdpContext{}; }
+    };
+    PendingSdpContext mPendingSdpContext;
 
     // Local vector to store the ICE Candidate info coming from the WebRTC stack
     std::vector<ICECandidateInfo> mLocalCandidates;
@@ -110,7 +137,4 @@ private:
     // UDP socket for RTP forwarding
     int mRTPSocket      = -1;
     int mAudioRTPSocket = -1;
-
-    // Close and reset the RTP socket
-    void CloseRTPSocket();
 };

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -88,11 +88,12 @@ private:
     // Close and reset the RTP sockets
     void CloseRTPSockets();
 
-    // PeerConnection callback handlers
-    void OnLocalDescriptionGenerated(const rtc::Description & desc);
-    void OnLocalCandidateGathered(const rtc::Candidate & candidate);
-    void OnConnectionStateChanged(rtc::PeerConnection::State state);
-    void OnGatheringStateChanged(rtc::PeerConnection::GatheringState state);
+    // PeerConnection callback handlers. The handlers are executed on the Matter thread.
+    void OnLocalDescriptionGenerated(const std::shared_ptr<rtc::PeerConnection> & connection, const rtc::Description & desc);
+    void OnLocalCandidateGathered(const std::shared_ptr<rtc::PeerConnection> & connection, const rtc::Candidate & candidate);
+    void OnConnectionStateChanged(const std::shared_ptr<rtc::PeerConnection> & connection, rtc::PeerConnection::State state);
+    void OnGatheringStateChanged(const std::shared_ptr<rtc::PeerConnection> & connection,
+                                 rtc::PeerConnection::GatheringState state);
 
     chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster>
         mWebRTCRegisteredServerCluster;

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -85,6 +85,8 @@ private:
     WebRTCManager();
     ~WebRTCManager();
 
+    static void OnDelayedProvideICECandidates(chip::System::Layer * systemLayer, void * appState);
+
     // Close and reset the RTP sockets
     void CloseRTPSockets();
 


### PR DESCRIPTION

#### Summary

Issues:
1) libdatachannel uses asynchronous event based threading model.
   All libdatachannel callbacks are invoked on libdatachannel helper
   threads. Current implementation does not perform locking
   synchronization around state.
2) WebRTCManager unconditionally generates an offer. In the 
   `SolicitOffer` flow this is incorrect since libdatachannel does not 
   generate an answer according to the camera provided offer.
3) Audio RTP socket is never closed.

Fixes:
1) Post libdatachannel state changes to the Matter thread. That way all 
   state changes to WebRTCManager happen on the Matter thread.
2) Defer SDP generation to the appropraite handlers (`ProvideOffer` or
   `HandleOffer`). Use a state machine (via `LocalSdpState`) to track
   whether the controller is waiting for an offer or answer. On
   libdatachannel state change (ie: `OnLocalDescriptionGenerated`)
   send the appropraite command to the camera based on the initiation
   flow.
3) Close audio RTP socket in `CloseRTPSockets`.
4) Fix typo in `Connect`.

#### Related issues


#### Testing

./src/python_testing/execute_python_tests.py run --env-file out/test_env.yaml --glob 'WEBRTC*' --keep-going

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
