### PR TITLE
Refactor CameraAVStreamManagementCluster constructor to use InitArguments

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -257,7 +257,7 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
         avsmOptionalAttrs.Set(CameraAvStreamManagement::OptionalAttribute::kImageRotation);
     }
 
-    uint32_t maxConcurrentVideoEncoders  = mCameraDevice->GetCameraHALInterface().GetMaxConcurrentEncoders();
+    uint8_t maxConcurrentVideoEncoders   = mCameraDevice->GetCameraHALInterface().GetMaxConcurrentEncoders();
     uint32_t maxEncodedPixelRate         = mCameraDevice->GetCameraHALInterface().GetMaxEncodedPixelRate();
     VideoSensorParamsStruct sensorParams = mCameraDevice->GetCameraHALInterface().GetVideoSensorParams();
     bool nightVisionUsesInfrared         = mCameraDevice->GetCameraHALInterface().GetNightVisionUsesInfrared();
@@ -284,7 +284,7 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
         .endpointId                   = mEndpoint,
         .features                     = avsmFeatures,
         .optionalAttrs                = avsmOptionalAttrs,
-        .maxConcurrentEncoders        = static_cast<uint8_t>(maxConcurrentVideoEncoders),
+        .maxConcurrentEncoders        = maxConcurrentVideoEncoders,
         .maxEncodedPixelRate          = maxEncodedPixelRate,
         .videoSensorParams            = sensorParams,
         .nightVisionUsesInfrared      = nightVisionUsesInfrared,

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -19,7 +19,7 @@
 #include "data-model-providers/codegen/CodegenDataModelProvider.h"
 #include "tls-certificate-management-instance.h"
 #include "tls-client-management-instance.h"
-#include <app/SafeAttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistenceProviderInstance.h>
 #include <app/clusters/push-av-stream-transport-server/CodegenIntegration.h>
 
 using namespace chip;
@@ -279,7 +279,7 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
 
     // Instantiate the CameraAVStreamMgmt Server
     CameraAVStreamManagementCluster::InitArguments args{
-        .context                      = CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
+        .context                      = CameraAVStreamManagementCluster::Context{ *app::GetAttributePersistenceProvider() },
         .delegate                     = mCameraDevice->GetCameraAVStreamMgmtDelegate(),
         .endpointId                   = mEndpoint,
         .features                     = avsmFeatures,

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -278,27 +278,26 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
     std::vector<StreamUsageEnum> streamUsagePriorities = mCameraDevice->GetCameraHALInterface().GetStreamUsagePriorities();
 
     // Instantiate the CameraAVStreamMgmt Server
-    CameraAVStreamManagementCluster::InitArguments args{
-        CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
-        mCameraDevice->GetCameraAVStreamMgmtDelegate(),
-        mEndpoint,
-        avsmFeatures,
-        avsmOptionalAttrs,
-        static_cast<uint8_t>(maxConcurrentVideoEncoders),
-        maxEncodedPixelRate,
-        sensorParams,
-        nightVisionUsesInfrared,
-        minViewport,
-        std::move(rateDistortionTradeOffPoints),
-        maxContentBufferSize,
-        micCapabilities,
-        spkrCapabilities,
-        twowayTalkSupport,
-        std::move(snapshotCapabilities),
-        maxNetworkBandwidth,
-        std::move(supportedStreamUsages),
-        std::move(streamUsagePriorities)
-    };
+    CameraAVStreamManagementCluster::InitArguments args{ CameraAVStreamManagementCluster::Context{
+                                                             *app::GetSafeAttributePersistenceProvider() },
+                                                         mCameraDevice->GetCameraAVStreamMgmtDelegate(),
+                                                         mEndpoint,
+                                                         avsmFeatures,
+                                                         avsmOptionalAttrs,
+                                                         static_cast<uint8_t>(maxConcurrentVideoEncoders),
+                                                         maxEncodedPixelRate,
+                                                         sensorParams,
+                                                         nightVisionUsesInfrared,
+                                                         minViewport,
+                                                         std::move(rateDistortionTradeOffPoints),
+                                                         maxContentBufferSize,
+                                                         micCapabilities,
+                                                         spkrCapabilities,
+                                                         twowayTalkSupport,
+                                                         std::move(snapshotCapabilities),
+                                                         maxNetworkBandwidth,
+                                                         std::move(supportedStreamUsages),
+                                                         std::move(streamUsagePriorities) };
     mAVStreamMgmtServer.Create(std::move(args));
 
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(mAVStreamMgmtServer.Registration());

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -19,7 +19,7 @@
 #include "data-model-providers/codegen/CodegenDataModelProvider.h"
 #include "tls-certificate-management-instance.h"
 #include "tls-client-management-instance.h"
-#include <app/persistence/AttributePersistenceProviderInstance.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/push-av-stream-transport-server/CodegenIntegration.h>
 
 using namespace chip;
@@ -279,7 +279,7 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
 
     // Instantiate the CameraAVStreamMgmt Server
     CameraAVStreamManagementCluster::InitArguments args{
-        .context                      = CameraAVStreamManagementCluster::Context{ *app::GetAttributePersistenceProvider() },
+        .context                      = CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
         .delegate                     = mCameraDevice->GetCameraAVStreamMgmtDelegate(),
         .endpointId                   = mEndpoint,
         .features                     = avsmFeatures,

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -278,12 +278,28 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
     std::vector<StreamUsageEnum> streamUsagePriorities = mCameraDevice->GetCameraHALInterface().GetStreamUsagePriorities();
 
     // Instantiate the CameraAVStreamMgmt Server
-    mAVStreamMgmtServer.Create(CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
-                               mCameraDevice->GetCameraAVStreamMgmtDelegate(), mEndpoint, avsmFeatures, avsmOptionalAttrs,
-                               maxConcurrentVideoEncoders, maxEncodedPixelRate, sensorParams, nightVisionUsesInfrared, minViewport,
-                               rateDistortionTradeOffPoints, maxContentBufferSize, micCapabilities, spkrCapabilities,
-                               twowayTalkSupport, snapshotCapabilities, maxNetworkBandwidth, supportedStreamUsages,
-                               streamUsagePriorities);
+    CameraAVStreamManagementCluster::InitArguments args{
+        CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
+        mCameraDevice->GetCameraAVStreamMgmtDelegate(),
+        mEndpoint,
+        avsmFeatures,
+        avsmOptionalAttrs,
+        static_cast<uint8_t>(maxConcurrentVideoEncoders),
+        maxEncodedPixelRate,
+        sensorParams,
+        nightVisionUsesInfrared,
+        minViewport,
+        std::move(rateDistortionTradeOffPoints),
+        maxContentBufferSize,
+        micCapabilities,
+        spkrCapabilities,
+        twowayTalkSupport,
+        std::move(snapshotCapabilities),
+        maxNetworkBandwidth,
+        std::move(supportedStreamUsages),
+        std::move(streamUsagePriorities)
+    };
+    mAVStreamMgmtServer.Create(std::move(args));
 
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(mAVStreamMgmtServer.Registration());
     if (err != CHIP_NO_ERROR)

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -278,26 +278,27 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
     std::vector<StreamUsageEnum> streamUsagePriorities = mCameraDevice->GetCameraHALInterface().GetStreamUsagePriorities();
 
     // Instantiate the CameraAVStreamMgmt Server
-    CameraAVStreamManagementCluster::InitArguments args{ CameraAVStreamManagementCluster::Context{
-                                                             *app::GetSafeAttributePersistenceProvider() },
-                                                         mCameraDevice->GetCameraAVStreamMgmtDelegate(),
-                                                         mEndpoint,
-                                                         avsmFeatures,
-                                                         avsmOptionalAttrs,
-                                                         static_cast<uint8_t>(maxConcurrentVideoEncoders),
-                                                         maxEncodedPixelRate,
-                                                         sensorParams,
-                                                         nightVisionUsesInfrared,
-                                                         minViewport,
-                                                         std::move(rateDistortionTradeOffPoints),
-                                                         maxContentBufferSize,
-                                                         micCapabilities,
-                                                         spkrCapabilities,
-                                                         twowayTalkSupport,
-                                                         std::move(snapshotCapabilities),
-                                                         maxNetworkBandwidth,
-                                                         std::move(supportedStreamUsages),
-                                                         std::move(streamUsagePriorities) };
+    CameraAVStreamManagementCluster::InitArguments args{
+        .context = CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
+        .delegate = mCameraDevice->GetCameraAVStreamMgmtDelegate(),
+        .endpointId = mEndpoint,
+        .features = avsmFeatures,
+        .optionalAttrs = avsmOptionalAttrs,
+        .maxConcurrentEncoders = static_cast<uint8_t>(maxConcurrentVideoEncoders),
+        .maxEncodedPixelRate = maxEncodedPixelRate,
+        .videoSensorParams = sensorParams,
+        .nightVisionUsesInfrared = nightVisionUsesInfrared,
+        .minViewPort = minViewport,
+        .rateDistortionTradeOffPoints = std::move(rateDistortionTradeOffPoints),
+        .maxContentBufferSize = maxContentBufferSize,
+        .microphoneCapabilities = micCapabilities,
+        .spkrCapabilities = spkrCapabilities,
+        .twoWayTalkSupport = twowayTalkSupport,
+        .snapshotCapabilities = std::move(snapshotCapabilities),
+        .maxNetworkBandwidth = maxNetworkBandwidth,
+        .supportedStreamUsages = std::move(supportedStreamUsages),
+        .streamUsagePriorities = std::move(streamUsagePriorities)
+    };
     mAVStreamMgmtServer.Create(std::move(args));
 
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(mAVStreamMgmtServer.Registration());

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -279,25 +279,25 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
 
     // Instantiate the CameraAVStreamMgmt Server
     CameraAVStreamManagementCluster::InitArguments args{
-        .context = CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
-        .delegate = mCameraDevice->GetCameraAVStreamMgmtDelegate(),
-        .endpointId = mEndpoint,
-        .features = avsmFeatures,
-        .optionalAttrs = avsmOptionalAttrs,
-        .maxConcurrentEncoders = static_cast<uint8_t>(maxConcurrentVideoEncoders),
-        .maxEncodedPixelRate = maxEncodedPixelRate,
-        .videoSensorParams = sensorParams,
-        .nightVisionUsesInfrared = nightVisionUsesInfrared,
-        .minViewPort = minViewport,
+        .context                      = CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
+        .delegate                     = mCameraDevice->GetCameraAVStreamMgmtDelegate(),
+        .endpointId                   = mEndpoint,
+        .features                     = avsmFeatures,
+        .optionalAttrs                = avsmOptionalAttrs,
+        .maxConcurrentEncoders        = static_cast<uint8_t>(maxConcurrentVideoEncoders),
+        .maxEncodedPixelRate          = maxEncodedPixelRate,
+        .videoSensorParams            = sensorParams,
+        .nightVisionUsesInfrared      = nightVisionUsesInfrared,
+        .minViewPort                  = minViewport,
         .rateDistortionTradeOffPoints = std::move(rateDistortionTradeOffPoints),
-        .maxContentBufferSize = maxContentBufferSize,
-        .microphoneCapabilities = micCapabilities,
-        .spkrCapabilities = spkrCapabilities,
-        .twoWayTalkSupport = twowayTalkSupport,
-        .snapshotCapabilities = std::move(snapshotCapabilities),
-        .maxNetworkBandwidth = maxNetworkBandwidth,
-        .supportedStreamUsages = std::move(supportedStreamUsages),
-        .streamUsagePriorities = std::move(streamUsagePriorities)
+        .maxContentBufferSize         = maxContentBufferSize,
+        .microphoneCapabilities       = micCapabilities,
+        .spkrCapabilities             = spkrCapabilities,
+        .twoWayTalkSupport            = twowayTalkSupport,
+        .snapshotCapabilities         = std::move(snapshotCapabilities),
+        .maxNetworkBandwidth          = maxNetworkBandwidth,
+        .supportedStreamUsages        = std::move(supportedStreamUsages),
+        .streamUsagePriorities        = std::move(streamUsagePriorities)
     };
     mAVStreamMgmtServer.Create(std::move(args));
 

--- a/scripts/attribute_persistence_provider_exclusions.txt
+++ b/scripts/attribute_persistence_provider_exclusions.txt
@@ -47,6 +47,7 @@ src/app/clusters/boolean-state-configuration-server/MigrateBooleanStateConfigura
 
 # Cluster server implementations that currently use SafeAttributePersistenceProvider
 src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
 src/app/clusters/mode-base-server/mode-base-server.cpp
 src/app/clusters/resource-monitoring-server/tests/TestResourceMonitoringCluster.cpp
 src/app/clusters/thread-network-directory-server/ThreadNetworkDirectoryCluster.cpp

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -1103,7 +1103,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetNightVision(TriStateAutoEnum aNig
     {
         mNightVision = aNightVision;
         auto path    = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVision::Id);
-        ReturnErrorOnFailure(WriteScalarValue(path, to_underlying(mNightVision)));
+        ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mNightVision)));
         mDelegate.OnAttributeChanged(Attributes::NightVision::Id);
         NotifyAttributeChanged(Attributes::NightVision::Id);
     }
@@ -1116,7 +1116,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetNightVisionIllum(TriStateAutoEnum
     {
         mNightVisionIllum = aNightVisionIllum;
         auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVisionIllum::Id);
-        ReturnErrorOnFailure(WriteScalarValue(path, to_underlying(mNightVisionIllum)));
+        ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mNightVisionIllum)));
         mDelegate.OnAttributeChanged(Attributes::NightVisionIllum::Id);
         NotifyAttributeChanged(Attributes::NightVisionIllum::Id);
     }
@@ -1278,7 +1278,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetStatusLightBrightness(Globals::Th
         mStatusLightBrightness = aStatusLightBrightness;
         auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightBrightness::Id);
         ReturnErrorOnFailure(
-            WriteScalarValue(path, to_underlying(mStatusLightBrightness)));
+            mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mStatusLightBrightness)));
         mDelegate.OnAttributeChanged(Attributes::StatusLightBrightness::Id);
         NotifyAttributeChanged(Attributes::StatusLightBrightness::Id);
     }
@@ -1290,7 +1290,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Load HDR Mode Enabled
     bool storedHDRModeEnabled = false;
-    err                       = ReadScalarValue(
+    err                       = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::HDRModeEnabled::Id),
         storedHDRModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1333,7 +1333,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SoftRecordingPrivacyModeEnabled
     bool softRecordingPrivacyModeEnabled = false;
-    err                                  = ReadScalarValue(
+    err                                  = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SoftRecordingPrivacyModeEnabled::Id),
         softRecordingPrivacyModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1351,7 +1351,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SoftLivestreamPrivacyModeEnabled
     bool softLivestreamPrivacyModeEnabled = false;
-    err                                   = ReadScalarValue(
+    err                                   = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SoftLivestreamPrivacyModeEnabled::Id),
         softLivestreamPrivacyModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1369,7 +1369,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load NightVision
     uint8_t nightVision = 0;
-    err                 = ReadScalarValue(
+    err                 = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVision::Id), nightVision);
     if (err == CHIP_NO_ERROR)
     {
@@ -1384,7 +1384,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load NightVisionIllum
     uint8_t nightVisionIllum = 0;
-    err                      = ReadScalarValue(
+    err                      = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVisionIllum::Id), nightVisionIllum);
     if (err == CHIP_NO_ERROR)
     {
@@ -1413,7 +1413,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SpeakerMuted
     bool speakerMuted = false;
-    err               = ReadScalarValue(
+    err               = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SpeakerMuted::Id), speakerMuted);
     if (err == CHIP_NO_ERROR)
     {
@@ -1428,7 +1428,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SpeakerVolumeLevel
     uint8_t speakerVolumeLevel = 0;
-    err                        = ReadScalarValue(
+    err                        = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SpeakerVolumeLevel::Id),
         speakerVolumeLevel);
     if (err == CHIP_NO_ERROR)
@@ -1444,7 +1444,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneMuted
     bool microphoneMuted = false;
-    err                  = ReadScalarValue(
+    err                  = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneMuted::Id), microphoneMuted);
     if (err == CHIP_NO_ERROR)
     {
@@ -1459,7 +1459,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneVolumeLevel
     uint8_t microphoneVolumeLevel = 0;
-    err                           = ReadScalarValue(
+    err                           = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneVolumeLevel::Id),
         microphoneVolumeLevel);
     if (err == CHIP_NO_ERROR)
@@ -1476,7 +1476,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneAGCEnabled
     bool microphoneAGCEnabled = false;
-    err                       = ReadScalarValue(
+    err                       = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneAGCEnabled::Id),
         microphoneAGCEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1493,7 +1493,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageRotation
     uint16_t imageRotation = 0;
-    err                    = ReadScalarValue(
+    err                    = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageRotation::Id), imageRotation);
     if (err == CHIP_NO_ERROR)
     {
@@ -1508,7 +1508,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageFlipHorizontal
     bool imageFlipHorizontal = false;
-    err                      = ReadScalarValue(
+    err                      = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageFlipHorizontal::Id),
         imageFlipHorizontal);
     if (err == CHIP_NO_ERROR)
@@ -1524,7 +1524,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageFlipVertical
     bool imageFlipVertical = false;
-    err                    = ReadScalarValue(
+    err                    = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageFlipVertical::Id),
         imageFlipVertical);
     if (err == CHIP_NO_ERROR)
@@ -1540,7 +1540,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load LocalVideoRecordingEnabled
     bool localVideoRecordingEnabled = false;
-    err                             = ReadScalarValue(
+    err                             = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::LocalVideoRecordingEnabled::Id),
         localVideoRecordingEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1558,7 +1558,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load LocalSnapshotRecordingEnabled
     bool localSnapshotRecordingEnabled = false;
-    err                                = ReadScalarValue(
+    err                                = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::LocalSnapshotRecordingEnabled::Id),
         localSnapshotRecordingEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1576,7 +1576,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load StatusLightEnabled
     bool statusLightEnabled = false;
-    err                     = ReadScalarValue(
+    err                     = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightEnabled::Id),
         statusLightEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1592,7 +1592,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load StatusLightBrightness
     uint8_t statusLightBrightness = 0;
-    err                           = ReadScalarValue(
+    err                           = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightBrightness::Id),
         statusLightBrightness);
     if (err == CHIP_NO_ERROR)
@@ -1628,7 +1628,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreViewport(const Globals::Structs
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::Viewport::Id);
     bufferSpan.reduce_size(writer.GetLengthWritten());
 
-    return mContext.attributePersistenceProvider.WriteValue(path, bufferSpan);
+    return mContext.safeAttributePersistenceProvider.SafeWriteValue(path, bufferSpan);
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::LoadViewport(Globals::Structs::ViewportStruct::Type & viewport)
@@ -1637,7 +1637,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadViewport(Globals::Structs::Viewp
     MutableByteSpan bufferSpan(buffer);
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::Viewport::Id);
-    ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(path, bufferSpan));
+    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeReadValue(path, bufferSpan));
 
     TLV::TLVReader reader;
 
@@ -1667,7 +1667,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreStreamUsagePriorities()
     bufferSpan.reduce_size(writer.GetLengthWritten());
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StreamUsagePriorities::Id);
-    return mContext.attributePersistenceProvider.WriteValue(path, bufferSpan);
+    return mContext.safeAttributePersistenceProvider.SafeWriteValue(path, bufferSpan);
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::LoadStreamUsagePriorities()
@@ -1676,7 +1676,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadStreamUsagePriorities()
     MutableByteSpan bufferSpan(buffer);
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StreamUsagePriorities::Id);
-    ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(path, bufferSpan));
+    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeReadValue(path, bufferSpan));
 
     TLV::TLVReader reader;
     reader.Init(bufferSpan);
@@ -1768,7 +1768,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreAllocatedStreams()
     size_t len = writer.GetLengthWritten();
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
-    ReturnErrorOnFailure(mContext.attributePersistenceProvider.WriteValue(path, ByteSpan(buffer, len)));
+    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeWriteValue(path, ByteSpan(buffer, len)));
 
     ChipLogProgress(Zcl, "Saved %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(Traits::kStreamType));
     return CHIP_NO_ERROR;
@@ -1785,7 +1785,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     auto path      = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
     auto & streams = (*this).*Traits::kStreamVectorMember;
 
-    CHIP_ERROR err = mContext.attributePersistenceProvider.ReadValue(path, span);
+    CHIP_ERROR err = mContext.safeAttributePersistenceProvider.SafeReadValue(path, span);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         streams.clear();

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -51,26 +51,16 @@ namespace app {
 namespace Clusters {
 namespace CameraAvStreamManagement {
 
-CameraAVStreamManagementCluster::CameraAVStreamManagementCluster(
-    const Context & aContext, CameraAVStreamManagementDelegate & aDelegate, EndpointId aEndpointId,
-    const BitFlags<Feature> aFeatures, const BitFlags<OptionalAttribute> aOptionalAttrs, uint8_t aMaxConcurrentEncoders,
-    uint32_t aMaxEncodedPixelRate, const VideoSensorParamsStruct & aVideoSensorParams, bool aNightVisionUsesInfrared,
-    const VideoResolutionStruct & aMinViewPortRes,
-    const std::vector<Structs::RateDistortionTradeOffPointsStruct::Type> & aRateDistortionTradeOffPoints,
-    uint32_t aMaxContentBufferSize, const AudioCapabilitiesStruct & aMicrophoneCapabilities,
-    const AudioCapabilitiesStruct & aSpeakerCapabilities, TwoWayTalkSupportTypeEnum aTwoWayTalkSupport,
-    const std::vector<Structs::SnapshotCapabilitiesStruct::Type> & aSnapshotCapabilities, uint32_t aMaxNetworkBandwidth,
-    const std::vector<Globals::StreamUsageEnum> & aSupportedStreamUsages,
-    const std::vector<Globals::StreamUsageEnum> & aStreamUsagePriorities) :
-    DefaultServerCluster({ aEndpointId, CameraAvStreamManagement::Id }),
-    mContext(aContext), mDelegate(aDelegate), mEnabledFeatures(aFeatures), mOptionalAttrs(aOptionalAttrs),
-    mMaxConcurrentEncoders(aMaxConcurrentEncoders), mMaxEncodedPixelRate(aMaxEncodedPixelRate),
-    mVideoSensorParams(aVideoSensorParams), mNightVisionUsesInfrared(aNightVisionUsesInfrared),
-    mMinViewPortResolution(aMinViewPortRes), mRateDistortionTradeOffPointsList(aRateDistortionTradeOffPoints),
-    mMaxContentBufferSize(aMaxContentBufferSize), mMicrophoneCapabilities(aMicrophoneCapabilities),
-    mSpeakerCapabilities(aSpeakerCapabilities), mTwoWayTalkSupport(aTwoWayTalkSupport),
-    mSnapshotCapabilitiesList(aSnapshotCapabilities), mMaxNetworkBandwidth(aMaxNetworkBandwidth),
-    mSupportedStreamUsages(aSupportedStreamUsages), mStreamUsagePriorities(aStreamUsagePriorities)
+CameraAVStreamManagementCluster::CameraAVStreamManagementCluster(InitArguments && aArgs) :
+    DefaultServerCluster({ aArgs.endpointId, CameraAvStreamManagement::Id }),
+    mContext(aArgs.context), mDelegate(aArgs.delegate), mEnabledFeatures(aArgs.features), mOptionalAttrs(aArgs.optionalAttrs),
+    mMaxConcurrentEncoders(aArgs.maxConcurrentEncoders), mMaxEncodedPixelRate(aArgs.maxEncodedPixelRate),
+    mVideoSensorParams(std::move(aArgs.videoSensorParams)), mNightVisionUsesInfrared(aArgs.nightVisionUsesInfrared),
+    mMinViewPortResolution(std::move(aArgs.minViewPort)), mRateDistortionTradeOffPointsList(std::move(aArgs.rateDistortionTradeOffPoints)),
+    mMaxContentBufferSize(aArgs.maxContentBufferSize), mMicrophoneCapabilities(std::move(aArgs.microphoneCapabilities)),
+    mSpeakerCapabilities(std::move(aArgs.spkrCapabilities)), mTwoWayTalkSupport(aArgs.twoWayTalkSupport),
+    mSnapshotCapabilitiesList(std::move(aArgs.snapshotCapabilities)), mMaxNetworkBandwidth(aArgs.maxNetworkBandwidth),
+    mSupportedStreamUsages(std::move(aArgs.supportedStreamUsages)), mStreamUsagePriorities(std::move(aArgs.streamUsagePriorities))
 {
     mDelegate.SetCameraAVStreamManagementCluster(this);
 }

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -52,11 +52,11 @@ namespace Clusters {
 namespace CameraAvStreamManagement {
 
 CameraAVStreamManagementCluster::CameraAVStreamManagementCluster(InitArguments && aArgs) :
-    DefaultServerCluster({ aArgs.endpointId, CameraAvStreamManagement::Id }),
-    mContext(aArgs.context), mDelegate(aArgs.delegate), mEnabledFeatures(aArgs.features), mOptionalAttrs(aArgs.optionalAttrs),
-    mMaxConcurrentEncoders(aArgs.maxConcurrentEncoders), mMaxEncodedPixelRate(aArgs.maxEncodedPixelRate),
-    mVideoSensorParams(std::move(aArgs.videoSensorParams)), mNightVisionUsesInfrared(aArgs.nightVisionUsesInfrared),
-    mMinViewPortResolution(std::move(aArgs.minViewPort)), mRateDistortionTradeOffPointsList(std::move(aArgs.rateDistortionTradeOffPoints)),
+    DefaultServerCluster({ aArgs.endpointId, CameraAvStreamManagement::Id }), mContext(aArgs.context), mDelegate(aArgs.delegate),
+    mEnabledFeatures(aArgs.features), mOptionalAttrs(aArgs.optionalAttrs), mMaxConcurrentEncoders(aArgs.maxConcurrentEncoders),
+    mMaxEncodedPixelRate(aArgs.maxEncodedPixelRate), mVideoSensorParams(std::move(aArgs.videoSensorParams)),
+    mNightVisionUsesInfrared(aArgs.nightVisionUsesInfrared), mMinViewPortResolution(std::move(aArgs.minViewPort)),
+    mRateDistortionTradeOffPointsList(std::move(aArgs.rateDistortionTradeOffPoints)),
     mMaxContentBufferSize(aArgs.maxContentBufferSize), mMicrophoneCapabilities(std::move(aArgs.microphoneCapabilities)),
     mSpeakerCapabilities(std::move(aArgs.spkrCapabilities)), mTwoWayTalkSupport(aArgs.twoWayTalkSupport),
     mSnapshotCapabilitiesList(std::move(aArgs.snapshotCapabilities)), mMaxNetworkBandwidth(aArgs.maxNetworkBandwidth),

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -1103,7 +1103,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetNightVision(TriStateAutoEnum aNig
     {
         mNightVision = aNightVision;
         auto path    = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVision::Id);
-        ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mNightVision)));
+        ReturnErrorOnFailure(WriteScalarValue(path, to_underlying(mNightVision)));
         mDelegate.OnAttributeChanged(Attributes::NightVision::Id);
         NotifyAttributeChanged(Attributes::NightVision::Id);
     }
@@ -1116,7 +1116,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetNightVisionIllum(TriStateAutoEnum
     {
         mNightVisionIllum = aNightVisionIllum;
         auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVisionIllum::Id);
-        ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mNightVisionIllum)));
+        ReturnErrorOnFailure(WriteScalarValue(path, to_underlying(mNightVisionIllum)));
         mDelegate.OnAttributeChanged(Attributes::NightVisionIllum::Id);
         NotifyAttributeChanged(Attributes::NightVisionIllum::Id);
     }
@@ -1278,7 +1278,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::SetStatusLightBrightness(Globals::Th
         mStatusLightBrightness = aStatusLightBrightness;
         auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightBrightness::Id);
         ReturnErrorOnFailure(
-            mContext.safeAttributePersistenceProvider.WriteScalarValue(path, to_underlying(mStatusLightBrightness)));
+            WriteScalarValue(path, to_underlying(mStatusLightBrightness)));
         mDelegate.OnAttributeChanged(Attributes::StatusLightBrightness::Id);
         NotifyAttributeChanged(Attributes::StatusLightBrightness::Id);
     }
@@ -1290,7 +1290,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Load HDR Mode Enabled
     bool storedHDRModeEnabled = false;
-    err                       = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                       = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::HDRModeEnabled::Id),
         storedHDRModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1333,7 +1333,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SoftRecordingPrivacyModeEnabled
     bool softRecordingPrivacyModeEnabled = false;
-    err                                  = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                                  = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SoftRecordingPrivacyModeEnabled::Id),
         softRecordingPrivacyModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1351,7 +1351,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SoftLivestreamPrivacyModeEnabled
     bool softLivestreamPrivacyModeEnabled = false;
-    err                                   = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                                   = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SoftLivestreamPrivacyModeEnabled::Id),
         softLivestreamPrivacyModeEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1369,7 +1369,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load NightVision
     uint8_t nightVision = 0;
-    err                 = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                 = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVision::Id), nightVision);
     if (err == CHIP_NO_ERROR)
     {
@@ -1384,7 +1384,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load NightVisionIllum
     uint8_t nightVisionIllum = 0;
-    err                      = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                      = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::NightVisionIllum::Id), nightVisionIllum);
     if (err == CHIP_NO_ERROR)
     {
@@ -1413,7 +1413,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SpeakerMuted
     bool speakerMuted = false;
-    err               = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err               = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SpeakerMuted::Id), speakerMuted);
     if (err == CHIP_NO_ERROR)
     {
@@ -1428,7 +1428,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load SpeakerVolumeLevel
     uint8_t speakerVolumeLevel = 0;
-    err                        = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                        = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::SpeakerVolumeLevel::Id),
         speakerVolumeLevel);
     if (err == CHIP_NO_ERROR)
@@ -1444,7 +1444,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneMuted
     bool microphoneMuted = false;
-    err                  = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                  = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneMuted::Id), microphoneMuted);
     if (err == CHIP_NO_ERROR)
     {
@@ -1459,7 +1459,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneVolumeLevel
     uint8_t microphoneVolumeLevel = 0;
-    err                           = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                           = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneVolumeLevel::Id),
         microphoneVolumeLevel);
     if (err == CHIP_NO_ERROR)
@@ -1476,7 +1476,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load MicrophoneAGCEnabled
     bool microphoneAGCEnabled = false;
-    err                       = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                       = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::MicrophoneAGCEnabled::Id),
         microphoneAGCEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1493,7 +1493,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageRotation
     uint16_t imageRotation = 0;
-    err                    = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                    = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageRotation::Id), imageRotation);
     if (err == CHIP_NO_ERROR)
     {
@@ -1508,7 +1508,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageFlipHorizontal
     bool imageFlipHorizontal = false;
-    err                      = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                      = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageFlipHorizontal::Id),
         imageFlipHorizontal);
     if (err == CHIP_NO_ERROR)
@@ -1524,7 +1524,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load ImageFlipVertical
     bool imageFlipVertical = false;
-    err                    = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                    = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::ImageFlipVertical::Id),
         imageFlipVertical);
     if (err == CHIP_NO_ERROR)
@@ -1540,7 +1540,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load LocalVideoRecordingEnabled
     bool localVideoRecordingEnabled = false;
-    err                             = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                             = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::LocalVideoRecordingEnabled::Id),
         localVideoRecordingEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1558,7 +1558,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load LocalSnapshotRecordingEnabled
     bool localSnapshotRecordingEnabled = false;
-    err                                = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                                = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::LocalSnapshotRecordingEnabled::Id),
         localSnapshotRecordingEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1576,7 +1576,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load StatusLightEnabled
     bool statusLightEnabled = false;
-    err                     = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                     = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightEnabled::Id),
         statusLightEnabled);
     if (err == CHIP_NO_ERROR)
@@ -1592,7 +1592,7 @@ void CameraAVStreamManagementCluster::LoadPersistentAttributes()
 
     // Load StatusLightBrightness
     uint8_t statusLightBrightness = 0;
-    err                           = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    err                           = ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StatusLightBrightness::Id),
         statusLightBrightness);
     if (err == CHIP_NO_ERROR)
@@ -1628,7 +1628,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreViewport(const Globals::Structs
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::Viewport::Id);
     bufferSpan.reduce_size(writer.GetLengthWritten());
 
-    return mContext.safeAttributePersistenceProvider.SafeWriteValue(path, bufferSpan);
+    return mContext.attributePersistenceProvider.WriteValue(path, bufferSpan);
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::LoadViewport(Globals::Structs::ViewportStruct::Type & viewport)
@@ -1637,7 +1637,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadViewport(Globals::Structs::Viewp
     MutableByteSpan bufferSpan(buffer);
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::Viewport::Id);
-    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeReadValue(path, bufferSpan));
+    ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(path, bufferSpan));
 
     TLV::TLVReader reader;
 
@@ -1667,7 +1667,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreStreamUsagePriorities()
     bufferSpan.reduce_size(writer.GetLengthWritten());
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StreamUsagePriorities::Id);
-    return mContext.safeAttributePersistenceProvider.SafeWriteValue(path, bufferSpan);
+    return mContext.attributePersistenceProvider.WriteValue(path, bufferSpan);
 }
 
 CHIP_ERROR CameraAVStreamManagementCluster::LoadStreamUsagePriorities()
@@ -1676,7 +1676,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadStreamUsagePriorities()
     MutableByteSpan bufferSpan(buffer);
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, Attributes::StreamUsagePriorities::Id);
-    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeReadValue(path, bufferSpan));
+    ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(path, bufferSpan));
 
     TLV::TLVReader reader;
     reader.Init(bufferSpan);
@@ -1768,7 +1768,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::StoreAllocatedStreams()
     size_t len = writer.GetLengthWritten();
 
     auto path = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
-    ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.SafeWriteValue(path, ByteSpan(buffer, len)));
+    ReturnErrorOnFailure(mContext.attributePersistenceProvider.WriteValue(path, ByteSpan(buffer, len)));
 
     ChipLogProgress(Zcl, "Saved %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(Traits::kStreamType));
     return CHIP_NO_ERROR;
@@ -1785,7 +1785,7 @@ CHIP_ERROR CameraAVStreamManagementCluster::LoadAllocatedStreams()
     auto path      = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
     auto & streams = (*this).*Traits::kStreamVectorMember;
 
-    CHIP_ERROR err = mContext.safeAttributePersistenceProvider.SafeReadValue(path, span);
+    CHIP_ERROR err = mContext.attributePersistenceProvider.ReadValue(path, span);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         streams.clear();

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -392,57 +392,37 @@ public:
         SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
     };
 
+    struct InitArguments
+    {
+        const Context & context;
+        CameraAVStreamManagementDelegate & delegate;
+        EndpointId endpointId;
+        BitFlags<Feature> features;
+        BitFlags<OptionalAttribute> optionalAttrs;
+        uint8_t maxConcurrentEncoders = 0;
+        uint32_t maxEncodedPixelRate = 0;
+        VideoSensorParamsStruct videoSensorParams;
+        bool nightVisionUsesInfrared = false;
+        VideoResolutionStruct minViewPort;
+        std::vector<RateDistortionTradeOffStruct> rateDistortionTradeOffPoints;
+        uint32_t maxContentBufferSize = 0;
+        AudioCapabilitiesStruct microphoneCapabilities;
+        AudioCapabilitiesStruct spkrCapabilities;
+        TwoWayTalkSupportTypeEnum twoWayTalkSupport = TwoWayTalkSupportTypeEnum::kNotSupported;
+        std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities;
+        uint32_t maxNetworkBandwidth = 0;
+        std::vector<Globals::StreamUsageEnum> supportedStreamUsages;
+        std::vector<Globals::StreamUsageEnum> streamUsagePriorities;
+    };
+
     /**
      * @brief Creates a Camera AV Stream Management cluster instance. The Init() function needs to be called for this instance
      * to be registered and called by the interaction model at the appropriate times.
      *
-     * @param aContext                          Context providing injected dependencies (e.g., SafeAttributePersistenceProvider).
-     *                                          Note: the caller must ensure that the provided SafeAttributePersistenceProvider
-     *                                          outlives this instance.
-     *
-     * @param aDelegate                         A pointer to the delegate to be used by this server.
-     *                                          Note: the caller must ensure that the delegate lives throughout the instance's
-     *                                          lifetime.
-     *
-     * @param aEndpointId                       The endpoint on which this cluster exists. This must match the zap configuration.
-     * @param aFeatures                         The bitflags value that identifies which features are supported by this instance.
-     * @param aOptionalAttrs                    The bitflags value that identifies the optional attributes supported by this
-     *                                          instance.
-     * @param aMaxConcurrentEncoders            The maximum number of video encoders supported by camera.
-     * @param aMaxEncodedPixelRate              The maximum data rate (encoded pixels/sec) supported by camera.
-     * @param aVideoSensorParams                The set of video sensor parameters for the camera.
-     * @param aNightVisionUsesInfrared          Indicates whether nightvision mode does or does not use infrared
-     * @param aMinViewPort                      Indicates minimum resolution (width/height) in pixels allowed for camera viewport.
-     * @param aRateDistortionTradeOffPoints     Indicates the list of rate distortion trade-off points for supported hardware
-     *                                          encoders.
-     * @param aMaxContentBufferSize             The maximum size of the content buffer containing data for all streams, including
-     *                                          pre-roll.
-     * @param aMicrophoneCapabilities           Indicates the audio capabilities of the speaker in terms of the codec used,
-     *                                          supported sample rates and the number of channels.
-     * @param aSpkrCapabilities                 Indicates the audio capabilities of the speaker in terms of the codec used,
-     *                                          supported sample rates and the number of channels.
-     * @param aTwoWayTalkSupport                Indicates the type of two-way talk support the device has, e.g., half-duplex,
-     *                                          full-duplex, etc.
-     * @param aSnapshotCapabilities             Indicates the set of supported snapshot capabilities by the device, e.g., the image
-     *                                          codec, the resolution and the maximum frame rate.
-     * @param aMaxNetworkBandwidth              Indicates the maximum network bandwidth (in bps) that the device would consume
-     * @param aSupportedStreamUsages            Indicates the possible stream types available
-     * @param aStreamUsagePriorities            Indicates the priority ranking of the available streams
-     * for the transmission of its media streams.
+     * @param aArgs                             Initialization arguments.
      *
      */
-    CameraAVStreamManagementCluster(const Context & aContext, CameraAVStreamManagementDelegate & aDelegate, EndpointId aEndpointId,
-                                    const BitFlags<Feature> aFeatures, const BitFlags<OptionalAttribute> aOptionalAttrs,
-                                    uint8_t aMaxConcurrentEncoders, uint32_t aMaxEncodedPixelRate,
-                                    const VideoSensorParamsStruct & aVideoSensorParams, bool aNightVisionUsesInfrared,
-                                    const VideoResolutionStruct & aMinViewPort,
-                                    const std::vector<RateDistortionTradeOffStruct> & aRateDistortionTradeOffPoints,
-                                    uint32_t aMaxContentBufferSize, const AudioCapabilitiesStruct & aMicrophoneCapabilities,
-                                    const AudioCapabilitiesStruct & aSpkrCapabilities, TwoWayTalkSupportTypeEnum aTwoWayTalkSupport,
-                                    const std::vector<SnapshotCapabilitiesStruct> & aSnapshotCapabilities,
-                                    uint32_t aMaxNetworkBandwidth,
-                                    const std::vector<Globals::StreamUsageEnum> & aSupportedStreamUsages,
-                                    const std::vector<Globals::StreamUsageEnum> & aStreamUsagePriorities);
+    CameraAVStreamManagementCluster(InitArguments && aArgs);
 
     ~CameraAVStreamManagementCluster() override;
 

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -23,8 +23,10 @@
 #include <clusters/CameraAvStreamManagement/Attributes.h>
 #include <clusters/CameraAvStreamManagement/Commands.h>
 
-#include <app/SafeAttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistenceProvider.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/support/BufferReader.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/TypeTraits.h>
 #include <optional>
 #include <protocols/interaction_model/StatusCode.h>
@@ -389,7 +391,7 @@ class CameraAVStreamManagementCluster : public DefaultServerCluster
 public:
     struct Context
     {
-        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+        AttributePersistenceProvider & attributePersistenceProvider;
     };
 
     struct InitArguments
@@ -726,6 +728,35 @@ private:
     template <AttributeId TAttributeId>
     CHIP_ERROR PersistAndNotify();
 
+    template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+    CHIP_ERROR WriteScalarValue(const ConcreteAttributePath & aPath, T aValue)
+    {
+        uint8_t value[sizeof(T)];
+        auto w = Encoding::LittleEndian::BufferWriter(value, sizeof(T));
+        if constexpr (std::is_signed_v<T>)
+        {
+            w.EndianPutSigned(aValue, sizeof(T));
+        }
+        else
+        {
+            w.EndianPut(aValue, sizeof(T));
+        }
+
+        return mContext.attributePersistenceProvider.WriteValue(aPath, ByteSpan(value));
+    }
+
+    template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+    CHIP_ERROR ReadScalarValue(const ConcreteAttributePath & aPath, T & aValue)
+    {
+        uint8_t attrData[sizeof(T)];
+        MutableByteSpan tempVal(attrData);
+        ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(aPath, tempVal));
+        VerifyOrReturnError(tempVal.size() == sizeof(T), CHIP_ERROR_INCORRECT_STATE);
+        Encoding::LittleEndian::Reader r(tempVal.data(), tempVal.size());
+        r.RawReadLowLevelBeCareful(&aValue);
+        return r.StatusCode();
+    }
+
     // Declared friend so that it can access the private stream vector members
     // from CameraAVStreamManagementCluster.
     template <AttributeId TAttributeId>
@@ -794,7 +825,7 @@ private:
             auto path    = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
             if (shouldPersist)
             {
-                ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, currentValue));
+                ReturnErrorOnFailure(WriteScalarValue(path, currentValue));
             }
             mDelegate.OnAttributeChanged(attributeId);
             NotifyAttributeChanged(attributeId);

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -406,22 +406,55 @@ public:
          */
         CameraAVStreamManagementDelegate & delegate;
 
+        /** The endpoint on which this cluster exists. This must match the zap configuration. */
         EndpointId endpointId;
+
+        /** The bitflags value that identifies which features are supported by this instance. */
         BitFlags<Feature> features;
+
+        /** The bitflags value that identifies the optional attributes supported by this instance. */
         BitFlags<OptionalAttribute> optionalAttrs;
+
+        /** The maximum number of video encoders supported by camera. */
         uint8_t maxConcurrentEncoders = 0;
+
+        /** The maximum data rate (encoded pixels/sec) supported by camera. */
         uint32_t maxEncodedPixelRate  = 0;
+
+        /** The set of video sensor parameters for the camera. */
         VideoSensorParamsStruct videoSensorParams;
+
+        /** Indicates whether nightvision mode does or does not use infrared. */
         bool nightVisionUsesInfrared = false;
+
+        /** Indicates minimum resolution (width/height) in pixels allowed for camera viewport. */
         VideoResolutionStruct minViewPort;
+
+        /** Indicates the list of rate distortion trade-off points for supported hardware encoders. */
         std::vector<RateDistortionTradeOffStruct> rateDistortionTradeOffPoints;
+
+        /** The maximum size of the content buffer containing data for all streams, including pre-roll. */
         uint32_t maxContentBufferSize = 0;
+
+        /** Indicates the audio capabilities of the microphone in terms of the codec used, supported sample rates and the number of channels. */
         AudioCapabilitiesStruct microphoneCapabilities;
+
+        /** Indicates the audio capabilities of the speaker in terms of the codec used, supported sample rates and the number of channels. */
         AudioCapabilitiesStruct spkrCapabilities;
+
+        /** Indicates the type of two-way talk support the device has, e.g., half-duplex, full-duplex, etc. */
         TwoWayTalkSupportTypeEnum twoWayTalkSupport = TwoWayTalkSupportTypeEnum::kNotSupported;
+
+        /** Indicates the set of supported snapshot capabilities by the device, e.g., the image codec, the resolution and the maximum frame rate. */
         std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities;
+
+        /** Indicates the maximum network bandwidth (in bps) that the device would consume for the transmission of its media streams. */
         uint32_t maxNetworkBandwidth = 0;
+
+        /** Indicates the possible stream types available. */
         std::vector<Globals::StreamUsageEnum> supportedStreamUsages;
+
+        /** Indicates the priority ranking of the available streams. */
         std::vector<Globals::StreamUsageEnum> streamUsagePriorities;
     };
 

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -419,7 +419,7 @@ public:
         uint8_t maxConcurrentEncoders = 0;
 
         /** The maximum data rate (encoded pixels/sec) supported by camera. */
-        uint32_t maxEncodedPixelRate  = 0;
+        uint32_t maxEncodedPixelRate = 0;
 
         /** The set of video sensor parameters for the camera. */
         VideoSensorParamsStruct videoSensorParams;
@@ -436,19 +436,23 @@ public:
         /** The maximum size of the content buffer containing data for all streams, including pre-roll. */
         uint32_t maxContentBufferSize = 0;
 
-        /** Indicates the audio capabilities of the microphone in terms of the codec used, supported sample rates and the number of channels. */
+        /** Indicates the audio capabilities of the microphone in terms of the codec used, supported sample rates and the number of
+         * channels. */
         AudioCapabilitiesStruct microphoneCapabilities;
 
-        /** Indicates the audio capabilities of the speaker in terms of the codec used, supported sample rates and the number of channels. */
+        /** Indicates the audio capabilities of the speaker in terms of the codec used, supported sample rates and the number of
+         * channels. */
         AudioCapabilitiesStruct spkrCapabilities;
 
         /** Indicates the type of two-way talk support the device has, e.g., half-duplex, full-duplex, etc. */
         TwoWayTalkSupportTypeEnum twoWayTalkSupport = TwoWayTalkSupportTypeEnum::kNotSupported;
 
-        /** Indicates the set of supported snapshot capabilities by the device, e.g., the image codec, the resolution and the maximum frame rate. */
+        /** Indicates the set of supported snapshot capabilities by the device, e.g., the image codec, the resolution and the
+         * maximum frame rate. */
         std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities;
 
-        /** Indicates the maximum network bandwidth (in bps) that the device would consume for the transmission of its media streams. */
+        /** Indicates the maximum network bandwidth (in bps) that the device would consume for the transmission of its media
+         * streams. */
         uint32_t maxNetworkBandwidth = 0;
 
         /** Indicates the possible stream types available. */

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -23,10 +23,8 @@
 #include <clusters/CameraAvStreamManagement/Attributes.h>
 #include <clusters/CameraAvStreamManagement/Commands.h>
 
-#include <app/persistence/AttributePersistenceProvider.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
-#include <lib/support/BufferReader.h>
-#include <lib/support/BufferWriter.h>
 #include <lib/support/TypeTraits.h>
 #include <optional>
 #include <protocols/interaction_model/StatusCode.h>
@@ -391,7 +389,7 @@ class CameraAVStreamManagementCluster : public DefaultServerCluster
 public:
     struct Context
     {
-        AttributePersistenceProvider & attributePersistenceProvider;
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
     };
 
     struct InitArguments
@@ -728,35 +726,6 @@ private:
     template <AttributeId TAttributeId>
     CHIP_ERROR PersistAndNotify();
 
-    template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-    CHIP_ERROR WriteScalarValue(const ConcreteAttributePath & aPath, T aValue)
-    {
-        uint8_t value[sizeof(T)];
-        auto w = Encoding::LittleEndian::BufferWriter(value, sizeof(T));
-        if constexpr (std::is_signed_v<T>)
-        {
-            w.EndianPutSigned(aValue, sizeof(T));
-        }
-        else
-        {
-            w.EndianPut(aValue, sizeof(T));
-        }
-
-        return mContext.attributePersistenceProvider.WriteValue(aPath, ByteSpan(value));
-    }
-
-    template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-    CHIP_ERROR ReadScalarValue(const ConcreteAttributePath & aPath, T & aValue)
-    {
-        uint8_t attrData[sizeof(T)];
-        MutableByteSpan tempVal(attrData);
-        ReturnErrorOnFailure(mContext.attributePersistenceProvider.ReadValue(aPath, tempVal));
-        VerifyOrReturnError(tempVal.size() == sizeof(T), CHIP_ERROR_INCORRECT_STATE);
-        Encoding::LittleEndian::Reader r(tempVal.data(), tempVal.size());
-        r.RawReadLowLevelBeCareful(&aValue);
-        return r.StatusCode();
-    }
-
     // Declared friend so that it can access the private stream vector members
     // from CameraAVStreamManagementCluster.
     template <AttributeId TAttributeId>
@@ -825,7 +794,7 @@ private:
             auto path    = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
             if (shouldPersist)
             {
-                ReturnErrorOnFailure(WriteScalarValue(path, currentValue));
+                ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, currentValue));
             }
             mDelegate.OnAttributeChanged(attributeId);
             NotifyAttributeChanged(attributeId);

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -394,8 +394,18 @@ public:
 
     struct InitArguments
     {
-        const Context & context;
+        /**
+         * Context providing injected dependencies.
+         * Note: the caller must ensure that the SafeAttributePersistenceProvider referenced by the context outlives this instance.
+         */
+        Context context;
+
+        /**
+         * A reference to the delegate to be used by this server.
+         * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+         */
         CameraAVStreamManagementDelegate & delegate;
+
         EndpointId endpointId;
         BitFlags<Feature> features;
         BitFlags<OptionalAttribute> optionalAttrs;
@@ -420,6 +430,8 @@ public:
      * to be registered and called by the interaction model at the appropriate times.
      *
      * @param aArgs                             Initialization arguments.
+     *                                          Note: The caller must ensure that resources referenced in aArgs (like the delegate
+     *                                          and the SafeAttributePersistenceProvider in context) outlive this cluster instance.
      *
      */
     CameraAVStreamManagementCluster(InitArguments && aArgs);

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -400,7 +400,7 @@ public:
         BitFlags<Feature> features;
         BitFlags<OptionalAttribute> optionalAttrs;
         uint8_t maxConcurrentEncoders = 0;
-        uint32_t maxEncodedPixelRate = 0;
+        uint32_t maxEncodedPixelRate  = 0;
         VideoSensorParamsStruct videoSensorParams;
         bool nightVisionUsesInfrared = false;
         VideoResolutionStruct minViewPort;

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -18,11 +18,12 @@
 
 #include <app/AttributeValueDecoder.h>
 #include <app/CommandHandler.h>
+#include <app/DefaultSafeAttributePersistenceProvider.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/tests/TestConstants.h>
 #include <app/data-model/Decode.h>
-#include <app/persistence/AttributePersistenceProvider.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
@@ -86,7 +87,7 @@ static std::vector<StreamUsageEnum> & GetSupportedStreamUsages()
 }
 
 static CameraAVStreamManagementCluster::InitArguments MakeInitArguments(CameraAVStreamManagementDelegate & delegate,
-                                                                        AttributePersistenceProvider & persistenceProvider)
+                                                                        SafeAttributePersistenceProvider & persistenceProvider)
 {
     CameraAVStreamManagementCluster::InitArguments args{
         .context    = { persistenceProvider },
@@ -286,24 +287,6 @@ private:
     uint8_t mSnapshotStreamCount;
 };
 
-class TestAttributePersistenceProvider : public app::AttributePersistenceProvider
-{
-public:
-    void SetProvider(app::AttributePersistenceProvider * provider) { mProvider = provider; }
-    CHIP_ERROR WriteValue(const app::ConcreteAttributePath & aPath, const ByteSpan & aValue) override
-    {
-        VerifyOrReturnError(mProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mProvider->WriteValue(aPath, aValue);
-    }
-    CHIP_ERROR ReadValue(const app::ConcreteAttributePath & aPath, MutableByteSpan & aValue) override
-    {
-        VerifyOrReturnError(mProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mProvider->ReadValue(aPath, aValue);
-    }
-
-private:
-    app::AttributePersistenceProvider * mProvider = nullptr;
-};
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestCameraAVStreamManagementCluster : public ::testing::Test
@@ -343,7 +326,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
 
     void SetUp() override
     {
-        mPersistenceProvider.SetProvider(&mClusterTester.GetServerClusterContext().attributeStorage);
+        VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
         EXPECT_EQ(mServer.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
         EXPECT_EQ(InitializeCameraAVSMDefaults(mServer), CHIP_NO_ERROR);
         EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
@@ -353,7 +336,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
     std::vector<AudioStreamStruct> mAudioStreams;
     std::vector<SnapshotStreamStruct> mSnapshotStreams;
     MockCameraAVStreamManagementDelegate mMockDelegate;
-    TestAttributePersistenceProvider mPersistenceProvider;
+    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
     CameraAvStreamManagement::CameraAVStreamManagementCluster mServer;
     ClusterTester mClusterTester;
 };
@@ -1786,7 +1769,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
 
     // 2. Write to persistence
     ConcreteAttributePath path(kTestEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
-    ASSERT_EQ(mPersistenceProvider.WriteValue(path, ByteSpan(buffer, len)), CHIP_NO_ERROR);
+    ASSERT_EQ(mPersistenceProvider.SafeWriteValue(path, ByteSpan(buffer, len)), CHIP_NO_ERROR);
 
     // 3. Trigger Init to load from persistence
     ASSERT_EQ(mServer.Init(), CHIP_NO_ERROR);

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -86,6 +86,44 @@ static std::vector<StreamUsageEnum> & GetSupportedStreamUsages()
     return supportedStreamUsage;
 }
 
+static CameraAVStreamManagementCluster::InitArguments MakeInitArguments(CameraAVStreamManagementDelegate & delegate, SafeAttributePersistenceProvider & persistenceProvider)
+{
+    CameraAVStreamManagementCluster::InitArguments args{
+        .context                      = { persistenceProvider },
+        .delegate                     = delegate,
+        .endpointId                   = kTestEndpointId,
+        .features                     = chip::BitFlags<CameraAvStreamManagement::Feature>(
+            CameraAvStreamManagement::Feature::kVideo, CameraAvStreamManagement::Feature::kAudio,
+            CameraAvStreamManagement::Feature::kSnapshot, CameraAvStreamManagement::Feature::kSpeaker,
+            CameraAvStreamManagement::Feature::kImageControl, CameraAvStreamManagement::Feature::kPrivacy,
+            CameraAvStreamManagement::Feature::kWatermark, CameraAvStreamManagement::Feature::kHighDynamicRange,
+            CameraAvStreamManagement::Feature::kNightVision),
+        .optionalAttrs                = chip::BitFlags<CameraAvStreamManagement::OptionalAttribute>(
+            CameraAvStreamManagement::OptionalAttribute::kHardPrivacyModeOn,
+            CameraAvStreamManagement::OptionalAttribute::kMicrophoneAGCEnabled,
+            CameraAvStreamManagement::OptionalAttribute::kImageRotation,
+            CameraAvStreamManagement::OptionalAttribute::kImageFlipHorizontal,
+            CameraAvStreamManagement::OptionalAttribute::kImageFlipVertical,
+            CameraAvStreamManagement::OptionalAttribute::kStatusLightEnabled,
+            CameraAvStreamManagement::OptionalAttribute::kStatusLightBrightness),
+        .maxConcurrentEncoders        = 1,
+        .maxEncodedPixelRate          = 248832000 /*1920*1080*120 */,
+        .videoSensorParams            = GetVideoSensorParams(),
+        .nightVisionUsesInfrared      = false,
+        .minViewPort                  = { 640, 480 },
+        .rateDistortionTradeOffPoints = GetRateDistortionTradeOffPoints(),
+        .maxContentBufferSize         = 4096,
+        .microphoneCapabilities       = GetAudioCapabilities(),
+        .spkrCapabilities             = GetAudioCapabilities(),
+        .twoWayTalkSupport            = TwoWayTalkSupportTypeEnum::kFullDuplex,
+        .snapshotCapabilities         = GetSnapshotCapabilities(),
+        .maxNetworkBandwidth          = 128000000,
+        .supportedStreamUsages        = GetSupportedStreamUsages(),
+        .streamUsagePriorities        = GetSupportedStreamUsages()
+    };
+    return args;
+}
+
 // Mock delegate for testing CameraAVStreamManagement
 class MockCameraAVStreamManagementDelegate : public CameraAVStreamManagementDelegate
 {
@@ -281,25 +319,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
 
     TestCameraAVStreamManagementCluster() :
         mMockDelegate(&mVideoStreams, &mAudioStreams, &mSnapshotStreams),
-        mServer(CameraAvStreamManagement::CameraAVStreamManagementCluster::Context{ mPersistenceProvider }, mMockDelegate,
-                kTestEndpointId,
-                chip::BitFlags<CameraAvStreamManagement::Feature>(
-                    CameraAvStreamManagement::Feature::kVideo, CameraAvStreamManagement::Feature::kAudio,
-                    CameraAvStreamManagement::Feature::kSnapshot, CameraAvStreamManagement::Feature::kSpeaker,
-                    CameraAvStreamManagement::Feature::kImageControl, CameraAvStreamManagement::Feature::kPrivacy,
-                    CameraAvStreamManagement::Feature::kWatermark, CameraAvStreamManagement::Feature::kHighDynamicRange,
-                    CameraAvStreamManagement::Feature::kNightVision),
-                chip::BitFlags<CameraAvStreamManagement::OptionalAttribute>(
-                    CameraAvStreamManagement::OptionalAttribute::kHardPrivacyModeOn,
-                    CameraAvStreamManagement::OptionalAttribute::kMicrophoneAGCEnabled,
-                    CameraAvStreamManagement::OptionalAttribute::kImageRotation,
-                    CameraAvStreamManagement::OptionalAttribute::kImageFlipHorizontal,
-                    CameraAvStreamManagement::OptionalAttribute::kImageFlipVertical,
-                    CameraAvStreamManagement::OptionalAttribute::kStatusLightEnabled,
-                    CameraAvStreamManagement::OptionalAttribute::kStatusLightBrightness),
-                1, 248832000 /*1920*1080*120 */, GetVideoSensorParams(), false, { 640, 480 }, GetRateDistortionTradeOffPoints(),
-                4096, GetAudioCapabilities(), GetAudioCapabilities(), TwoWayTalkSupportTypeEnum::kFullDuplex,
-                GetSnapshotCapabilities(), 128000000, GetSupportedStreamUsages(), GetSupportedStreamUsages()),
+        mServer(MakeInitArguments(mMockDelegate, mPersistenceProvider)),
         mClusterTester(mServer)
     {}
 

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -86,19 +86,20 @@ static std::vector<StreamUsageEnum> & GetSupportedStreamUsages()
     return supportedStreamUsage;
 }
 
-static CameraAVStreamManagementCluster::InitArguments MakeInitArguments(CameraAVStreamManagementDelegate & delegate, SafeAttributePersistenceProvider & persistenceProvider)
+static CameraAVStreamManagementCluster::InitArguments MakeInitArguments(CameraAVStreamManagementDelegate & delegate,
+                                                                        SafeAttributePersistenceProvider & persistenceProvider)
 {
     CameraAVStreamManagementCluster::InitArguments args{
-        .context                      = { persistenceProvider },
-        .delegate                     = delegate,
-        .endpointId                   = kTestEndpointId,
-        .features                     = chip::BitFlags<CameraAvStreamManagement::Feature>(
+        .context    = { persistenceProvider },
+        .delegate   = delegate,
+        .endpointId = kTestEndpointId,
+        .features   = chip::BitFlags<CameraAvStreamManagement::Feature>(
             CameraAvStreamManagement::Feature::kVideo, CameraAvStreamManagement::Feature::kAudio,
             CameraAvStreamManagement::Feature::kSnapshot, CameraAvStreamManagement::Feature::kSpeaker,
             CameraAvStreamManagement::Feature::kImageControl, CameraAvStreamManagement::Feature::kPrivacy,
             CameraAvStreamManagement::Feature::kWatermark, CameraAvStreamManagement::Feature::kHighDynamicRange,
             CameraAvStreamManagement::Feature::kNightVision),
-        .optionalAttrs                = chip::BitFlags<CameraAvStreamManagement::OptionalAttribute>(
+        .optionalAttrs = chip::BitFlags<CameraAvStreamManagement::OptionalAttribute>(
             CameraAvStreamManagement::OptionalAttribute::kHardPrivacyModeOn,
             CameraAvStreamManagement::OptionalAttribute::kMicrophoneAGCEnabled,
             CameraAvStreamManagement::OptionalAttribute::kImageRotation,
@@ -319,8 +320,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
 
     TestCameraAVStreamManagementCluster() :
         mMockDelegate(&mVideoStreams, &mAudioStreams, &mSnapshotStreams),
-        mServer(MakeInitArguments(mMockDelegate, mPersistenceProvider)),
-        mClusterTester(mServer)
+        mServer(MakeInitArguments(mMockDelegate, mPersistenceProvider)), mClusterTester(mServer)
     {}
 
     void SetUp() override

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -18,8 +18,7 @@
 
 #include <app/AttributeValueDecoder.h>
 #include <app/CommandHandler.h>
-#include <app/DefaultSafeAttributePersistenceProvider.h>
-#include <app/SafeAttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistenceProvider.h>
 #include <app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/tests/TestConstants.h>
@@ -87,7 +86,7 @@ static std::vector<StreamUsageEnum> & GetSupportedStreamUsages()
 }
 
 static CameraAVStreamManagementCluster::InitArguments MakeInitArguments(CameraAVStreamManagementDelegate & delegate,
-                                                                        SafeAttributePersistenceProvider & persistenceProvider)
+                                                                        AttributePersistenceProvider & persistenceProvider)
 {
     CameraAVStreamManagementCluster::InitArguments args{
         .context    = { persistenceProvider },
@@ -287,6 +286,24 @@ private:
     uint8_t mSnapshotStreamCount;
 };
 
+class TestAttributePersistenceProvider : public app::AttributePersistenceProvider
+{
+public:
+    void SetProvider(app::AttributePersistenceProvider * provider) { mProvider = provider; }
+    CHIP_ERROR WriteValue(const app::ConcreteAttributePath & aPath, const ByteSpan & aValue) override
+    {
+        VerifyOrReturnError(mProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mProvider->WriteValue(aPath, aValue);
+    }
+    CHIP_ERROR ReadValue(const app::ConcreteAttributePath & aPath, MutableByteSpan & aValue) override
+    {
+        VerifyOrReturnError(mProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mProvider->ReadValue(aPath, aValue);
+    }
+private:
+    app::AttributePersistenceProvider * mProvider = nullptr;
+};
+
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestCameraAVStreamManagementCluster : public ::testing::Test
 {
@@ -325,7 +342,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
 
     void SetUp() override
     {
-        VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
+        mPersistenceProvider.SetProvider(&mClusterTester.GetServerClusterContext().attributeStorage);
         EXPECT_EQ(mServer.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
         EXPECT_EQ(InitializeCameraAVSMDefaults(mServer), CHIP_NO_ERROR);
         EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
@@ -335,7 +352,7 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
     std::vector<AudioStreamStruct> mAudioStreams;
     std::vector<SnapshotStreamStruct> mSnapshotStreams;
     MockCameraAVStreamManagementDelegate mMockDelegate;
-    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
+    TestAttributePersistenceProvider mPersistenceProvider;
     CameraAvStreamManagement::CameraAVStreamManagementCluster mServer;
     ClusterTester mClusterTester;
 };
@@ -1768,7 +1785,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReferenceCountResetOnBoot)
 
     // 2. Write to persistence
     ConcreteAttributePath path(kTestEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
-    ASSERT_EQ(mPersistenceProvider.SafeWriteValue(path, ByteSpan(buffer, len)), CHIP_NO_ERROR);
+    ASSERT_EQ(mPersistenceProvider.WriteValue(path, ByteSpan(buffer, len)), CHIP_NO_ERROR);
 
     // 3. Trigger Init to load from persistence
     ASSERT_EQ(mServer.Init(), CHIP_NO_ERROR);

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -287,7 +287,6 @@ private:
     uint8_t mSnapshotStreamCount;
 };
 
-
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestCameraAVStreamManagementCluster : public ::testing::Test
 {

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -18,11 +18,11 @@
 
 #include <app/AttributeValueDecoder.h>
 #include <app/CommandHandler.h>
-#include <app/persistence/AttributePersistenceProvider.h>
 #include <app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/tests/TestConstants.h>
 #include <app/data-model/Decode.h>
+#include <app/persistence/AttributePersistenceProvider.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
@@ -300,6 +300,7 @@ public:
         VerifyOrReturnError(mProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
         return mProvider->ReadValue(aPath, aValue);
     }
+
 private:
     app::AttributePersistenceProvider * mProvider = nullptr;
 };


### PR DESCRIPTION
#### Summary

 The constructor for CameraAVStreamManagementCluster took 19 arguments
 individually. This change introduces an InitArguments struct to bundle
 these arguments, improving readability and maintainability.

 Updated examples/camera-app to use the new constructor.


#### Related issues
Fixes #42573 

#### Testing
Run tests and check CI sanity

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
