### PR TITLE
[all-devices] derive "device source directories" from the source file list

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/enabled_devices.cmake
+++ b/examples/all-devices-app/all-devices-common/devices/enabled_devices.cmake
@@ -29,30 +29,6 @@
 # app_config/enabled_devices.h is reachable as <app_config/enabled_devices.h>.
 
 # ---------------------------------------------------------------------------
-# Source directories (unconditional — all device sources are always compiled;
-# LTO eliminates unreachable device code when only a subset is registered).
-# ---------------------------------------------------------------------------
-set(ALL_DEVICES_DEVICE_SRCDIRS
-    # keep-sorted: start
-    "${ALL_DEVICES_COMMON_DIR}/devices/boolean-state-sensor"
-    "${ALL_DEVICES_COMMON_DIR}/devices/chime"
-    "${ALL_DEVICES_COMMON_DIR}/devices/dimmable-light"
-    "${ALL_DEVICES_COMMON_DIR}/devices/dimmable-light/impl"
-    "${ALL_DEVICES_COMMON_DIR}/devices/interface"
-    "${ALL_DEVICES_COMMON_DIR}/devices/occupancy-sensor"
-    "${ALL_DEVICES_COMMON_DIR}/devices/occupancy-sensor/impl"
-    "${ALL_DEVICES_COMMON_DIR}/devices/on-off-light"
-    "${ALL_DEVICES_COMMON_DIR}/devices/root-node"
-    "${ALL_DEVICES_COMMON_DIR}/devices/soil-sensor"
-    "${ALL_DEVICES_COMMON_DIR}/devices/soil-sensor/impl"
-    "${ALL_DEVICES_COMMON_DIR}/devices/speaker"
-    "${ALL_DEVICES_COMMON_DIR}/devices/speaker/impl"
-    "${ALL_DEVICES_COMMON_DIR}/devices/temperature-sensor"
-    "${ALL_DEVICES_COMMON_DIR}/devices/temperature-sensor/impl"
-    # keep-sorted: end
-)
-
-# ---------------------------------------------------------------------------
 # Source files for devices and common interfaces (for non-component CMake builds).
 # Excludes root-node specialization files (Thread/WiFi) which require platform
 # specific selection.
@@ -77,6 +53,18 @@ set(ALL_DEVICES_DEVICE_SOURCES
     "${ALL_DEVICES_COMMON_DIR}/devices/temperature-sensor/impl/IncreasingTemperatureSensorDevice.cpp"
     # keep-sorted: end
 )
+
+# ---------------------------------------------------------------------------
+# Source directories (unconditional — all device sources are always compiled;
+# LTO eliminates unreachable device code when only a subset is registered).
+# Derived automatically from ALL_DEVICES_DEVICE_SOURCES.
+# ---------------------------------------------------------------------------
+set(ALL_DEVICES_DEVICE_SRCDIRS "")
+foreach(_src IN LISTS ALL_DEVICES_DEVICE_SOURCES)
+    get_filename_component(_dir "${_src}" DIRECTORY)
+    list(APPEND ALL_DEVICES_DEVICE_SRCDIRS "${_dir}")
+endforeach()
+list(REMOVE_DUPLICATES ALL_DEVICES_DEVICE_SRCDIRS)
 
 # ---------------------------------------------------------------------------
 # Device selection.


### PR DESCRIPTION
#### Summary

ESP32 builds require the directory list, where as most others (e.g. telink now) require the file list. It seems more convenient to just specify things once and if we have a list of files, we can figure out directories.

#### Testing

CI will check.
I compiled `esp32-m5stack-all-devices` locally.