### PR TITLE
[Cherry-pick] Add a command-line parameter `--camera-framerate` to the Linux camera-app to allow overriding the default frame rate. (#72013)

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -897,10 +897,15 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
+    const uint16_t framerate = std::clamp(LinuxDeviceOptions::GetInstance().cameraFramerate.ValueOr(k30fpsVideoFrameRate),
+                                          allocatedStream.minFrameRate, allocatedStream.maxFrameRate);
+
+    mCurrentVideoFrameRate = framerate;
+
     // Create Gstreamer video pipeline using the final allocated stream parameters
     CameraError error          = CameraError::SUCCESS;
     GstElement * videoPipeline = CreateVideoPipeline(mVideoDevicePath, allocatedStream.minResolution.width,
-                                                     allocatedStream.minResolution.height, allocatedStream.minFrameRate, error);
+                                                     allocatedStream.minResolution.height, framerate, error);
     if (videoPipeline == nullptr)
     {
         ChipLogError(Camera, "Failed to create video pipeline.");
@@ -919,7 +924,7 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
     }
 
     ChipLogProgress(Camera, "Starting video stream (id=%u): %u×%u @ %ufps", streamID, allocatedStream.minResolution.width,
-                    allocatedStream.minResolution.height, allocatedStream.minFrameRate);
+                    allocatedStream.minResolution.height, framerate);
 
     // Start the pipeline
     ChipLogProgress(Camera, "Requesting PLAYING …");

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -155,6 +155,7 @@ enum
     kDeviceOption_Camera_TestAudiosrc,
     kDeviceOption_Camera_AudioPlayback,
     kDeviceOption_Camera_VideoDevice,
+    kDeviceOption_Camera_Framerate,
 #endif
     kDeviceOption_VendorName,
     kDeviceOption_ProductName,
@@ -264,6 +265,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "camera-test-audiosrc", kNoArgument, kDeviceOption_Camera_TestAudiosrc },
     { "camera-audio-playback", kNoArgument, kDeviceOption_Camera_AudioPlayback },
     { "camera-video-device", kArgumentRequired, kDeviceOption_Camera_VideoDevice },
+    { "camera-framerate", kArgumentRequired, kDeviceOption_Camera_Framerate },
 #endif
     {}
 };
@@ -490,6 +492,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --camera-audio-playback\n"
     "       Enables audio playback gstreamer pipeline to play the audio received from remote peer.\n"
+    "\n"
+    "  --camera-framerate <fps>\n"
+    "       Framerate for video streaming (default: 30).\n"
     "\n"
 #endif
     "\n";
@@ -997,6 +1002,17 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     }
     case kDeviceOption_Camera_VideoDevice: {
         LinuxDeviceOptions::GetInstance().cameraVideoDevice.SetValue(aValue);
+        break;
+    }
+    case kDeviceOption_Camera_Framerate: {
+        unsigned long value = strtoul(aValue, nullptr, 0);
+        if (value > UINT16_MAX)
+        {
+            PrintArgError("%s: Invalid camera framerate: %s\n", aProgram, aValue);
+            retval = false;
+            break;
+        }
+        LinuxDeviceOptions::GetInstance().cameraFramerate.SetValue(static_cast<uint16_t>(value));
         break;
     }
 #endif

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -69,6 +69,7 @@ struct LinuxDeviceOptions
     bool cameraTestAudiosrc  = false;
     bool cameraAudioPlayback = false;
     chip::Optional<std::string> cameraVideoDevice;
+    chip::Optional<uint16_t> cameraFramerate;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     bool mWiFiPAF                = false;
     const char * mWiFiPAFExtCmds = nullptr;


### PR DESCRIPTION


* Add a command-line parameter `--camera-framerate` to the Linux camera app to allow overriding the default frame rate.

    - Default to 30 fps if the parameter is not provided.
    - Validate that the specified frame rate is within the allowed range of the allocated stream in `CameraDevice::StartVideoStream`.
    - Return an error if the validation fails.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Change hard-coded fps value to a defined one for default and add a check for the framrate param range.

* Address copilot comments.

* Update examples/camera-app/linux/src/camera-device.cpp



* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------

#### Summary

<!--
    This section will help the reviewer better understand the context of this change.
    Please provide a TLDR appropriate to the change's complexity on what was changed and why.
    If fixing an error, explain the root cause and the chosen solution's rationale, especially if not obvious.
    Include context like links to related documents/issues/test plans and highlight notable information or specific concerns.

    See guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#pr-summary-description
    See title formatting: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting

    Please replace this HTML comment with the actual PR summary.
-->

#### Related issues

<!--
    This section will help the reviewer easily navigate to the GitHub issues related to this PR change.
    Please mention all the related issues in this section.

    Tip: use the syntax of Fixes #.... to mark issues completed on PR merge or use #... to reference issues that are addressed.

    Examples:
        Fixes: #12345
        #12345
        N/A (not preferable)

    Please replace this HTML comment with the actual information about related issues.
-->

#### Testing

<!--
    This section will help the reviewer understand how this PR change was tested.
    As a general rule, a proposed PR change must not break the existing code and must be well-tested.
    Please include information about testing.

    See testing guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#testing

    Examples:
        added unit tests
        verified by YAML test: TC_ABC.yaml
        added Python test: TC_DEF.py
        manually tested (mention steps to reproduce)

    Please replace this HTML comment with the actual information about how the testing was done.
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
