### PR TITLE
[ESP32] fix ESP-IDF v6.0 compatibility issues

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -505,8 +505,10 @@ if (CONFIG_ENABLE_DELTA_OTA)
     list(APPEND matter_requires espressif__esp_delta_ota)
 endif()
 
-add_prebuilt_library(matterlib "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a"
-                     REQUIRES ${matter_requires})
+if(NOT TARGET matterlib)
+    add_prebuilt_library(matterlib "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a"
+                         REQUIRES ${matter_requires})
+endif()
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group
                                                 ${chip_libraries}

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -37,7 +37,11 @@
 
 #ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
 #include "driver/usb_serial_jtag.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "driver/usb_serial_jtag_vfs.h"
+#else
 #include "esp_vfs_usb_serial_jtag.h"
+#endif
 #endif
 
 namespace chip {
@@ -100,9 +104,6 @@ int streamer_esp32_init(streamer_t * streamer)
 #endif // CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
 
 #ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
-    esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
-    esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
-
     fcntl(fileno(stdout), F_SETFL, O_NONBLOCK);
     fcntl(fileno(stdin), F_SETFL, O_NONBLOCK);
 
@@ -111,8 +112,16 @@ int streamer_esp32_init(streamer_t * streamer)
         .rx_buffer_size = 256,
     };
     usb_serial_jtag_driver_install(&usb_serial_jtag_config);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    usb_serial_jtag_vfs_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+    usb_serial_jtag_vfs_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+    usb_serial_jtag_vfs_use_driver();
+#else
+    esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+    esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
     esp_vfs_usb_serial_jtag_use_driver();
     esp_vfs_dev_uart_register();
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     esp_console_config_t console_config = {
         .max_cmdline_length = CONFIG_CHIP_SHELL_CMD_LINE_BUF_MAX_LENGTH,

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -67,14 +67,14 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp32_emac_config.smi_gpio.mdc_num        = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_gpio.mdio_num       = CONFIG_ETH_MDIO_GPIO;
 #else
-    esp32_emac_config.smi_mdc_gpio_num        = CONFIG_ETH_MDC_GPIO;
-    esp32_emac_config.smi_mdio_gpio_num       = CONFIG_ETH_MDIO_GPIO;
+    esp32_emac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
+    esp32_emac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
 #endif
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
     esp_eth_phy_t * phy                       = esp_eth_phy_new_generic(&phy_config);
 #else
-    esp_eth_phy_t * phy                       = esp_eth_phy_new_ip101(&phy_config);
+    esp_eth_phy_t * phy                 = esp_eth_phy_new_ip101(&phy_config);
 #endif
 #endif
 

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -64,17 +64,17 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
 #else // Default ethernet board configuration
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-    esp32_emac_config.smi_gpio.mdc_num        = CONFIG_ETH_MDC_GPIO;
-    esp32_emac_config.smi_gpio.mdio_num       = CONFIG_ETH_MDIO_GPIO;
+    esp32_emac_config.smi_gpio.mdc_num  = CONFIG_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num = CONFIG_ETH_MDIO_GPIO;
 #else
     esp32_emac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
 #endif
-    esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+    esp_eth_mac_t * mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-    esp_eth_phy_t * phy                       = esp_eth_phy_new_generic(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_generic(&phy_config);
 #else
-    esp_eth_phy_t * phy                 = esp_eth_phy_new_ip101(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_ip101(&phy_config);
 #endif
 #endif
 

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -56,13 +56,26 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
 
 #ifdef CONFIG_ETH_USE_OPENETH
     esp_eth_mac_t * mac = esp_eth_mac_new_openeth(&mac_config);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_eth_phy_t * phy = esp_eth_phy_new_generic(&phy_config);
+#else
     esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
+#endif
 #else // Default ethernet board configuration
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp32_emac_config.smi_gpio.mdc_num        = CONFIG_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num       = CONFIG_ETH_MDIO_GPIO;
+#else
     esp32_emac_config.smi_mdc_gpio_num        = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_mdio_gpio_num       = CONFIG_ETH_MDIO_GPIO;
+#endif
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_eth_phy_t * phy                       = esp_eth_phy_new_generic(&phy_config);
+#else
     esp_eth_phy_t * phy                       = esp_eth_phy_new_ip101(&phy_config);
+#endif
 #endif
 
     esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -64,17 +64,17 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
 #else // Default ethernet board configuration
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-    esp32_emac_config.smi_gpio.mdc_num  = CONFIG_ETH_MDC_GPIO;
-    esp32_emac_config.smi_gpio.mdio_num = CONFIG_ETH_MDIO_GPIO;
+    esp32_emac_config.smi_gpio.mdc_num        = CONFIG_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num       = CONFIG_ETH_MDIO_GPIO;
 #else
     esp32_emac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
 #endif
-    esp_eth_mac_t * mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+    esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-    esp_eth_phy_t * phy = esp_eth_phy_new_generic(&phy_config);
+    esp_eth_phy_t * phy                       = esp_eth_phy_new_generic(&phy_config);
 #else
-    esp_eth_phy_t * phy = esp_eth_phy_new_ip101(&phy_config);
+    esp_eth_phy_t * phy                 = esp_eth_phy_new_ip101(&phy_config);
 #endif
 #endif
 

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -25,9 +25,9 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <crypto/CHIPCryptoPAL.h>
 #include "DiagnosticDataProviderImpl.h"
 #include "ESP32/ESP32Utils.h"
+#include <crypto/CHIPCryptoPAL.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp>
 

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -26,7 +26,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include "DiagnosticDataProviderImpl.h"
-#include "ESP32/ESP32Utils.h"
+#include "ESP32Utils.h"
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp>

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -26,8 +26,8 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <crypto/CHIPCryptoPAL.h>
-#include <platform/ESP32/DiagnosticDataProviderImpl.h>
-#include <platform/ESP32/ESP32Utils.h>
+#include "DiagnosticDataProviderImpl.h"
+#include "ESP32/ESP32Utils.h"
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp>
 

--- a/src/platform/ESP32/PlatformManagerImpl_LwIP.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl_LwIP.cpp
@@ -18,8 +18,8 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <platform/ESP32/ESP32Utils.h>
-#include <platform/ESP32/PlatformManagerImpl.h>
+#include "ESP32Utils.h"
+#include "PlatformManagerImpl.h"
 
 #include "esp_event.h"
 #include "esp_netif.h"


### PR DESCRIPTION
#### Summary
ESP-IDF v6.0 introduced several breaking changes that breaks a few build variants:

1. build fails if we use the USB-JTAG configuration with ESP-IDF v6.0, reason is, VFS USB Serial JTAG APIs renamed (esp_vfs_usb_serial_jtag.h removed)

<details> <summary> click to view failure </summary>

```
obj/third_party/connectedhomeip/src/lib/shell/libCHIPShell.streamer_esp32.cpp.o
../../../../../../../../opt/espressif/connectedhomeip/config/esp32/third_party/connectedhomeip/src/lib/shell/streamer_esp32.cpp:40:10: fatal error: esp_vfs_usb_serial_jtag.h: No such file or directory
   40 | #include "esp_vfs_usb_serial_jtag.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

</details>

2. When built with ethernet telemetry build fails, reason being ethernet PHY drivers moved to external esp-eth-drivers repository and ethernet EMAC SMI GPIO config struct changes.

<details> <summary> click to view failure </summary>

```
../../../../../../../../opt/espressif/connectedhomeip/config/esp32/third_party/connectedhomeip/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp:59:27: error: 'esp_eth_phy_new_dp83848' was not declared in this scope; did you mean 'esp_eth_phy_new_generic'?
   59 |     esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~
      |                           esp_eth_phy_new_generic
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
```

</details>

3. Guard add_prebuilt_library(matterlib ...) with if(NOT TARGET matterlib) to prevent duplicate target error when external projects also create a matterlib target

#### Testing
- Verified fix by building lighting-app for ESP32-C3 with `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y`
- Verified fix by building with `CONFIG_ENABLE_ETHERNET_TELEMETRY=y` and disabling wifi station and wifi telemetry