### PR TITLE
Improve POSIX sample app named pipes handling

### DIFF
--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -21,76 +21,82 @@
 #include <chrono>
 #include <errno.h>
 #include <fcntl.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/CodeUtils.h>
 #include <poll.h>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <thread>
 
 #include <string>
 
 static constexpr const size_t kChipEventCmdBufSize = 256;
 
-CHIP_ERROR NamedPipeCommands::Start(const std::string & path, NamedPipeCommandDelegate * delegate)
+CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, const std::string & outPath, NamedPipeCommandDelegate * delegate)
 {
-    VerifyOrReturnError(!mStarted, CHIP_NO_ERROR);
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!mRunning.exchange(true), CHIP_ERROR_INCORRECT_STATE);
 
-    mStarted              = true;
-    mDelegate             = delegate;
-    mChipEventFifoPath    = path;
-    mChipEventFifoPathOut = "";
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mDelegate    = delegate;
+    mFifoInPath  = inPath;
+    mFifoOutPath = outPath;
 
     // Creating the named file(FIFO)
-    VerifyOrReturnError((mkfifo(path.c_str(), 0666) == 0) || (errno == EEXIST), CHIP_ERROR_OPEN_FAILED);
-    VerifyOrReturnError(
-        pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
-        CHIP_ERROR_UNEXPECTED_EVENT);
+    VerifyOrExit((mkfifo(inPath.c_str(), 0660) == 0) || (errno == EEXIST), err = CHIP_ERROR_OPEN_FAILED);
 
-    return CHIP_NO_ERROR;
+    VerifyOrExit(pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
+                 err = CHIP_ERROR_UNEXPECTED_EVENT);
+
+    if (!outPath.empty())
+    {
+        VerifyOrExit((mkfifo(outPath.c_str(), 0660) == 0) || (errno == EEXIST), err = CHIP_ERROR_OPEN_FAILED);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        mRunning = false;
+    }
+    return err;
 }
 
-CHIP_ERROR NamedPipeCommands::Start(const std::string & path, const std::string & path_out, NamedPipeCommandDelegate * delegate)
+CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, NamedPipeCommandDelegate * delegate)
 {
-    VerifyOrReturnError(!mStarted, CHIP_NO_ERROR);
-    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    mStarted              = true;
-    mDelegate             = delegate;
-    mChipEventFifoPath    = path;
-    mChipEventFifoPathOut = path_out;
-
-    // Creating the named file(FIFO)
-    VerifyOrReturnError((mkfifo(path.c_str(), 0666) == 0) || (errno == EEXIST), CHIP_ERROR_OPEN_FAILED);
-    VerifyOrReturnError(
-        pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
-        CHIP_ERROR_UNEXPECTED_EVENT);
-
-    VerifyOrReturnError((mkfifo(path_out.c_str(), 0666) == 0) || (errno == EEXIST), CHIP_ERROR_OPEN_FAILED);
-
-    return CHIP_NO_ERROR;
+    return Start(inPath, /*outPath=*/ "", delegate);
 }
 
 CHIP_ERROR NamedPipeCommands::Stop()
 {
-    VerifyOrReturnError(mStarted, CHIP_NO_ERROR);
+    VerifyOrReturnError(mRunning.exchange(false), CHIP_NO_ERROR);
 
-    mStarted  = false;
-    mDelegate = nullptr;
-
-    VerifyOrReturnError(pthread_cancel(mChipEventCommandListener) == 0, CHIP_ERROR_CANCELLED);
+    // Unblock the listener thread by writing a placeholder byte to the FIFO.
+    int fd = open(mFifoInPath.c_str(), O_WRONLY | O_NONBLOCK);
+    if (fd != -1)
+    {
+        char placeholder = '\0';
+        if (write(fd, &placeholder, 1) != 1)
+        {
+            ChipLogError(NotSpecified, "Failed to write placeholder byte to unblock listener");
+        }
+        close(fd);
+    }
 
     // Wait further for the thread to terminate if we had previously created it.
     VerifyOrReturnError(pthread_join(mChipEventCommandListener, nullptr) == 0, CHIP_ERROR_SHUT_DOWN);
 
-    VerifyOrReturnError(unlink(mChipEventFifoPath.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
-    mChipEventFifoPath.clear();
+    mDelegate = nullptr;
 
-    if (!mChipEventFifoPathOut.empty())
+    VerifyOrReturnError(unlink(mFifoInPath.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
+    mFifoInPath.clear();
+
+    if (!mFifoOutPath.empty())
     {
-        VerifyOrReturnError(unlink(mChipEventFifoPathOut.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
-        mChipEventFifoPathOut.clear();
+        VerifyOrReturnError(unlink(mFifoOutPath.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
+        mFifoOutPath.clear();
     }
 
     return CHIP_NO_ERROR;
@@ -109,7 +115,7 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
 
     while (true)
     {
-        fd = open(mChipEventFifoPathOut.c_str(), O_WRONLY | O_NONBLOCK);
+        fd = open(mFifoOutPath.c_str(), O_WRONLY | O_NONBLOCK);
         if (fd >= 0)
         {
             break;
@@ -117,7 +123,7 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
 
         if (errno != ENXIO) // ENXIO == no reader
         {
-            ChipLogError(NotSpecified, "Failed to open out FIFO '%s': errno=%d", mChipEventFifoPathOut.c_str(), errno);
+            ChipLogError(NotSpecified, "Failed to open out FIFO '%s': errno=%d", mFifoOutPath.c_str(), errno);
             return;
         }
 
@@ -125,23 +131,18 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
         if (elapsed >= kOpenTimeoutMs)
         {
-            ChipLogError(NotSpecified, "Timed out waiting for reader on out FIFO '%s'", mChipEventFifoPathOut.c_str());
+            ChipLogError(NotSpecified, "Timed out waiting for reader on out FIFO '%s'", mFifoOutPath.c_str());
             return;
         }
 
-        usleep(kRetrySleepMs * 1000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(kRetrySleepMs));
     }
 
-    ssize_t written = write(fd, json.data(), json.size());
-    if (written < 0 || static_cast<size_t>(written) != json.size())
+    std::string payload = json + "\n";
+    ssize_t written = write(fd, payload.data(), payload.size());
+    if (written < 0 || static_cast<size_t>(written) != payload.size())
     {
-        ChipLogError(DeviceLayer, "Failed to write full JSON to out pipe");
-    }
-
-    written = write(fd, "\n", 1);
-    if (written != 1)
-    {
-        ChipLogError(DeviceLayer, "Failed to write newline to out pipe");
+        ChipLogError(DeviceLayer, "Failed to write JSON payload to out pipe");
     }
 
     close(fd);
@@ -150,30 +151,43 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
 void * NamedPipeCommands::EventCommandListenerTask(void * arg)
 {
     char readbuf[kChipEventCmdBufSize];
-
     NamedPipeCommands * self = reinterpret_cast<NamedPipeCommands *>(arg);
 
-    for (;;)
-    {
-        int fd = open(self->mChipEventFifoPath.c_str(), O_RDONLY);
-        if (fd == -1)
-        {
-            ChipLogError(NotSpecified, "Failed to open Event FIFO");
-            break;
-        }
+    ChipLogProgress(NotSpecified, "Starting named pipe handling on %s", self->mFifoInPath.c_str());
 
+    // Open with O_RDWR to prevent read() from returning 0 (EOF) and busy-looping when writers close the FIFO.
+    int fd = open(self->mFifoInPath.c_str(), O_RDWR);
+
+    if (fd == -1)
+    {
+        ChipLogError(NotSpecified, "Failed to open Event FIFO");
+        self->mRunning = false;
+    }
+
+    while (self->mRunning)
+    {
         ssize_t readBytes = read(fd, readbuf, kChipEventCmdBufSize);
         if (readBytes > 0)
         {
             readbuf[readBytes - 1] = '\0';
-            ChipLogProgress(NotSpecified, "Received payload: \"%s\"", readbuf);
+            if (readbuf[0] == '\0')
+            {
+                continue;
+            }
+
+            ChipLogProgress(NotSpecified, "Received payload: '%s'", readbuf);
 
             // Process the received command request from event fifo
-            self->mDelegate->OnEventCommandReceived(readbuf);
+            if (self->mDelegate) {
+                self->mDelegate->OnEventCommandReceived(readbuf);
+            }
         }
-
+    }
+    if (fd != -1)
+    {
         close(fd);
     }
+    ChipLogProgress(NotSpecified, "Done with named pipe handling on %s", self->mFifoInPath.c_str());
 
     return nullptr;
 }

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -60,6 +60,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         mRunning = false;
+        Unlink();
     }
     return err;
 }
@@ -71,33 +72,29 @@ CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, NamedPipeCommand
 
 CHIP_ERROR NamedPipeCommands::Stop()
 {
-    VerifyOrReturnError(mRunning.exchange(false), CHIP_NO_ERROR);
-
-    // Unblock the listener thread by writing a placeholder byte to the FIFO.
-    int fd = open(mFifoInPath.c_str(), O_WRONLY | O_NONBLOCK);
-    if (fd != -1)
+    if (mRunning.exchange(false))
     {
-        char placeholder = '\0';
-        if (write(fd, &placeholder, 1) != 1)
+        // Unblock the listener thread by writing a placeholder byte to the FIFO.
+        int fd = open(mFifoInPath.c_str(), O_WRONLY | O_NONBLOCK);
+        if (fd != -1)
         {
-            ChipLogError(NotSpecified, "Failed to write placeholder byte to unblock listener");
+            char placeholder = '\0';
+            if (write(fd, &placeholder, 1) != 1)
+            {
+                ChipLogError(NotSpecified, "Failed to write placeholder byte to unblock listener");
+            }
+            close(fd);
         }
-        close(fd);
-    }
 
-    // Wait further for the thread to terminate if we had previously created it.
-    VerifyOrReturnError(pthread_join(mChipEventCommandListener, nullptr) == 0, CHIP_ERROR_SHUT_DOWN);
+        // Wait further for the thread to terminate if we had previously created it.
+        if (pthread_join(mChipEventCommandListener, nullptr) != 0)
+        {
+            ChipLogError(NotSpecified, "Failed to join listener thread");
+        }
+    }
 
     mDelegate = nullptr;
-
-    VerifyOrReturnError(unlink(mFifoInPath.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
-    mFifoInPath.clear();
-
-    if (!mFifoOutPath.empty())
-    {
-        VerifyOrReturnError(unlink(mFifoOutPath.c_str()) == 0, CHIP_ERROR_WRITE_FAILED);
-        mFifoOutPath.clear();
-    }
+    Unlink();
 
     return CHIP_NO_ERROR;
 }
@@ -146,6 +143,21 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
     }
 
     close(fd);
+}
+
+void NamedPipeCommands::Unlink()
+{
+    if (!mFifoInPath.empty())
+    {
+        unlink(mFifoInPath.c_str());
+        mFifoInPath.clear();
+    }
+
+    if (!mFifoOutPath.empty())
+    {
+        unlink(mFifoOutPath.c_str());
+        mFifoOutPath.clear();
+    }
 }
 
 void * NamedPipeCommands::EventCommandListenerTask(void * arg)

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -166,10 +166,18 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
 
     while (self->mRunning)
     {
-        ssize_t readBytes = read(fd, readbuf, kChipEventCmdBufSize);
+        ssize_t readBytes = read(fd, readbuf, sizeof(readbuf) - 1);
         if (readBytes > 0)
         {
-            readbuf[readBytes - 1] = '\0';
+            // Null-terminate for processing (not guaranteed by writer).
+            readbuf[readBytes] = '\0';
+
+            // Strip trailing newline if present
+            if (readbuf[readBytes - 1] == '\n')
+            {
+                readbuf[readBytes - 1] = '\0';
+            }
+
             if (readbuf[0] == '\0')
             {
                 continue;

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -19,6 +19,7 @@
 #include "NamedPipeCommands.h"
 
 #include <chrono>
+#include <signal.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <lib/support/CodeUtils.h>
@@ -48,16 +49,17 @@ CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, const std::strin
     mFifoInPath  = inPath;
     mFifoOutPath = outPath;
 
-    // Creating the named file(FIFO)
+    // 1. Creating the named file(FIFO)
     VerifyOrExit((mkfifo(inPath.c_str(), 0660) == 0) || (errno == EEXIST), err = CHIP_ERROR_OPEN_FAILED);
-
-    VerifyOrExit(pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
-                 err = CHIP_ERROR_UNEXPECTED_EVENT);
 
     if (!outPath.empty())
     {
         VerifyOrExit((mkfifo(outPath.c_str(), 0660) == 0) || (errno == EEXIST), err = CHIP_ERROR_OPEN_FAILED);
     }
+
+    // 2. Spawn listener thread last
+    VerifyOrExit(pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
+                 err = CHIP_ERROR_UNEXPECTED_EVENT);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -78,6 +80,10 @@ CHIP_ERROR NamedPipeCommands::Stop()
     if (mRunning.exchange(false))
     {
         mDone = true;
+
+        // Ignore SIGPIPE to prevent process termination if the listener thread closes the read end concurrently.
+        signal(SIGPIPE, SIG_IGN);
+
         // Unblock the listener thread by writing a placeholder byte to the FIFO.
         int fd = open(mFifoInPath.c_str(), O_WRONLY | O_NONBLOCK);
         if (fd != -1)
@@ -90,10 +96,19 @@ CHIP_ERROR NamedPipeCommands::Stop()
             close(fd);
         }
 
-        // Wait further for the thread to terminate if we had previously created it.
-        if (pthread_join(mChipEventCommandListener, nullptr) != 0)
+        // Prevent deadlock: do not pthread_join if Stop() is called from the listener thread itself.
+        if (pthread_equal(pthread_self(), mChipEventCommandListener) == 0)
         {
-            ChipLogError(NotSpecified, "Failed to join listener thread");
+            // Wait further for the thread to terminate if we had previously created it.
+            if (pthread_join(mChipEventCommandListener, nullptr) != 0)
+            {
+                ChipLogError(NotSpecified, "Failed to join listener thread");
+            }
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "NamedPipeCommands::Stop() called from listener thread; detaching thread.");
+            pthread_detach(mChipEventCommandListener);
         }
     }
 
@@ -207,13 +222,16 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
         // Null-terminate for processing (not guaranteed by writer).
         readbuf[numBytesRead] = '\0';
 
-        // Strip trailing newline if present
-        if (readbuf[numBytesRead - 1] == '\n')
+        // Strip any trailing \0 (placeholder bytes), \n, or \r before processing.
+        while (numBytesRead > 0 && (readbuf[numBytesRead - 1] == '\n' ||
+                                    readbuf[numBytesRead - 1] == '\r' ||
+                                    readbuf[numBytesRead - 1] == '\0'))
         {
-            readbuf[numBytesRead - 1] = '\0';
+            numBytesRead--;
+            readbuf[numBytesRead] = '\0';
         }
 
-        if (readbuf[0] == '\0')
+        if (numBytesRead == 0)
         {
             continue;
         }

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -37,6 +37,7 @@ static constexpr const size_t kChipEventCmdBufSize = 256;
 CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, const std::string & outPath, NamedPipeCommandDelegate * delegate)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!mDone, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(!mRunning.exchange(true), CHIP_ERROR_INCORRECT_STATE);
 
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -74,6 +75,7 @@ CHIP_ERROR NamedPipeCommands::Stop()
 {
     if (mRunning.exchange(false))
     {
+        mDone = true;
         // Unblock the listener thread by writing a placeholder byte to the FIFO.
         int fd = open(mFifoInPath.c_str(), O_WRONLY | O_NONBLOCK);
         if (fd != -1)
@@ -178,32 +180,49 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
 
     while (self->mRunning)
     {
-        ssize_t readBytes = read(fd, readbuf, sizeof(readbuf) - 1);
-        if (readBytes > 0)
+        ssize_t numBytesRead = read(fd, readbuf, sizeof(readbuf) - 1);
+        if (numBytesRead <= 0)
         {
-            // Null-terminate for processing (not guaranteed by writer).
-            readbuf[readBytes] = '\0';
-
-            // Strip trailing newline if present
-            if (readbuf[readBytes - 1] == '\n')
-            {
-                readbuf[readBytes - 1] = '\0';
-            }
-
-            if (readbuf[0] == '\0')
+            // If the read was interrupted by a signal before any data was available,
+            // we should retry the read operation.
+            if (numBytesRead < 0 && errno == EINTR)
             {
                 continue;
             }
 
-            ChipLogProgress(NotSpecified, "Received payload: '%s'", readbuf);
-
-            // Process the received command request from event fifo
-            if (self->mDelegate)
+            // For any other read failure (including EOF where numBytesRead == 0), we exit the loop.
+            // Note: Since the FIFO is opened with O_RDWR, we don't expect to receive EOF
+            // when all external writers disconnect.
+            if (numBytesRead < 0)
             {
-                self->mDelegate->OnEventCommandReceived(readbuf);
+                ChipLogError(NotSpecified, "Error reading from FIFO: %d", errno);
             }
+            break;
+        }
+
+        // Null-terminate for processing (not guaranteed by writer).
+        readbuf[numBytesRead] = '\0';
+
+        // Strip trailing newline if present
+        if (readbuf[numBytesRead - 1] == '\n')
+        {
+            readbuf[numBytesRead - 1] = '\0';
+        }
+
+        if (readbuf[0] == '\0')
+        {
+            continue;
+        }
+
+        ChipLogProgress(NotSpecified, "Received payload: '%s'", readbuf);
+
+        // Process the received command request from event fifo
+        if (self->mDelegate)
+        {
+            self->mDelegate->OnEventCommandReceived(readbuf);
         }
     }
+
     if (fd != -1)
     {
         close(fd);

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -200,6 +200,8 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
             break;
         }
 
+        // TODO: Consider making a future delimited version to support payloads > 256.
+
         // Null-terminate for processing (not guaranteed by writer).
         readbuf[numBytesRead] = '\0';
 

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -21,14 +21,14 @@
 #include <chrono>
 #include <errno.h>
 #include <fcntl.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <poll.h>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <thread>
+#include <unistd.h>
 
 #include <string>
 
@@ -66,7 +66,7 @@ exit:
 
 CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, NamedPipeCommandDelegate * delegate)
 {
-    return Start(inPath, /*outPath=*/ "", delegate);
+    return Start(inPath, /*outPath=*/"", delegate);
 }
 
 CHIP_ERROR NamedPipeCommands::Stop()
@@ -139,7 +139,7 @@ void NamedPipeCommands::WriteToOutPipe(const std::string & json)
     }
 
     std::string payload = json + "\n";
-    ssize_t written = write(fd, payload.data(), payload.size());
+    ssize_t written     = write(fd, payload.data(), payload.size());
     if (written < 0 || static_cast<size_t>(written) != payload.size())
     {
         ChipLogError(DeviceLayer, "Failed to write JSON payload to out pipe");
@@ -178,7 +178,8 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
             ChipLogProgress(NotSpecified, "Received payload: '%s'", readbuf);
 
             // Process the received command request from event fifo
-            if (self->mDelegate) {
+            if (self->mDelegate)
+            {
                 self->mDelegate->OnEventCommandReceived(readbuf);
             }
         }

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -32,7 +32,9 @@
 
 #include <string>
 
-static constexpr const size_t kChipEventCmdBufSize = 256;
+namespace {
+constexpr size_t kChipEventCmdBufSize = 256;
+} // namespace
 
 CHIP_ERROR NamedPipeCommands::Start(const std::string & inPath, const std::string & outPath, NamedPipeCommandDelegate * delegate)
 {
@@ -175,7 +177,7 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
     if (fd == -1)
     {
         ChipLogError(NotSpecified, "Failed to open Event FIFO");
-        self->mRunning = false;
+        return nullptr;
     }
 
     while (self->mRunning)

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -19,13 +19,13 @@
 #include "NamedPipeCommands.h"
 
 #include <chrono>
-#include <signal.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <poll.h>
 #include <pthread.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <thread>
@@ -223,9 +223,8 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
         readbuf[numBytesRead] = '\0';
 
         // Strip any trailing \0 (placeholder bytes), \n, or \r before processing.
-        while (numBytesRead > 0 && (readbuf[numBytesRead - 1] == '\n' ||
-                                    readbuf[numBytesRead - 1] == '\r' ||
-                                    readbuf[numBytesRead - 1] == '\0'))
+        while (numBytesRead > 0 &&
+               (readbuf[numBytesRead - 1] == '\n' || readbuf[numBytesRead - 1] == '\r' || readbuf[numBytesRead - 1] == '\0'))
         {
             numBytesRead--;
             readbuf[numBytesRead] = '\0';

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -60,16 +60,50 @@ public:
  *
  *   echo '{"Name": "SimulateSwitchIdle", "EndpointId": 3}' > /tmp/chip_all_clusters_fifo_1146610
  *
- * Note: Instances of NamedPipeCommands are one-time use. Once Stop() is called,
+ * NOTE: Start() and Stop() must be called from the same thread (e.g., during outer
+ * application initialization and shutdown sequencing) to ensure proper lifecycle
+ * and synchronization.
+ *
+ * NOTE: Instances of NamedPipeCommands are one-time use. Once Stop() is called,
  * the instance cannot be restarted.
+ *
  */
 class NamedPipeCommands
 {
 public:
+    /**
+     * @brief Start listening for named pipe commands.
+     *
+     * @param[in] inPath Path to the input FIFO to create and listen on.
+     * @param[in] delegate Delegate to handle received commands.
+     */
     CHIP_ERROR Start(const std::string & inPath, NamedPipeCommandDelegate * delegate);
+
+    /**
+     * @brief Start listening for named pipe commands with an output pipe.
+     *
+     * @param[in] inPath Path to the input FIFO to create and listen on.
+     * @param[in] outPath Path to an output FIFO for sending responses.
+     * @param[in] delegate Delegate to handle received commands.
+     */
     CHIP_ERROR Start(const std::string & inPath, const std::string & outPath, NamedPipeCommandDelegate * delegate);
+
+    /**
+     * @brief Stop listening for commands and shut down the listener thread.
+     */
     CHIP_ERROR Stop();
+
+    /**
+     * @brief Write a JSON string to the output pipe.
+     *
+     * This method handles opening the pipe in a non-blocking fashion with retries
+     * to avoid deadlocking the application if the test side hasn't opened the
+     * pipe yet.
+     *
+     * @param[in] json JSON payload to write to the output pipe.
+     */
     void WriteToOutPipe(const std::string & json);
+
     const std::string & OutPath() const { return mFifoOutPath; }
 
 private:

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -18,15 +18,15 @@
 
 #pragma once
 
-#include <lib/core/CHIPError.h>
 #include <atomic>
+#include <lib/core/CHIPError.h>
 #include <pthread.h>
 #include <string>
 
 class NamedPipeCommandDelegate
 {
 public:
-    virtual ~NamedPipeCommandDelegate()                    = default;
+    virtual ~NamedPipeCommandDelegate() = default;
     /**
      * @brief Handle a single NamedPipeCommands payload.
      *
@@ -70,7 +70,7 @@ public:
     const std::string & OutPath() const { return mFifoOutPath; }
 
 private:
-    std::atomic<bool> mRunning{false};
+    std::atomic<bool> mRunning{ false };
     pthread_t mChipEventCommandListener;
     std::string mFifoInPath;
     std::string mFifoOutPath;

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <atomic>
 #include <pthread.h>
 #include <string>
 
@@ -26,23 +27,53 @@ class NamedPipeCommandDelegate
 {
 public:
     virtual ~NamedPipeCommandDelegate()                    = default;
+    /**
+     * @brief Handle a single NamedPipeCommands payload.
+     *
+     * This method must handle dispatching to the Matter stack via `PlatformMgr().ScheduleWork(...)`
+     * and must make copies internally of the input string if it needs to be passed beyond initial parsing.
+     *
+     * @param[in] json A null-terminated-string containing the JSON command payload to process.
+     */
     virtual void OnEventCommandReceived(const char * json) = 0;
 };
 
+/**
+ * This class implements a listener for named pipes (FIFOs). It uses a UNIX daemon
+ * best-practice pattern of opening the FIFO with O_RDWR. This prevents the `read()`
+ * call from constantly busy-looping and returning 0 (EOF) when external writers
+ * (like a one-shot `echo` command) connect, write, and immediately disconnect.
+ *
+ * Each handler has an input `inPath` (e.g. "/tmp/matter_test_pipe") and may also
+ * have an `outPath` which can be used with `WriteToOutPipe` to communicate
+ * payloads to another app's input pipe.
+ *
+ * All payloads should be JSON to work with existing conventions (although the
+ * NamedPipeCommands class does no parsing of its own or any real JSON checks.
+ *
+ * The handling of incoming payloads is done via NamedPipeCommandDelegate class
+ * instances which expect a single JSON string payload, usually of the shape:
+ *
+ *   {"Name": <Some command>, "EndpointId": <Target endpoint>, ...other args}
+ *
+ * Example of a typical command written to inPath of `/tmp/chip_all_clusters_fifo_1146610`:
+ *
+ *   echo '{"Name": "SimulateSwitchIdle", "EndpointId": 3}' > /tmp/chip_all_clusters_fifo_1146610
+ */
 class NamedPipeCommands
 {
 public:
-    CHIP_ERROR Start(const std::string & path, NamedPipeCommandDelegate * delegate);
-    CHIP_ERROR Start(const std::string & path, const std::string & path_out, NamedPipeCommandDelegate * delegate);
+    CHIP_ERROR Start(const std::string & inPath, NamedPipeCommandDelegate * delegate);
+    CHIP_ERROR Start(const std::string & inPath, const std::string & outPath, NamedPipeCommandDelegate * delegate);
     CHIP_ERROR Stop();
     void WriteToOutPipe(const std::string & json);
-    const std::string & OutPath() const { return mChipEventFifoPathOut; }
+    const std::string & OutPath() const { return mFifoOutPath; }
 
 private:
-    bool mStarted = false;
+    std::atomic<bool> mRunning{false};
     pthread_t mChipEventCommandListener;
-    std::string mChipEventFifoPath;
-    std::string mChipEventFifoPathOut;
+    std::string mFifoInPath;
+    std::string mFifoOutPath;
     NamedPipeCommandDelegate * mDelegate = nullptr;
 
     static void * EventCommandListenerTask(void * arg);

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -76,5 +76,6 @@ private:
     std::string mFifoOutPath;
     NamedPipeCommandDelegate * mDelegate = nullptr;
 
+    void Unlink();
     static void * EventCommandListenerTask(void * arg);
 };

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -109,7 +109,7 @@ public:
 private:
     std::atomic<bool> mRunning{ false };
     std::atomic<bool> mDone{ false };
-    pthread_t mChipEventCommandListener = nullptr;
+    pthread_t mChipEventCommandListener{};
     std::string mFifoInPath;
     std::string mFifoOutPath;
     NamedPipeCommandDelegate * mDelegate = nullptr;

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -71,6 +71,7 @@ public:
 
 private:
     std::atomic<bool> mRunning{ false };
+    std::atomic<bool> mDone{ false };
     pthread_t mChipEventCommandListener;
     std::string mFifoInPath;
     std::string mFifoOutPath;

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -109,7 +109,7 @@ public:
 private:
     std::atomic<bool> mRunning{ false };
     std::atomic<bool> mDone{ false };
-    pthread_t mChipEventCommandListener;
+    pthread_t mChipEventCommandListener = nullptr;
     std::string mFifoInPath;
     std::string mFifoOutPath;
     NamedPipeCommandDelegate * mDelegate = nullptr;

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -59,6 +59,9 @@ public:
  * Example of a typical command written to inPath of `/tmp/chip_all_clusters_fifo_1146610`:
  *
  *   echo '{"Name": "SimulateSwitchIdle", "EndpointId": 3}' > /tmp/chip_all_clusters_fifo_1146610
+ *
+ * Note: Instances of NamedPipeCommands are one-time use. Once Stop() is called,
+ * the instance cannot be restarted.
  */
 class NamedPipeCommands
 {


### PR DESCRIPTION
#### Summary
- Add documentation.
- Cleanup names.
- Make start and stop safe across threads.
- Make the read loop scalable to stream handling later.
- Fix bug where under some circumstances, named pipe could get stuck busy-looping.
- Make read loop more standard and similar to classical FIFO read loop.
- Remove pthread_cancel for stopping the thread and use a clean exit + join.
- Add better logging for both commands and lifecycle.
- Remove startup duplication.
- Improve permission to remove "other" user access (use group instead).

#### Testing

- All named-pipe-based Python integration tests still pass.
- Interruption of process leads to orderly shutdown and correct logs.