### PR TITLE
[Silabs ]Remove leftover watchdog virtual functions

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -289,8 +289,6 @@ CHIP_ERROR BaseApplication::Init()
         appError(err);
         return err;
     }
-
-    GetPlatform().WatchdogInit();
     return err;
 }
 

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -299,8 +299,6 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
-
-    GetPlatform().WatchdogDisable();
     error = SilabsConfig::FactoryResetConfig();
     if (error != CHIP_NO_ERROR)
     {

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -73,12 +73,6 @@ public:
      */
     virtual sl_status_t EnableSi70xxSensorGpio() { return SL_STATUS_OK; }
 
-    // Watchdog
-    virtual void WatchdogInit(){};
-    virtual void WatchdogFeed(){};
-    virtual void WatchdogEnable(){};
-    virtual void WatchdogDisable(){};
-
     /**
      * @brief Function trigger the platform to execute a software reset.
      *              Anything after this function will not be executed since the device will reboot.


### PR DESCRIPTION
#### Summary
This is a fixup/follow-up of #72036
I apparently did not commit the removal of the empty virtual function for old common watchdog platform interface

```
    virtual void WatchdogInit(){};
    virtual void WatchdogFeed(){};
    virtual void WatchdogEnable(){};
    virtual void WatchdogDisable(){};
```

#### Related issues
n/a

#### Testing
N/A removal of no-op virtual functions