### PR TITLE
[silabs, all-devices] Add shell support for setting the device type

### DIFF
--- a/examples/all-devices-app/silabs/BUILD.gn
+++ b/examples/all-devices-app/silabs/BUILD.gn
@@ -91,7 +91,13 @@ silabs_executable("all_devices_app") {
     defines += [ "SL_STATUS_LED=0" ]
   }
 
-  sources = [ "src/AppTask.cpp" ]
+  sources = [
+    "include/AppKeys.h",
+    "include/AppTask.h",
+    "include/DeviceShellCommands.h",
+    "src/AppTask.cpp",
+    "src/DeviceShellCommands.cpp",
+  ]
 
   deps = [
     ":sdk",

--- a/examples/all-devices-app/silabs/BUILD.gn
+++ b/examples/all-devices-app/silabs/BUILD.gn
@@ -94,10 +94,15 @@ silabs_executable("all_devices_app") {
   sources = [
     "include/AppKeys.h",
     "include/AppTask.h",
-    "include/DeviceShellCommands.h",
     "src/AppTask.cpp",
-    "src/DeviceShellCommands.cpp",
   ]
+
+  if (chip_build_libshell) {
+    sources += [
+      "include/DeviceShellCommands.h",
+      "src/DeviceShellCommands.cpp",
+    ]
+  }
 
   deps = [
     ":sdk",

--- a/examples/all-devices-app/silabs/include/AppKeys.h
+++ b/examples/all-devices-app/silabs/include/AppKeys.h
@@ -1,0 +1,23 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+namespace chip {
+
+static constexpr const char * kDeviceTypeKey = "all-devices/dev-type";
+
+}

--- a/examples/all-devices-app/silabs/include/DeviceShellCommands.h
+++ b/examples/all-devices-app/silabs/include/DeviceShellCommands.h
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
+#include <lib/shell/commands/Help.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <string>
+
+namespace chip {
+namespace Shell {
+
+class DeviceCommands
+{
+public:
+    // delete the copy constructor
+    DeviceCommands(const DeviceCommands &) = delete;
+    // delete the move constructor
+    DeviceCommands(DeviceCommands &&) = delete;
+    // delete the assignment operator
+    DeviceCommands & operator=(const DeviceCommands &) = delete;
+
+    static DeviceCommands & GetInstance()
+    {
+        static DeviceCommands instance;
+        return instance;
+    }
+
+    // Register the devtype commands
+    void Register();
+
+private:
+    DeviceCommands() {}
+
+    static CHIP_ERROR DeviceHandler(int argc, char ** argv)
+    {
+        if (argc == 0)
+        {
+            sSubShell.ForEachCommand(PrintCommandHelp, nullptr);
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR error = sSubShell.ExecCommand(argc, argv);
+
+        if (error != CHIP_NO_ERROR)
+        {
+            streamer_printf(streamer_get(), "Error: %" CHIP_ERROR_FORMAT "\r\n", error.Format());
+        }
+
+        return error;
+    }
+
+    static CHIP_ERROR SetDeviceTypeHandler(int argc, char ** argv);
+    static CHIP_ERROR GetDeviceTypeHandler(int argc, char ** argv);
+    static CHIP_ERROR ListDeviceTypesHandler(int argc, char ** argv);
+
+    static Shell::Engine sSubShell;
+};
+
+} // namespace Shell
+} // namespace chip

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -198,7 +198,7 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
 
     char storedDeviceType[64] = {};
     uint16_t storedLen        = sizeof(storedDeviceType);
-    CHIP_ERROR storedErr      = storage.SyncGetKeyValue(kDeviceTypeKey, storedDeviceType, storedLen);
+    CHIP_ERROR storedErr      = storage.SyncGetKeyValue(chip::kDeviceTypeKey, storedDeviceType, storedLen);
     if (storedErr == CHIP_NO_ERROR && storedLen > 0)
     {
         deviceType = std::string(storedDeviceType, strnlen(storedDeviceType, storedLen));

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -20,6 +20,11 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "AppKeys.h"
+
+#ifdef ENABLE_CHIP_SHELL
+#include <DeviceShellCommands.h>
+#endif
 
 #include <cstring>
 #include <memory>
@@ -108,6 +113,9 @@ void AppTask::AppTaskMain(void * pvParameter)
 CHIP_ERROR AppTask::AppInit()
 {
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(&AppTask::ButtonEventHandler);
+#ifdef ENABLE_CHIP_SHELL
+    chip::Shell::DeviceCommands::GetInstance().Register();
+#endif
     return CHIP_NO_ERROR;
 }
 
@@ -186,11 +194,11 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .storageDelegate   = storage,
     });
 
-    std::string deviceType = "on-off-light"; // Default
+    std::string deviceType = chip::app::DeviceFactory::GetInstance().GetDefaultDevice();
 
     char storedDeviceType[64] = {};
     uint16_t storedLen        = sizeof(storedDeviceType);
-    CHIP_ERROR storedErr      = storage.SyncGetKeyValue("all-devices/dev-type", storedDeviceType, storedLen);
+    CHIP_ERROR storedErr      = storage.SyncGetKeyValue(kDeviceTypeKey, storedDeviceType, storedLen);
     if (storedErr == CHIP_NO_ERROR && storedLen > 0)
     {
         deviceType = std::string(storedDeviceType, strnlen(storedDeviceType, storedLen));

--- a/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
+++ b/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
@@ -1,0 +1,126 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceShellCommands.h"
+#include "AppKeys.h"
+
+#include <app/server/Server.h>
+#include <devices/device-factory/DeviceFactory.h>
+#include <lib/shell/streamer.h>
+#include <platform/silabs/SilabsConfig.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+
+namespace chip {
+namespace Shell {
+
+Shell::Engine DeviceCommands::sSubShell;
+
+void DeviceCommands::Register()
+{
+    static const shell_command_t subCommands[] = {
+        { &SetDeviceTypeHandler, "set", "Usage: devtype set <device-type>" },
+        { &GetDeviceTypeHandler, "get", "Usage: devtype get" },
+        { &ListDeviceTypesHandler, "list", "Usage: devtype list" },
+    };
+    sSubShell.RegisterCommands(subCommands, MATTER_ARRAY_SIZE(subCommands));
+
+    // Register the root `devtype` command in the top-level shell.
+    static const shell_command_t devtypeCommand = { &DeviceHandler, "devtype", "Device type management commands" };
+
+    Engine::Root().RegisterCommands(&devtypeCommand, 1);
+}
+
+CHIP_ERROR DeviceCommands::SetDeviceTypeHandler(int argc, char ** argv)
+{
+    if (argc != 1)
+    {
+        const auto supportedDeviceTypes = chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes();
+        streamer_printf(streamer_get(), "Usage: devtype set <device-type>\r\n");
+        streamer_printf(streamer_get(), "Supported device types:\r\n");
+        for (const auto & deviceType : supportedDeviceTypes)
+        {
+            streamer_printf(streamer_get(), "  - %s\r\n", deviceType.c_str());
+        }
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    const char * deviceType = argv[0];
+
+    if (!chip::app::DeviceFactory::GetInstance().IsValidDevice(deviceType))
+    {
+        streamer_printf(streamer_get(), "Invalid device type: %s\r\n", deviceType);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    PersistentStorageDelegate & storage = Server::GetInstance().GetPersistentStorage();
+    CHIP_ERROR err = storage.SyncSetKeyValue(kDeviceTypeKey, deviceType, static_cast<uint16_t>(strlen(deviceType)));
+    if (err != CHIP_NO_ERROR)
+    {
+        streamer_printf(streamer_get(), "Failed to save device type to KVS: %" CHIP_ERROR_FORMAT "\r\n", err.Format());
+        return err;
+    }
+
+    streamer_printf(streamer_get(), "Device type set to: %s. Rebooting %d seconds...\r\n", deviceType, SL_KVS_SAVE_DELAY_SECONDS);
+
+    // Reboot the device after a short delay...
+    // Silabs KVS has a  delay to commit, so wait a bit
+    return DeviceLayer::SystemLayer().StartTimer(
+        System::Clock::Milliseconds32(SL_KVS_SAVE_DELAY_SECONDS * 1000 + 100),
+        [](System::Layer *, void *) { chip::DeviceLayer::Silabs::GetPlatform().SoftwareReset(); }, nullptr);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceCommands::GetDeviceTypeHandler(int argc, char ** argv)
+{
+    PersistentStorageDelegate & storage = Server::GetInstance().GetPersistentStorage();
+    char storedDeviceType[64]           = {};
+    uint16_t storedLen                  = sizeof(storedDeviceType);
+    CHIP_ERROR err                      = storage.SyncGetKeyValue(kDeviceTypeKey, storedDeviceType, storedLen);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        streamer_printf(streamer_get(), "Failed to get stored device type: %" CHIP_ERROR_FORMAT " (using default: %s)\r\n",
+                        err.Format(), chip::app::DeviceFactory::GetInstance().GetDefaultDevice().c_str());
+        return err;
+    }
+
+    if (storedLen <= 0 || storedLen > sizeof(storedDeviceType))
+    {
+        streamer_printf(streamer_get(), "Invalid device type length: %d (using default: %s)\r\n", storedLen,
+                        chip::app::DeviceFactory::GetInstance().GetDefaultDevice().c_str());
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    streamer_printf(streamer_get(), "Current device type: %.*s\r\n", storedLen, storedDeviceType);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceCommands::ListDeviceTypesHandler(int argc, char ** argv)
+{
+    const auto supportedDeviceTypes = chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes();
+    streamer_printf(streamer_get(), "Supported device types:\r\n");
+    for (const auto & deviceType : supportedDeviceTypes)
+    {
+        streamer_printf(streamer_get(), "  - %s\r\n", deviceType.c_str());
+    }
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Shell
+} // namespace chip

--- a/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
+++ b/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
@@ -19,11 +19,11 @@
 #include "AppKeys.h"
 
 #include <app/server/Server.h>
+#include <cstring>
 #include <devices/device-factory/DeviceFactory.h>
 #include <lib/shell/streamer.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
-#include <cstring>
 
 namespace chip {
 namespace Shell {

--- a/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
+++ b/examples/all-devices-app/silabs/src/DeviceShellCommands.cpp
@@ -23,6 +23,7 @@
 #include <lib/shell/streamer.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+#include <cstring>
 
 namespace chip {
 namespace Shell {
@@ -81,8 +82,6 @@ CHIP_ERROR DeviceCommands::SetDeviceTypeHandler(int argc, char ** argv)
     return DeviceLayer::SystemLayer().StartTimer(
         System::Clock::Milliseconds32(SL_KVS_SAVE_DELAY_SECONDS * 1000 + 100),
         [](System::Layer *, void *) { chip::DeviceLayer::Silabs::GetPlatform().SoftwareReset(); }, nullptr);
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceCommands::GetDeviceTypeHandler(int argc, char ** argv)
@@ -96,7 +95,7 @@ CHIP_ERROR DeviceCommands::GetDeviceTypeHandler(int argc, char ** argv)
     {
         streamer_printf(streamer_get(), "Failed to get stored device type: %" CHIP_ERROR_FORMAT " (using default: %s)\r\n",
                         err.Format(), chip::app::DeviceFactory::GetInstance().GetDefaultDevice().c_str());
-        return err;
+        return CHIP_NO_ERROR;
     }
 
     if (storedLen <= 0 || storedLen > sizeof(storedDeviceType))
@@ -106,7 +105,7 @@ CHIP_ERROR DeviceCommands::GetDeviceTypeHandler(int argc, char ** argv)
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    streamer_printf(streamer_get(), "Current device type: %.*s\r\n", storedLen, storedDeviceType);
+    streamer_printf(streamer_get(), "Current device type: %.*s\r\n", static_cast<int>(storedLen), storedDeviceType);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary

Two fixes:
  - use the `default` device type instead of hardcoding on-off-light (since other apps have contact sensor as a default)
  - add shell handler for get/set/list for device types

#### Testing

Tested in shell that get/set/list works

<img width="780" height="944" alt="image" src="https://github.com/user-attachments/assets/486bc983-64b6-4ef5-91d2-c39ae927ce79" />
