### PR TITLE
Fix TestServer flake by filtering event in handler

### DIFF
--- a/src/app/tests/TestServer.cpp
+++ b/src/app/tests/TestServer.cpp
@@ -36,8 +36,6 @@ public:
     {
         ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
-        // Clear any leaked fail-safe state from previous test suites
-        Server::GetInstance().GetFailSafeContext().DisarmFailSafe();
     }
     static void TearDownTestSuite()
     {
@@ -46,21 +44,24 @@ public:
     }
 };
 
-class TestEventHandler
+class TestFactoryResetEventHandler
 {
 public:
     ChipDeviceEvent mEvent{};
 
     static void EventHandler(const ChipDeviceEvent * event, intptr_t arg)
     {
-        reinterpret_cast<TestEventHandler *>(arg)->mEvent = *event;
+        if (event->Type == DeviceEventType::kFactoryReset)
+        {
+            reinterpret_cast<TestFactoryResetEventHandler *>(arg)->mEvent = *event;
+        }
     }
 };
 
 TEST_F(TestServer, TestFactoryResetEvent)
 {
-    TestEventHandler handler;
-    EXPECT_SUCCESS(PlatformMgr().AddEventHandler(TestEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler)));
+    TestFactoryResetEventHandler handler;
+    EXPECT_SUCCESS(PlatformMgr().AddEventHandler(TestFactoryResetEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler)));
 
     Server::GetInstance().ScheduleFactoryReset();
 
@@ -70,7 +71,7 @@ TEST_F(TestServer, TestFactoryResetEvent)
 
     EXPECT_EQ(handler.mEvent.Type, DeviceEventType::kFactoryReset);
 
-    PlatformMgr().RemoveEventHandler(TestEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler));
+    PlatformMgr().RemoveEventHandler(TestFactoryResetEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler));
 }
 
 } // namespace server


### PR DESCRIPTION
This PR fixes the flake in `TestServer.TestFactoryResetEvent` by having the event handler filter for `kFactoryReset` instead of capturing any event. Unrelated events (like leaked fail-safe timers) will no longer clobber the captured test event. Also renames the class to `TestFactoryResetEventHandler` for clarity.

This happened frequently in the nRF tests CI job because it uses a monolith of tests and a singleton object. We're likely leaking events/not cleaning up timers properly from one test to another.

<img width="1059" height="226" alt="image (13)" src="https://github.com/user-attachments/assets/0e0446ca-0501-4618-a1f6-e1a3b5cdbb75" />


### Testing
Tested locally in Zephyr native simulator container.