### PR TITLE
[ESP32] ESP-IDF v6.1 Support

### DIFF
--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -86,8 +86,11 @@ with open(compile_commands_path) as compile_commands_json:
         for flag in compile_flags:
             expanded_flags.extend(expand_response_file(flag))
 
-        replace = "-I%s" % args.idf_path
-        replace_with = "-isystem%s" % args.idf_path
+        # Keep ESP-IDF libc overrides ahead of toolchain libc headers, matching native ESP-IDF builds
+        def normalize_idf_include(flag):
+            if flag == "-I%s/components/esp_libc/platform_include" % args.idf_path:
+                return flag
+            return flag.replace("-I%s" % args.idf_path, "-isystem%s" % args.idf_path)
 
         # Escape any embedded double quotes for GN string syntax, then wrap in quotes
         def quote_for_gn(flag):
@@ -95,7 +98,7 @@ with open(compile_commands_path) as compile_commands_json:
             escaped = flag.replace('\\', '\\\\').replace('"', '\\"')
             return f'"{escaped}"'
 
-        expanded_flags = [quote_for_gn(f).replace(replace, replace_with) for f in expanded_flags]
+        expanded_flags = [quote_for_gn(normalize_idf_include(f)) for f in expanded_flags]
 
         if args.filter_out:
             filter_out = [f'"{f}"' for f in args.filter_out.split(';')]

--- a/docs/platforms/esp32/setup_idf_chip.md
+++ b/docs/platforms/esp32/setup_idf_chip.md
@@ -60,30 +60,10 @@ source scripts/bootstrap.sh -p all,esp32
 Whenever Matter environment is out of date, it can be updated by running above
 command.
 
-In IDF v4.4.x, `esptool` is part of the esp-idf repository, but in IDF v5.x, it
-is moved out as a Python package which can be installed using pip.
-
-If you are using IDF v5.x or later, please install `esptool` using the command
-below:
-
-```
-# Please make sure to run this command in the Matter Python environment
-python3 -m pip install esptool
-```
-
 ## Using ESP-IDF v6.0 (beta)
 
-ESP-IDF v6.0 requires additional Python dependencies to be installed in the
-Matter environment. Run the following after bootstrapping:
-
-```
-# Please make sure to run these commands in the Matter Python environment
-pip install -U cryptography==45.0.4
-pip install esp-idf-kconfig==3.6.0
-```
-
-> **Note:** Only examples without display support have been verified with
-> ESP-IDF v6.0. Tested on ESP32-C3-Devkit
+Only examples without display support have been verified with ESP-IDF v6.0.
+Tested on ESP32-C3-Devkit.
 
 ---
 

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -164,7 +164,7 @@ pygments==2.14.0
     # via ipython
 pykwalify==1.8.0
     # via west
-pyparsing==3.0.9
+pyparsing==3.2.5
     # via bluezoo
 python-dateutil==2.8.2
     # via

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -2,8 +2,8 @@ click>=7.0
 future>=0.15.2
 # pyparsing: Min version was set based on https://github.com/pyparsing/pyparsing/issues/319
 # pyparsing: Max version was set to avoid breaking changes
-pyparsing>=3.0.3,<3.1
-idf-component-manager==2.4.2
+pyparsing>=3.1.0,<3.3
+idf-component-manager~=2.2
 pygdbmi<=0.9.0.2
 reedsolo>=1.5.3,<=1.5.4
 bitarray==2.6.0
@@ -13,5 +13,5 @@ construct>=2.10.70
 python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
 esp_idf_monitor==1.8.0
-esp-idf-kconfig==2.5.0
+esp-idf-kconfig>=3.2.0,<4.0.0
 esp_idf_nvs_partition_gen==0.1.9


### PR DESCRIPTION
#### Summary

Add ESP-IDF v6.1 support (mainly for the upcoming ESP32H4 and ESP32S31 chips).

#### Related issues

N/A

#### Testing

Built and test `examples/lighting-app/esp32` with below targets:

- ESP32C3
- ESP32H4 (`idf.py --preview set-target esp32h4 build`)
- ESP32S31 (`idf.py --preview set-target esp32s31 build`)

> [!NOTE]
> You do need [this patch](https://gist.github.com/Sped0n/b1ae498d4bbe51a433a6b2f4c3fdf629) to get pass the light example build for ESP32H4 and ESP32S31.