### PR TITLE
Qualify Const Member Functions in GroupDataProvider

### DIFF
--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -202,8 +202,8 @@ public:
     CHIP_ERROR RemoveFabric(FabricIndex) override { return CHIP_NO_ERROR; }
     GroupSessionIterator * IterateGroupSessions(uint16_t) override { return nullptr; }
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex, GroupId) override { return nullptr; }
-    uint16_t getMaxMembershipCount() override { return 0; }
-    uint16_t getMaxMcastAddrCount() override { return 0; }
+    uint16_t getMaxMembershipCount() const override { return 0; }
+    uint16_t getMaxMcastAddrCount() const override { return 0; }
     bool ConsumeAuxAclNotificationNeeded() override { return false; }
 
     bool mHasEndpoint = true;

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -259,7 +259,7 @@ public:
 
     // TODO(#72056): Once groupcast is enabled by default, this should just return mMaxGroupsPerFabric. See GroupDataProviderImpl()
     // constructor.
-    uint16_t GetMaxGroupsPerFabric()
+    uint16_t GetMaxGroupsPerFabric() const
     {
         return static_cast<uint16_t>(IsGroupcastEnabled() ? (getMaxMembershipCount() / 2) : mMaxGroupsPerFabric);
     }
@@ -402,11 +402,11 @@ public:
 
     void SetGroupcastEnabled(bool groupcastVal) { mGroupcastEnabled = groupcastVal; }
 
-    bool IsGroupcastEnabled() { return mGroupcastEnabled; }
+    bool IsGroupcastEnabled() const { return mGroupcastEnabled; }
 
     // Groupcast
-    virtual uint16_t getMaxMembershipCount() = 0;
-    virtual uint16_t getMaxMcastAddrCount()  = 0;
+    virtual uint16_t getMaxMembershipCount() const = 0;
+    virtual uint16_t getMaxMcastAddrCount() const = 0;
 
     /**
      * @brief Check if a notification is needed for Auxiliary ACL changes and reset the flag.

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -406,7 +406,7 @@ public:
 
     // Groupcast
     virtual uint16_t getMaxMembershipCount() const = 0;
-    virtual uint16_t getMaxMcastAddrCount() const = 0;
+    virtual uint16_t getMaxMcastAddrCount() const  = 0;
 
     /**
      * @brief Check if a notification is needed for Auxiliary ACL changes and reset the flag.

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -113,8 +113,8 @@ public:
     GroupSessionIterator * IterateGroupSessions(uint16_t session_id) override;
 
     // Groupcast configurations
-    uint16_t getMaxMembershipCount() override { return kMaxMembershipCount; }
-    uint16_t getMaxMcastAddrCount() override { return kMaxMcastAddrCount; }
+    uint16_t getMaxMembershipCount() const override { return kMaxMembershipCount; }
+    uint16_t getMaxMcastAddrCount() const override { return kMaxMcastAddrCount; }
 
     bool ConsumeAuxAclNotificationNeeded() override
     {


### PR DESCRIPTION
#### Summary

This PR qualifies some const member functions. This change stems from a request to keep `GetMaxGroupsPerFabric()` as a const member function, as this was unintentionally removed as part of #72047. To do this, the functions called within `GetMaxGroupsPerFabric()` were made const too.

#### Testing

- CI should still pass