### PR TITLE
feat(casting): Add iOS Device Instance Info Provider API (#71601)

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		3CD73F1E2A9E83C1009D82D1 /* MCCommissionableDataProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CD73F1D2A9E83C1009D82D1 /* MCCommissionableDataProvider.mm */; };
 		3CD73F202A9EA060009D82D1 /* MCDeviceAttestationCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD73F1F2A9EA060009D82D1 /* MCDeviceAttestationCredentials.h */; };
 		3CD73F222A9EA078009D82D1 /* MCDeviceAttestationCredentials.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CD73F212A9EA077009D82D1 /* MCDeviceAttestationCredentials.mm */; };
+		3CD73F242B1EA001009D82D1 /* MCDeviceInstanceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD73F232B1EA001009D82D1 /* MCDeviceInstanceInfo.h */; };
+		3CD73F262B1EA002009D82D1 /* MCDeviceInstanceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD73F252B1EA002009D82D1 /* MCDeviceInstanceInfo.m */; };
+		3CD73F282B1EA003009D82D1 /* MCDeviceInstanceInfoProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD73F272B1EA003009D82D1 /* MCDeviceInstanceInfoProvider.h */; };
+		3CD73F2A2B1EA004009D82D1 /* MCDeviceInstanceInfoProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CD73F292B1EA004009D82D1 /* MCDeviceInstanceInfoProvider.mm */; };
 		3CE5ECCE2A673B30007CF331 /* CommissioningCallbackHandlers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CE5ECCD2A673B30007CF331 /* CommissioningCallbackHandlers.h */; };
 		3CE5ECD02A673E2C007CF331 /* CommissioningCallbackHandlers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5ECCF2A673E2C007CF331 /* CommissioningCallbackHandlers.m */; };
 		3CF71C0A2A992D0D003A5CE5 /* MCCastingApp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF71C092A992D0D003A5CE5 /* MCCastingApp.h */; };
@@ -178,6 +182,10 @@
 		3CD73F1D2A9E83C1009D82D1 /* MCCommissionableDataProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MCCommissionableDataProvider.mm; sourceTree = "<group>"; };
 		3CD73F1F2A9EA060009D82D1 /* MCDeviceAttestationCredentials.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MCDeviceAttestationCredentials.h; sourceTree = "<group>"; };
 		3CD73F212A9EA077009D82D1 /* MCDeviceAttestationCredentials.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MCDeviceAttestationCredentials.mm; sourceTree = "<group>"; };
+		3CD73F232B1EA001009D82D1 /* MCDeviceInstanceInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MCDeviceInstanceInfo.h; sourceTree = "<group>"; };
+		3CD73F252B1EA002009D82D1 /* MCDeviceInstanceInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MCDeviceInstanceInfo.m; sourceTree = "<group>"; };
+		3CD73F272B1EA003009D82D1 /* MCDeviceInstanceInfoProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MCDeviceInstanceInfoProvider.h; sourceTree = "<group>"; };
+		3CD73F292B1EA004009D82D1 /* MCDeviceInstanceInfoProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MCDeviceInstanceInfoProvider.mm; sourceTree = "<group>"; };
 		3CE5ECCD2A673B30007CF331 /* CommissioningCallbackHandlers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommissioningCallbackHandlers.h; sourceTree = "<group>"; };
 		3CE5ECCF2A673E2C007CF331 /* CommissioningCallbackHandlers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CommissioningCallbackHandlers.m; sourceTree = "<group>"; };
 		3CF71C092A992D0D003A5CE5 /* MCCastingApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MCCastingApp.h; sourceTree = "<group>"; };
@@ -321,6 +329,10 @@
 				3CD73F212A9EA077009D82D1 /* MCDeviceAttestationCredentials.mm */,
 				3C6920452AA1093300D0F613 /* MCDeviceAttestationCredentialsProvider.h */,
 				3C6920472AA1094000D0F613 /* MCDeviceAttestationCredentialsProvider.mm */,
+				3CD73F232B1EA001009D82D1 /* MCDeviceInstanceInfo.h */,
+				3CD73F252B1EA002009D82D1 /* MCDeviceInstanceInfo.m */,
+				3CD73F272B1EA003009D82D1 /* MCDeviceInstanceInfoProvider.h */,
+				3CD73F292B1EA004009D82D1 /* MCDeviceInstanceInfoProvider.mm */,
 				3C69204B2AA136BA00D0F613 /* MCCommonCaseDeviceServerInitParamsProvider.h */,
 				3CF8532528E37ED800F07B9F /* MatterError.h */,
 				3CF8532628E37F1000F07B9F /* MatterError.mm */,
@@ -370,6 +382,8 @@
 				3CF71C102A99312D003A5CE5 /* MCCommissionableData.h in Headers */,
 				3C4F522A2B51DFAE00BB8A10 /* MCCommand_Internal.h in Headers */,
 				3CD73F202A9EA060009D82D1 /* MCDeviceAttestationCredentials.h in Headers */,
+				3CD73F242B1EA001009D82D1 /* MCDeviceInstanceInfo.h in Headers */,
+				3CD73F282B1EA003009D82D1 /* MCDeviceInstanceInfoProvider.h in Headers */,
 				3CCB8740286A593700771BAD /* CastingServerBridge.h in Headers */,
 				3CE5ECCE2A673B30007CF331 /* CommissioningCallbackHandlers.h in Headers */,
 				39589F162B91556B00BE040C /* MCInteractionModelStructs.h in Headers */,
@@ -506,6 +520,8 @@
 				3CD73F1E2A9E83C1009D82D1 /* MCCommissionableDataProvider.mm in Sources */,
 				39F589E02C1781E4000AAADD /* MCCommissionerDeclaration.mm in Sources */,
 				3CD73F222A9EA078009D82D1 /* MCDeviceAttestationCredentials.mm in Sources */,
+				3CD73F262B1EA002009D82D1 /* MCDeviceInstanceInfo.m in Sources */,
+				3CD73F2A2B1EA004009D82D1 /* MCDeviceInstanceInfoProvider.mm in Sources */,
 				39BF57C72B8CFFB90081653C /* MCAttributeObjects.mm in Sources */,
 				3C2346252B362BBB00FA276E /* MCCastingPlayerDiscovery.mm in Sources */,
 				3C4F52242B507CA800BB8A10 /* MCCluster.mm in Sources */,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -20,12 +20,14 @@
 #import "MCCommissionableDataProvider.h"
 #import "MCCommonCaseDeviceServerInitParamsProvider.h"
 #import "MCDeviceAttestationCredentialsProvider.h"
+#import "MCDeviceInstanceInfoProvider.h"
 #import "MCErrorUtils.h"
 #import "MCRotatingDeviceIdUniqueIdProvider.h"
 
 #import "core/Types.h"
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 
 #import <Foundation/Foundation.h>
 
@@ -35,6 +37,7 @@
 @property matter::casting::support::MCRotatingDeviceIdUniqueIdProvider uniqueIdProvider;
 @property matter::casting::support::MCCommissionableDataProvider * commissionableDataProvider;
 @property matter::casting::support::MCDeviceAttestationCredentialsProvider * dacProvider;
+@property matter::casting::support::MCDeviceInstanceInfoProviderBridge * deviceInstanceInfoProvider;
 @property MCCommonCaseDeviceServerInitParamsProvider * serverInitParamsProvider;
 
 // queue used when calling the client code on completion blocks from any MatterTvCastingBridge API
@@ -95,6 +98,17 @@
 
     _serverInitParamsProvider = new MCCommonCaseDeviceServerInitParamsProvider();
 
+    // Initialize MCDeviceInstanceInfoProviderBridge if the dataSource provides a delegate
+    if ([dataSource respondsToSelector:@selector(castingAppDidReceiveRequestForDeviceInstanceInfoProvider:)]) {
+        id<MCDeviceInstanceInfoProvider> infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
+        if (infoProvider != nil) {
+            ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting up pull-based MCDeviceInstanceInfoProviderBridge");
+            delete _deviceInstanceInfoProvider;
+            _deviceInstanceInfoProvider = new matter::casting::support::MCDeviceInstanceInfoProviderBridge();
+            _deviceInstanceInfoProvider->SetDelegate(infoProvider);
+        }
+    }
+
     // Create cpp AppParameters
     // TODO: Properly validate revocation!
     chip::Credentials::DeviceAttestationRevocationDelegate * kDeviceAttestationRevocationNotChecked = nullptr;
@@ -107,6 +121,12 @@
     // Initialize cpp CastingApp
     VerifyOrReturnValue(matter::casting::core::CastingApp::GetInstance()->Initialize(_appParameters) == CHIP_NO_ERROR,
         [MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
+
+    // Register the custom DeviceInstanceInfoProvider if one was created
+    if (_deviceInstanceInfoProvider != nullptr) {
+        ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting custom DeviceInstanceInfoProvider");
+        chip::DeviceLayer::SetDeviceInstanceInfoProvider(_deviceInstanceInfoProvider);
+    }
 
     // Get and store the CHIP Work queue
     _workQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDataSource.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDataSource.h
@@ -17,6 +17,7 @@
 
 #import "MCCommissionableData.h"
 #import "MCDeviceAttestationCredentials.h"
+#import "MCDeviceInstanceInfo.h"
 #import "MatterError.h"
 
 #ifndef MCDataSource_h
@@ -53,6 +54,19 @@
  * @returns MATTER_NO_ERROR on success. Otherwise, a MATTER_ERROR with a code corresponding to the underlying failure
  */
 - (MatterError * _Nonnull)castingApp:(id _Nonnull)sender didReceiveRequestToSignCertificateRequest:(NSData * _Nonnull)csrData outRawSignature:(NSData * _Nonnull * _Nonnull)outRawSignature;
+
+@optional
+
+/**
+ * @brief Provides an object conforming to MCDeviceInstanceInfoProvider that the platform
+ * will query at runtime for device instance info fields (vendorName, productName, etc.)
+ * used during Matter commissioning.
+ *
+ * The platform pulls values from the returned provider each time they are needed,
+ * allowing the app to return dynamic data. Methods not implemented or returning nil
+ * will fall back to compile-time defaults.
+ */
+- (id<MCDeviceInstanceInfoProvider> _Nullable)castingAppDidReceiveRequestForDeviceInstanceInfoProvider:(id _Nonnull)sender;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
@@ -1,0 +1,46 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifndef MCDeviceInstanceInfo_h
+#define MCDeviceInstanceInfo_h
+
+/**
+ * @brief Pull-based protocol for providing device instance info at runtime.
+ *
+ * Implement this protocol to supply device instance information fields
+ * used during Matter commissioning. The platform layer queries these methods
+ * when it needs each value, allowing the app to return dynamic/current data.
+ *
+ * All methods are optional. If a method is not implemented or returns nil,
+ * the platform falls back to compile-time defaults.
+ */
+@protocol MCDeviceInstanceInfoProvider <NSObject>
+@optional
+
+- (NSString * _Nullable)vendorName;
+- (NSNumber * _Nullable)vendorId;
+- (NSString * _Nullable)productName;
+- (NSNumber * _Nullable)productId;
+- (NSString * _Nullable)serialNumber;
+- (NSNumber * _Nullable)hardwareVersion;
+- (NSString * _Nullable)hardwareVersionString;
+
+@end
+
+#endif /* MCDeviceInstanceInfo_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.m
@@ -1,0 +1,19 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// MCDeviceInstanceInfo.h now defines a protocol (@protocol MCDeviceInstanceInfoProvider).
+// No implementation file is needed for a protocol definition.

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfoProvider.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfoProvider.h
@@ -1,0 +1,70 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#import "MCDeviceInstanceInfo.h"
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
+#include <platform/ConfigurationManager.h>
+#include <platform/Darwin/DeviceInstanceInfoProviderImpl.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+
+#ifndef MCDeviceInstanceInfoProvider_h
+#define MCDeviceInstanceInfoProvider_h
+
+namespace matter {
+namespace casting {
+namespace support {
+
+/**
+ * Pull-based DeviceInstanceInfoProvider that queries an ObjC delegate
+ * each time the platform layer requests a value.
+ */
+class MCDeviceInstanceInfoProviderBridge : public chip::DeviceLayer::DeviceInstanceInfoProvider
+{
+public:
+    void SetDelegate(id<MCDeviceInstanceInfoProvider> _Nullable delegate) { mDelegate = delegate; }
+
+    // Overridden methods — query delegate if available, else fall back to default
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
+    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
+
+    // Delegated methods — always use default implementation
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(chip::MutableByteSpan & uniqueIdSpan) override;
+
+private:
+    __weak id<MCDeviceInstanceInfoProvider> _Nullable mDelegate = nil;
+    chip::DeviceLayer::DeviceInstanceInfoProviderImpl mDefaultProvider;
+};
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter
+
+#endif /* MCDeviceInstanceInfoProvider_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfoProvider.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfoProvider.mm
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MCDeviceInstanceInfoProvider.h"
+
+#include <lib/support/CHIPMemString.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#import <Foundation/Foundation.h>
+
+namespace matter {
+namespace casting {
+    namespace support {
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetVendorName(char * buf, size_t bufSize)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(vendorName)]) {
+                NSString * value = [delegate vendorName];
+                if (value != nil) {
+                    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetVendorName(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetVendorId(uint16_t & vendorId)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(vendorId)]) {
+                NSNumber * value = [delegate vendorId];
+                if (value != nil) {
+                    vendorId = [value unsignedShortValue];
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetVendorId(vendorId);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetProductName(char * buf, size_t bufSize)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(productName)]) {
+                NSString * value = [delegate productName];
+                if (value != nil) {
+                    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetProductName(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetProductId(uint16_t & productId)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(productId)]) {
+                NSNumber * value = [delegate productId];
+                if (value != nil) {
+                    productId = [value unsignedShortValue];
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetProductId(productId);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetSerialNumber(char * buf, size_t bufSize)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(serialNumber)]) {
+                NSString * value = [delegate serialNumber];
+                if (value != nil) {
+                    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetSerialNumber(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetHardwareVersion(uint16_t & hardwareVersion)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(hardwareVersion)]) {
+                NSNumber * value = [delegate hardwareVersion];
+                if (value != nil) {
+                    hardwareVersion = [value unsignedShortValue];
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetHardwareVersion(hardwareVersion);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetHardwareVersionString(char * buf, size_t bufSize)
+        {
+            id<MCDeviceInstanceInfoProvider> delegate = mDelegate;
+            if (delegate != nil && [delegate respondsToSelector:@selector(hardwareVersionString)]) {
+                NSString * value = [delegate hardwareVersionString];
+                if (value != nil) {
+                    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+                    return CHIP_NO_ERROR;
+                }
+            }
+            return mDefaultProvider.GetHardwareVersionString(buf, bufSize);
+        }
+
+        // Delegated methods — always forward to default provider
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetPartNumber(char * buf, size_t bufSize)
+        {
+            return mDefaultProvider.GetPartNumber(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetProductURL(char * buf, size_t bufSize)
+        {
+            return mDefaultProvider.GetProductURL(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetProductLabel(char * buf, size_t bufSize)
+        {
+            return mDefaultProvider.GetProductLabel(buf, bufSize);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
+        {
+            return mDefaultProvider.GetManufacturingDate(year, month, day);
+        }
+
+        CHIP_ERROR MCDeviceInstanceInfoProviderBridge::GetRotatingDeviceIdUniqueId(chip::MutableByteSpan & uniqueIdSpan)
+        {
+            return mDefaultProvider.GetRotatingDeviceIdUniqueId(uniqueIdSpan);
+        }
+
+    }; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
@@ -67,6 +67,10 @@ class MCAppParametersDataSource : NSObject, MCDataSource
         return commissionableData
     }
     
+    func castingAppDidReceiveRequestForDeviceInstanceInfoProvider(_ sender: Any) -> (any MCDeviceInstanceInfoProvider)? {
+        return SampleDeviceInstanceInfoProvider()
+    }
+    
     // dummy DAC values for demonstration only
     let kDevelopmentDAC_Cert_FFF1_8001: Data = Data(base64Encoded: "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=")!;
     
@@ -117,6 +121,19 @@ class MCAppParametersDataSource : NSObject, MCDataSource
         return MCCryptoUtils.ecdsaAsn1SignatureToRaw(withFeLengthBytes: 32,
                                                     asn1Signature: asn1SignatureData!,
                                                          outRawSignature: &outRawSignature.pointee)
+    }
+}
+
+// Sample implementation of MCDeviceInstanceInfoProvider (pull-based).
+// The platform queries these methods at runtime whenever it needs a value.
+// Return nil from any method to fall back to compile-time defaults.
+class SampleDeviceInstanceInfoProvider: NSObject, MCDeviceInstanceInfoProvider {
+    func vendorName() -> String? {
+        return "Test Vendor"
+    }
+
+    func productName() -> String? {
+        return "Test Casting App"
     }
 }
 

--- a/examples/tv-casting-app/tests/test_casting_app_registration.py
+++ b/examples/tv-casting-app/tests/test_casting_app_registration.py
@@ -1,0 +1,468 @@
+"""
+Unit Tests — MCCastingApp Registration Logic
+
+**Validates: Requirements 4.3, 4.4, 5.1, 5.2**
+
+These tests parse `MCCastingApp.mm` to verify that the provider registration
+logic in `initializeWithDataSource:` correctly handles three scenarios:
+
+1. The optional `castingAppDidReceiveRequestForDeviceInstanceInfo:` method
+   is not implemented by the data source — registration is skipped.
+2. The optional method is implemented but returns nil — registration is skipped.
+3. The `MCDeviceInstanceInfoProvider::Initialize()` call fails — an error is
+   returned and initialization does not proceed.
+
+Feature: ios-device-instance-info-provider
+"""
+
+import os
+import re
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MC_CASTING_APP_MM = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCCastingApp.mm",
+)
+MC_DATA_SOURCE_H = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCDataSource.h",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _extract_initialize_method_body(content: str) -> str:
+    """
+    Extract the body of the `initializeWithDataSource:` method from
+    MCCastingApp.mm. Returns the full method body as a string.
+    """
+    # Find the method signature
+    pattern = r"-\s*\(NSError\s*\*\)\s*initializeWithDataSource:\(id\)dataSource\s*\{"
+    match = re.search(pattern, content)
+    assert match is not None, (
+        "Could not find initializeWithDataSource: method in MCCastingApp.mm"
+    )
+
+    # Extract the body by counting braces
+    start = match.start()
+    brace_count = 0
+    body_start = None
+    for i in range(match.end() - 1, len(content)):
+        if content[i] == "{":
+            if body_start is None:
+                body_start = i
+            brace_count += 1
+        elif content[i] == "}":
+            brace_count -= 1
+            if brace_count == 0:
+                return content[body_start: i + 1]
+
+    raise AssertionError(
+        "Could not find matching closing brace for initializeWithDataSource:"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: Registration skipped when optional method is not implemented
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationSkippedWhenMethodNotImplemented:
+    """
+    **Validates: Requirements 4.3, 5.1, 5.2**
+
+    When the data source does not implement the optional
+    `castingAppDidReceiveRequestForDeviceInstanceInfo:` method,
+    the code must check `respondsToSelector:` and skip provider creation.
+    """
+
+    def test_responds_to_selector_check_exists(self):
+        """
+        The initializeWithDataSource: method must contain a
+        `respondsToSelector:` check for the optional method before
+        attempting to call it.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        pattern = r"respondsToSelector:\s*@selector\s*\(\s*castingAppDidReceiveRequestForDeviceInstanceInfo:\s*\)"
+        match = re.search(pattern, body)
+        assert match is not None, (
+            "MCCastingApp.mm initializeWithDataSource: is missing "
+            "respondsToSelector: check for castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        )
+
+    def test_responds_to_selector_guards_method_call(self):
+        """
+        The call to `castingAppDidReceiveRequestForDeviceInstanceInfo:` must
+        be inside the `if` block guarded by `respondsToSelector:`. This
+        ensures the method is only called when the data source implements it.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # The respondsToSelector check should appear BEFORE the method call
+        selector_pattern = r"respondsToSelector:\s*@selector\s*\(\s*castingAppDidReceiveRequestForDeviceInstanceInfo:\s*\)"
+        call_pattern = r"\[\s*dataSource\s+castingAppDidReceiveRequestForDeviceInstanceInfo:"
+
+        selector_match = re.search(selector_pattern, body)
+        call_match = re.search(call_pattern, body)
+
+        assert selector_match is not None, (
+            "Missing respondsToSelector: check"
+        )
+        assert call_match is not None, (
+            "Missing call to castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        )
+        assert selector_match.start() < call_match.start(), (
+            "The respondsToSelector: check must appear before the method call "
+            "to castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        )
+
+    def test_provider_creation_inside_selector_guard(self):
+        """
+        The MCDeviceInstanceInfoProvider creation (heap allocation) must be
+        inside the respondsToSelector guard block, so it is skipped when
+        the method is not implemented.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # Find the if-block that checks respondsToSelector
+        selector_pattern = r"if\s*\(\s*\[dataSource\s+respondsToSelector:\s*@selector\s*\(\s*castingAppDidReceiveRequestForDeviceInstanceInfo:\s*\)\s*\]\s*\)"
+        selector_match = re.search(selector_pattern, body)
+        assert selector_match is not None, (
+            "Missing if-block with respondsToSelector: check"
+        )
+
+        # The provider allocation should appear after this guard
+        alloc_pattern = r"new\s+matter::casting::support::MCDeviceInstanceInfoProvider\s*\(\s*\)"
+        alloc_match = re.search(alloc_pattern, body)
+        assert alloc_match is not None, (
+            "Missing MCDeviceInstanceInfoProvider heap allocation in initializeWithDataSource:"
+        )
+        assert alloc_match.start() > selector_match.start(), (
+            "MCDeviceInstanceInfoProvider allocation must be inside the "
+            "respondsToSelector: guard block"
+        )
+
+    def test_no_set_provider_without_guard(self):
+        """
+        The call to SetDeviceInstanceInfoProvider must be guarded by a
+        nil check on the provider pointer, ensuring it is only called
+        when a provider was actually created.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # SetDeviceInstanceInfoProvider should be guarded by a nullptr check
+        set_pattern = r"SetDeviceInstanceInfoProvider\s*\("
+        set_match = re.search(set_pattern, body)
+        assert set_match is not None, (
+            "Missing SetDeviceInstanceInfoProvider call in initializeWithDataSource:"
+        )
+
+        # There should be a nullptr check before SetDeviceInstanceInfoProvider
+        guard_pattern = r"if\s*\(\s*_deviceInstanceInfoProvider\s*!=\s*nullptr\s*\)"
+        guard_match = re.search(guard_pattern, body)
+        assert guard_match is not None, (
+            "Missing nullptr guard before SetDeviceInstanceInfoProvider call. "
+            "The provider registration must be conditional on the provider being created."
+        )
+        assert guard_match.start() < set_match.start(), (
+            "The nullptr guard must appear before the SetDeviceInstanceInfoProvider call"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Registration skipped when optional method returns nil
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationSkippedWhenMethodReturnsNil:
+    """
+    **Validates: Requirements 4.3, 5.1**
+
+    When the optional method is implemented but returns nil, the code
+    must check the return value and skip provider creation.
+    """
+
+    def test_nil_check_on_device_instance_info(self):
+        """
+        After calling castingAppDidReceiveRequestForDeviceInstanceInfo:,
+        the code must check if the returned MCDeviceInstanceInfo is non-nil
+        before creating the provider.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # The code should store the result and check for nil
+        # Pattern: MCDeviceInstanceInfo * deviceInstanceInfo = [dataSource ...]
+        assignment_pattern = r"MCDeviceInstanceInfo\s*\*\s*(\w+)\s*=\s*\[dataSource\s+castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        assignment_match = re.search(assignment_pattern, body)
+        assert assignment_match is not None, (
+            "Missing assignment of castingAppDidReceiveRequestForDeviceInstanceInfo: "
+            "return value to a local variable"
+        )
+
+        var_name = assignment_match.group(1)
+
+        # There should be a nil check on the variable
+        nil_check_pattern = rf"if\s*\(\s*{re.escape(var_name)}\s*!=\s*nil\s*\)"
+        nil_check_match = re.search(nil_check_pattern, body)
+        assert nil_check_match is not None, (
+            f"Missing nil check on '{var_name}' after calling "
+            "castingAppDidReceiveRequestForDeviceInstanceInfo:. "
+            "Provider creation must be skipped when the method returns nil."
+        )
+
+    def test_provider_creation_inside_nil_check(self):
+        """
+        The MCDeviceInstanceInfoProvider creation must be inside the nil
+        check block, so it is skipped when the method returns nil.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # Find the variable name
+        assignment_pattern = r"MCDeviceInstanceInfo\s*\*\s*(\w+)\s*=\s*\[dataSource\s+castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        assignment_match = re.search(assignment_pattern, body)
+        assert assignment_match is not None
+        var_name = assignment_match.group(1)
+
+        # Find the nil check
+        nil_check_pattern = rf"if\s*\(\s*{re.escape(var_name)}\s*!=\s*nil\s*\)"
+        nil_check_match = re.search(nil_check_pattern, body)
+        assert nil_check_match is not None
+
+        # The provider allocation must come after the nil check
+        alloc_pattern = r"new\s+matter::casting::support::MCDeviceInstanceInfoProvider\s*\(\s*\)"
+        alloc_match = re.search(alloc_pattern, body)
+        assert alloc_match is not None, (
+            "Missing MCDeviceInstanceInfoProvider heap allocation"
+        )
+        assert alloc_match.start() > nil_check_match.start(), (
+            "MCDeviceInstanceInfoProvider allocation must be inside the "
+            f"nil check on '{var_name}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Error returned when Initialize() fails
+# ---------------------------------------------------------------------------
+
+
+class TestErrorOnInitializeFailure:
+    """
+    **Validates: Requirements 4.4, 5.2**
+
+    When MCDeviceInstanceInfoProvider::Initialize() fails (returns a
+    non-success CHIP_ERROR), the code must return an error and not
+    proceed with CastingApp::Initialize().
+    """
+
+    def test_initialize_return_value_checked(self):
+        """
+        The return value of MCDeviceInstanceInfoProvider::Initialize()
+        must be checked. If it fails, the method should return an error.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # Look for the Initialize call with error checking
+        # Pattern: VerifyOrReturnValue(_deviceInstanceInfoProvider->Initialize(...) == CHIP_NO_ERROR, ...)
+        # or: if (_deviceInstanceInfoProvider->Initialize(...) != CHIP_NO_ERROR) { return ...; }
+        verify_pattern = r"VerifyOrReturnValue\s*\(\s*_deviceInstanceInfoProvider->Initialize\s*\("
+        if_pattern = r"_deviceInstanceInfoProvider->Initialize\s*\([^)]*\)\s*!=\s*CHIP_NO_ERROR"
+
+        verify_match = re.search(verify_pattern, body)
+        if_match = re.search(if_pattern, body)
+
+        assert verify_match is not None or if_match is not None, (
+            "MCCastingApp.mm does not check the return value of "
+            "MCDeviceInstanceInfoProvider::Initialize(). If initialization "
+            "fails, the method must return an error."
+        )
+
+    def test_initialize_failure_returns_error(self):
+        """
+        When Initialize() fails, the code must return an NSError
+        (via MCErrorUtils) rather than proceeding with CastingApp::Initialize().
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # The VerifyOrReturnValue macro returns the second argument on failure.
+        # Check that the second argument is an error conversion.
+        verify_pattern = (
+            r"VerifyOrReturnValue\s*\(\s*"
+            r"_deviceInstanceInfoProvider->Initialize\s*\([^)]*\)\s*==\s*CHIP_NO_ERROR\s*,"
+            r"\s*\[MCErrorUtils\s+NSErrorFromChipError:"
+        )
+        match = re.search(verify_pattern, body)
+        assert match is not None, (
+            "MCCastingApp.mm must return an NSError (via MCErrorUtils) when "
+            "MCDeviceInstanceInfoProvider::Initialize() fails. Expected pattern: "
+            "VerifyOrReturnValue(_deviceInstanceInfoProvider->Initialize(...) == CHIP_NO_ERROR, "
+            "[MCErrorUtils NSErrorFromChipError:...])"
+        )
+
+    def test_initialize_failure_before_casting_app_initialize(self):
+        """
+        The MCDeviceInstanceInfoProvider::Initialize() check must occur
+        before CastingApp::Initialize() is called, ensuring that a
+        validation failure prevents further initialization.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        # Find the provider Initialize check
+        provider_init_pattern = r"_deviceInstanceInfoProvider->Initialize\s*\("
+        provider_init_match = re.search(provider_init_pattern, body)
+        assert provider_init_match is not None, (
+            "Missing MCDeviceInstanceInfoProvider::Initialize() call"
+        )
+
+        # Find CastingApp::Initialize()
+        casting_init_pattern = r"CastingApp::GetInstance\(\)->Initialize\s*\("
+        casting_init_match = re.search(casting_init_pattern, body)
+        assert casting_init_match is not None, (
+            "Missing CastingApp::Initialize() call"
+        )
+
+        assert provider_init_match.start() < casting_init_match.start(), (
+            "MCDeviceInstanceInfoProvider::Initialize() must be called before "
+            "CastingApp::Initialize() so that validation failures prevent "
+            "further initialization"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: SetDeviceInstanceInfoProvider called after CastingApp::Initialize()
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistrationOrder:
+    """
+    **Validates: Requirements 4.3, 5.2**
+
+    The custom DeviceInstanceInfoProvider must be registered via
+    SetDeviceInstanceInfoProvider() AFTER CastingApp::Initialize()
+    succeeds, as specified in the design document.
+    """
+
+    def test_set_provider_after_casting_app_initialize(self):
+        """
+        SetDeviceInstanceInfoProvider must be called after
+        CastingApp::Initialize() to override the default provider
+        that is set up during chip stack initialization.
+        """
+        content = _read_file(MC_CASTING_APP_MM)
+        body = _extract_initialize_method_body(content)
+
+        casting_init_pattern = r"CastingApp::GetInstance\(\)->Initialize\s*\("
+        set_provider_pattern = r"SetDeviceInstanceInfoProvider\s*\(\s*_deviceInstanceInfoProvider\s*\)"
+
+        casting_init_match = re.search(casting_init_pattern, body)
+        set_provider_match = re.search(set_provider_pattern, body)
+
+        assert casting_init_match is not None, (
+            "Missing CastingApp::Initialize() call"
+        )
+        assert set_provider_match is not None, (
+            "Missing SetDeviceInstanceInfoProvider() call"
+        )
+        assert casting_init_match.start() < set_provider_match.start(), (
+            "SetDeviceInstanceInfoProvider() must be called AFTER "
+            "CastingApp::Initialize() so the custom provider overrides "
+            "the default one set during chip stack initialization"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: MCDataSource protocol declares the method as @optional
+# ---------------------------------------------------------------------------
+
+
+class TestDataSourceProtocolDeclaration:
+    """
+    **Validates: Requirements 5.1, 5.2**
+
+    The MCDataSource protocol must declare the device instance info
+    method as @optional to maintain backward compatibility.
+    """
+
+    def test_optional_method_declared(self):
+        """
+        MCDataSource.h must contain an @optional section with the
+        castingAppDidReceiveRequestForDeviceInstanceInfo: method.
+        """
+        content = _read_file(MC_DATA_SOURCE_H)
+
+        # Find @optional section
+        optional_match = re.search(r"@optional", content)
+        assert optional_match is not None, (
+            "MCDataSource.h is missing @optional section"
+        )
+
+        # The method declaration should appear after @optional
+        method_pattern = r"-\s*\(\s*MCDeviceInstanceInfo\s*\*\s*_Nullable\s*\)\s*castingAppDidReceiveRequestForDeviceInstanceInfo:\s*\(\s*id\s+_Nonnull\s*\)\s*sender\s*;"
+        method_match = re.search(method_pattern, content)
+        assert method_match is not None, (
+            "MCDataSource.h is missing the declaration of "
+            "castingAppDidReceiveRequestForDeviceInstanceInfo: method"
+        )
+        assert method_match.start() > optional_match.start(), (
+            "castingAppDidReceiveRequestForDeviceInstanceInfo: must be "
+            "declared after @optional to ensure backward compatibility"
+        )
+
+    def test_no_required_methods_added(self):
+        """
+        The new method must not be in the @required section. All existing
+        required methods must remain unchanged.
+        """
+        content = _read_file(MC_DATA_SOURCE_H)
+
+        # Split content at @optional to get the required section
+        optional_pos = content.find("@optional")
+        assert optional_pos != -1, "Missing @optional section"
+
+        required_section = content[:optional_pos]
+
+        # The device instance info method should NOT appear in the required section
+        method_pattern = r"castingAppDidReceiveRequestForDeviceInstanceInfo:"
+        assert re.search(method_pattern, required_section) is None, (
+            "castingAppDidReceiveRequestForDeviceInstanceInfo: must NOT be "
+            "in the required section of MCDataSource protocol"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/examples/tv-casting-app/tests/test_invalid_input_rejection.py
+++ b/examples/tv-casting-app/tests/test_invalid_input_rejection.py
@@ -1,0 +1,303 @@
+"""
+Property Test — Property 3: Invalid Input Rejection
+
+**Validates: Requirements 1.3, 1.4, 1.5, 1.6, 4.4**
+
+This test parses `MCDeviceInstanceInfo.m` and verifies that the initializer
+rejects any combination of inputs where at least one string field exceeds
+its maximum allowed length. The source code must contain guard patterns
+that return nil when any field is over-length.
+
+For any MCDeviceInstanceInfo object that contains at least one field
+violating its length constraint, initialization SHALL return nil (fail).
+
+Feature: ios-device-instance-info-provider
+Property 3: Invalid Input Rejection
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MC_DEVICE_INSTANCE_INFO_M = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCDeviceInstanceInfo.m",
+)
+
+# ---------------------------------------------------------------------------
+# Expected max lengths per the Matter spec and design doc
+# ---------------------------------------------------------------------------
+
+STRING_FIELDS = {
+    "vendorName": 32,
+    "productName": 32,
+    "serialNumber": 32,
+    "hardwareVersionString": 64,
+}
+
+# ---------------------------------------------------------------------------
+# Helpers — source code parsing
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _extract_max_length_constants(content: str) -> dict:
+    """
+    Extract max length constants from the .m file.
+
+    Looks for patterns like:
+        static const NSUInteger kMaxVendorNameLength = 32;
+    """
+    pattern = r"static\s+const\s+NSUInteger\s+kMax(\w+)Length\s*=\s*(\d+)\s*;"
+    matches = re.findall(pattern, content)
+    result = {}
+    for name_part, value in matches:
+        # Convert e.g. "VendorName" -> "vendorName"
+        field_name = name_part[0].lower() + name_part[1:]
+        result[field_name] = int(value)
+    return result
+
+
+def _extract_validation_guards(content: str) -> list:
+    """
+    Extract the validation guard patterns from the initializer.
+
+    Looks for patterns like:
+        if (vendorName != nil && vendorName.length > kMaxVendorNameLength) {
+            return nil;
+        }
+
+    Returns a list of field names that have validation guards.
+    """
+    pattern = (
+        r"if\s*\(\s*(\w+)\s*!=\s*nil\s*&&\s*\1\.length\s*>\s*kMax(\w+)Length\s*\)"
+        r"\s*\{\s*return\s+nil\s*;"
+    )
+    matches = re.findall(pattern, content, re.DOTALL)
+    return [field_name for field_name, _ in matches]
+
+
+def _verify_source_has_all_guards(content: str):
+    """
+    Verify that the source code has validation guards for all string fields
+    and that the max length constants match expected values.
+    """
+    constants = _extract_max_length_constants(content)
+    guards = _extract_validation_guards(content)
+
+    for field, expected_max in STRING_FIELDS.items():
+        assert field in constants, (
+            f"Missing max length constant for '{field}' in MCDeviceInstanceInfo.m. "
+            f"Found constants: {constants}"
+        )
+        assert constants[field] == expected_max, (
+            f"Max length mismatch for '{field}': expected {expected_max}, "
+            f"found {constants[field]}"
+        )
+        assert field in guards, (
+            f"Missing validation guard for '{field}' in MCDeviceInstanceInfo.m. "
+            f"Found guards for: {guards}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+# Strategy for a string that is within the max length for a given field
+def _valid_string_for_field(field_name):
+    max_len = STRING_FIELDS[field_name]
+    return st.text(min_size=0, max_size=max_len)
+
+
+# Strategy for a string that exceeds the max length for a given field
+def _overlength_string_for_field(field_name):
+    max_len = STRING_FIELDS[field_name]
+    return st.text(min_size=max_len + 1, max_size=max_len + 50)
+
+
+# Strategy that generates a dict of string field values where at least one
+# field exceeds its max length. Each field is either None, valid, or overlength.
+# We ensure at least one field is overlength.
+@st.composite
+def _device_info_with_at_least_one_overlength(draw):
+    """
+    Generate a dict mapping each string field to either None, a valid string,
+    or an overlength string — with the constraint that at least one field
+    is overlength.
+    """
+    fields = list(STRING_FIELDS.keys())
+
+    # Pick at least one field to be overlength
+    overlength_fields = draw(
+        st.lists(
+            st.sampled_from(fields),
+            min_size=1,
+            max_size=len(fields),
+            unique=True,
+        )
+    )
+
+    result = {}
+    for field in fields:
+        if field in overlength_fields:
+            result[field] = draw(_overlength_string_for_field(field))
+        else:
+            # Randomly choose None or a valid string
+            choice = draw(st.sampled_from(["none", "valid"]))
+            if choice == "none":
+                result[field] = None
+            else:
+                result[field] = draw(_valid_string_for_field(field))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(field_values=_device_info_with_at_least_one_overlength())
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+    deadline=None,
+)
+def test_init_returns_nil_when_any_field_overlength(field_values):
+    """
+    **Validates: Requirements 1.3, 1.4, 1.5, 1.6, 4.4**
+
+    Property 3: For any MCDeviceInstanceInfo object that contains at least
+    one string field exceeding its maximum allowed length, the initializer
+    SHALL return nil.
+
+    We verify this by checking that the source code contains guard patterns
+    that return nil when any field exceeds its limit. Since at least one
+    field in the generated input is overlength, the guard for that field
+    will trigger and the initializer will return nil.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+
+    # First verify all guards and constants are present
+    _verify_source_has_all_guards(content)
+
+    # Identify which fields are overlength in this generated input
+    overlength_fields = []
+    for field, value in field_values.items():
+        if value is not None and len(value) > STRING_FIELDS[field]:
+            overlength_fields.append(field)
+
+    # At least one field must be overlength (guaranteed by the strategy)
+    assert len(overlength_fields) > 0, (
+        "Strategy error: no overlength fields generated"
+    )
+
+    # For each overlength field, verify the source code would reject it:
+    # The guard pattern `if (field != nil && field.length > kMaxFieldLength) { return nil; }`
+    # means the initializer returns nil as soon as it encounters the first
+    # overlength field. Since guards are checked sequentially, any single
+    # overlength field causes rejection.
+    constants = _extract_max_length_constants(content)
+    guards = _extract_validation_guards(content)
+
+    for field in overlength_fields:
+        value = field_values[field]
+        max_len = constants[field]
+
+        # The field is non-nil and exceeds max length
+        assert value is not None
+        assert len(value) > max_len, (
+            f"Expected '{field}' to be overlength (>{max_len}), "
+            f"but length is {len(value)}"
+        )
+
+        # The guard exists for this field, so init will return nil
+        assert field in guards, (
+            f"No validation guard for overlength field '{field}'"
+        )
+
+
+@given(
+    overlength_field=st.sampled_from(list(STRING_FIELDS.keys())),
+    extra_length=st.integers(min_value=1, max_value=50),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_single_overlength_field_causes_rejection(overlength_field, extra_length):
+    """
+    **Validates: Requirements 1.3, 1.4, 1.5, 1.6, 4.4**
+
+    Property 3: When exactly one string field exceeds its max length and
+    all other fields are valid (or nil), the initializer SHALL still
+    return nil. This confirms that a single invalid field is sufficient
+    to reject the entire object.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    _verify_source_has_all_guards(content)
+
+    constants = _extract_max_length_constants(content)
+    guards = _extract_validation_guards(content)
+
+    max_len = constants[overlength_field]
+    invalid_length = max_len + extra_length
+
+    # The overlength field exceeds its limit
+    assert invalid_length > max_len
+
+    # The guard for this field exists and would return nil
+    assert overlength_field in guards, (
+        f"No validation guard for '{overlength_field}' — "
+        f"a string of length {invalid_length} (max {max_len}) would not be rejected"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running invalid input rejection property tests...")
+    tests = [
+        (
+            "3a: Init returns nil when any field is overlength",
+            test_init_returns_nil_when_any_field_overlength,
+        ),
+        (
+            "3b: Single overlength field causes rejection",
+            test_single_overlength_field_causes_rejection,
+        ),
+    ]
+    all_passed = True
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            all_passed = False
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/examples/tv-casting-app/tests/test_override_fallback_roundtrip.py
+++ b/examples/tv-casting-app/tests/test_override_fallback_roundtrip.py
@@ -1,0 +1,508 @@
+"""
+Property Test — Property 1: Override/Fallback Round-Trip
+
+**Validates: Requirements 1.2, 2.3, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.15, 3.16**
+
+For any MCDeviceInstanceInfo object with an arbitrary subset of fields set to
+non-nil valid values and the remaining fields set to nil, when an
+MCDeviceInstanceInfoProvider is initialized with that object, each getter
+method SHALL return the app-provided value for non-nil fields and the
+compile-time default value for nil fields.
+
+Since we cannot compile and run the Objective-C++/C++ code in a Python test,
+this test parses the source code of MCDeviceInstanceInfoProvider.mm and
+MCDeviceInstanceInfoProvider.h to verify the override/fallback logic is
+correctly implemented for every combination of nil/non-nil fields.
+
+Feature: ios-device-instance-info-provider, Property 1: Override/Fallback Round-Trip
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+PROVIDER_MM = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCDeviceInstanceInfoProvider.mm",
+)
+
+PROVIDER_H = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCDeviceInstanceInfoProvider.h",
+)
+
+# ---------------------------------------------------------------------------
+# Field definitions
+# ---------------------------------------------------------------------------
+
+# String fields: name -> (flag name, buffer name, getter method name)
+STRING_FIELDS = {
+    "vendorName": ("mHasVendorName", "mVendorName", "GetVendorName"),
+    "productName": ("mHasProductName", "mProductName", "GetProductName"),
+    "serialNumber": ("mHasSerialNumber", "mSerialNumber", "GetSerialNumber"),
+    "hardwareVersionString": (
+        "mHasHardwareVersionString",
+        "mHardwareVersionString",
+        "GetHardwareVersionString",
+    ),
+}
+
+# Numeric fields: name -> (optional member name, getter method name)
+NUMERIC_FIELDS = {
+    "vendorId": ("mVendorId", "GetVendorId"),
+    "productId": ("mProductId", "GetProductId"),
+    "hardwareVersion": ("mHardwareVersion", "GetHardwareVersion"),
+}
+
+ALL_FIELD_NAMES = list(STRING_FIELDS.keys()) + list(NUMERIC_FIELDS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Helpers — source code reading
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Structural verification helpers
+# ---------------------------------------------------------------------------
+
+
+def _verify_initialize_copies_string(content: str, field_name: str, flag: str, buffer: str):
+    """
+    Verify that Initialize() checks if the ObjC property is non-nil,
+    copies the string into the internal buffer, and sets the flag.
+
+    Expected pattern:
+        if (deviceInstanceInfo.<field> != nil) {
+            chip::Platform::CopyString(<buffer>, [deviceInstanceInfo.<field> UTF8String]);
+            <flag> = true;
+        }
+    """
+    pattern = (
+        r"if\s*\(\s*deviceInstanceInfo\." + re.escape(field_name) + r"\s*!=\s*nil\s*\)"
+        r"\s*\{[^}]*CopyString\s*\(\s*" + re.escape(buffer) + r"\s*,"
+        r"[^}]*" + re.escape(flag) + r"\s*=\s*true\s*;"
+    )
+    match = re.search(pattern, content, re.DOTALL)
+    assert match is not None, (
+        f"Initialize() does not correctly copy '{field_name}' into '{buffer}' "
+        f"and set '{flag}' = true when non-nil"
+    )
+
+
+def _verify_initialize_stores_numeric(content: str, field_name: str, optional_member: str):
+    """
+    Verify that Initialize() checks if the ObjC property is non-nil
+    and stores the value via SetValue on the Optional member.
+
+    Expected pattern:
+        if (deviceInstanceInfo.<field> != nil) {
+            <optional_member>.SetValue([deviceInstanceInfo.<field> unsignedShortValue]);
+        }
+    """
+    pattern = (
+        r"if\s*\(\s*deviceInstanceInfo\." + re.escape(field_name) + r"\s*!=\s*nil\s*\)"
+        r"\s*\{[^}]*" + re.escape(optional_member) + r"\.SetValue\s*\("
+    )
+    match = re.search(pattern, content, re.DOTALL)
+    assert match is not None, (
+        f"Initialize() does not correctly store '{field_name}' into "
+        f"'{optional_member}' via SetValue when non-nil"
+    )
+
+
+def _extract_string_getter_body(content: str, getter: str) -> str:
+    """
+    Extract the full method body for a string getter by finding the
+    method signature and then matching braces to find the closing brace.
+    """
+    sig_pattern = (
+        r"CHIP_ERROR\s+MCDeviceInstanceInfoProvider::" + re.escape(getter)
+        + r"\s*\(\s*char\s*\*\s*buf\s*,\s*size_t\s*bufSize\s*\)\s*\{"
+    )
+    sig_match = re.search(sig_pattern, content)
+    assert sig_match is not None, (
+        f"Could not find method signature for {getter}(char * buf, size_t bufSize)"
+    )
+    # Walk forward from the opening brace, counting braces
+    start = sig_match.end()  # position right after the opening {
+    depth = 1
+    pos = start
+    while pos < len(content) and depth > 0:
+        if content[pos] == "{":
+            depth += 1
+        elif content[pos] == "}":
+            depth -= 1
+        pos += 1
+    return content[start: pos - 1]  # exclude the final }
+
+
+def _verify_string_getter_override_branch(content: str, getter: str, flag: str, buffer: str):
+    """
+    Verify that the string getter checks the flag, verifies bufSize,
+    and copies from the internal buffer when the flag is set.
+
+    Expected pattern inside Get<Field>(char * buf, size_t bufSize):
+        if (<flag>) {
+            VerifyOrReturnError(bufSize >= strlen(<buffer>) + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
+            chip::Platform::CopyString(buf, bufSize, <buffer>);
+            return CHIP_NO_ERROR;
+        }
+    """
+    body = _extract_string_getter_body(content, getter)
+
+    # Check flag guard
+    assert re.search(r"if\s*\(\s*" + re.escape(flag) + r"\s*\)", body), (
+        f"{getter} does not check '{flag}' to determine if override is present"
+    )
+
+    # Check buffer-too-small guard
+    assert re.search(
+        r"VerifyOrReturnError\s*\(\s*bufSize\s*>=\s*strlen\s*\(\s*"
+        + re.escape(buffer) + r"\s*\)\s*\+\s*1\s*,\s*CHIP_ERROR_BUFFER_TOO_SMALL\s*\)",
+        body,
+    ), (
+        f"{getter} does not check bufSize against strlen({buffer}) + 1 "
+        f"and return CHIP_ERROR_BUFFER_TOO_SMALL"
+    )
+
+    # Check CopyString from buffer
+    assert re.search(
+        r"CopyString\s*\(\s*buf\s*,\s*bufSize\s*,\s*" + re.escape(buffer) + r"\s*\)",
+        body,
+    ), (
+        f"{getter} does not copy from '{buffer}' into output buf when flag is set"
+    )
+
+
+def _verify_string_getter_fallback_branch(content: str, getter: str):
+    """
+    Verify that the string getter delegates to mDefaultProvider when
+    the flag is not set.
+
+    Expected pattern at end of method:
+        return mDefaultProvider.Get<Field>(buf, bufSize);
+    """
+    body = _extract_string_getter_body(content, getter)
+
+    assert re.search(
+        r"return\s+mDefaultProvider\." + re.escape(getter) + r"\s*\(\s*buf\s*,\s*bufSize\s*\)\s*;",
+        body,
+    ), (
+        f"{getter} does not delegate to mDefaultProvider.{getter}(buf, bufSize) "
+        f"when the override flag is not set"
+    )
+
+
+def _extract_numeric_getter_body_and_param(content: str, getter: str):
+    """
+    Extract the full method body and parameter name for a numeric getter
+    by finding the method signature and then matching braces.
+    """
+    sig_pattern = (
+        r"CHIP_ERROR\s+MCDeviceInstanceInfoProvider::" + re.escape(getter)
+        + r"\s*\(\s*uint16_t\s*&\s*(\w+)\s*\)\s*\{"
+    )
+    sig_match = re.search(sig_pattern, content)
+    assert sig_match is not None, (
+        f"Could not find method signature for {getter}(uint16_t &)"
+    )
+    param_name = sig_match.group(1)
+    start = sig_match.end()
+    depth = 1
+    pos = start
+    while pos < len(content) and depth > 0:
+        if content[pos] == "{":
+            depth += 1
+        elif content[pos] == "}":
+            depth -= 1
+        pos += 1
+    return content[start: pos - 1], param_name
+
+
+def _verify_numeric_getter_override_branch(content: str, getter: str, optional_member: str):
+    """
+    Verify that the numeric getter checks HasValue() on the Optional member
+    and returns Value() when present.
+
+    Expected pattern:
+        if (<optional_member>.HasValue()) {
+            <param> = <optional_member>.Value();
+            return CHIP_NO_ERROR;
+        }
+    """
+    body, _param_name = _extract_numeric_getter_body_and_param(content, getter)
+
+    assert re.search(
+        r"if\s*\(\s*" + re.escape(optional_member) + r"\.HasValue\s*\(\s*\)\s*\)",
+        body,
+    ), (
+        f"{getter} does not check '{optional_member}.HasValue()' for override"
+    )
+
+    assert re.search(
+        re.escape(optional_member) + r"\.Value\s*\(\s*\)",
+        body,
+    ), (
+        f"{getter} does not return '{optional_member}.Value()' when override is present"
+    )
+
+
+def _verify_numeric_getter_fallback_branch(content: str, getter: str):
+    """
+    Verify that the numeric getter delegates to mDefaultProvider when
+    the Optional does not have a value.
+    """
+    body, param_name = _extract_numeric_getter_body_and_param(content, getter)
+
+    assert re.search(
+        r"return\s+mDefaultProvider\." + re.escape(getter)
+        + r"\s*\(\s*" + re.escape(param_name) + r"\s*\)\s*;",
+        body,
+    ), (
+        f"{getter} does not delegate to mDefaultProvider.{getter}({param_name}) "
+        f"when the Optional has no value"
+    )
+
+
+def _verify_header_has_flag_and_buffer(header: str, flag: str, buffer: str):
+    """Verify the header declares the boolean flag and char buffer."""
+    assert re.search(r"bool\s+" + re.escape(flag) + r"\s*=\s*false\s*;", header), (
+        f"Header missing declaration: bool {flag} = false;"
+    )
+    assert re.search(r"char\s+" + re.escape(buffer) + r"\s*\[", header), (
+        f"Header missing char buffer declaration for {buffer}"
+    )
+
+
+def _verify_header_has_optional(header: str, optional_member: str):
+    """Verify the header declares the chip::Optional member."""
+    assert re.search(
+        r"chip::Optional\s*<\s*uint16_t\s*>\s+" + re.escape(optional_member) + r"\s*;",
+        header,
+    ), (
+        f"Header missing declaration: chip::Optional<uint16_t> {optional_member};"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+# Strategy for a random subset of the 7 fields being "provided" (non-nil)
+field_presence_strategy = st.fixed_dictionaries(
+    {name: st.booleans() for name in ALL_FIELD_NAMES}
+)
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(field_presence=field_presence_strategy)
+@settings(
+    max_examples=128,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_override_fallback_roundtrip_initialize(field_presence):
+    """
+    **Validates: Requirements 1.2, 2.3, 3.2**
+
+    Property 1 (Initialize): For any combination of nil/non-nil fields,
+    Initialize() SHALL copy non-nil string values into internal buffers
+    and set the corresponding flag, and store non-nil numeric values via
+    SetValue on the Optional member. Nil fields leave flags false and
+    Optionals empty.
+
+    We verify this by checking that the source code of Initialize()
+    contains the correct conditional copy/store pattern for each field.
+    """
+    mm_content = _read_file(PROVIDER_MM)
+
+    for field_name, (flag, buffer, _getter) in STRING_FIELDS.items():
+        if field_presence[field_name]:
+            # Non-nil: Initialize must copy string and set flag
+            _verify_initialize_copies_string(mm_content, field_name, flag, buffer)
+        else:
+            # Nil: the conditional block should NOT execute, so the flag
+            # stays false (its default). Verify the guard is conditional
+            # on != nil so nil values are skipped.
+            pattern = (
+                r"if\s*\(\s*deviceInstanceInfo\." + re.escape(field_name)
+                + r"\s*!=\s*nil\s*\)"
+            )
+            assert re.search(pattern, mm_content), (
+                f"Initialize() does not guard '{field_name}' copy behind "
+                f"a nil check — nil values would incorrectly set the flag"
+            )
+
+    for field_name, (optional_member, _getter) in NUMERIC_FIELDS.items():
+        if field_presence[field_name]:
+            _verify_initialize_stores_numeric(mm_content, field_name, optional_member)
+        else:
+            pattern = (
+                r"if\s*\(\s*deviceInstanceInfo\." + re.escape(field_name)
+                + r"\s*!=\s*nil\s*\)"
+            )
+            assert re.search(pattern, mm_content), (
+                f"Initialize() does not guard '{field_name}' store behind "
+                f"a nil check — nil values would incorrectly set the Optional"
+            )
+
+
+@given(field_presence=field_presence_strategy)
+@settings(
+    max_examples=128,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_override_fallback_roundtrip_string_getters(field_presence):
+    """
+    **Validates: Requirements 3.3, 3.4, 3.5, 3.6, 3.11, 3.12, 3.15, 3.16**
+
+    Property 1 (String Getters): For each string field, when the flag is
+    set (non-nil field was provided), the getter SHALL check bufSize and
+    copy from the internal buffer. When the flag is not set (nil field),
+    the getter SHALL delegate to mDefaultProvider.
+    """
+    mm_content = _read_file(PROVIDER_MM)
+
+    for field_name, (flag, buffer, getter) in STRING_FIELDS.items():
+        if field_presence[field_name]:
+            _verify_string_getter_override_branch(mm_content, getter, flag, buffer)
+        else:
+            _verify_string_getter_fallback_branch(mm_content, getter)
+
+
+@given(field_presence=field_presence_strategy)
+@settings(
+    max_examples=128,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_override_fallback_roundtrip_numeric_getters(field_presence):
+    """
+    **Validates: Requirements 3.7, 3.8, 3.9, 3.10, 3.13, 3.14**
+
+    Property 1 (Numeric Getters): For each numeric field, when the
+    Optional has a value (non-nil field was provided), the getter SHALL
+    return the stored value. When the Optional is empty (nil field),
+    the getter SHALL delegate to mDefaultProvider.
+    """
+    mm_content = _read_file(PROVIDER_MM)
+
+    for field_name, (optional_member, getter) in NUMERIC_FIELDS.items():
+        if field_presence[field_name]:
+            _verify_numeric_getter_override_branch(mm_content, getter, optional_member)
+        else:
+            _verify_numeric_getter_fallback_branch(mm_content, getter)
+
+
+@given(field_presence=field_presence_strategy)
+@settings(
+    max_examples=128,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_override_fallback_roundtrip_header_declarations(field_presence):
+    """
+    **Validates: Requirements 3.2**
+
+    Property 1 (Header Declarations): For each field, the header SHALL
+    declare the appropriate private members — boolean flags and char
+    buffers for string fields, chip::Optional<uint16_t> for numeric
+    fields — ensuring the override/fallback mechanism has proper storage.
+    """
+    header_content = _read_file(PROVIDER_H)
+
+    for field_name, (flag, buffer, _getter) in STRING_FIELDS.items():
+        if field_presence[field_name]:
+            _verify_header_has_flag_and_buffer(header_content, flag, buffer)
+
+    for field_name, (optional_member, _getter) in NUMERIC_FIELDS.items():
+        if field_presence[field_name]:
+            _verify_header_has_optional(header_content, optional_member)
+
+
+@given(field_presence=field_presence_strategy)
+@settings(
+    max_examples=128,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_override_fallback_roundtrip_buffer_too_small_guard(field_presence):
+    """
+    **Validates: Requirements 3.3, 3.5, 3.11, 3.15**
+
+    Property 1 (Buffer Size Check): For each string field that is
+    provided (non-nil), the getter SHALL check bufSize and return
+    CHIP_ERROR_BUFFER_TOO_SMALL if the buffer is insufficient.
+    """
+    mm_content = _read_file(PROVIDER_MM)
+
+    for field_name, (flag, buffer, getter) in STRING_FIELDS.items():
+        if field_presence[field_name]:
+            # The override branch must include the buffer-too-small guard
+            body = _extract_string_getter_body(mm_content, getter)
+
+            assert re.search(
+                r"CHIP_ERROR_BUFFER_TOO_SMALL",
+                body,
+            ), (
+                f"{getter} does not return CHIP_ERROR_BUFFER_TOO_SMALL "
+                f"when bufSize is insufficient for the override value"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running override/fallback round-trip property tests...")
+    tests = [
+        ("1a: Initialize copies/stores correctly", test_override_fallback_roundtrip_initialize),
+        ("1b: String getters override/fallback", test_override_fallback_roundtrip_string_getters),
+        ("1c: Numeric getters override/fallback", test_override_fallback_roundtrip_numeric_getters),
+        ("1d: Header declarations", test_override_fallback_roundtrip_header_declarations),
+        ("1e: Buffer-too-small guard", test_override_fallback_roundtrip_buffer_too_small_guard),
+    ]
+    all_passed = True
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            all_passed = False
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/examples/tv-casting-app/tests/test_string_field_length_validation.py
+++ b/examples/tv-casting-app/tests/test_string_field_length_validation.py
@@ -1,0 +1,339 @@
+"""
+Property Test — Property 2: String Field Length Validation
+
+**Validates: Requirements 1.3, 1.4, 1.5, 1.6**
+
+This test parses `MCDeviceInstanceInfo.m` and verifies that the initializer
+validates string field lengths correctly: vendorName, productName, and
+serialNumber have a max length of 32 characters, and hardwareVersionString
+has a max length of 64 characters.
+
+For any string of length 0–100, the init SHALL succeed iff the string is
+within the field's max allowed length. Nil values are always accepted.
+
+Feature: ios-device-instance-info-provider
+Property 2: String Field Length Validation
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MC_DEVICE_INSTANCE_INFO_M = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "darwin",
+    "MatterTvCastingBridge",
+    "MatterTvCastingBridge",
+    "MCDeviceInstanceInfo.m",
+)
+
+# ---------------------------------------------------------------------------
+# Expected max lengths per the Matter spec and design doc
+# ---------------------------------------------------------------------------
+
+EXPECTED_MAX_LENGTHS = {
+    "vendorName": 32,
+    "productName": 32,
+    "serialNumber": 32,
+    "hardwareVersionString": 64,
+}
+
+# ---------------------------------------------------------------------------
+# Helpers — source code parsing
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _extract_max_length_constants(content: str) -> dict:
+    """
+    Extract max length constants from the .m file.
+
+    Looks for patterns like:
+        static const NSUInteger kMaxVendorNameLength = 32;
+    """
+    pattern = r"static\s+const\s+NSUInteger\s+kMax(\w+)Length\s*=\s*(\d+)\s*;"
+    matches = re.findall(pattern, content)
+    result = {}
+    for name_part, value in matches:
+        # Convert e.g. "VendorName" -> "vendorName"
+        field_name = name_part[0].lower() + name_part[1:]
+        result[field_name] = int(value)
+    return result
+
+
+def _extract_validation_guards(content: str) -> list:
+    """
+    Extract the validation guard patterns from the initializer.
+
+    Looks for patterns like:
+        if (vendorName != nil && vendorName.length > kMaxVendorNameLength) {
+            return nil;
+        }
+
+    Returns a list of field names that have validation guards.
+    """
+    pattern = (
+        r"if\s*\(\s*(\w+)\s*!=\s*nil\s*&&\s*\1\.length\s*>\s*kMax(\w+)Length\s*\)"
+        r"\s*\{\s*return\s+nil\s*;"
+    )
+    matches = re.findall(pattern, content, re.DOTALL)
+    return [field_name for field_name, _ in matches]
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(length=st.integers(min_value=0, max_value=100))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_vendor_name_length_validation_rule(length):
+    """
+    **Validates: Requirements 1.3**
+
+    Property 2: For any string of length 0–100 used as vendorName,
+    MCDeviceInstanceInfo init SHALL succeed iff length <= 32.
+    The source code must contain a guard that returns nil when
+    vendorName.length > 32.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    constants = _extract_max_length_constants(content)
+    max_len = constants.get("vendorName")
+
+    assert max_len is not None, (
+        "Could not find kMaxVendorNameLength constant in MCDeviceInstanceInfo.m"
+    )
+    assert max_len == EXPECTED_MAX_LENGTHS["vendorName"], (
+        f"vendorName max length mismatch: expected {EXPECTED_MAX_LENGTHS['vendorName']}, "
+        f"found {max_len}"
+    )
+
+    # Verify the validation guard exists
+    guards = _extract_validation_guards(content)
+    assert "vendorName" in guards, (
+        "MCDeviceInstanceInfo.m is missing validation guard for vendorName. "
+        f"Found guards for: {guards}"
+    )
+
+    # Property: init succeeds iff length <= max_len
+    should_succeed = length <= max_len
+    assert should_succeed == (length <= 32), (
+        f"vendorName validation logic error: string of length {length} "
+        f"should {'succeed' if length <= 32 else 'fail'} but max_len={max_len}"
+    )
+
+
+@given(length=st.integers(min_value=0, max_value=100))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_product_name_length_validation_rule(length):
+    """
+    **Validates: Requirements 1.4**
+
+    Property 2: For any string of length 0–100 used as productName,
+    MCDeviceInstanceInfo init SHALL succeed iff length <= 32.
+    The source code must contain a guard that returns nil when
+    productName.length > 32.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    constants = _extract_max_length_constants(content)
+    max_len = constants.get("productName")
+
+    assert max_len is not None, (
+        "Could not find kMaxProductNameLength constant in MCDeviceInstanceInfo.m"
+    )
+    assert max_len == EXPECTED_MAX_LENGTHS["productName"], (
+        f"productName max length mismatch: expected {EXPECTED_MAX_LENGTHS['productName']}, "
+        f"found {max_len}"
+    )
+
+    guards = _extract_validation_guards(content)
+    assert "productName" in guards, (
+        "MCDeviceInstanceInfo.m is missing validation guard for productName. "
+        f"Found guards for: {guards}"
+    )
+
+    should_succeed = length <= max_len
+    assert should_succeed == (length <= 32), (
+        f"productName validation logic error: string of length {length} "
+        f"should {'succeed' if length <= 32 else 'fail'} but max_len={max_len}"
+    )
+
+
+@given(length=st.integers(min_value=0, max_value=100))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_serial_number_length_validation_rule(length):
+    """
+    **Validates: Requirements 1.5**
+
+    Property 2: For any string of length 0–100 used as serialNumber,
+    MCDeviceInstanceInfo init SHALL succeed iff length <= 32.
+    The source code must contain a guard that returns nil when
+    serialNumber.length > 32.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    constants = _extract_max_length_constants(content)
+    max_len = constants.get("serialNumber")
+
+    assert max_len is not None, (
+        "Could not find kMaxSerialNumberLength constant in MCDeviceInstanceInfo.m"
+    )
+    assert max_len == EXPECTED_MAX_LENGTHS["serialNumber"], (
+        f"serialNumber max length mismatch: expected {EXPECTED_MAX_LENGTHS['serialNumber']}, "
+        f"found {max_len}"
+    )
+
+    guards = _extract_validation_guards(content)
+    assert "serialNumber" in guards, (
+        "MCDeviceInstanceInfo.m is missing validation guard for serialNumber. "
+        f"Found guards for: {guards}"
+    )
+
+    should_succeed = length <= max_len
+    assert should_succeed == (length <= 32), (
+        f"serialNumber validation logic error: string of length {length} "
+        f"should {'succeed' if length <= 32 else 'fail'} but max_len={max_len}"
+    )
+
+
+@given(length=st.integers(min_value=0, max_value=100))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_hardware_version_string_length_validation_rule(length):
+    """
+    **Validates: Requirements 1.6**
+
+    Property 2: For any string of length 0–100 used as hardwareVersionString,
+    MCDeviceInstanceInfo init SHALL succeed iff length <= 64.
+    The source code must contain a guard that returns nil when
+    hardwareVersionString.length > 64.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    constants = _extract_max_length_constants(content)
+    max_len = constants.get("hardwareVersionString")
+
+    assert max_len is not None, (
+        "Could not find kMaxHardwareVersionStringLength constant in MCDeviceInstanceInfo.m"
+    )
+    assert max_len == EXPECTED_MAX_LENGTHS["hardwareVersionString"], (
+        f"hardwareVersionString max length mismatch: "
+        f"expected {EXPECTED_MAX_LENGTHS['hardwareVersionString']}, found {max_len}"
+    )
+
+    guards = _extract_validation_guards(content)
+    assert "hardwareVersionString" in guards, (
+        "MCDeviceInstanceInfo.m is missing validation guard for hardwareVersionString. "
+        f"Found guards for: {guards}"
+    )
+
+    should_succeed = length <= max_len
+    assert should_succeed == (length <= 64), (
+        f"hardwareVersionString validation logic error: string of length {length} "
+        f"should {'succeed' if length <= 64 else 'fail'} but max_len={max_len}"
+    )
+
+
+@given(
+    field=st.sampled_from(list(EXPECTED_MAX_LENGTHS.keys())),
+    length=st.integers(min_value=0, max_value=100),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_all_string_fields_validation_consistency(field, length):
+    """
+    **Validates: Requirements 1.3, 1.4, 1.5, 1.6**
+
+    Property 2: For any string field and any string of length 0–100,
+    the validation constant in MCDeviceInstanceInfo.m SHALL match the
+    expected max length, and the validation guard SHALL exist. Init
+    succeeds iff length <= max_length for that field.
+    """
+    content = _read_file(MC_DEVICE_INSTANCE_INFO_M)
+    constants = _extract_max_length_constants(content)
+    guards = _extract_validation_guards(content)
+
+    expected_max = EXPECTED_MAX_LENGTHS[field]
+    actual_max = constants.get(field)
+
+    assert actual_max is not None, (
+        f"Could not find max length constant for '{field}' in MCDeviceInstanceInfo.m. "
+        f"Found constants: {constants}"
+    )
+    assert actual_max == expected_max, (
+        f"Max length mismatch for '{field}': expected {expected_max}, found {actual_max}"
+    )
+    assert field in guards, (
+        f"MCDeviceInstanceInfo.m is missing validation guard for '{field}'. "
+        f"Found guards for: {guards}"
+    )
+
+    # The property: init succeeds iff length <= max_length
+    init_should_succeed = length <= expected_max
+    # Verify the source code enforces this via the guard pattern:
+    # if (field != nil && field.length > kMaxFieldLength) { return nil; }
+    # This means: returns nil when length > max, succeeds when length <= max
+    code_rejects = length > actual_max
+    assert init_should_succeed != code_rejects, (
+        f"Validation logic inconsistency for '{field}' with length {length}: "
+        f"expected init to {'succeed' if init_should_succeed else 'fail'}, "
+        f"but code would {'reject' if code_rejects else 'accept'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running string field length validation property tests...")
+    tests = [
+        ("2a: vendorName length validation", test_vendor_name_length_validation_rule),
+        ("2b: productName length validation", test_product_name_length_validation_rule),
+        ("2c: serialNumber length validation", test_serial_number_length_validation_rule),
+        ("2d: hardwareVersionString length validation", test_hardware_version_string_length_validation_rule),
+        ("2e: All fields validation consistency", test_all_string_fields_validation_consistency),
+    ]
+    all_passed = True
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            all_passed = False
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)


### PR DESCRIPTION
#### Summary

* feat(casting): Add iOS Device Instance Info Provider API

Add app-level API on iOS (Darwin) allowing casting applications to override device instance info fields (ProductName, VendorName, VendorId, ProductId, SerialNumber, HardwareVersion, HardwareVersionString) used during Matter commissioning. This brings iOS to parity with Android's existing runtime override support.

New files:
- MCDeviceInstanceInfo.h/.m: ObjC data model with field validation
- MCDeviceInstanceInfoProvider.h/.mm: C++ bridge implementing DeviceInstanceInfoProvider with fallback to compile-time defaults

Modified files:
- MCDataSource.h: Added @optional method for device instance info
- MCCastingApp.mm: Provider creation and registration logic
- MCInitializationExample.swift: Example usage of the new API
- project.pbxproj: Xcode project file references

Includes property-based tests (Hypothesis) validating string field length constraints, invalid input rejection, override/fallback round-trip logic, and MCCastingApp registration behavior.

* fix(casting): Address PR review — UTF-8 validation, bounded copies, leak fix

Use lengthOfBytesUsingEncoding:NSUTF8StringEncoding for string length checks since Matter spec limits are in bytes, not UTF-16 code units. Switch to 3-arg CopyString with sizeof(dest) for bounds safety. Delete existing provider before re-allocation to prevent memory leak.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* refactor(casting): Replace snapshot model with pull-based protocol for iOS device instance info

Replace MCDeviceInstanceInfo (init-time snapshot class) with MCDeviceInstanceInfoProvider (pull-based @protocol). The C++ bridge now queries the ObjC delegate each time the platform needs a value, matching the Android PreferencesConfigurationManager pattern.

This makes the API more scalable — adding new fields only requires adding optional protocol methods, not expanding a model class.

---------


(cherry picked from commit d67b0db481617d861bb95def8d9b0e646eadd72e)


#### Testing

build, iOS