### PR TITLE
Minimize the sysroot only in create_sysroot.py, make sysroot even smaller

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-195 : [crosscompile] Remove executables from armhf and aarch64 sysroots
+196 : [crosscompile] Don't duplicate minimization done by create_sysroot.py in the Dockerfile

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -22,11 +22,6 @@ RUN set -x \
   && echo "experimental/matter/sysroot/ubuntu-24.04-aarch64 version:${SYSROOT_VERSION}" > ensure_file.txt \
   && echo "experimental/matter/sysroot/ubuntu-24.04-armhf version:${SYSROOT_VERSION}" >> ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
-  && for arch in aarch64 armhf; do \
-       for d in usr/bin usr/lib/firmware usr/lib/git-core usr/lib/modules lib/firmware lib/git-core lib/modules; do \
-         rm -rf "/opt/ubuntu-24.04-${arch}-sysroot/${d}"; \
-       done; \
-     done \
   && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/create_sysroot.py
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/create_sysroot.py
@@ -208,6 +208,7 @@ def cleanup_sysroot(sysroot_dir):
 
     # Clean up large unneeded subdirectories inside usr/lib to save space
     # Remove executables as we don't need them for the build and they just confuse `cmake`
+    # Remove docs, info/man pages, shell completions, i18n, fonts, icons, X11 and MIME data, timezone data, etc.
     excludes = [
         "usr/lib/*/dri",
         "usr/lib/firmware",
@@ -217,7 +218,26 @@ def cleanup_sysroot(sysroot_dir):
         "usr/lib/systemd",
 
         "usr/bin",
-        "usr/sbin"
+        "usr/sbin",
+
+        "usr/share/doc",
+        "usr/share/gtk-doc",
+        "usr/share/common-licenses",
+        "usr/share/info",
+        "usr/share/man",
+        "usr/share/bash-completion",
+        "usr/share/i18n",
+        "usr/share/locale",
+        "usr/share/iso-codes",
+        "usr/share/fonts",
+        "usr/share/fontconfig",
+        "usr/share/consolefonts",
+        "usr/share/icons",
+        "usr/share/pixmaps",
+        "usr/share/X11",
+        "usr/share/mime",
+        "usr/share/zoneinfo",
+        "usr/share/ca-certificates",
     ]
     for pattern in excludes:
         full_pattern = os.path.join(sysroot_dir, pattern)


### PR DESCRIPTION
#### Summary

We don't need extra steps in the `Dockerfile` as the `create_sysroot.py` script already minimizes the sysroot.

Additionally, remove additional paths such as docs, man pages, X11 data, fonts, locales, timezone data, etc. This saves us an extra 107MB:

```shell
du -sh ubuntu-24.04-aarch64-sysroot ubuntu-24.04-aarch64-sysroot.orig 
855M	ubuntu-24.04-aarch64-sysroot
962M	ubuntu-24.04-aarch64-sysroot.orig
```

#### Testing

Local builds for `armhf` and `aarch64` with the aforementioned paths removed from the sysroot.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
