### PR TITLE
 [CameraAVStreamManagement] Reset referenceCount to 0 on boot

### DIFF
--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -1816,6 +1816,8 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     {
         typename Traits::StreamStructType stream;
         ReturnErrorOnFailure(DataModel::Decode(reader, stream));
+        // Zero out the referenceCount and allow it to be updated based on how
+        // the stream gets used by the transports.
         stream.referenceCount = 0;
         streams.push_back(stream);
     }
@@ -1827,12 +1829,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     ChipLogProgress(Zcl, "Loaded %u %s streams", static_cast<unsigned int>(streams.size()),
                     StreamTypeToString(Traits::kStreamType));
 
-    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
-
-    // Persist the zeroed reference counts back to KVS without sending notifications
-    ReturnErrorOnFailure(StoreAllocatedStreams<attributeId>());
-
-    return CHIP_NO_ERROR;
+    return reader.VerifyEndOfContainer();
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -1827,10 +1827,12 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     ChipLogProgress(Zcl, "Loaded %u %s streams", static_cast<unsigned int>(streams.size()),
                     StreamTypeToString(Traits::kStreamType));
 
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+
     // Persist the zeroed reference counts back to KVS without sending notifications
     ReturnErrorOnFailure(StoreAllocatedStreams<attributeId>());
 
-    return reader.VerifyEndOfContainer();
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -1816,6 +1816,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     {
         typename Traits::StreamStructType stream;
         ReturnErrorOnFailure(DataModel::Decode(reader, stream));
+        stream.referenceCount = 0;
         streams.push_back(stream);
     }
 
@@ -1825,6 +1826,9 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
 
     ChipLogProgress(Zcl, "Loaded %u %s streams", static_cast<unsigned int>(streams.size()),
                     StreamTypeToString(Traits::kStreamType));
+
+    // Persist the zeroed reference counts back to KVS without sending notifications
+    ReturnErrorOnFailure(StoreAllocatedStreams<attributeId>());
 
     return reader.VerifyEndOfContainer();
 }

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -1731,7 +1731,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestUpdateSnapshotStreamRefCount)
 TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
 {
     // 1. Prepare data with non-zero referenceCount
-    VideoStreamStruct stream;
+    VideoStreamStruct stream{};
     stream.videoStreamID  = 1;
     stream.referenceCount = 5; // Non-zero
 
@@ -1760,21 +1760,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
     auto it = allocatedVideoStreams.begin();
     ASSERT_TRUE(it.Next());
     EXPECT_EQ(it.GetValue().referenceCount, 0);
-
-    // 5. Verify that KVS was also updated to 0
-    uint8_t readBuffer[kMaxAllocatedVideoStreamsSerializedSize];
-    MutableByteSpan readSpan(readBuffer);
-    ASSERT_EQ(mPersistenceProvider.SafeReadValue(path, readSpan), CHIP_NO_ERROR);
-
-    TLV::TLVReader reader;
-    reader.Init(readSpan);
-    ASSERT_EQ(reader.Next(TLV::kTLVType_Array, TLV::AnonymousTag()), CHIP_NO_ERROR);
-    ASSERT_EQ(reader.EnterContainer(arrayType), CHIP_NO_ERROR);
-    ASSERT_EQ(reader.Next(), CHIP_NO_ERROR);
-
-    VideoStreamStruct loadedStream;
-    ASSERT_EQ(DataModel::Decode(reader, loadedStream), CHIP_NO_ERROR);
-    EXPECT_EQ(loadedStream.referenceCount, 0);
 }
 
 } // namespace

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -1728,4 +1728,53 @@ TEST_F(TestCameraAVStreamManagementCluster, TestUpdateSnapshotStreamRefCount)
     EXPECT_EQ(mServer.UpdateSnapshotStreamRefCount(999, true), CHIP_ERROR_NOT_FOUND);
 }
 
+TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
+{
+    // 1. Prepare data with non-zero referenceCount
+    VideoStreamStruct stream;
+    stream.videoStreamID = 1;
+    stream.referenceCount = 5; // Non-zero
+
+    uint8_t buffer[kMaxAllocatedVideoStreamsSerializedSize];
+    TLV::TLVWriter writer;
+    writer.Init(buffer);
+
+    TLV::TLVType arrayType;
+    ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType), CHIP_NO_ERROR);
+    ASSERT_EQ(DataModel::Encode(writer, TLV::AnonymousTag(), stream), CHIP_NO_ERROR);
+    ASSERT_EQ(writer.EndContainer(arrayType), CHIP_NO_ERROR);
+
+    size_t len = writer.GetLengthWritten();
+
+    // 2. Write to persistence
+    ConcreteAttributePath path(kTestEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
+    ASSERT_EQ(mPersistenceProvider.SafeWriteValue(path, ByteSpan(buffer, len)), CHIP_NO_ERROR);
+
+    // 3. Trigger Init to load from persistence
+    ASSERT_EQ(mServer.Init(), CHIP_NO_ERROR);
+
+    // 4. Verify in-memory state has reset refCount
+    Attributes::AllocatedVideoStreams::TypeInfo::DecodableType allocatedVideoStreams;
+    ASSERT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
+
+    auto it = allocatedVideoStreams.begin();
+    ASSERT_TRUE(it.Next());
+    EXPECT_EQ(it.GetValue().referenceCount, 0);
+
+    // 5. Verify that KVS was also updated to 0
+    uint8_t readBuffer[kMaxAllocatedVideoStreamsSerializedSize];
+    MutableByteSpan readSpan(readBuffer);
+    ASSERT_EQ(mPersistenceProvider.SafeReadValue(path, readSpan), CHIP_NO_ERROR);
+
+    TLV::TLVReader reader;
+    reader.Init(readSpan);
+    ASSERT_EQ(reader.Next(TLV::kTLVType_Array, TLV::AnonymousTag()), CHIP_NO_ERROR);
+    ASSERT_EQ(reader.EnterContainer(arrayType), CHIP_NO_ERROR);
+    ASSERT_EQ(reader.Next(), CHIP_NO_ERROR);
+
+    VideoStreamStruct loadedStream;
+    ASSERT_EQ(DataModel::Decode(reader, loadedStream), CHIP_NO_ERROR);
+    EXPECT_EQ(loadedStream.referenceCount, 0);
+}
+
 } // namespace

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -1732,7 +1732,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
 {
     // 1. Prepare data with non-zero referenceCount
     VideoStreamStruct stream;
-    stream.videoStreamID = 1;
+    stream.videoStreamID  = 1;
     stream.referenceCount = 5; // Non-zero
 
     uint8_t buffer[kMaxAllocatedVideoStreamsSerializedSize];


### PR DESCRIPTION
#### Summary

 Reset the `referenceCount` field to 0 for all allocated streams (video, audio,
 snapshot) when loading them from persistent storage during boot up.

 This prevents stale reference counts from transient sessions (e.g., WebRTC) that are
 lost across reboots. Persistent sessions (e.g., PushAV) will re-populate the count
 when they reconnect and re-acquire the streams.

#### Related issues
Fixes #71993 

#### Testing
Execute Camera AVSM test cases

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
