### PR TITLE
[camera-controller] Fix chip-camera-controller build on macOS

### DIFF
--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -23,8 +23,20 @@ import("${chip_root}/src/lib/core/core.gni")
 
 assert(chip_build_tools)
 
+if (current_os == "mac") {
+  import("${build_root}/config/linux/pkg_config.gni")
+
+  pkg_config("openssl") {
+    packages = [ "openssl" ]
+  }
+}
+
 config("config") {
   cflags = [ "-Wno-shadow" ]
+
+  if (current_os == "mac") {
+    cflags_cc = [ "-Wno-implicit-int-conversion" ]
+  }
 
   include_dirs = [
     ".",
@@ -134,6 +146,10 @@ executable("chip-camera-controller") {
     "${chip_root}/src/platform/logging:stdio",
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
+
+  if (current_os == "mac") {
+    configs += [ ":openssl" ]
+  }
 
   output_dir = root_out_dir
 }

--- a/examples/camera-controller/commands/common/DeviceScanner.cpp
+++ b/examples/camera-controller/commands/common/DeviceScanner.cpp
@@ -72,7 +72,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 
     for (size_t i = 0; i < resolutionData.numIPs; i++)
     {
-        auto params                = Controller::SetUpCodePairerParameters(resolutionData, i);
+        auto params                = Controller::SetUpCodePairerParameters(resolutionData, std::make_optional(discriminator), i);
         DeviceScannerResult result = { params, vendorId, productId, discriminator, chip::MakeOptional(resolutionData) };
         interfaceData.push_back(result);
     }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -502,7 +502,9 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
         // New candidates may have arrived during transmission, so we remove from the front
         if (mLocalCandidates.size() > candidateCount)
         {
-            mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + candidateCount);
+            using DiffType = std::vector<ICECandidateInfo>::difference_type;
+            mLocalCandidates.erase(mLocalCandidates.begin(),
+                                   mLocalCandidates.begin() + static_cast<DiffType>(candidateCount));
             if (!mLocalCandidates.empty())
             {
                 ChipLogProgress(Camera, "%zu new candidate(s) arrived during transmission, keeping for next batch",

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -503,8 +503,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
         if (mLocalCandidates.size() > candidateCount)
         {
             using DiffType = std::vector<ICECandidateInfo>::difference_type;
-            mLocalCandidates.erase(mLocalCandidates.begin(),
-                                   mLocalCandidates.begin() + static_cast<DiffType>(candidateCount));
+            mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + static_cast<DiffType>(candidateCount));
             if (!mLocalCandidates.empty())
             {
                 ChipLogProgress(Camera, "%zu new candidate(s) arrived during transmission, keeping for next batch",


### PR DESCRIPTION
* Darwin-gated `-Wno-implicit-int-conversion` (in `cflags_cc`, so it survives the global `-Wconversion` on Mac) for libdatachannel headers.
* Darwin-gated `pkg_config("openssl")` so the linker finds Homebrew's OpenSSL; libdatachannel asks for `-lssl -lcrypto` but doesn't add a lib_dir, and macOS no longer ships OpenSSL.
* Explicit `static_cast<difference_type>(candidateCount)` in WebRTCManager.cpp to satisfy Mac's `-Wconversion -Werror`.
* Update DeviceScanner.cpp (Darwin-only source) to the current 3-arg `SetUpCodePairerParameters(data, longDiscriminator, index)` signature.

#### Testing
CI
