### PR TITLE
Add and Leverage A Few wpa_supplicant Client Methods

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -139,7 +139,6 @@ public:
     CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
 
 private:
-    bool _IsWiFiInterfaceEnabled() CHIP_REQUIRES(mWpaSupplicantMutex);
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -70,13 +70,6 @@ static constexpr char kWpaSupplicantBlobUnknown[] = "fi.w1.wpa_supplicant1.BlobU
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 
-bool ConnectivityManagerImpl::_IsWiFiInterfaceEnabled()
-{
-    VerifyOrReturnValue(mWpaSupplicant.iface, false);
-    // Check if the interface is not disabled, e.g. due to rfkill or some other reasons.
-    return g_strcmp0(wpa_supplicant_1_interface_get_state(mWpaSupplicant.iface.get()), "interface_disabled") != 0;
-}
-
 ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
@@ -848,7 +841,7 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
     GAutoPtr<GVariant> argsDeleter(g_variant_ref_sink(args)); // args may be floating, ensure we don't leak it
     GAutoPtr<GError> err;
 
-    VerifyOrReturnError(_IsWiFiInterfaceEnabled(), CHIP_ERROR_INCORRECT_STATE,
+    VerifyOrReturnError(WpaSupplicantClient::IsWiFiInterfaceEnabled(), CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "WiFi interface is disabled (blocked)"));
 
     const char * networkPath = wpa_supplicant_1_interface_get_current_network(mWpaSupplicant.iface.get());

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -264,7 +264,7 @@ void ConnectivityManagerImpl::UpdateNetworkStatus()
 
     VerifyOrReturn(IsWiFiStationEnabled());
 
-    CHIP_ERROR err = GetConfiguredNetwork(configuredNetwork);
+    CHIP_ERROR err = WpaSupplicantClient::GetConfiguredNetwork(configuredNetwork);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to get configured network when updating network status: %s", err.AsString());
@@ -1225,47 +1225,7 @@ int32_t ConnectivityManagerImpl::GetDisconnectReason()
 
 CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::Network & network)
 {
-    // This function can be called without g_main_context_get_thread_default() being set.
-    // The network proxy object is created in a synchronous manner, so the D-Bus call will
-    // be completed before this function returns. Also, no external callbacks are registered
-    // with the proxy object.
-
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    GAutoPtr<GError> err;
-
-    if (!mWpaSupplicant.iface)
-    {
-        ChipLogDetail(DeviceLayer, "Wifi network not currently connected");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    const char * networkPath = wpa_supplicant_1_interface_get_current_network(mWpaSupplicant.iface.get());
-    // wpa_supplicant DBus API: if network path of current network is "/", means no networks is currently selected.
-    if ((networkPath == nullptr) || (strcmp(networkPath, "/") == 0))
-    {
-        return CHIP_ERROR_KEY_NOT_FOUND;
-    }
-
-    GAutoPtr<WpaSupplicant1Network> networkInfo(wpa_supplicant_1_network_proxy_new_for_bus_sync(
-        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, networkPath, nullptr, &err.GetReceiver()));
-    VerifyOrReturnError(
-        networkInfo, CHIP_ERROR_INTERNAL,
-        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to create network proxy: %s", err->message));
-
-    network.connected     = wpa_supplicant_1_network_get_enabled(networkInfo.get());
-    GVariant * properties = wpa_supplicant_1_network_get_properties(networkInfo.get());
-    VerifyOrReturnError(properties != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
-
-    GAutoPtr<GVariant> ssid(g_variant_lookup_value(properties, "ssid", nullptr));
-    gsize length;
-    const gchar * ssidStr = g_variant_get_string(ssid.get(), &length);
-    // TODO: wpa_supplicant will return ssid with quotes! We should have a better way to get the actual ssid in bytes.
-    gsize length_actual = length - 2;
-    VerifyOrReturnError(length_actual <= sizeof(network.networkID), CHIP_ERROR_INTERNAL);
-    ChipLogDetail(DeviceLayer, "Current connected network: %s", StringOrNullMarker(ssidStr));
-    memcpy(network.networkID, ssidStr + 1, length_actual);
-    network.networkIDLen = length_actual;
-    return CHIP_NO_ERROR;
+    return WpaSupplicantClient::GetConfiguredNetwork(network);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::StopAutoScan()

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -78,6 +78,13 @@ bool WpaSupplicantClient::IsStarted() const noexcept
     return !!mWpaSupplicant.iface;
 }
 
+bool WpaSupplicantClient::IsWiFiInterfaceEnabled() const noexcept
+{
+    VerifyOrReturnValue(mWpaSupplicant.iface, false);
+    // Check if the interface is not disabled (for example, due to rfkill or some other reasons).
+    return g_strcmp0(wpa_supplicant_1_interface_get_state(mWpaSupplicant.iface.get()), "interface_disabled") != 0;
+}
+
 CHIP_ERROR WpaSupplicantClient::GetIfName(CharSpan & outIfName) const noexcept
 {
     outIfName = CharSpan::fromCharString(mWiFiIfName);

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -26,6 +26,14 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
+namespace {
+
+// MARK: Global Variables
+
+static constexpr char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
+
+} // namespace
+
 void WpaSupplicantClient::GDBusWpaSupplicant::Reset()
 {
     iface.reset();
@@ -85,6 +93,53 @@ bool WpaSupplicantClient::IsWiFiInterfaceEnabled() const noexcept
     return g_strcmp0(wpa_supplicant_1_interface_get_state(mWpaSupplicant.iface.get()), "interface_disabled") != 0;
 }
 
+CHIP_ERROR WpaSupplicantClient::GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork) noexcept
+{
+    // This function can be called without g_main_context_get_thread_default() being set.
+    // The network proxy object is created in a synchronous manner, so the D-Bus call will
+    // be completed before this function returns. Also, no external callbacks are registered
+    // with the proxy object.
+
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    GAutoPtr<GError> err;
+
+    if (!mWpaSupplicant.iface)
+    {
+        ChipLogDetail(DeviceLayer, "Wifi network not currently connected");
+
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    const char * networkPath = wpa_supplicant_1_interface_get_current_network(mWpaSupplicant.iface.get());
+    // wpa_supplicant DBus API: if network path of current network is "/", means no networks is currently selected.
+    if ((networkPath == nullptr) || (strcmp(networkPath, "/") == 0))
+    {
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    GAutoPtr<WpaSupplicant1Network> networkInfo(wpa_supplicant_1_network_proxy_new_for_bus_sync(
+        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, networkPath, nullptr, &err.GetReceiver()));
+    VerifyOrReturnError(
+        networkInfo, CHIP_ERROR_INTERNAL,
+        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to create network proxy: %s", err->message));
+
+    outNetwork.connected  = wpa_supplicant_1_network_get_enabled(networkInfo.get());
+    GVariant * properties = wpa_supplicant_1_network_get_properties(networkInfo.get());
+    VerifyOrReturnError(properties != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    GAutoPtr<GVariant> ssid(g_variant_lookup_value(properties, "ssid", nullptr));
+    gsize length;
+    const gchar * ssidStr = g_variant_get_string(ssid.get(), &length);
+    // TODO: wpa_supplicant will return ssid with quotes! We should have a better way to get the actual ssid in bytes.
+    gsize length_actual = length - 2;
+    VerifyOrReturnError(length_actual <= sizeof(outNetwork.networkID), CHIP_ERROR_INTERNAL);
+    ChipLogDetail(DeviceLayer, "Current connected network: %s", StringOrNullMarker(ssidStr));
+    memcpy(outNetwork.networkID, ssidStr + 1, length_actual);
+    outNetwork.networkIDLen = length_actual;
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR WpaSupplicantClient::GetIfName(CharSpan & outIfName) const noexcept
 {
     outIfName = CharSpan::fromCharString(mWiFiIfName);
@@ -100,7 +155,6 @@ CHIP_ERROR WpaSupplicantClient::SetIfName(const CharSpan & inIfName) noexcept
 
     return CHIP_NO_ERROR;
 }
-
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -19,6 +19,7 @@
 
 #include <mutex>
 
+#include <lib/support/CHIPMemString.h>
 #include <platform/CHIPDeviceConfig.h>
 
 namespace chip {
@@ -83,6 +84,16 @@ CHIP_ERROR WpaSupplicantClient::GetIfName(CharSpan & outIfName) const noexcept
 
     return CHIP_NO_ERROR;
 }
+
+CHIP_ERROR WpaSupplicantClient::SetIfName(const CharSpan & inIfName) noexcept
+{
+    VerifyOrReturnError(inIfName.size() < std::size(mWiFiIfName), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    Platform::CopyString(mWiFiIfName, inIfName);
+
+    return CHIP_NO_ERROR;
+}
+
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -49,6 +49,8 @@ CHIP_ERROR WpaSupplicantClient::Init(ConnectivityManagerImpl & inConnectivityMan
     // propagation through to this client 'Shutdown' and re-add the
     // assertion.
 
+    mWiFiIfName[0] = '\0';
+
     mConnectivityManagerImpl = &inConnectivityManagerImpl;
 
     return CHIP_NO_ERROR;
@@ -73,6 +75,13 @@ bool WpaSupplicantClient::IsStarted() const noexcept
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     return !!mWpaSupplicant.iface;
+}
+
+CHIP_ERROR WpaSupplicantClient::GetIfName(CharSpan & outIfName) const noexcept
+{
+    outIfName = CharSpan::fromCharString(mWiFiIfName);
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Internal

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -171,8 +171,30 @@ protected:
      *    A reference to the mutable character span to which to assign
      *    the Wi-Fi network interface name extent.
      *
+     *  @sa SetIfName
+     *
      */
     CHIP_ERROR GetIfName(CharSpan & outIfName) const noexcept;
+
+    /**
+     *  @brief
+     *    Set the Wi-Fi network interface name.
+     *
+     *  @param[in]  inIfName
+     *    A reference to the immutable character span from which to
+     *    copy the Wi-Fi network interface name.
+     *
+     *  @retval  CHIP_NO_ERROR
+     *    If successful.
+     *
+     *  @retval  CHIP_ERROR_BUFFER_TOO_SMALL
+     *    If the length of @a inIfName exceeds the internal buffer
+     *    space.
+     *
+     *  @sa GetIfName
+     *
+     */
+    CHIP_ERROR SetIfName(const CharSpan & inIfName) noexcept;
 
     struct GDBusWpaSupplicant
     {

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -21,6 +21,8 @@
 
 #include <glib.h>
 
+#include <inet/InetInterface.h>
+#include <lib/support/Span.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/wpa/DBusWpa.h>
@@ -161,6 +163,17 @@ protected:
      */
     bool IsStarted() const noexcept;
 
+    /**
+     *  @brief
+     *    Get the Wi-Fi network interface name.
+     *
+     *  @param[out]  outIfName
+     *    A reference to the mutable character span to which to assign
+     *    the Wi-Fi network interface name extent.
+     *
+     */
+    CHIP_ERROR GetIfName(CharSpan & outIfName) const noexcept;
+
     struct GDBusWpaSupplicant
     {
         GAutoPtr<WpaSupplicant1> proxy;
@@ -184,6 +197,7 @@ protected:
 
 private:
     ConnectivityManagerImpl * mConnectivityManagerImpl = nullptr;
+    char mWiFiIfName[Inet::InterfaceId::kMaxIfNameLength];
 };
 
 } // namespace Internal

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -165,6 +165,17 @@ protected:
 
     /**
      *  @brief
+     *    Return whether the Wi-Fi network interface is enabled.
+     *
+     *  @return
+     *    @c True if the Wi-Fi network interface is enabled;
+     *    otherwise, @c false.
+     *
+     */
+    bool IsWiFiInterfaceEnabled() const noexcept CHIP_REQUIRES(mWpaSupplicantMutex);
+
+    /**
+     *  @brief
      *    Get the Wi-Fi network interface name.
      *
      *  @param[out]  outIfName

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -29,6 +29,7 @@
 #include <platform/Linux/dbus/wpa/DBusWpaBss.h>
 #include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
 #include <platform/Linux/dbus/wpa/DBusWpaNetwork.h>
+#include <platform/NetworkCommissioning.h>
 #include <system/SystemMutex.h>
 
 #define WPA_SUPPLICANT_CLIENT_LOG_PREFIX "wpa_supplicant: "
@@ -173,6 +174,25 @@ protected:
      *
      */
     bool IsWiFiInterfaceEnabled() const noexcept CHIP_REQUIRES(mWpaSupplicantMutex);
+
+    /**
+     *  @brief
+     *    Get the Wi-Fi station service set identifier (SSID) and
+     *    connected state.
+     *
+     *  This attempts to get, if any, the currently connected (that
+     *  is, associated) Wi-Fi station service set identifier (SSID)
+     *  and connected state.
+     *
+     *  @param[out]  outNetwork
+     *    A reference to the mutable network commissioning state to
+     *    which to copy the currently connected Wi-Fi station SSID and
+     *    connected state.
+     *
+     *  @sa IsWiFiInterfaceEnabled
+     *
+     */
+    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork) noexcept;
 
     /**
      *  @brief


### PR DESCRIPTION
#### Summary

Per #42516 and [this overview](https://github.com/user-attachments/files/25854289/Matter.ConnectivityManager.Linux.Platform.Refactoring.html), this continues the work from #71694 and adds and leverages several methods to the recently-introduced and -leveraged wpa_supplicant client class:

### Added

* `IsWiFiInterfaceEnabled`
* `GetConfiguredNetwork`
* `GetIfName`
* `SetIfName`

### Leveraged

* `IsWiFiInterfaceEnabled`
* `GetConfiguredNetwork`

`GetIfName` and `SetIfName` will be leveraged in a subsequent pull request.

#### Related issues

#42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.4 Apple "Home" app with a wpa_supplicant implementation using this infrastructure.