### PR TITLE
[Realtek] Check ExecCommand return value in matter_cmd_handler

### DIFF
--- a/src/lib/shell/MainLoopBee.cpp
+++ b/src/lib/shell/MainLoopBee.cpp
@@ -48,9 +48,9 @@ otError matter_cmd_handler(void * aContext, uint8_t argc, char * argv[])
             errorStr[0] = 0;
         }
         return OT_ERROR_FAILED;
-      }
+    }
 
-      return OT_ERROR_NONE;
+    return OT_ERROR_NONE;
 }
 
 otCliCommand bee_cmd[] = {

--- a/src/lib/shell/MainLoopBee.cpp
+++ b/src/lib/shell/MainLoopBee.cpp
@@ -41,12 +41,6 @@ otError matter_cmd_handler(void * aContext, uint8_t argc, char * argv[])
 
     if (retval != CHIP_NO_ERROR)
     {
-        char errorStr[160];
-        bool errorStrFound = FormatCHIPError(errorStr, sizeof(errorStr), retval);
-        if (!errorStrFound)
-        {
-            errorStr[0] = 0;
-        }
         return OT_ERROR_FAILED;
     }
 

--- a/src/lib/shell/MainLoopBee.cpp
+++ b/src/lib/shell/MainLoopBee.cpp
@@ -37,8 +37,20 @@ typedef otError (*cmd)(void *, uint8_t, char **);
 
 otError matter_cmd_handler(void * aContext, uint8_t argc, char * argv[])
 {
-    Engine::Root().ExecCommand(argc, argv);
-    return OT_ERROR_NONE;
+    CHIP_ERROR retval = Engine::Root().ExecCommand(argc, argv);
+
+    if (retval != CHIP_NO_ERROR)
+    {
+        char errorStr[160];
+        bool errorStrFound = FormatCHIPError(errorStr, sizeof(errorStr), retval);
+        if (!errorStrFound)
+        {
+            errorStr[0] = 0;
+        }
+        return OT_ERROR_FAILED;
+      }
+
+      return OT_ERROR_NONE;
 }
 
 otCliCommand bee_cmd[] = {


### PR DESCRIPTION

#### Summary

Return OT_ERROR_FAILED when ExecCommand fails instead of always returning OT_ERROR_NONE, allowing the caller to detect command execution errors.


#### Testing
Manually tested on Realtek platform
All above operations complete successfully
No unexpected error logs or regressions observed in console output