### PR TITLE
Add a new overload for MTRCommissioningDelegate's commissioning:succeededForNodeID:metrics: that takes a context dictionary

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -109,10 +109,25 @@ MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2))
 
 /**
  * Notification that commissioning has succeeded.
+ *
+ * This selector will not be used if commissioning:succeededForNodeID:metrics:context: is supported.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
     succeededForNodeID:(NSNumber *)nodeID
                metrics:(MTRMetrics *)metrics;
+
+/**
+ * Notification that commissioning has succeeded.
+ *
+ * If supported, this selector will be used in preference to commissioning:succeededForNodeID:metrics:.
+ *
+ * The context parameter is a dictionary with NSString keys and values of type id.
+ * The supported keys are defined above in this file.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    succeededForNodeID:(NSNumber *)nodeID
+               metrics:(MTRMetrics *)metrics
+               context:(NSDictionary<NSString *, id> *)context MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -297,6 +297,7 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     commissioningComplete:(NSError * _Nullable)error
                    nodeID:(NSNumber * _Nullable)nodeID
                   metrics:(MTRMetrics *)metrics
+                  context:(NSDictionary<NSString *, id> *)context
 {
     if (error) {
         [self _dispatchCommissioningError:error forCommissioningID:nodeID withMetrics:metrics];
@@ -319,7 +320,9 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     [strongController commissioningDone:self];
 
     dispatch_async(_delegateQueue, ^{
-        if ([strongDelegate respondsToSelector:@selector(commissioning:succeededForNodeID:metrics:)]) {
+        if ([strongDelegate respondsToSelector:@selector(commissioning:succeededForNodeID:metrics:context:)]) {
+            [strongDelegate commissioning:self succeededForNodeID:nodeID metrics:metrics context:context];
+        } else if ([strongDelegate respondsToSelector:@selector(commissioning:succeededForNodeID:metrics:)]) {
             [strongDelegate commissioning:self succeededForNodeID:nodeID metrics:metrics];
         }
     });

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -624,9 +624,12 @@ using namespace chip::Tracing::DarwinFramework;
     commissioningComplete:(NSError * _Nullable)error
                    nodeID:(NSNumber * _Nullable)nodeID
                   metrics:(MTRMetrics *)metrics
+                  context:(NSDictionary<NSString *, id> *)context
 {
     [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+        if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:context:)]) {
+            [delegate controller:controller commissioningComplete:error nodeID:nodeID metrics:metrics context:context];
+        } else if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
             [delegate controller:controller commissioningComplete:error nodeID:nodeID metrics:metrics];
         } else if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)]) {
             [delegate controller:controller commissioningComplete:error nodeID:nodeID];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
@@ -59,8 +59,8 @@ MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  */
 - (void)controller:(MTRDeviceController *)controller
     commissioningComplete:(NSError * _Nullable)error
-    MTR_DEPRECATED("Please use controller:commissioningComplete:nodeID:", ios(16.4, 17.0), macos(13.3, 14.0), watchos(9.4, 10.0),
-        tvos(16.4, 17.0));
+    MTR_DEPRECATED_WITH_REPLACEMENT("controller:commissioningComplete:nodeID:",
+        ios(16.4, 17.0), macos(13.3, 14.0), watchos(9.4, 10.0), tvos(16.4, 17.0));
 
 /**
  * Notify the delegate when commissioning is completed.
@@ -84,12 +84,35 @@ MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  *
  * The metrics object contains information corresponding to the commissioning session.
  *
- * If supported, this selector will be used in preference to controller:commissioningComplete:nodeID:.
+ * This selector will not be used if controller:commissioningComplete:nodeID:metrics:context: is supported.
  */
 - (void)controller:(MTRDeviceController *)controller
     commissioningComplete:(NSError * _Nullable)error
                    nodeID:(NSNumber * _Nullable)nodeID
-                  metrics:(MTRMetrics *)metrics MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
+                  metrics:(MTRMetrics *)metrics
+    MTR_DEPRECATED_WITH_REPLACEMENT("controller:commissioningComplete:nodeID:metrics:context:",
+        ios(17.6, 27.0), macos(14.6, 27.0), watchos(10.6, 27.0), tvos(17.6, 27.0));
+
+/**
+ * Notify the delegate when commissioning is completed.
+ *
+ * Exactly one of error and nodeID will be nil.
+ *
+ * If nodeID is not nil, then it represents the node id the node was assigned, as encoded in its operational certificate.
+ *
+ * The metrics object contains information corresponding to the commissioning session.
+ *
+ * The context parameter is a dictionary. See MTRCommissioningDelegate's commissioning:succeededForNodeID:metrics:context:
+ * for the supported keys.
+ *
+ * If supported, this selector will be used in preference to controller:commissioningComplete:nodeID: and
+ * controller:commissioningComplete:nodeID:metrics:.
+ */
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+                  metrics:(MTRMetrics *)metrics
+                  context:(NSDictionary<NSString *, id> *)context MTR_AVAILABLE(ios(27.0), macos(27.0), watchos(27.0), tvos(27.0));
 
 /**
  * Notify the delegate when commissioning infomation has been read from the commissionee.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -205,7 +205,7 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
 
                 // If the client implements the context delegate, prefer that over others
                 if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:context:)]) {
-                    [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics context:@{}];
+                    [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics context:@ {}];
                 } else if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
                     [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics];
                 } else {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -97,7 +97,7 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
         // to mark end of commissioning request.
         // Since OnPairingComplete(failure_code) might not be invoked in all cases, use this opportunity to inform of failed commissioning
         // and default the error to timeout since that is best guess in this layer.
-        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed && [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed && ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)] || [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:context:)])) {
             OnCommissioningComplete(mDeviceNodeId, CHIP_ERROR_TIMEOUT);
         }
     }
@@ -194,7 +194,8 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
         MTR_LOG("%@ Device commissioning complete with metrics %@", strongController, metrics);
 
         if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||
-            [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+            [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)] ||
+            [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:context:)]) {
             dispatch_async(mQueue, ^{
                 NSError * nsError = [MTRError errorForCHIPErrorCode:error];
                 NSNumber * nodeID = nil;
@@ -202,8 +203,10 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
                     nodeID = @(nodeId);
                 }
 
-                // If the client implements the metrics delegate, prefer that over others
-                if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+                // If the client implements the context delegate, prefer that over others
+                if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:context:)]) {
+                    [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics context:@{}];
+                } else if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
                     [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics];
                 } else {
                     [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID];

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -2172,6 +2172,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
     succeededForNodeID:(NSNumber *)nodeID
                metrics:(MTRMetrics *)metrics
+               context:(NSDictionary<NSString *, id> *)context
 {
     auto * currentCommissioning = self.currentCommissioning;
     if (commissioning != currentCommissioning) {
@@ -2190,7 +2191,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         [self _commissioningDone:commissioning];
     }
 
-    [self controller:self commissioningComplete:nil nodeID:nodeID metrics:metrics];
+    [self controller:self commissioningComplete:nil nodeID:nodeID metrics:metrics context:context];
 }
 
 #pragma mark - MTRCommissioningDelegate_Internal implementation
@@ -2257,7 +2258,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         [self _commissioningDone:commissioning];
     }
 
-    [self controller:self commissioningComplete:error nodeID:deviceID metrics:metrics];
+    [self controller:self commissioningComplete:error nodeID:deviceID metrics:metrics context:@{}];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -557,7 +557,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 //- (oneway void)controller:(NSUUID *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error {
 //
 //}
-//- (oneway void)controller:(NSUUID *)controller commissioningComplete:(NSError * _Nullable)error nodeID:(NSNumber * _Nullable)nodeID metrics:(MTRMetrics * _Nullable)metrics {
+//- (oneway void)controller:(NSUUID *)controller commissioningComplete:(NSError * _Nullable)error nodeID:(NSNumber * _Nullable)nodeID metrics:(MTRMetrics * _Nullable)metrics context:(NSDictionary<NSString *, id> * _Nullable)context {
 //
 //}
 //- (oneway void)controller:(NSUUID *)controller readCommissioningInfo:(MTRProductIdentity *)info {

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
@@ -35,7 +35,7 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
 // Not Supported via XPC
 //- (oneway void)controller:(NSUUID *)controller statusUpdate:(MTRCommissioningStatus)status;
 //- (oneway void)controller:(NSUUID *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error;
-//- (oneway void)controller:(NSUUID *)controller commissioningComplete:(NSError * _Nullable)error nodeID:(NSNumber * _Nullable)nodeID metrics:(MTRMetrics * _Nullable)metrics;
+//- (oneway void)controller:(NSUUID *)controller commissioningComplete:(NSError * _Nullable)error nodeID:(NSNumber * _Nullable)nodeID metrics:(MTRMetrics * _Nullable)metrics context:(NSDictionary<NSString *, id> * _Nullable)context;
 //- (oneway void)controller:(NSUUID *)controller readCommissioningInfo:(MTRProductIdentity *)info;
 @optional
 - (oneway void)controller:(NSUUID *)controller controllerConfigurationUpdated:(NSDictionary *)configuration MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3));

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -167,6 +167,7 @@ typedef void (^AttestationHandler)(dispatch_block_t);
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
     succeededForNodeID:(NSNumber *)nodeID
                metrics:(MTRMetrics *)metrics
+               context:(NSDictionary<NSString *, id> *)context
 {
     if (self.expectFailure) {
         XCTFail("Did not expect commissioning to succeed");
@@ -374,6 +375,7 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
 @property (atomic, readwrite) BOOL commissioningCompleteCalled;
 @property (atomic, readwrite) BOOL readCommissioneeInfoCalled;
 @property (atomic, readwrite, strong) XCTestExpectation * allCallbacksCalledExpectation;
+@property (atomic, readwrite, strong) XCTestExpectation * deprecatedCallbackExpectation;
 @end
 
 @implementation MTRPairingTestMonitoringControllerDelegate
@@ -406,8 +408,30 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
 
 - (void)controller:(MTRDeviceController *)controller
     commissioningComplete:(NSError * _Nullable)error
+{
+    [self.deprecatedCallbackExpectation fulfill];
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+{
+    [self.deprecatedCallbackExpectation fulfill];
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
                    nodeID:(NSNumber * _Nullable)nodeID
                   metrics:(MTRMetrics *)metrics
+{
+    [self.deprecatedCallbackExpectation fulfill];
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+                  metrics:(MTRMetrics *)metrics
+                  context:(NSDictionary<NSString *, id> *)context
 {
     self.commissioningCompleteCalled = YES;
     [self _checkIfAllCallbacksCalled];
@@ -518,6 +542,9 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
     __auto_type * monitoringControllerDelegate = [[MTRPairingTestMonitoringControllerDelegate alloc] init];
     XCTestExpectation * allCallbacksCalledExpectation = [self expectationWithDescription:@"All callbacks called on monitoring delegate"];
     monitoringControllerDelegate.allCallbacksCalledExpectation = allCallbacksCalledExpectation;
+    XCTestExpectation * deprecatedCallbackExpectation = [self expectationWithDescription:@"Deprecated callback called on monitoring delegate"];
+    deprecatedCallbackExpectation.inverted = YES;
+    monitoringControllerDelegate.deprecatedCallbackExpectation = deprecatedCallbackExpectation;
     [sController addDeviceControllerDelegate:monitoringControllerDelegate queue:callbackQueue];
     XCTAssertEqual([sController unitTestDelegateCount], 2);
 
@@ -537,7 +564,7 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
     XCTAssertTrue([sController setupCommissioningSessionWithPayload:payload newNodeID:@(sDeviceId) error:&error]);
     XCTAssertNil(error);
 
-    [self waitForExpectations:@[ expectation, allCallbacksCalledExpectation ] timeout:kPairingTimeoutInSeconds];
+    [self waitForExpectations:@[ expectation, allCallbacksCalledExpectation, deprecatedCallbackExpectation ] timeout:kPairingTimeoutInSeconds];
     XCTAssertNil(controllerDelegate.commissioningCompleteError);
 
     // Test that the monitoring delegate got all the callbacks


### PR DESCRIPTION
#### Summary

In the future we will need to pass additional data through `succeededForNodeID`. Using a dictionary context allows us to add data without needing to change the signature every time (deprecating the existing signatures, etc).

#### Related issues

N/A

#### Testing

* Added test to make sure the new overload is called if it's defined.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
