### PR TITLE
[CI] Speed up Darwin by enabling ccache in darwin-tests

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -22,6 +22,11 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install ccache (Darwin)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew install ccache
     - name: Configure ccache
       uses: pyTooling/Actions/with-post-step@cc576ce25a588e4fd623f3a4ea528f397141e931 # v0.4.5
       with:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -54,6 +54,8 @@ jobs:
       # it.
       BUILD_VARIANT_FRAMEWORK_TOOL: no-ble
       LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
+      DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}
+      CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
     if: github.actor != 'restyled-io[bot]'
     # Namespace MacOS 26 profile is configured as "26.3 with Xcode 26.2" currently
@@ -95,6 +97,13 @@ jobs:
       - name: Clean Build
         run: xcodebuild clean
         working-directory: src/darwin/Framework
+      - name: Setup and Restore Cache
+        id: ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          build-variant: ${{ matrix.build_variant }}
+          disable: ${{ env.DISABLE_CCACHE }}
+          cache-suffix: ${{ env.CCACHE_KEY_SUFFIX }}
       - name: Build Apps Using Unified Build
         run: |
           ./scripts/run_in_build_env.sh \
@@ -104,6 +113,7 @@ jobs:
                 --target darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}-unified \
                 --target darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}-unified \
                 --target darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}-unified \
+                --pw-command-launcher=ccache \
                 build \
                 --copy-artifacts-to objdir-clone \
              "
@@ -123,9 +133,12 @@ jobs:
                 --target darwin-${{matrix.arch}}-evse-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-water-heater-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-all-devices-${BUILD_VARIANT} \
+                --pw-command-launcher=ccache \
                 build \
                 --copy-artifacts-to objdir-clone \
              "
+      - name: ccache stats
+        run: ccache -s
       - name: Run Tests
         run: |
           ./scripts/run_in_build_env.sh \
@@ -192,3 +205,18 @@ jobs:
           path: objdir-clone/
           # objdirs are big; don't hold on to them too long.
           retention-days: 5
+      - name: Ensure only useful ccache is kept
+        if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
+        run: ccache --evict-older-than 1d || true
+      - name: Delete existing ccache before save
+        if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
+        uses: ./.github/actions/delete-cache
+        with:
+            cache-key: ${{ env.CCACHE_KEY }}
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save ccache
+        if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
+        uses: actions/cache/save@v5
+        with:
+            path: .ccache
+            key: ${{ env.CCACHE_KEY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -640,11 +640,6 @@ jobs:
               run: |
                 brew install coreutils
                 echo "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
-            - name: Install ccache
-              run: |
-                brew install ccache
-            - name: Verify ccache installation
-              run: which ccache
             - name: Try to ensure the directories for core dumping and diagnostic
                   log collection exist and we can write them.
               run: |


### PR DESCRIPTION
#### Summary

* adds a brew install step for setup-ccache action when running on darwin

* cribbed from https://github.com/project-chip/connectedhomeip/pull/42268 by @soares-sergio 

#### Testing

Relying on CI to verify.
