### PR TITLE
[OTAProvider Example] hardening of Example

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -25,6 +25,7 @@
 #include <credentials/FabricTable.h>
 #include <crypto/RandUtils.h>
 #include <lib/core/TLV.h>
+#include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMemString.h>
 #include <protocols/bdx/BdxUri.h>
 
@@ -69,12 +70,12 @@ constexpr uint32_t kBdxServerPollIntervalMillis    = 50;                        
 
 void GetUpdateTokenString(const chip::ByteSpan & token, char * buf, size_t bufSize)
 {
-    const uint8_t * tokenData = static_cast<const uint8_t *>(token.data());
-    size_t minLength          = std::min(token.size(), bufSize);
-    for (size_t i = 0; i < (minLength / 2) - 1; ++i)
+    if (buf == nullptr || bufSize == 0)
     {
-        snprintf(&buf[i * 2], bufSize, "%02X", tokenData[i]);
+        return;
     }
+    CHIP_ERROR err = chip::Encoding::BytesToUppercaseHexString(token.data(), token.size(), buf, bufSize);
+    ReturnOnFailure(err, buf[0] = '\0');
 }
 
 void GenerateUpdateToken(uint8_t * buf, size_t bufSize)

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -376,6 +376,7 @@ void OTAProviderExample::SaveCommandSnapshot(const QueryImage::DecodableType & c
     mRequestorSoftwareVersion = commandData.softwareVersion;
     mRequestorCanConsent      = commandData.requestorCanConsent.ValueOr(false);
 
+    memset(mLocation, 0, sizeof(mLocation));
     if (commandData.location.HasValue())
     {
         chip::CharSpan loc = commandData.location.Value();
@@ -387,12 +388,7 @@ void OTAProviderExample::SaveCommandSnapshot(const QueryImage::DecodableType & c
         else
         {
             ChipLogError(AppServer, "Location field size=%zu, expected 2; clearing", loc.size());
-            memset(mLocation, 0, sizeof(mLocation));
         }
-    }
-    else
-    {
-        memset(mLocation, 0, sizeof(mLocation));
     }
 
     size_t i  = 0;

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -277,7 +277,14 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
         // provider supplying the response is not the provider supplying the OTA image.
         FabricIndex fabricIndex       = commandObj->GetAccessingFabricIndex();
         const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
-        NodeId nodeId                 = fabricInfo->GetPeerId().GetNodeId();
+        if (fabricInfo == nullptr)
+        {
+            ChipLogError(SoftwareUpdate, "No fabric for index %u, cannot send QueryImageResponse",
+                         static_cast<unsigned>(fabricIndex));
+            commandObj->AddStatus(commandPath, Status::Failure);
+            return;
+        }
+        NodeId nodeId = fabricInfo->GetPeerId().GetNodeId();
 
         // Generate the ImageURI if one is not already preset
         if (strlen(mImageUri) == 0)

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -368,14 +368,24 @@ void OTAProviderExample::SaveCommandSnapshot(const QueryImage::DecodableType & c
     mRequestorSoftwareVersion = commandData.softwareVersion;
     mRequestorCanConsent      = commandData.requestorCanConsent.ValueOr(false);
 
-    chip::CharSpan loc = commandData.location.Value();
-    if (loc.size() >= sizeof(mLocation))
+    if (commandData.location.HasValue())
     {
-        ChipLogError(AppServer, "Location too long (%u)", static_cast<unsigned>(loc.size()));
-        return;
+        chip::CharSpan loc = commandData.location.Value();
+        // Location attribute SHALL be an ISO 3166-1 alpha-2 code
+        if (loc.size() == 2)
+        {
+            Platform::CopyString(mLocation, sizeof(mLocation), loc);
+        }
+        else
+        {
+            ChipLogError(AppServer, "Location field size=%zu, expected 2; clearing", loc.size());
+            memset(mLocation, 0, sizeof(mLocation));
+        }
     }
-
-    Platform::CopyString(mLocation, sizeof(mLocation), commandData.location.Value());
+    else
+    {
+        memset(mLocation, 0, sizeof(mLocation));
+    }
 
     size_t i  = 0;
     auto iter = commandData.protocolsSupported.begin();


### PR DESCRIPTION
#### Summary

Hardening of `OTAProviderExample` 

- **`SaveCommandSnapshot`**: guard `commandData.location.Value()` with `HasValue()`; the `QueryImage.location` field is Optional, so an absent field hit `VerifyOrDie` inside `Optional::Value()`. Also enforce the ISO 3166-1 alpha-2 `size == 2` constraint per spec.

- **`SendQueryImageResponse`**: null-check the `FabricInfo *` returned by `FindFabricWithIndex`; the dereference crashed on `kUndefinedFabricIndex` or a fabric removed concurrently with command processing.

- **`GetUpdateTokenString`**: replace hand-rolled hex loop (integer underflow on 0/1-byte tokens → unbounded loop, OOB reads, wild-pointer `snprintf` writes) with `chip::Encoding::BytesToUppercaseHexString`. Reachable via `ApplyUpdateRequest` / `NotifyUpdateApplied` since `updateToken` length is not enforced by the cluster code.

#### Testing

CI