### PR TITLE
[ESP32] fix value-initialization of esp_ecdsa_opaque_key_t

### DIFF
--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -81,7 +81,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
     size_t key_size_in_bits = 256;
 
     // opaque reference for the efuse-stored ec key
-    esp_ecdsa_opaque_key_t opaque_key = { 0 };
+    esp_ecdsa_opaque_key_t opaque_key = {};
     opaque_key.curve                  = ESP_ECDSA_CURVE_SECP256R1;
     opaque_key.efuse_block            = static_cast<uint8_t>(efuseBlock);
 


### PR DESCRIPTION
#### Summary

```
../../../../../../../../opt/espressif/connectedhomeip/config/esp32/third_party/connectedhomeip/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp:84:43: error: invalid conversion from 'int' to 'esp_ecdsa_curve_t' [-fpermissive]
   84 |     esp_ecdsa_opaque_key_t opaque_key = { 0 };
      |                                           ^
      |                                           |
      |                                           int
```

`esp_ecdsa_opaque_key_t opaque_key = { 0 };` triggers `-Werror=permissive` on GCC 15 (used   in ESP-IDF v6.0 toolchain). The first field is an enum and C++ does not allow implicit int to enum conversion. This breaks the build for any app enabling `chip_use_esp32_ecdsa_peripheral`.

#### Testing

- tried building app with `CONFIG_USE_ESP32_ECDSA_PERIPHERAL=y` and made sure the warnings goes away.