### PR TITLE
Add Humidifier/Dehumidifier device type.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -222,7 +222,7 @@ limitations under the License.
         <scope>Endpoint</scope>
         <clusters>
             <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Humidistat" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Humidistat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Water Tank Level Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -212,6 +212,23 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-humidifierdehumidifier</name>
+        <domain>CHIP</domain>
+        <typeName>Humidifier/Dehumidifier</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x007D</deviceId>
+        <revision editable="false">1</revision>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Humidistat" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Water Tank Level Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-onofflight</name>
         <domain>CHIP</domain>
         <typeName>On/Off Light</typeName>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7144,6 +7144,7 @@ typedef NS_ENUM(uint32_t, MTRDeviceTypeIDType) {
     MTRDeviceTypeIDTypeExtractorHoodID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000007A,
     MTRDeviceTypeIDTypeOvenID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000007B,
     MTRDeviceTypeIDTypeLaundryDryerID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000007C,
+    MTRDeviceTypeIDTypeHumidifierDehumidifierID MTR_PROVISIONALLY_AVAILABLE = 0x0000007D,
     MTRDeviceTypeIDTypeNetworkInfrastructureManagerID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000090,
     MTRDeviceTypeIDTypeThreadBorderRouterID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000091,
     MTRDeviceTypeIDTypeOnOffLightID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000100,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -65,6 +65,7 @@ static /* constexpr */ const MTRDeviceTypeData knownDeviceTypes[] = {
     { 0x0000007A, MTRDeviceTypeClass::Simple, @"Extractor Hood" },
     { 0x0000007B, MTRDeviceTypeClass::Simple, @"Oven" },
     { 0x0000007C, MTRDeviceTypeClass::Simple, @"Laundry Dryer" },
+    { 0x0000007D, MTRDeviceTypeClass::Simple, @"Humidifier/Dehumidifier" },
     { 0x00000090, MTRDeviceTypeClass::Simple, @"Network Infrastructure Manager" },
     { 0x00000091, MTRDeviceTypeClass::Simple, @"Thread Border Router" },
     { 0x00000100, MTRDeviceTypeClass::Simple, @"On/Off Light" },

--- a/zzz_generated/app-common/devices/Ids.h
+++ b/zzz_generated/app-common/devices/Ids.h
@@ -149,6 +149,9 @@ constexpr uint8_t kOvenDeviceTypeRevision = 2;
 constexpr DeviceTypeId kLaundryDryerDeviceTypeId  = 0x0000007C;
 constexpr uint8_t kLaundryDryerDeviceTypeRevision = 2;
 
+constexpr DeviceTypeId kHumidifierDehumidifierDeviceTypeId  = 0x0000007D;
+constexpr uint8_t kHumidifierDehumidifierDeviceTypeRevision = 1;
+
 constexpr DeviceTypeId kNetworkInfrastructureManagerDeviceTypeId  = 0x00000090;
 constexpr uint8_t kNetworkInfrastructureManagerDeviceTypeRevision = 2;
 

--- a/zzz_generated/app-common/devices/Types.h
+++ b/zzz_generated/app-common/devices/Types.h
@@ -234,6 +234,11 @@ constexpr DataModel::DeviceTypeEntry kLaundryDryer = {
     .deviceTypeRevision = kLaundryDryerDeviceTypeRevision,
 };
 
+constexpr DataModel::DeviceTypeEntry kHumidifierDehumidifier = {
+    .deviceTypeId       = kHumidifierDehumidifierDeviceTypeId,
+    .deviceTypeRevision = kHumidifierDehumidifierDeviceTypeRevision,
+};
+
 constexpr DataModel::DeviceTypeEntry kNetworkInfrastructureManager = {
     .deviceTypeId       = kNetworkInfrastructureManagerDeviceTypeId,
     .deviceTypeRevision = kNetworkInfrastructureManagerDeviceTypeRevision,

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -7483,6 +7483,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Oven";
     case 0x0000007C:
         return "Laundry Dryer";
+    case 0x0000007D:
+        return "Humidifier/Dehumidifier";
     case 0x00000090:
         return "Network Infrastructure Manager";
     case 0x00000091:


### PR DESCRIPTION
#### Summary

This PR adds a new Humidifier/Dehumidifier device type for Matter. The device types XML file was generated using Alchemy.

Clusters:
- Humidistat (required)
- Relative Humidity Measurement (optional)
- Identify (optional)
- Fan Control( optional)
- Water Tank Level Monitoring (optional)

#### Related issues

n/a

#### Testing

- Verified generated manually.
- Built the SDK successfully.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase