### PR TITLE
[Telink] Fix OTA_EXTRA_ARGS config apply

### DIFF
--- a/config/zephyr/ota-image.cmake
+++ b/config/zephyr/ota-image.cmake
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2021 Project CHIP Authors
+#   Copyright (c) 2021-2026 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ function(chip_ota_image TARGET_NAME)
         )
     endif()
 
-    separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CHIP_OTA_IMAGE_EXTRA_ARGS}")
+    separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS}")
 
     list(APPEND OTA_ARGS ${OTA_EXTRA_ARGS})
     list(APPEND OTA_ARGS ${ARG_INPUT_FILES})

--- a/config/zephyr/ota-image_sysbuild.cmake
+++ b/config/zephyr/ota-image_sysbuild.cmake
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2021 Project CHIP Authors
+#   Copyright (c) 2021-2026 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ function(chip_ota_image TARGET_NAME)
     )
   endif()
 
-  separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CHIP_OTA_IMAGE_EXTRA_ARGS}")
+  separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS}")
 
   list(APPEND OTA_ARGS ${OTA_EXTRA_ARGS})
   list(APPEND OTA_ARGS ${ARG_INPUT_FILES})


### PR DESCRIPTION
#### Summary

Fix passing `CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS` to `ota_image_tool.py` in the Zephyr OTA image generation flow.

This allows optional Matter OTA header fields, such as `MinApplicableSoftwareVersion` and `MaxApplicableSoftwareVersion`, to be added via Kconfig.

#### Testing

Built Telink OTA image with:

`CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS="--min-version 1 --max-version 4"`

Verified generated matter.ota header contains:

```
[5] Min Version: 1
[6] Max Version: 4
```