### PR TITLE
Remove CacheAndSync and Make TrustFirst Security Policy Default

### DIFF
--- a/examples/chip-tool/commands/group/Commands.h
+++ b/examples/chip-tool/commands/group/Commands.h
@@ -282,8 +282,7 @@ public:
         chip::MutableByteSpan compressed_fabric_id_span(compressed_fabric_id);
         ReturnLogErrorOnFailure(CurrentCommissioner().GetCompressedFabricIdBytes(compressed_fabric_id_span));
 
-        if ((keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kCacheAndSync &&
-             keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst) ||
+        if (keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst ||
             (epochKey.size()) != chip::Credentials::GroupDataProvider::EpochKey::kLengthBytes)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1805,8 +1805,7 @@ JNI_METHOD(jboolean, addKeySet)
         static_cast<chip::Credentials::GroupDataProvider::SecurityPolicy>(jKeyPolicy);
     chip::JniByteArray jniEpochKey(env, epochKey);
     size_t epochKeySize = static_cast<size_t>(jniEpochKey.size());
-    if ((keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kCacheAndSync &&
-         keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst) ||
+    if (keyPolicy != chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst ||
         epochKeySize != chip::Credentials::GroupDataProvider::EpochKey::kLengthBytes)
     {
         return JNI_FALSE;

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -182,7 +182,7 @@ public:
         // Logical id provided by the Administrator that configured the entry
         uint16_t keyset_id = 0;
         // Security policy to use for groups that use this keyset
-        SecurityPolicy policy = SecurityPolicy::kCacheAndSync;
+        SecurityPolicy policy = SecurityPolicy::kTrustFirst;
         // Number of keys present
         uint8_t num_keys_used = 0;
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -650,7 +650,7 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
     bool first                     = true;
 
     uint16_t keyset_id                       = 0;
-    GroupDataProvider::SecurityPolicy policy = GroupDataProvider::SecurityPolicy::kCacheAndSync;
+    GroupDataProvider::SecurityPolicy policy = GroupDataProvider::SecurityPolicy::kTrustFirst;
     uint8_t keys_count                       = 0;
     Crypto::GroupOperationalCredentials operational_keys[KeySet::kEpochKeysMax];
 
@@ -670,7 +670,7 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
 
     void Clear() override
     {
-        policy     = GroupDataProvider::SecurityPolicy::kCacheAndSync;
+        policy     = GroupDataProvider::SecurityPolicy::kTrustFirst;
         keys_count = 0;
         Crypto::ClearSecretData(reinterpret_cast<uint8_t *>(operational_keys), sizeof(operational_keys));
         next = kInvalidKeysetId;
@@ -1654,6 +1654,7 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(in_keyset.num_keys_used >= 1 && in_keyset.num_keys_used <= KeySet::kEpochKeysMax,
                         CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(in_keyset.policy == SecurityPolicy::kTrustFirst, CHIP_ERROR_INVALID_ARGUMENT);
     FabricData fabric(fabric_index);
     KeySetData keyset;
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -754,8 +754,8 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
         if (policy == GroupDataProvider::SecurityPolicy::kCacheAndSync)
         {
             ChipLogDetail(NotSpecified,
-                            "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id,
-                            fabric_index);
+                          "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id,
+                          fabric_index);
             policy = GroupDataProvider::SecurityPolicy::kTrustFirst;
         }
         // keys_count

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -749,6 +749,13 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
         // policy
         ReturnErrorOnFailure(reader.Next(TagPolicy()));
         ReturnErrorOnFailure(reader.Get(policy));
+        // CacheAndSync is unimplemented, and should not have been used as the default security policy.
+        // If a KeySet was saved with this policy, we re-map it here to be TrustFirst.
+        if (policy == GroupDataProvider::SecurityPolicy::kCacheAndSync)
+        {
+            ChipLogProgress(NotSpecified, "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id, fabric_index);
+            policy = GroupDataProvider::SecurityPolicy::kTrustFirst;
+        }
         // keys_count
         ReturnErrorOnFailure(reader.Next(TagNumKeys()));
         ReturnErrorOnFailure(reader.Get(keys_count));
@@ -1658,7 +1665,7 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     if (in_keyset.policy != SecurityPolicy::kTrustFirst)
     {
         ChipLogError(NotSpecified, "Unsupported group key security policy: %d", static_cast<int>(in_keyset.policy));
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
     FabricData fabric(fabric_index);
     KeySetData keyset;

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -753,7 +753,7 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
         // If a KeySet was saved with this policy, we re-map it here to be TrustFirst.
         if (policy == GroupDataProvider::SecurityPolicy::kCacheAndSync)
         {
-            ChipLogProgress(NotSpecified,
+            ChipLogDetail(NotSpecified,
                             "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id,
                             fabric_index);
             policy = GroupDataProvider::SecurityPolicy::kTrustFirst;

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 #include <credentials/GroupDataProviderImpl.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CodeUtils.h>
@@ -1654,7 +1655,11 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(in_keyset.num_keys_used >= 1 && in_keyset.num_keys_used <= KeySet::kEpochKeysMax,
                         CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(in_keyset.policy == SecurityPolicy::kTrustFirst, CHIP_ERROR_INVALID_ARGUMENT);
+    if (in_keyset.policy != SecurityPolicy::kTrustFirst)
+    {
+        ChipLogError(NotSpecified, "Unsupported group key security policy: %d", static_cast<int>(in_keyset.policy));
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
     FabricData fabric(fabric_index);
     KeySetData keyset;
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -753,7 +753,9 @@ struct KeySetData : PersistableData<kPersistentBufferMax>
         // If a KeySet was saved with this policy, we re-map it here to be TrustFirst.
         if (policy == GroupDataProvider::SecurityPolicy::kCacheAndSync)
         {
-            ChipLogProgress(NotSpecified, "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id, fabric_index);
+            ChipLogProgress(NotSpecified,
+                            "Re-mapping security policy from CacheAndSync to TrustFirst for keyset %u (fabric index %u)", keyset_id,
+                            fabric_index);
             policy = GroupDataProvider::SecurityPolicy::kTrustFirst;
         }
         // keys_count

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 #include <credentials/GroupDataProviderImpl.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CodeUtils.h>
@@ -23,6 +22,7 @@
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/PersistentData.h>
 #include <lib/support/Pool.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <stdlib.h>
 
 namespace chip {

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -28,10 +28,10 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <platform/KeyValueStoreManager.h>
-#include <lib/support/DefaultStorageKeyAllocator.h>
 
 using namespace chip::Credentials;
 using GroupInfo      = GroupDataProvider::GroupInfo;
@@ -890,7 +890,7 @@ TEST_F(TestGroupDataProvider, TestKeySetCacheAndSyncRemap)
 
     // 2. Read the saved TLV from storage
     auto keyName = DefaultStorageKeyAllocator::FabricKeyset(kFabric1, kKeysetId1);
-    
+
     uint8_t tlvBuffer[128];
     uint16_t tlvLength = sizeof(tlvBuffer);
     EXPECT_EQ(sDelegate.SyncGetKeyValue(keyName.KeyName(), tlvBuffer, tlvLength), CHIP_NO_ERROR);
@@ -908,7 +908,7 @@ TEST_F(TestGroupDataProvider, TestKeySetCacheAndSyncRemap)
     ASSERT_EQ(tlvBuffer[1], 0x24); // Context Tag 1-byte value
     ASSERT_EQ(tlvBuffer[2], 0x01); // Tag 1 (Policy)
     ASSERT_EQ(tlvBuffer[3], 0x00); // Value (kTrustFirst)
-    
+
     tlvBuffer[3] = 1; // Change to kCacheAndSync (1)
 
     // 4. Write it back to storage
@@ -926,7 +926,7 @@ TEST_F(TestGroupDataProvider, TestKeySetInvalidPolicy)
     EXPECT_TRUE(provider);
     ResetProvider(provider);
 
-    // Verify setting a keyset with an invalid security policy (like the currently unimplemented 
+    // Verify setting a keyset with an invalid security policy (like the currently unimplemented
     // cache and sync policy), throws an error
     KeySet keySetToSet(kKeysetId1, SecurityPolicy::kCacheAndSync, 1);
     keySetToSet.epoch_keys[0].start_time = 1234;

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -31,6 +31,7 @@
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <platform/KeyValueStoreManager.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
 
 using namespace chip::Credentials;
 using GroupInfo      = GroupDataProvider::GroupInfo;
@@ -874,6 +875,67 @@ TEST_F(TestGroupDataProvider, TestKeySets)
     EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId2, keyset));
     EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId1, keyset));
     EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+}
+
+TEST_F(TestGroupDataProvider, TestKeySetCacheAndSyncRemap)
+{
+    GroupDataProvider * provider = GetGroupDataProvider();
+    EXPECT_TRUE(provider);
+
+    // Reset test
+    ResetProvider(provider);
+
+    // 1. Add a valid KeySet (it will have TrustFirst policy)
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1), CHIP_NO_ERROR);
+
+    // 2. Read the saved TLV from storage
+    auto keyName = DefaultStorageKeyAllocator::FabricKeyset(kFabric1, kKeysetId1);
+    
+    uint8_t tlvBuffer[128];
+    uint16_t tlvLength = sizeof(tlvBuffer);
+    EXPECT_EQ(sDelegate.SyncGetKeyValue(keyName.KeyName(), tlvBuffer, tlvLength), CHIP_NO_ERROR);
+
+    // 3. Sanity check and patch the policy to CacheAndSync (1) in-place.
+    // We rely on the TLV encoding of KeySetData:
+    // - Outer structure start: 0x15
+    // - Policy field: Context Tag 1, U8/U16 value.
+    // Since value is 0 (kTrustFirst), it is encoded as 1-byte UInt8 (0x04) with Context Tag (0x20) -> 0x24.
+    // Tag is 1.
+    // Value is 0.
+    // So bytes are: [0x15, 0x24, 0x01, 0x00]
+    ASSERT_GE(tlvLength, 4u);
+    ASSERT_EQ(tlvBuffer[0], 0x15); // Structure
+    ASSERT_EQ(tlvBuffer[1], 0x24); // Context Tag 1-byte value
+    ASSERT_EQ(tlvBuffer[2], 0x01); // Tag 1 (Policy)
+    ASSERT_EQ(tlvBuffer[3], 0x00); // Value (kTrustFirst)
+    
+    tlvBuffer[3] = 1; // Change to kCacheAndSync (1)
+
+    // 4. Write it back to storage
+    EXPECT_EQ(sDelegate.SyncSetKeyValue(keyName.KeyName(), tlvBuffer, tlvLength), CHIP_NO_ERROR);
+
+    // 5. Read it back via provider and verify it is remapped to TrustFirst
+    KeySet keyset;
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_EQ(keyset.policy, SecurityPolicy::kTrustFirst);
+}
+
+TEST_F(TestGroupDataProvider, TestKeySetInvalidPolicy)
+{
+    GroupDataProvider * provider = GetGroupDataProvider();
+    EXPECT_TRUE(provider);
+    ResetProvider(provider);
+
+    // Verify setting a keyset with an invalid security policy (like the currently unimplemented 
+    // cache and sync policy), throws an error
+    KeySet keySetToSet(kKeysetId1, SecurityPolicy::kCacheAndSync, 1);
+    keySetToSet.epoch_keys[0].start_time = 1234;
+    memset(keySetToSet.epoch_keys[0].key, 0, sizeof(keySetToSet.epoch_keys[0].key));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, keySetToSet), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+
+    // Verify setting the same keyset but with a valid policy works without error
+    keySetToSet.policy = SecurityPolicy::kTrustFirst;
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, keySetToSet), CHIP_NO_ERROR);
 }
 
 TEST_F(TestGroupDataProvider, TestIpk)

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -125,10 +125,10 @@ static const GroupKey kGroup3Keyset1(kGroup3, kKeysetId1);
 static const GroupKey kGroup3Keyset2(kGroup3, kKeysetId2);
 static const GroupKey kGroup3Keyset3(kGroup3, kKeysetId3);
 
-static KeySet kKeySet0(kKeysetId0, SecurityPolicy::kCacheAndSync, 3);
+static KeySet kKeySet0(kKeysetId0, SecurityPolicy::kTrustFirst, 3);
 static KeySet kKeySet1(kKeysetId1, SecurityPolicy::kTrustFirst, 1);
 static KeySet kKeySet2(kKeysetId2, SecurityPolicy::kTrustFirst, 2);
-static KeySet kKeySet3(kKeysetId3, SecurityPolicy::kCacheAndSync, 3);
+static KeySet kKeySet3(kKeysetId3, SecurityPolicy::kTrustFirst, 3);
 static KeySet kKeySet4(kKeysetId4, SecurityPolicy::kTrustFirst, 1);
 
 uint8_t kZeroKey[EpochKey::kLengthBytes] = { 0 };

--- a/src/lib/support/TestGroupData.h
+++ b/src/lib/support/TestGroupData.h
@@ -66,7 +66,7 @@ inline CHIP_ERROR InitData(chip::Credentials::GroupDataProvider * provider, chip
     // Key Sets
 
     chip::Credentials::GroupDataProvider::KeySet keyset1(kKeySet1,
-                                                         chip::Credentials::GroupDataProvider::SecurityPolicy::kCacheAndSync, 3);
+                                                         chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst, 3);
     const chip::Credentials::GroupDataProvider::EpochKey epoch_keys1[] = {
         { 1110000, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
         { 1110001, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
@@ -77,7 +77,7 @@ inline CHIP_ERROR InitData(chip::Credentials::GroupDataProvider * provider, chip
     ReturnErrorOnFailure(err);
 
     chip::Credentials::GroupDataProvider::KeySet keyset2(kKeySet2,
-                                                         chip::Credentials::GroupDataProvider::SecurityPolicy::kCacheAndSync, 3);
+                                                         chip::Credentials::GroupDataProvider::SecurityPolicy::kTrustFirst, 3);
     const chip::Credentials::GroupDataProvider::EpochKey epoch_keys2[] = {
         { 2220000, { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf } },
         { 2220001, { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef } },


### PR DESCRIPTION
#### Summary

This PR ensures that the default security policy used for the group data provider and test group data is `kTrustFirst`. Occurances of `kCacheAndSync` are being replaced with `kTrustFirst` because as of right now, cache and sync is not fully implemented. This PR also edits the `SetKeySet()` and `Deserialize()` function to expect `kTrustFirst` policy and deserialize all previously saved key sets as `kTrustFirst`. 

#### Testing

- Replaced `kCacheAndSync` with `kTrustFirst` in test data 
- Added tests for the `Deserialize()` and `SetKeySet()` functions
- CI should still pass