### PR TITLE
[devcontainer] Fix LegacyKeyValueFormat warning

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_VERSION
 
 # All tools required for compilation belong in chip-build, forms "truth" for CHIP build tooling
 FROM ghcr.io/project-chip/chip-build-vscode:${BUILD_VERSION}
-LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
+LABEL org.opencontainers.image.source="https://github.com/project-chip/connectedhomeip"
 
 # This Dockerfile contains things useful for an interactive development environment
 ARG USERNAME=vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_VERSION
 
 # All tools required for compilation belong in chip-build, forms "truth" for CHIP build tooling
 FROM ghcr.io/project-chip/chip-build-vscode:${BUILD_VERSION}
-LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
+LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
 
 # This Dockerfile contains things useful for an interactive development environment
 ARG USERNAME=vscode

--- a/src/python_testing/TC_IDM_4_3.py
+++ b/src/python_testing/TC_IDM_4_3.py
@@ -172,7 +172,7 @@ class TC_IDM_4_3(IDMBaseTest, BasicCompositionTests):
         max_wait = sub_timeout_sec + 1
         try:
             await asyncio.wait_for(empty_report_event.wait(), timeout=max_wait)
-        except TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             asserts.fail("Empty report was not received")
 
         asserts.assert_is_not_none(empty_report_time, "Empty report timing not captured")

--- a/src/python_testing/TC_IDM_4_3.py
+++ b/src/python_testing/TC_IDM_4_3.py
@@ -172,7 +172,7 @@ class TC_IDM_4_3(IDMBaseTest, BasicCompositionTests):
         max_wait = sub_timeout_sec + 1
         try:
             await asyncio.wait_for(empty_report_event.wait(), timeout=max_wait)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             asserts.fail("Empty report was not received")
 
         asserts.assert_is_not_none(empty_report_time, "Empty report timing not captured")

--- a/src/python_testing/TC_IDM_4_3.py
+++ b/src/python_testing/TC_IDM_4_3.py
@@ -172,7 +172,7 @@ class TC_IDM_4_3(IDMBaseTest, BasicCompositionTests):
         max_wait = sub_timeout_sec + 1
         try:
             await asyncio.wait_for(empty_report_event.wait(), timeout=max_wait)
-        except (asyncio.TimeoutError, TimeoutError):
+        except TimeoutError:
             asserts.fail("Empty report was not received")
 
         asserts.assert_is_not_none(empty_report_time, "Empty report timing not captured")


### PR DESCRIPTION
#### Summary

This is fixing warning message after re-opening VS Code in dev container:

```sh
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 19)
```

#### Related issues

N/A (not preferable)

#### Testing

I did manual test only: restart VS Code, reopen it in the container and verify this warning is no longer there

#### Readability checklist
