### PR TITLE
[OTA] Handle allocation failure in image-header parser and TLV accumulator

### DIFF
--- a/src/lib/core/OTAImageHeader.cpp
+++ b/src/lib/core/OTAImageHeader.cpp
@@ -80,6 +80,13 @@ CHIP_ERROR OTAImageHeaderParser::AccumulateAndDecode(ByteSpan & buffer, OTAImage
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
+    // Init() may have left mBuffer null on alloc failure.
+    if (mState != State::kNotInitialized && mBuffer.Get() == nullptr)
+    {
+        Clear();
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
     if (mState == State::kInitialized)
     {
         Append(buffer, kFixedHeaderSize - mBufferOffset);

--- a/src/platform/nxp/common/ota/OTATlvProcessor.cpp
+++ b/src/platform/nxp/common/ota/OTATlvProcessor.cpp
@@ -96,13 +96,16 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
-    // Init() may have left mBuffer null on alloc failure.
-    VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
-
     uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
-    memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
-    mBufferOffset += numBytes;
-    block = block.SubSpan(numBytes);
+    // Init() returns void; an alloc failure leaves mBuffer null.
+    // Only enforce the precondition when there is data to copy.
+    if (numBytes > 0)
+    {
+        VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
+        memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
+        mBufferOffset += numBytes;
+        block = block.SubSpan(numBytes);
+    }
 
     if (mBufferOffset < mThreshold)
     {

--- a/src/platform/nxp/common/ota/OTATlvProcessor.cpp
+++ b/src/platform/nxp/common/ota/OTATlvProcessor.cpp
@@ -96,6 +96,9 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
+    // Init() may have left mBuffer null on alloc failure.
+    VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
     uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
     memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
     mBufferOffset += numBytes;

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -126,6 +126,9 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
+    // Init() may have left mBuffer null on alloc failure.
+    VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
     uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
     memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
     mBufferOffset += numBytes;

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -126,13 +126,16 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
-    // Init() may have left mBuffer null on alloc failure.
-    VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
-
     uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
-    memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
-    mBufferOffset += numBytes;
-    block = block.SubSpan(numBytes);
+    // Init() returns void; an alloc failure leaves mBuffer null.
+    // Only enforce the precondition when there is data to copy.
+    if (numBytes > 0)
+    {
+        VerifyOrReturnError(mBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
+        memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
+        mBufferOffset += numBytes;
+        block = block.SubSpan(numBytes);
+    }
 
     if (mBufferOffset < mThreshold)
     {


### PR DESCRIPTION
#### Summary
`Platform::ScopedMemoryBuffer::Alloc()`  stores `nullptr` internally when the underlying allocator fails. Three OTA paths ignored the return value, then later memcpy'd into the buffer:


- `OTAImageHeaderParser::Init()` — shared parser used by all platform OTAImageProcessorImpl implementations.
- `OTADataAccumulator::Init(threshold)` in the Silabs multi-OTA TLV processor.
- `OTADataAccumulator::Init(threshold)` in the NXP multi-OTA TLV processor

Fix: In order to keep Init() signatures void to avoid a big blast radius, the defensive checks were added before any `memcpy` that uses the buffers.


#### Testing

CI Testing
