### PR TITLE
[MSAN fix ]Calling RemoveEventHandler from a shutdown method

### DIFF
--- a/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
+++ b/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
@@ -44,12 +44,13 @@ public:
         AttributeAccessInterface(Optional<EndpointId>(endpointId), Id), mDelegate(delegate), mServerEndpointId(endpointId),
         mFailsafeContext(failSafeContext)
     {}
-    virtual ~ServerInstance()
+    virtual ~ServerInstance() = default;
+
+    CHIP_ERROR Init();
+    void Shutdown()
     {
         DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     }
-
-    CHIP_ERROR Init();
 
     // CommandHanlerInterface
     void InvokeCommand(HandlerContext & ctx) override;

--- a/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
+++ b/src/app/clusters/thread-border-router-management-server/ThreadBorderRouterManagementCluster.h
@@ -47,10 +47,7 @@ public:
     virtual ~ServerInstance() = default;
 
     CHIP_ERROR Init();
-    void Shutdown()
-    {
-        DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
-    }
+    void Shutdown() { DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)); }
 
     // CommandHanlerInterface
     void InvokeCommand(HandlerContext & ctx) override;


### PR DESCRIPTION
#### Summary
- MSAN TestThreadBorderRouterManagementCluster failed in nightly build.
- Reason: ServerInstance was static in unit test, and PlatformManagerImpl's destructor ran before the ServerInstance destructor
- Fix: TBRM ServerInstance now calls RemoveEventHandler from a Shutdown() method instead of its destructor. Owners (and callers of Init()) must call Shutdown() before PlatformMgr().Shutdown().



#### Testing
ran MSAN TestThreadBorderRouterManagementCluster locally
