### PR TITLE
ESP32: esp-idf v6.0 fixes for thread based SOCs

### DIFF
--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
 {
     Clear();
 
-    psa_status_t status = PSA_SUCCESS;
+    psa_status_t status     = PSA_SUCCESS;
     size_t key_size_in_bits = 256;
 
     // opaque reference for the efuse-stored ec key
@@ -74,7 +74,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
 
     // validate efuse block exists and has correct key purpose
     psa_key_id_t key_id = PSA_KEY_ID_NULL;
-    status = psa_import_key(&key_attr, reinterpret_cast<const uint8_t *>(&opaque_key), sizeof(opaque_key), &key_id);
+    status              = psa_import_key(&key_attr, reinterpret_cast<const uint8_t *>(&opaque_key), sizeof(opaque_key), &key_id);
     psa_reset_key_attributes(&key_attr);
 
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
@@ -88,8 +88,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length,
-                                            P256ECDSASignature & out_signature) const
+CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
@@ -102,8 +101,8 @@ CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t ms
     uint8_t signature[kP256_ECDSA_Signature_Length_Raw];
     size_t sig_len = 0;
 
-    psa_status_t status = psa_sign_hash(ctx->key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest, sizeof(digest), signature,
-                                        sizeof(signature), &sig_len);
+    psa_status_t status =
+        psa_sign_hash(ctx->key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest, sizeof(digest), signature, sizeof(signature), &sig_len);
 
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(Crypto, "psa_sign_hash failed, status:%d", static_cast<int>(status)));
@@ -111,7 +110,6 @@ CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t ms
 
     memcpy(out_signature.Bytes(), signature, sig_len);
     return out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw);
-
 }
 
 } // namespace Crypto
@@ -198,8 +196,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length,
-                                            P256ECDSASignature & out_signature) const
+CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -52,8 +52,25 @@ static inline const PsaEcdsaContext * to_const_psa_ctx(const chip::Crypto::P256K
 namespace chip {
 namespace Crypto {
 
+ESP32P256Keypair::~ESP32P256Keypair()
+{
+    if (mInitialized)
+    {
+        const PsaEcdsaContext * ctx = to_const_psa_ctx(&mKeypair);
+        psa_destroy_key(ctx->key_id);
+    }
+}
+
 CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
 {
+    VerifyOrReturnError(efuseBlock >= 0 && efuseBlock <= UINT8_MAX, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Destroy existing PSA key handle if re-initializing
+    if (mInitialized)
+    {
+        PsaEcdsaContext * ctx = to_psa_ctx(&mKeypair);
+        psa_destroy_key(ctx->key_id);
+    }
     Clear();
 
     psa_status_t status     = PSA_SUCCESS;
@@ -166,6 +183,11 @@ static void _log_mbedTLS_error(int error_code)
 
 namespace chip {
 namespace Crypto {
+
+ESP32P256Keypair::~ESP32P256Keypair()
+{
+    // Base class destructor calls Clear() which handles mbedtls_ecp_keypair_free
+}
 
 CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
 {

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2023-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,107 @@
 #include <lib/core/CHIPSafeCasts.h>
 #include <platform/ESP32/ESP32CHIPCryptoPAL.h>
 
+#include <esp_idf_version.h>
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+
+// ESP-IDF v6.0+ uses PSA Crypto for hardware ECDSA operations
+#include <psa/crypto.h>
+#include <psa_crypto_driver_esp_ecdsa.h>
+
+namespace {
+
+struct PsaEcdsaContext
+{
+    psa_key_id_t key_id;
+};
+
+static_assert(sizeof(PsaEcdsaContext) <= chip::Crypto::kMAX_P256Keypair_Context_Size,
+              "PsaEcdsaContext exceeds P256KeypairContext size");
+
+static inline PsaEcdsaContext * to_psa_ctx(chip::Crypto::P256KeypairContext * context)
+{
+    return chip::SafePointerCast<PsaEcdsaContext *>(context);
+}
+
+static inline const PsaEcdsaContext * to_const_psa_ctx(const chip::Crypto::P256KeypairContext * context)
+{
+    return chip::SafePointerCast<const PsaEcdsaContext *>(context);
+}
+
+} // anonymous namespace
+
+namespace chip {
+namespace Crypto {
+
+CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
+{
+    Clear();
+
+    psa_status_t status = PSA_SUCCESS;
+    size_t key_size_in_bits = 256;
+
+    // opaque reference for the efuse-stored ec key
+    esp_ecdsa_opaque_key_t opaque_key = {};
+    opaque_key.curve                  = ESP_ECDSA_CURVE_SECP256R1;
+    opaque_key.efuse_block            = static_cast<uint8_t>(efuseBlock);
+    opaque_key.use_km_key             = false;
+
+    psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+    psa_set_key_type(&key_attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+    psa_set_key_bits(&key_attr, key_size_in_bits);
+    psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_SIGN_HASH);
+    psa_set_key_algorithm(&key_attr, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+    psa_set_key_lifetime(&key_attr, PSA_KEY_LIFETIME_ESP_ECDSA_VOLATILE);
+
+    // validate efuse block exists and has correct key purpose
+    psa_key_id_t key_id = PSA_KEY_ID_NULL;
+    status = psa_import_key(&key_attr, reinterpret_cast<const uint8_t *>(&opaque_key), sizeof(opaque_key), &key_id);
+    psa_reset_key_attributes(&key_attr);
+
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(Crypto, "psa_import_key failed, status:%d", static_cast<int>(status)));
+
+    // store key id in the keypair context
+    PsaEcdsaContext * ctx = to_psa_ctx(&mKeypair);
+    ctx->key_id           = key_id;
+
+    mInitialized = true;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length,
+                                            P256ECDSASignature & out_signature) const
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
+    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Compute SHA256 hash
+    uint8_t digest[kSHA256_Hash_Length];
+    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, digest));
+
+    const PsaEcdsaContext * ctx = to_const_psa_ctx(&mKeypair);
+    uint8_t signature[kP256_ECDSA_Signature_Length_Raw];
+    size_t sig_len = 0;
+
+    psa_status_t status = psa_sign_hash(ctx->key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest, sizeof(digest), signature,
+                                        sizeof(signature), &sig_len);
+
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(Crypto, "psa_sign_hash failed, status:%d", static_cast<int>(status)));
+    VerifyOrReturnError(sig_len == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INTERNAL);
+
+    memcpy(out_signature.Bytes(), signature, sig_len);
+    return out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw);
+
+}
+
+} // namespace Crypto
+} // namespace chip
+
+#else // ESP_IDF_VERSION < 6.0.0
+
+// Legacy implementation using mbedTLS ECDSA alt for IDF < 6.0
 #include <ecdsa/ecdsa_alt.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/ctr_drbg.h>
@@ -97,7 +198,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
+CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length,
+                                            P256ECDSASignature & out_signature) const
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
@@ -145,3 +247,5 @@ exit:
 
 } // namespace Crypto
 } // namespace chip
+
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -55,10 +55,13 @@ namespace Crypto {
 
 ESP32P256Keypair::~ESP32P256Keypair()
 {
+    // Destroy PSA key handle before base destructor runs P256Keypair::Clear().
+    // Base Clear() checks mInitialized and skips mbedTLS free once we set it false.
     if (mInitialized)
     {
-        const PsaEcdsaContext * ctx = to_const_psa_ctx(&mKeypair);
+        PsaEcdsaContext * ctx = to_psa_ctx(&mKeypair);
         psa_destroy_key(ctx->key_id);
+        mInitialized = false;
     }
 }
 
@@ -73,7 +76,6 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
         psa_destroy_key(ctx->key_id);
         mInitialized = false;
     }
-    Clear();
 
     psa_status_t status     = PSA_SUCCESS;
     size_t key_size_in_bits = 256;

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -71,6 +71,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
     {
         PsaEcdsaContext * ctx = to_psa_ctx(&mKeypair);
         psa_destroy_key(ctx->key_id);
+        mInitialized = false;
     }
     Clear();
 

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -26,6 +26,7 @@
 // ESP-IDF v6.0+ uses PSA Crypto for hardware ECDSA operations
 #include <psa/crypto.h>
 #include <psa_crypto_driver_esp_ecdsa.h>
+#include <rom/efuse.h>
 
 namespace {
 
@@ -63,7 +64,7 @@ ESP32P256Keypair::~ESP32P256Keypair()
 
 CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
 {
-    VerifyOrReturnError(efuseBlock >= 0 && efuseBlock <= UINT8_MAX, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(efuseBlock >= 0 && efuseBlock < ETS_EFUSE_BLOCK_MAX, CHIP_ERROR_INVALID_ARGUMENT);
 
     // Destroy existing PSA key handle if re-initializing
     if (mInitialized)

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -81,10 +81,9 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
     size_t key_size_in_bits = 256;
 
     // opaque reference for the efuse-stored ec key
-    esp_ecdsa_opaque_key_t opaque_key = {};
+    esp_ecdsa_opaque_key_t opaque_key = { 0 };
     opaque_key.curve                  = ESP_ECDSA_CURVE_SECP256R1;
     opaque_key.efuse_block            = static_cast<uint8_t>(efuseBlock);
-    opaque_key.use_km_key             = false;
 
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
     psa_set_key_type(&key_attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.h
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.h
@@ -30,6 +30,8 @@ namespace Crypto {
 class ESP32P256Keypair : public P256Keypair
 {
 public:
+    ~ESP32P256Keypair();
+
     using P256Keypair::Initialize;
 
     /**

--- a/src/platform/ESP32/ESP32DnssdImpl.cpp
+++ b/src/platform/ESP32/ESP32DnssdImpl.cpp
@@ -413,8 +413,15 @@ static CHIP_ERROR ParseIPAddresses(ResolveContext * ctx)
             auto * addr = ctx->mAddrQueryResult->addr;
             while (addr)
             {
-                LogErrorOnFailure(GetIPAddress(ctx->mAddresses[addressIndex], addr));
-                addressIndex++;
+                CHIP_ERROR err = GetIPAddress(ctx->mAddresses[addressIndex], addr);
+                if (err == CHIP_NO_ERROR)
+                {
+                    addressIndex++;
+                }
+                else
+                {
+                    ChipLogError(DeviceLayer, "GetIPAddress failed, error:%" CHIP_ERROR_FORMAT, err.Format());
+                }
                 addr = addr->next;
             }
             return CHIP_NO_ERROR;

--- a/src/platform/ESP32/ESP32DnssdImpl.cpp
+++ b/src/platform/ESP32/ESP32DnssdImpl.cpp
@@ -413,7 +413,7 @@ static CHIP_ERROR ParseIPAddresses(ResolveContext * ctx)
             auto * addr = ctx->mAddrQueryResult->addr;
             while (addr)
             {
-                GetIPAddress(ctx->mAddresses[addressIndex], addr);
+                LogErrorOnFailure(GetIPAddress(ctx->mAddresses[addressIndex], addr));
                 addressIndex++;
                 addr = addr->next;
             }
@@ -494,7 +494,9 @@ exit:
     {
         ctx->mResolveCb(ctx->mCbContext, ctx->mService, Span<Inet::IPAddress>(ctx->mAddresses, ctx->mAddressCount), error);
     }
-    RemoveMdnsQuery(reinterpret_cast<GenericContext *>(ctx));
+    // This removes the query from the list and frees the memory, so returning the
+    // error code from above rather than the one when removing the query to avoid losing the original error.
+    LogErrorOnFailure(RemoveMdnsQuery(reinterpret_cast<GenericContext *>(ctx)));
     return error;
 }
 
@@ -531,7 +533,7 @@ static void MdnsQueryDone(intptr_t context)
     {
         BrowseContext * browseCtx  = reinterpret_cast<BrowseContext *>(ctx);
         browseCtx->mPtrQueryResult = result;
-        OnBrowseDone(browseCtx);
+        LogErrorOnFailure(OnBrowseDone(browseCtx));
     }
     else if (ctx->mContextType == ContextType::Resolve)
     {
@@ -550,7 +552,7 @@ static void MdnsQueryDone(intptr_t context)
             if (!result)
             {
                 resolveCtx->mResolveCb(ctx->mCbContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INVALID_ARGUMENT);
-                RemoveMdnsQuery(ctx);
+                LogErrorOnFailure(RemoveMdnsQuery(ctx));
                 return;
             }
             // If SRV Query Result is empty, the result is for SRV Query.
@@ -572,7 +574,7 @@ static void MdnsQueryDone(intptr_t context)
                     if (!resolveCtx->mSrvQueryHandle)
                     {
                         resolveCtx->mResolveCb(ctx->mCbContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_NO_MEMORY);
-                        RemoveMdnsQuery(ctx);
+                        LogErrorOnFailure(RemoveMdnsQuery(ctx));
                         return;
                     }
                 }
@@ -585,7 +587,7 @@ static void MdnsQueryDone(intptr_t context)
             else
             {
                 resolveCtx->mResolveCb(ctx->mCbContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INCORRECT_STATE);
-                RemoveMdnsQuery(ctx);
+                LogErrorOnFailure(RemoveMdnsQuery(ctx));
                 return;
             }
         }
@@ -604,14 +606,14 @@ static void MdnsQueryDone(intptr_t context)
         }
         if (resolveCtx->mTxtQueryFinished && resolveCtx->mSrvAddrQueryFinished)
         {
-            OnResolveDone(resolveCtx);
+            LogErrorOnFailure(OnResolveDone(resolveCtx));
         }
     }
 }
 
 static void MdnsQueryNotifier(mdns_search_once_t * searchHandle)
 {
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(MdnsQueryDone, reinterpret_cast<intptr_t>(searchHandle));
+    LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().ScheduleWork(MdnsQueryDone, reinterpret_cast<intptr_t>(searchHandle)));
 }
 
 CHIP_ERROR EspDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,

--- a/src/platform/ESP32/ESP32DnssdImpl.cpp
+++ b/src/platform/ESP32/ESP32DnssdImpl.cpp
@@ -424,6 +424,7 @@ static CHIP_ERROR ParseIPAddresses(ResolveContext * ctx)
                 }
                 addr = addr->next;
             }
+            ctx->mAddressCount = addressIndex;
             return CHIP_NO_ERROR;
         }
     }

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -122,7 +122,11 @@ void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t even
         case IP_EVENT_GOT_IP6:
             memcpy(&event.Platform.ESPSystemEvent.Data.IpGotIp6, eventData, sizeof(event.Platform.ESPSystemEvent.Data.IpGotIp6));
             break;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+        case IP_EVENT_ASSIGNED_IP_TO_CLIENT:
+#else
         case IP_EVENT_AP_STAIPASSIGNED:
+#endif
             memcpy(&event.Platform.ESPSystemEvent.Data.IpApStaIpAssigned, eventData,
                    sizeof(event.Platform.ESPSystemEvent.Data.IpApStaIpAssigned));
             break;

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -2073,7 +2073,7 @@ void BLEManagerImpl::OnDeviceScanned(const ble_addr_t & addr, const chip::Ble::C
     DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds16(kConnectTimeout), HandleConnectTimeout, nullptr);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    mDeviceScanner.StopScan();
+    LogErrorOnFailure(mDeviceScanner.StopScan());
 
     ConnectDevice(addr, kConnectTimeout);
 }
@@ -2144,7 +2144,7 @@ void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const S
     mBLEScanConfig.mAppState      = appState;
 
     // Initiate async scan
-    PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));
+    LogErrorOnFailure(PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator)));
 }
 
 CHIP_ERROR BLEManagerImpl::CancelConnection()

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
@@ -217,6 +217,7 @@ CHIP_ERROR GenericOpenThreadBorderRouterDelegate::SetPendingDataset(const Thread
     VerifyOrReturnError(otInst, CHIP_ERROR_INCORRECT_STATE);
 
     otOperationalDatasetTlvs datasetTlvs;
+    VerifyOrReturnError(pendingDataset.AsByteSpan().size() <= sizeof(datasetTlvs.mTlvs), CHIP_ERROR_INVALID_ARGUMENT);
     memcpy(datasetTlvs.mTlvs, pendingDataset.AsByteSpan().data(), pendingDataset.AsByteSpan().size());
     datasetTlvs.mLength = static_cast<uint8_t>(pendingDataset.AsByteSpan().size());
     {

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR GenericOpenThreadBorderRouterDelegate::SetPendingDataset(const Thread
 
     otOperationalDatasetTlvs datasetTlvs;
     memcpy(datasetTlvs.mTlvs, pendingDataset.AsByteSpan().data(), pendingDataset.AsByteSpan().size());
-    datasetTlvs.mLength = pendingDataset.AsByteSpan().size();
+    datasetTlvs.mLength = static_cast<uint8_t>(pendingDataset.AsByteSpan().size());
     {
         ScopedThreadLock threadLock;
         VerifyOrReturnError(otDatasetSetPendingTlvs(otInst, &datasetTlvs) == OT_ERROR_NONE, CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
#### Summary

While testing the ESP32-H2, came across a few more build failures. Also H2 contains the ECDSA secure element, so it needs a PSA API based implementation for `ECDSA_sign_msg()` during device attestation process.

- implemented the `ECDSA_sign_msg()` using PSA APIs for SOCs supporting ecdsa hardware signing
- fixed a few CHIP_ERROR nodiscard
- handled deprecated event enum IP_EVENT_AP_STAIPASSIGNED for v6.0
- fixed the implicit conversion from size_t to uint8_t

#### Testing

- Tested building the examples/lighting-app/esp32 with H2
- On H2, enabled the secure cert dac provider and a factory provider options, generated these partition, and flashed them, verified that commissioning works using chip-tool. (referred https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/esp32/secure_cert_partition.md guide for test steps)