### PR TITLE
[EFR32] fix all devices compile, add to CI

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -70,6 +70,7 @@ jobs:
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
+                --target efr32-brd4187c-all-devices \
                 --target efr32-brd4187c-light \
                 --target efr32-brd4187c-thermostat-use-ot-lib \
                 --target efr32-brd4187c-switch-shell-use-ot-coap-lib \

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -183,6 +183,7 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .groupDataProvider = *groupDataProvider,
         .fabricTable       = chip::Server::GetInstance().GetFabricTable(),
         .timerDelegate     = sTimerDelegate,
+        .storageDelegate   = storage,
     });
 
     std::string deviceType = "on-off-light"; // Default


### PR DESCRIPTION
#### Summary

Fix silabs all-devices after #72111 added a device factory argument (storage).
Added this build to CI so we do not break in the future.

Separate PR will likely be to remove this as ServerClusterContext contains a PersistentStorageDelegate.

#### Testing

Built and flashed `efr32-brd4187c-all-devices`.
Commissioned via ` ./out/linux-x64-chip-tool-clang/chip-tool pairing ble-thread 123 hex:.... 20202021 3840`
Read worked like `./out/linux-x64-chip-tool-clang/chip-tool descriptor read device-type-list 123 1 --trace-to json:log`

<img width="1656" height="577" alt="image" src="https://github.com/user-attachments/assets/8e8f3071-00f6-4341-b193-a5839af2953d" />
