### PR TITLE
[Python style] Apply pyupgrade rules UP034, UP037, UP039, UP041

### DIFF
--- a/examples/fabric-admin/scripts/fabric-sync-app.py
+++ b/examples/fabric-admin/scripts/fabric-sync-app.py
@@ -200,7 +200,7 @@ async def main(args):
             # the bridge is already commissioned.
             expected_output="Reading attribute: Cluster=0x0000_001D Endpoint=0x1 AttributeId=0x0000_0000",
             timeout=1.5)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         # Commission the bridge to the admin.
         cmd = f"fabricsync add-local-bridge {bridge_node_id}"
         if args.passcode is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ select = [
     "UP034",
     "UP037",
     "UP039",
+    "UP040",
+    "UP041",
 ]
 ignore = [
     "ASYNC109", # Sometimes we use "timeout" argument in async functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ exclude = [
     "examples/tv-casting-app/tests/",
     # TODO(#37698)
     "docs/development_controllers/matter-repl/*.ipynb",
+    # Generated files
+    "src/controller/python/matter/clusters/CHIPClusters.py",
+    "src/controller/python/matter/clusters/Objects.py",
 ]
 
 [tool.pyright]
@@ -55,6 +58,7 @@ select = [
     "UP024", "UP025",
     "UP033",
     "UP034",
+    "UP037",
 ]
 ignore = [
     "ASYNC109", # Sometimes we use "timeout" argument in async functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ select = [
     "UP033",
     "UP034",
     "UP037",
+    "UP039",
 ]
 ignore = [
     "ASYNC109", # Sometimes we use "timeout" argument in async functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,7 @@ select = [
     "A",
     # pyupgrade rules to update syntax to the new preferred variant
     "UP001", "UP003", "UP004", "UP008", "UP009", "UP010", "UP011", "UP012", "UP013", "UP014", "UP015", "UP017", "UP018", "UP023",
-    "UP024", "UP025",
-    "UP033",
-    "UP034",
-    "UP037",
-    "UP039",
-    "UP040",
-    "UP041",
+    "UP024", "UP025", "UP033", "UP034", "UP037", "UP039", "UP040", "UP041",
 ]
 ignore = [
     "ASYNC109", # Sometimes we use "timeout" argument in async functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ select = [
     # pyupgrade rules to update syntax to the new preferred variant
     "UP001", "UP003", "UP004", "UP008", "UP009", "UP010", "UP011", "UP012", "UP013", "UP014", "UP015", "UP017", "UP018", "UP023",
     "UP024", "UP025",
+    "UP033",
+    "UP034",
 ]
 ignore = [
     "ASYNC109", # Sometimes we use "timeout" argument in async functions

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -53,9 +53,8 @@ def ValidateRepoPath(context, parameter, value):
     for name in ['BUILD.gn', '.gn', os.path.join('scripts', 'bootstrap.sh')]:
         expected_file = os.path.join(value, name)
         if not os.path.exists(expected_file):
-            raise click.BadParameter(
-                ("'%s' does not look like a valid repository path: "
-                 "%s not found.") % (value, expected_file))
+            raise click.BadParameter("'%s' does not look like a valid repository path: "
+                                     "%s not found." % (value, expected_file))
     return value
 
 

--- a/scripts/flashing/firmware_utils.py
+++ b/scripts/flashing/firmware_utils.py
@@ -267,7 +267,7 @@ class Flasher:
             note = tool_info.get('error', 'Unable to execute {tool}.')
             note = textwrap.dedent(note).format(tool=tool, **vars(self.option))
             # textwrap.fill only handles single paragraphs:
-            note = '\n\n'.join((textwrap.fill(p) for p in note.split('\n\n')))
+            note = '\n\n'.join(textwrap.fill(p) for p in note.split('\n\n'))
             print(note, file=sys.stderr)
             return False
         return True

--- a/scripts/py_matter_idl/matter/idl/test_backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter/idl/test_backwards_compatibility.py
@@ -35,7 +35,7 @@ class Compatibility(Flag):
     BACKWARD_FAIL = auto()  # new -> old is wrong
 
 
-class DisableLogger():
+class DisableLogger:
     def __enter__(self):
         logging.disable(logging.CRITICAL)
 

--- a/scripts/py_matter_yamltests/matter/yamltests/hooks.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/hooks.py
@@ -18,7 +18,7 @@ from typing import Optional
 from .parser import TestStep
 
 
-class TestParserHooks():
+class TestParserHooks:
     __test__ = False
 
     def parsing_start(self, count: int):
@@ -79,7 +79,7 @@ class TestParserHooks():
         pass
 
 
-class TestRunnerHooks():
+class TestRunnerHooks:
     __test__ = False
 
     def start(self, count: int):
@@ -236,7 +236,7 @@ class TestRunnerHooks():
         pass
 
 
-class WebSocketRunnerHooks():
+class WebSocketRunnerHooks:
     def connecting(self, url: str):
         """
         This method is called when the websocket is attempting to connect to a remote.

--- a/scripts/py_matter_yamltests/matter/yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/pics_checker.py
@@ -38,7 +38,7 @@ class InvalidPICSParsingError(Exception):
     pass
 
 
-class PICSChecker():
+class PICSChecker:
     """Class to compute a PICS expression"""
 
     def __init__(self, pics_file: str):

--- a/scripts/py_matter_yamltests/matter/yamltests/pseudo_clusters/clusters/accessory_server_bridge.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/pseudo_clusters/clusters/accessory_server_bridge.py
@@ -88,7 +88,7 @@ def _get_start_options(request):
     return options
 
 
-class AccessoryServerBridge():
+class AccessoryServerBridge:
     def start(request):
         register_key = _get_option(request, 'registerKey', _DEFAULT_KEY)
         options = _get_start_options(request)

--- a/scripts/tests/chipyaml/adapters/chiptool/decoder.py
+++ b/scripts/tests/chipyaml/adapters/chiptool/decoder.py
@@ -140,7 +140,7 @@ class MatterLog:
         return list(map(MatterLog, logs))
 
 
-class Converter():
+class Converter:
     """
     This class converts between the JSON representation used by chip-tool to transmit
     information and the response format expected by the test suite.
@@ -314,7 +314,7 @@ class OctetStringConverter(BaseConverter):
         return value
 
 
-class StructFieldsNameConverter():
+class StructFieldsNameConverter:
     """
     Converts fields identifiers to the field names specified in the cluster definition.
     """

--- a/scripts/tests/chipyaml/tests_logger.py
+++ b/scripts/tests/chipyaml/tests_logger.py
@@ -36,7 +36,7 @@ _FAILURE = click.style('\N{ballot x}', fg='red')
 _WARNING = click.style('\N{warning sign}', fg='yellow')
 
 
-class TestColoredLogPrinter():
+class TestColoredLogPrinter:
     def __init__(self, log_format='[{module}] {message}'):
         self.__log_format = log_format
         self.__log_styles = {

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -156,7 +156,7 @@ class AppProcessManager:
         return self.app_process
 
 
-class IpPacketCaptureManager():
+class IpPacketCaptureManager:
     def __init__(self, dump_filename: pathlib.Path):
         self.tcpdump_process = None
         self.dump_filename = dump_filename

--- a/scripts/tools/check_includes.py
+++ b/scripts/tools/check_includes.py
@@ -49,7 +49,7 @@ OVERRIDE = 'T' + 'ODO: update check_includes_config.py'
 
 def any_re(res: Iterable[str]) -> Pattern:
     """Given a list of RE strings, return an RE to match any of them."""
-    return re.compile('|'.join((f'({i})' for i in res)))
+    return re.compile('|'.join(f'({i})' for i in res))
 
 
 def main():

--- a/scripts/tools/memory/memdf/util/markdown.py
+++ b/scripts/tools/memory/memdf/util/markdown.py
@@ -20,7 +20,7 @@ def read_hierified(f):
     """Read a markdown table in ‘hierified’ format."""
 
     line = f.readline()
-    header = tuple((s.strip() for s in line.split('|')[1:-1]))
+    header = tuple(s.strip() for s in line.split('|')[1:-1])
 
     _ = f.readline()  # The line under the header.
 

--- a/scripts/tools/memory/report_tree.py
+++ b/scripts/tools/memory/report_tree.py
@@ -58,8 +58,8 @@ class SourceTree:
     def __init__(self, name: str):
         self.name = name
         self.root = self.Node(memdf.name.TOTAL)
-        self.source_to_node: Dict[str, 'SourceTree.Node'] = {}
-        self.symbol_to_node: Dict[str, 'SourceTree.Node'] = {}
+        self.source_to_node: Dict[str, SourceTree.Node] = {}
+        self.symbol_to_node: Dict[str, SourceTree.Node] = {}
 
     def source_node(self, source: str) -> 'SourceTree.Node':
         """Create a SourceTree.Node for a source file."""

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -568,14 +568,14 @@ def main():
     if args.schema and no_jsonschema_module:
         log.error("Requested verification of the JSON file using jsonschema, but the module is not installed. \n"
                   "Install only the module by invoking: pip3 install jsonschema \n"
-                   "Alternatively, install it with all dependencies for Matter by invoking: pip3 install "
-                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
+                  "Alternatively, install it with all dependencies for Matter by invoking: pip3 install "
+                  "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
         sys.exit(1)
 
     if args.generate_onboarding and no_onboarding_modules:
         log.error("Requested generation of onboarding codes, but the some modules are not installed. \n"
                   "Install all dependencies for Matter by invoking: pip3 install "
-                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
+                  "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
         sys.exit(1)
 
     generator = FactoryDataGenerator(args)

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -566,16 +566,16 @@ def main():
         sys.exit(1)
 
     if args.schema and no_jsonschema_module:
-        log.error(("Requested verification of the JSON file using jsonschema, but the module is not installed. \n"
+        log.error("Requested verification of the JSON file using jsonschema, but the module is not installed. \n"
                   "Install only the module by invoking: pip3 install jsonschema \n"
                    "Alternatively, install it with all dependencies for Matter by invoking: pip3 install "
-                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory."))
+                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
         sys.exit(1)
 
     if args.generate_onboarding and no_onboarding_modules:
-        log.error(("Requested generation of onboarding codes, but the some modules are not installed. \n"
+        log.error("Requested generation of onboarding codes, but the some modules are not installed. \n"
                   "Install all dependencies for Matter by invoking: pip3 install "
-                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory."))
+                   "-r ./scripts/setup/requirements.nrfconnect.txt from the Matter root directory.")
         sys.exit(1)
 
     generator = FactoryDataGenerator(args)

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -228,7 +228,7 @@ class ZAPGenerateTarget:
         )
 
 
-class GoldenTestImageTarget():
+class GoldenTestImageTarget:
     def __init__(self):
         # NOTE: output-path is inside the tree. This is because clang-format
         #       will search for a .clang-format file in the directory tree
@@ -267,7 +267,7 @@ class GoldenTestImageTarget():
         log.info("  %s", shlex.join(self.command))
 
 
-class JinjaCodegenTarget():
+class JinjaCodegenTarget:
     def __init__(self, generator: str, output_directory: str, idl_path: str):
         # This runs a test, but the important bit is we pass `--regenerate`
         # to it and this will cause it to OVERWRITE golden images.

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -351,7 +351,7 @@ class CommissioningContext(CallbackContext):
 
 
 class CommissionableNode(discovery.CommissionableNode):
-    def SetDeviceController(self, devCtrl: 'ChipDeviceController'):
+    def SetDeviceController(self, devCtrl: ChipDeviceController):
         self._devCtrl = devCtrl
 
     def Commission(self, nodeId: int, setupPinCode: int) -> int:

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -377,7 +377,7 @@ class CommissionableNode(discovery.CommissionableNode):
                 yield k, self.__dict__[k]
 
 
-class DeviceProxyWrapper():
+class DeviceProxyWrapper:
     ''' Encapsulates a pointer to OperationalDeviceProxy on the c++ side that needs to be
         freed when DeviceProxyWrapper goes out of scope. There is a potential issue where
         if this is copied around that a double free will occur, but how this is used today
@@ -497,7 +497,7 @@ DiscoveryFilterType: typing.TypeAlias = discovery.FilterType
 DiscoveryType: typing.TypeAlias = discovery.DiscoveryType
 
 
-class ChipDeviceControllerBase():
+class ChipDeviceControllerBase:
     activeList: typing.Set = set()
 
     def __init__(self, name: str = ''):
@@ -1518,7 +1518,7 @@ class ChipDeviceControllerBase():
                 LOGGER.info('Using PASE connection')
                 return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.COMMISSIONEE, self._dmLib)
 
-        class DeviceAvailableClosure():
+        class DeviceAvailableClosure:
             def deviceAvailable(self, device, err):
                 nonlocal returnDevice
                 nonlocal returnErr
@@ -1592,7 +1592,7 @@ class ChipDeviceControllerBase():
         eventLoop = asyncio.get_running_loop()
         future = eventLoop.create_future()
 
-        class DeviceAvailableClosure():
+        class DeviceAvailableClosure:
             def __init__(self, loop, future: asyncio.Future):
                 self._returnDevice = c_void_p(None)
                 self._returnErr = None

--- a/src/controller/python/matter/MatterTlvJson.py
+++ b/src/controller/python/matter/MatterTlvJson.py
@@ -26,7 +26,7 @@ from .clusters.Attribute import AttributeCache, AttributePath, ValueDecodeFailur
 from .tlv import TLVReader
 
 
-class TLVJsonConverter():
+class TLVJsonConverter:
     ''' Converter class used to convert MatterJsonTlv attribute wildcard dump files into an AttributeCache.
 
         Attribute wildcard dump files can be generated as a side effect of basic composition tests, or

--- a/src/controller/python/matter/clusters/Attribute.py
+++ b/src/controller/python/matter/clusters/Attribute.py
@@ -155,13 +155,13 @@ class EventPath:
     Urgent: Optional[int] = None
 
     @staticmethod
-    def from_cluster(EndpointId: int, Cluster: Cluster, EventId: Optional[int] = None, Urgent: Optional[int] = None) -> "EventPath":
+    def from_cluster(EndpointId: int, Cluster: Cluster, EventId: Optional[int] = None, Urgent: Optional[int] = None) -> EventPath:
         if Cluster is None:
             raise ValueError("Cluster cannot be None")
         return EventPath(EndpointId=EndpointId, ClusterId=Cluster.id, EventId=EventId, Urgent=Urgent)
 
     @staticmethod
-    def from_event(EndpointId: int, Event: ClusterEvent, Urgent: Optional[int] = None) -> "EventPath":
+    def from_event(EndpointId: int, Event: ClusterEvent, Urgent: Optional[int] = None) -> EventPath:
         if Event is None:
             raise ValueError("Event cannot be None")
         return EventPath(EndpointId=EndpointId, ClusterId=Event.cluster_id, EventId=Event.event_id, Urgent=Urgent)

--- a/src/controller/python/matter/clusters/Types.py
+++ b/src/controller/python/matter/clusters/Types.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 
-class Nullable():
+class Nullable:
     def __repr__(self):
         return 'Null'
 

--- a/src/controller/python/matter/discovery/__init__.py
+++ b/src/controller/python/matter/discovery/__init__.py
@@ -79,7 +79,7 @@ class PendingDiscovery:
 
 
 @dataclass
-class CommissionableNode():
+class CommissionableNode:
     instanceName: Optional[str] = None
     hostName: Optional[str] = None
     port: Optional[int] = None

--- a/src/controller/python/tests/scripts/base.py
+++ b/src/controller/python/tests/scripts/base.py
@@ -1276,7 +1276,7 @@ class BaseTestHelper:
             # condition between the last attribute update and the callback.
             try:
                 await asyncio.wait_for(taskAttributeChange, 1)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # If attribute change task did not finish something is wrong. Cancel
                 # the task.
                 taskAttributeChange.cancel()

--- a/src/controller/python/tests/scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/tests/scripts/cirque_restart_remote_device.py
@@ -60,12 +60,12 @@ class restartRemoteDevice(threading.Thread):
         try:
             client.connect(self.remote_ip, self.ssh_port, self.user, self.password)
             client.exec_command(
-                ("kill \"$(ps aux | grep -E \'out/debug/{}\' | grep -v grep | grep -v gdb | "
-                 "awk \'{{print $2}}\')\"").format(self.remote_server_app))
+                "kill \"$(ps aux | grep -E \'out/debug/{}\' | grep -v grep | grep -v gdb | "
+                "awk \'{{print $2}}\')\"".format(self.remote_server_app))
             time.sleep(1)
             stdin, stdout, stderr = client.exec_command(
-                ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
-                 "awk \'{{print $2}}\'").format(self.remote_server_app))
+                "ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                "awk \'{{print $2}}\'".format(self.remote_server_app))
             if not stdout.read().decode().strip():
                 logger.info(f"Succeed to kill remote process {self.remote_server_app}")
             else:

--- a/src/controller/python/tests/scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/tests/scripts/cirque_restart_remote_device.py
@@ -60,12 +60,12 @@ class restartRemoteDevice(threading.Thread):
         try:
             client.connect(self.remote_ip, self.ssh_port, self.user, self.password)
             client.exec_command(
-                "kill \"$(ps aux | grep -E \'out/debug/{}\' | grep -v grep | grep -v gdb | "
-                "awk \'{{print $2}}\')\"".format(self.remote_server_app))
+                "kill \"$(ps aux | grep -E \'out/debug/{}\' | grep -v grep | grep -v gdb | awk \'{{print $2}}\')\"".format(
+                    self.remote_server_app))
             time.sleep(1)
             stdin, stdout, stderr = client.exec_command(
-                "ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
-                "awk \'{{print $2}}\'".format(self.remote_server_app))
+                "ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | awk \'{{print $2}}\'".format(
+                    self.remote_server_app))
             if not stdout.read().decode().strip():
                 logger.info(f"Succeed to kill remote process {self.remote_server_app}")
             else:

--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -137,7 +137,7 @@ class TC_CNET_4_9(MatterBaseTest):
 
         # Verify that there is a single connected network across ALL network commissioning clusters
         for ep in networks_dict:
-            connected_network_count[ep] = sum((x.connected for x in networks_dict[ep]))
+            connected_network_count[ep] = sum(x.connected for x in networks_dict[ep])
             log.info(f"Connected networks count by endpoint: {connected_network_count}")
             asserts.assert_equal(sum(connected_network_count.values()), 1,
                                  "Verify that only one entry has connected status as TRUE across ALL endpoints")

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -855,7 +855,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 13: Manually put the device in the Stopped(0x00) operational state
         self.step(13)
-        if self.pics_guard(self.check_pics((f"{self.test_info.pics_code}.S.M.ST_STOPPED"))):
+        if self.pics_guard(self.check_pics(f"{self.test_info.pics_code}.S.M.ST_STOPPED")):
             self.send_manual_or_pipe_command(name="OperationalStateChange",
                                              device=self.device,
                                              operation="Stop")
@@ -876,7 +876,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 16: Manually put the device in the Error(0x03) operational state
         self.step(16)
-        if self.pics_guard(self.check_pics((f"{self.test_info.pics_code}.S.M.ST_ERROR"))):
+        if self.pics_guard(self.check_pics(f"{self.test_info.pics_code}.S.M.ST_ERROR")):
             self.send_manual_or_pipe_command(name="OperationalStateChange",
                                              device=self.device,
                                              operation="OnFault",
@@ -1170,7 +1170,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 21: TH waits for half of initial-countdown-time
         self.step(21)
-        await asyncio.sleep((initial_countdown_time / 2))
+        await asyncio.sleep(initial_countdown_time / 2)
 
         # STEP 22: TH sends Resume command to the DUT
         self.step(22)

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -89,7 +89,7 @@ class EventSpecificChangeCallback:
         return res.Data
 
 
-class TC_OPSTATE_BASE():
+class TC_OPSTATE_BASE:
     def setup_base(self, test_info=None):
         asserts.assert_true(test_info is not None,
                             "You shall define the test info!")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -129,7 +129,7 @@ class PairingStatus:
         return str(self.exception) if self.exception else "Pairing Successful"
 
 
-class Commission():
+class Commission:
     def __init__(
         self,
         dev_ctrl: ChipDeviceCtrl.ChipDeviceController,

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
@@ -58,7 +58,7 @@ def warning_wrapper(override_flag: str):
     return warning_wrapper_internal
 
 
-class DefaultChecker():
+class DefaultChecker:
     @warning_wrapper(FLAG_PRODUCT_NAME)
     def check_default_product_name(self):
         cluster = Clusters.BasicInformation

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/global_attribute_ids.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/global_attribute_ids.py
@@ -75,7 +75,7 @@ class CommandIdType(Enum):
 # because the class handles the non-inclusive range.
 
 
-class IdRange():
+class IdRange:
     def __init__(self, _min, _max):
         self.min_max = range(_min, _max+1)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -135,7 +135,7 @@ class AttributeMatcher:
         return self._description
 
     @staticmethod
-    def from_callable(description: str, matcher: Callable[[AttributeValue], bool]) -> "AttributeMatcher":
+    def from_callable(description: str, matcher: Callable[[AttributeValue], bool]) -> AttributeMatcher:
         """Take a single callable and wrap it into an AttributeMatcher object. Useful to wrap closures."""
         class AttributeMatcherFromCallable(AttributeMatcher):
             def __init__(self, description, matcher: Callable[[AttributeValue], bool]):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -545,7 +545,7 @@ class AsyncMock(MagicMock):
         return super().__call__(*args, **kwargs)
 
 
-class MockTestRunner():
+class MockTestRunner:
     """
     Test runner for mocking Matter device interactions.
 

--- a/src/python_testing/mdns_discovery/mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/mdns_discovery.py
@@ -18,7 +18,7 @@
 import json
 import logging
 import time
-from asyncio import Event, Semaphore, TimeoutError, create_task, gather, sleep, wait_for  # noqa: A004
+from asyncio import Event, Semaphore, create_task, gather, sleep, wait_for
 from typing import Dict, List, Optional
 
 from mdns_discovery.data_classes.aaaa_record import AaaaRecord

--- a/src/python_testing/mdns_discovery/service_listeners/mdns_service_listener.py
+++ b/src/python_testing/mdns_discovery/service_listeners/mdns_service_listener.py
@@ -16,7 +16,7 @@
 #
 
 import logging
-from asyncio import Event, TimeoutError, wait_for  # noqa: A004
+from asyncio import Event, wait_for
 
 from zeroconf import ServiceListener, Zeroconf
 

--- a/src/python_testing/mdns_discovery/tests/test_asserts.py
+++ b/src/python_testing/mdns_discovery/tests/test_asserts.py
@@ -1054,7 +1054,7 @@ class TestAssertValidPhKey(unittest.TestCase):
 
     def test_invalid_due_to_out_of_range(self):
         # Only bits 1 through 22 are defined.
-        msg = fail_msg(assert_valid_ph_key, str((1 << 23)))
+        msg = fail_msg(assert_valid_ph_key, str(1 << 23))
         self.assertIn(self.BIT_MSG, msg)
 
     def test_invalid_due_to_empty_string(self):

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -94,7 +94,7 @@ class Failure:
     exception: typing.Optional[Exception]
 
 
-class Hooks():
+class Hooks:
     def __init__(self):
         self.failures = {}
         self.current_step = 'unknown'

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -147,7 +147,7 @@ class CADMINBaseTest(MatterBaseTest):
         try:
             window_status_accumulator.await_all_expected_report_matches([status_match], timeout_sec=timeout_sec)
             log.info(f"✅ Window status changed to {status_name} (status={is_open_expected})")
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             error_msg = f"Timeout waiting for window status {is_open_expected} ({status_name}) after {timeout_sec}s: {e}"
             log.error(f"❌ {error_msg}")
             asserts.fail(error_msg)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -672,8 +672,8 @@ class TestConformanceSupport(MatterBaseTest):
 
         # Ensure that we can only have greater terms with exactly 2 value
         xml = create_xml('<attribute name="attr1" />'
-                          '<attribute name="attr2" />'
-                          '<literal value="1" />')
+                         '<attribute name="attr2" />'
+                         '<literal value="1" />')
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -662,8 +662,8 @@ class TestConformanceSupport(MatterBaseTest):
                     f'{xml_mid}'
                     f'</{term}>'
                     '</mandatoryConform>')
-        xml = create_xml(('<attribute name="attr1" />'
-                          '<literal value="1" />'))
+        xml = create_xml('<attribute name="attr1" />'
+                         '<literal value="1" />')
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # TODO: switch this to check greater than once the update to the base is done (#33422)
@@ -671,9 +671,9 @@ class TestConformanceSupport(MatterBaseTest):
         asserts.assert_equal(str(xml_callable), f'attr1 {symbol} 1')
 
         # Ensure that we can only have greater terms with exactly 2 value
-        xml = create_xml(('<attribute name="attr1" />'
+        xml = create_xml('<attribute name="attr1" />'
                           '<attribute name="attr2" />'
-                          '<literal value="1" />'))
+                          '<literal value="1" />')
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
@@ -681,7 +681,7 @@ class TestConformanceSupport(MatterBaseTest):
         except ConformanceException:
             pass
 
-        xml = create_xml(('<attribute name="attr1" />'))
+        xml = create_xml('<attribute name="attr1" />')
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
@@ -690,8 +690,8 @@ class TestConformanceSupport(MatterBaseTest):
             pass
 
         # Only attributes and literals allowed because arithmetic operations require values
-        xml = create_xml(('<feature name="AB" />'
-                          '<literal value="1" />'))
+        xml = create_xml('<feature name="AB" />'
+                         '<literal value="1" />')
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)

--- a/src/python_testing/test_testing/common_icdm_data.py
+++ b/src/python_testing/test_testing/common_icdm_data.py
@@ -30,7 +30,7 @@ uat = c.Bitmaps.UserActiveModeTriggerBitmap
 
 
 @dataclass
-class ICDMData():
+class ICDMData:
     FeatureMap: int
     IdleModeDuration: int
     ActiveModeDuration: int

--- a/src/python_testing/test_testing/test_TC_DGGEN_3_2.py
+++ b/src/python_testing/test_testing/test_TC_DGGEN_3_2.py
@@ -26,7 +26,7 @@ from matter.testing.runner import MockTestRunner
 
 
 @dataclass
-class TestSpec():
+class TestSpec:
     max_paths: int
     dmtest_feature_map: int
     expect_pass: bool

--- a/src/python_testing/test_testing/test_TC_TMP_2_1.py
+++ b/src/python_testing/test_testing/test_TC_TMP_2_1.py
@@ -28,7 +28,7 @@ from matter.testing.runner import MockTestRunner
 
 
 @dataclass
-class TestSpec():
+class TestSpec:
     min: typing.Optional[int]
     max: typing.Optional[int]
     measured: int


### PR DESCRIPTION
#### Summary

We use Python 3.11 as the minimum version, yet a lot of files use legacy or redundant syntax. Pyupgrade rules allow to semi-automatically refresh the syntax for the most common cases. For full rationale why it's beneficial to the project see https://github.com/project-chip/connectedhomeip/pull/72157

This PR consolidates the rest of smaller changes which allow for automatic ruff fix as https://github.com/project-chip/connectedhomeip/pull/72157 got merged.

List of rules enabled in this PR (some are noop):

* [`UP033` – `lru-cache-with-maxsize-none`](https://docs.astral.sh/ruff/rules/lru-cache-with-maxsize-none/) – use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`.
* [`UP034` – `extraneous-parentheses`](https://docs.astral.sh/ruff/rules/extraneous-parentheses/) – avoid extraneous parentheses.
* [`UP037` – `quoted-annotation`](https://docs.astral.sh/ruff/rules/quoted-annotation/) – remove unnecessary quotes from type annotations.
* [`UP039` – `unnecessary-class-parentheses`](https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses/) – remove unnecessary parentheses after a class definition.
* [`UP040` – `non-pep695-type-alias`](https://docs.astral.sh/ruff/rules/non-pep695-type-alias/) – use the PEP 695 `type` keyword for type aliases.
* [`UP041` – `timeout-error-alias`](https://docs.astral.sh/ruff/rules/timeout-error-alias/) – replace aliased timeout errors with `TimeoutError`.

Each rule which produced some diff has its own commit. All changes are autogenerated with `ruff check --fix`, and separately manually reviewed to ensure no regressions.

#### Related issues

Full set of rules is enabled in https://github.com/MarekPikula/connectedhomeip/pull/7

All related upstream PRs:

- https://github.com/project-chip/connectedhomeip/pull/72157
- https://github.com/project-chip/connectedhomeip/pull/72159
- https://github.com/project-chip/connectedhomeip/pull/72160
- https://github.com/project-chip/connectedhomeip/pull/72180
- https://github.com/project-chip/connectedhomeip/pull/72181

#### Testing

`ruff check` and CI.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
