### PR TITLE
Add test case 2.5 for the Joint Fabric data store

### DIFF
--- a/examples/jf-admin-app/linux/JFADatastoreSync.cpp
+++ b/examples/jf-admin-app/linux/JFADatastoreSync.cpp
@@ -29,6 +29,8 @@
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
 
+#include <unordered_map>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -64,6 +66,8 @@ public:
         std::vector<AclTargetType> aclObjectTargetsStorage;
         std::vector<std::vector<uint64_t>> aclSubjectsStorage;
         std::vector<std::vector<AclTargetType>> aclTargetsStorage;
+        Optional<std::vector<chip::app::Clusters::Binding::Structs::TargetStruct::Type>> bindingTargetsToWrite;
+        std::unordered_map<chip::GroupId, uint16_t> groupKeySetMap;
         std::function<void()> onSuccess;
         std::function<void(CHIP_ERROR, const std::vector<T> &)> onFetchSuccess;
         std::function<void(CHIP_ERROR, const T &)> onReadEntrySuccess;
@@ -128,6 +132,12 @@ public:
             nodeId(nId), groupKeySetId(MakeOptional(gksId)), objectToWrite(), objectsToWrite(), onReadEntrySuccess(onReadFn)
         {}
 
+        CallbackContext(chip::NodeId nId, EndpointId eId, const std::vector<T> & objects, std::function<void()> onSuccessFn) :
+            nodeId(nId), endpointId(eId), objectToWrite(), objectsToWrite(), onSuccess(onSuccessFn)
+        {
+            objectsToWrite = MakeOptional(objects);
+        }
+
         CallbackContext(chip::NodeId nId, const std::vector<T> & objects, std::function<void()> onSuccessFn) :
             nodeId(nId), objectToWrite(), objectsToWrite(), onSuccess(onSuccessFn)
         {
@@ -187,7 +197,11 @@ public:
     DevicePairedCommand(chip::NodeId nodeId, const T & object, std::function<void()> onSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext = std::make_shared<CallbackContext>(nodeId, object, onSuccess);
     }
@@ -195,7 +209,11 @@ public:
     DevicePairedCommand(chip::NodeId nodeId, std::function<void(CHIP_ERROR, const std::vector<T> &)> onFetchSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext   = std::make_shared<CallbackContext>(nodeId, onFetchSuccess);
         mFetchOnly = true;
@@ -204,7 +222,11 @@ public:
     DevicePairedCommand(chip::NodeId nodeId, std::function<void(CHIP_ERROR, const std::vector<uint16_t> &)> onReadSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext  = std::make_shared<CallbackContext>(nodeId, onReadSuccess);
         mReadOnly = true;
@@ -214,7 +236,11 @@ public:
                         std::function<void(CHIP_ERROR, const std::vector<T> &)> onFetchSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext   = std::make_shared<CallbackContext>(nodeId, endpointId, onFetchSuccess);
         mFetchOnly = true;
@@ -223,16 +249,37 @@ public:
     DevicePairedCommand(chip::NodeId nodeId, uint16_t groupKeySetId, std::function<void(CHIP_ERROR, const T &)> onReadSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext  = std::make_shared<CallbackContext>(nodeId, groupKeySetId, onReadSuccess);
         mReadOnly = true;
     }
 
+    DevicePairedCommand(chip::NodeId nodeId, EndpointId endpointId, const std::vector<T> & objects, std::function<void()> onSuccess,
+                        std::function<void()> removalCallback) :
+        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
+    {
+        mContext         = std::make_shared<CallbackContext>(nodeId, endpointId, objects, onSuccess);
+        mReplaceExisting = true;
+    }
+
     DevicePairedCommand(chip::NodeId nodeId, const std::vector<T> & objects, std::function<void()> onSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mRemovalCallback(removalCallback)
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
+        mOnFetchGroupsConnectionFailureCallback(OnFetchGroupsConnectionFailureFn, this),
+        mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
+        mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
         mContext         = std::make_shared<CallbackContext>(nodeId, objects, onSuccess);
         mReplaceExisting = true;
@@ -268,15 +315,89 @@ public:
                     }
                     else
                     {
-                        // Invoke Groups:AddGroup on the device's endpoint
-                        chip::app::Clusters::Groups::Commands::AddGroup::Type addGroup;
-                        addGroup.groupID   = cbContext->objectToWrite.Value().groupID;
-                        addGroup.groupName = "GroupName"_span;
+                        // Ensure GroupKeyMap contains mapping for this specific group before AddGroup.
+                        // Writing the full list can fail with constraint errors if stale/invalid mappings exist.
+                        const auto targetGroupId = cbContext->objectToWrite.Value().groupID;
+                        Optional<uint16_t> targetGroupKeySetId;
 
-                        chip::Controller::ClusterBase groupsCluster(exchangeMgr, sessionHandle,
-                                                                    cbContext->objectToWrite.Value().endpointID);
+                        const auto & groupEntries = Server::GetInstance().GetJointFabricDatastore().GetGroupEntries();
+                        for (const auto & groupEntry : groupEntries)
+                        {
+                            if (groupEntry.groupID != targetGroupId)
+                            {
+                                continue;
+                            }
 
-                        err = groupsCluster.InvokeCommand(addGroup, pairingCommand, OnCommandResponse, OnCommandFailure);
+                            if (groupEntry.groupKeySetID.IsNull())
+                            {
+                                break;
+                            }
+
+                            targetGroupKeySetId = MakeOptional(groupEntry.groupKeySetID.Value());
+                            break;
+                        }
+
+                        if (targetGroupKeySetId.HasValue())
+                        {
+                            ChipLogProgress(Controller, "Writing GroupKeyMap for group 0x%04x with keyset %u before AddGroup",
+                                            targetGroupId, targetGroupKeySetId.Value());
+
+                            chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type mapEntry;
+                            mapEntry.groupId       = targetGroupId;
+                            mapEntry.groupKeySetID = targetGroupKeySetId.Value();
+
+                            chip::Controller::ClusterBase groupKeyMgmtCluster(exchangeMgr, sessionHandle, kRootEndpointId);
+                            chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo::Type groupKeyMapList =
+                                chip::app::DataModel::List<
+                                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(&mapEntry, 1);
+
+                            err = groupKeyMgmtCluster
+                                      .WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
+                                          groupKeyMapList, pairingCommand,
+                                          [](void * lambdaContext) {
+                                              auto * instance      = static_cast<DevicePairedCommand *>(lambdaContext);
+                                              auto lambdaCbContext = instance->mContext;
+
+                                              CHIP_ERROR connErr = GetDeviceCommissioner()->GetConnectedDevice(
+                                                  lambdaCbContext->nodeId, &instance->mOnAddGroupConnectedCallback,
+                                                  &instance->mOnAddGroupConnectionFailureCallback);
+                                              if (connErr != CHIP_NO_ERROR)
+                                              {
+                                                  ChipLogError(Controller,
+                                                               "Failed to reconnect for AddGroup after GroupKeyMap write: %s",
+                                                               ErrorStr(connErr));
+                                                  if (instance && instance->mRemovalCallback)
+                                                  {
+                                                      instance->mRemovalCallback();
+                                                  }
+                                              }
+                                          },
+                                          [](void * lambdaContext, CHIP_ERROR writeError) {
+                                              auto * instance = static_cast<DevicePairedCommand *>(lambdaContext);
+                                              ChipLogError(Controller, "Failed to write GroupKeyMap before AddGroup: %s",
+                                                           ErrorStr(writeError));
+                                              if (instance && instance->mRemovalCallback)
+                                              {
+                                                  instance->mRemovalCallback();
+                                              }
+                                          });
+                        }
+                        else
+                        {
+                            ChipLogError(Controller,
+                                         "No datastore GroupKeyMap mapping found for group 0x%04x; attempting AddGroup directly",
+                                         targetGroupId);
+
+                            // Fallback: missing key-map info for target group; attempt AddGroup directly.
+                            chip::app::Clusters::Groups::Commands::AddGroup::Type addGroup;
+                            addGroup.groupID   = cbContext->objectToWrite.Value().groupID;
+                            addGroup.groupName = "GroupName"_span;
+
+                            chip::Controller::ClusterBase groupsCluster(exchangeMgr, sessionHandle,
+                                                                        cbContext->objectToWrite.Value().endpointID);
+
+                            err = groupsCluster.InvokeCommand(addGroup, pairingCommand, OnCommandResponse, OnCommandFailure);
+                        }
                     }
                 }
                 else if constexpr (std::is_same_v<
@@ -339,26 +460,136 @@ public:
                 {
                     if (pairingCommand->mReplaceExisting == false)
                     {
-                        // populate keySetWrite from cbContext->objectToWrite
-                        chip::app::Clusters::Binding::Structs::TargetStruct::Type target;
-                        target.node     = cbContext->objectToWrite.Value().binding.node;
-                        target.endpoint = cbContext->objectToWrite.Value().binding.endpoint;
-                        target.cluster  = cbContext->objectToWrite.Value().binding.cluster;
-                        target.group    = cbContext->objectToWrite.Value().binding.group;
-                        // Create a small array containing the single target and construct a DataModel::List from it
-                        chip::app::Clusters::Binding::Structs::TargetStruct::Type targets[] = { target };
-                        chip::app::Clusters::Binding::Attributes::Binding::TypeInfo::Type keySetWrite =
-                            chip::app::DataModel::List<chip::app::Clusters::Binding::Structs::TargetStruct::Type>(
-                                targets, sizeof(targets) / sizeof(targets[0]));
+                        chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle,
+                                                                     cbContext->objectToWrite.Value().endpointID);
 
-                        chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle, kRootEndpointId);
+                        if (cbContext->objectToWrite.Value().statusEntry.state ==
+                            Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
+                        {
+                            if (!cbContext->bindingTargetsToWrite.HasValue())
+                            {
+                                err = bindingCluster.ReadAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
+                                    pairingCommand,
+                                    // Success lambda
+                                    [](void * lambdaContext,
+                                       const chip::app::Clusters::Binding::Attributes::Binding::TypeInfo::DecodableType &
+                                           dataResponse) {
+                                        auto * instance      = static_cast<DevicePairedCommand *>(lambdaContext);
+                                        auto lambdaCbContext = instance->mContext;
 
-                        err = bindingCluster.WriteAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
-                            keySetWrite, pairingCommand, OnWriteSuccessResponse, OnWriteFailureResponse);
+                                        if (!lambdaCbContext || !lambdaCbContext->objectToWrite.HasValue())
+                                        {
+                                            OnWriteFailureResponse(instance, CHIP_ERROR_INCORRECT_STATE);
+                                            return;
+                                        }
+
+                                        const auto & targetBinding = lambdaCbContext->objectToWrite.Value().binding;
+
+                                        std::vector<chip::app::Clusters::Binding::Structs::TargetStruct::Type> filteredTargets;
+
+                                        auto iter            = dataResponse.begin();
+                                        size_t originalCount = 0;
+                                        size_t removedCount  = 0;
+                                        while (iter.Next())
+                                        {
+                                            const auto & responseEntry = iter.GetValue();
+                                            originalCount++;
+
+                                            const bool isMatch = (responseEntry.node == targetBinding.node) &&
+                                                (responseEntry.group == targetBinding.group) &&
+                                                (responseEntry.endpoint == targetBinding.endpoint) &&
+                                                (responseEntry.cluster == targetBinding.cluster);
+
+                                            if (isMatch)
+                                            {
+                                                removedCount++;
+                                                continue;
+                                            }
+
+                                            chip::app::Clusters::Binding::Structs::TargetStruct::Type existingTarget;
+                                            existingTarget.node     = responseEntry.node;
+                                            existingTarget.group    = responseEntry.group;
+                                            existingTarget.endpoint = responseEntry.endpoint;
+                                            existingTarget.cluster  = responseEntry.cluster;
+                                            filteredTargets.push_back(existingTarget);
+                                        }
+
+                                        CHIP_ERROR iterErr = iter.GetStatus();
+                                        if (iterErr != CHIP_NO_ERROR)
+                                        {
+                                            ChipLogError(Controller, "Failed to iterate Binding during delete sync: %s",
+                                                         ErrorStr(iterErr));
+                                            OnWriteFailureResponse(instance, iterErr);
+                                            return;
+                                        }
+
+                                        lambdaCbContext->bindingTargetsToWrite = MakeOptional(filteredTargets);
+                                        ChipLogProgress(Controller,
+                                                        "Binding delete sync read-modify-write: node=" ChipLogFormatX64
+                                                        " endpoint=%u original=%u removed=%u remaining=%u",
+                                                        ChipLogValueX64(lambdaCbContext->nodeId),
+                                                        static_cast<unsigned>(lambdaCbContext->objectToWrite.Value().endpointID),
+                                                        static_cast<unsigned>(originalCount), static_cast<unsigned>(removedCount),
+                                                        static_cast<unsigned>(filteredTargets.size()));
+
+                                        CHIP_ERROR reconnectErr = GetDeviceCommissioner()->GetConnectedDevice(
+                                            lambdaCbContext->nodeId, &instance->mOnDeviceConnectedCallback,
+                                            &instance->mOnDeviceConnectionFailureCallback);
+                                        if (reconnectErr != CHIP_NO_ERROR)
+                                        {
+                                            OnWriteFailureResponse(instance, reconnectErr);
+                                        }
+                                    },
+                                    // Failure lambda
+                                    [](void * lambdaContext, CHIP_ERROR readError) {
+                                        auto * instance = static_cast<DevicePairedCommand *>(lambdaContext);
+                                        OnWriteFailureResponse(instance, readError);
+                                    });
+
+                                if (err != CHIP_NO_ERROR)
+                                {
+                                    OnWriteFailureResponse(pairingCommand, err);
+                                }
+                                return;
+                            }
+
+                            auto & targets = cbContext->bindingTargetsToWrite.Value();
+                            chip::app::Clusters::Binding::Attributes::Binding::TypeInfo::Type bindingList =
+                                chip::app::DataModel::List<chip::app::Clusters::Binding::Structs::TargetStruct::Type>(
+                                    targets.data(), static_cast<uint32_t>(targets.size()));
+                            ChipLogProgress(Controller,
+                                            "Binding delete sync writing filtered BindingList: node=" ChipLogFormatX64
+                                            " endpoint=%u entries=%u",
+                                            ChipLogValueX64(cbContext->nodeId),
+                                            static_cast<unsigned>(cbContext->objectToWrite.Value().endpointID),
+                                            static_cast<unsigned>(targets.size()));
+
+                            err = bindingCluster.WriteAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
+                                bindingList, pairingCommand, OnWriteSuccessResponse, OnWriteFailureResponse);
+                        }
+                        else
+                        {
+                            cbContext->bindingTargetsToWrite.ClearValue();
+
+                            chip::app::Clusters::Binding::Structs::TargetStruct::Type target;
+                            target.node     = cbContext->objectToWrite.Value().binding.node;
+                            target.endpoint = cbContext->objectToWrite.Value().binding.endpoint;
+                            target.cluster  = cbContext->objectToWrite.Value().binding.cluster;
+                            target.group    = cbContext->objectToWrite.Value().binding.group;
+
+                            chip::app::Clusters::Binding::Structs::TargetStruct::Type targets[] = { target };
+                            chip::app::Clusters::Binding::Attributes::Binding::TypeInfo::Type bindingList =
+                                chip::app::DataModel::List<chip::app::Clusters::Binding::Structs::TargetStruct::Type>(
+                                    targets, sizeof(targets) / sizeof(targets[0]));
+
+                            err = bindingCluster.WriteAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
+                                bindingList, pairingCommand, OnWriteSuccessResponse, OnWriteFailureResponse);
+                        }
                     }
                     else
                     {
                         // Create a list of targets from the objectsToWrite vector
+                        // NOTE: An empty list must still be written to TH2 (e.g. when the last binding is deleted).
                         std::vector<chip::app::Clusters::Binding::Structs::TargetStruct::Type> targets;
                         for (const auto & bindingEntry : cbContext->objectsToWrite.Value())
                         {
@@ -374,7 +605,7 @@ public:
                             chip::app::DataModel::List<chip::app::Clusters::Binding::Structs::TargetStruct::Type>(
                                 targets.data(), static_cast<uint32_t>(targets.size()));
 
-                        chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle, kRootEndpointId);
+                        chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle, cbContext->endpointId);
 
                         err = bindingCluster.WriteAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
                             bindingList, pairingCommand, OnWriteSuccessResponse, OnWriteFailureResponse);
@@ -520,8 +751,7 @@ public:
                 else if constexpr (std::is_same_v<
                                        T, app::Clusters::JointFabricDatastore::Structs::DatastoreGroupInformationEntryStruct::Type>)
                 {
-                    chip::Controller::ClusterBase groupKeyMgmtCluster(exchangeMgr, sessionHandle,
-                                                                      pairingCommand->mContext->endpointId);
+                    chip::Controller::ClusterBase groupKeyMgmtCluster(exchangeMgr, sessionHandle, kRootEndpointId);
 
                     err =
                         groupKeyMgmtCluster
@@ -534,33 +764,48 @@ public:
                                     auto * instance      = static_cast<DevicePairedCommand *>(lambdaContext);
                                     auto lambdaCbContext = instance->mContext;
 
-                                    std::vector<T> groupInfoEntries;
-
-                                    auto iter = dataResponse.begin();
-                                    while (iter.Next())
+                                    if (!lambdaCbContext)
                                     {
-                                        auto & responseEntry = iter.GetValue();
-
-                                        T entry;
-                                        entry.groupID       = responseEntry.groupId;
-                                        entry.groupKeySetID = responseEntry.groupKeySetID;
-                                        groupInfoEntries.push_back(entry);
+                                        if (instance && instance->mRemovalCallback)
+                                        {
+                                            instance->mRemovalCallback();
+                                        }
+                                        return;
                                     }
 
-                                    if (iter.GetStatus() != CHIP_NO_ERROR)
+                                    lambdaCbContext->groupKeySetMap.clear();
+
+                                    auto keyMapIter = dataResponse.begin();
+                                    while (keyMapIter.Next())
                                     {
-                                        ChipLogError(Controller, "Failed to iterate GroupKeyMap: %s", ErrorStr(iter.GetStatus()));
+                                        const auto & responseEntry                             = keyMapIter.GetValue();
+                                        lambdaCbContext->groupKeySetMap[responseEntry.groupId] = responseEntry.groupKeySetID;
                                     }
 
-                                    if (lambdaCbContext && lambdaCbContext->onFetchSuccess)
+                                    CHIP_ERROR keyMapErr = keyMapIter.GetStatus();
+                                    if (keyMapErr != CHIP_NO_ERROR)
                                     {
-                                        lambdaCbContext->onFetchSuccess(CHIP_NO_ERROR, groupInfoEntries);
+                                        ChipLogError(Controller, "Failed to iterate GroupKeyMap: %s", ErrorStr(keyMapErr));
                                     }
 
-                                    // Clean up in-flight command
-                                    if (instance && instance->mRemovalCallback)
+                                    CHIP_ERROR commandErr = GetDeviceCommissioner()->GetConnectedDevice(
+                                        lambdaCbContext->nodeId, &instance->mOnFetchGroupsConnectedCallback,
+                                        &instance->mOnFetchGroupsConnectionFailureCallback);
+
+                                    if (commandErr != CHIP_NO_ERROR)
                                     {
-                                        instance->mRemovalCallback();
+                                        ChipLogError(Controller, "Failed to reconnect for GetGroupMembership: %s",
+                                                     ErrorStr(commandErr));
+                                        if (lambdaCbContext->onFetchSuccess)
+                                        {
+                                            lambdaCbContext->onFetchSuccess(commandErr, {});
+                                        }
+
+                                        // Clean up in-flight command
+                                        if (instance && instance->mRemovalCallback)
+                                        {
+                                            instance->mRemovalCallback();
+                                        }
                                     }
                                 },
                                 // Failure lambda
@@ -583,7 +828,7 @@ public:
                 else if constexpr (std::is_same_v<
                                        T, app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>)
                 {
-                    chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle, kRootEndpointId);
+                    chip::Controller::ClusterBase bindingCluster(exchangeMgr, sessionHandle, cbContext->endpointId);
 
                     err = bindingCluster.ReadAttribute<chip::app::Clusters::Binding::Attributes::Binding::TypeInfo>(
                         pairingCommand,
@@ -605,7 +850,7 @@ public:
                                 entry.binding.endpoint = responseEntry.endpoint;
                                 entry.binding.cluster  = responseEntry.cluster;
                                 entry.binding.group    = responseEntry.group;
-                                entry.endpointID       = lambdaCbContext->objectToWrite.Value().endpointID;
+                                entry.endpointID       = lambdaCbContext->endpointId;
                                 bindingEntries.push_back(entry);
                             }
 
@@ -908,6 +1153,195 @@ public:
         }
     }
 
+    static void OnFetchGroupsConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                                         const chip::SessionHandle & sessionHandle)
+    {
+        auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
+        auto cbContext        = pairingCommand->mContext;
+
+        if (!pairingCommand || !cbContext)
+        {
+            return;
+        }
+
+        if constexpr (std::is_same_v<T, app::Clusters::JointFabricDatastore::Structs::DatastoreGroupInformationEntryStruct::Type>)
+        {
+            chip::Controller::ClusterBase groupsCluster(exchangeMgr, sessionHandle, cbContext->endpointId);
+            chip::app::Clusters::Groups::Commands::GetGroupMembership::Type getGroupMembership;
+            getGroupMembership.groupList = chip::Span<const chip::GroupId>();
+
+            CHIP_ERROR commandErr = groupsCluster.InvokeCommand(
+                getGroupMembership, pairingCommand,
+                // Success lambda
+                [](void * innerContext,
+                   const chip::app::Clusters::Groups::Commands::GetGroupMembership::Type::ResponseType & response) {
+                    auto * innerInstance      = static_cast<DevicePairedCommand *>(innerContext);
+                    auto innerLambdaCbContext = innerInstance->mContext;
+
+                    std::vector<T> groupInfoEntries;
+
+                    CHIP_ERROR mappingErr = CHIP_NO_ERROR;
+                    auto iter             = response.groupList.begin();
+                    while (iter.Next())
+                    {
+                        const auto groupId = iter.GetValue();
+                        T entry;
+                        entry.groupID = groupId;
+
+                        auto keySetIt = innerLambdaCbContext->groupKeySetMap.find(groupId);
+                        if (keySetIt != innerLambdaCbContext->groupKeySetMap.end())
+                        {
+                            entry.groupKeySetID = keySetIt->second;
+                        }
+                        else
+                        {
+                            entry.groupKeySetID = 0;
+                            mappingErr          = CHIP_ERROR_KEY_NOT_FOUND;
+                            ChipLogError(Controller, "Missing GroupKeyMap entry for group 0x%04x while fetching endpoint %u",
+                                         static_cast<unsigned>(groupId), static_cast<unsigned>(innerLambdaCbContext->endpointId));
+                        }
+
+                        groupInfoEntries.push_back(entry);
+                    }
+
+                    CHIP_ERROR iterErr = iter.GetStatus();
+                    if (iterErr != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(Controller, "Failed to iterate GetGroupMembership response: %s", ErrorStr(iterErr));
+                    }
+
+                    CHIP_ERROR finalErr = iterErr;
+                    if (finalErr == CHIP_NO_ERROR)
+                    {
+                        finalErr = mappingErr;
+                    }
+
+                    if (innerLambdaCbContext && innerLambdaCbContext->onFetchSuccess)
+                    {
+                        innerLambdaCbContext->onFetchSuccess(finalErr, groupInfoEntries);
+                    }
+
+                    // Clean up in-flight command
+                    if (innerInstance && innerInstance->mRemovalCallback)
+                    {
+                        innerInstance->mRemovalCallback();
+                    }
+                },
+                // Failure lambda
+                [](void * innerContext, CHIP_ERROR invokeErr) {
+                    auto * innerInstance      = static_cast<DevicePairedCommand *>(innerContext);
+                    auto innerLambdaCbContext = innerInstance->mContext;
+
+                    if (innerLambdaCbContext && innerLambdaCbContext->onFetchSuccess)
+                    {
+                        innerLambdaCbContext->onFetchSuccess(invokeErr, {});
+                    }
+
+                    // Clean up in-flight command
+                    if (innerInstance && innerInstance->mRemovalCallback)
+                    {
+                        innerInstance->mRemovalCallback();
+                    }
+                });
+
+            if (commandErr != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to invoke GetGroupMembership: %s", ErrorStr(commandErr));
+                if (cbContext->onFetchSuccess)
+                {
+                    cbContext->onFetchSuccess(commandErr, {});
+                }
+
+                // Clean up in-flight command
+                if (pairingCommand->mRemovalCallback)
+                {
+                    pairingCommand->mRemovalCallback();
+                }
+            }
+        }
+        else
+        {
+            ChipLogError(Controller, "OnFetchGroupsConnectedFn invoked for unsupported type");
+            if (cbContext->onFetchSuccess)
+            {
+                cbContext->onFetchSuccess(CHIP_ERROR_INCORRECT_STATE, {});
+            }
+
+            if (pairingCommand->mRemovalCallback)
+            {
+                pairingCommand->mRemovalCallback();
+            }
+        }
+    }
+
+    static void OnFetchGroupsConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
+    {
+        auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
+        auto cbContext        = pairingCommand->mContext;
+
+        ChipLogError(DeviceLayer, "Failed to reconnect for group membership fetch on node " ChipLogFormatX64 ": %s",
+                     ChipLogValueX64(peerId.GetNodeId()), ErrorStr(error));
+
+        if (cbContext && cbContext->onFetchSuccess)
+        {
+            cbContext->onFetchSuccess(error, {});
+        }
+
+        if (pairingCommand && pairingCommand->mRemovalCallback)
+        {
+            pairingCommand->mRemovalCallback();
+        }
+    }
+
+    static void OnAddGroupConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                                      const chip::SessionHandle & sessionHandle)
+    {
+        auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
+        auto cbContext        = pairingCommand->mContext;
+
+        if (!pairingCommand || !cbContext)
+        {
+            return;
+        }
+
+        if constexpr (std::is_same_v<T, app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type>)
+        {
+            chip::app::Clusters::Groups::Commands::AddGroup::Type addGroup;
+            addGroup.groupID   = cbContext->objectToWrite.Value().groupID;
+            addGroup.groupName = "GroupName"_span;
+
+            chip::Controller::ClusterBase groupsCluster(exchangeMgr, sessionHandle, cbContext->objectToWrite.Value().endpointID);
+            CHIP_ERROR err = groupsCluster.InvokeCommand(addGroup, pairingCommand, OnCommandResponse, OnCommandFailure);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to invoke AddGroup after GroupKeyMap write: %s", ErrorStr(err));
+                if (pairingCommand->mRemovalCallback)
+                {
+                    pairingCommand->mRemovalCallback();
+                }
+            }
+        }
+        else
+        {
+            ChipLogError(Controller, "OnAddGroupConnectedFn invoked for unsupported type");
+            if (pairingCommand->mRemovalCallback)
+            {
+                pairingCommand->mRemovalCallback();
+            }
+        }
+    }
+
+    static void OnAddGroupConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
+    {
+        auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
+        ChipLogError(DeviceLayer, "Failed to reconnect for AddGroup on node " ChipLogFormatX64 ": %s",
+                     ChipLogValueX64(peerId.GetNodeId()), ErrorStr(error));
+        if (pairingCommand && pairingCommand->mRemovalCallback)
+        {
+            pairingCommand->mRemovalCallback();
+        }
+    }
+
     static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
     {
         auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
@@ -947,10 +1381,74 @@ public:
     /* Callback when command results in failure */
     static void OnWriteFailureResponse(void * context, CHIP_ERROR error)
     {
-        ChipLogProgress(Controller, "OnWriteFailureResponse - Failed to write Data: %s", ErrorStr(error));
+        ChipLogError(Controller, "OnWriteFailureResponse - Failed to write Data: %s", ErrorStr(error));
 
         auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
         auto cbContext        = pairingCommand->mContext;
+
+        if constexpr (std::is_same_v<T, app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>)
+        {
+            if (cbContext && cbContext->objectToWrite.HasValue())
+            {
+                const auto & bindingEntry = cbContext->objectToWrite.Value();
+                ChipLogError(Controller,
+                             "Binding write failure details: node=" ChipLogFormatX64
+                             " endpoint=%u listId=%u target(node=%s, group=%s, endpoint=%s, cluster=%s)",
+                             ChipLogValueX64(bindingEntry.nodeID), static_cast<unsigned>(bindingEntry.endpointID),
+                             static_cast<unsigned>(bindingEntry.listID), bindingEntry.binding.node.HasValue() ? "set" : "null",
+                             bindingEntry.binding.group.HasValue() ? "set" : "null",
+                             bindingEntry.binding.endpoint.HasValue() ? "set" : "null",
+                             bindingEntry.binding.cluster.HasValue() ? "set" : "null");
+            }
+
+            // Keep the refresh state machine moving, but ensure failed writes are not treated as committed.
+            if (cbContext && cbContext->objectToWrite.HasValue())
+            {
+                auto failedEntry                    = cbContext->objectToWrite.Value();
+                failedEntry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                failedEntry.statusEntry.failureCode = static_cast<uint32_t>(error.AsInteger());
+                cbContext->objectToWrite            = MakeOptional(failedEntry);
+
+                auto & endpointBindingList = Server::GetInstance().GetJointFabricDatastore().GetEndpointBindingList();
+                for (auto & entry : endpointBindingList)
+                {
+                    if (entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
+                        entry.listID == failedEntry.listID)
+                    {
+                        entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                        entry.statusEntry.failureCode = failedEntry.statusEntry.failureCode;
+                        break;
+                    }
+                }
+            }
+
+            if (cbContext && cbContext->objectsToWrite.HasValue())
+            {
+                auto failedEntries = cbContext->objectsToWrite.Value();
+                for (auto & failedEntry : failedEntries)
+                {
+                    failedEntry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                    failedEntry.statusEntry.failureCode = static_cast<uint32_t>(error.AsInteger());
+                }
+                cbContext->objectsToWrite = MakeOptional(failedEntries);
+
+                auto & endpointBindingList = Server::GetInstance().GetJointFabricDatastore().GetEndpointBindingList();
+                for (auto & entry : endpointBindingList)
+                {
+                    for (const auto & failedEntry : failedEntries)
+                    {
+                        if (entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
+                            entry.listID == failedEntry.listID)
+                        {
+                            entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                            entry.statusEntry.failureCode = failedEntry.statusEntry.failureCode;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         if (cbContext && cbContext->onSuccess)
         {
             cbContext->onSuccess();
@@ -967,10 +1465,21 @@ public:
     static void OnCommandResponse(void * context,
                                   const chip::app::Clusters::Groups::Commands::AddGroup::Type::ResponseType & response)
     {
-        ChipLogProgress(Controller, "OnCommandResponse - Command executed Successfully");
-
         auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
         auto cbContext        = pairingCommand->mContext;
+
+        if (response.status == 0)
+        {
+            ChipLogProgress(Controller, "AddGroup response status=0x%02x group=0x%04x", static_cast<unsigned>(response.status),
+                            static_cast<unsigned>(response.groupID));
+        }
+        else
+        {
+            ChipLogError(Controller, "AddGroup returned non-success status=0x%02x group=0x%04x",
+                         static_cast<unsigned>(response.status), static_cast<unsigned>(response.groupID));
+        }
+
+        // Continue state machine regardless of payload status; caller only exposes completion callback.
         if (cbContext && cbContext->onSuccess)
         {
             cbContext->onSuccess();
@@ -1008,10 +1517,21 @@ public:
     static void OnCommandResponse(void * context,
                                   const chip::app::Clusters::Groups::Commands::RemoveGroup::Type::ResponseType & response)
     {
-        ChipLogProgress(Controller, "OnCommandResponse - Command executed Successfully");
-
         auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
         auto cbContext        = pairingCommand->mContext;
+
+        if (response.status == 0)
+        {
+            ChipLogProgress(Controller, "RemoveGroup response status=0x%02x group=0x%04x", static_cast<unsigned>(response.status),
+                            static_cast<unsigned>(response.groupID));
+        }
+        else
+        {
+            ChipLogError(Controller, "RemoveGroup returned non-success status=0x%02x group=0x%04x",
+                         static_cast<unsigned>(response.status), static_cast<unsigned>(response.groupID));
+        }
+
+        // Continue state machine regardless of payload status; caller only exposes completion callback.
         if (cbContext && cbContext->onSuccess)
         {
             cbContext->onSuccess();
@@ -1039,6 +1559,10 @@ public:
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnFetchGroupsConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnFetchGroupsConnectionFailureCallback;
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnAddGroupConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnAddGroupConnectionFailureCallback;
     std::shared_ptr<CallbackContext> mContext;
     std::function<void()> mRemovalCallback;
     bool mFetchOnly       = false;
@@ -1122,11 +1646,13 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 
             if (bindingEntryOwned.statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
             {
+                // TH2 TargetStruct entries have no listID; match by binding target fields instead.
                 mergedBindings.erase(std::remove_if(mergedBindings.begin(), mergedBindings.end(),
                                                     [&bindingEntryOwned](const auto & entry) {
-                                                        return entry.nodeID == bindingEntryOwned.nodeID &&
-                                                            entry.endpointID == bindingEntryOwned.endpointID &&
-                                                            entry.listID == bindingEntryOwned.listID;
+                                                        return entry.binding.node == bindingEntryOwned.binding.node &&
+                                                            entry.binding.group == bindingEntryOwned.binding.group &&
+                                                            entry.binding.endpoint == bindingEntryOwned.binding.endpoint &&
+                                                            entry.binding.cluster == bindingEntryOwned.binding.cluster;
                                                     }),
                                      mergedBindings.end());
             }
@@ -1135,7 +1661,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
                 mergedBindings.push_back(bindingEntryOwned);
             }
 
-            CHIP_ERROR writeErr = SyncNode(nodeId, mergedBindings, onSuccess);
+            CHIP_ERROR writeErr = SyncNode(nodeId, bindingEntryOwned.endpointID, mergedBindings, onSuccess);
             if (writeErr != CHIP_NO_ERROR)
             {
                 ChipLogError(DeviceLayer, "Failed to write appended binding list: %s", ErrorStr(writeErr));
@@ -1145,6 +1671,28 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
                 }
             }
         });
+}
+
+CHIP_ERROR JFADatastoreSync::SyncNode(
+    NodeId nodeId, EndpointId endpointId,
+    std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
+    std::function<void()> onSuccess)
+{
+    ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
+
+    const uint64_t inFlightToken = AllocateInFlightCommandToken();
+
+    std::shared_ptr<DevicePairedCommand<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>>
+        pairingCommand = std::make_shared<
+            DevicePairedCommand<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>>(
+            nodeId, endpointId, bindingEntries, onSuccess, [this, inFlightToken]() { RemoveInFlightCommand(inFlightToken); });
+
+    StoreInFlightCommand(inFlightToken, pairingCommand);
+
+    ReturnErrorOnFailure(GetDeviceCommissioner()->GetConnectedDevice(nodeId, &pairingCommand->mOnDeviceConnectedCallback,
+                                                                     &pairingCommand->mOnDeviceConnectionFailureCallback));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR JFADatastoreSync::SyncNode(

--- a/examples/jf-admin-app/linux/JFADatastoreSync.cpp
+++ b/examples/jf-admin-app/linux/JFADatastoreSync.cpp
@@ -22,14 +22,17 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <app/data-model/Encode.h>
+#include <array>
 
 #include <controller/CHIPCluster.h>
-#include <lib/support/logging/CHIPLogging.h>
-
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
+#include <controller/WriteInteraction.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include <unordered_map>
+#include <unordered_set>
 
 using namespace chip;
 using namespace chip::app;
@@ -62,18 +65,19 @@ public:
         Optional<uint16_t> groupKeySetId;
         Optional<T> objectToWrite;
         Optional<std::vector<T>> objectsToWrite;
+        std::vector<T> * sourceObjectsToWrite = nullptr;
         std::vector<uint64_t> aclObjectSubjectsStorage;
         std::vector<AclTargetType> aclObjectTargetsStorage;
         std::vector<std::vector<uint64_t>> aclSubjectsStorage;
         std::vector<std::vector<AclTargetType>> aclTargetsStorage;
         Optional<std::vector<chip::app::Clusters::Binding::Structs::TargetStruct::Type>> bindingTargetsToWrite;
         std::unordered_map<chip::GroupId, uint16_t> groupKeySetMap;
-        std::function<void()> onSuccess;
+        std::function<void(CHIP_ERROR)> onSuccess;
         std::function<void(CHIP_ERROR, const std::vector<T> &)> onFetchSuccess;
         std::function<void(CHIP_ERROR, const T &)> onReadEntrySuccess;
         std::function<void(CHIP_ERROR, const std::vector<uint16_t> &)> onReadListSuccess;
 
-        CallbackContext(chip::NodeId nId, const T & object, std::function<void()> onSuccessFn) :
+        CallbackContext(chip::NodeId nId, const T & object, std::function<void(CHIP_ERROR)> onSuccessFn) :
             nodeId(nId), objectToWrite(), objectsToWrite(), onSuccess(onSuccessFn)
         {
             if constexpr (std::is_same_v<T, AclEntryType>)
@@ -132,14 +136,18 @@ public:
             nodeId(nId), groupKeySetId(MakeOptional(gksId)), objectToWrite(), objectsToWrite(), onReadEntrySuccess(onReadFn)
         {}
 
-        CallbackContext(chip::NodeId nId, EndpointId eId, const std::vector<T> & objects, std::function<void()> onSuccessFn) :
-            nodeId(nId), endpointId(eId), objectToWrite(), objectsToWrite(), onSuccess(onSuccessFn)
+        CallbackContext(chip::NodeId nId, EndpointId eId, const std::vector<T> & objects,
+                        std::function<void(CHIP_ERROR)> onSuccessFn, std::vector<T> * sourceObjects = nullptr) :
+            nodeId(nId),
+            endpointId(eId), objectToWrite(), objectsToWrite(), sourceObjectsToWrite(sourceObjects), onSuccess(onSuccessFn)
         {
             objectsToWrite = MakeOptional(objects);
         }
 
-        CallbackContext(chip::NodeId nId, const std::vector<T> & objects, std::function<void()> onSuccessFn) :
-            nodeId(nId), objectToWrite(), objectsToWrite(), onSuccess(onSuccessFn)
+        CallbackContext(chip::NodeId nId, const std::vector<T> & objects, std::function<void(CHIP_ERROR)> onSuccessFn,
+                        std::vector<T> * sourceObjects = nullptr) :
+            nodeId(nId),
+            objectToWrite(), objectsToWrite(), sourceObjectsToWrite(sourceObjects), onSuccess(onSuccessFn)
         {
             if constexpr (std::is_same_v<T, AclEntryType>)
             {
@@ -194,7 +202,7 @@ public:
         }
     };
 
-    DevicePairedCommand(chip::NodeId nodeId, const T & object, std::function<void()> onSuccess,
+    DevicePairedCommand(chip::NodeId nodeId, const T & object, std::function<void(CHIP_ERROR)> onSuccess,
                         std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
@@ -259,8 +267,8 @@ public:
         mReadOnly = true;
     }
 
-    DevicePairedCommand(chip::NodeId nodeId, EndpointId endpointId, const std::vector<T> & objects, std::function<void()> onSuccess,
-                        std::function<void()> removalCallback) :
+    DevicePairedCommand(chip::NodeId nodeId, EndpointId endpointId, const std::vector<T> & objects,
+                        std::function<void(CHIP_ERROR)> onSuccess, std::function<void()> removalCallback) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
         mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
@@ -272,8 +280,8 @@ public:
         mReplaceExisting = true;
     }
 
-    DevicePairedCommand(chip::NodeId nodeId, const std::vector<T> & objects, std::function<void()> onSuccess,
-                        std::function<void()> removalCallback) :
+    DevicePairedCommand(chip::NodeId nodeId, const std::vector<T> & objects, std::function<void(CHIP_ERROR)> onSuccess,
+                        std::function<void()> removalCallback, std::vector<T> * sourceObjectsToWrite = nullptr) :
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
         mOnFetchGroupsConnectedCallback(OnFetchGroupsConnectedFn, this),
@@ -281,7 +289,7 @@ public:
         mOnAddGroupConnectedCallback(OnAddGroupConnectedFn, this),
         mOnAddGroupConnectionFailureCallback(OnAddGroupConnectionFailureFn, this), mRemovalCallback(removalCallback)
     {
-        mContext         = std::make_shared<CallbackContext>(nodeId, objects, onSuccess);
+        mContext         = std::make_shared<CallbackContext>(nodeId, objects, onSuccess, sourceObjectsToWrite);
         mReplaceExisting = true;
     }
 
@@ -339,48 +347,110 @@ public:
 
                         if (targetGroupKeySetId.HasValue())
                         {
-                            ChipLogProgress(Controller, "Writing GroupKeyMap for group 0x%04x with keyset %u before AddGroup",
+                            std::vector<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> mergedEntries;
+                            std::unordered_map<chip::GroupId, size_t> groupIndex;
+                            std::unordered_set<uint16_t> validKeySetIds;
+
+                            const auto & groupKeySets = Server::GetInstance().GetJointFabricDatastore().GetGroupKeySetList();
+                            for (const auto & groupKeySet : groupKeySets)
+                            {
+                                if (groupKeySet.groupKeySetID != 0)
+                                {
+                                    validKeySetIds.insert(groupKeySet.groupKeySetID);
+                                }
+                            }
+
+                            for (const auto & groupEntry : groupEntries)
+                            {
+                                if (groupEntry.groupKeySetID.IsNull())
+                                {
+                                    continue;
+                                }
+
+                                const auto entryGroupId = groupEntry.groupID;
+                                const auto entryKeySet  = groupEntry.groupKeySetID.Value();
+                                if (entryKeySet == 0 || validKeySetIds.find(entryKeySet) == validKeySetIds.end())
+                                {
+                                    continue;
+                                }
+                                auto it = groupIndex.find(entryGroupId);
+
+                                if (it == groupIndex.end())
+                                {
+                                    chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type mapEntry;
+                                    mapEntry.groupId       = entryGroupId;
+                                    mapEntry.groupKeySetID = entryKeySet;
+                                    mapEntry.fabricIndex   = sessionHandle->GetFabricIndex();
+
+                                    groupIndex[entryGroupId] = mergedEntries.size();
+                                    mergedEntries.push_back(mapEntry);
+                                }
+                                else
+                                {
+                                    // Keep latest datastore mapping for duplicate group IDs.
+                                    mergedEntries[it->second].groupKeySetID = entryKeySet;
+                                }
+                            }
+
+                            const auto targetIt = groupIndex.find(targetGroupId);
+                            if (targetIt == groupIndex.end())
+                            {
+                                chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type mapEntry;
+                                mapEntry.groupId       = targetGroupId;
+                                mapEntry.groupKeySetID = targetGroupKeySetId.Value();
+                                mapEntry.fabricIndex   = sessionHandle->GetFabricIndex();
+                                mergedEntries.push_back(mapEntry);
+                            }
+                            else
+                            {
+                                mergedEntries[targetIt->second].groupKeySetID = targetGroupKeySetId.Value();
+                            }
+
+                            ChipLogProgress(Controller,
+                                            "Writing merged GroupKeyMap for group 0x%04x with keyset %u before AddGroup",
                                             targetGroupId, targetGroupKeySetId.Value());
 
-                            chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type mapEntry;
-                            mapEntry.groupId       = targetGroupId;
-                            mapEntry.groupKeySetID = targetGroupKeySetId.Value();
+                            auto mergedList = chip::app::DataModel::List<
+                                const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(
+                                mergedEntries.data(), mergedEntries.size());
 
-                            chip::Controller::ClusterBase groupKeyMgmtCluster(exchangeMgr, sessionHandle, kRootEndpointId);
-                            chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo::Type groupKeyMapList =
-                                chip::app::DataModel::List<
-                                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(&mapEntry, 1);
+                            err = chip::Controller::WriteAttribute<decltype(mergedList)>(
+                                sessionHandle, kRootEndpointId, chip::app::Clusters::GroupKeyManagement::Id,
+                                chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::Id, mergedList,
+                                [pairingCommand](const chip::app::ConcreteAttributePath &) {
+                                    auto lambdaCbContext = pairingCommand->mContext;
 
-                            err = groupKeyMgmtCluster
-                                      .WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
-                                          groupKeyMapList, pairingCommand,
-                                          [](void * lambdaContext) {
-                                              auto * instance      = static_cast<DevicePairedCommand *>(lambdaContext);
-                                              auto lambdaCbContext = instance->mContext;
+                                    CHIP_ERROR connErr = GetDeviceCommissioner()->GetConnectedDevice(
+                                        lambdaCbContext->nodeId, &pairingCommand->mOnAddGroupConnectedCallback,
+                                        &pairingCommand->mOnAddGroupConnectionFailureCallback);
+                                    if (connErr != CHIP_NO_ERROR)
+                                    {
+                                        ChipLogError(Controller, "Failed to reconnect for AddGroup after GroupKeyMap write: %s",
+                                                     ErrorStr(connErr));
+                                        if (pairingCommand->mRemovalCallback)
+                                        {
+                                            pairingCommand->mRemovalCallback();
+                                        }
+                                    }
+                                },
+                                [pairingCommand](const chip::app::ConcreteAttributePath *, CHIP_ERROR writeError) {
+                                    ChipLogError(Controller, "Failed to write GroupKeyMap before AddGroup: %s",
+                                                 ErrorStr(writeError));
+                                    if (pairingCommand->mRemovalCallback)
+                                    {
+                                        pairingCommand->mRemovalCallback();
+                                    }
+                                },
+                                chip::NullOptional);
 
-                                              CHIP_ERROR connErr = GetDeviceCommissioner()->GetConnectedDevice(
-                                                  lambdaCbContext->nodeId, &instance->mOnAddGroupConnectedCallback,
-                                                  &instance->mOnAddGroupConnectionFailureCallback);
-                                              if (connErr != CHIP_NO_ERROR)
-                                              {
-                                                  ChipLogError(Controller,
-                                                               "Failed to reconnect for AddGroup after GroupKeyMap write: %s",
-                                                               ErrorStr(connErr));
-                                                  if (instance && instance->mRemovalCallback)
-                                                  {
-                                                      instance->mRemovalCallback();
-                                                  }
-                                              }
-                                          },
-                                          [](void * lambdaContext, CHIP_ERROR writeError) {
-                                              auto * instance = static_cast<DevicePairedCommand *>(lambdaContext);
-                                              ChipLogError(Controller, "Failed to write GroupKeyMap before AddGroup: %s",
-                                                           ErrorStr(writeError));
-                                              if (instance && instance->mRemovalCallback)
-                                              {
-                                                  instance->mRemovalCallback();
-                                              }
-                                          });
+                            if (err != CHIP_NO_ERROR)
+                            {
+                                ChipLogError(Controller, "Failed to write merged GroupKeyMap before AddGroup: %s", ErrorStr(err));
+                                if (pairingCommand->mRemovalCallback)
+                                {
+                                    pairingCommand->mRemovalCallback();
+                                }
+                            }
                         }
                         else
                         {
@@ -1368,7 +1438,7 @@ public:
         auto cbContext        = pairingCommand->mContext;
         if (cbContext && cbContext->onSuccess)
         {
-            cbContext->onSuccess();
+            cbContext->onSuccess(CHIP_NO_ERROR);
         }
 
         // Clean up in-flight command
@@ -1409,15 +1479,18 @@ public:
                 failedEntry.statusEntry.failureCode = static_cast<uint32_t>(error.AsInteger());
                 cbContext->objectToWrite            = MakeOptional(failedEntry);
 
-                auto & endpointBindingList = Server::GetInstance().GetJointFabricDatastore().GetEndpointBindingList();
-                for (auto & entry : endpointBindingList)
+                if (cbContext->sourceObjectsToWrite != nullptr)
                 {
-                    if (entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
-                        entry.listID == failedEntry.listID)
+                    auto & sourceEntries = *cbContext->sourceObjectsToWrite;
+                    auto sourceIt = std::find_if(sourceEntries.begin(), sourceEntries.end(), [&failedEntry](const auto & entry) {
+                        return entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
+                            entry.listID == failedEntry.listID;
+                    });
+
+                    if (sourceIt != sourceEntries.end())
                     {
-                        entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
-                        entry.statusEntry.failureCode = failedEntry.statusEntry.failureCode;
-                        break;
+                        sourceIt->statusEntry.state       = failedEntry.statusEntry.state;
+                        sourceIt->statusEntry.failureCode = failedEntry.statusEntry.failureCode;
                     }
                 }
             }
@@ -1432,17 +1505,21 @@ public:
                 }
                 cbContext->objectsToWrite = MakeOptional(failedEntries);
 
-                auto & endpointBindingList = Server::GetInstance().GetJointFabricDatastore().GetEndpointBindingList();
-                for (auto & entry : endpointBindingList)
+                if (cbContext->sourceObjectsToWrite != nullptr)
                 {
+                    auto & sourceEntries = *cbContext->sourceObjectsToWrite;
                     for (const auto & failedEntry : failedEntries)
                     {
-                        if (entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
-                            entry.listID == failedEntry.listID)
+                        auto sourceIt =
+                            std::find_if(sourceEntries.begin(), sourceEntries.end(), [&failedEntry](const auto & entry) {
+                                return entry.nodeID == failedEntry.nodeID && entry.endpointID == failedEntry.endpointID &&
+                                    entry.listID == failedEntry.listID;
+                            });
+
+                        if (sourceIt != sourceEntries.end())
                         {
-                            entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
-                            entry.statusEntry.failureCode = failedEntry.statusEntry.failureCode;
-                            break;
+                            sourceIt->statusEntry.state       = failedEntry.statusEntry.state;
+                            sourceIt->statusEntry.failureCode = failedEntry.statusEntry.failureCode;
                         }
                     }
                 }
@@ -1451,7 +1528,7 @@ public:
 
         if (cbContext && cbContext->onSuccess)
         {
-            cbContext->onSuccess();
+            cbContext->onSuccess(error);
         }
 
         // Clean up in-flight command
@@ -1479,10 +1556,10 @@ public:
                          static_cast<unsigned>(response.status), static_cast<unsigned>(response.groupID));
         }
 
-        // Continue state machine regardless of payload status; caller only exposes completion callback.
+        const CHIP_ERROR addGroupResult = (response.status == 0) ? CHIP_NO_ERROR : CHIP_IM_GLOBAL_STATUS(Failure);
         if (cbContext && cbContext->onSuccess)
         {
-            cbContext->onSuccess();
+            cbContext->onSuccess(addGroupResult);
         }
 
         // Clean up in-flight command
@@ -1503,7 +1580,7 @@ public:
         auto cbContext        = pairingCommand->mContext;
         if (cbContext && cbContext->onSuccess)
         {
-            cbContext->onSuccess();
+            cbContext->onSuccess(CHIP_NO_ERROR);
         }
 
         // Clean up in-flight command
@@ -1531,10 +1608,10 @@ public:
                          static_cast<unsigned>(response.status), static_cast<unsigned>(response.groupID));
         }
 
-        // Continue state machine regardless of payload status; caller only exposes completion callback.
+        const CHIP_ERROR removeGroupResult = (response.status == 0) ? CHIP_NO_ERROR : CHIP_IM_GLOBAL_STATUS(Failure);
         if (cbContext && cbContext->onSuccess)
         {
-            cbContext->onSuccess();
+            cbContext->onSuccess(removeGroupResult);
         }
 
         // Clean up in-flight command
@@ -1549,8 +1626,14 @@ public:
     {
         ChipLogProgress(Controller, "OnCommandFailure - Failed to execute Command: %s", ErrorStr(error));
 
-        // Clean up in-flight command
         auto * pairingCommand = static_cast<DevicePairedCommand *>(context);
+        auto cbContext        = pairingCommand ? pairingCommand->mContext : nullptr;
+        if (cbContext && cbContext->onSuccess)
+        {
+            cbContext->onSuccess(error);
+        }
+
+        // Clean up in-flight command
         if (pairingCommand && pairingCommand->mRemovalCallback)
         {
             pairingCommand->mRemovalCallback();
@@ -1580,7 +1663,7 @@ CHIP_ERROR JFADatastoreSync::Init(Server & server)
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId,
     const app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type & endpointGroupIDEntry,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1601,7 +1684,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId, const app::Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type & nodeKeySetEntry,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1622,7 +1705,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId, const app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type & bindingEntry,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Appending binding entry for node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1667,7 +1750,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
                 ChipLogError(DeviceLayer, "Failed to write appended binding list: %s", ErrorStr(writeErr));
                 if (onSuccess)
                 {
-                    onSuccess();
+                    onSuccess(writeErr);
                 }
             }
         });
@@ -1676,7 +1759,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId, EndpointId endpointId,
     std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1698,7 +1781,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId,
     std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1707,7 +1790,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
     std::shared_ptr<DevicePairedCommand<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>>
         pairingCommand = std::make_shared<
             DevicePairedCommand<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type>>(
-            nodeId, bindingEntries, onSuccess, [this, inFlightToken]() { RemoveInFlightCommand(inFlightToken); });
+            nodeId, bindingEntries, onSuccess, [this, inFlightToken]() { RemoveInFlightCommand(inFlightToken); }, &bindingEntries);
 
     StoreInFlightCommand(inFlightToken, pairingCommand);
 
@@ -1720,7 +1803,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 CHIP_ERROR
 JFADatastoreSync::SyncNode(NodeId nodeId,
                            const app::Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type & aclEntry,
-                           std::function<void()> onSuccess)
+                           std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Appending ACL entry for node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1773,7 +1856,7 @@ JFADatastoreSync::SyncNode(NodeId nodeId,
                 ChipLogError(DeviceLayer, "Failed to fetch ACL list before append: %s", ErrorStr(fetchErr));
                 if (onSuccess)
                 {
-                    onSuccess();
+                    onSuccess(fetchErr);
                 }
                 return;
             }
@@ -1801,7 +1884,7 @@ JFADatastoreSync::SyncNode(NodeId nodeId,
                 ChipLogError(DeviceLayer, "Failed to write appended ACL list: %s", ErrorStr(writeErr));
                 if (onSuccess)
                 {
-                    onSuccess();
+                    onSuccess(writeErr);
                 }
             }
         });
@@ -1809,7 +1892,7 @@ JFADatastoreSync::SyncNode(NodeId nodeId,
 
 CHIP_ERROR JFADatastoreSync::SyncNode(
     NodeId nodeId, const std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type> & aclEntries,
-    std::function<void()> onSuccess)
+    std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 
@@ -1831,7 +1914,7 @@ CHIP_ERROR JFADatastoreSync::SyncNode(
 CHIP_ERROR
 JFADatastoreSync::SyncNode(NodeId nodeId,
                            const app::Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet,
-                           std::function<void()> onSuccess)
+                           std::function<void(CHIP_ERROR)> onSuccess)
 {
     ChipLogProgress(DeviceLayer, "Creating Pairing Command with node id: " ChipLogFormatX64, ChipLogValueX64(nodeId));
 

--- a/examples/jf-admin-app/linux/include/JFADatastoreSync.h
+++ b/examples/jf-admin-app/linux/include/JFADatastoreSync.h
@@ -47,6 +47,10 @@ public:
              const app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type & bindingEntry,
              std::function<void()> onSuccess) override;
     CHIP_ERROR
+    SyncNode(NodeId nodeId, EndpointId endpointId,
+             std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
+             std::function<void()> onSuccess) override;
+    CHIP_ERROR
     SyncNode(NodeId nodeId,
              std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
              std::function<void()> onSuccess) override;

--- a/examples/jf-admin-app/linux/include/JFADatastoreSync.h
+++ b/examples/jf-admin-app/linux/include/JFADatastoreSync.h
@@ -37,31 +37,31 @@ public:
     CHIP_ERROR
     SyncNode(NodeId nodeId,
              const app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type & endpointGroupIDEntry,
-             std::function<void()> onSuccess) override;
+             std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR
     SyncNode(NodeId nodeId,
              const app::Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type & nodeKeySetEntry,
-             std::function<void()> onSuccess) override;
+             std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR
     SyncNode(NodeId nodeId,
              const app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type & bindingEntry,
-             std::function<void()> onSuccess) override;
+             std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR
     SyncNode(NodeId nodeId, EndpointId endpointId,
              std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-             std::function<void()> onSuccess) override;
+             std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR
     SyncNode(NodeId nodeId,
              std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-             std::function<void()> onSuccess) override;
+             std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR SyncNode(NodeId nodeId, const app::Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type & aclEntry,
-                        std::function<void()> onSuccess) override;
+                        std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR SyncNode(NodeId nodeId,
                         const std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type> & aclEntries,
-                        std::function<void()> onSuccess) override;
+                        std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR SyncNode(NodeId nodeId,
                         const app::Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet,
-                        std::function<void()> onSuccess) override;
+                        std::function<void(CHIP_ERROR)> onSuccess) override;
     CHIP_ERROR FetchEndpointList(
         NodeId nodeId,
         std::function<void(CHIP_ERROR,

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -581,7 +581,15 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     {
                         if (entry.endpointID == bindingEntry.endpointID && BindingMatches(entry.binding, bindingEntry.binding))
                         {
-                            entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                            if (bindingEntry.statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
+                            {
+                                entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                                entry.statusEntry.failureCode = bindingEntry.statusEntry.failureCode;
+                            }
+                            else
+                            {
+                                entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                            }
                             break;
                         }
                     }
@@ -1471,37 +1479,6 @@ CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip
 
     VerifyOrReturnError(IsGroupIDInDatastore(groupId, index) == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
-    if (mGroupInformationEntries[index].groupKeySetID.IsNull() == false)
-    {
-        uint16_t groupKeySetID = mGroupInformationEntries[index].groupKeySetID.Value();
-
-        // make sure mNodeKeySetEntries contains an entry for this keyset and node, else add one and update device
-        bool nodeKeySetExists = false;
-        for (auto & entry : mNodeKeySetEntries)
-        {
-            if (entry.nodeID == nodeId && entry.groupKeySetID == groupKeySetID)
-            {
-                nodeKeySetExists = true;
-                break; // Found the group key set, no need to add it again
-            }
-        }
-
-        if (!nodeKeySetExists)
-        {
-            // Create a new group key set entry if it doesn't exist
-            Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type newNodeKeySet;
-            newNodeKeySet.nodeID            = nodeId;
-            newNodeKeySet.groupKeySetID     = groupKeySetID;
-            newNodeKeySet.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
-
-            mNodeKeySetEntries.push_back(newNodeKeySet);
-
-            ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, newNodeKeySet, [this]() {
-                mNodeKeySetEntries.back().statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
-            }));
-        }
-    }
-
     // Check if the group ID already exists for the endpoint
     for (auto & entry : mEndpointGroupIDEntries)
     {
@@ -1520,12 +1497,68 @@ CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip
     newGroupEntry.groupID           = groupId;
     newGroupEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
 
-    // Add the new ACL entry to the datastore
+    // Add the new endpoint-group entry to the datastore.
     mEndpointGroupIDEntries.push_back(newGroupEntry);
 
-    return mDelegate->SyncNode(nodeId, newGroupEntry, [this]() {
-        mEndpointGroupIDEntries.back().statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
-    });
+    auto markEndpointGroupCommitted = [this, nodeId, endpointId, groupId]() {
+        for (auto & endpointGroupEntry : mEndpointGroupIDEntries)
+        {
+            if (endpointGroupEntry.nodeID == nodeId && endpointGroupEntry.endpointID == endpointId &&
+                endpointGroupEntry.groupID == groupId)
+            {
+                endpointGroupEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                break;
+            }
+        }
+    };
+
+    // Ensure the node has the required keyset before issuing AddGroup on the target endpoint.
+    if (mGroupInformationEntries[index].groupKeySetID.IsNull() == false)
+    {
+        uint16_t groupKeySetID = mGroupInformationEntries[index].groupKeySetID.Value();
+
+        bool nodeKeySetExists = false;
+        for (const auto & entry : mNodeKeySetEntries)
+        {
+            if (entry.nodeID == nodeId && entry.groupKeySetID == groupKeySetID)
+            {
+                nodeKeySetExists = true;
+                break;
+            }
+        }
+
+        if (!nodeKeySetExists)
+        {
+            Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type newNodeKeySet;
+            newNodeKeySet.nodeID            = nodeId;
+            newNodeKeySet.groupKeySetID     = groupKeySetID;
+            newNodeKeySet.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
+
+            mNodeKeySetEntries.push_back(newNodeKeySet);
+
+            return mDelegate->SyncNode(
+                nodeId, newNodeKeySet, [this, nodeId, groupKeySetID, newGroupEntry, markEndpointGroupCommitted]() {
+                    for (auto & nodeKeySetEntry : mNodeKeySetEntries)
+                    {
+                        if (nodeKeySetEntry.nodeID == nodeId && nodeKeySetEntry.groupKeySetID == groupKeySetID)
+                        {
+                            nodeKeySetEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                            break;
+                        }
+                    }
+
+                    CHIP_ERROR err = mDelegate->SyncNode(nodeId, newGroupEntry,
+                                                         [markEndpointGroupCommitted]() { markEndpointGroupCommitted(); });
+                    if (err != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(DataManagement, "Failed to sync endpoint group after keyset sync: %" CHIP_ERROR_FORMAT,
+                                     err.Format());
+                    }
+                });
+        }
+    }
+
+    return mDelegate->SyncNode(nodeId, newGroupEntry, [markEndpointGroupCommitted]() { markEndpointGroupCommitted(); });
 }
 
 CHIP_ERROR JointFabricDatastore::RemoveGroupIDFromEndpointForNode(NodeId nodeId, chip::EndpointId endpointId, chip::GroupId groupId)
@@ -1702,8 +1735,20 @@ JointFabricDatastore::AddBindingToEndpointForNode(
     // Add the new binding entry to the datastore
     mEndpointBindingEntries.push_back(newBindingEntry);
 
-    return mDelegate->SyncNode(nodeId, newBindingEntry, [this]() {
-        mEndpointBindingEntries.back().statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+    const uint16_t syncedListId = newBindingEntry.listID;
+    return mDelegate->SyncNode(nodeId, newBindingEntry, [this, nodeId, endpointId, syncedListId]() {
+        for (auto & entry : mEndpointBindingEntries)
+        {
+            if (entry.nodeID == nodeId && entry.endpointID == endpointId && entry.listID == syncedListId)
+            {
+                // Delegate callbacks may move the entry to CommitFailed; do not overwrite that.
+                if (entry.statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kPending)
+                {
+                    entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                }
+                break;
+            }
+        }
     });
 }
 

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -768,6 +768,56 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
     break;
     case kRefreshingGroupKeySets: {
         // 4. Ensure per-node key-set entries for each GroupKeySet are synced to devices.
+        if (mRefreshingNodeKeySetDeletions.empty())
+        {
+            for (const auto & groupKeySet : mGroupKeySetList)
+            {
+                for (const auto & nodeKeySetEntry : mNodeKeySetEntries)
+                {
+                    if (nodeKeySetEntry.groupKeySetID == groupKeySet.groupKeySetID &&
+                        nodeKeySetEntry.statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
+                    {
+                        mRefreshingNodeKeySetDeletions.emplace_back(nodeKeySetEntry.nodeID, nodeKeySetEntry.groupKeySetID);
+                    }
+                }
+            }
+        }
+
+        if (mRefreshingNodeKeySetDeletionIndex < mRefreshingNodeKeySetDeletions.size())
+        {
+            const auto [nodeIdToErase, groupKeySetIdToErase] = mRefreshingNodeKeySetDeletions[mRefreshingNodeKeySetDeletionIndex];
+            Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type nullEntry{ 0 };
+            CHIP_ERROR syncErr =
+                mDelegate->SyncNode(nodeIdToErase, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR innerErr) {
+                    if (innerErr == CHIP_NO_ERROR)
+                    {
+                        mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
+                                                                [nodeIdToErase, groupKeySetIdToErase](const auto & entry) {
+                                                                    return entry.nodeID == nodeIdToErase &&
+                                                                        entry.groupKeySetID == groupKeySetIdToErase;
+                                                                }),
+                                                 mNodeKeySetEntries.end());
+                    }
+
+                    ++mRefreshingNodeKeySetDeletionIndex;
+                    if (ContinueRefresh() != CHIP_NO_ERROR)
+                    {
+                        // Ignore errors in continuation from within the callback.
+                    }
+                });
+            if (syncErr != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer,
+                             "Failed deleting group key set during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                             ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                mRefreshingNodeId = kUndefinedNodeId;
+                mRefreshState     = kIdle;
+                return syncErr;
+            }
+
+            return CHIP_NO_ERROR;
+        }
+
         for (auto gksIt = mGroupKeySetList.begin(); gksIt != mGroupKeySetList.end(); ++gksIt)
         {
             const uint16_t groupKeySetId = gksIt->groupKeySetID;
@@ -807,37 +857,6 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                         return syncErr;
                     }
                     ++nkIt;
-                }
-                else if (nkIt->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
-                {
-                    // zero-initialized struct to indicate deletion for the SyncNode call
-                    Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type nullEntry{ 0 };
-
-                    auto nodeIdToErase        = nkIt->nodeID;
-                    auto groupKeySetIdToErase = nkIt->groupKeySetID;
-                    CHIP_ERROR syncErr        = mDelegate->SyncNode(
-                        nkIt->nodeID, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR innerErr) {
-                            if (innerErr != CHIP_NO_ERROR)
-                            {
-                                return;
-                            }
-                            mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
-                                                                           [&](const auto & entry) {
-                                                                        return entry.nodeID == nodeIdToErase &&
-                                                                            entry.groupKeySetID == groupKeySetIdToErase;
-                                                                    }),
-                                                            mNodeKeySetEntries.end());
-                        });
-                    if (syncErr != CHIP_NO_ERROR)
-                    {
-                        ChipLogError(AppServer,
-                                     "Failed deleting group key set during refresh for node 0x" ChipLogFormatX64
-                                     ": %" CHIP_ERROR_FORMAT,
-                                     ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
-                        mRefreshingNodeId = kUndefinedNodeId;
-                        mRefreshState     = kIdle;
-                        return syncErr;
-                    }
                 }
                 else if (nkIt->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
                 {
@@ -883,6 +902,9 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                 }
             }
         }
+
+        mRefreshingNodeKeySetDeletions.clear();
+        mRefreshingNodeKeySetDeletionIndex = 0;
 
         // Request ACL List from the device and transition to kRefreshingACLs.
         ReturnErrorOnFailure(mDelegate->FetchACLList(

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -436,16 +436,26 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     const NodeId nodeId   = entryToSync.nodeID;
                     const EndpointId epId = entryToSync.endpointID;
                     const GroupId groupId = entryToSync.groupID;
-                    ReturnErrorOnFailure(
-                        mDelegate->SyncNode(mRefreshingNodeId, entryToSync, [this, nodeId, epId, groupId](CHIP_ERROR syncErr) {
-                            if (syncErr != CHIP_NO_ERROR)
+                    CHIP_ERROR syncErr =
+                        mDelegate->SyncNode(mRefreshingNodeId, entryToSync, [this, nodeId, epId, groupId](CHIP_ERROR innerErr) {
+                            if (innerErr != CHIP_NO_ERROR)
                             {
                                 return;
                             }
                             detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & e) {
                                 return e.nodeID == nodeId && e.endpointID == epId && e.groupID == groupId;
                             });
-                        }));
+                        });
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(AppServer,
+                                     "Failed syncing group entry during refresh for node 0x" ChipLogFormatX64
+                                     ": %" CHIP_ERROR_FORMAT,
+                                     ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                        mRefreshingNodeId = kUndefinedNodeId;
+                        mRefreshState     = kIdle;
+                        return syncErr;
+                    }
                 }
                 else if (it->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
                 {
@@ -454,9 +464,9 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     };
 
                     auto entryToErase = *it;
-                    ReturnErrorOnFailure(
-                        mDelegate->SyncNode(mRefreshingNodeId, endpointGroupIdNullEntry, [this, entryToErase](CHIP_ERROR syncErr) {
-                            if (syncErr != CHIP_NO_ERROR)
+                    CHIP_ERROR syncErr =
+                        mDelegate->SyncNode(mRefreshingNodeId, endpointGroupIdNullEntry, [this, entryToErase](CHIP_ERROR innerErr) {
+                            if (innerErr != CHIP_NO_ERROR)
                             {
                                 return;
                             }
@@ -468,7 +478,17 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                                                                                  entry.groupID == entryToErase.groupID;
                                                                          }),
                                                           mEndpointGroupIDEntries.end());
-                        }));
+                        });
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(AppServer,
+                                     "Failed deleting group entry during refresh for node 0x" ChipLogFormatX64
+                                     ": %" CHIP_ERROR_FORMAT,
+                                     ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                        mRefreshingNodeId = kUndefinedNodeId;
+                        mRefreshState     = kIdle;
+                        return syncErr;
+                    }
                 }
                 else if (it->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
                 {
@@ -500,6 +520,8 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
     break;
 
     case kRefreshingBindings: {
+        mRefreshingBindingEntries.clear();
+
         // Check if we still have endpoints to process for group fetching
         if (mRefreshingEndpointIndex < mRefreshingEndpointsList.size())
         {
@@ -764,16 +786,26 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     // Make a copy of the group key set to send to the node.
                     const NodeId entryNodeId = nkIt->nodeID;
                     auto groupKeySet         = *gksIt;
-                    ReturnErrorOnFailure(
-                        mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR syncErr) {
-                            if (syncErr != CHIP_NO_ERROR)
+                    CHIP_ERROR syncErr =
+                        mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR innerErr) {
+                            if (innerErr != CHIP_NO_ERROR)
                             {
                                 return;
                             }
                             detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
                                 return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
                             });
-                        }));
+                        });
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(AppServer,
+                                     "Failed syncing group key set during refresh for node 0x" ChipLogFormatX64
+                                     ": %" CHIP_ERROR_FORMAT,
+                                     ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                        mRefreshingNodeId = kUndefinedNodeId;
+                        mRefreshState     = kIdle;
+                        return syncErr;
+                    }
                     ++nkIt;
                 }
                 else if (nkIt->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
@@ -783,19 +815,29 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
 
                     auto nodeIdToErase        = nkIt->nodeID;
                     auto groupKeySetIdToErase = nkIt->groupKeySetID;
-                    ReturnErrorOnFailure(mDelegate->SyncNode(
-                        nkIt->nodeID, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR syncErr) {
-                            if (syncErr != CHIP_NO_ERROR)
+                    CHIP_ERROR syncErr        = mDelegate->SyncNode(
+                        nkIt->nodeID, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR innerErr) {
+                            if (innerErr != CHIP_NO_ERROR)
                             {
                                 return;
                             }
                             mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
-                                                                    [&](const auto & entry) {
+                                                                           [&](const auto & entry) {
                                                                         return entry.nodeID == nodeIdToErase &&
                                                                             entry.groupKeySetID == groupKeySetIdToErase;
                                                                     }),
-                                                     mNodeKeySetEntries.end());
-                        }));
+                                                            mNodeKeySetEntries.end());
+                        });
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(AppServer,
+                                     "Failed deleting group key set during refresh for node 0x" ChipLogFormatX64
+                                     ": %" CHIP_ERROR_FORMAT,
+                                     ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                        mRefreshingNodeId = kUndefinedNodeId;
+                        mRefreshState     = kIdle;
+                        return syncErr;
+                    }
                 }
                 else if (nkIt->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
                 {
@@ -812,16 +854,26 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                         // Retry the failed commit by attempting to SyncNode again.
                         const NodeId entryNodeId = nkIt->nodeID;
                         auto groupKeySet         = *gksIt;
-                        ReturnErrorOnFailure(
-                            mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR syncErr) {
-                                if (syncErr != CHIP_NO_ERROR)
+                        CHIP_ERROR syncErr =
+                            mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR innerErr) {
+                                if (innerErr != CHIP_NO_ERROR)
                                 {
                                     return;
                                 }
                                 detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
                                     return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
                                 });
-                            }));
+                            });
+                        if (syncErr != CHIP_NO_ERROR)
+                        {
+                            ChipLogError(AppServer,
+                                         "Failed retrying group key set during refresh for node 0x" ChipLogFormatX64
+                                         ": %" CHIP_ERROR_FORMAT,
+                                         ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                            mRefreshingNodeId = kUndefinedNodeId;
+                            mRefreshState     = kIdle;
+                            return syncErr;
+                        }
                         ++nkIt;
                     }
                 }
@@ -917,6 +969,8 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
     }
     break;
     case kRefreshingACLs: {
+        mRefreshingACLEntries.clear();
+
         // 5.
         for (auto it = mACLEntries.begin(); it != mACLEntries.end();)
         {
@@ -974,11 +1028,11 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
             ++it;
         }
 
-        ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, mRefreshingACLEntries, [this](CHIP_ERROR syncErr) {
-            if (syncErr != CHIP_NO_ERROR)
+        CHIP_ERROR syncErr = mDelegate->SyncNode(mRefreshingNodeId, mRefreshingACLEntries, [this](CHIP_ERROR innerErr) {
+            if (innerErr != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Failed syncing ACLs during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
-                             ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+                             ChipLogValueX64(mRefreshingNodeId), innerErr.Format());
 
                 // Keep entries pending/failed for retry, but always close out refresh state.
                 mRefreshingNodeId = kUndefinedNodeId;
@@ -1028,7 +1082,15 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
 
             mRefreshingNodeId = kUndefinedNodeId;
             mRefreshState     = kIdle;
-        }));
+        });
+        if (syncErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Failed syncing ACLs during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                         ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+            mRefreshingNodeId = kUndefinedNodeId;
+            mRefreshState     = kIdle;
+            return syncErr;
+        }
     }
     break;
     }
@@ -1202,6 +1264,8 @@ CHIP_ERROR JointFabricDatastore::RemoveAdmin(NodeId nodeId)
 CHIP_ERROR
 JointFabricDatastore::UpdateNodeKeySetList(Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet)
 {
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     bool entryUpdated = false;
 
     for (size_t i = 0; i < mNodeKeySetEntries.size(); ++i)

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -436,11 +436,16 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     const NodeId nodeId   = entryToSync.nodeID;
                     const EndpointId epId = entryToSync.endpointID;
                     const GroupId groupId = entryToSync.groupID;
-                    ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, entryToSync, [this, nodeId, epId, groupId]() {
-                        detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & e) {
-                            return e.nodeID == nodeId && e.endpointID == epId && e.groupID == groupId;
-                        });
-                    }));
+                    ReturnErrorOnFailure(
+                        mDelegate->SyncNode(mRefreshingNodeId, entryToSync, [this, nodeId, epId, groupId](CHIP_ERROR syncErr) {
+                            if (syncErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
+                            detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & e) {
+                                return e.nodeID == nodeId && e.endpointID == epId && e.groupID == groupId;
+                            });
+                        }));
                 }
                 else if (it->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
                 {
@@ -449,15 +454,21 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     };
 
                     auto entryToErase = *it;
-                    ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, endpointGroupIdNullEntry, [this, entryToErase]() {
-                        mEndpointGroupIDEntries.erase(std::remove_if(mEndpointGroupIDEntries.begin(), mEndpointGroupIDEntries.end(),
-                                                                     [&](const auto & entry) {
-                                                                         return entry.nodeID == entryToErase.nodeID &&
-                                                                             entry.endpointID == entryToErase.endpointID &&
-                                                                             entry.groupID == entryToErase.groupID;
-                                                                     }),
-                                                      mEndpointGroupIDEntries.end());
-                    }));
+                    ReturnErrorOnFailure(
+                        mDelegate->SyncNode(mRefreshingNodeId, endpointGroupIdNullEntry, [this, entryToErase](CHIP_ERROR syncErr) {
+                            if (syncErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
+                            mEndpointGroupIDEntries.erase(std::remove_if(mEndpointGroupIDEntries.begin(),
+                                                                         mEndpointGroupIDEntries.end(),
+                                                                         [&](const auto & entry) {
+                                                                             return entry.nodeID == entryToErase.nodeID &&
+                                                                                 entry.endpointID == entryToErase.endpointID &&
+                                                                                 entry.groupID == entryToErase.groupID;
+                                                                         }),
+                                                          mEndpointGroupIDEntries.end());
+                        }));
                 }
                 else if (it->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
                 {
@@ -594,7 +605,18 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
             ++it;
         }
 
-        ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, mRefreshingBindingEntries, [this]() {
+        ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, mRefreshingBindingEntries, [this](CHIP_ERROR syncErr) {
+            if (syncErr != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer,
+                             "Failed syncing bindings during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                             ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+
+                // Keep entries pending/failed for retry, but always close out refresh state.
+                mRefreshingNodeId = kUndefinedNodeId;
+                mRefreshState     = kIdle;
+                return;
+            }
             for (auto & entry : mEndpointBindingEntries)
             {
                 if (entry.nodeID == mRefreshingNodeId &&
@@ -612,7 +634,8 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                             }
                             else
                             {
-                                entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                                entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                                entry.statusEntry.failureCode = 0;
                             }
                             break;
                         }
@@ -741,11 +764,16 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     // Make a copy of the group key set to send to the node.
                     const NodeId entryNodeId = nkIt->nodeID;
                     auto groupKeySet         = *gksIt;
-                    ReturnErrorOnFailure(mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId]() {
-                        detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
-                            return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
-                        });
-                    }));
+                    ReturnErrorOnFailure(
+                        mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR syncErr) {
+                            if (syncErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
+                            detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
+                                return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
+                            });
+                        }));
                     ++nkIt;
                 }
                 else if (nkIt->statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
@@ -755,8 +783,12 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
 
                     auto nodeIdToErase        = nkIt->nodeID;
                     auto groupKeySetIdToErase = nkIt->groupKeySetID;
-                    ReturnErrorOnFailure(
-                        mDelegate->SyncNode(nkIt->nodeID, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase]() {
+                    ReturnErrorOnFailure(mDelegate->SyncNode(
+                        nkIt->nodeID, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR syncErr) {
+                            if (syncErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
                             mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
                                                                     [&](const auto & entry) {
                                                                         return entry.nodeID == nodeIdToErase &&
@@ -780,11 +812,16 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                         // Retry the failed commit by attempting to SyncNode again.
                         const NodeId entryNodeId = nkIt->nodeID;
                         auto groupKeySet         = *gksIt;
-                        ReturnErrorOnFailure(mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId]() {
-                            detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
-                                return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
-                            });
-                        }));
+                        ReturnErrorOnFailure(
+                            mDelegate->SyncNode(nkIt->nodeID, groupKeySet, [this, entryNodeId, groupKeySetId](CHIP_ERROR syncErr) {
+                                if (syncErr != CHIP_NO_ERROR)
+                                {
+                                    return;
+                                }
+                                detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
+                                    return e.nodeID == entryNodeId && e.groupKeySetID == groupKeySetId;
+                                });
+                            }));
                         ++nkIt;
                     }
                 }
@@ -937,7 +974,17 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
             ++it;
         }
 
-        ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, mRefreshingACLEntries, [this]() {
+        ReturnErrorOnFailure(mDelegate->SyncNode(mRefreshingNodeId, mRefreshingACLEntries, [this](CHIP_ERROR syncErr) {
+            if (syncErr != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer, "Failed syncing ACLs during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                             ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
+
+                // Keep entries pending/failed for retry, but always close out refresh state.
+                mRefreshingNodeId = kUndefinedNodeId;
+                mRefreshState     = kIdle;
+                return;
+            }
             for (auto & entry : mACLEntries)
             {
                 if (entry.nodeID == mRefreshingNodeId &&
@@ -963,21 +1010,25 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                                                      Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending;
                                              }),
                               mACLEntries.end());
+            // 6.
+            if (SetNode(mRefreshingNodeId, Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted) != CHIP_NO_ERROR)
+            {
+                mRefreshingNodeId = kUndefinedNodeId;
+                mRefreshState     = kIdle;
+                return;
+            }
+
+            ChipLogDetail(AppServer, "Finished refreshing node (ID: 0x" ChipLogFormatX64 "). Node is now marked as Committed.",
+                          ChipLogValueX64(mRefreshingNodeId));
+
+            for (Listener * listener = mListeners; listener != nullptr; listener = listener->mNext)
+            {
+                listener->MarkNodeListChanged();
+            }
+
+            mRefreshingNodeId = kUndefinedNodeId;
+            mRefreshState     = kIdle;
         }));
-
-        // 6.
-        ReturnErrorOnFailure(SetNode(mRefreshingNodeId, Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted));
-
-        ChipLogDetail(AppServer, "Finished refreshing node (ID: 0x" ChipLogFormatX64 "). Node is now marked as Committed.",
-                      ChipLogValueX64(mRefreshingNodeId));
-
-        for (Listener * listener = mListeners; listener != nullptr; listener = listener->mNext)
-        {
-            listener->MarkNodeListChanged();
-        }
-
-        mRefreshingNodeId = kUndefinedNodeId;
-        mRefreshState     = kIdle;
     }
     break;
     }
@@ -1164,11 +1215,16 @@ JointFabricDatastore::UpdateNodeKeySetList(Clusters::JointFabricDatastore::Struc
 
                 const NodeId entryNodeId          = entry.nodeID;
                 const uint16_t entryGroupKeySetID = groupKeySet.groupKeySetID;
-                LogErrorOnFailure(mDelegate->SyncNode(entry.nodeID, groupKeySet, [this, entryNodeId, entryGroupKeySetID]() {
-                    detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
-                        return e.nodeID == entryNodeId && e.groupKeySetID == entryGroupKeySetID;
-                    });
-                }));
+                LogErrorOnFailure(
+                    mDelegate->SyncNode(entry.nodeID, groupKeySet, [this, entryNodeId, entryGroupKeySetID](CHIP_ERROR syncErr) {
+                        if (syncErr != CHIP_NO_ERROR)
+                        {
+                            return;
+                        }
+                        detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & e) {
+                            return e.nodeID == entryNodeId && e.groupKeySetID == entryGroupKeySetID;
+                        });
+                    }));
 
                 if (entryUpdated == false)
                 {
@@ -1294,7 +1350,12 @@ JointFabricDatastore::UpdateGroup(const Clusters::JointFabricDatastore::Commands
                     const NodeId entryNodeId         = epGroupEntry.nodeID;
                     const EndpointId entryEndpointId = epGroupEntry.endpointID;
                     CHIP_ERROR syncErr               = mDelegate->SyncNode(
-                        epGroupEntry.nodeID, entryToSync, [this, entryNodeId, entryEndpointId, updatedGroupId]() {
+                        epGroupEntry.nodeID, entryToSync,
+                        [this, entryNodeId, entryEndpointId, updatedGroupId](CHIP_ERROR callbackErr) {
+                            if (callbackErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
                             detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & e) {
                                 return e.nodeID == entryNodeId && e.endpointID == entryEndpointId && e.groupID == updatedGroupId;
                             });
@@ -1411,10 +1472,15 @@ JointFabricDatastore::UpdateGroup(const Clusters::JointFabricDatastore::Commands
             // index would mark the wrong/invalid slot if an interleaved Invoke mutated the vector.
             const NodeId entryNodeId   = acl.nodeID;
             const uint16_t entryListId = acl.listID;
-            ReturnErrorOnFailure(mDelegate->SyncNode(acl.nodeID, entryToEncode, [this, entryNodeId, entryListId]() {
-                detail::MarkEntryCommittedIfFound(
-                    mACLEntries, [&](const auto & e) { return e.nodeID == entryNodeId && e.listID == entryListId; });
-            }));
+            ReturnErrorOnFailure(
+                mDelegate->SyncNode(acl.nodeID, entryToEncode, [this, entryNodeId, entryListId](CHIP_ERROR syncErr) {
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        return;
+                    }
+                    detail::MarkEntryCommittedIfFound(
+                        mACLEntries, [&](const auto & e) { return e.nodeID == entryNodeId && e.listID == entryListId; });
+                }));
         }
     }
 
@@ -1556,25 +1622,39 @@ CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip
 
             mNodeKeySetEntries.push_back(newNodeKeySet);
 
-            return mDelegate->SyncNode(nodeId, newNodeKeySet, [this, nodeId, groupKeySetID, newGroupEntry, endpointId, groupId]() {
-                detail::MarkEntryCommittedIfFound(
-                    mNodeKeySetEntries, [&](const auto & e) { return e.nodeID == nodeId && e.groupKeySetID == groupKeySetID; });
+            return mDelegate->SyncNode(
+                nodeId, newNodeKeySet, [this, nodeId, newGroupEntry, endpointId, groupId](CHIP_ERROR syncErr) {
+                    if (syncErr != CHIP_NO_ERROR)
+                    {
+                        return;
+                    }
+                    // Keep the NodeKeySet entry pending here. It is intended to be finalized by the
+                    // refresh flow after mirrored state is observed, not immediately on this write.
 
-                CHIP_ERROR err = mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId]() {
-                    detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & entry) {
-                        return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.groupID == groupId;
-                    });
+                    CHIP_ERROR err =
+                        mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId](CHIP_ERROR groupSyncErr) {
+                            if (groupSyncErr != CHIP_NO_ERROR)
+                            {
+                                return;
+                            }
+                            detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & entry) {
+                                return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.groupID == groupId;
+                            });
+                        });
+                    if (err != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(DataManagement, "Failed to sync endpoint group after keyset sync: %" CHIP_ERROR_FORMAT,
+                                     err.Format());
+                    }
                 });
-                if (err != CHIP_NO_ERROR)
-                {
-                    ChipLogError(DataManagement, "Failed to sync endpoint group after keyset sync: %" CHIP_ERROR_FORMAT,
-                                 err.Format());
-                }
-            });
         }
     }
 
-    return mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId]() {
+    return mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId](CHIP_ERROR syncErr) {
+        if (syncErr != CHIP_NO_ERROR)
+        {
+            return;
+        }
         detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & entry) {
             return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.groupID == groupId;
         });
@@ -1596,17 +1676,22 @@ CHIP_ERROR JointFabricDatastore::RemoveGroupIDFromEndpointForNode(NodeId nodeId,
             const auto erasedNodeId     = it->nodeID;
             const auto erasedEndpointId = it->endpointID;
             const auto erasedGroupId    = it->groupID;
-            ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, *it, [this, erasedNodeId, erasedEndpointId, erasedGroupId]() {
-                for (auto eraseIt = mEndpointGroupIDEntries.begin(); eraseIt != mEndpointGroupIDEntries.end(); ++eraseIt)
-                {
-                    if (eraseIt->nodeID == erasedNodeId && eraseIt->endpointID == erasedEndpointId &&
-                        eraseIt->groupID == erasedGroupId)
+            ReturnErrorOnFailure(
+                mDelegate->SyncNode(nodeId, *it, [this, erasedNodeId, erasedEndpointId, erasedGroupId](CHIP_ERROR syncErr) {
+                    if (syncErr != CHIP_NO_ERROR)
                     {
-                        mEndpointGroupIDEntries.erase(eraseIt);
-                        break;
+                        return;
                     }
-                }
-            }));
+                    for (auto eraseIt = mEndpointGroupIDEntries.begin(); eraseIt != mEndpointGroupIDEntries.end(); ++eraseIt)
+                    {
+                        if (eraseIt->nodeID == erasedNodeId && eraseIt->endpointID == erasedEndpointId &&
+                            eraseIt->groupID == erasedGroupId)
+                        {
+                            mEndpointGroupIDEntries.erase(eraseIt);
+                            break;
+                        }
+                    }
+                }));
 
             if (IsGroupIDInDatastore(groupId, index) == CHIP_NO_ERROR)
             {
@@ -1618,16 +1703,21 @@ CHIP_ERROR JointFabricDatastore::RemoveGroupIDFromEndpointForNode(NodeId nodeId,
                         it2->statusEntry.state         = Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending;
                         const auto erasedKeySetNodeId  = it2->nodeID;
                         const auto erasedKeySetGroupId = it2->groupKeySetID;
-                        ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, *it2, [this, erasedKeySetNodeId, erasedKeySetGroupId]() {
-                            for (auto eraseIt = mNodeKeySetEntries.begin(); eraseIt != mNodeKeySetEntries.end(); ++eraseIt)
-                            {
-                                if (eraseIt->nodeID == erasedKeySetNodeId && eraseIt->groupKeySetID == erasedKeySetGroupId)
+                        ReturnErrorOnFailure(
+                            mDelegate->SyncNode(nodeId, *it2, [this, erasedKeySetNodeId, erasedKeySetGroupId](CHIP_ERROR syncErr) {
+                                if (syncErr != CHIP_NO_ERROR)
                                 {
-                                    mNodeKeySetEntries.erase(eraseIt);
-                                    break;
+                                    return;
                                 }
-                            }
-                        }));
+                                for (auto eraseIt = mNodeKeySetEntries.begin(); eraseIt != mNodeKeySetEntries.end(); ++eraseIt)
+                                {
+                                    if (eraseIt->nodeID == erasedKeySetNodeId && eraseIt->groupKeySetID == erasedKeySetGroupId)
+                                    {
+                                        mNodeKeySetEntries.erase(eraseIt);
+                                        break;
+                                    }
+                                }
+                            }));
 
                         break;
                     }
@@ -1756,7 +1846,11 @@ JointFabricDatastore::AddBindingToEndpointForNode(
     mEndpointBindingEntries.push_back(newBindingEntry);
 
     const uint16_t syncedListId = newBindingEntry.listID;
-    return mDelegate->SyncNode(nodeId, newBindingEntry, [this, nodeId, endpointId, syncedListId]() {
+    return mDelegate->SyncNode(nodeId, newBindingEntry, [this, nodeId, endpointId, syncedListId](CHIP_ERROR syncErr) {
+        if (syncErr != CHIP_NO_ERROR)
+        {
+            return;
+        }
         detail::MarkEntryCommittedIfFound(mEndpointBindingEntries, [&](const auto & entry) {
             return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.listID == syncedListId;
         });
@@ -1778,7 +1872,11 @@ JointFabricDatastore::RemoveBindingFromEndpointForNode(uint16_t listId, NodeId n
             it->statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending;
             // Re-resolve by stable key inside the async completion instead of capturing the raw
             // iterator (which dangles if an interleaved Add*/Remove* reallocates the vector).
-            return mDelegate->SyncNode(nodeId, *it, [this, listId, nodeId, endpointId]() {
+            return mDelegate->SyncNode(nodeId, *it, [this, listId, nodeId, endpointId](CHIP_ERROR syncErr) {
+                if (syncErr != CHIP_NO_ERROR)
+                {
+                    return;
+                }
                 mEndpointBindingEntries.erase(std::remove_if(mEndpointBindingEntries.begin(), mEndpointBindingEntries.end(),
                                                              [&](const auto & entry) {
                                                                  return entry.nodeID == nodeId && entry.listID == listId &&
@@ -1976,7 +2074,11 @@ JointFabricDatastore::AddACLToNode(
     const auto committedNodeId = storedEntry.nodeID;
     const auto committedListId = storedEntry.listID;
 
-    return mDelegate->SyncNode(nodeId, entryToEncode, [this, committedNodeId, committedListId]() {
+    return mDelegate->SyncNode(nodeId, entryToEncode, [this, committedNodeId, committedListId](CHIP_ERROR syncErr) {
+        if (syncErr != CHIP_NO_ERROR)
+        {
+            return;
+        }
         for (auto & entry : mACLEntries)
         {
             if (entry.nodeID == committedNodeId && entry.listID == committedListId)
@@ -2009,7 +2111,11 @@ CHIP_ERROR JointFabricDatastore::RemoveACLFromNode(uint16_t listId, NodeId nodeI
             entryToDelete.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending;
             // Re-resolve by stable key inside the async completion instead of capturing the raw
             // iterator (which dangles if an interleaved Add*/Remove* reallocates the vector).
-            return mDelegate->SyncNode(nodeId, entryToDelete, [this, listId, nodeId]() {
+            return mDelegate->SyncNode(nodeId, entryToDelete, [this, listId, nodeId](CHIP_ERROR syncErr) {
+                if (syncErr != CHIP_NO_ERROR)
+                {
+                    return;
+                }
                 mACLEntries.erase(
                     std::remove_if(mACLEntries.begin(), mACLEntries.end(),
                                    [&](const auto & entry) { return entry.nodeID == nodeId && entry.listID == listId; }),
@@ -2064,7 +2170,11 @@ CHIP_ERROR JointFabricDatastore::AddNodeKeySetEntry(GroupId groupId, uint16_t gr
             // Sync to the node and mark committed on success. Re-resolve by stable key inside the
             // completion; capturing the index would mark the wrong/invalid slot if an interleaved
             // Invoke mutated the vector before the async completion fires.
-            ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, newEntry, [this, nodeId, groupKeySetId]() {
+            ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, newEntry, [this, nodeId, groupKeySetId](CHIP_ERROR syncErr) {
+                if (syncErr != CHIP_NO_ERROR)
+                {
+                    return;
+                }
                 detail::MarkEntryCommittedIfFound(
                     mNodeKeySetEntries, [&](const auto & e) { return e.nodeID == nodeId && e.groupKeySetID == groupKeySetId; });
             }));
@@ -2099,14 +2209,19 @@ CHIP_ERROR JointFabricDatastore::RemoveNodeKeySetEntry(GroupId groupId, uint16_t
 
                 auto nodeIdToErase        = it->nodeID;
                 auto groupKeySetIdToErase = it->groupKeySetID;
-                ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase]() {
-                    mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
-                                                            [&](const auto & entry) {
-                                                                return entry.nodeID == nodeIdToErase &&
-                                                                    entry.groupKeySetID == groupKeySetIdToErase;
-                                                            }),
-                                             mNodeKeySetEntries.end());
-                }));
+                ReturnErrorOnFailure(
+                    mDelegate->SyncNode(nodeId, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR syncErr) {
+                        if (syncErr != CHIP_NO_ERROR)
+                        {
+                            return;
+                        }
+                        mNodeKeySetEntries.erase(std::remove_if(mNodeKeySetEntries.begin(), mNodeKeySetEntries.end(),
+                                                                [&](const auto & entry) {
+                                                                    return entry.nodeID == nodeIdToErase &&
+                                                                        entry.groupKeySetID == groupKeySetIdToErase;
+                                                                }),
+                                                 mNodeKeySetEntries.end());
+                    }));
 
                 return CHIP_NO_ERROR;
             }
@@ -2129,7 +2244,11 @@ CHIP_ERROR JointFabricDatastore::TestAddNodeKeySetEntry(GroupId groupId, uint16_
 
     // Sync to the node and mark committed on success. Re-resolve by stable key inside the completion
     // rather than capturing the index, which an interleaved Invoke could invalidate.
-    return mDelegate->SyncNode(nodeId, newEntry, [this, nodeId, groupKeySetId]() {
+    return mDelegate->SyncNode(nodeId, newEntry, [this, nodeId, groupKeySetId](CHIP_ERROR syncErr) {
+        if (syncErr != CHIP_NO_ERROR)
+        {
+            return;
+        }
         detail::MarkEntryCommittedIfFound(mNodeKeySetEntries,
                                           [&](const auto & e) { return e.nodeID == nodeId && e.groupKeySetID == groupKeySetId; });
     });

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -605,7 +605,15 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                     {
                         if (entry.endpointID == bindingEntry.endpointID && BindingMatches(entry.binding, bindingEntry.binding))
                         {
-                            entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                            if (bindingEntry.statusEntry.state == Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed)
+                            {
+                                entry.statusEntry.state       = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitFailed;
+                                entry.statusEntry.failureCode = bindingEntry.statusEntry.failureCode;
+                            }
+                            else
+                            {
+                                entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+                            }
                             break;
                         }
                     }
@@ -1503,39 +1511,6 @@ CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip
 
     VerifyOrReturnError(IsGroupIDInDatastore(groupId, index) == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
-    if (mGroupInformationEntries[index].groupKeySetID.IsNull() == false)
-    {
-        uint16_t groupKeySetID = mGroupInformationEntries[index].groupKeySetID.Value();
-
-        // make sure mNodeKeySetEntries contains an entry for this keyset and node, else add one and update device
-        bool nodeKeySetExists = false;
-        for (auto & entry : mNodeKeySetEntries)
-        {
-            if (entry.nodeID == nodeId && entry.groupKeySetID == groupKeySetID)
-            {
-                nodeKeySetExists = true;
-                break; // Found the group key set, no need to add it again
-            }
-        }
-
-        if (!nodeKeySetExists)
-        {
-            // Create a new group key set entry if it doesn't exist
-            Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type newNodeKeySet;
-            newNodeKeySet.nodeID            = nodeId;
-            newNodeKeySet.groupKeySetID     = groupKeySetID;
-            newNodeKeySet.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
-
-            mNodeKeySetEntries.push_back(newNodeKeySet);
-
-            ReturnErrorOnFailure(mDelegate->SyncNode(nodeId, newNodeKeySet, [this, nodeId, groupKeySetID]() {
-                detail::MarkEntryCommittedIfFound(mNodeKeySetEntries, [&](const auto & entry) {
-                    return entry.nodeID == nodeId && entry.groupKeySetID == groupKeySetID;
-                });
-            }));
-        }
-    }
-
     // Check if the group ID already exists for the endpoint
     for (auto & entry : mEndpointGroupIDEntries)
     {
@@ -1554,8 +1529,50 @@ CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip
     newGroupEntry.groupID           = groupId;
     newGroupEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
 
-    // Add the new ACL entry to the datastore
+    // Add the new endpoint-group entry to the datastore.
     mEndpointGroupIDEntries.push_back(newGroupEntry);
+
+    // Ensure the node has the required keyset before issuing AddGroup on the target endpoint.
+    if (mGroupInformationEntries[index].groupKeySetID.IsNull() == false)
+    {
+        uint16_t groupKeySetID = mGroupInformationEntries[index].groupKeySetID.Value();
+
+        bool nodeKeySetExists = false;
+        for (const auto & entry : mNodeKeySetEntries)
+        {
+            if (entry.nodeID == nodeId && entry.groupKeySetID == groupKeySetID)
+            {
+                nodeKeySetExists = true;
+                break;
+            }
+        }
+
+        if (!nodeKeySetExists)
+        {
+            Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type newNodeKeySet;
+            newNodeKeySet.nodeID            = nodeId;
+            newNodeKeySet.groupKeySetID     = groupKeySetID;
+            newNodeKeySet.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kPending;
+
+            mNodeKeySetEntries.push_back(newNodeKeySet);
+
+            return mDelegate->SyncNode(nodeId, newNodeKeySet, [this, nodeId, groupKeySetID, newGroupEntry, endpointId, groupId]() {
+                detail::MarkEntryCommittedIfFound(
+                    mNodeKeySetEntries, [&](const auto & e) { return e.nodeID == nodeId && e.groupKeySetID == groupKeySetID; });
+
+                CHIP_ERROR err = mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId]() {
+                    detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & entry) {
+                        return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.groupID == groupId;
+                    });
+                });
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(DataManagement, "Failed to sync endpoint group after keyset sync: %" CHIP_ERROR_FORMAT,
+                                 err.Format());
+                }
+            });
+        }
+    }
 
     return mDelegate->SyncNode(nodeId, newGroupEntry, [this, nodeId, endpointId, groupId]() {
         detail::MarkEntryCommittedIfFound(mEndpointGroupIDEntries, [&](const auto & entry) {
@@ -1738,10 +1755,10 @@ JointFabricDatastore::AddBindingToEndpointForNode(
     // Add the new binding entry to the datastore
     mEndpointBindingEntries.push_back(newBindingEntry);
 
-    const uint16_t listID = newBindingEntry.listID;
-    return mDelegate->SyncNode(nodeId, newBindingEntry, [this, nodeId, endpointId, listID]() {
+    const uint16_t syncedListId = newBindingEntry.listID;
+    return mDelegate->SyncNode(nodeId, newBindingEntry, [this, nodeId, endpointId, syncedListId]() {
         detail::MarkEntryCommittedIfFound(mEndpointBindingEntries, [&](const auto & entry) {
-            return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.listID == listID;
+            return entry.nodeID == nodeId && entry.endpointID == endpointId && entry.listID == syncedListId;
         });
     });
 }

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -785,7 +785,10 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
 
         if (mRefreshingNodeKeySetDeletionIndex < mRefreshingNodeKeySetDeletions.size())
         {
-            const auto [nodeIdToErase, groupKeySetIdToErase] = mRefreshingNodeKeySetDeletions[mRefreshingNodeKeySetDeletionIndex];
+            // Structured bindings cannot be captured by lambdas prior to C++20.
+            const auto & nodeKeySetDeletion = mRefreshingNodeKeySetDeletions[mRefreshingNodeKeySetDeletionIndex];
+            NodeId nodeIdToErase            = nodeKeySetDeletion.first;
+            uint16_t groupKeySetIdToErase   = nodeKeySetDeletion.second;
             Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type nullEntry{ 0 };
             CHIP_ERROR syncErr =
                 mDelegate->SyncNode(nodeIdToErase, nullEntry, [this, nodeIdToErase, groupKeySetIdToErase](CHIP_ERROR innerErr) {
@@ -810,8 +813,10 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                 ChipLogError(AppServer,
                              "Failed deleting group key set during refresh for node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
                              ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
-                mRefreshingNodeId = kUndefinedNodeId;
-                mRefreshState     = kIdle;
+                mRefreshingNodeKeySetDeletions.clear();
+                mRefreshingNodeKeySetDeletionIndex = 0;
+                mRefreshingNodeId                  = kUndefinedNodeId;
+                mRefreshState                      = kIdle;
                 return syncErr;
             }
 
@@ -852,8 +857,10 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                                      "Failed syncing group key set during refresh for node 0x" ChipLogFormatX64
                                      ": %" CHIP_ERROR_FORMAT,
                                      ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
-                        mRefreshingNodeId = kUndefinedNodeId;
-                        mRefreshState     = kIdle;
+                        mRefreshingNodeKeySetDeletions.clear();
+                        mRefreshingNodeKeySetDeletionIndex = 0;
+                        mRefreshingNodeId                  = kUndefinedNodeId;
+                        mRefreshState                      = kIdle;
                         return syncErr;
                     }
                     ++nkIt;
@@ -889,8 +896,10 @@ CHIP_ERROR JointFabricDatastore::ContinueRefresh()
                                          "Failed retrying group key set during refresh for node 0x" ChipLogFormatX64
                                          ": %" CHIP_ERROR_FORMAT,
                                          ChipLogValueX64(mRefreshingNodeId), syncErr.Format());
-                            mRefreshingNodeId = kUndefinedNodeId;
-                            mRefreshState     = kIdle;
+                            mRefreshingNodeKeySetDeletions.clear();
+                            mRefreshingNodeKeySetDeletionIndex = 0;
+                            mRefreshingNodeId                  = kUndefinedNodeId;
+                            mRefreshState                      = kIdle;
                             return syncErr;
                         }
                         ++nkIt;

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -168,6 +168,14 @@ public:
         }
 
         virtual CHIP_ERROR
+        SyncNode(NodeId nodeId, EndpointId endpointId,
+                 std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
+                 std::function<void()> onSuccess)
+        {
+            return CHIP_ERROR_NOT_IMPLEMENTED;
+        }
+
+        virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
                  std::function<void()> onSuccess)

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -570,6 +570,8 @@ private:
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type> mEndpointGroupIDEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> mEndpointBindingEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type> mNodeKeySetEntries;
+    std::vector<std::pair<NodeId, uint16_t>> mRefreshingNodeKeySetDeletions;
+    size_t mRefreshingNodeKeySetDeletionIndex = 0;
     std::vector<datastore::ACLEntryStruct> mACLEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointEntryStruct::Type> mEndpointEntries;
     std::map<std::pair<NodeId, EndpointId>, std::vector<char>> mEndpointFriendlyNameStorage;

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -172,7 +172,7 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  const Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type & endpointGroupIDEntry,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
@@ -180,7 +180,7 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  const Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type & nodeKeySetEntry,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
@@ -188,7 +188,7 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  const Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type & bindingEntry,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
@@ -196,7 +196,7 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId, EndpointId endpointId,
                  std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
@@ -204,14 +204,14 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
 
         virtual CHIP_ERROR SyncNode(NodeId nodeId,
                                     const Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type & aclEntry,
-                                    std::function<void()> onSuccess)
+                                    std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
@@ -219,14 +219,14 @@ public:
         virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  const std::vector<app::Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type> & aclEntries,
-                 std::function<void()> onSuccess)
+                 std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
 
         virtual CHIP_ERROR SyncNode(NodeId nodeId,
                                     const Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet,
-                                    std::function<void()> onSuccess)
+                                    std::function<void(CHIP_ERROR)> onSuccess)
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -194,6 +194,14 @@ public:
         }
 
         virtual CHIP_ERROR
+        SyncNode(NodeId nodeId, EndpointId endpointId,
+                 std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
+                 std::function<void()> onSuccess)
+        {
+            return CHIP_ERROR_NOT_IMPLEMENTED;
+        }
+
+        virtual CHIP_ERROR
         SyncNode(NodeId nodeId,
                  std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> & bindingEntries,
                  std::function<void()> onSuccess)

--- a/src/app/server/tests/TestJointFabricDatastore.cpp
+++ b/src/app/server/tests/TestJointFabricDatastore.cpp
@@ -46,73 +46,76 @@ class TrackingDelegate : public JointFabricDatastore::Delegate
 {
 public:
     CHIP_ERROR SyncNode(NodeId nodeId, const EndpointGroupIdEntryType & endpointGroupIDEntry,
-                        std::function<void()> onSuccess) override
+                        std::function<void(CHIP_ERROR)> onSuccess) override
     {
         lastEndpointGroupSync    = endpointGroupIDEntry;
         hasLastEndpointGroupSync = true;
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const NodeKeySetEntryType & nodeKeySetEntry, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const NodeKeySetEntryType & nodeKeySetEntry,
+                        std::function<void(CHIP_ERROR)> onSuccess) override
     {
         lastNodeKeySetSync    = nodeKeySetEntry;
         hasLastNodeKeySetSync = true;
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const BindingEntryType & bindingEntry, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const BindingEntryType & bindingEntry, std::function<void(CHIP_ERROR)> onSuccess) override
     {
         lastBindingSync    = bindingEntry;
         hasLastBindingSync = true;
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, std::vector<BindingEntryType> & bindingEntries, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, std::vector<BindingEntryType> & bindingEntries,
+                        std::function<void(CHIP_ERROR)> onSuccess) override
     {
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const ACLEntryType & aclEntry, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const ACLEntryType & aclEntry, std::function<void(CHIP_ERROR)> onSuccess) override
     {
         lastAclSync    = aclEntry;
         hasLastAclSync = true;
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const std::vector<ACLEntryType> & aclEntries, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const std::vector<ACLEntryType> & aclEntries,
+                        std::function<void(CHIP_ERROR)> onSuccess) override
     {
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const GroupKeySetType & groupKeySet, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const GroupKeySetType & groupKeySet, std::function<void(CHIP_ERROR)> onSuccess) override
     {
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
@@ -675,9 +678,9 @@ class DeferringBindingDelegate : public TrackingDelegate
 public:
     bool deferNext   = false;
     bool hasDeferred = false;
-    std::function<void()> deferred;
+    std::function<void(CHIP_ERROR)> deferred;
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const BindingEntryType & bindingEntry, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const BindingEntryType & bindingEntry, std::function<void(CHIP_ERROR)> onSuccess) override
     {
         if (deferNext)
         {
@@ -688,7 +691,7 @@ public:
         }
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
@@ -697,7 +700,7 @@ public:
     {
         if (hasDeferred && deferred)
         {
-            deferred();
+            deferred(CHIP_NO_ERROR);
         }
     }
 };
@@ -754,9 +757,9 @@ class DeferringAclDelegate : public TrackingDelegate
 public:
     bool deferNext   = false;
     bool hasDeferred = false;
-    std::function<void()> deferred;
+    std::function<void(CHIP_ERROR)> deferred;
 
-    CHIP_ERROR SyncNode(NodeId nodeId, const ACLEntryType & aclEntry, std::function<void()> onSuccess) override
+    CHIP_ERROR SyncNode(NodeId nodeId, const ACLEntryType & aclEntry, std::function<void(CHIP_ERROR)> onSuccess) override
     {
         if (deferNext)
         {
@@ -767,7 +770,7 @@ public:
         }
         if (onSuccess)
         {
-            onSuccess();
+            onSuccess(CHIP_NO_ERROR);
         }
         return CHIP_NO_ERROR;
     }
@@ -776,7 +779,7 @@ public:
     {
         if (hasDeferred && deferred)
         {
-            deferred();
+            deferred(CHIP_NO_ERROR);
         }
     }
 };

--- a/src/app/server/tests/TestJointFabricDatastore.cpp
+++ b/src/app/server/tests/TestJointFabricDatastore.cpp
@@ -472,6 +472,74 @@ TEST(JointFabricDatastoreTest, RefreshNodeFetchesGroupKeySetsAndCommitsNode)
               JointFabricCluster::DatastoreStateEnum::kCommitted);
 }
 
+TEST(JointFabricDatastoreTest, AddGroupIDToEndpointForNodeAddsMissingNodeKeySet)
+{
+    JointFabricDatastore store;
+    TrackingDelegate delegate;
+
+    ASSERT_EQ(store.SetDelegate(&delegate), CHIP_NO_ERROR);
+    ASSERT_EQ(store.AddPendingNode(123, "controller-a"_span), CHIP_NO_ERROR);
+    ASSERT_EQ(store.TestAddEndpointEntry(1, 123, "endpoint-a"_span), CHIP_NO_ERROR);
+
+    JointFabricCluster::Commands::AddGroup::DecodableType addGroup;
+    addGroup.groupID      = 10;
+    addGroup.friendlyName = "group-a"_span;
+    addGroup.groupKeySetID.SetNonNull(55);
+    addGroup.groupPermission = JointFabricCluster::DatastoreAccessControlEntryPrivilegeEnum::kView;
+
+    ASSERT_EQ(store.AddGroup(addGroup), CHIP_NO_ERROR);
+    ASSERT_EQ(store.AddGroupIDToEndpointForNode(123, 1, 10), CHIP_NO_ERROR);
+
+    ASSERT_EQ(store.GetEndpointGroupIDList().size(), 1u);
+    ASSERT_EQ(store.GetNodeKeySetList().size(), 1u);
+
+    const auto & nodeKeySet = store.GetNodeKeySetList()[0];
+    EXPECT_EQ(nodeKeySet.nodeID, 123u);
+    EXPECT_EQ(nodeKeySet.groupKeySetID, 55u);
+    EXPECT_EQ(nodeKeySet.statusEntry.state, JointFabricCluster::DatastoreStateEnum::kPending);
+
+    ASSERT_TRUE(delegate.hasLastNodeKeySetSync);
+    EXPECT_EQ(delegate.lastNodeKeySetSync.nodeID, 123u);
+    EXPECT_EQ(delegate.lastNodeKeySetSync.groupKeySetID, 55u);
+    EXPECT_EQ(delegate.lastNodeKeySetSync.statusEntry.state, JointFabricCluster::DatastoreStateEnum::kPending);
+
+    ASSERT_TRUE(delegate.hasLastEndpointGroupSync);
+    EXPECT_EQ(delegate.lastEndpointGroupSync.nodeID, 123u);
+    EXPECT_EQ(delegate.lastEndpointGroupSync.endpointID, 1u);
+    EXPECT_EQ(delegate.lastEndpointGroupSync.groupID, 10u);
+    EXPECT_EQ(delegate.lastEndpointGroupSync.statusEntry.state, JointFabricCluster::DatastoreStateEnum::kPending);
+}
+
+TEST(JointFabricDatastoreTest, AddGroupIDToEndpointForNodeIsIdempotentForDuplicateAssignments)
+{
+    JointFabricDatastore store;
+    TrackingDelegate delegate;
+
+    ASSERT_EQ(store.SetDelegate(&delegate), CHIP_NO_ERROR);
+    ASSERT_EQ(store.AddPendingNode(123, "controller-a"_span), CHIP_NO_ERROR);
+    ASSERT_EQ(store.TestAddEndpointEntry(1, 123, "endpoint-a"_span), CHIP_NO_ERROR);
+
+    JointFabricCluster::Commands::AddGroup::DecodableType addGroup;
+    addGroup.groupID      = 10;
+    addGroup.friendlyName = "group-a"_span;
+    addGroup.groupKeySetID.SetNonNull(55);
+    addGroup.groupPermission = JointFabricCluster::DatastoreAccessControlEntryPrivilegeEnum::kView;
+
+    ASSERT_EQ(store.AddGroup(addGroup), CHIP_NO_ERROR);
+    ASSERT_EQ(store.AddGroupIDToEndpointForNode(123, 1, 10), CHIP_NO_ERROR);
+    ASSERT_EQ(store.GetEndpointGroupIDList().size(), 1u);
+    ASSERT_EQ(store.GetNodeKeySetList().size(), 1u);
+
+    delegate.ResetCapturedSyncs();
+
+    ASSERT_EQ(store.AddGroupIDToEndpointForNode(123, 1, 10), CHIP_NO_ERROR);
+
+    EXPECT_EQ(store.GetEndpointGroupIDList().size(), 1u);
+    EXPECT_EQ(store.GetNodeKeySetList().size(), 1u);
+    EXPECT_FALSE(delegate.hasLastEndpointGroupSync);
+    EXPECT_FALSE(delegate.hasLastNodeKeySetSync);
+}
+
 TEST(JointFabricDatastoreTest, RemoveGroupIdFromEndpointSyncsDeletePendingEntries)
 {
     JointFabricDatastore store;

--- a/src/python_testing/TC_JFDS_2_5.py
+++ b/src/python_testing/TC_JFDS_2_5.py
@@ -1,0 +1,1576 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This test requires a TH2_SERVER application. Please specify with --string-arg th2_server_app_path:<path_to_app>
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     script-args: >
+#       --string-arg jfa_server_app:${JF_ADMIN_APP}
+#       --string-arg jfc_server_app:${JF_CONTROL_APP}
+#       --string-arg th2_server_app:${ALL_CLUSTERS_APP}
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import base64
+import asyncio
+import logging
+import os
+import random
+import tempfile
+from configparser import ConfigParser
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter import CertificateAuthority
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError, Status
+from matter.storage import VolatileTemporaryPersistentStorage
+from matter.testing.apps import AppServerSubprocess, JFControllerSubprocess
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_JFDS_2_5(MatterBaseTest):
+
+    @staticmethod
+    def _enum_as_int(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+
+    @staticmethod
+    def _enum_name_or_value(value):
+        if hasattr(value, "name"):
+            return value.name
+        return TC_JFDS_2_5._enum_as_int(value)
+
+    @staticmethod
+    def _enum_equals(actual, expected):
+        try:
+            return type(expected)(actual) == expected
+        except (TypeError, ValueError):
+            return False
+
+    @staticmethod
+    def _assert_enum_equal(actual, expected, message):
+        try:
+            actual_enum = type(expected)(actual)
+        except (TypeError, ValueError):
+            asserts.fail(f"{message}. Expected enum {type(expected).__name__}.{expected.name}, got {actual!r}")
+            return
+        asserts.assert_equal(actual_enum, expected, message)
+
+    @classmethod
+    def _normalize_nullable(cls, value):
+        if value is NullValue or value is None:
+            return None
+        return cls._enum_as_int(value)
+
+    @classmethod
+    def _normalize_acl_targets(cls, targets):
+        if targets is NullValue or targets is None:
+            return []
+
+        normalized = []
+        for target in targets:
+            normalized.append((
+                cls._normalize_nullable(target.cluster),
+                cls._normalize_nullable(target.endpoint),
+                cls._normalize_nullable(target.deviceType),
+            ))
+        return sorted(normalized)
+
+    @classmethod
+    def _normalize_acl_entry(cls, acl_entry):
+        subjects = [] if acl_entry.subjects in (NullValue, None) else sorted(acl_entry.subjects)
+        return {
+            "privilege": cls._enum_name_or_value(acl_entry.privilege),
+            "auth_mode": cls._enum_name_or_value(acl_entry.authMode),
+            "subjects": subjects,
+            "targets": cls._normalize_acl_targets(acl_entry.targets),
+        }
+
+    @classmethod
+    def _normalize_binding_target(cls, binding):
+        return {
+            "node": cls._normalize_nullable(binding.node),
+            "group": cls._normalize_nullable(binding.group),
+            "endpoint": cls._normalize_nullable(binding.endpoint),
+            "cluster": cls._normalize_nullable(binding.cluster),
+        }
+
+    @classmethod
+    def _extract_datastore_bindings(cls, endpoint_binding_entry):
+        if hasattr(endpoint_binding_entry, "bindingList"):
+            return list(endpoint_binding_entry.bindingList)
+        if hasattr(endpoint_binding_entry, "binding"):
+            return [endpoint_binding_entry.binding]
+        return []
+
+    @async_test_body
+    async def setup_class(self):
+        super().setup_class()
+
+        self.fabric_a_ctrl = None
+        self.storage_fabric_a = self.user_params.get("fabric_a_storage", None)
+        self.storage_directory_ecosystem_a_admin = None
+        self.storage_directory_ecosystem_a_ctrl = None
+        self.storage_directory_ecosystem_a_th2 = None
+        self.storage_fabric_a_admin = None
+        self.storage_fabric_a_ctrl = None
+        self.storage_fabric_a_th2 = None
+        self.devCtrlEcoA = None
+        self.certAuthorityManagerA = None
+        self.fabric_a_persistent_storage = None
+        self.th2_app = None
+
+        jfc_server_app = self.user_params.get("jfc_server_app", None)
+        if not jfc_server_app:
+            asserts.fail("This test requires a Joint Fabric Controller app. Specify app path with --string-arg jfc_server_app:<path_to_app>")
+        if not os.path.exists(jfc_server_app):
+            asserts.fail(f"The path {jfc_server_app} does not exist")
+
+        jfa_server_app = self.user_params.get("jfa_server_app", None)
+        if not jfa_server_app:
+            asserts.fail("This test requires a Joint Fabrics Admin app. Specify app path with --string-arg jfa_server_app:<path_to_app>")
+        if not os.path.exists(jfa_server_app):
+            asserts.fail(f"The path {jfa_server_app} does not exist")
+
+        # Get path to TH2 Server app from user parameters
+        th2_server_app = self.user_params.get("th2_server_app", None)
+        # Validate TH2 Server app
+        if not th2_server_app:
+            asserts.fail("This test requires a TH2 Server app. Specify app path with --string-arg th2_server_app:<path_to_app>")
+        if not os.path.exists(th2_server_app):
+            asserts.fail(f"The path {th2_server_app} does not exist")
+
+        # Create distinct storage directories per app to avoid KVS collisions.
+        if self.storage_fabric_a is None:
+            self.storage_directory_ecosystem_a_admin = tempfile.TemporaryDirectory(
+                prefix=self.__class__.__name__ + "_A_admin_")
+            self.storage_directory_ecosystem_a_ctrl = tempfile.TemporaryDirectory(
+                prefix=self.__class__.__name__ + "_A_ctrl_")
+            self.storage_directory_ecosystem_a_th2 = tempfile.TemporaryDirectory(
+                prefix=self.__class__.__name__ + "_A_th2_")
+            self.storage_fabric_a_admin = self.storage_directory_ecosystem_a_admin.name
+            self.storage_fabric_a_ctrl = self.storage_directory_ecosystem_a_ctrl.name
+            self.storage_fabric_a_th2 = self.storage_directory_ecosystem_a_th2.name
+            log.info("Temporary storage directories: admin=%s ctrl=%s th2=%s",
+                     self.storage_fabric_a_admin, self.storage_fabric_a_ctrl, self.storage_fabric_a_th2)
+        else:
+            self.storage_fabric_a_admin = os.path.join(self.storage_fabric_a, "jf_admin")
+            self.storage_fabric_a_ctrl = os.path.join(self.storage_fabric_a, "jf_ctrl")
+            self.storage_fabric_a_th2 = os.path.join(self.storage_fabric_a, "th2_app")
+            os.makedirs(self.storage_fabric_a_admin, exist_ok=True)
+            os.makedirs(self.storage_fabric_a_ctrl, exist_ok=True)
+            os.makedirs(self.storage_fabric_a_th2, exist_ok=True)
+
+        #####################################################################################################################################
+        #
+        # Initialize Ecosystem A
+        #
+        #####################################################################################################################################
+        self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
+        self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
+
+        # Start Fabric A JF-Administrator App
+        self.fabric_a_admin = AppServerSubprocess(
+            jfa_server_app,
+            storage_dir=self.storage_fabric_a_admin,
+            port=random.randint(5001, 5999),
+            discriminator=random.randint(0, 4095),
+            passcode=self.jfadmin_fabric_a_passcode,
+            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
+        self.fabric_a_admin.start(
+            expected_output="Server initialization complete",
+            timeout=10)
+
+        # Start Fabric A JF-Controller App
+        self.fabric_a_ctrl = JFControllerSubprocess(
+            jfc_server_app,
+            "JFC_A",  # Name of the controller instance, used for logging purposes in the JF-Controller app
+            rpc_server_port=33033,
+            storage_dir=self.storage_fabric_a_ctrl,
+            vendor_id=self.jfctrl_fabric_a_vid)
+        self.fabric_a_ctrl.start(
+            expected_output="CHIP task running",
+            timeout=10)
+
+        # Commission JF-ADMIN app with JF-Controller on Fabric A
+        self.fabric_a_ctrl.send(
+            message=f"pairing onnetwork 1 {self.jfadmin_fabric_a_passcode} --anchor true",
+            expected_output="[JF] Anchor Administrator (nodeId=1) commissioned with success",
+            timeout=10)
+
+        # Extract the Ecosystem A certificates and inject them in the storage that will be provided to a new Python Controller later
+        jfcStorage = ConfigParser()
+        jfcStorage.read(os.path.join(self.storage_fabric_a_ctrl, 'chip_tool_config.alpha.ini'))
+        self.ecoACtrlStorage = {
+            "sdk-config": {
+                "ExampleOpCredsCAKey1": jfcStorage.get("Default", "ExampleOpCredsCAKey0"),
+                "ExampleOpCredsICAKey1": jfcStorage.get("Default", "ExampleOpCredsICAKey0"),
+                "ExampleCARootCert1": jfcStorage.get("Default", "ExampleCARootCert0"),
+                "ExampleCAIntermediateCert1": jfcStorage.get("Default", "ExampleCAIntermediateCert0"),
+            },
+            "repl-config": {
+                "caList": {
+                    "1": [
+                        {
+                            "fabricId": 1,
+                            "vendorId": self.jfctrl_fabric_a_vid
+                        }
+                    ]
+                }
+            }
+        }
+        # Extract CATs to be provided to the Python Controller later
+        self.ecoACATs = base64.b64decode(jfcStorage.get("Default", "CommissionerCATs"))[::-1].hex().strip('0')
+
+        # Setup TH2: Commission a second node on the same fabric
+        self.th2_passcode = random.randint(110220011, 110220999)
+        self.th2_node_id = 2
+        self.th2_port = random.randint(6001, 6999)
+        self.th2_kvs_path = os.path.join(self.storage_fabric_a_th2, "kvs-th2")
+
+        # Start TH2 App (another admin node)
+        self.th2_app = AppServerSubprocess(
+            th2_server_app,
+            storage_dir=self.storage_fabric_a_th2,
+            port=self.th2_port,
+            discriminator=random.randint(0, 4095),
+            passcode=self.th2_passcode,
+            extra_args=["--capabilities", "0x04"],
+            kvs_path=self.th2_kvs_path)
+        self.th2_app.start(
+            expected_output="Server initialization complete",
+            timeout=10)
+
+        # Creating a Controller for Ecosystem A
+        self.fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
+            self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
+        self.certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
+            chipStack=self.matter_stack._chip_stack,
+            persistentStorage=self.fabric_a_persistent_storage)
+        self.certAuthorityManagerA.LoadAuthoritiesFromStorage()
+        self.devCtrlEcoA = self.certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+            nodeId=101,
+            paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
+            catTags=[int(self.ecoACATs, 16)])
+
+        # Commission TH2 with JF-Controller on Fabric A
+        self.fabric_a_ctrl.send(
+            message=f"pairing onnetwork {self.th2_node_id} {self.th2_passcode} --regular 1",
+            expected_output="[CTL] Commissioning complete for node ID 0x0000000000000002: success",
+            timeout=10)
+
+        # Verify commissioning was successful
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
+            returnClusterObject=True)
+        asserts.assert_is_not_none(response, "TH2 commissioning failed")
+
+        # Setup KS1: Add KeySet to datastore
+        self.th_keyset_id = 0x0042
+        # Store the original epoch key bytes locally; KeySetRead always returns Null for
+        # epoch key material (write-only by spec), so this is the only way to know the value.
+        self.th_keyset_epoch = bytes.fromhex('0123456789ABCDEFFEDCBA9876543210')
+
+        # Wait for commissioning to complete before sending commands
+        await asyncio.sleep(1)
+
+        # Create KeySet with AddKeySet command
+        keyset_struct = Clusters.JointFabricDatastore.Structs.DatastoreGroupKeySetStruct(
+            groupKeySetID=self.th_keyset_id,
+            groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
+            epochKey0=bytes.fromhex('00112233445566778899AABBCCDDEEFF'),
+            epochStartTime0=1,
+            epochKey1=bytes.fromhex('FFEEDDCCBBAA99887766554433221100'),
+            epochStartTime1=100000,
+            epochKey2=self.th_keyset_epoch,
+            epochStartTime2=200000
+        )
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.AddKeySet(keyset_struct),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1
+        )
+
+        # Setup G1: Add Group to datastore
+        self.th_group_id = 0x0101
+        self.th_group_cat = 0x0001
+        self.th_group_cat_version = 0x0001
+
+        add_group_cmd = Clusters.JointFabricDatastore.Commands.AddGroup(
+            groupID=self.th_group_id,
+            friendlyName="TestGroup",
+            groupKeySetID=self.th_keyset_id,
+            groupCAT=self.th_group_cat,
+            groupCATVersion=self.th_group_cat_version,
+            groupPermission=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kView
+        )
+
+        await self.send_single_cmd(
+            cmd=add_group_cmd,
+            dev_ctrl=self.devCtrlEcoA,
+            endpoint=1,
+            node_id=1
+        )
+
+    def teardown_class(self):
+        # Shutdown in the correct order: Controller -> CertificateAuthorityManager -> PersistentStorage
+        if self.devCtrlEcoA is not None:
+            self.devCtrlEcoA.Shutdown()
+            self.devCtrlEcoA = None
+
+        if self.certAuthorityManagerA is not None:
+            self.certAuthorityManagerA.Shutdown()
+            self.certAuthorityManagerA = None
+
+        if self.fabric_a_persistent_storage is not None:
+            self.fabric_a_persistent_storage.Shutdown()
+            self.fabric_a_persistent_storage = None
+        # Stop all Subprocesses that were started in this test case
+        if self.th2_app is not None:
+            self.th2_app.terminate()
+        if self.fabric_a_admin is not None:
+            self.fabric_a_admin.terminate()
+        if self.fabric_a_ctrl is not None:
+            self.fabric_a_ctrl.terminate()
+
+        super().teardown_class()
+
+    @async_test_body
+    async def test_TC_JFDS_2_5(self):
+        # Step 1: TH reads NodeList attribute from DUT
+        self.step(1, "TH reads NodeList attribute from DUT")
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
+            returnClusterObject=True)
+        node_list = response[1][Clusters.JointFabricDatastore].nodeList
+
+        # Verify that th_node_id is not in the list
+        th_node_in_list = any(node.nodeID == self.th2_node_id for node in node_list)
+        asserts.assert_false(th_node_in_list, "th_node_id should not be in NodeList initially")
+
+        # Step 2: TH sends AddPendingNode command to DUT
+        self.step(2, "TH sends AddPendingNode command to DUT with NodeId=th_node_id, FriendlyName: 'tc-jf-2.5'")
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.AddPendingNode(
+                nodeID=self.th2_node_id,
+                friendlyName="tc-jf-2.5",
+            ),
+            node_id=1,
+            dev_ctrl=self.devCtrlEcoA,
+            endpoint=1,
+        )
+
+        # Step 3: TH sends AddPendingNode command with duplicate NodeId
+        self.step(3, "TH sends AddPendingNode command to DUT with NodeId=th_node_id (duplicate), FriendlyName: 'tc-jf-2.5'")
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.AddPendingNode(
+                    nodeID=self.th2_node_id,
+                    friendlyName="tc-jf-2.5",
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for duplicate node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError, "Duplicate node should return CONSTRAINT_ERROR")
+
+        # Step 4: TH reads NodeList attribute from DUT
+        self.step(4, "TH reads NodeList attribute from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
+            returnClusterObject=True)
+        node_list_step4 = response[1][Clusters.JointFabricDatastore].nodeList
+
+        # Find the newly added node
+        step2_node = None
+        for node in node_list_step4:
+            if node.nodeID == self.th2_node_id:
+                step2_node = node
+                break
+
+        asserts.assert_is_not_none(step2_node, "Node with th_node_id should be in NodeList")
+        asserts.assert_equal(step2_node.friendlyName, "tc-jf-2.5", "FriendlyName should match step 2")
+        self._assert_enum_equal(
+            step2_node.commissioningStatusEntry.state,
+            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kPending,
+            "Status should be Pending")
+
+        # Step 5: TH sends UpdateNode command to DUT
+        self.step(5, "TH sends UpdateNode command to DUT with NodeId=th_node_id and other values different from step 2, FriendlyName: 'tc-jf-2.5-update'")
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.UpdateNode(
+                nodeID=self.th2_node_id,
+                friendlyName="tc-jf-2.5-update",
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 6: TH reads NodeList attribute from DUT
+        self.step(6, "TH reads NodeList attribute from DUT")
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
+            returnClusterObject=True)
+        node_list_step6 = response[1][Clusters.JointFabricDatastore].nodeList
+
+        # Find the updated node
+        step5_node = None
+        for node in node_list_step6:
+            if node.nodeID == self.th2_node_id:
+                step5_node = node
+                break
+
+        asserts.assert_is_not_none(step5_node, "Node with th_node_id should be in NodeList")
+        asserts.assert_equal(step5_node.friendlyName, "tc-jf-2.5-update", "FriendlyName should match step 5 update")
+        self._assert_enum_equal(
+            step5_node.commissioningStatusEntry.state,
+            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kPending,
+            "Status should be Pending")
+
+        # Step 7: TH sends UpdateNode command with non-existent NodeId
+        self.step(7, "TH sends UpdateNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), FriendlyName: 'tc-jf-2.5-update'")
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.UpdateNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    friendlyName="tc-jf-2.5-update",
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                endpoint=1,
+                node_id=1
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError, "Non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 8: TH sends RefreshNode command to DUT
+        self.step(8, "TH sends RefreshNode command to DUT with NodeId=th_node_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.RefreshNode(nodeID=self.th2_node_id),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 9: TH monitors NodeList attribute, waiting for Status to change to Committed
+        self.step(9, "TH monitors NodeList attribute from DUT, waiting for the Status of entry with NodeId=th_node_id changes to Committed")
+
+        # Poll NodeList until the node status changes to Committed (with timeout)
+        max_retries = 30  # 30 seconds timeout
+        node_committed = False
+        committed_node = None
+
+        for retry in range(max_retries):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
+                returnClusterObject=True)
+            node_list_step10 = response[1][Clusters.JointFabricDatastore].nodeList
+
+            for node in node_list_step10:
+                if node.nodeID == self.th2_node_id:
+                    if self._enum_equals(node.commissioningStatusEntry.state,
+                                         Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted):
+                        node_committed = True
+                        committed_node = node
+                        break
+
+            if node_committed:
+                break
+
+            await asyncio.sleep(1)  # Wait 1 second before next poll
+
+        asserts.assert_true(node_committed, "Node status should change to Committed")
+        asserts.assert_is_not_none(committed_node, "Committed node entry should exist")
+
+        # Step 10: Read the NodeList entry and verify NodeKeySetList
+        self.step(10, "Read the NodeList entry for NodeId=th_node_id")
+
+        # Get the NodeKeySetList from the datastore entry for th_node_id
+        node_keyset_list_dut = committed_node.nodeKeySetList if hasattr(committed_node, 'nodeKeySetList') else []
+
+        # Read the GroupKeyManagement cluster's KeySetList from TH2
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id, attributes=[(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap)],
+            returnClusterObject=True)
+        th2_keyset_list = response[0][Clusters.GroupKeyManagement].groupKeyMap
+
+        # Verify 1:1 correspondence - same number of entries
+        asserts.assert_equal(len(node_keyset_list_dut), len(th2_keyset_list),
+                             "NodeKeySetList should have 1:1 correspondence with TH2's GroupKeyMap")
+
+        # Verify each KeySet entry exists in both lists
+        dut_keyset_ids = {keyset.groupKeySetID for keyset in node_keyset_list_dut}
+        th2_keyset_ids = {keyset.groupKeySetID for keyset in th2_keyset_list}
+        asserts.assert_equal(dut_keyset_ids, th2_keyset_ids,
+                             "KeySet IDs should match between DUT and TH2")
+
+        # Step 11: Read the NodeList entry and verify NodeACLList
+        self.step(11, "Read the NodeList entry for NodeId=th_node_id")
+
+        # Get NodeACLList from DUT for th_node_id
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeACLList)],
+            returnClusterObject=True)
+        node_acl_list_step12 = response[1][Clusters.JointFabricDatastore].nodeACLList
+
+        # Find the ACL entry for th_node_id
+        th2_acl_entry_dut = None
+        for acl_entry in node_acl_list_step12:
+            if acl_entry.nodeID == self.th2_node_id:
+                th2_acl_entry_dut = acl_entry
+                break
+
+        asserts.assert_is_not_none(th2_acl_entry_dut, "ACL entry for th_node_id should exist in DUT")
+
+        # Read ACL from TH2
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
+            returnClusterObject=True)
+        th2_acl_list = response[0][Clusters.AccessControl].acl
+
+        # Compare only ACL entries mirrored for th_node_id.
+        dut_acl_entries = [entry.ACLEntry for entry in node_acl_list_step12 if entry.nodeID == self.th2_node_id]
+        asserts.assert_equal(len(dut_acl_entries), len(th2_acl_list),
+                             "NodeACLList should have 1:1 correspondence with TH2's ACL entries")
+
+        normalized_th2_acls = [self._normalize_acl_entry(acl) for acl in th2_acl_list]
+        for dut_acl_entry in dut_acl_entries:
+            normalized_dut_acl = self._normalize_acl_entry(dut_acl_entry)
+            asserts.assert_in(
+                normalized_dut_acl,
+                normalized_th2_acls,
+                f"Mirrored ACL entry should match TH2 ACL contents: {normalized_dut_acl}")
+
+        # Step 12: Read the NodeList entry and verify NodeEndpointList
+        self.step(12, "Read the NodeList entry for NodeId=th_node_id")
+
+        # Get NodeEndpointList from DUT for th_node_id
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeEndpointList)],
+            returnClusterObject=True)
+        node_endpoint_list = response[1][Clusters.JointFabricDatastore].nodeEndpointList
+
+        # Find the endpoint entry for th_node_id
+        th2_endpoint_entry = None
+        for endpoint_entry in node_endpoint_list:
+            if endpoint_entry.nodeID == self.th2_node_id:
+                th2_endpoint_entry = endpoint_entry
+                break
+
+        asserts.assert_is_not_none(th2_endpoint_entry, "Endpoint entry for th_node_id should exist in DUT")
+
+        # Read Descriptor Parts list from TH2 to get all endpoints
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id, attributes=[(0, Clusters.Descriptor.Attributes.PartsList)],
+            returnClusterObject=True)
+        th2_parts_list = response[0][Clusters.Descriptor].partsList
+
+        # Extract endpoint IDs from DUT's NodeEndpointList
+        dut_endpoint_ids = [ep.endpointID for ep in node_endpoint_list]
+
+        # Verify 1:1 correspondence
+        asserts.assert_equal(sorted(dut_endpoint_ids), sorted(th2_parts_list),
+                             "NodeEndpointList should have 1:1 correspondence with TH2's endpoints")
+
+        # Verify at least one non-zero endpoint exists and save it as th_app_endpoint_id
+        non_zero_endpoints = [ep for ep in dut_endpoint_ids if ep != 0]
+        asserts.assert_true(len(non_zero_endpoints) > 0, "Should have at least one application endpoint (non-zero)")
+        self.th_app_endpoint_id = non_zero_endpoints[0]  # Save for potential future use
+
+        # Step 13: Read the NodeList entry and verify EndpointGroupIDList
+        self.step(13, "Read the NodeList entry for NodeId=th_node_id")
+
+        # Get EndpointGroupIDList from DUT
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointGroupIDList)],
+            returnClusterObject=True)
+        endpoint_group_list = response[1][Clusters.JointFabricDatastore].endpointGroupIDList
+
+        # Find entries for th_node_id
+        th2_endpoint_groups = [entry for entry in endpoint_group_list if entry.nodeID == self.th2_node_id]
+
+        # For each endpoint on TH2, verify the GroupList correspondence
+        for th2_endpoint_id in th2_parts_list:
+            # Read Groups cluster GroupTable from TH2 endpoint
+            try:
+                response = await self.devCtrlEcoA.ReadAttribute(
+                    nodeId=self.th2_node_id, attributes=[(th2_endpoint_id, Clusters.Groups.Attributes.GroupTable)],
+                    returnClusterObject=True)
+                th2_group_table = response[th2_endpoint_id][Clusters.Groups].groupTable
+
+                # Find corresponding entry in DUT's EndpointGroupIDList
+                dut_endpoint_group_entry = None
+                for entry in th2_endpoint_groups:
+                    if entry.endpointID == th2_endpoint_id:
+                        dut_endpoint_group_entry = entry
+                        break
+
+                if len(th2_group_table) > 0:
+                    # If TH2 has groups on this endpoint, DUT should have a corresponding entry
+                    asserts.assert_is_not_none(dut_endpoint_group_entry,
+                                               f"DUT should have EndpointGroupIDList entry for endpoint {th2_endpoint_id}")
+
+                    # Verify 1:1 correspondence of group IDs
+                    th2_group_ids = {group.groupID for group in th2_group_table}
+                    dut_group_ids = set(dut_endpoint_group_entry.groupIDList)
+                    asserts.assert_equal(th2_group_ids, dut_group_ids,
+                                         f"Group IDs should match for endpoint {th2_endpoint_id}")
+            except Exception:
+                # Groups cluster may not be supported on all endpoints, which is fine
+                pass
+
+        # Step 14: Read the NodeList entry and verify EndpointBindingList
+        self.step(14, "Read the NodeList entry for NodeId=th_node_id")
+
+        # Get EndpointBindingList from DUT
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointBindingList)],
+            returnClusterObject=True)
+        endpoint_binding_list = response[1][Clusters.JointFabricDatastore].endpointBindingList
+
+        # Find entries for th_node_id
+        th2_endpoint_bindings = [entry for entry in endpoint_binding_list if entry.nodeID == self.th2_node_id]
+
+        # Aggregate DUT mirrored bindings per endpoint.
+        dut_bindings_by_endpoint = {}
+        for entry in th2_endpoint_bindings:
+            endpoint_id = entry.endpointID
+            if endpoint_id not in dut_bindings_by_endpoint:
+                dut_bindings_by_endpoint[endpoint_id] = []
+            for binding in self._extract_datastore_bindings(entry):
+                dut_bindings_by_endpoint[endpoint_id].append(self._normalize_binding_target(binding))
+
+        binding_capable_endpoints = set()
+
+        # For each endpoint on TH2, verify the BindingList correspondence
+        for th2_endpoint_id in th2_parts_list:
+            # Determine whether this TH2 endpoint supports the Binding cluster.
+            descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id,
+                attributes=[(th2_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+                returnClusterObject=True)
+            th2_server_list = descriptor_response[th2_endpoint_id][Clusters.Descriptor].serverList
+
+            if Clusters.Binding.id not in th2_server_list:
+                continue
+
+            binding_capable_endpoints.add(th2_endpoint_id)
+
+            # Read Binding cluster Binding attribute from TH2 endpoint.
+            binding_response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id,
+                attributes=[(th2_endpoint_id, Clusters.Binding.Attributes.Binding)],
+                returnClusterObject=True)
+            asserts.assert_true(
+                th2_endpoint_id in binding_response and Clusters.Binding in binding_response[th2_endpoint_id],
+                f"TH2 endpoint {th2_endpoint_id} reports Binding in ServerList but Binding cluster read is unavailable")
+
+            th2_binding_table = binding_response[th2_endpoint_id][Clusters.Binding].binding
+            normalized_th2_bindings = [self._normalize_binding_target(binding) for binding in th2_binding_table]
+            normalized_dut_bindings = dut_bindings_by_endpoint.get(th2_endpoint_id, [])
+
+            asserts.assert_equal(
+                len(normalized_dut_bindings),
+                len(normalized_th2_bindings),
+                f"Binding count should match for endpoint {th2_endpoint_id}")
+
+            for normalized_dut_binding in normalized_dut_bindings:
+                asserts.assert_in(
+                    normalized_dut_binding,
+                    normalized_th2_bindings,
+                    f"Mirrored binding should match TH2 binding for endpoint {th2_endpoint_id}: {normalized_dut_binding}")
+
+            for normalized_th2_binding in normalized_th2_bindings:
+                asserts.assert_in(
+                    normalized_th2_binding,
+                    normalized_dut_bindings,
+                    f"DUT should mirror TH2 binding for endpoint {th2_endpoint_id}: {normalized_th2_binding}")
+
+        # DUT should not mirror bindings for endpoints that do not support Binding on TH2.
+        for endpoint_id, normalized_dut_bindings in dut_bindings_by_endpoint.items():
+            if endpoint_id in binding_capable_endpoints:
+                continue
+            asserts.assert_equal(
+                len(normalized_dut_bindings),
+                0,
+                f"DUT should not contain bindings for TH2 endpoint {endpoint_id} that has no Binding cluster")
+
+        # Step 15: TH sends AddACLToNode command with non-existent NodeId
+        self.step(15, "TH sends AddACLToNode command to DUT with NodeId=0x0000_0000_0000_000a (not found)")
+
+        acl_struct = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kManage,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[self.th2_node_id],
+            targets=[Clusters.AccessControl.Structs.AccessControlTargetStruct(
+                cluster=0,
+                endpoint=1,
+                deviceType=0
+            )]
+        )
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.AddACLToNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    ACLEntry=acl_struct
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "AddACLToNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 16: TH sends AddACLToNode command with valid NodeId
+        self.step(16, "TH sends AddACLToNode command to DUT with NodeId=th_node_id, ACL fields: Privilege Manage (4), AuthMode CASE (2), Subjects [th_node_id2], Targets [{Cluster: null, Endpoint: 0, DeviceType: null}]")
+
+        acl_to_add = Clusters.JointFabricDatastore.Structs.DatastoreAccessControlEntryStruct(
+            privilege=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kManage,
+            authMode=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryAuthModeEnum.kCase,
+            subjects=[self.th2_node_id],
+            targets=[Clusters.JointFabricDatastore.Structs.DatastoreAccessControlTargetStruct(
+                cluster=NullValue,
+                endpoint=0,
+                deviceType=NullValue
+            )]
+        )
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.AddACLToNode(
+                nodeID=self.th2_node_id,
+                ACLEntry=acl_to_add
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 17: TH reads NodeACLList and verifies the new ACL entry
+        self.step(17, "TH reads NodeACLList entries NodeId=th_node_id from DUT and reads ACLList from TH2")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeACLList)],
+            returnClusterObject=True)
+        node_acl_list_step18 = response[1][Clusters.JointFabricDatastore].nodeACLList
+
+        # Find the ACL entry matching step 17
+        matching_acl = None
+        th_acllist_id = None
+        expected_acl = self._normalize_acl_entry(acl_to_add)
+
+        for acl in node_acl_list_step18:
+            if acl.nodeID == self.th2_node_id and self._normalize_acl_entry(acl.ACLEntry) == expected_acl:
+                matching_acl = acl
+                # Get the ListID
+                th_acllist_id = acl.listID
+
+        asserts.assert_is_not_none(matching_acl, "NodeACLList should contain the ACL entry added in step 17")
+
+        # Note the ListID
+        self.th_acllist_id = th_acllist_id
+
+        # Step 18: TH reads ACLList from TH2 and verifies the ACL entry exists there
+        self.step(18, "TH reads NodeACLList entries NodeId=th_node_id from DUT and reads ACLList from TH2")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
+            returnClusterObject=True)
+        th2_acl_list_step19 = response[0][Clusters.AccessControl].acl
+
+        # Find the ACL entry matching step 17
+        th2_normalized_acls = [self._normalize_acl_entry(acl) for acl in th2_acl_list_step19]
+        asserts.assert_in(expected_acl, th2_normalized_acls,
+                          "TH2's ACLList should contain the ACL entry added in step 17")
+
+        # Step 19: TH reads ACLList from TH2 and verifies Admin CAT entry
+        self.step(19, "TH reads ACLList from TH2")
+
+        # We already have th2_acl_list_step19 from step 19
+        admin_cat_acl = None
+        th_admin_cat_version = None
+
+        for acl in th2_acl_list_step19:
+            if (acl.privilege == Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister and
+                    acl.authMode == Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase):
+                # Check if subjects contains Admin CAT (0xFFFF_xxxx pattern)
+                for subject in acl.subjects:
+                    if (subject & 0xFFFF_0000_0000_0000) == 0xFFFF_0000_0000_0000:
+                        admin_cat_acl = acl
+                        # Extract the CAT version (lower 16 bits of the identifier)
+                        th_admin_cat_version = subject & 0xFFFF
+                        break
+                if admin_cat_acl:
+                    break
+
+        asserts.assert_is_not_none(admin_cat_acl, "TH2's ACLList should contain an Admin CAT entry with Administer privilege")
+        has_empty_targets = (admin_cat_acl.targets == NullValue) or (len(admin_cat_acl.targets) == 0)
+        asserts.assert_true(has_empty_targets, "Admin CAT ACL should have empty/null targets list")
+
+        # Store the admin CAT version for potential future use
+        self.th_admin_cat_version = th_admin_cat_version
+
+        # Step 20: TH reads GroupList attribute from DUT
+        self.step(20, "TH reads GroupList attribute from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.GroupList)],
+            returnClusterObject=True)
+        group_list_step21 = response[1][Clusters.JointFabricDatastore].groupList
+
+        # Find the Admin CAT group entry
+        admin_cat_group = None
+        admin_cat_group_id = None
+        admin_cat_version = None
+
+        for group in group_list_step21:
+            # Admin CAT group has groupCAT = 0xFFFF
+            if group.groupCAT == 0xFFFF:
+                admin_cat_group = group
+                admin_cat_group_id = group.groupID
+                admin_cat_version = group.groupCATVersion
+                break
+
+        asserts.assert_is_not_none(admin_cat_group, "GroupList should contain an Admin CAT group entry")
+
+        # Store the admin CAT group ID and version
+        self.admin_cat_group_id = admin_cat_group_id
+        self.admin_cat_version = admin_cat_version
+
+        # Keep expected "next version" values for the retained negative Admin CAT check.
+        new_admin_cat_version = self.admin_cat_version + 1
+        new_admin_cat_subject = 0xFFFF_0000_0000_0000 | new_admin_cat_version
+
+        # Step 21: TH reads NodeACLList and verifies new Admin CAT version was not applied
+        self.step(21, "TH reads NodeACLList entries NodeId=th_node_id from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeACLList)],
+            returnClusterObject=True)
+        node_acl_list_step23 = response[1][Clusters.JointFabricDatastore].nodeACLList
+
+        # Find the ACL entry for th_node_id
+        th2_acl_entry_step23 = None
+        for acl_entry in node_acl_list_step23:
+            if acl_entry.nodeID == self.th2_node_id:
+                th2_acl_entry_step23 = acl_entry
+                break
+
+        asserts.assert_is_not_none(th2_acl_entry_step23, "ACL entry for th_node_id should exist")
+
+        # Verify no Admin CAT ACL with new version exists
+        admin_cat_acl_pending = None
+
+        if (self._enum_equals(th2_acl_entry_step23.ACLEntry.privilege,
+                              Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kAdminister) and
+            self._enum_equals(th2_acl_entry_step23.ACLEntry.authMode,
+                              Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryAuthModeEnum.kCase) and
+                new_admin_cat_subject in th2_acl_entry_step23.ACLEntry.subjects and
+                len(th2_acl_entry_step23.ACLEntry.targets) == 0):
+            admin_cat_acl_pending = th2_acl_entry_step23
+
+        asserts.assert_is_none(admin_cat_acl_pending,
+                               f"NodeACLList should not contain Admin CAT ACL with new version {new_admin_cat_version}")
+
+        # Step 22: TH sends RemoveACLFromNode command with non-existent NodeId
+        self.step(22, "TH sends RemoveACLFromNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), ListID=th_acllist_id")
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.RemoveACLFromNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    listID=self.th_acllist_id
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "RemoveACLFromNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 23: TH sends RemoveACLFromNode command with valid NodeId
+        self.step(23, "TH sends RemoveACLFromNode command to DUT with NodeId=th_node_id, ListID=th_acllist_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.RemoveACLFromNode(
+                nodeID=self.th2_node_id,
+                listID=self.th_acllist_id
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 24: TH reads NodeACLList and ACLList from TH2 to verify removal
+        self.step(24, "TH reads NodeACLList entries with NodeId=th_node_id from DUT and reads ACLList from TH2")
+
+        removed_acl = Clusters.JointFabricDatastore.Structs.DatastoreAccessControlEntryStruct(
+            privilege=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kManage,
+            authMode=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryAuthModeEnum.kCase,
+            subjects=[self.th2_node_id],
+            targets=[Clusters.JointFabricDatastore.Structs.DatastoreAccessControlTargetStruct(
+                cluster=NullValue,
+                endpoint=0,
+                deviceType=NullValue,
+            )],
+        )
+
+        acl_with_listid_found = True
+        removed_acl_still_on_th2 = True
+        th2_normalized_acls_step28 = []
+        refresh_issued = False
+
+        # Removal to datastore is immediate, but mirror to TH2 can lag.
+        for _ in range(30):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeACLList)],
+                returnClusterObject=True)
+            node_acl_list_step28 = response[1][Clusters.JointFabricDatastore].nodeACLList
+            acl_with_listid_found = any(acl.listID == self.th_acllist_id for acl in node_acl_list_step28)
+
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
+                returnClusterObject=True)
+            th2_acl_list_step28 = response[0][Clusters.AccessControl].acl
+            th2_normalized_acls_step28 = [self._normalize_acl_entry(acl) for acl in th2_acl_list_step28]
+
+            removed_acl_normalized = self._normalize_acl_entry(removed_acl)
+            removed_acl_still_on_th2 = removed_acl_normalized in th2_normalized_acls_step28
+
+            if not acl_with_listid_found and not removed_acl_still_on_th2:
+                break
+
+            # If datastore is already clean but TH2 still stale, nudge sync once.
+            if not acl_with_listid_found and removed_acl_still_on_th2 and not refresh_issued:
+                await self.send_single_cmd(
+                    cmd=Clusters.JointFabricDatastore.Commands.RefreshNode(nodeID=self.th2_node_id),
+                    dev_ctrl=self.devCtrlEcoA,
+                    node_id=1,
+                    endpoint=1,
+                )
+                refresh_issued = True
+
+            await asyncio.sleep(1)
+
+        asserts.assert_false(acl_with_listid_found,
+                             f"NodeACLList should NOT contain ACL entry with ListID={self.th_acllist_id}")
+
+        # Verify the ACL matching step 17 is NOT in TH2's ACLList
+        removed_acl_normalized = self._normalize_acl_entry(removed_acl)
+        asserts.assert_not_in(
+            removed_acl_normalized,
+            th2_normalized_acls_step28,
+            f"TH2's ACLList should NOT contain the ACL entry that was removed. Last observed ACLs: {th2_normalized_acls_step28}")
+
+        # Step 25: TH sends UpdateEndpointForNode command with non-existent NodeId
+        self.step(25, "TH sends UpdateEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a, EndpointID=th_app_endpoint_id")
+
+        endpoint_struct = Clusters.JointFabricDatastore.Commands.UpdateEndpointForNode(
+            nodeID=0x0000_0000_0000_000a,
+            endpointID=self.th_app_endpoint_id,
+            friendlyName="tc-jf-2.5-ep"
+        )
+
+        try:
+            await self.send_single_cmd(
+                cmd=endpoint_struct,
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "UpdateEndpointForNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 26: TH sends UpdateEndpointForNode command with valid NodeId
+        self.step(26, "TH sends UpdateEndpointForNode command to DUT with NodeId=th_node_id, EndpointID=th_app_endpoint_id")
+
+        endpoint_to_update = Clusters.JointFabricDatastore.Commands.UpdateEndpointForNode(
+            nodeID=self.th2_node_id,
+            endpointID=self.th_app_endpoint_id,
+            friendlyName="tc-jf-2.5-ep"
+        )
+
+        await self.send_single_cmd(
+            cmd=endpoint_to_update,
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 27: TH reads NodeEndpointList and verifies the updated endpoint
+        self.step(27, "TH reads NodeEndpointList attribute from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeEndpointList)],
+            returnClusterObject=True)
+        node_endpoint_list_step31 = response[1][Clusters.JointFabricDatastore].nodeEndpointList
+
+        # Find the endpoint entry for th_node_id
+        th2_endpoint_entry_step31 = None
+        for endpoint_entry in node_endpoint_list_step31:
+            if endpoint_entry.nodeID == self.th2_node_id and endpoint_entry.endpointID == self.th_app_endpoint_id and endpoint_entry.friendlyName == "tc-jf-2.5-ep":
+                th2_endpoint_entry_step31 = endpoint_entry
+                break
+
+        asserts.assert_is_not_none(th2_endpoint_entry_step31, "Endpoint entry for th_node_id should exist")
+
+        # Step 28: TH sends AddGroupIDToEndpointForNode command with non-existent NodeId
+        self.step(28, "TH sends AddGroupIDToEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.AddGroupIDToEndpointForNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    endpointID=self.th_app_endpoint_id,
+                    groupID=self.th_group_id
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "AddGroupIDToEndpointForNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 29: TH sends AddGroupIDToEndpointForNode command with valid NodeId
+        self.step(29, "TH sends AddGroupIDToEndpointForNode command to DUT with NodeId=th_node_id, EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.AddGroupIDToEndpointForNode(
+                nodeID=self.th2_node_id,
+                endpointID=self.th_app_endpoint_id,
+                groupID=self.th_group_id
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        await asyncio.sleep(2)  # Wait for the group addition to propagate
+
+        # Step 30: TH reads EndpointGroupIDList and verifies the group entry
+        self.step(30, "TH reads EndpointGroupIDList attribute from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointGroupIDList)],
+            returnClusterObject=True)
+        endpoint_group_list_step34 = response[1][Clusters.JointFabricDatastore].endpointGroupIDList
+
+        # Find the entry for th_node_id and th_app_endpoint_id
+        target_endpoint_group = None
+        for entry in endpoint_group_list_step34:
+            if entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id:
+                target_endpoint_group = entry
+                break
+
+        asserts.assert_is_not_none(target_endpoint_group,
+                                   f"EndpointGroupIDList should contain entry for NodeId={self.th2_node_id} and EndpointID={self.th_app_endpoint_id}")
+
+        group_id = target_endpoint_group.groupID
+        asserts.assert_equal(self.th_group_id, group_id, "GroupID should match the one added to the endpoint")
+
+        # Verify Status is Committed
+        self._assert_enum_equal(
+            target_endpoint_group.statusEntry.state,
+            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted,
+            "Status should be Committed")
+
+        # Step 31: TH reads GroupList from the given endpoint on TH2
+        self.step(31, "TH reads GroupList from the given endpoint on TH2")
+
+        descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id,
+            attributes=[(self.th_app_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+            returnClusterObject=True)
+        th2_server_list = descriptor_response[self.th_app_endpoint_id][Clusters.Descriptor].serverList
+        asserts.assert_in(
+            Clusters.Groups.id,
+            th2_server_list,
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 35")
+
+        group_response = await self.send_single_cmd(
+            cmd=Clusters.Groups.Commands.GetGroupMembership(groupList=[self.th_group_id]),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=self.th2_node_id,
+            endpoint=self.th_app_endpoint_id,
+        )
+        asserts.assert_in(
+            self.th_group_id,
+            group_response.groupList,
+            f"Group {self.th_group_id} should be present on TH2 endpoint {self.th_app_endpoint_id}")
+        # Note: The status "Committed" is implied by the group being present in the table
+
+        # Step 32: TH reads KeySetList from the given endpoint on TH2
+        self.step(32, "TH reads KeySetList from the given endpoint on TH2")
+
+        # Read the actual KeySet for th_keyset_id using KeySetRead
+        keyset_read_response = await self.send_single_cmd(
+            cmd=Clusters.GroupKeyManagement.Commands.KeySetRead(groupKeySetID=self.th_keyset_id),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=self.th2_node_id,
+            endpoint=0,
+        )
+        th2_keyset = keyset_read_response.groupKeySet
+
+        asserts.assert_is_not_none(th2_keyset,
+                                   f"KeySetRead should return KeySetID={self.th_keyset_id}")
+        asserts.assert_equal(th2_keyset.groupKeySetID, self.th_keyset_id,
+                             f"KeySet groupKeySetID should be {self.th_keyset_id}")
+        # Note: epoch key bytes (epochKey0-2) are always returned as Null by KeySetRead per spec
+        # (they are write-only). th_keyset_epoch was stored at setup time.
+
+        # Step 33: TH reads NodeKeySetList and verifies Status Success
+        self.step(33, "TH reads NodeKeySetList attribute from DUT for NodeId=th_node_id and KeySetID=th_keyset_id")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeKeySetList)],
+            returnClusterObject=True)
+        node_keyset_list_step38 = response[1][Clusters.JointFabricDatastore].nodeKeySetList
+
+        # Find the keyset entry for th_node_id and th_keyset_id
+        th2_keyset_entry = None
+        for entry in node_keyset_list_step38:
+            if entry.nodeID == self.th2_node_id and entry.groupKeySetID == self.th_keyset_id:
+                th2_keyset_entry = entry
+                break
+
+        asserts.assert_is_not_none(th2_keyset_entry, "NodeKeySetList should contain entry for th_node_id")
+        self._assert_enum_equal(
+            th2_keyset_entry.statusEntry.state,
+            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted,
+            "StatusEntry should be Success")
+
+        # Step 34: TH reads KeySetList from TH2 and verifies new EpochKey2
+        self.step(34, "TH reads KeySetList from the given endpoint on TH2")
+
+        # Read the actual KeySet for th_keyset_id using KeySetRead
+        keyset_read_response = await self.send_single_cmd(
+            cmd=Clusters.GroupKeyManagement.Commands.KeySetRead(groupKeySetID=self.th_keyset_id),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=self.th2_node_id,
+            endpoint=0,
+        )
+        th2_keyset = keyset_read_response.groupKeySet
+
+        asserts.assert_is_not_none(th2_keyset,
+                                   f"KeySetRead should return KeySetID={self.th_keyset_id}")
+        asserts.assert_equal(th2_keyset.groupKeySetID, self.th_keyset_id,
+                             f"KeySet groupKeySetID should be {self.th_keyset_id}")
+        # Note: epoch key bytes (epochKey0-2) are always returned as Null by KeySetRead per spec
+        # (they are write-only). th_keyset_epoch was stored at setup time.
+
+        # Step 35: TH sends RemoveGroupIDFromEndpointForNode command with non-existent NodeId
+        self.step(35, "TH sends RemoveGroupIDFromEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a, EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.RemoveGroupIDFromEndpointForNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    endpointID=self.th_app_endpoint_id,
+                    groupID=self.th_group_id
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "RemoveGroupIDFromEndpointForNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 36: TH sends RemoveGroupIDFromEndpointForNode command with valid NodeId
+        self.step(36, "TH sends RemoveGroupIDFromEndpointForNode command to DUT with NodeId=th_node_id, EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.RemoveGroupIDFromEndpointForNode(
+                nodeID=self.th2_node_id,
+                endpointID=self.th_app_endpoint_id,
+                groupID=self.th_group_id
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 37: TH reads EndpointGroupIDList and verifies group removal
+        self.step(37, "TH reads EndpointGroupIDList attribute from DUT")
+
+        max_retries = 10
+        removal_observed = False
+        remaining_matches = []
+        for _ in range(max_retries):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointGroupIDList)],
+                returnClusterObject=True)
+            endpoint_group_list_step43 = response[1][Clusters.JointFabricDatastore].endpointGroupIDList
+
+            remaining_matches = [
+                entry for entry in endpoint_group_list_step43
+                if entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id and entry.groupID == self.th_group_id
+            ]
+
+            if len(remaining_matches) == 0:
+                removal_observed = True
+                break
+
+            await asyncio.sleep(1)
+
+        asserts.assert_true(
+            removal_observed,
+            f"EndpointGroupIDList still contains NodeID={self.th2_node_id}, EndpointID={self.th_app_endpoint_id}, "
+            f"GroupID={self.th_group_id} after {max_retries}s; remaining entries={remaining_matches}")
+
+        # Step 38: TH reads GroupList from TH2 and verifies group removal
+        self.step(38, "TH reads from TH2 reads the GroupList from the given endpoint")
+
+        descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id,
+            attributes=[(self.th_app_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+            returnClusterObject=True)
+        th2_server_list_step44 = descriptor_response[self.th_app_endpoint_id][Clusters.Descriptor].serverList
+        asserts.assert_in(
+            Clusters.Groups.id,
+            th2_server_list_step44,
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 44")
+
+        get_group_cmd = Clusters.Groups.Commands.GetGroupMembership(
+            groupList=[self.th_group_id]
+        )
+
+        group_resp = await self.send_single_cmd(
+            cmd=get_group_cmd,
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=self.th2_node_id,
+            endpoint=self.th_app_endpoint_id,
+        )
+
+        asserts.assert_not_in(self.th_group_id, group_resp.groupList,
+                              f"Group {self.th_group_id} should not be present on TH2")
+
+        # Step 39: TH reads KeySetList from TH2 and verifies keyset does not exist
+        self.step(39, "TH reads KeySetList from the given endpoint on TH2")
+
+        # Read the actual KeySet for th_keyset_id using KeySetRead
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.GroupKeyManagement.Commands.KeySetRead(groupKeySetID=self.th_keyset_id),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=self.th2_node_id,
+                endpoint=0,
+            )
+            asserts.fail(f"Expected KeySetRead to fail with NotFound for KeySetID={self.th_keyset_id}")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Expected Status.NotFound for KeySetID={self.th_keyset_id}, got {e.status}")
+
+        # Step 40: TH sends AddBindingToEndpointForNode command with non-existent NodeId
+        self.step(40, "TH sends AddBindingToEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a and EndpointID=th_app_endpoint_id")
+
+        binding_struct = Clusters.JointFabricDatastore.Structs.DatastoreBindingTargetStruct(
+            node=self.th2_node_id,
+            group=None,
+            endpoint=0x01,
+            cluster=None
+        )
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.AddBindingToEndpointForNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    endpointID=self.th_app_endpoint_id,
+                    binding=binding_struct
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "AddBindingToEndpointForNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 41: TH sends AddBindingToEndpointForNode command with valid NodeId
+        self.step(41, "TH sends AddBindingToEndpointForNode command to DUT with NodeId=th_node_id and EndpointID=th_app_endpoint_id")
+
+        binding_to_add = Clusters.JointFabricDatastore.Structs.DatastoreBindingTargetStruct(
+            node=self.th2_node_id,
+            group=None,
+            endpoint=0x01,
+            cluster=None
+        )
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.AddBindingToEndpointForNode(
+                nodeID=self.th2_node_id,
+                endpointID=self.th_app_endpoint_id,
+                binding=binding_to_add
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 42: TH reads EndpointBindingList from DUT and BindingList from TH2
+        self.step(42, "TH reads EndpointBindingList attribute from DUT and from TH2 reads the BindingList from the given endpoint")
+
+        expected_binding = self._normalize_binding_target(binding_to_add)
+        target_endpoint_binding = None
+        binding_committed = False
+
+        for _ in range(10):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointBindingList)],
+                returnClusterObject=True)
+            endpoint_binding_list_step48 = response[1][Clusters.JointFabricDatastore].endpointBindingList
+
+            for entry in endpoint_binding_list_step48:
+                if (entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id and
+                        self._normalize_binding_target(entry.binding) == expected_binding):
+                    target_endpoint_binding = entry
+                    self.th_binding_list_id = entry.listID
+                    if (entry.statusEntry.state ==
+                            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted):
+                        binding_committed = True
+                    break
+
+            if binding_committed:
+                break
+
+            await asyncio.sleep(1)
+
+        asserts.assert_is_not_none(target_endpoint_binding,
+                                   "EndpointBindingList should contain the binding added in step 47")
+        asserts.assert_true(binding_committed, "StatusEntry should change to Committed")
+
+        asserts.assert_equal(self._normalize_binding_target(target_endpoint_binding.binding), expected_binding,
+                             "DUT mirrored binding should exactly match the requested binding values")
+
+        descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id,
+            attributes=[(self.th_app_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+            returnClusterObject=True)
+        th2_server_list_step48 = descriptor_response[self.th_app_endpoint_id][Clusters.Descriptor].serverList
+        asserts.assert_in(
+            Clusters.Binding.id,
+            th2_server_list_step48,
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 48")
+
+        th2_matching_binding = None
+        last_th2_binding_list = []
+        for _ in range(10):
+            th2_bindings_list_resp = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id,
+                attributes=[(self.th_app_endpoint_id, Clusters.Binding.Attributes.Binding)],
+                returnClusterObject=True
+            )
+            asserts.assert_true(
+                self.th_app_endpoint_id in th2_bindings_list_resp and Clusters.Binding in th2_bindings_list_resp[
+                    self.th_app_endpoint_id],
+                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 48")
+
+            th2_binding_list = th2_bindings_list_resp[self.th_app_endpoint_id][Clusters.Binding].binding
+            last_th2_binding_list = [self._normalize_binding_target(binding) for binding in th2_binding_list]
+
+            for binding in th2_binding_list:
+                if self._normalize_binding_target(binding) == expected_binding:
+                    th2_matching_binding = binding
+                    break
+
+            if th2_matching_binding is not None:
+                break
+
+            await asyncio.sleep(1)
+
+        asserts.assert_is_not_none(
+            th2_matching_binding,
+            f"TH2's BindingList should contain the binding added in step 47. "
+            f"Expected={expected_binding}, LastObserved={last_th2_binding_list}")
+
+        # Step 43: TH sends RemoveBindingFromEndpointForNode command with non-existent NodeId
+        self.step(43, "TH sends RemoveBindingFromEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a and EndpointID=th_app_endpoint_id, ListID=th_binding_list_id")
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.RemoveBindingFromEndpointForNode(
+                    nodeID=0x0000_0000_0000_000a,
+                    endpointID=self.th_app_endpoint_id,
+                    listID=self.th_binding_list_id
+                ),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "RemoveBindingFromEndpointForNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 44: TH sends RemoveBindingFromEndpointForNode command with valid NodeId
+        self.step(44, "TH sends RemoveBindingFromEndpointForNode command to DUT with NodeId=th_node_id and EndpointID=th_app_endpoint_id, ListID=th_binding_list_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.RemoveBindingFromEndpointForNode(
+                nodeID=self.th2_node_id,
+                endpointID=self.th_app_endpoint_id,
+                listID=self.th_binding_list_id
+            ),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 45: TH reads EndpointBindingList from DUT and BindingList from TH2 to verify removal
+        self.step(45, "TH reads EndpointBindingList attribute from DUT and from TH2 reads the BindingList from the given endpoint")
+
+        # Poll DUT EndpointBindingList until the removed entry is absent.
+        max_retries = 10
+        dut_binding_removed = False
+        for _ in range(max_retries):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointBindingList)],
+                returnClusterObject=True)
+            endpoint_binding_list_step51 = response[1][Clusters.JointFabricDatastore].endpointBindingList
+
+            matching_entries = [
+                entry for entry in endpoint_binding_list_step51
+                if entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id and entry.listID == self.th_binding_list_id
+            ]
+
+            if len(matching_entries) == 0:
+                dut_binding_removed = True
+                break
+
+            await asyncio.sleep(1)
+
+        asserts.assert_true(
+            dut_binding_removed,
+            f"EndpointBindingList should not contain ListID={self.th_binding_list_id} for NodeID={self.th2_node_id}, "
+            f"EndpointID={self.th_app_endpoint_id} after {max_retries}s")
+
+        descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=self.th2_node_id,
+            attributes=[(self.th_app_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+            returnClusterObject=True)
+        th2_server_list_step51 = descriptor_response[self.th_app_endpoint_id][Clusters.Descriptor].serverList
+        asserts.assert_in(
+            Clusters.Binding.id,
+            th2_server_list_step51,
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 51")
+
+        # Poll TH2 BindingList until the removed binding is absent.
+        th2_binding_removed = False
+        for _ in range(max_retries):
+            th2_bindings_list_resp = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id,
+                attributes=[(self.th_app_endpoint_id, Clusters.Binding.Attributes.Binding)],
+                returnClusterObject=True
+            )
+            asserts.assert_true(
+                self.th_app_endpoint_id in th2_bindings_list_resp and Clusters.Binding in th2_bindings_list_resp[
+                    self.th_app_endpoint_id],
+                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 51")
+
+            th2_binding_list = th2_bindings_list_resp[self.th_app_endpoint_id][Clusters.Binding].binding
+            th2_matching_binding_found = any(
+                self._normalize_binding_target(binding) == expected_binding for binding in th2_binding_list
+            )
+
+            if not th2_matching_binding_found:
+                th2_binding_removed = True
+                break
+
+            await asyncio.sleep(1)
+
+        asserts.assert_true(th2_binding_removed,
+                            f"TH2 BindingList still contains removed binding after {max_retries}s: {expected_binding}")
+
+        # Step 46: TH sends RemoveNode command with non-existent NodeId
+        self.step(46, "TH sends RemoveNode command to DUT with NodeId=0x0000_0000_0000_000a")
+
+        try:
+            await self.send_single_cmd(
+                cmd=Clusters.JointFabricDatastore.Commands.RemoveNode(nodeID=0x0000_0000_0000_000a),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=1,
+                endpoint=1,
+            )
+            asserts.fail("Expected CONSTRAINT_ERROR for non-existent node")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError,
+                                 "RemoveNode with non-existent node should return CONSTRAINT_ERROR")
+
+        # Step 47: TH sends RemoveNode command with valid NodeId
+        self.step(47, "TH sends RemoveNode command to DUT with NodeId=th_node_id")
+
+        await self.send_single_cmd(
+            cmd=Clusters.JointFabricDatastore.Commands.RemoveNode(nodeID=self.th2_node_id),
+            dev_ctrl=self.devCtrlEcoA,
+            node_id=1,
+            endpoint=1,
+        )
+
+        # Step 48: TH reads NodeList and verifies node removal
+        self.step(48, "TH reads NodeList attribute from DUT")
+
+        response = await self.devCtrlEcoA.ReadAttribute(
+            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
+            returnClusterObject=True)
+        node_list_step54 = response[1][Clusters.JointFabricDatastore].nodeList
+
+        # Verify th_node_id is NOT in the list
+        node_found = False
+        for node in node_list_step54:
+            if node.nodeID == self.th2_node_id:
+                node_found = True
+                break
+
+        asserts.assert_false(node_found, f"NodeList should NOT contain entry with NodeId={self.th2_node_id}")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_JFDS_2_5.py
+++ b/src/python_testing/TC_JFDS_2_5.py
@@ -33,8 +33,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import base64
 import asyncio
+import base64
 import logging
 import os
 import random
@@ -763,7 +763,8 @@ class TC_JFDS_2_5(MatterBaseTest):
                                  "AddACLToNode with non-existent node should return CONSTRAINT_ERROR")
 
         # Step 16: TH sends AddACLToNode command with valid NodeId
-        self.step(16, "TH sends AddACLToNode command to DUT with NodeId=th_node_id, ACL fields: Privilege Manage (4), AuthMode CASE (2), Subjects [th_node_id2], Targets [{Cluster: null, Endpoint: 0, DeviceType: null}]")
+        self.step(
+            16, "TH sends AddACLToNode command to DUT with NodeId=th_node_id, ACL fields: Privilege Manage (4), AuthMode CASE (2), Subjects [th_node_id2], Targets [{Cluster: null, Endpoint: 0, DeviceType: null}]")
 
         acl_to_add = Clusters.JointFabricDatastore.Structs.DatastoreAccessControlEntryStruct(
             privilege=Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kManage,

--- a/src/python_testing/TC_JFDS_2_5.py
+++ b/src/python_testing/TC_JFDS_2_5.py
@@ -33,8 +33,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import base64
 import asyncio
+import base64
 import logging
 import os
 import random

--- a/src/python_testing/TC_JFDS_2_5.py
+++ b/src/python_testing/TC_JFDS_2_5.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 
-# This test requires a TH2_SERVER application. Please specify with --string-arg th2_server_app_path:<path_to_app>
+# This test requires a TH2_SERVER application. Please specify with --string-arg th2_server_app:<path_to_app>
 
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
@@ -33,8 +33,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import asyncio
 import base64
+import asyncio
 import logging
 import os
 import random
@@ -139,6 +139,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         super().setup_class()
 
         self.fabric_a_ctrl = None
+        self.fabric_a_admin = None
         self.storage_fabric_a = self.user_params.get("fabric_a_storage", None)
         self.storage_directory_ecosystem_a_admin = None
         self.storage_directory_ecosystem_a_ctrl = None
@@ -368,6 +369,9 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         super().teardown_class()
 
+    def pics_TC_JFDS_2_5(self) -> list[str]:
+        return ["JFDS.S"]
+
     @async_test_body
     async def test_TC_JFDS_2_5(self):
         # Step 1: TH reads NodeList attribute from DUT
@@ -395,6 +399,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 3: TH sends AddPendingNode command with duplicate NodeId
         self.step(3, "TH sends AddPendingNode command to DUT with NodeId=th_node_id (duplicate), FriendlyName: 'tc-jf-2.5'")
+        # Spec requires CONSTRAINT_ERROR when NodeID already exists in the datastore (duplicate entries are not allowed).
         try:
             await self.send_single_cmd(
                 cmd=Clusters.JointFabricDatastore.Commands.AddPendingNode(
@@ -466,6 +471,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 7: TH sends UpdateNode command with non-existent NodeId
         self.step(7, "TH sends UpdateNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), FriendlyName: 'tc-jf-2.5-update'")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
         try:
             await self.send_single_cmd(
                 cmd=Clusters.JointFabricDatastore.Commands.UpdateNode(
@@ -502,9 +508,9 @@ class TC_JFDS_2_5(MatterBaseTest):
             response = await self.devCtrlEcoA.ReadAttribute(
                 nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
                 returnClusterObject=True)
-            node_list_step10 = response[1][Clusters.JointFabricDatastore].nodeList
+            node_list_polled = response[1][Clusters.JointFabricDatastore].nodeList
 
-            for node in node_list_step10:
+            for node in node_list_polled:
                 if node.nodeID == self.th2_node_id:
                     if self._enum_equals(node.commissioningStatusEntry.state,
                                          Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted):
@@ -532,10 +538,6 @@ class TC_JFDS_2_5(MatterBaseTest):
             returnClusterObject=True)
         th2_keyset_list = response[0][Clusters.GroupKeyManagement].groupKeyMap
 
-        # Verify 1:1 correspondence - same number of entries
-        asserts.assert_equal(len(node_keyset_list_dut), len(th2_keyset_list),
-                             "NodeKeySetList should have 1:1 correspondence with TH2's GroupKeyMap")
-
         # Verify each KeySet entry exists in both lists
         dut_keyset_ids = {keyset.groupKeySetID for keyset in node_keyset_list_dut}
         th2_keyset_ids = {keyset.groupKeySetID for keyset in th2_keyset_list}
@@ -549,11 +551,11 @@ class TC_JFDS_2_5(MatterBaseTest):
         response = await self.devCtrlEcoA.ReadAttribute(
             nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeACLList)],
             returnClusterObject=True)
-        node_acl_list_step12 = response[1][Clusters.JointFabricDatastore].nodeACLList
+        node_acl_list_initial = response[1][Clusters.JointFabricDatastore].nodeACLList
 
         # Find the ACL entry for th_node_id
         th2_acl_entry_dut = None
-        for acl_entry in node_acl_list_step12:
+        for acl_entry in node_acl_list_initial:
             if acl_entry.nodeID == self.th2_node_id:
                 th2_acl_entry_dut = acl_entry
                 break
@@ -567,7 +569,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         th2_acl_list = response[0][Clusters.AccessControl].acl
 
         # Compare only ACL entries mirrored for th_node_id.
-        dut_acl_entries = [entry.ACLEntry for entry in node_acl_list_step12 if entry.nodeID == self.th2_node_id]
+        dut_acl_entries = [entry.ACLEntry for entry in node_acl_list_initial if entry.nodeID == self.th2_node_id]
         asserts.assert_equal(len(dut_acl_entries), len(th2_acl_list),
                              "NodeACLList should have 1:1 correspondence with TH2's ACL entries")
 
@@ -603,8 +605,8 @@ class TC_JFDS_2_5(MatterBaseTest):
             returnClusterObject=True)
         th2_parts_list = response[0][Clusters.Descriptor].partsList
 
-        # Extract endpoint IDs from DUT's NodeEndpointList
-        dut_endpoint_ids = [ep.endpointID for ep in node_endpoint_list]
+        # Extract endpoint IDs mirrored for th_node_id from DUT's NodeEndpointList
+        dut_endpoint_ids = [ep.endpointID for ep in node_endpoint_list if ep.nodeID == self.th2_node_id]
 
         # Verify 1:1 correspondence
         asserts.assert_equal(sorted(dut_endpoint_ids), sorted(th2_parts_list),
@@ -629,33 +631,40 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # For each endpoint on TH2, verify the GroupList correspondence
         for th2_endpoint_id in th2_parts_list:
-            # Read Groups cluster GroupTable from TH2 endpoint
-            try:
-                response = await self.devCtrlEcoA.ReadAttribute(
-                    nodeId=self.th2_node_id, attributes=[(th2_endpoint_id, Clusters.Groups.Attributes.GroupTable)],
-                    returnClusterObject=True)
-                th2_group_table = response[th2_endpoint_id][Clusters.Groups].groupTable
+            descriptor_response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=self.th2_node_id,
+                attributes=[(th2_endpoint_id, Clusters.Descriptor.Attributes.ServerList)],
+                returnClusterObject=True)
+            th2_server_list = descriptor_response[th2_endpoint_id][Clusters.Descriptor].serverList
 
-                # Find corresponding entry in DUT's EndpointGroupIDList
-                dut_endpoint_group_entry = None
-                for entry in th2_endpoint_groups:
-                    if entry.endpointID == th2_endpoint_id:
-                        dut_endpoint_group_entry = entry
-                        break
+            if Clusters.Groups.id not in th2_server_list:
+                continue
 
-                if len(th2_group_table) > 0:
-                    # If TH2 has groups on this endpoint, DUT should have a corresponding entry
-                    asserts.assert_is_not_none(dut_endpoint_group_entry,
-                                               f"DUT should have EndpointGroupIDList entry for endpoint {th2_endpoint_id}")
+            # GetGroupMembership with empty list returns all groups on the endpoint.
+            group_membership_resp = await self.send_single_cmd(
+                cmd=Clusters.Groups.Commands.GetGroupMembership(groupList=[]),
+                dev_ctrl=self.devCtrlEcoA,
+                node_id=self.th2_node_id,
+                endpoint=th2_endpoint_id,
+            )
+            th2_group_ids_on_endpoint = set(group_membership_resp.groupList)
 
-                    # Verify 1:1 correspondence of group IDs
-                    th2_group_ids = {group.groupID for group in th2_group_table}
-                    dut_group_ids = set(dut_endpoint_group_entry.groupIDList)
-                    asserts.assert_equal(th2_group_ids, dut_group_ids,
-                                         f"Group IDs should match for endpoint {th2_endpoint_id}")
-            except Exception:
-                # Groups cluster may not be supported on all endpoints, which is fine
-                pass
+            # Find corresponding entry in DUT's EndpointGroupIDList
+            dut_endpoint_group_entry = None
+            for entry in th2_endpoint_groups:
+                if entry.endpointID == th2_endpoint_id:
+                    dut_endpoint_group_entry = entry
+                    break
+
+            if len(th2_group_ids_on_endpoint) > 0:
+                # If TH2 has groups on this endpoint, DUT should have a corresponding entry
+                asserts.assert_is_not_none(dut_endpoint_group_entry,
+                                           f"DUT should have EndpointGroupIDList entry for endpoint {th2_endpoint_id}")
+
+                # Verify 1:1 correspondence of group IDs
+                dut_group_ids = set(dut_endpoint_group_entry.groupIDList)
+                asserts.assert_equal(th2_group_ids_on_endpoint, dut_group_ids,
+                                     f"Group IDs should match for endpoint {th2_endpoint_id}")
 
         # Step 14: Read the NodeList entry and verify EndpointBindingList
         self.step(14, "Read the NodeList entry for NodeId=th_node_id")
@@ -735,6 +744,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 15: TH sends AddACLToNode command with non-existent NodeId
         self.step(15, "TH sends AddACLToNode command to DUT with NodeId=0x0000_0000_0000_000a (not found)")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         acl_struct = Clusters.AccessControl.Structs.AccessControlEntryStruct(
             privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kManage,
@@ -805,8 +815,9 @@ class TC_JFDS_2_5(MatterBaseTest):
                 matching_acl = acl
                 # Get the ListID
                 th_acllist_id = acl.listID
+                break
 
-        asserts.assert_is_not_none(matching_acl, "NodeACLList should contain the ACL entry added in step 17")
+        asserts.assert_is_not_none(matching_acl, "NodeACLList should contain the ACL entry added in step 16")
 
         # Note the ListID
         self.th_acllist_id = th_acllist_id
@@ -822,7 +833,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         # Find the ACL entry matching step 17
         th2_normalized_acls = [self._normalize_acl_entry(acl) for acl in th2_acl_list_step19]
         asserts.assert_in(expected_acl, th2_normalized_acls,
-                          "TH2's ACLList should contain the ACL entry added in step 17")
+                          "TH2's ACLList should contain the ACL entry added in step 16")
 
         # Step 19: TH reads ACLList from TH2 and verifies Admin CAT entry
         self.step(19, "TH reads ACLList from TH2")
@@ -834,11 +845,11 @@ class TC_JFDS_2_5(MatterBaseTest):
         for acl in th2_acl_list_step19:
             if (acl.privilege == Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister and
                     acl.authMode == Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase):
-                # Check if subjects contains Admin CAT (0xFFFF_xxxx pattern)
+                # Check if subjects contains the Admin CAT CASE-auth tag node ID pattern:
+                # 0xFFFF_FFFD_FFFF_xxxx (identifier=0xFFFF, version in low 16 bits)
                 for subject in acl.subjects:
-                    if (subject & 0xFFFF_0000_0000_0000) == 0xFFFF_0000_0000_0000:
+                    if (subject & 0xFFFF_FFFF_FFFF_0000) == 0xFFFF_FFFD_FFFF_0000:
                         admin_cat_acl = acl
-                        # Extract the CAT version (lower 16 bits of the identifier)
                         th_admin_cat_version = subject & 0xFFFF
                         break
                 if admin_cat_acl:
@@ -857,14 +868,14 @@ class TC_JFDS_2_5(MatterBaseTest):
         response = await self.devCtrlEcoA.ReadAttribute(
             nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.GroupList)],
             returnClusterObject=True)
-        group_list_step21 = response[1][Clusters.JointFabricDatastore].groupList
+        group_list = response[1][Clusters.JointFabricDatastore].groupList
 
         # Find the Admin CAT group entry
         admin_cat_group = None
         admin_cat_group_id = None
         admin_cat_version = None
 
-        for group in group_list_step21:
+        for group in group_list:
             # Admin CAT group has groupCAT = 0xFFFF
             if group.groupCAT == 0xFFFF:
                 admin_cat_group = group
@@ -880,7 +891,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Keep expected "next version" values for the retained negative Admin CAT check.
         new_admin_cat_version = self.admin_cat_version + 1
-        new_admin_cat_subject = 0xFFFF_0000_0000_0000 | new_admin_cat_version
+        new_admin_cat_subject = 0xFFFF_FFFD_FFFF_0000 | new_admin_cat_version
 
         # Step 21: TH reads NodeACLList and verifies new Admin CAT version was not applied
         self.step(21, "TH reads NodeACLList entries NodeId=th_node_id from DUT")
@@ -890,31 +901,28 @@ class TC_JFDS_2_5(MatterBaseTest):
             returnClusterObject=True)
         node_acl_list_step23 = response[1][Clusters.JointFabricDatastore].nodeACLList
 
-        # Find the ACL entry for th_node_id
-        th2_acl_entry_step23 = None
-        for acl_entry in node_acl_list_step23:
-            if acl_entry.nodeID == self.th2_node_id:
-                th2_acl_entry_step23 = acl_entry
-                break
+        # Find all ACL entries for th_node_id
+        th2_acl_entries_step23 = [e for e in node_acl_list_step23 if e.nodeID == self.th2_node_id]
+        asserts.assert_true(len(th2_acl_entries_step23) > 0, "ACL entry for th_node_id should exist")
 
-        asserts.assert_is_not_none(th2_acl_entry_step23, "ACL entry for th_node_id should exist")
-
-        # Verify no Admin CAT ACL with new version exists
+        # Verify no Admin CAT ACL with new version exists across all mirrored entries for th_node_id
         admin_cat_acl_pending = None
-
-        if (self._enum_equals(th2_acl_entry_step23.ACLEntry.privilege,
-                              Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kAdminister) and
-            self._enum_equals(th2_acl_entry_step23.ACLEntry.authMode,
-                              Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryAuthModeEnum.kCase) and
-                new_admin_cat_subject in th2_acl_entry_step23.ACLEntry.subjects and
-                len(th2_acl_entry_step23.ACLEntry.targets) == 0):
-            admin_cat_acl_pending = th2_acl_entry_step23
+        for acl_entry in th2_acl_entries_step23:
+            if (self._enum_equals(acl_entry.ACLEntry.privilege,
+                                  Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryPrivilegeEnum.kAdminister) and
+                self._enum_equals(acl_entry.ACLEntry.authMode,
+                                  Clusters.JointFabricDatastore.Enums.DatastoreAccessControlEntryAuthModeEnum.kCase) and
+                    new_admin_cat_subject in acl_entry.ACLEntry.subjects and
+                    len(acl_entry.ACLEntry.targets) == 0):
+                admin_cat_acl_pending = acl_entry
+                break
 
         asserts.assert_is_none(admin_cat_acl_pending,
                                f"NodeACLList should not contain Admin CAT ACL with new version {new_admin_cat_version}")
 
         # Step 22: TH sends RemoveACLFromNode command with non-existent NodeId
         self.step(22, "TH sends RemoveACLFromNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), ListID=th_acllist_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         try:
             await self.send_single_cmd(
@@ -1007,6 +1015,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 25: TH sends UpdateEndpointForNode command with non-existent NodeId
         self.step(25, "TH sends UpdateEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a, EndpointID=th_app_endpoint_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         endpoint_struct = Clusters.JointFabricDatastore.Commands.UpdateEndpointForNode(
             nodeID=0x0000_0000_0000_000a,
@@ -1061,6 +1070,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 28: TH sends AddGroupIDToEndpointForNode command with non-existent NodeId
         self.step(28, "TH sends AddGroupIDToEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a (not found), EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         try:
             await self.send_single_cmd(
@@ -1092,34 +1102,35 @@ class TC_JFDS_2_5(MatterBaseTest):
             endpoint=1,
         )
 
-        await asyncio.sleep(2)  # Wait for the group addition to propagate
-
         # Step 30: TH reads EndpointGroupIDList and verifies the group entry
         self.step(30, "TH reads EndpointGroupIDList attribute from DUT")
 
-        response = await self.devCtrlEcoA.ReadAttribute(
-            nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointGroupIDList)],
-            returnClusterObject=True)
-        endpoint_group_list_step34 = response[1][Clusters.JointFabricDatastore].endpointGroupIDList
-
-        # Find the entry for th_node_id and th_app_endpoint_id
         target_endpoint_group = None
-        for entry in endpoint_group_list_step34:
-            if entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id:
-                target_endpoint_group = entry
+        group_committed = False
+        for _ in range(10):
+            response = await self.devCtrlEcoA.ReadAttribute(
+                nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointGroupIDList)],
+                returnClusterObject=True)
+            endpoint_group_list_after_add = response[1][Clusters.JointFabricDatastore].endpointGroupIDList
+
+            for entry in endpoint_group_list_after_add:
+                if (entry.nodeID == self.th2_node_id and
+                        entry.endpointID == self.th_app_endpoint_id and
+                        entry.groupID == self.th_group_id):
+                    target_endpoint_group = entry
+                    if (entry.statusEntry.state ==
+                            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted):
+                        group_committed = True
+                    break
+
+            if group_committed:
                 break
 
+            await asyncio.sleep(1)
+
         asserts.assert_is_not_none(target_endpoint_group,
-                                   f"EndpointGroupIDList should contain entry for NodeId={self.th2_node_id} and EndpointID={self.th_app_endpoint_id}")
-
-        group_id = target_endpoint_group.groupID
-        asserts.assert_equal(self.th_group_id, group_id, "GroupID should match the one added to the endpoint")
-
-        # Verify Status is Committed
-        self._assert_enum_equal(
-            target_endpoint_group.statusEntry.state,
-            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted,
-            "Status should be Committed")
+                                   f"EndpointGroupIDList should contain entry for NodeId={self.th2_node_id}, EndpointID={self.th_app_endpoint_id}, GroupID={self.th_group_id}")
+        asserts.assert_true(group_committed, "StatusEntry should change to Committed")
 
         # Step 31: TH reads GroupList from the given endpoint on TH2
         self.step(31, "TH reads GroupList from the given endpoint on TH2")
@@ -1132,7 +1143,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         asserts.assert_in(
             Clusters.Groups.id,
             th2_server_list,
-            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 35")
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 31")
 
         group_response = await self.send_single_cmd(
             cmd=Clusters.Groups.Commands.GetGroupMembership(groupList=[self.th_group_id]),
@@ -1165,7 +1176,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         # Note: epoch key bytes (epochKey0-2) are always returned as Null by KeySetRead per spec
         # (they are write-only). th_keyset_epoch was stored at setup time.
 
-        # Step 33: TH reads NodeKeySetList and verifies Status Success
+        # Step 33: TH reads NodeKeySetList and verifies Status Pending
         self.step(33, "TH reads NodeKeySetList attribute from DUT for NodeId=th_node_id and KeySetID=th_keyset_id")
 
         response = await self.devCtrlEcoA.ReadAttribute(
@@ -1183,8 +1194,8 @@ class TC_JFDS_2_5(MatterBaseTest):
         asserts.assert_is_not_none(th2_keyset_entry, "NodeKeySetList should contain entry for th_node_id")
         self._assert_enum_equal(
             th2_keyset_entry.statusEntry.state,
-            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitted,
-            "StatusEntry should be Success")
+            Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kPending,
+            "StatusEntry should be Pending")
 
         # Step 34: TH reads KeySetList from TH2 and verifies new EpochKey2
         self.step(34, "TH reads KeySetList from the given endpoint on TH2")
@@ -1207,6 +1218,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 35: TH sends RemoveGroupIDFromEndpointForNode command with non-existent NodeId
         self.step(35, "TH sends RemoveGroupIDFromEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a, EndpointID=th_app_endpoint_id, GroupID=th_group_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         try:
             await self.send_single_cmd(
@@ -1277,7 +1289,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         asserts.assert_in(
             Clusters.Groups.id,
             th2_server_list_step44,
-            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 44")
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Groups cluster for step 38")
 
         get_group_cmd = Clusters.Groups.Commands.GetGroupMembership(
             groupList=[self.th_group_id]
@@ -1295,6 +1307,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 39: TH reads KeySetList from TH2 and verifies keyset does not exist
         self.step(39, "TH reads KeySetList from the given endpoint on TH2")
+        # When the last group referencing a keyset is removed from a node, the keyset is also removed; KeySetRead must return NotFound.
 
         # Read the actual KeySet for th_keyset_id using KeySetRead
         try:
@@ -1311,6 +1324,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 40: TH sends AddBindingToEndpointForNode command with non-existent NodeId
         self.step(40, "TH sends AddBindingToEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a and EndpointID=th_app_endpoint_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         binding_struct = Clusters.JointFabricDatastore.Structs.DatastoreBindingTargetStruct(
             node=self.th2_node_id,
@@ -1367,9 +1381,9 @@ class TC_JFDS_2_5(MatterBaseTest):
             response = await self.devCtrlEcoA.ReadAttribute(
                 nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.EndpointBindingList)],
                 returnClusterObject=True)
-            endpoint_binding_list_step48 = response[1][Clusters.JointFabricDatastore].endpointBindingList
+            endpoint_binding_list_polled = response[1][Clusters.JointFabricDatastore].endpointBindingList
 
-            for entry in endpoint_binding_list_step48:
+            for entry in endpoint_binding_list_polled:
                 if (entry.nodeID == self.th2_node_id and entry.endpointID == self.th_app_endpoint_id and
                         self._normalize_binding_target(entry.binding) == expected_binding):
                     target_endpoint_binding = entry
@@ -1385,7 +1399,7 @@ class TC_JFDS_2_5(MatterBaseTest):
             await asyncio.sleep(1)
 
         asserts.assert_is_not_none(target_endpoint_binding,
-                                   "EndpointBindingList should contain the binding added in step 47")
+                                   "EndpointBindingList should contain the binding added in step 41")
         asserts.assert_true(binding_committed, "StatusEntry should change to Committed")
 
         asserts.assert_equal(self._normalize_binding_target(target_endpoint_binding.binding), expected_binding,
@@ -1399,7 +1413,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         asserts.assert_in(
             Clusters.Binding.id,
             th2_server_list_step48,
-            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 48")
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 42")
 
         th2_matching_binding = None
         last_th2_binding_list = []
@@ -1412,7 +1426,7 @@ class TC_JFDS_2_5(MatterBaseTest):
             asserts.assert_true(
                 self.th_app_endpoint_id in th2_bindings_list_resp and Clusters.Binding in th2_bindings_list_resp[
                     self.th_app_endpoint_id],
-                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 48")
+                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 42")
 
             th2_binding_list = th2_bindings_list_resp[self.th_app_endpoint_id][Clusters.Binding].binding
             last_th2_binding_list = [self._normalize_binding_target(binding) for binding in th2_binding_list]
@@ -1429,11 +1443,12 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         asserts.assert_is_not_none(
             th2_matching_binding,
-            f"TH2's BindingList should contain the binding added in step 47. "
+            f"TH2's BindingList should contain the binding added in step 41. "
             f"Expected={expected_binding}, LastObserved={last_th2_binding_list}")
 
         # Step 43: TH sends RemoveBindingFromEndpointForNode command with non-existent NodeId
         self.step(43, "TH sends RemoveBindingFromEndpointForNode command to DUT with NodeId=0x0000_0000_0000_000a and EndpointID=th_app_endpoint_id, ListID=th_binding_list_id")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         try:
             await self.send_single_cmd(
@@ -1501,7 +1516,7 @@ class TC_JFDS_2_5(MatterBaseTest):
         asserts.assert_in(
             Clusters.Binding.id,
             th2_server_list_step51,
-            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 51")
+            f"TH2 endpoint {self.th_app_endpoint_id} must support Binding cluster for step 45")
 
         # Poll TH2 BindingList until the removed binding is absent.
         th2_binding_removed = False
@@ -1514,7 +1529,7 @@ class TC_JFDS_2_5(MatterBaseTest):
             asserts.assert_true(
                 self.th_app_endpoint_id in th2_bindings_list_resp and Clusters.Binding in th2_bindings_list_resp[
                     self.th_app_endpoint_id],
-                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 51")
+                f"TH2 endpoint {self.th_app_endpoint_id} reports Binding but Binding attribute is unavailable in step 45")
 
             th2_binding_list = th2_bindings_list_resp[self.th_app_endpoint_id][Clusters.Binding].binding
             th2_matching_binding_found = any(
@@ -1532,6 +1547,7 @@ class TC_JFDS_2_5(MatterBaseTest):
 
         # Step 46: TH sends RemoveNode command with non-existent NodeId
         self.step(46, "TH sends RemoveNode command to DUT with NodeId=0x0000_0000_0000_000a")
+        # Spec requires CONSTRAINT_ERROR when the target NodeID is absent from the datastore.
 
         try:
             await self.send_single_cmd(
@@ -1561,11 +1577,11 @@ class TC_JFDS_2_5(MatterBaseTest):
         response = await self.devCtrlEcoA.ReadAttribute(
             nodeId=1, attributes=[(1, Clusters.JointFabricDatastore.Attributes.NodeList)],
             returnClusterObject=True)
-        node_list_step54 = response[1][Clusters.JointFabricDatastore].nodeList
+        node_list_final = response[1][Clusters.JointFabricDatastore].nodeList
 
         # Verify th_node_id is NOT in the list
         node_found = False
-        for node in node_list_step54:
+        for node in node_list_final:
             if node.nodeID == self.th2_node_id:
                 node_found = True
                 break


### PR DESCRIPTION
#### Summary
Add Python test scripts for JFDS-2.5.

#### Related issues
Addresses Issues:
- https://github.com/project-chip/connectedhomeip/issues/72134.

#### Testing
Test Instructions to execute Python Tests

Build and Activate the Python Environment
```
./scripts/build_python.sh -i out/python_env

source out/python_env/bin/activate
```

Run the Test
Execute the JFDS 2.5 Python test script with the required application paths:

```
python3 src/python_testing/TC_JFDS_2_5.py \
  --string-arg "jfa_server_app:/home/vijay/apps/jfa-app" \
  --string-arg "jfc_server_app:/home/vijay/apps/jfc-app"
```