### PR TITLE
[darwin examplex] Always clear all signal handlers on app exists.

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -1051,12 +1051,10 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     auto & platformMgr = chip::DeviceLayer::PlatformMgrImpl();
     platformMgr.RegisterSignalHandler(SIGINT, ^{
-        platformMgr.UnregisterAllSignalHandlers();
         StopSignalHandler(SIGINT);
     });
 
     platformMgr.RegisterSignalHandler(SIGTERM, ^{
-        platformMgr.UnregisterAllSignalHandlers();
         StopSignalHandler(SIGTERM);
     });
 #else
@@ -1097,6 +1095,10 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
 
 #if defined(ENABLE_CHIP_SHELL)
     shellThread.join();
+#endif
+
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN && CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    platformMgr.UnregisterAllSignalHandlers();
 #endif
 
     Server::GetInstance().Shutdown();


### PR DESCRIPTION
#### Summary

CI reports a memory leak:

```
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.521 - APP  STDERR: Direct leak of 128 byte(s) in 1 object(s) allocated from:
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.522 - APP  STDERR:     #0 0x000103639354 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x55354)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.523 - APP  STDERR:     #1 0x00018ca6c6ec in _malloc_type_calloc_outlined+0x64 (libsystem_malloc.dylib:arm64e+0x1e6ec)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.523 - APP  STDERR:     #2 0x00018c7ff7d8 in class_createInstance+0x48 (libobjc.A.dylib:arm64e+0x77d8)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.523 - APP  STDERR:     #3 0x00018caa184c in _os_object_alloc_realized+0x1c (libdispatch.dylib:arm64e+0x284c)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.524 - APP  STDERR:     #4 0x00018cab588c in dispatch_source_create+0x38 (libdispatch.dylib:arm64e+0x1688c)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.525 - APP  STDERR:     #5 0x00010278e354 in chip::DeviceLayer::PlatformManagerImpl::RegisterSignalHandler(int, void () block_pointer)+0x3ec (lit-icd-app:arm64+0x1005b2354)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.525 - APP  STDERR:     #6 0x0001022a1cf8 in ChipLinuxAppMainLoop(chip::ServerInitParams&, AppMainLoopImplementation*)+0x1960 (lit-icd-app:arm64+0x1000c5cf8)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.525 - APP  STDERR:     #7 0x0001021dde3c in main+0x9a0 (lit-icd-app:arm64+0x100001e3c)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.526 - APP  STDERR:     #8 0x00018c89fda0 in start+0x1b4c (dyld:arm64e+0x1fda0)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.526 - APP  STDERR: 
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.527 - APP  STDERR: Indirect leak of 80 byte(s) in 1 object(s) allocated from:
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.527 - APP  STDERR:     #0 0x000103639354 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x55354)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.527 - APP  STDERR:     #1 0x00018ca6c6ec in _malloc_type_calloc_outlined+0x64 (libsystem_malloc.dylib:arm64e+0x1e6ec)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.527 - APP  STDERR:     #2 0x00018caa0918 in _dispatch_calloc_typed+0x20 (libdispatch.dylib:arm64e+0x1918)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.529 - APP  STDERR:     #3 0x00018cac0838 in _dispatch_unote_create+0x8c (libdispatch.dylib:arm64e+0x21838)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.529 - APP  STDERR:     #4 0x00018cab5874 in dispatch_source_create+0x20 (libdispatch.dylib:arm64e+0x16874)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.530 - APP  STDERR:     #5 0x00010278e354 in chip::DeviceLayer::PlatformManagerImpl::RegisterSignalHandler(int, void () block_pointer)+0x3ec (lit-icd-app:arm64+0x1005b2354)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.530 - APP  STDERR:     #6 0x0001022a1cf8 in ChipLinuxAppMainLoop(chip::ServerInitParams&, AppMainLoopImplementation*)+0x1960 (lit-icd-app:arm64+0x1000c5cf8)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.530 - APP  STDERR:     #7 0x0001021dde3c in main+0x9a0 (lit-icd-app:arm64+0x100001e3c)
ERROR   [Worker] Test_TC_ICDM_4_1: 15:03:07.530 - APP  STDERR:     #8 0x00018c89fda0 in start+0x1b4c (dyld:arm64e+0x1fda0)
```

Normally if we only stop on signal handlers, the clear should have happened... however it seems it does not, so moving the logic to become unconditional, in case we have other ways to stop the app.

#### Testing

CI will test - change is short.