### PR TITLE
Add logging of keys for secure sessions, disabled by default

### DIFF
--- a/src/crypto/RawKeySessionKeystore.cpp
+++ b/src/crypto/RawKeySessionKeystore.cpp
@@ -17,7 +17,9 @@
 
 #include <crypto/RawKeySessionKeystore.h>
 
+#include <lib/core/CHIPConfig.h>
 #include <lib/support/BufferReader.h>
+#include <lib/support/BytesToHex.h>
 
 #include <cstdint>
 
@@ -77,6 +79,16 @@ CHIP_ERROR RawKeySessionKeystore::DeriveSessionKeys(const ByteSpan & secret, con
 
     ReturnErrorOnFailure(hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
                                           keyMaterial, sizeof(keyMaterial)));
+
+#if CHIP_CONFIG_LOG_SESSION_KEYS
+    {
+        constexpr size_t kKeyLen       = sizeof(Symmetric128BitsKeyByteArray);
+        constexpr size_t kChallengeLen = AttestationChallenge::Capacity();
+        Encoding::LogBufferAsHex("Session keys: I2R", ByteSpan(keyMaterial, kKeyLen));
+        Encoding::LogBufferAsHex("Session keys: R2I", ByteSpan(keyMaterial + kKeyLen, kKeyLen));
+        Encoding::LogBufferAsHex("Session keys: Challenge", ByteSpan(keyMaterial + 2 * kKeyLen, kChallengeLen));
+    }
+#endif // CHIP_CONFIG_LOG_SESSION_KEYS
 
     Encoding::LittleEndian::Reader reader(keyMaterial, sizeof(keyMaterial));
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -510,6 +510,23 @@
 #endif // CHIP_CONFIG_ENABLE_CONDITION_LOGGING
 
 /**
+ *  @def CHIP_CONFIG_LOG_SESSION_KEYS
+ *
+ *  @brief
+ *    Log session encryption keys (I2R, R2I, attestation challenge) during PASE
+ *    and CASE session establishment, allowing captured traffic to be decrypted
+ *    for debugging purposes.
+ *
+ *  @note
+ *    WARNING: This option writes secret key material to the chip log. It MUST
+ *    NEVER be enabled in production builds. Use only on development hardware
+ *    for traffic analysis.
+ */
+#ifndef CHIP_CONFIG_LOG_SESSION_KEYS
+#define CHIP_CONFIG_LOG_SESSION_KEYS 0
+#endif // CHIP_CONFIG_LOG_SESSION_KEYS
+
+/**
  *  @def CHIP_CONFIG_TEST
  *
  *  @brief

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -21,6 +21,7 @@
 #include <app/SpecificationDefinedRevisions.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/TLVTypes.h>
+#include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/TypeTraits.h>
 #include <platform/CHIPDeviceEvent.h>
@@ -44,6 +45,16 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
     // Prepare SecureSession fields, including key derivation, first, before activation
     Transport::SecureSession * secureSession = mSecureSessionHolder->AsSecureSession();
     ReturnErrorOnFailure(DeriveSecureSession(secureSession->GetCryptoContext()));
+
+#if CHIP_CONFIG_LOG_SESSION_KEYS
+    {
+        ChipLogProgress(SecureChannel, "Session keys: Type=%s LSID=%u PSID=%u Role=%s",
+                        secureSession->GetSecureSessionType() == Transport::SecureSession::Type::kPASE ? "PASE" : "CASE",
+                        secureSession->GetLocalSessionId(), GetPeerSessionId(),
+                        mRole == CryptoContext::SessionRole::kInitiator ? "Initiator" : "Responder");
+        Encoding::LogBufferAsHex("Session keys: Challenge", secureSession->GetCryptoContext().GetAttestationChallenge());
+    }
+#endif // CHIP_CONFIG_LOG_SESSION_KEYS
 
     uint16_t peerSessionId = GetPeerSessionId();
     secureSession->SetPeerAddress(peerAddress);


### PR DESCRIPTION
#### Summary

Add logging of keys for secure sessions, disabled by default (enable with CHIP_CONFIG_LOG_SESSION_KEYS). This would allow decrypting other messages after the fact.

#### Related issues

N/A

#### Testing

Tested by decrypting certain messages using the logged keys.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
