### PR TITLE
Fix event handler leaks in various clusters and platform support

### DIFF
--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -484,7 +484,7 @@ void MatterJointFabricAdministratorPluginServerInitCallback()
 
 void MatterJointFabricAdministratorPluginServerShutdownCallback()
 {
-    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler);
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(&gJointFabricAdministratorGlobalInstance));
     AttributeAccessInterfaceRegistry::Instance().Unregister(&gJointFabricAdministratorGlobalInstance);
     ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gJointFabricAdministratorGlobalInstance));
 }

--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -484,7 +484,8 @@ void MatterJointFabricAdministratorPluginServerInitCallback()
 
 void MatterJointFabricAdministratorPluginServerShutdownCallback()
 {
-    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(&gJointFabricAdministratorGlobalInstance));
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler,
+                                                  reinterpret_cast<intptr_t>(&gJointFabricAdministratorGlobalInstance));
     AttributeAccessInterfaceRegistry::Instance().Unregister(&gJointFabricAdministratorGlobalInstance);
     ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gJointFabricAdministratorGlobalInstance));
 }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -205,6 +205,7 @@ CHIP_ERROR NetworkCommissioningCluster::Init()
 
 void NetworkCommissioningCluster::Deinit()
 {
+    mClusterContext.platformManager.RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     if (sInstances.Contains(this))
     {

--- a/src/app/clusters/network-commissioning/tests/FakeDrivers.h
+++ b/src/app/clusters/network-commissioning/tests/FakeDrivers.h
@@ -174,6 +174,7 @@ public:
 private:
     NetworkCommissioningStatusEnum mAddOrUpdateStatus = NetworkCommissioningStatusEnum::kUnknownError;
     bool mEnabledAllowed                              = false;
+
 public:
     bool mRevertConfigurationCalled = false;
 };

--- a/src/app/clusters/network-commissioning/tests/FakeDrivers.h
+++ b/src/app/clusters/network-commissioning/tests/FakeDrivers.h
@@ -131,7 +131,11 @@ public:
 
     // Internal::WirelessDriver
     CHIP_ERROR CommitConfiguration() override { return CHIP_NO_ERROR; }
-    CHIP_ERROR RevertConfiguration() override { return CHIP_NO_ERROR; }
+    CHIP_ERROR RevertConfiguration() override
+    {
+        mRevertConfigurationCalled = true;
+        return CHIP_NO_ERROR;
+    }
 
     uint8_t GetScanNetworkTimeoutSeconds() override { return 2; }
     uint8_t GetConnectNetworkTimeoutSeconds() override { return 2; }
@@ -170,6 +174,8 @@ public:
 private:
     NetworkCommissioningStatusEnum mAddOrUpdateStatus = NetworkCommissioningStatusEnum::kUnknownError;
     bool mEnabledAllowed                              = false;
+public:
+    bool mRevertConfigurationCalled = false;
 };
 
 } // namespace Testing

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -127,4 +127,61 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
+{
+    Testing::FakeWiFiDriver fakeWifiDriver;
+    
+    // Positive test: handler is active and reacts to event
+    {
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
+        ClusterTester tester(cluster);
+        ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
+        ASSERT_EQ(cluster.Init(), CHIP_NO_ERROR);
+
+        fakeWifiDriver.mRevertConfigurationCalled = false;
+
+        // Post the event
+        DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kFailSafeTimerExpired };
+        
+        ASSERT_EQ(DeviceLayer::PlatformMgr().PostEvent(&event), CHIP_NO_ERROR);
+
+        // Run event loop to process the event
+        ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
+            [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, (intptr_t) nullptr), CHIP_NO_ERROR);
+        DeviceLayer::PlatformMgr().RunEventLoop();
+
+        EXPECT_TRUE(fakeWifiDriver.mRevertConfigurationCalled);
+        
+        cluster.Deinit();
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Negative test: handler is removed and does not react to event.
+    // We prove that Deinit removed the handler by verifying that posting the event
+    // does NOT trigger RevertConfiguration, whereas it did in the positive test above.
+    {
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
+        ClusterTester tester(cluster);
+        ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
+        ASSERT_EQ(cluster.Init(), CHIP_NO_ERROR);
+
+        cluster.Deinit();
+
+        fakeWifiDriver.mRevertConfigurationCalled = false;
+
+        // Post the event
+        DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kFailSafeTimerExpired };
+        ASSERT_EQ(DeviceLayer::PlatformMgr().PostEvent(&event), CHIP_NO_ERROR);
+
+        // Run event loop to process the event
+        ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
+            [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, (intptr_t) nullptr), CHIP_NO_ERROR);
+        DeviceLayer::PlatformMgr().RunEventLoop();
+
+        EXPECT_FALSE(fakeWifiDriver.mRevertConfigurationCalled);
+        
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+}
+
 } // namespace

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -146,10 +146,14 @@ TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
         ASSERT_EQ(DeviceLayer::PlatformMgr().PostEvent(&event), CHIP_NO_ERROR);
 
         // Run event loop to process the event
-        ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); },
-                      (intptr_t) nullptr),
-                  CHIP_NO_ERROR);
+        // Run event loop to process the event
+        CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(
+            [](intptr_t) -> void {
+                CHIP_ERROR stopErr = DeviceLayer::PlatformMgr().StopEventLoopTask();
+                EXPECT_EQ(stopErr, CHIP_NO_ERROR);
+            },
+            (intptr_t) nullptr);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
         DeviceLayer::PlatformMgr().RunEventLoop();
 
         EXPECT_TRUE(fakeWifiDriver.mRevertConfigurationCalled);
@@ -176,10 +180,14 @@ TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
         ASSERT_EQ(DeviceLayer::PlatformMgr().PostEvent(&event), CHIP_NO_ERROR);
 
         // Run event loop to process the event
-        ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); },
-                      (intptr_t) nullptr),
-                  CHIP_NO_ERROR);
+        // Run event loop to process the event
+        CHIP_ERROR err = DeviceLayer::PlatformMgr().ScheduleWork(
+            [](intptr_t) -> void {
+                CHIP_ERROR stopErr = DeviceLayer::PlatformMgr().StopEventLoopTask();
+                EXPECT_EQ(stopErr, CHIP_NO_ERROR);
+            },
+            (intptr_t) nullptr);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
         DeviceLayer::PlatformMgr().RunEventLoop();
 
         EXPECT_FALSE(fakeWifiDriver.mRevertConfigurationCalled);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -130,7 +130,7 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
-    
+
     // Positive test: handler is active and reacts to event
     {
         NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
@@ -142,16 +142,18 @@ TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
 
         // Post the event
         DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kFailSafeTimerExpired };
-        
+
         ASSERT_EQ(DeviceLayer::PlatformMgr().PostEvent(&event), CHIP_NO_ERROR);
 
         // Run event loop to process the event
         ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
-            [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, (intptr_t) nullptr), CHIP_NO_ERROR);
+                      [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); },
+                      (intptr_t) nullptr),
+                  CHIP_NO_ERROR);
         DeviceLayer::PlatformMgr().RunEventLoop();
 
         EXPECT_TRUE(fakeWifiDriver.mRevertConfigurationCalled);
-        
+
         cluster.Deinit();
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
@@ -175,11 +177,13 @@ TEST_F(TestNetworkCommissioningCluster, TestDeinitRemovesEventHandler)
 
         // Run event loop to process the event
         ASSERT_EQ(DeviceLayer::PlatformMgr().ScheduleWork(
-            [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, (intptr_t) nullptr), CHIP_NO_ERROR);
+                      [](intptr_t) -> void { EXPECT_EQ(DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); },
+                      (intptr_t) nullptr),
+                  CHIP_NO_ERROR);
         DeviceLayer::PlatformMgr().RunEventLoop();
 
         EXPECT_FALSE(fakeWifiDriver.mRevertConfigurationCalled);
-        
+
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
 }

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -1105,7 +1105,7 @@ CHIP_ERROR OperationalCredentialsCluster::Startup(ServerClusterContext & context
 
 void OperationalCredentialsCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    mOpCredsContext.platformManager.RemoveEventHandler(OnPlatformEventHandler);
+    mOpCredsContext.platformManager.RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     mOpCredsContext.fabricTable.RemoveFabricDelegate(this);
     DefaultServerCluster::Shutdown(shutdownType);
 }

--- a/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.cpp
+++ b/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.cpp
@@ -373,7 +373,7 @@ CHIP_ERROR ServerInstance::Init()
     VerifyOrReturnError(mDelegate, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(this));
     VerifyOrReturnError(chip::app::AttributeAccessInterfaceRegistry::Instance().Register(this), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
+    ReturnErrorOnFailure(DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
     return mDelegate->Init(this);
 }
 

--- a/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
+++ b/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
@@ -44,7 +44,10 @@ public:
         AttributeAccessInterface(Optional<EndpointId>(endpointId), Id), mDelegate(delegate), mServerEndpointId(endpointId),
         mFailsafeContext(failSafeContext)
     {}
-    virtual ~ServerInstance() = default;
+    virtual ~ServerInstance()
+    {
+        DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
+    }
 
     CHIP_ERROR Init();
 

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -365,7 +365,7 @@ CHIP_ERROR TimeSynchronizationCluster::Startup(ServerClusterContext & context)
 
 void TimeSynchronizationCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    mTimeSyncContext.platformManager.RemoveEventHandler(OnPlatformEventWrapper, 0);
+    mTimeSyncContext.platformManager.RemoveEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
     mTimeSyncContext.fabricTable.RemoveFabricDelegate(this);
     DefaultServerCluster::Shutdown(shutdownType);
 }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -881,7 +881,7 @@ void Server::ScheduleFactoryReset()
 void Server::Shutdown()
 {
     assertChipStackLockedByCurrentThread();
-    PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, 0);
+    PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
     mCASEServer.Shutdown();
     mCASESessionManager.Shutdown();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -94,6 +94,7 @@ void GenericThreadDriver::OnThreadStateChangeHandler(const ChipDeviceEvent * eve
 
 void GenericThreadDriver::Shutdown()
 {
+    PlatformMgr().RemoveEventHandler(OnThreadStateChangeHandler, reinterpret_cast<intptr_t>(this));
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
 }
 

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
@@ -40,7 +40,7 @@ public:
     GenericOpenThreadBorderRouterDelegate(PersistentStorageDelegate * storage) : mStorage(storage) {}
     ~GenericOpenThreadBorderRouterDelegate()
     {
-        DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
+        DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     }
 
     CHIP_ERROR Init(AttributeChangeCallback * callback) override;

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
@@ -38,7 +38,9 @@ class GenericOpenThreadBorderRouterDelegate : public Delegate
 public:
     static constexpr char kFailsafeActiveDatasetConfigured[] = "g/fs/tbradc";
     GenericOpenThreadBorderRouterDelegate(PersistentStorageDelegate * storage) : mStorage(storage) {}
-    ~GenericOpenThreadBorderRouterDelegate() = default;
+    ~GenericOpenThreadBorderRouterDelegate() {
+        DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
+    }
 
     CHIP_ERROR Init(AttributeChangeCallback * callback) override;
 

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
@@ -38,7 +38,8 @@ class GenericOpenThreadBorderRouterDelegate : public Delegate
 public:
     static constexpr char kFailsafeActiveDatasetConfigured[] = "g/fs/tbradc";
     GenericOpenThreadBorderRouterDelegate(PersistentStorageDelegate * storage) : mStorage(storage) {}
-    ~GenericOpenThreadBorderRouterDelegate() {
+    ~GenericOpenThreadBorderRouterDelegate()
+    {
         DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     }
 

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
@@ -40,8 +40,9 @@ public:
     GenericOpenThreadBorderRouterDelegate(PersistentStorageDelegate * storage) : mStorage(storage) {}
     ~GenericOpenThreadBorderRouterDelegate()
     {
-        // "Remove when not registered (i.e. without init)" is expected to be handled ok by RemoveEventHandler
-        // (since tracking some state of is initialized or not feels more annoying and uses more RAM).
+        // Note: It is safe to call RemoveEventHandler here even if Init() was not called or failed.
+        // RemoveEventHandler handles unregistered handlers gracefully, allowing us to avoid adding
+        // a state flag to track initialization.
         DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     }
 

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.h
@@ -40,6 +40,8 @@ public:
     GenericOpenThreadBorderRouterDelegate(PersistentStorageDelegate * storage) : mStorage(storage) {}
     ~GenericOpenThreadBorderRouterDelegate()
     {
+        // "Remove when not registered (i.e. without init)" is expected to be handled ok by RemoveEventHandler
+        // (since tracking some state of is initialized or not feels more annoying and uses more RAM).
         DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     }
 


### PR DESCRIPTION
This PR fixes event handler leaks in TimeSynchronizationCluster, OperationalCredentialsCluster, Server.cpp, and NetworkCommissioningCluster, as well as OpenThread platform support. These leaks caused crashes in CI during `TestServer` after fail-safe expiry.

### Testing
- Verified by running tests in CI where these leaks were causing crashes.
- Verified that the fixes resolve the dangling pointer issues when event handlers are not removed properly.