### PR TITLE
Update Type of Group Auxiliary Delegate in Access Control

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -23,6 +23,8 @@
 
 #include "AccessControl.h"
 
+#include "GroupAuxiliaryAccessControlDelegate.h"
+
 #include <lib/core/Global.h>
 #include <lib/support/TypeTraits.h>
 
@@ -213,6 +215,17 @@ char GetRequestTypeStringForLogging(RequestType requestType)
 Global<AccessControl::Entry::Delegate> AccessControl::Entry::mDefaultDelegate;
 Global<AccessControl::EntryIterator::Delegate> AccessControl::EntryIterator::mDefaultDelegate;
 
+AccessControl::~AccessControl()
+{
+    UnregisterGroupAuxiliaryDelegate();
+
+    // Never-initialized AccessControl instances will not have the delegate set.
+    if (IsInitialized())
+    {
+        mDelegate->Release();
+    }
+}
+
 CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate, DeviceTypeResolver & deviceTypeResolver)
 {
     VerifyOrReturnError(!IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
@@ -241,6 +254,30 @@ void AccessControl::Finish()
     {
         mGroupAuxDelegate->Finish();
         UnregisterGroupAuxiliaryDelegate();
+    }
+}
+
+CHIP_ERROR AccessControl::AuxiliaryEntries(FabricIndex fabricIndex, EntryIterator & iterator) const
+{
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(IsGroupAuxiliaryDelegateRegistered(), CHIP_ERROR_NOT_IMPLEMENTED);
+    return mGroupAuxDelegate->AuxiliaryEntries(iterator, &fabricIndex);
+}
+
+CHIP_ERROR AccessControl::RegisterGroupAuxiliaryDelegate(GroupAuxiliaryAccessControlDelegate * delegate)
+{
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mGroupAuxDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mGroupAuxDelegate = delegate;
+    return CHIP_NO_ERROR;
+}
+
+void AccessControl::UnregisterGroupAuxiliaryDelegate()
+{
+    if (IsGroupAuxiliaryDelegateRegistered())
+    {
+        mGroupAuxDelegate->Release();
+        mGroupAuxDelegate = nullptr;
     }
 }
 

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -39,6 +39,8 @@
 namespace chip {
 namespace Access {
 
+class GroupAuxiliaryAccessControlDelegate;
+
 class AccessControl
 {
 public:
@@ -426,19 +428,7 @@ public:
     AccessControl(const AccessControl &)             = delete;
     AccessControl & operator=(const AccessControl &) = delete;
 
-    ~AccessControl()
-    {
-        if (IsGroupAuxiliaryDelegateRegistered())
-        {
-            mGroupAuxDelegate->Release();
-        }
-
-        // Never-initialized AccessControl instances will not have the delegate set.
-        if (IsInitialized())
-        {
-            mDelegate->Release();
-        }
-    }
+    ~AccessControl();
 
     /**
      * Initialize the access control module. Must be called before first use.
@@ -655,12 +645,7 @@ public:
      * @param [in]  fabricIndex   Fabric index for which to iterate auxiliary entries.
      * @param [out] iterator      Iterator controlling the iteration.
      */
-    CHIP_ERROR AuxiliaryEntries(FabricIndex fabricIndex, EntryIterator & iterator) const
-    {
-        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(IsGroupAuxiliaryDelegateRegistered(), CHIP_ERROR_NOT_IMPLEMENTED);
-        return mGroupAuxDelegate->AuxiliaryEntries(iterator, &fabricIndex);
-    }
+    CHIP_ERROR AuxiliaryEntries(FabricIndex fabricIndex, EntryIterator & iterator) const;
 
     // Adds a listener to the end of the listener list, if not already in the list.
     void AddEntryListener(EntryListener & listener);
@@ -680,27 +665,14 @@ public:
      * @retval #CHIP_ERROR_INCORRECT_STATE if a delegate is already registered.
      * @retval #CHIP_NO_ERROR on success.
      */
-    CHIP_ERROR RegisterGroupAuxiliaryDelegate(Delegate * delegate)
-    {
-        VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(mGroupAuxDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
-        mGroupAuxDelegate = delegate;
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR RegisterGroupAuxiliaryDelegate(GroupAuxiliaryAccessControlDelegate * delegate);
 
     bool IsGroupAuxiliaryDelegateRegistered() const { return (mGroupAuxDelegate != nullptr); }
 
     /**
      * @brief Unregisters the delegate handling auxiliary access control entries.
      */
-    void UnregisterGroupAuxiliaryDelegate()
-    {
-        if (IsGroupAuxiliaryDelegateRegistered())
-        {
-            mGroupAuxDelegate->Release();
-            mGroupAuxDelegate = nullptr;
-        }
-    }
+    void UnregisterGroupAuxiliaryDelegate();
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
     // Set an optional AcceessRestriction object for MNGD feature.
@@ -763,8 +735,8 @@ private:
     // the LN feature, and the access control cluster protected by the AUX feature. It is expected that
     // this delegate will have an implementation of the AuxiliaryEntries() funciton for reporting these
     // entries. It is also expected to implement a Check() function to actually use these entries
-    // to approve/deny access control.
-    Delegate * mGroupAuxDelegate = nullptr;
+    // to approve/deny access control. Must call Initialize() on this before use.
+    GroupAuxiliaryAccessControlDelegate * mGroupAuxDelegate = nullptr;
 
     DeviceTypeResolver * mDeviceTypeResolver = nullptr;
 

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -2172,7 +2172,7 @@ TEST_F(TestAccessControl, TestGroupAuxiliaryDelegateLifecycle)
 TEST_F(TestAccessControl, TestGroupAuxiliaryDelegateRegistration)
 {
     // The delegate is already registered in SetUpTestSuite.
-    AccessControl::Delegate * delegate = &gGroupAuxiliaryAccessControlDelegate;
+    GroupAuxiliaryAccessControlDelegate * delegate = &gGroupAuxiliaryAccessControlDelegate;
 
     // Verify registering again fails.
     EXPECT_EQ(accessControl.RegisterGroupAuxiliaryDelegate(delegate), CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
#### Summary

This PR is a follow-up to #71547. This PR ensures that the new `GroupAuxiliaryAccessControlDelegate` type is used for the definition of `mGroupAuxDelegate` in AccessControl, and this type is now also used in the `RegisterGroupAuxiliaryDelegate()` function. This replaces the use of the more general `AccessControl::Delegate` that was used before. Since the PR referenced above changed the type for the group aux delegate to be `GroupAuxiliaryAccessControlDelegate`, this change should follow throughout in other areas of the code.

#### Testing

- CI should still pass, this is just a code refactor no functionality change
