### PR TITLE
Darwin: Use Linux PCSC NFCCommissioningManagerImpl on Mac

### DIFF
--- a/src/darwin/Framework/Configs/Matter.xcconfig
+++ b/src/darwin/Framework/Configs/Matter.xcconfig
@@ -33,7 +33,7 @@ OTHER_LDFLAGS = $(inherited) -Wl,-hidden-lCHIP // don't export any symbols from 
 
 OTHER_LDFLAGS = $(inherited) $(LDFLAGS_COMMON_LIBRARIES) $(LDFLAGS_PLATFORM_LIBRARIES) // dependencies
 LDFLAGS_COMMON_LIBRARIES = -framework Foundation -framework Security -framework CoreData -framework CoreBluetooth -lnetwork
-LDFLAGS_PLATFORM_LIBRARIES[sdk=macosx*] = -framework IOKit -framework CoreWLAN -framework SystemConfiguration
+LDFLAGS_PLATFORM_LIBRARIES[sdk=macosx*] = -framework IOKit -framework CoreWLAN -framework SystemConfiguration -framework PCSC
 
 STRIP_STYLE = non-global
 VERSION_INFO_EXPORT_DECL = __attribute__((visibility("hidden")))

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		3D010DCF2D408FA300CFFA02 /* MTRCommissioneeInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3D010DCE2D408FA300CFFA02 /* MTRCommissioneeInfo.mm */; };
 		3D010DD02D408FA300CFFA02 /* MTRCommissioneeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D010DCD2D408FA300CFFA02 /* MTRCommissioneeInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D010DD22D4091CC00CFFA02 /* MTRCommissioneeInfo_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D010DD12D4091C800CFFA02 /* MTRCommissioneeInfo_Internal.h */; };
+		3D09F1292FD785B70056DBAD /* PCSC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D09F1282FD785B70056DBAD /* PCSC.framework */; platformFilters = (macos, ); };
 		3D0C484B29DA4FA0006D811F /* MTRErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */; };
 		3D3928D72BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D3928D62BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m */; settings = {COMPILER_FLAGS = "-UMTR_NO_AVAILABILITY -Wno-unguarded-availability-new"; }; };
 		3D4733AF2BDF1B80003DC19B /* MTRSetupPayloadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D4733AE2BDF1B80003DC19B /* MTRSetupPayloadTests.m */; };
@@ -667,6 +668,7 @@
 		3D010DCD2D408FA300CFFA02 /* MTRCommissioneeInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioneeInfo.h; sourceTree = "<group>"; };
 		3D010DCE2D408FA300CFFA02 /* MTRCommissioneeInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommissioneeInfo.mm; sourceTree = "<group>"; };
 		3D010DD12D4091C800CFFA02 /* MTRCommissioneeInfo_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioneeInfo_Internal.h; sourceTree = "<group>"; };
+		3D09F1282FD785B70056DBAD /* PCSC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PCSC.framework; path = System/Library/Frameworks/PCSC.framework; sourceTree = SDKROOT; };
 		3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRErrorTests.m; sourceTree = "<group>"; };
 		3D3928D62BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRAvailabilityTests.m; sourceTree = "<group>"; };
 		3D4733AE2BDF1B80003DC19B /* MTRSetupPayloadTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRSetupPayloadTests.m; sourceTree = "<group>"; };
@@ -1190,6 +1192,7 @@
 				B4382F8B2D6F554B00F79AFC /* HomeKit.framework in Frameworks */,
 				039145E52993124800257B3E /* SystemConfiguration.framework in Frameworks */,
 				039145E3299311FF00257B3E /* IOKit.framework in Frameworks */,
+				3D09F1292FD785B70056DBAD /* PCSC.framework in Frameworks */,
 				039546962991CEEC006D42A8 /* libCHIP.a in Frameworks */,
 				037C3D742991B32700B7EEE2 /* Matter.framework in Frameworks */,
 				037C3CA72991A44B00B7EEE2 /* Foundation.framework in Frameworks */,
@@ -2179,6 +2182,7 @@
 		BA09EB3E2474762900605257 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3D09F1282FD785B70056DBAD /* PCSC.framework */,
 				B46C4AA72D6CD2580024F65E /* HomeKit.framework */,
 				B4382F8A2D6F554B00F79AFC /* HomeKit.framework */,
 				039145EF29931B2D00257B3E /* CoreBluetooth.framework */,

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -251,9 +251,10 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  *  }
  *  @endcode
  *
- *  @param[in]  aValue    64-bit value that will be split in 32-bit MSB/LSB part
+ *  @param[in]  aValue    unsigned 64-bit value that will be split in 32-bit MSB/LSB part
  */
-#define ChipLogValueX64(aValue) static_cast<uint32_t>(aValue >> 32), static_cast<uint32_t>(aValue)
+#define ChipLogValueX64(aValue)                                                                                                    \
+    static_cast<uint32_t>(static_cast<uint64_t>(aValue) >> 32), static_cast<uint32_t>(static_cast<uint64_t>(aValue))
 
 /*
  *  @brief

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -48,6 +48,9 @@ config("darwin_config") {
       "CoreWLAN.framework",
       "IOKit.framework",
     ]
+    if (chip_enable_nfc_based_commissioning) {
+      frameworks += [ "PCSC.framework" ]
+    }
   }
 
   cflags = [ "-Wconversion" ]
@@ -159,10 +162,18 @@ static_library("Darwin") {
   }
 
   if (chip_enable_nfc_based_commissioning) {
-    sources += [
-      "NFCCommissioningManagerImpl.cpp",
-      "NFCCommissioningManagerImpl.h",
-    ]
+    if (current_os == "mac") {
+      # On macOS, use the Linux PC/SC-based implementation
+      sources += [
+        "../Linux/NFCCommissioningManagerImpl.cpp",
+        "../Linux/NFCCommissioningManagerImpl.h",
+      ]
+    } else {
+      sources += [
+        "NFCCommissioningManagerImpl.cpp",
+        "NFCCommissioningManagerImpl.h",
+      ]
+    }
 
     deps += [ "${chip_root}/src/transport/raw:nfc-application-delegate" ]
   }

--- a/src/platform/Darwin/NFCCommissioningManagerImpl.h
+++ b/src/platform/Darwin/NFCCommissioningManagerImpl.h
@@ -23,6 +23,13 @@
 
 #pragma once
 
+#include <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+// On macOS, use the Linux PC/SC-based implementation
+#include <platform/Linux/NFCCommissioningManagerImpl.h>
+#else
+
 #include <platform/internal/NFCCommissioningManager.h>
 #include <transport/raw/NfcApplicationDelegate.h>
 
@@ -73,3 +80,5 @@ private:
 } // namespace chip
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
+
+#endif // TARGET_OS_OSX

--- a/src/platform/Linux/NFCCommissioningManagerImpl.cpp
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.cpp
@@ -73,8 +73,6 @@ namespace {} // namespace
         return CHIP_ERROR_INTERNAL;                                                                                                \
     }
 
-static SCARD_IO_REQUEST pioSendPci;
-
 // This NFC Tag contains all the variables, handles and buffers related to one NFC tag instance
 class TagInstance
 {
@@ -83,6 +81,7 @@ private:
     const Transport::PeerAddress peerAddress;
     char * readerName;
     SCARDHANDLE cardHandle;
+    const SCARD_IO_REQUEST * pioSendPci;
     uint16_t discriminator;
 
     bool mIsValid = true;
@@ -99,8 +98,9 @@ private:
     uint32_t mChainedResponseLength = 0;
 
 public:
-    TagInstance(Transport::NFCBase * base, const Transport::PeerAddress address, const char * name, SCARDHANDLE handle) :
-        nfcBase(base), peerAddress(address), cardHandle(handle)
+    TagInstance(Transport::NFCBase * base, const Transport::PeerAddress address, const char * name, SCARDHANDLE handle,
+                const SCARD_IO_REQUEST * sendPci) :
+        nfcBase(base), peerAddress(address), cardHandle(handle), pioSendPci(sendPci)
     {
         readerName    = strdup(name); // Allocate memory and copy the string
         discriminator = 0;            // Will be retrieved when RetrieveDiscriminator() is called
@@ -361,7 +361,7 @@ public:
             0x00                                                  // Le
         };
 
-        LONG result = SCardTransmit(cardHandle, &pioSendPci, select_matter_applet, sizeof(select_matter_applet), NULL, dataReceived,
+        LONG result = SCardTransmit(cardHandle, pioSendPci, select_matter_applet, sizeof(select_matter_applet), NULL, dataReceived,
                                     &receivedLength);
         if (result == SCARD_S_SUCCESS)
         {
@@ -463,7 +463,7 @@ public:
         // After the transceive, they will contain the length of the received data.
         DWORD dwRecvLength = static_cast<DWORD>(*pRcvLength);
 
-        LONG result = SCardTransmit(cardHandle, &pioSendPci, pSendBuffer, sendBufferLength, NULL, pRcvBuffer, &dwRecvLength);
+        LONG result = SCardTransmit(cardHandle, pioSendPci, pSendBuffer, sendBufferLength, NULL, pRcvBuffer, &dwRecvLength);
 
         if ((result == SCARD_S_SUCCESS) && (dwRecvLength >= 2))
         {
@@ -536,13 +536,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-SCARDCONTEXT hPcscContext;
-std::shared_ptr<TagInstance> lastTagInstanceUsed;
-
-// Empty vector of TagInstance pointers
-std::vector<std::shared_ptr<TagInstance>> tagInstances;
-
-NFCCommissioningManagerImpl NFCCommissioningManagerImpl::sInstance;
+Global<NFCCommissioningManagerImpl> NFCCommissioningManagerImpl::sInstance;
 
 // ===== start impl of NFCCommissioningManager internal interface, ref NFCCommissioningManager.h
 
@@ -577,10 +571,10 @@ CHIP_ERROR NFCCommissioningManagerImpl::EnsureProcessingThreadStarted()
     }
 
     // Creates an Application Context to the PC/SC Resource Manager.
-    LONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM, NULL, NULL, &hPcscContext);
+    LONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM, NULL, NULL, &mPcscContext);
     CHECK_FOR_SCARD_SUCCESS("SCardEstablishContext", result)
 
-    lastTagInstanceUsed = nullptr;
+    mLastTagInstanceUsed = nullptr;
 
     // Start the NFC processing thread
     mThreadRunning = true;
@@ -608,8 +602,8 @@ bool NFCCommissioningManagerImpl::CanSendToPeer(const Transport::PeerAddress & a
     // nfcShortId is used to find the peer device
     uint16_t nfcShortId = address.GetNFCShortId();
 
-    // Check if lastTagInstanceUsed corresponds to the same nfcShortId
-    if ((lastTagInstanceUsed != nullptr) && (lastTagInstanceUsed->GetDiscriminator() == nfcShortId))
+    // Check if mLastTagInstanceUsed corresponds to the same nfcShortId
+    if ((mLastTagInstanceUsed != nullptr) && (mLastTagInstanceUsed->GetDiscriminator() == nfcShortId))
     {
         return true;
     }
@@ -636,7 +630,7 @@ bool NFCCommissioningManagerImpl::CanSendToPeer(const Transport::PeerAddress & a
     }
 
     // Save the pointer to this TagInstance for a faster access at next call
-    lastTagInstanceUsed = tagInstance;
+    mLastTagInstanceUsed = tagInstance;
 
     return canSendToPeer;
 }
@@ -659,10 +653,10 @@ CHIP_ERROR NFCCommissioningManagerImpl::SendToNfcTag(const Transport::PeerAddres
     // nfcShortId is used to find the peer device
     uint16_t nfcShortId = address.GetNFCShortId();
 
-    // Check if lastTagInstanceUsed corresponds to the same nfcShortId
-    if ((lastTagInstanceUsed != nullptr) && (lastTagInstanceUsed->GetDiscriminator() == nfcShortId))
+    // Check if mLastTagInstanceUsed corresponds to the same nfcShortId
+    if ((mLastTagInstanceUsed != nullptr) && (mLastTagInstanceUsed->GetDiscriminator() == nfcShortId))
     {
-        targetedTagInstance = lastTagInstanceUsed;
+        targetedTagInstance = mLastTagInstanceUsed;
     }
     else
     {
@@ -737,7 +731,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanAllReaders(uint16_t nfcShortId)
     LPTSTR mszReaders; // LPTSTR is a "typedef char *"
     DWORD dwReaders;
 
-    result = SCardListReaders(hPcscContext, NULL, NULL, &dwReaders);
+    result = SCardListReaders(mPcscContext, NULL, NULL, &dwReaders);
     CHECK_FOR_SCARD_SUCCESS("SCardListReaders", result)
 
     // dwReaders now contains "mszReaders" data size
@@ -749,7 +743,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanAllReaders(uint16_t nfcShortId)
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    result = SCardListReaders(hPcscContext, NULL, mszReaders, &dwReaders);
+    result = SCardListReaders(mPcscContext, NULL, mszReaders, &dwReaders);
     CHECK_FOR_SCARD_SUCCESS("SCardListReaders", result)
 
     // "mszReaders" contains a multi-string with list of readers.
@@ -791,19 +785,21 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
     // Before launching a new scan of a reader, we should discard all the saved instances using this readerName
     EraseAllTagInstancesUsingReaderName(readerName);
 
-    LONG result = SCardConnect(hPcscContext, readerName, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, &cardHandle,
+    LONG result = SCardConnect(mPcscContext, readerName, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, &cardHandle,
                                &dwActiveProtocol);
     switch (result)
     {
     case static_cast<LONG>(SCARD_S_SUCCESS):
+    {
+        const SCARD_IO_REQUEST * sendPci = nullptr;
         switch (dwActiveProtocol)
         {
         case static_cast<DWORD>(SCARD_PROTOCOL_T0):
-            pioSendPci = *SCARD_PCI_T0;
+            sendPci = SCARD_PCI_T0;
             break;
 
         case static_cast<DWORD>(SCARD_PROTOCOL_T1):
-            pioSendPci = *SCARD_PCI_T1;
+            sendPci = SCARD_PCI_T1;
             break;
         }
 
@@ -817,12 +813,13 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
         {
             // This couple (readerName, cardHandle) is not known yet: Create a new TagInstance
             auto newTagInstance =
-                std::make_shared<TagInstance>(mNFCBase, Transport::PeerAddress::NFC(nfcShortId), readerName, cardHandle);
+                std::make_shared<TagInstance>(mNFCBase, Transport::PeerAddress::NFC(nfcShortId), readerName, cardHandle, sendPci);
 
             ReturnErrorOnFailure(newTagInstance->RetrieveDiscriminator());
 
-            tagInstances.push_back(newTagInstance);
+            mTagInstances.push_back(newTagInstance);
         }
+    }
         break;
 
     case static_cast<LONG>(SCARD_E_NO_SMARTCARD):
@@ -842,7 +839,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
 std::shared_ptr<TagInstance> NFCCommissioningManagerImpl::SearchTagInstanceFromReaderNameAndCardHandle(const char * readerName,
                                                                                                        SCARDHANDLE cardHandle)
 {
-    for (auto & instance : tagInstances)
+    for (auto & instance : mTagInstances)
     {
         if (strcmp(instance->GetReaderName(), readerName) == 0 && instance->GetCardHandle() == cardHandle)
         {
@@ -855,7 +852,7 @@ std::shared_ptr<TagInstance> NFCCommissioningManagerImpl::SearchTagInstanceFromR
 // Function to search for a TagInstance based on discriminator
 std::shared_ptr<TagInstance> NFCCommissioningManagerImpl::SearchTagInstanceFromDiscriminator(uint16_t discriminator)
 {
-    for (auto & instance : tagInstances)
+    for (auto & instance : mTagInstances)
     {
         if (instance->GetDiscriminator() == discriminator)
         {
@@ -868,19 +865,19 @@ std::shared_ptr<TagInstance> NFCCommissioningManagerImpl::SearchTagInstanceFromD
 // Erase all the TagInstance(s) using the given readerName
 void NFCCommissioningManagerImpl::EraseAllTagInstancesUsingReaderName(const char * readerName)
 {
-    if ((lastTagInstanceUsed != nullptr) && (strcmp(lastTagInstanceUsed->GetReaderName(), readerName) == 0))
+    if ((mLastTagInstanceUsed != nullptr) && (strcmp(mLastTagInstanceUsed->GetReaderName(), readerName) == 0))
     {
-        lastTagInstanceUsed = nullptr;
+        mLastTagInstanceUsed = nullptr;
     }
 
-    for (auto it = tagInstances.begin(); it != tagInstances.end();)
+    for (auto it = mTagInstances.begin(); it != mTagInstances.end();)
     {
         if (strcmp((*it)->GetReaderName(), readerName) == 0)
         {
             (*it)->Invalidate(); // Mark as invalid before erasing
-            // tagInstance will be deleted automatically when both the tagInstances vector
+            // tagInstance will be deleted automatically when both the mTagInstances vector
             //  and the message queue will no more use it.
-            it = tagInstances.erase(it);
+            it = mTagInstances.erase(it);
         }
         else
         {

--- a/src/platform/Linux/NFCCommissioningManagerImpl.cpp
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.cpp
@@ -100,7 +100,8 @@ private:
 public:
     TagInstance(Transport::NFCBase * base, const Transport::PeerAddress address, const char * name, SCARDHANDLE handle,
                 const SCARD_IO_REQUEST * sendPci) :
-        nfcBase(base), peerAddress(address), cardHandle(handle), pioSendPci(sendPci)
+        nfcBase(base),
+        peerAddress(address), cardHandle(handle), pioSendPci(sendPci)
     {
         readerName    = strdup(name); // Allocate memory and copy the string
         discriminator = 0;            // Will be retrieved when RetrieveDiscriminator() is called
@@ -789,8 +790,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
                                &dwActiveProtocol);
     switch (result)
     {
-    case static_cast<LONG>(SCARD_S_SUCCESS):
-    {
+    case static_cast<LONG>(SCARD_S_SUCCESS): {
         const SCARD_IO_REQUEST * sendPci = nullptr;
         switch (dwActiveProtocol)
         {
@@ -820,7 +820,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
             mTagInstances.push_back(newTagInstance);
         }
     }
-        break;
+    break;
 
     case static_cast<LONG>(SCARD_E_NO_SMARTCARD):
         ChipLogProgress(DeviceLayer, "No NFC Tag detected");

--- a/src/platform/Linux/NFCCommissioningManagerImpl.cpp
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.cpp
@@ -506,19 +506,31 @@ public:
 
     CHIP_ERROR SendOnNfcTagResponse(System::PacketBufferHandle && buffer)
     {
-        auto * ctx       = new NfcResponseContext();
+        auto * ctx = new (std::nothrow) NfcResponseContext();
+        VerifyOrReturnError(ctx != nullptr, CHIP_ERROR_NO_MEMORY);
         ctx->nfcBase     = nfcBase;
         ctx->peerAddress = peerAddress;
         ctx->buffer      = std::move(buffer);
-        return DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagResponse, reinterpret_cast<intptr_t>(ctx));
+        CHIP_ERROR err   = DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagResponse, reinterpret_cast<intptr_t>(ctx));
+        if (err != CHIP_NO_ERROR)
+        {
+            delete ctx;
+        }
+        return err;
     }
 
     CHIP_ERROR SendOnNfcTagError()
     {
-        auto * ctx       = new NfcResponseContext();
+        auto * ctx = new (std::nothrow) NfcResponseContext();
+        VerifyOrReturnError(ctx != nullptr, CHIP_ERROR_NO_MEMORY);
         ctx->nfcBase     = nfcBase;
         ctx->peerAddress = peerAddress;
-        return DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagError, reinterpret_cast<intptr_t>(ctx));
+        CHIP_ERROR err   = DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagError, reinterpret_cast<intptr_t>(ctx));
+        if (err != CHIP_NO_ERROR)
+        {
+            delete ctx;
+        }
+        return err;
     }
 };
 

--- a/src/platform/Linux/NFCCommissioningManagerImpl.cpp
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.cpp
@@ -30,6 +30,13 @@
 #include <lib/support/SafeInt.h>
 #include <platform/internal/NFCCommissioningManager.h>
 
+#ifdef __APPLE__
+#include <PCSC/winscard.h>
+#include <PCSC/wintypes.h>
+#else
+#include <winscard.h>
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 
 using namespace chip;
@@ -396,7 +403,7 @@ public:
 
     void ResetChainedResponseBuffer(void) { mChainedResponseLength = 0; }
 
-    CHIP_ERROR AddDataToChainedResponseBuffer(uint8_t * data, int dataLen)
+    CHIP_ERROR AddDataToChainedResponseBuffer(uint8_t * data, uint32_t dataLen)
     {
         // Check that mChainedResponseBuffer will not overflow
         VerifyOrReturnLogError((mChainedResponseLength + dataLen) <= sizeof(mChainedResponseBuffer), CHIP_ERROR_MESSAGE_TOO_LONG);
@@ -476,18 +483,42 @@ public:
 
     /////////////////////////////////////////////////////////////////
 
+    struct NfcResponseContext
+    {
+        Transport::NFCBase * nfcBase;
+        Transport::PeerAddress peerAddress;
+        System::PacketBufferHandle buffer;
+    };
+
+    static void DispatchNfcTagResponse(intptr_t arg)
+    {
+        auto * ctx = reinterpret_cast<NfcResponseContext *>(arg);
+        ctx->nfcBase->OnNfcTagResponse(ctx->peerAddress, std::move(ctx->buffer));
+        delete ctx;
+    }
+
+    static void DispatchNfcTagError(intptr_t arg)
+    {
+        auto * ctx = reinterpret_cast<NfcResponseContext *>(arg);
+        ctx->nfcBase->OnNfcTagError(ctx->peerAddress);
+        delete ctx;
+    }
+
     CHIP_ERROR SendOnNfcTagResponse(System::PacketBufferHandle && buffer)
     {
-        chip::DeviceLayer::StackLock lock;
-        nfcBase->OnNfcTagResponse(peerAddress, std::move(buffer));
-        return CHIP_NO_ERROR;
+        auto * ctx       = new NfcResponseContext();
+        ctx->nfcBase     = nfcBase;
+        ctx->peerAddress = peerAddress;
+        ctx->buffer      = std::move(buffer);
+        return DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagResponse, reinterpret_cast<intptr_t>(ctx));
     }
 
     CHIP_ERROR SendOnNfcTagError()
     {
-        chip::DeviceLayer::StackLock lock;
-        nfcBase->OnNfcTagError(peerAddress);
-        return CHIP_NO_ERROR;
+        auto * ctx       = new NfcResponseContext();
+        ctx->nfcBase     = nfcBase;
+        ctx->peerAddress = peerAddress;
+        return DeviceLayer::PlatformMgr().ScheduleWork(DispatchNfcTagError, reinterpret_cast<intptr_t>(ctx));
     }
 };
 
@@ -534,7 +565,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::EnsureProcessingThreadStarted()
     }
 
     // Creates an Application Context to the PC/SC Resource Manager.
-    long result = SCardEstablishContext(SCARD_SCOPE_SYSTEM, NULL, NULL, &hPcscContext);
+    LONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM, NULL, NULL, &hPcscContext);
     CHECK_FOR_SCARD_SUCCESS("SCardEstablishContext", result)
 
     lastTagInstanceUsed = nullptr;
@@ -690,7 +721,7 @@ void NFCCommissioningManagerImpl::NfcThreadMain()
 // Start scan on all available readers and scan for NFC Tags.
 CHIP_ERROR NFCCommissioningManagerImpl::ScanAllReaders(uint16_t nfcShortId)
 {
-    long result;
+    LONG result;
     LPTSTR mszReaders; // LPTSTR is a "typedef char *"
     DWORD dwReaders;
 
@@ -748,18 +779,18 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
     // Before launching a new scan of a reader, we should discard all the saved instances using this readerName
     EraseAllTagInstancesUsingReaderName(readerName);
 
-    long result = SCardConnect(hPcscContext, readerName, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, &cardHandle,
+    LONG result = SCardConnect(hPcscContext, readerName, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, &cardHandle,
                                &dwActiveProtocol);
     switch (result)
     {
-    case SCARD_S_SUCCESS:
+    case static_cast<LONG>(SCARD_S_SUCCESS):
         switch (dwActiveProtocol)
         {
-        case SCARD_PROTOCOL_T0:
+        case static_cast<DWORD>(SCARD_PROTOCOL_T0):
             pioSendPci = *SCARD_PCI_T0;
             break;
 
-        case SCARD_PROTOCOL_T1:
+        case static_cast<DWORD>(SCARD_PROTOCOL_T1):
             pioSendPci = *SCARD_PCI_T1;
             break;
         }
@@ -782,7 +813,7 @@ CHIP_ERROR NFCCommissioningManagerImpl::ScanReader(uint16_t nfcShortId, char * r
         }
         break;
 
-    case SCARD_E_NO_SMARTCARD:
+    case static_cast<LONG>(SCARD_E_NO_SMARTCARD):
         ChipLogProgress(DeviceLayer, "No NFC Tag detected");
         break;
 

--- a/src/platform/Linux/NFCCommissioningManagerImpl.h
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.h
@@ -35,9 +35,7 @@
 #include <queue>
 #include <thread>
 #ifdef __APPLE__
-// Use pcsclite.h instead of winscard.h to avoid pulling in wintypes.h,
-// which defines BOOL as int16_t and conflicts with ObjC's BOOL.
-#include <PCSC/pcsclite.h>
+#include <PCSC/winscard.h>
 #else
 #include <winscard.h>
 #endif

--- a/src/platform/Linux/NFCCommissioningManagerImpl.h
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.h
@@ -34,7 +34,11 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#ifdef __APPLE__
+#include <PCSC/pcsclite.h>
+#else
 #include <winscard.h>
+#endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 

--- a/src/platform/Linux/NFCCommissioningManagerImpl.h
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.h
@@ -25,6 +25,7 @@
 
 #include <transport/raw/NfcApplicationDelegate.h>
 
+#include <lib/core/Global.h>
 #include <platform/internal/NFCCommissioningManager.h>
 
 #include <atomic>
@@ -164,7 +165,7 @@ private:
     friend NFCCommissioningManager & NFCCommissioningMgr();
     friend NFCCommissioningManagerImpl & NFCCommissioningMgrImpl();
 
-    static NFCCommissioningManagerImpl sInstance;
+    static Global<NFCCommissioningManagerImpl> sInstance;
 
     void EraseAllTagInstancesUsingReaderName(const char * readerName);
     std::shared_ptr<TagInstance> SearchTagInstanceFromReaderNameAndCardHandle(const char * readerName, SCARDHANDLE cardHandle);
@@ -174,6 +175,10 @@ private:
     CHIP_ERROR ScanReader(uint16_t nfcShortId, char * readerName);
 
     Transport::NFCBase * mNFCBase = nullptr;
+
+    SCARDCONTEXT mPcscContext = 0;
+    std::shared_ptr<TagInstance> mLastTagInstanceUsed;
+    std::vector<std::shared_ptr<TagInstance>> mTagInstances;
 
     // Thread and synchronization primitives
     std::thread mNfcThread;
@@ -197,7 +202,7 @@ private:
  */
 inline NFCCommissioningManager & NFCCommissioningMgr()
 {
-    return NFCCommissioningManagerImpl::sInstance;
+    return NFCCommissioningManagerImpl::sInstance.get();
 }
 
 /**
@@ -208,7 +213,7 @@ inline NFCCommissioningManager & NFCCommissioningMgr()
  */
 inline NFCCommissioningManagerImpl & NFCCommissioningMgrImpl()
 {
-    return NFCCommissioningManagerImpl::sInstance;
+    return NFCCommissioningManagerImpl::sInstance.get();
 }
 
 } // namespace Internal

--- a/src/platform/Linux/NFCCommissioningManagerImpl.h
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.h
@@ -35,6 +35,8 @@
 #include <queue>
 #include <thread>
 #ifdef __APPLE__
+// Use pcsclite.h instead of winscard.h to avoid pulling in wintypes.h,
+// which defines BOOL as int16_t and conflicts with ObjC's BOOL.
 #include <PCSC/pcsclite.h>
 #else
 #include <winscard.h>


### PR DESCRIPTION
#### Summary

Use Linux PCSC NFCCommissioningManagerImpl on Mac

NFC support via PCSC can then be enabled with
chip_enable_nfc_based_commissioning = true

Mainly this involves just making sure the pcsc/winstypes like LONG are used consistently, since they map to different underlying types on Linux and Mac, and ensuring callbacks for correctly with the Darwin platform layer that uses a dispatch queue instead of a global lock.

Also make ChipLogValueX64 cast to uint64_t first rather than assuming it, since the NFC code calls it with values of other types (e.g. LONG).

#### Testing

Manually tested NFC commissioning using `chip-tool pairing nfc-thread ...` with a USB CCID NFC reader.
