### PR TITLE
[Silabs] Fix some bugs in lighting app refactor 

### DIFF
--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -413,9 +413,9 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
         }
     }
 
-    if (offEffectDuration == 0)
+    else
     {
-        ChipLogProgress(Zcl, "OffWithEffect: unsupported effect, completing immediately");
+        ChipLogDetail(Zcl, "OffWithEffect: unsupported effect, completing immediately");
         sOffEffectArmed = false;
         if (osTimerIsRunning(sLightTimer))
         {

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -416,12 +416,11 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
     if (offEffectDuration == 0)
     {
         ChipLogProgress(Zcl, "OffWithEffect: unsupported effect, completing immediately");
-        sOffEffectArmed = true;
-        AppEvent event{};
-        event.Type               = AppEvent::kEventType_Timer;
-        event.TimerEvent.Context = nullptr;
-        event.Handler            = &OffEffectTimerEventHandler;
-        appInstance().PostEvent(&event);
+        sOffEffectArmed = false;
+        if (osTimerIsRunning(sLightTimer))
+        {
+            osTimerStop(sLightTimer);
+        }
         return;
     }
 

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -128,7 +128,7 @@ void OffEffectTimerEventHandler(AppEvent * /* aEvent */)
     {
         return;
     }
-    sOffEffectArmed = false; 
+    sOffEffectArmed = false;
 
     sLightOn = false;
     sLightLED.Set(false);

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -90,6 +90,7 @@ LEDWidget sLightLED;
 
 bool sLightOn           = false;
 osTimerId_t sLightTimer = nullptr;
+bool sOffEffectArmed    = false;
 
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
 uint8_t sCurrentLevel      = 254;
@@ -123,6 +124,12 @@ void PostLightControlColorEvent(ColorAction_t action, const RGBLEDWidget::ColorD
 
 void OffEffectTimerEventHandler(AppEvent * /* aEvent */)
 {
+    if (!sOffEffectArmed)
+    {
+        return;
+    }
+    sOffEffectArmed = false; 
+
     sLightOn = false;
     sLightLED.Set(false);
 #ifdef DISPLAY_ENABLED
@@ -169,6 +176,7 @@ void AppTask::LightActionEventHandler(AppEvent * aEvent)
     sLightOn = !sLightOn;
     sLightLED.Set(sLightOn);
 
+    sOffEffectArmed = false;
     if (osTimerIsRunning(sLightTimer))
     {
         if (osTimerStop(sLightTimer) == osError)
@@ -405,8 +413,22 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
         }
     }
 
+    if (offEffectDuration == 0)
+    {
+        ChipLogProgress(Zcl, "OffWithEffect: unsupported effect, completing immediately");
+        sOffEffectArmed = true;
+        AppEvent event{};
+        event.Type               = AppEvent::kEventType_Timer;
+        event.TimerEvent.Context = nullptr;
+        event.Handler            = &OffEffectTimerEventHandler;
+        appInstance().PostEvent(&event);
+        return;
+    }
+
+    sOffEffectArmed = true;
     if (osTimerStart(sLightTimer, pdMS_TO_TICKS(offEffectDuration)) != osOK)
     {
+        sOffEffectArmed = false;
         SILABS_LOG("sLightTimer timer start() failed");
         appError(APP_ERROR_START_TIMER_FAILED);
     }
@@ -428,12 +450,22 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
             ChipLogProgress(Zcl, "sending light state update");
             MatterAwsSendMsg("light/state", (const char *) (value ? (*value ? "on" : "off") : "invalid"));
 #endif // SL_MATTER_ENABLE_AWS
-            sLightOn = (*value != 0);
+            const bool lightOn = (*value != 0);
+            if (!lightOn && sOffEffectArmed)
+            {
+                break;
+            }
+            if (lightOn)
+            {
+                sOffEffectArmed = false;
+            }
+
+            sLightOn = lightOn;
             sLightLED.Set(sLightOn);
 #ifdef DISPLAY_ENABLED
             BaseApplication::GetLCD().WriteDemoUI(sLightOn);
 #endif
-            if (sLightOn && osTimerIsRunning(sLightTimer))
+            if (lightOn && osTimerIsRunning(sLightTimer))
             {
                 if (osTimerStop(sLightTimer) == osError)
                 {

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -457,7 +457,6 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
                 break;
             }
 
-
             sLightOn = lightOn;
             sLightLED.Set(sLightOn);
 #ifdef DISPLAY_ENABLED

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -92,6 +92,18 @@ bool sLightOn           = false;
 osTimerId_t sLightTimer = nullptr;
 bool sOffEffectArmed    = false;
 
+void StopLightTimerIfRunning()
+{
+    if (osTimerIsRunning(sLightTimer))
+    {
+        if (osTimerStop(sLightTimer) == osError)
+        {
+            SILABS_LOG("sLightTimer stop() failed");
+            appError(APP_ERROR_STOP_TIMER_FAILED);
+        }
+    }
+}
+
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
 uint8_t sCurrentLevel      = 254;
 uint8_t sCurrentHue        = 0;
@@ -124,11 +136,9 @@ void PostLightControlColorEvent(ColorAction_t action, const RGBLEDWidget::ColorD
 
 void OffEffectTimerEventHandler(AppEvent * /* aEvent */)
 {
-    if (!sOffEffectArmed)
-    {
-        return;
-    }
+    VerifyOrReturn(sOffEffectArmed);
     sOffEffectArmed = false;
+    StopLightTimerIfRunning();
 
     sLightOn = false;
     sLightLED.Set(false);
@@ -177,14 +187,7 @@ void AppTask::LightActionEventHandler(AppEvent * aEvent)
     sLightLED.Set(sLightOn);
 
     sOffEffectArmed = false;
-    if (osTimerIsRunning(sLightTimer))
-    {
-        if (osTimerStop(sLightTimer) == osError)
-        {
-            SILABS_LOG("sLightTimer stop() failed");
-            appError(APP_ERROR_STOP_TIMER_FAILED);
-        }
-    }
+    StopLightTimerIfRunning();
 
 #ifdef DISPLAY_ENABLED
     BaseApplication::GetLCD().WriteDemoUI(sLightOn);
@@ -417,10 +420,7 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
     {
         ChipLogDetail(Zcl, "OffWithEffect: unsupported effect, completing immediately");
         sOffEffectArmed = false;
-        if (osTimerIsRunning(sLightTimer))
-        {
-            osTimerStop(sLightTimer);
-        }
+        StopLightTimerIfRunning();
         return;
     }
 
@@ -428,6 +428,7 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
     if (osTimerStart(sLightTimer, pdMS_TO_TICKS(offEffectDuration)) != osOK)
     {
         sOffEffectArmed = false;
+        StopLightTimerIfRunning();
         SILABS_LOG("sLightTimer timer start() failed");
         appError(APP_ERROR_START_TIMER_FAILED);
     }
@@ -457,6 +458,7 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
             if (lightOn)
             {
                 sOffEffectArmed = false;
+                StopLightTimerIfRunning();
             }
 
             sLightOn = lightOn;
@@ -464,14 +466,6 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
 #ifdef DISPLAY_ENABLED
             BaseApplication::GetLCD().WriteDemoUI(sLightOn);
 #endif
-            if (lightOn && osTimerIsRunning(sLightTimer))
-            {
-                if (osTimerStop(sLightTimer) == osError)
-                {
-                    SILABS_LOG("sLightTimer stop() failed");
-                    appError(APP_ERROR_STOP_TIMER_FAILED);
-                }
-            }
         }
         break;
 

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -92,8 +92,9 @@ bool sLightOn           = false;
 osTimerId_t sLightTimer = nullptr;
 bool sOffEffectArmed    = false;
 
-void StopLightTimerIfRunning()
+void DisarmOffWithEffectTimer()
 {
+    sOffEffectArmed = false;
     if (osTimerIsRunning(sLightTimer))
     {
         if (osTimerStop(sLightTimer) == osError)
@@ -137,8 +138,7 @@ void PostLightControlColorEvent(ColorAction_t action, const RGBLEDWidget::ColorD
 void OffEffectTimerEventHandler(AppEvent * /* aEvent */)
 {
     VerifyOrReturn(sOffEffectArmed);
-    sOffEffectArmed = false;
-    StopLightTimerIfRunning();
+    DisarmOffWithEffectTimer();
 
     sLightOn = false;
     sLightLED.Set(false);
@@ -186,8 +186,7 @@ void AppTask::LightActionEventHandler(AppEvent * aEvent)
     sLightOn = !sLightOn;
     sLightLED.Set(sLightOn);
 
-    sOffEffectArmed = false;
-    StopLightTimerIfRunning();
+    DisarmOffWithEffectTimer();
 
 #ifdef DISPLAY_ENABLED
     BaseApplication::GetLCD().WriteDemoUI(sLightOn);
@@ -419,16 +418,14 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
     else
     {
         ChipLogDetail(Zcl, "OffWithEffect: unsupported effect, completing immediately");
-        sOffEffectArmed = false;
-        StopLightTimerIfRunning();
+        DisarmOffWithEffectTimer();
         return;
     }
 
     sOffEffectArmed = true;
     if (osTimerStart(sLightTimer, pdMS_TO_TICKS(offEffectDuration)) != osOK)
     {
-        sOffEffectArmed = false;
-        StopLightTimerIfRunning();
+        DisarmOffWithEffectTimer();
         SILABS_LOG("sLightTimer timer start() failed");
         appError(APP_ERROR_START_TIMER_FAILED);
     }
@@ -457,8 +454,7 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
             }
             if (lightOn)
             {
-                sOffEffectArmed = false;
-                StopLightTimerIfRunning();
+                DisarmOffWithEffectTimer();
             }
 
             sLightOn = lightOn;

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -448,14 +448,15 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
             MatterAwsSendMsg("light/state", (const char *) (value ? (*value ? "on" : "off") : "invalid"));
 #endif // SL_MATTER_ENABLE_AWS
             const bool lightOn = (*value != 0);
-            if (!lightOn && sOffEffectArmed)
-            {
-                break;
-            }
             if (lightOn)
             {
                 DisarmOffWithEffectTimer();
             }
+            else if (sOffEffectArmed)
+            {
+                break;
+            }
+
 
             sLightOn = lightOn;
             sLightLED.Set(sLightOn);

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -425,7 +425,7 @@ void AppTask::OnTriggerOffWithEffect(OnOffEffect * effect)
     sOffEffectArmed = true;
     if (osTimerStart(sLightTimer, pdMS_TO_TICKS(offEffectDuration)) != osOK)
     {
-        DisarmOffWithEffectTimer();
+        sOffEffectArmed = false;
         SILABS_LOG("sLightTimer timer start() failed");
         appError(APP_ERROR_START_TIMER_FAILED);
     }


### PR DESCRIPTION
#### Summary
During refactor for onoff app, came across a few bugs that are common to lighting app implementation:
- When initializing osTimerStart(sLightTimer, pdMS_TO_TICKS(offEffectDuration)), offEffectDuration is initialized to 0. If it is not updated, osTimerStart returns osErrorParameter which cause != osOk check to trigger and crash the device
- DMPostAttributeChangeCallback and OffEffectTimerEventHandler set sLightOn = false, even when off with effect timer is actively running casuing the LED to turn off instantaneously and override the effect. This is inconsistent with previous implementation, which skipped immediate off actions when off with effect timer was running. 

Respective fixes:
- If offEffectDuration fails to get set properly, we log unsupported effect and immediately post to OffEffectTimerEventHandler avoiding device crash
- Introduce sOffEffectArmed, and break when off command is sent and the timer is armed 

#### Related issues
N/A

#### Testing
CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
