### PR TITLE
[Interop] Add missing import in production_device_checks.py

### DIFF
--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -68,7 +68,7 @@ try:
     from matter.testing.matter_stack_state import MatterStackState
     from matter.testing.matter_test_config import MatterTestConfig
     from matter.testing.matter_testing import MatterBaseTest
-    from matter.testing.runner import run_tests_no_exit
+    from matter.testing.runner import TestStep, run_tests_no_exit
 except ImportError:
     sys.path.append(os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
#### Summary

Add missing import in `production_device_checks.py`

#### Related issues
-

#### Testing

Tested manually using IDT (Interoperability Debug Tool)

