### PR TITLE
Bump sysroot version in chip-build-crosscompile Dockerfile

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-196 : [crosscompile] Don't duplicate minimization done by create_sysroot.py in the Dockerfile
+197 : [crosscompile] Bump {armhf,aarch64} sysroot tag to `version:build-2026.05.14`

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt
 # are generally not required for compilation
 # Executables are also removed as those confuse cmake. It tries to run `make` from the sysroot and fails.
 RUN set -x \
-  && SYSROOT_VERSION="build-2026.05.07" \
+  && SYSROOT_VERSION="build-2026.05.14" \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
   && echo "experimental/matter/sysroot/ubuntu-24.04-aarch64 version:${SYSROOT_VERSION}" > ensure_file.txt \


### PR DESCRIPTION
#### Summary

After https://github.com/project-chip/connectedhomeip/pull/72053 was merged and the new sysroot uploaded to `cipd` we need to bump the version tag in the `Dockerfile` so the new sysroot will be included in `chip-build-crosscompile`.

#### Testing

Testing of the build with the new sysroot was performed during work on https://github.com/project-chip/connectedhomeip/pull/72053

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
