### PR TITLE
[Silabs] Replace user watchdog to silabs watchdog manager

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -36,6 +36,11 @@
 #endif // defined(SL_MATTER_EM4_SLEEP) && (SL_MATTER_EM4_SLEEP == 1)
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
+#include <sl_component_catalog.h>
+#ifdef SL_CATALOG_WATCHDOG_MANAGER_PRESENT
+#include <sl_watchdog_manager.h>
+#endif // SL_CATALOG_WATCHDOG_MANAGER_PRESENT
+
 #ifdef SL_WIFI
 #include <platform/silabs/NetworkCommissioningWiFiDriver.h>
 #include <platform/silabs/wifi/WifiInterface.h> // nogncheck
@@ -422,16 +427,17 @@ void OnEM4Trigger(uint32_t duration)
 // FreeRTOS Callbacks
 // ================================================================================
 
+#ifdef SL_CATALOG_WATCHDOG_MANAGER_PRESENT
+void sl_watchdog_manager_user_idle_hook(void)
+#else
 extern "C" void vApplicationIdleHook(void)
+#endif
 {
 #if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE) && CHIP_CONFIG_ENABLE_ICD_SERVER)
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
     GetPlatform().SleepButtonActionHandler();
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #endif // ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE) && CHIP_CONFIG_ENABLE_ICD_SERVER)
-#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
-    GetPlatform().WatchdogFeed();
-#endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -33,11 +33,6 @@
 #include "sl_system_kernel.h"
 #endif
 
-#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
-#include "sl_clock_manager.h"
-#include "sl_hal_wdog.h"
-#endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
-
 #ifdef ENABLE_WSTK_LEDS
 extern "C" {
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
@@ -313,46 +308,6 @@ sl_status_t SilabsPlatform::EnableSi70xxSensorGpio()
     return SL_STATUS_OK;
 }
 #endif // defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
-
-#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
-void SilabsPlatform::WatchdogInit()
-{
-    // Initialize WDOG with default configuration
-    sl_hal_wdog_init_t wdogInit = SL_HAL_WDOG_INIT_DEFAULT;
-    wdogInit.reset_disable      = true;                // For debug, do not trigger a system reset on timeout
-    wdogInit.period_select      = SL_WDOG_PERIOD_128k; // Set timeout period. 4s with our default LF clock at 32.768kHz
-
-    //  Initialize WDOG with our configuration
-    sl_clock_manager_enable_bus_clock(SL_BUS_CLOCK_WDOG0);
-    sl_hal_wdog_init(WDOG0, &wdogInit);
-
-    // Enable Watchdog Timeout interrupt
-    sl_hal_wdog_clear_interrupts(WDOG0, WDOG_IF_TOUT);
-    sl_hal_wdog_enable_interrupts(WDOG0, WDOG_IF_TOUT);
-
-    WatchdogEnable();
-}
-
-void SilabsPlatform::WatchdogFeed()
-{
-    sl_hal_wdog_feed(WDOG0);
-}
-
-void SilabsPlatform::WatchdogEnable()
-{
-    // Enable NVIC interrupt for WDOG
-    sl_interrupt_manager_clear_irq_pending(WDOG0_IRQn);
-    sl_interrupt_manager_enable_irq(WDOG0_IRQn);
-
-    sl_hal_wdog_enable(WDOG0);
-}
-
-void SilabsPlatform::WatchdogDisable()
-{
-    sl_hal_wdog_disable(WDOG0);
-    sl_interrupt_manager_disable_irq(WDOG0_IRQn);
-}
-#endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
 
 } // namespace Silabs
 } // namespace DeviceLayer

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -91,13 +91,6 @@ public:
      */
     CHIP_ERROR NvmInit();
 
-#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
-    void WatchdogInit();
-    void WatchdogFeed();
-    void WatchdogEnable();
-    void WatchdogDisable();
-#endif
-
 private:
     friend SilabsPlatform & GetPlatform(void);
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -97,8 +97,8 @@ declare_args() {
   # Enable Multi-PAN support for Matter over Thread devices
   sl_openthread_multi_pan_enable = false
 
-  # Enable a Watchdog with debug features to catch software hangs
-  sl_matter_debug_watchdog_enable = false
+  # Use/Enable a sl_watchdog_manager features to catch software hangs
+  sl_config_watchdog_manager_enable = false
 }
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
@@ -239,6 +239,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src",
       "${efr32_sdk_root}/platform_core/platform/service/udelay/inc",
       "${efr32_sdk_root}/platform_core/platform/service/legacy_hal/inc",
+      "${efr32_sdk_root}/platform_core/platform/service/watchdog_manager/inc",
       "${efr32_sdk_root}/glib/platform/middleware/glib",
       "${efr32_sdk_root}/glib/platform/middleware/glib/config",
       "${efr32_sdk_root}/glib/platform/middleware/glib/glib",
@@ -607,10 +608,11 @@ template("efr32_sdk") {
       }
     }
 
-    if (sl_matter_debug_watchdog_enable) {
-      defines += [ "SL_MATTER_DEBUG_WATCHDOG_ENABLE=1" ]
+    # This define is solely used with gn build for our static board configuration (matter_support)
+    if (sl_config_watchdog_manager_enable) {
+      defines += [ "SL_CONFIG_WATCHDOG_MANAGER_ENABLE=1" ]
     } else {
-      defines += [ "SL_MATTER_DEBUG_WATCHDOG_ENABLE=0" ]
+      defines += [ "SL_CONFIG_WATCHDOG_MANAGER_ENABLE=0" ]
     }
 
     if (chip_build_libshell) {  # matter shell
@@ -736,6 +738,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/emlib/src/em_rmu.c",
       "${efr32_sdk_root}/platform_core/platform/emlib/src/em_system.c",
       "${efr32_sdk_root}/platform_core/platform/emlib/src/em_timer.c",
+      "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_emu.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_gpio.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_prs.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_sysrtc.c",
@@ -935,9 +938,12 @@ template("efr32_sdk") {
       ]
     }
 
-    if (sl_matter_debug_watchdog_enable) {
+    if (sl_config_watchdog_manager_enable) {
       sources += [
-        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_wdog.c",
+        "${efr32_sdk_root}/platform/service/watchdog_manager/src/sl_watchdog_manager.c",
+        "${efr32_sdk_root}/platform_core/platform/service/watchdog_manager/src/sl_watchdog_manager_hal_wdog.c",
+        "${efr32_sdk_root}/platform_core/platform/service/watchdog_manager/src/sl_watchdog_manager_platform.c",
+        "${efr32_sdk_root}/platform_core/platform/service/watchdog_manager/src/sl_watchdog_manager_power.c",
       ]
     }
 


### PR DESCRIPTION
#### Summary
Move our debug user managed watchdog to silabs watchdog manager available in simplicity sdk

#### Related issues
n/a

#### Testing
No change for standard build.
`sl_watchdog_manager` was tested manually and through silabs internal test suite.