### PR TITLE
[Telink] Adopt  TELINK_TLX_SHA_HW_SLOTS value for TLX SoCs

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -522,6 +522,7 @@ config MBEDTLS_PSA_CRYPTO_C
     default n
 
 config TELINK_TLX_SHA_HW_SLOTS
+    int
     default 8 if SOC_RISCV_TELINK_TLX
 
 endif # !ZEPHYR_VERSION_3_3

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -521,6 +521,9 @@ config MBEDTLS_PSA_CRYPTO_C
     bool "MBEDTLS_PSA_CRYPTO_C"
     default n
 
+config TELINK_TLX_SHA_HW_SLOTS
+    default 8 if SOC_RISCV_TELINK_TLX
+
 endif # !ZEPHYR_VERSION_3_3
 
 config GETOPT_LONG


### PR DESCRIPTION
#### Summary

Adopt  TELINK_TLX_SHA_HW_SLOTS value for TLX SoCs to fix Received error (protocol code 2) during pairing process: 54

#### Testing

- Builds verified by GitHub CI
- Tested manually by initiating OTA process using TLX SoCs