### PR TITLE
[devcontainers] Add nano, ripgrep and time

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,8 +43,11 @@ RUN apt-get update \
         icecc \
         iputils-ping \
         lsb-release \
+        nano \
         openssh-client \
+        ripgrep \
         sudo \
+        time \
         valgrind \
         vim \
         zsh \


### PR DESCRIPTION
#### Summary

Add a few additional packages to the devcontainer environment:

- `nano` – we already have `vim`, and `nano` is the preferred editor for some (and default in Ubuntu, so people might be expecting it).
- `ripgrep` – frequently used by AI agents instead of `grep`.
- `time` – useful for local benchmarks and performance evaluation (used in #72018)

#### Related issues

None

#### Testing

Local devcontainer setup with VS Code.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
