### PR TITLE
esp32: fix CHIPoBLE disabled after every controller event

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -434,9 +434,6 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
     default:
         break;
     }
-
-    mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
-    return;
 }
 
 static int OnUnsubscribeCharComplete(uint16_t conn_handle, const struct ble_gatt_error * error, struct ble_gatt_attr * attr,


### PR DESCRIPTION
#### Summary
Fix CHIPoBLE disabled after every controller event. It was introduced by https://github.com/project-chip/connectedhomeip/pull/43280/changes

#### Testing
Test ble controller on esp_matter controller on esp32s3.
