### PR TITLE
[all-devices-app] Option to select BLE controller

### DIFF
--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -70,7 +70,7 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
     case kOptionBLE:
         if (!ParseInt(value, mConfig.bleController))
         {
-            ChipLogError(Support, "Invalid BLE controller specified: %s\n", value);
+            ChipLogError(Support, "Invalid BLE controller specified: %s", value);
             return false;
         }
         return true;
@@ -86,7 +86,7 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
         unsigned long val = strtoul(value, &endptr, 0);
         if (*endptr != '\0' || val > 0xFFF)
         {
-            ChipLogError(Support, "Invalid discriminator: %s\n", value);
+            ChipLogError(Support, "Invalid discriminator: %s", value);
             return false;
         }
         mConfig.discriminator = static_cast<uint16_t>(val);
@@ -103,11 +103,11 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
         unsigned long val = strtoul(value, &endptr, 0);
         if (*endptr != '\0' || val > 0xFFFF)
         {
-            ChipLogError(Support, "Invalid port: %s\n", value);
+            ChipLogError(Support, "Invalid port: %s", value);
             return false;
         }
         mConfig.port = static_cast<uint16_t>(val);
-        ChipLogProgress(AppServer, "Port option set to %u\n", static_cast<uint16_t>(val));
+        ChipLogProgress(AppServer, "Port option set to %u", static_cast<uint16_t>(val));
         return true;
     }
     case kOptionInterfaceId:

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -36,6 +36,7 @@ constexpr uint16_t kOptionVendorId      = 0xffd5;
 constexpr uint16_t kOptionProductId     = 0xffd6;
 constexpr uint16_t kOptionPort          = 0xffd7;
 constexpr uint16_t kOptionInterfaceId   = 0xffd8;
+constexpr uint16_t kOptionBLE           = 0xffd9;
 
 DeviceTypeParser AppOptions::sParser;
 AppOptions::AppConfig AppOptions::mConfig;
@@ -66,6 +67,13 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
         mConfig.deviceTypeEntries = sParser.GetDeviceTypeEntries();
         return true;
     }
+    case kOptionBLE:
+        if (!ParseInt(value, mConfig.bleController))
+        {
+            ChipLogError(Support, "Invalid BLE controller specified: %s\n", value);
+            return false;
+        }
+        return true;
     case kOptionWiFi:
         mConfig.enableWiFi = true;
         ChipLogProgress(AppServer, "WiFi usage enabled");
@@ -117,6 +125,9 @@ OptionSet * AppOptions::GetOptions()
 {
     static OptionDef sAllDevicesAppOptionDefs[] = {
         { "device", kArgumentRequired, kOptionDeviceType },
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+        { "ble-controller", kArgumentRequired, kOptionBLE },
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
         { "wifi", kNoArgument, kOptionWiFi },
 #endif
@@ -142,6 +153,11 @@ OptionSet * AppOptions::GetOptions()
         result += "       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'\n";
         result += "       Can be specified multiple times for multi-endpoint devices.\n";
         result += "       Example: --device chime:1 --device speaker:2,parent=1\n\n";
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+        result += "  --ble-controller <number>\n";
+        result += "       Select the BLE controller to use (default: 0)\n\n";
+#endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
         result += "  --wifi\n";

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -33,8 +33,8 @@ public:
     struct AppConfig
     {
         std::vector<DeviceTypeParser::Entry> deviceTypeEntries;
-        unsigned int bleController = 0;
-        bool enableWiFi = false;
+        uint32_t bleController = 0;
+        bool enableWiFi        = false;
         std::string kvsPath;
         std::optional<uint16_t> discriminator;
         std::optional<uint16_t> vendorId;

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -33,6 +33,7 @@ public:
     struct AppConfig
     {
         std::vector<DeviceTypeParser::Entry> deviceTypeEntries;
+        unsigned int bleController = 0;
         bool enableWiFi = false;
         std::string kvsPath;
         std::optional<uint16_t> discriminator;

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -399,7 +399,7 @@ CHIP_ERROR Initialize(int argc, char * argv[])
 
 #if CONFIG_NETWORK_LAYER_BLE
     ReturnErrorOnFailure(DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr));
-    ReturnErrorOnFailure(DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, false));
+    ReturnErrorOnFailure(DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(AppOptions::GetConfig().bleController, false));
     ReturnErrorOnFailure(DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
 #endif
 


### PR DESCRIPTION
#### Summary

On hosts where BLE controller is not numbered as 0 (after adding and removing BLE adapters) its not possible to run all-devices app with BLE advertising. To fix that new `--ble-controller` option has been added (same like for old examples).

#### Testing

Tested locally that specifying `--ble-controller` allows to change used adapter.

```console
$ out/linux-x64-all-devices/all-devices-app
...
[1778681244.255] [454494:454494] [DL] Disabling CHIPoBLE service due to error: src/platform/Linux/BLEManagerImpl.cpp:524: Ble Error 0x00000401: BLE adapter unavailable
```

```console
$ out/linux-x64-all-devices/all-devices-app --ble-controller 1
...
[1778681215.148] [453782:453783] [DL] BLE advertisement started successfully
```