### PR TITLE
feat(casting): Add deviceName support to iOS MCDeviceInstanceInfoProvider

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -27,6 +27,7 @@
 #import "core/Types.h"
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <platform/Darwin/PosixConfig.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #import <Foundation/Foundation.h>
@@ -123,6 +124,18 @@
     if (_deviceInstanceInfoProvider != nullptr) {
         ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting custom DeviceInstanceInfoProvider");
         chip::DeviceLayer::SetDeviceInstanceInfoProvider(_deviceInstanceInfoProvider);
+
+        // Write deviceName into PosixConfig so ConfigurationManagerImpl::GetCommissionableDeviceName()
+        // returns it at runtime for UDC requests and mDNS advertisements.
+        id<MCDeviceInstanceInfoProvider> infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
+        if (infoProvider != nil && [infoProvider respondsToSelector:@selector(deviceName)]) {
+            NSString * deviceName = [infoProvider deviceName];
+            if (deviceName != nil) {
+                ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting commissionable device name");
+                chip::DeviceLayer::Internal::PosixConfig::WriteConfigValueStr(
+                    chip::DeviceLayer::Internal::PosixConfig::kConfigKey_DeviceName, [deviceName UTF8String]);
+            }
+        }
     }
 
     // Get and store the CHIP Work queue

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -97,8 +97,9 @@
     _serverInitParamsProvider = new MCCommonCaseDeviceServerInitParamsProvider();
 
     // Initialize MCDeviceInstanceInfoProviderBridge if the dataSource provides a delegate
+    id<MCDeviceInstanceInfoProvider> infoProvider = nil;
     if ([dataSource respondsToSelector:@selector(castingAppDidReceiveRequestForDeviceInstanceInfoProvider:)]) {
-        id<MCDeviceInstanceInfoProvider> infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
+        infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
         if (infoProvider != nil) {
             ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting up pull-based MCDeviceInstanceInfoProviderBridge");
             delete _deviceInstanceInfoProvider;
@@ -127,13 +128,19 @@
 
         // Write deviceName into PosixConfig so ConfigurationManagerImpl::GetCommissionableDeviceName()
         // returns it at runtime for UDC requests and mDNS advertisements.
-        id<MCDeviceInstanceInfoProvider> infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
         if (infoProvider != nil && [infoProvider respondsToSelector:@selector(deviceName)]) {
             NSString * deviceName = [infoProvider deviceName];
+            CHIP_ERROR err = CHIP_NO_ERROR;
             if (deviceName != nil) {
                 ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting commissionable device name");
-                chip::DeviceLayer::Internal::PosixConfig::WriteConfigValueStr(
+                err = chip::DeviceLayer::Internal::PosixConfig::WriteConfigValueStr(
                     chip::DeviceLayer::Internal::PosixConfig::kConfigKey_DeviceName, [deviceName UTF8String]);
+            } else {
+                err = chip::DeviceLayer::Internal::PosixConfig::ClearConfigValue(
+                    chip::DeviceLayer::Internal::PosixConfig::kConfigKey_DeviceName);
+            }
+            if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) {
+                ChipLogError(AppServer, "MCCastingApp.initializeWithDataSource() failed to update device name: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -36,17 +36,26 @@
 namespace {
 __weak id<MCDeviceInstanceInfoProvider> sDeviceInstanceInfoDelegate = nil;
 
-CHIP_ERROR DeviceNameProviderCallback(char * buf, size_t bufSize)
+CHIP_ERROR ConfigValueProviderCallback(const char * configNamespace, const char * name,
+                                       char * buf, size_t bufSize, size_t & outLen)
 {
     id<MCDeviceInstanceInfoProvider> delegate = sDeviceInstanceInfoDelegate;
-    if (delegate != nil && [delegate respondsToSelector:@selector(deviceName)]) {
-        NSString * name = [delegate deviceName];
-        if (name != nil) {
-            chip::Platform::CopyString(buf, bufSize, [name UTF8String]);
-            return CHIP_NO_ERROR;
-        }
+    if (delegate == nil) {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     }
-    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+
+    NSString * value = nil;
+    if (strcmp(name, "device-name") == 0 && [delegate respondsToSelector:@selector(deviceName)]) {
+        value = [delegate deviceName];
+    }
+
+    if (value == nil) {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+
+    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+    outLen = strlen(buf);
+    return CHIP_NO_ERROR;
 }
 } // namespace
 
@@ -144,12 +153,10 @@ CHIP_ERROR DeviceNameProviderCallback(char * buf, size_t bufSize)
         ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting custom DeviceInstanceInfoProvider");
         chip::DeviceLayer::SetDeviceInstanceInfoProvider(_deviceInstanceInfoProvider);
 
-        // Register the runtime device name provider so GetCommissionableDeviceName()
-        // queries the delegate on every call (matching Android's pull-based model).
-        if (infoProvider != nil && [infoProvider respondsToSelector:@selector(deviceName)]) {
-            sDeviceInstanceInfoDelegate = infoProvider;
-            chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(DeviceNameProviderCallback);
-        }
+        // Register the general-purpose config value provider so platform queries
+        // (e.g. GetCommissionableDeviceName) call through to the delegate at runtime.
+        sDeviceInstanceInfoDelegate = infoProvider;
+        chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ConfigValueProviderCallback);
     }
 
     // Get and store the CHIP Work queue

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -27,10 +27,28 @@
 #import "core/Types.h"
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
-#include <platform/Darwin/PosixConfig.h>
+#include <lib/support/CHIPMemString.h>
+#include <platform/Darwin/ConfigurationManagerImpl.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #import <Foundation/Foundation.h>
+
+namespace {
+__weak id<MCDeviceInstanceInfoProvider> sDeviceInstanceInfoDelegate = nil;
+
+CHIP_ERROR DeviceNameProviderCallback(char * buf, size_t bufSize)
+{
+    id<MCDeviceInstanceInfoProvider> delegate = sDeviceInstanceInfoDelegate;
+    if (delegate != nil && [delegate respondsToSelector:@selector(deviceName)]) {
+        NSString * name = [delegate deviceName];
+        if (name != nil) {
+            chip::Platform::CopyString(buf, bufSize, [name UTF8String]);
+            return CHIP_NO_ERROR;
+        }
+    }
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+} // namespace
 
 @interface MCCastingApp ()
 
@@ -126,22 +144,11 @@
         ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting custom DeviceInstanceInfoProvider");
         chip::DeviceLayer::SetDeviceInstanceInfoProvider(_deviceInstanceInfoProvider);
 
-        // Write deviceName into PosixConfig so ConfigurationManagerImpl::GetCommissionableDeviceName()
-        // returns it at runtime for UDC requests and mDNS advertisements.
+        // Register the runtime device name provider so GetCommissionableDeviceName()
+        // queries the delegate on every call (matching Android's pull-based model).
         if (infoProvider != nil && [infoProvider respondsToSelector:@selector(deviceName)]) {
-            NSString * deviceName = [infoProvider deviceName];
-            CHIP_ERROR err = CHIP_NO_ERROR;
-            if (deviceName != nil) {
-                ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting commissionable device name");
-                err = chip::DeviceLayer::Internal::PosixConfig::WriteConfigValueStr(
-                    chip::DeviceLayer::Internal::PosixConfig::kConfigKey_DeviceName, [deviceName UTF8String]);
-            } else {
-                err = chip::DeviceLayer::Internal::PosixConfig::ClearConfigValue(
-                    chip::DeviceLayer::Internal::PosixConfig::kConfigKey_DeviceName);
-            }
-            if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) {
-                ChipLogError(AppServer, "MCCastingApp.initializeWithDataSource() failed to update device name: %" CHIP_ERROR_FORMAT, err.Format());
-            }
+            sDeviceInstanceInfoDelegate = infoProvider;
+            chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(DeviceNameProviderCallback);
         }
     }
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -37,7 +37,7 @@ namespace {
 __weak id<MCDeviceInstanceInfoProvider> sDeviceInstanceInfoDelegate = nil;
 
 CHIP_ERROR ConfigValueProviderCallback(const char * configNamespace, const char * name,
-                                       char * buf, size_t bufSize, size_t & outLen)
+    char * buf, size_t bufSize, size_t & outLen)
 {
     id<MCDeviceInstanceInfoProvider> delegate = sDeviceInstanceInfoDelegate;
     if (delegate == nil) {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
@@ -41,6 +41,15 @@
 - (NSNumber * _Nullable)hardwareVersion;
 - (NSString * _Nullable)hardwareVersionString;
 
+/**
+ * @brief The commissionable device name shown on the casting target's commissioning prompt.
+ *
+ * On Android, this corresponds to kConfigKey_DeviceName in PreferencesConfigurationManager.
+ * The value is written into the platform ConfigurationManager at init time so it is used
+ * by UDC and mDNS advertisements.
+ */
+- (NSString * _Nullable)deviceName;
+
 @end
 
 #endif /* MCDeviceInstanceInfo_h */

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
@@ -137,7 +137,7 @@ class SampleDeviceInstanceInfoProvider: NSObject, MCDeviceInstanceInfoProvider {
     }
 
     func deviceName() -> String? {
-        return "My Living Room Speaker"
+        return "My Casting App"
     }
 }
 

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
@@ -135,6 +135,10 @@ class SampleDeviceInstanceInfoProvider: NSObject, MCDeviceInstanceInfoProvider {
     func productName() -> String? {
         return "Test Casting App"
     }
+
+    func deviceName() -> String? {
+        return "My Living Room Speaker"
+    }
 }
 
 // This class is a singleton

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -261,7 +261,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, siz
 #if CHIP_DISABLE_PLATFORM_KVS
     return GenericConfigurationManagerImpl<Internal::PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
 #else  // CHIP_DISABLE_PLATFORM_KVS
-    size_t outLen = 0;
+    size_t outLen  = 0;
     CHIP_ERROR err = ReadConfigValueStr(Internal::PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -259,15 +259,23 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
 #if CHIP_DISABLE_PLATFORM_KVS
-    if (mDeviceNameProvider != nullptr)
+    if (mConfigValueProvider != nullptr)
     {
-        return mDeviceNameProvider(buf, bufSize);
+        size_t outLen = 0;
+        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace,
+                                             PosixConfig::kConfigKey_DeviceName.Name, buf, bufSize, outLen);
+        if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+        {
+            return err;
+        }
     }
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else  // CHIP_DISABLE_PLATFORM_KVS
-    if (mDeviceNameProvider != nullptr)
+    if (mConfigValueProvider != nullptr)
     {
-        CHIP_ERROR err = mDeviceNameProvider(buf, bufSize);
+        size_t outLen = 0;
+        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace,
+                                             PosixConfig::kConfigKey_DeviceName.Name, buf, bufSize, outLen);
         if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
             return err;

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -258,7 +258,6 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 
 CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
-#if CHIP_DISABLE_PLATFORM_KVS
     if (mConfigValueProvider != nullptr)
     {
         size_t outLen  = 0;
@@ -269,18 +268,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, siz
             return err;
         }
     }
+
+#if CHIP_DISABLE_PLATFORM_KVS
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else  // CHIP_DISABLE_PLATFORM_KVS
-    if (mConfigValueProvider != nullptr)
-    {
-        size_t outLen  = 0;
-        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace, PosixConfig::kConfigKey_DeviceName.Name,
-                                              buf, bufSize, outLen);
-        if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-        {
-            return err;
-        }
-    }
     size_t outLen  = 0;
     CHIP_ERROR err = ReadConfigValueStr(PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -259,13 +259,13 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
 #if CHIP_DISABLE_PLATFORM_KVS
-    return GenericConfigurationManagerImpl<Internal::PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else  // CHIP_DISABLE_PLATFORM_KVS
     size_t outLen  = 0;
-    CHIP_ERROR err = ReadConfigValueStr(Internal::PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
+    CHIP_ERROR err = ReadConfigValueStr(PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
-        return GenericConfigurationManagerImpl<Internal::PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
+        return GenericConfigurationManagerImpl<PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
     }
     return err;
 #endif // CHIP_DISABLE_PLATFORM_KVS

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -261,9 +261,9 @@ CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, siz
 #if CHIP_DISABLE_PLATFORM_KVS
     if (mConfigValueProvider != nullptr)
     {
-        size_t outLen = 0;
-        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace,
-                                             PosixConfig::kConfigKey_DeviceName.Name, buf, bufSize, outLen);
+        size_t outLen  = 0;
+        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace, PosixConfig::kConfigKey_DeviceName.Name,
+                                              buf, bufSize, outLen);
         if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
             return err;
@@ -273,9 +273,9 @@ CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, siz
 #else  // CHIP_DISABLE_PLATFORM_KVS
     if (mConfigValueProvider != nullptr)
     {
-        size_t outLen = 0;
-        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace,
-                                             PosixConfig::kConfigKey_DeviceName.Name, buf, bufSize, outLen);
+        size_t outLen  = 0;
+        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace, PosixConfig::kConfigKey_DeviceName.Name,
+                                              buf, bufSize, outLen);
         if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
             return err;

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -256,6 +256,21 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 #endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
+{
+#if CHIP_DISABLE_PLATFORM_KVS
+    return GenericConfigurationManagerImpl<Internal::PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
+#else  // CHIP_DISABLE_PLATFORM_KVS
+    size_t outLen = 0;
+    CHIP_ERROR err = ReadConfigValueStr(Internal::PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        return GenericConfigurationManagerImpl<Internal::PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
+    }
+    return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
+}
+
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
 #if CHIP_DISABLE_PLATFORM_KVS

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -259,8 +259,20 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
 #if CHIP_DISABLE_PLATFORM_KVS
+    if (mDeviceNameProvider != nullptr)
+    {
+        return mDeviceNameProvider(buf, bufSize);
+    }
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else  // CHIP_DISABLE_PLATFORM_KVS
+    if (mDeviceNameProvider != nullptr)
+    {
+        CHIP_ERROR err = mDeviceNameProvider(buf, bufSize);
+        if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+        {
+            return err;
+        }
+    }
     size_t outLen  = 0;
     CHIP_ERROR err = ReadConfigValueStr(PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -54,8 +54,8 @@ public:
      * @return CHIP_NO_ERROR if a value was provided,
      *         CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND to fall through to the next source
      */
-    using ConfigValueProvider = CHIP_ERROR (*)(const char * configNamespace, const char * name,
-                                              char * buf, size_t bufSize, size_t & outLen);
+    using ConfigValueProvider = CHIP_ERROR (*)(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                               size_t & outLen);
 
     CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR StoreProductId(uint16_t productId);

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -42,19 +42,31 @@ inline constexpr int kCountryCodeLength = 2;
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
-    using DeviceNameProvider = CHIP_ERROR (*)(char * buf, size_t bufSize);
+    /**
+     * General-purpose callback for providing configuration values at runtime.
+     * Mirrors Android's ConfigurationManager.readConfigValueStr(namespace, name).
+     *
+     * @param configNamespace  The config namespace (e.g. "chip-factory")
+     * @param name             The config key name (e.g. "device-name")
+     * @param buf              Buffer to write the value into
+     * @param bufSize          Size of the buffer
+     * @param outLen           Set to the length of the value written (excluding null terminator)
+     * @return CHIP_NO_ERROR if a value was provided,
+     *         CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND to fall through to the next source
+     */
+    using ConfigValueProvider = CHIP_ERROR (*)(const char * configNamespace, const char * name,
+                                              char * buf, size_t bufSize, size_t & outLen);
 
     CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR StoreProductId(uint16_t productId);
     CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
 
     /**
-     * Set a callback that provides the commissionable device name at runtime.
-     * When set, GetCommissionableDeviceName() calls through to this provider
-     * on each query, enabling dynamic values (analogous to Android's
-     * PreferencesConfigurationManager.readConfigValueStr for kConfigKey_DeviceName).
+     * Set a general-purpose config value provider that is consulted at runtime
+     * before PosixConfig or compile-time defaults. Analogous to Android's
+     * PreferencesConfigurationManager.readConfigValueStr().
      */
-    void SetDeviceNameProvider(DeviceNameProvider provider) { mDeviceNameProvider = provider; }
+    void SetConfigValueProvider(ConfigValueProvider provider) { mConfigValueProvider = provider; }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetWiFiNetworkInformations(WiFiNetworkInfos & infos);
@@ -90,7 +102,7 @@ private:
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
 
-    DeviceNameProvider mDeviceNameProvider = nullptr;
+    ConfigValueProvider mConfigValueProvider = nullptr;
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -44,6 +44,7 @@ class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImp
 public:
     CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR StoreProductId(uint16_t productId);
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetWiFiNetworkInformations(WiFiNetworkInfos & infos);

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -42,9 +42,19 @@ inline constexpr int kCountryCodeLength = 2;
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
+    using DeviceNameProvider = CHIP_ERROR (*)(char * buf, size_t bufSize);
+
     CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR StoreProductId(uint16_t productId);
     CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
+
+    /**
+     * Set a callback that provides the commissionable device name at runtime.
+     * When set, GetCommissionableDeviceName() calls through to this provider
+     * on each query, enabling dynamic values (analogous to Android's
+     * PreferencesConfigurationManager.readConfigValueStr for kConfigKey_DeviceName).
+     */
+    void SetDeviceNameProvider(DeviceNameProvider provider) { mDeviceNameProvider = provider; }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetWiFiNetworkInformations(WiFiNetworkInfos & infos);
@@ -79,6 +89,8 @@ private:
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
+
+    DeviceNameProvider mDeviceNameProvider = nullptr;
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -48,7 +48,7 @@ public:
      *
      * @param configNamespace  The config namespace (e.g. "chip-factory")
      * @param name             The config key name (e.g. "device-name")
-     * @param buf              Buffer to write the value into
+     * @param buf              Buffer to write the null-terminated value into
      * @param bufSize          Size of the buffer
      * @param outLen           Set to the length of the value written (excluding null terminator)
      * @return CHIP_NO_ERROR if a value was provided,

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -55,6 +55,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_Spake2pSalt           = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
 const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfigNamespace_ChipFactory, "vendor-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_DeviceName            = { kConfigNamespace_ChipFactory, "device-name" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed        = { kConfigNamespace_ChipConfig, "fail-safe-armed" };

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -68,6 +68,7 @@ public:
     static const Key kConfigKey_ConfigurationVersion;
     static const Key kConfigKey_VendorId;
     static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_DeviceName;
 
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_RebootCount;

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -31,7 +31,6 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/StringBuilderAdapters.h>
-#include <lib/dnssd/TxtFields.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/BuildTime.h>
@@ -481,7 +480,7 @@ TEST_F(TestConfigurationMgr, GetProductId)
 
 TEST_F(TestConfigurationMgr, GetCommissionableDeviceName)
 {
-    char buf[chip::Dnssd::kKeyDeviceNameMaxLength + 1];
+    char buf[64];
 
     if (!ConfigurationMgr().IsCommissionableDeviceNameEnabled())
     {
@@ -500,7 +499,7 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
 {
     using namespace chip::DeviceLayer::Internal;
 
-    char buf[chip::Dnssd::kKeyDeviceNameMaxLength + 1];
+    char buf[64];
     const char * testName = "My Test Device";
 
     // Write a device name to PosixConfig

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -519,15 +519,21 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
 }
 
-static CHIP_ERROR TestDeviceNameProvider(char * buf, size_t bufSize)
+static CHIP_ERROR TestConfigValueProvider(const char * configNamespace, const char * name,
+                                          char * buf, size_t bufSize, size_t & outLen)
 {
-    const char * name = "Dynamic Device Name";
-    if (bufSize <= strlen(name))
+    if (strcmp(name, "device-name") == 0)
     {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
+        const char * value = "Dynamic Device Name";
+        if (bufSize <= strlen(value))
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        strcpy(buf, value);
+        outLen = strlen(value);
+        return CHIP_NO_ERROR;
     }
-    strcpy(buf, name);
-    return CHIP_NO_ERROR;
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
@@ -535,36 +541,43 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
     char buf[64];
 
     // Set a dynamic provider
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(TestDeviceNameProvider);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(TestConfigValueProvider);
 
     CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, "Dynamic Device Name");
 
     // Clear provider, verify fallback to compile-time default
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
     err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
 }
 
-static CHIP_ERROR ProviderThatReturnsNotFound(char * buf, size_t bufSize)
+static CHIP_ERROR ProviderThatReturnsNotFound(const char * configNamespace, const char * name,
+                                              char * buf, size_t bufSize, size_t & outLen)
 {
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
-static CHIP_ERROR ProviderWithSmallBuffer(char * buf, size_t bufSize)
+static CHIP_ERROR ProviderWithSmallBuffer(const char * configNamespace, const char * name,
+                                          char * buf, size_t bufSize, size_t & outLen)
 {
-    const char * name = "This name is longer than a tiny buffer";
-    if (bufSize <= strlen(name))
+    if (strcmp(name, "device-name") == 0)
     {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
+        const char * value = "This name is longer than a tiny buffer";
+        if (bufSize <= strlen(value))
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        strcpy(buf, value);
+        outLen = strlen(value);
+        return CHIP_NO_ERROR;
     }
-    strcpy(buf, name);
-    return CHIP_NO_ERROR;
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
-TEST_F(TestConfigurationMgr, DeviceNameProviderTakesPriorityOverConfig)
+TEST_F(TestConfigurationMgr, ConfigValueProviderTakesPriorityOverConfig)
 {
     using namespace chip::DeviceLayer::Internal;
 
@@ -576,32 +589,32 @@ TEST_F(TestConfigurationMgr, DeviceNameProviderTakesPriorityOverConfig)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Set a provider — it should take priority over the config value
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(TestDeviceNameProvider);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(TestConfigValueProvider);
     err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, "Dynamic Device Name");
 
     // Provider returns NOT_FOUND — should fall through to PosixConfig
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(ProviderThatReturnsNotFound);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ProviderThatReturnsNotFound);
     err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, configName);
 
     // Clean up
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
     PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
 }
 
-TEST_F(TestConfigurationMgr, DeviceNameProviderBufferTooSmall)
+TEST_F(TestConfigurationMgr, ConfigValueProviderBufferTooSmall)
 {
     char smallBuf[5];
 
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(ProviderWithSmallBuffer);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ProviderWithSmallBuffer);
     CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(smallBuf, sizeof(smallBuf));
     EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Clean up
-    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
 }
 
 TEST_F(TestConfigurationMgr, DeviceNameConfigBufferTooSmall)

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -39,6 +39,7 @@
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #ifdef __APPLE__
+#include <platform/Darwin/ConfigurationManagerImpl.h>
 #include <platform/Darwin/PosixConfig.h>
 #endif
 
@@ -513,6 +514,35 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
 
     // Clear the config key and verify fallback to compile-time default
     PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+
+static CHIP_ERROR TestDeviceNameProvider(char * buf, size_t bufSize)
+{
+    const char * name = "Dynamic Device Name";
+    if (bufSize <= strlen(name))
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+    strcpy(buf, name);
+    return CHIP_NO_ERROR;
+}
+
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
+{
+    char buf[64];
+
+    // Set a dynamic provider
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(TestDeviceNameProvider);
+
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, "Dynamic Device Name");
+
+    // Clear provider, verify fallback to compile-time default
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
     err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -547,6 +547,79 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
 }
+
+static CHIP_ERROR ProviderThatReturnsNotFound(char * buf, size_t bufSize)
+{
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+static CHIP_ERROR ProviderWithSmallBuffer(char * buf, size_t bufSize)
+{
+    const char * name = "This name is longer than a tiny buffer";
+    if (bufSize <= strlen(name))
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+    strcpy(buf, name);
+    return CHIP_NO_ERROR;
+}
+
+TEST_F(TestConfigurationMgr, DeviceNameProviderTakesPriorityOverConfig)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char buf[64];
+    const char * configName = "Config Name";
+
+    // Write a value to PosixConfig
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, configName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Set a provider — it should take priority over the config value
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(TestDeviceNameProvider);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, "Dynamic Device Name");
+
+    // Provider returns NOT_FOUND — should fall through to PosixConfig
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(ProviderThatReturnsNotFound);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, configName);
+
+    // Clean up
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+}
+
+TEST_F(TestConfigurationMgr, DeviceNameProviderBufferTooSmall)
+{
+    char smallBuf[5];
+
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(ProviderWithSmallBuffer);
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(smallBuf, sizeof(smallBuf));
+    EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // Clean up
+    ConfigurationManagerImpl::GetDefaultInstance().SetDeviceNameProvider(nullptr);
+}
+
+TEST_F(TestConfigurationMgr, DeviceNameConfigBufferTooSmall)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char smallBuf[5];
+    const char * longName = "A name that exceeds the buffer";
+
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, longName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetCommissionableDeviceName(smallBuf, sizeof(smallBuf));
+    EXPECT_NE(err, CHIP_NO_ERROR);
+
+    // Clean up
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+}
 #endif // __APPLE__
 
 } // namespace

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -31,11 +31,17 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/TxtFields.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/BuildTime.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
+
+#ifdef __APPLE__
+#include <platform/Darwin/PosixConfig.h>
+#endif
 
 using namespace chip;
 using namespace chip::Logging;
@@ -472,5 +478,46 @@ TEST_F(TestConfigurationMgr, GetProductId)
     EXPECT_GE(productId, 1u);
     EXPECT_LE(productId, 0xffff);
 }
+
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceName)
+{
+    char buf[chip::Dnssd::kKeyDeviceNameMaxLength + 1];
+
+    if (!ConfigurationMgr().IsCommissionableDeviceNameEnabled())
+    {
+        // If device name is not enabled, skip this test
+        GTEST_SKIP();
+    }
+
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GT(strlen(buf), 0u);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+
+#ifdef __APPLE__
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char buf[chip::Dnssd::kKeyDeviceNameMaxLength + 1];
+    const char * testName = "My Test Device";
+
+    // Write a device name to PosixConfig
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, testName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Verify ConfigurationMgr returns the stored value
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, testName);
+
+    // Clear the config key and verify fallback to compile-time default
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+#endif // __APPLE__
 
 } // namespace

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -519,8 +519,8 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
 }
 
-static CHIP_ERROR TestConfigValueProvider(const char * configNamespace, const char * name,
-                                          char * buf, size_t bufSize, size_t & outLen)
+static CHIP_ERROR TestConfigValueProvider(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                          size_t & outLen)
 {
     if (strcmp(name, "device-name") == 0)
     {
@@ -554,14 +554,14 @@ TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
     EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
 }
 
-static CHIP_ERROR ProviderThatReturnsNotFound(const char * configNamespace, const char * name,
-                                              char * buf, size_t bufSize, size_t & outLen)
+static CHIP_ERROR ProviderThatReturnsNotFound(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                              size_t & outLen)
 {
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
-static CHIP_ERROR ProviderWithSmallBuffer(const char * configNamespace, const char * name,
-                                          char * buf, size_t bufSize, size_t & outLen)
+static CHIP_ERROR ProviderWithSmallBuffer(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                          size_t & outLen)
 {
     if (strcmp(name, "device-name") == 0)
     {


### PR DESCRIPTION
### Summary

- Adds `deviceName` optional method to the `MCDeviceInstanceInfoProvider` protocol on iOS, allowing casting apps to override the commissionable device name shown on casting targets during commissioning
- Adds `kConfigKey_DeviceName` to Darwin `PosixConfig` and overrides `GetCommissionableDeviceName` in `ConfigurationManagerImpl` to read from it (with compile-time default fallback)
- At init time, the casting app writes the delegate-provided device name into `PosixConfig` so it's used by UDC requests and mDNS advertisements

This mirrors Android's `PreferencesConfigurationManager.readConfigValueStr()` pattern for `kConfigKey_DeviceName`, completing parity for the device name field.

### Testing

- [ ] Verify iOS casting app shows custom device name on casting target's commissioning prompt
- [ ] Verify nil return from `deviceName` falls back to compile-time `CHIP_DEVICE_CONFIG_DEVICE_NAME`
- [ ] Verify no regression on Darwin platforms that don't set the config key