### PR TITLE
feat(tv-casting-app): Phase 2 APK size reduction (2.8 MB → 2.6 MB) (#71482)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -392,6 +392,8 @@ delayedQueryActionTimeSec
 delayQuery
 deliverables
 demangle
+dep
+Depacketization
 deployable
 depottools
 deps
@@ -551,6 +553,7 @@ evk
 EVSE
 exceptfds
 ExchangeContext
+Excludable
 exe
 ExecStart
 executables
@@ -609,6 +612,7 @@ fvisibility
 FW
 Fxx
 gbl
+gc
 gcloud
 GDB
 gdbgui
@@ -667,6 +671,7 @@ gzbf
 HaloaceticAcidsConcentrationMeasurement
 HandleCommand
 hardcoded
+hardcodes
 hardknott
 hardwarever
 HardwareVersion
@@ -746,6 +751,7 @@ integrations
 IntelliSense
 InteractionModelEngine
 InteractionModelVersion
+interop
 Interoperable
 introvideos
 InvokeCommandRequests
@@ -785,6 +791,7 @@ jre
 js
 json
 jsoncpp
+jsontlv
 JTAG
 Jupyter
 jupyterlab
@@ -850,6 +857,7 @@ lightin
 LightingApp
 LightingColor
 LightingState
+linker's
 LinkSoftwareAndDocumentationPack
 lladdr
 LocalConfigDisabled
@@ -1614,6 +1622,7 @@ vous
 VPN
 VSC
 VSCode
+vtable
 WaitNewInputEvent
 WakeOnLan
 WantedBy

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1300,6 +1300,7 @@ RTL
 rtld
 RTOS
 RTT
+RTTI
 RTX
 runArgs
 runIf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -294,7 +294,20 @@ jobs:
                   type-safe getters
               if: always()
               run: |
-                  git grep -I -n 'emberAfReadAttribute' -- './*' ':(exclude).github/workflows/lint.yml' ':(exclude)src/app/util/attribute-table.h' ':(exclude)zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp' ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors.cpp.zapt' ':(exclude)src/app/util/attribute-table.cpp'  && exit 1 || exit 0
+                  git grep -I -n 'emberAfReadAttribute' -- './*'                                                    \
+                      ':(exclude).agents/skills/'                                                                   \
+                      ':(exclude).github/workflows/lint.yml'                                                        \
+                      ':(exclude)AGENTS.md'                                                                  \
+                      ':(exclude)examples/tv-casting-app/tv-casting-common/Accessors-override.cpp'                   \
+                      ':(exclude)src/app/dynamic_server/DynamicDispatcher.cpp'                                      \
+                      ':(exclude)src/app/util/attribute-table.cpp'                                                  \
+                      ':(exclude)src/app/util/attribute-table.h'                                                    \
+                      ':(exclude)src/app/util/mock/CodegenEmberMocks.cpp'                                           \
+                      ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors.cpp.zapt'                 \
+                      ':(exclude)src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm'                         \
+                      ':(exclude)src/data-model-providers/codegen/ClusterIntegration.cpp'                           \
+                      ':(exclude)zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp'        \
+                      && exit 1 || exit 0
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,
@@ -309,8 +322,11 @@ jobs:
                   git grep -I -n 'emberAfWriteAttribute' -- './*'                                            \
                       ':(exclude).github/workflows/lint.yml'                                                 \
                       ':(exclude)examples/common/pigweed/rpc_services/Attributes.h'                          \
-                      ':(exclude)src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp'     \
-                      ':(exclude)src/data-model-providers/codegen/tests/EmberReadWriteOverride.cpp'       \
+                      ':(exclude)examples/common/server-cluster-shim/ServerClusterShim.cpp'                  \
+                      ':(exclude)examples/tv-casting-app/tv-casting-common/Accessors-override.cpp'            \
+                      ':(exclude)src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp'        \
+                      ':(exclude)src/data-model-providers/codegen/tests/EmberReadWriteOverride.cpp'          \
+                      ':(exclude)src/data-model-providers/codegen/tests/EmberReadWriteOverride.h'            \
                       ':(exclude)src/app/dynamic_server/DynamicDispatcher.cpp'                               \
                       ':(exclude)src/app/util/attribute-table.cpp'                                           \
                       ':(exclude)src/app/util/attribute-table.h'                                             \

--- a/build/chip/java/config.gni
+++ b/build/chip/java/config.gni
@@ -23,26 +23,6 @@ declare_args() {
   # If the 'matter_enable_java_generated_api' feature is enabled, this feature must be enabled.
   matter_enable_tlv_decoder_api = true
 
-  # Controls compilation of the C++ ZAP-generated TLV decoder files
-  # (CHIPAttributeTLVValueDecoder.cpp, CHIPEventTLVValueDecoder.cpp).
-  # These files reference app::DataModel::Decode() for every cluster,
-  # creating a link-time dependency on all ~200+ cluster implementations.
-  # Apps that use the slim cluster-objects override and don't call the
-  # C++ TLV decode path (e.g. the casting app's simplified JNI API) can
-  # set this to false to break that dependency.  The Java-side
-  # ChipTLVValueDecoder.java is controlled separately by
-  # matter_enable_tlv_decoder_api above.
-  matter_enable_tlv_decoder_cpp = true
-
-  # When non-empty, compile this file instead of the zap-generated
-  # CHIPAttributeTLVValueDecoder.cpp.  Used by the casting app to
-  # supply a slim decoder covering only the 18 casting clusters.
-  chip_tlv_decoder_attribute_source_override = ""
-
-  # When non-empty, compile this file instead of the zap-generated
-  # CHIPEventTLVValueDecoder.cpp.  Same pattern as above.
-  chip_tlv_decoder_event_source_override = ""
-
   matter_enable_java_compilation = false
   if (java_home != "" && (current_os == "linux" || current_os == "mac")) {
     java_matter_controller_dependent_paths += [ "${java_home}/include/" ]

--- a/examples/tv-casting-app/APK_SIZE_ANALYSIS.md
+++ b/examples/tv-casting-app/APK_SIZE_ANALYSIS.md
@@ -8,24 +8,27 @@ Casting App on Android (arm64-v8a).
 
 ## 1. Optimized vs. Non-Optimized Comparison (arm64-v8a)
 
-| Metric                   | Default build               | Optimized build            | Reduction |
+| Metric                   | Default build               | Optimized build (phase 3)  | Reduction |
 | ------------------------ | --------------------------- | -------------------------- | --------- |
 |                          | `optimize_apk_size=false`   | `optimize_apk_size=true`   |           |
 |                          | `use_static_libcxx=false`   | `use_static_libcxx=true`   |           |
-| **`libTvCastingApp.so`** | 19 MB                       | 2.8 MB                     | 85 %      |
+| **`libTvCastingApp.so`** | 18 MB                       | 2.6 MB                     | 86 %      |
 | **`libc++_shared.so`**   | 8.9 MB (shipped separately) | 1.3 MB (statically linked) | 85 %      |
-| **Total native libs**    | 27.9 MB                     | 2.8 MB (single `.so`)      | 90 %      |
+| **Total native libs**    | 27.9 MB                     | 2.6 MB (single `.so`)      | 91 %      |
 
 ### What drives the reduction
 
-| Optimization                           | Mechanism                                                                                                                                       | Impact                                                                                                    |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Slim cluster-objects override          | Compile ~36 casting clusters instead of ~200+ via `chip_cluster_objects_source_override`                                                        | Major `.so` reduction                                                                                     |
-| Slim TLV decoder overrides             | Compile TLV decoders for 18 casting clusters only via `chip_tlv_decoder_attribute_source_override` and `chip_tlv_decoder_event_source_override` | Removes link-time deps on ~200+ clusters while keeping `ChipClusters.java` read/subscribe APIs functional |
-| Remove legacy chip-tool sources        | Exclude ~20 source files + tracing/JSON deps                                                                                                    | Further `.so` reduction                                                                                   |
-| Static libc++ with dead-code stripping | `−static-libstdc++` + `--gc-sections` + LTO                                                                                                     | Eliminates separate 8.9 MB `libc++_shared.so`; only referenced symbols survive                            |
-| Compiler / linker flags                | `-Os`, `-g0`, `-flto=thin`, `--icf=safe`, `-fvisibility=hidden`                                                                                 | ~10–20 % further `.so` reduction                                                                          |
-| R8 Java shrinking                      | `minifyEnabled true` in Gradle debug build                                                                                                      | Reduces DEX size (Java / Kotlin)                                                                          |
+| Optimization                           | Mechanism                                                                                                | Impact                                                                                                    |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Slim cluster-objects override          | Compile ~29 casting clusters instead of ~200+ via `chip_data_model_overrides_dir`                        | Major `.so` reduction                                                                                     |
+| Slim TLV decoder overrides             | Compile TLV decoders for 18 casting clusters only via `chip_data_model_overrides_dir`                    | Removes link-time deps on ~200+ clusters while keeping `ChipClusters.java` read/subscribe APIs functional |
+| Remove legacy chip-tool sources        | Exclude ~20 source files + tracing/JSON deps                                                             | Further `.so` reduction                                                                                   |
+| Static libc++ with dead-code stripping | `−static-libstdc++` + `--gc-sections` + LTO                                                              | Eliminates separate 8.9 MB `libc++_shared.so`; only referenced symbols survive                            |
+| Compiler / linker flags                | `-Os`, `-g0`, `-flto=thin`, `--icf=safe`, `-fvisibility=hidden`                                          | ~10–20 % further `.so` reduction                                                                          |
+| R8 Java shrinking                      | `minifyEnabled true` in Gradle debug build                                                               | Reduces DEX size (Java / Kotlin)                                                                          |
+| Cluster server exclusion (phase 3)     | Compile only 13 cluster server dirs via `chip_data_model_overrides_dir` + `cluster-servers-override.gni` | ~1.1 MB `.o` savings                                                                                      |
+| Slim Accessors.cpp (phase 3)           | Compile accessors for 29 clusters only via `chip_data_model_overrides_dir` + `Accessors-override.cpp`    | ~826 KB `.o` savings                                                                                      |
+| jsoncpp/jsontlv removal (phase 3)      | Not feasible — `AndroidCallbacks.cpp` and `AndroidInteractionClient.cpp` use jsontlv at runtime          | ~350 KB (not achievable)                                                                                  |
 
 ---
 
@@ -43,14 +46,12 @@ casting use case.
 -   Messaging layer (exchange management, protocol dispatch)
 -   Interaction model engine (read / write / invoke / subscribe)
 
-### Casting-specific clusters (39 clusters, ~157 `.ipp` includes)
+### Casting-specific clusters (29 clusters, ~116 `.ipp` includes)
 
-**Infrastructure clusters (21):** AccessControl, AdministratorCommissioning,
-BasicInformation, Binding, Descriptor, EthernetNetworkDiagnostics, FixedLabel,
-GeneralCommissioning, GeneralDiagnostics, GroupKeyManagement, Groups,
-IcdManagement, Identify, LocalizationConfiguration, NetworkCommissioning,
-OperationalCredentials, SoftwareDiagnostics, TimeFormatLocalization,
-TimeSynchronization, UnitLocalization, UserLabel, WiFiNetworkDiagnostics
+**Infrastructure clusters (12):** AccessControl, AdministratorCommissioning,
+BasicInformation, Binding, Descriptor, GeneralCommissioning, GeneralDiagnostics,
+GroupKeyManagement, Groups, Identify, NetworkCommissioning,
+OperationalCredentials
 
 **Casting clusters (17):** AccountLogin, ApplicationBasic, ApplicationLauncher,
 AudioOutput, Channel, ContentAppObserver, ContentControl, ContentLauncher,
@@ -78,11 +79,10 @@ TargetNavigator, WakeOnLan
 ### Java controller interaction model
 
 -   `android_chip_im_jni` — interaction model JNI bindings
--   Slim TLV decoders (`casting-CHIPAttributeTLVValueDecoder.cpp`,
-    `casting-CHIPEventTLVValueDecoder.cpp`) — hand-maintained files covering
+-   Slim TLV decoders (`CHIPAttributeTLVValueDecoder-override.cpp`,
+    `CHIPEventTLVValueDecoder-override.cpp`) — hand-maintained files covering
     only the 18 casting clusters, selected at build time via
-    `chip_tlv_decoder_attribute_source_override` and
-    `chip_tlv_decoder_event_source_override`. These keep `ChipClusters.java`
+    `chip_data_model_overrides_dir`. These keep `ChipClusters.java`
     read/subscribe APIs functional at runtime while avoiding link-time
     dependencies on all ~200+ cluster implementations.
 
@@ -107,8 +107,12 @@ TargetNavigator, WakeOnLan
 
 -   ~164 non-casting cluster implementations (DoorLock, Thermostat,
     PumpConfigurationAndControl, etc.)
+-   ~31 non-casting cluster server implementations (phase 3 — only 13 of ~44
+    cluster server directories are compiled)
 -   Full zap-generated TLV decoder files for all ~200+ clusters (replaced by
     slim 18-cluster versions)
+-   Full zap-generated Accessors.cpp for all ~200+ clusters (phase 3 — replaced
+    by slim 29-cluster `Accessors-override.cpp`)
 -   Legacy chip-tool command sources (`Command.cpp`, `Commands.cpp`,
     `CHIPCommand.cpp`, `RemoteDataModelLogger.cpp`, etc.)
 -   Tracing dependencies (`commandline`, `json`, `jsoncpp`)
@@ -146,7 +150,7 @@ overhead is removed.
 
 | Component                                         | Estimated size   | Notes                                                                  |
 | ------------------------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `libTvCastingApp.so` (arm64-v8a, optimized)       | 2.8 MB           | Measured — primary size contributor                                    |
+| `libTvCastingApp.so` (arm64-v8a, optimized)       | 2.6 MB           | Measured post-phase 3 — primary size contributor                       |
 | Java casting API classes (`com.matter.casting.*`) | ~0.1 MB          | `TvCastingApp.jar` is 91 KB                                            |
 | `CHIPInteractionModel.jar`                        | ~7.3 MB (pre-R8) | Shrinks significantly with R8 — only casting-relevant classes retained |
 | `AndroidPlatform.jar`                             | ~54 KB           | Platform abstraction                                                   |
@@ -156,7 +160,7 @@ overhead is removed.
 
 | Scenario                                               | Estimated size |
 | ------------------------------------------------------ | -------------- |
-| Native library only (`libTvCastingApp.so`, arm64-v8a)  | 2.8 MB         |
+| Native library only (`libTvCastingApp.so`, arm64-v8a)  | 2.6 MB         |
 | Native + Java classes (before R8)                      | ~10 MB         |
 | Native + Java classes (after R8 shrinking by host app) | ~4–5 MB        |
 | Compressed in APK (ZIP deflate, single ABI)            | ~2–3 MB        |
@@ -216,11 +220,10 @@ The `size-optimized` modifier sets the following GN args automatically:
 
 For the TV Casting App specifically, the build also sets:
 
--   `chip_cluster_objects_source_override` — slim cluster-objects (~36 clusters)
--   `chip_tlv_decoder_attribute_source_override` — slim attribute TLV decoder
-    (18 casting clusters)
--   `chip_tlv_decoder_event_source_override` — slim event TLV decoder (18
-    casting clusters)
+-   `chip_data_model_overrides_dir` — points to the `tv-casting-common/`
+    directory containing all slim override files (cluster-objects, TLV decoders,
+    cluster servers, and accessors). The build system looks for well-known
+    filenames inside this directory and uses them as source overrides.
 
 Output lands in `out/android-arm64-tv-casting-app-size-optimized/`.
 
@@ -238,17 +241,17 @@ ls -lh out/android-arm64-tv-casting-app-size-optimized/lib/jni/arm64-v8a/*.so
 
 Expected results (arm64-v8a, March 2026):
 
-| File                 | Default     | Optimized                  |
-| -------------------- | ----------- | -------------------------- |
-| `libTvCastingApp.so` | 19 MB       | 2.8 MB                     |
-| `libc++_shared.so`   | 8.9 MB      | 1.3 MB (static, folded in) |
-| **Total**            | **27.9 MB** | **2.8 MB**                 |
+| File                 | Default     | Optimized                       |
+| -------------------- | ----------- | ------------------------------- |
+| `libTvCastingApp.so` | 19 MB       | 2.6 MB (measured, post-phase 3) |
+| `libc++_shared.so`   | 8.9 MB      | 1.3 MB (static, folded in)      |
+| **Total**            | **27.9 MB** | **2.6 MB**                      |
 
 ### Desktop — Build with slim cluster set (for cluster vetting)
 
 The tv-casting-app desktop build already uses the slim
-`casting-cluster-objects.cpp` (set via `chip_cluster_objects_source_override` in
-the platform `args.gni`). This makes it a fast way to verify that the reduced
+`cluster-objects-override.cpp` (set via `chip_data_model_overrides_dir` in the
+platform `args.gni`). This makes it a fast way to verify that the reduced
 cluster set compiles and links correctly without needing the Android SDK.
 
 On macOS (Apple Silicon):
@@ -270,7 +273,7 @@ registers all cluster commands (including UnitTesting) and will fail to link
 against the slim cluster file.
 
 The resulting `chip-tv-casting-app` binary uses the same
-`casting-cluster-objects.cpp` that the optimized Android build now uses, so a
+`cluster-objects-override.cpp` that the optimized Android build now uses, so a
 successful build confirms the slim cluster file is self-consistent and no
 required symbols are missing.
 
@@ -280,7 +283,7 @@ To run it:
 out/darwin-arm64-tv-casting-app-chip-casting-simplified/chip-tv-casting-app
 ```
 
-If you modify `casting-cluster-objects.cpp` (e.g. adding or removing cluster
+If you modify `cluster-objects-override.cpp` (e.g. adding or removing cluster
 `.ipp` includes), rebuild the desktop target first — it compiles in seconds and
 will surface any missing-symbol errors immediately, before waiting for a full
 Android build.
@@ -302,15 +305,15 @@ python -m pytest examples/tv-casting-app/tests/ -v
 
 ### What each test file validates
 
-| Test file                                 | What it catches                                                                                                                                                                                                                                                       |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `test_cluster_set_membership.py`          | The slim attribute and event decoders contain case statements for exactly the 18 casting clusters — no more, no less. Catches accidental cluster additions or removals.                                                                                               |
-| `test_non_casting_error_handling.py`      | Both decoders have a `default:` case that sets the correct `CHIP_ERROR_IM_MALFORMED_*_PATH_IB` error and returns `nullptr`. Catches missing error paths for non-casting cluster IDs.                                                                                  |
-| `test_interface_compatibility.py`         | The `#include` sets and function signatures (`DecodeAttributeValue`, `DecodeEventValue`) in the slim decoders match the full zap-generated decoders. Catches link-time incompatibilities with the JNI bridge.                                                         |
-| `test_decode_logic_equivalence.py`        | For each of the 18 casting clusters, the switch-case body in the slim decoder is identical (modulo whitespace) to the full zap-generated decoder. Catches copy-paste drift when upstream zap templates change.                                                        |
-| `test_gn_conditional_source_selection.py` | `src/controller/java/BUILD.gn` contains `if (override != "")` conditionals for both attribute and event decoder overrides, with correct fallback to the zap-generated files. Catches broken GN plumbing.                                                              |
-| `test_android_py_casting_args.py`         | `scripts/build/builders/android.py` sets the slim decoder override paths for `TV_CASTING_APP` when `optimize_size` is true, does not disable `matter_enable_tlv_decoder_cpp`, and preserves the existing cluster-objects override. Catches build-script regressions.  |
-| `test_preservation_non_casting_builds.py` | `config.gni` declares the override args with empty-string defaults and keeps `matter_enable_tlv_decoder_cpp = true`. The `args.gni` default (non-optimized) block does not set any overrides. Catches regressions that would break non-casting or non-Android builds. |
+| Test file                                 | What it catches                                                                                                                                                                                                                         |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test_cluster_set_membership.py`          | The slim attribute and event decoders contain case statements for exactly the 18 casting clusters — no more, no less. Catches accidental cluster additions or removals.                                                                 |
+| `test_non_casting_error_handling.py`      | Both decoders have a `default:` case that sets the correct `CHIP_ERROR_IM_MALFORMED_*_PATH_IB` error and returns `nullptr`. Catches missing error paths for non-casting cluster IDs.                                                    |
+| `test_interface_compatibility.py`         | The `#include` sets and function signatures (`DecodeAttributeValue`, `DecodeEventValue`) in the slim decoders match the full zap-generated decoders. Catches link-time incompatibilities with the JNI bridge.                           |
+| `test_decode_logic_equivalence.py`        | For each of the 18 casting clusters, the switch-case body in the slim decoder is identical (modulo whitespace) to the full zap-generated decoder. Catches copy-paste drift when upstream zap templates change.                          |
+| `test_gn_conditional_source_selection.py` | `src/controller/java/BUILD.gn` contains `if (chip_data_model_overrides_dir != "")` conditionals for TLV decoder overrides, with correct fallback to the zap-generated files. Catches broken GN plumbing.                                |
+| `test_android_py_casting_args.py`         | `scripts/build/builders/android.py` sets `chip_data_model_overrides_dir` for `TV_CASTING_APP` when `optimize_size` is true, and preserves the existing cluster-objects override. Catches build-script regressions.                      |
+| `test_preservation_non_casting_builds.py` | `common_flags.gni` declares `chip_data_model_overrides_dir` with empty-string default. The `args.gni` default (non-optimized) block does not set any overrides. Catches regressions that would break non-casting or non-Android builds. |
 
 ### When to run them
 
@@ -322,5 +325,436 @@ python -m pytest examples/tv-casting-app/tests/ -v
 
 ---
 
-_Updated March 2026 with measured build sizes after slim TLV decoder
-integration._ _Validates: Requirements 2.1, 2.2, 2.3, 2.4_
+_Updated March 2026 with measured build sizes after slim TLV decoder integration
+and phase 3 optimizations._ _Validates: Requirements 2.1, 2.2, 2.3, 2.4_
+
+---
+
+## 6. Phase 2 Optimizations (~2.8 MB → ~2.6 MB)
+
+Phase 1 reduced `libTvCastingApp.so` from 19 MB to 2.8 MB. Phase 2 targets an
+additional ~200 KB reduction by trimming non-essential infrastructure from the
+already-slim binary. All changes are gated behind `optimize_apk_size=true`.
+
+### Phase 2 optimization summary
+
+| Optimization                     | Mechanism                                                                                                                                                                 | Estimated savings |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| Cluster trimming (10 clusters)   | Remove `.ipp` includes for 10 non-essential infrastructure clusters from `cluster-objects-override.cpp` and disable their server-side definitions in `tv-casting-app.zap` | ~400–500 KB       |
+| Disable extra data-model logging | Set `chip_data_model_extra_logging=false` — excludes verbose log-formatting code and string tables for attribute/command path names                                       | ~100–150 KB       |
+| Disable host unit-test hooks     | Set `CONFIG_BUILD_FOR_HOST_UNIT_TEST=0` — excludes test-only code paths in CASESession, ExchangeContext, FabricTable, and MRP configuration                               | ~50–100 KB        |
+| Disable RTTI                     | Set `enable_rtti=false` — removes `type_info` structures and vtable metadata generated by the C++ compiler                                                                | ~100–200 KB       |
+| Remove ICD client dependencies   | Exclude `src/app/icd/client:handler` and `src/app/icd/client:manager` from the tv-casting-common build target                                                             | ~50–100 KB        |
+
+### Clusters removed in phase 2
+
+The following 10 infrastructure clusters were removed from the slim cluster file
+and disabled in the ZAP server-side configuration. A casting client does not
+serve these clusters — they are diagnostic, localization, and management
+clusters irrelevant to the casting use case:
+
+-   EthernetNetworkDiagnostics
+-   SoftwareDiagnostics
+-   WiFiNetworkDiagnostics
+-   TimeSynchronization
+-   TimeFormatLocalization
+-   UnitLocalization
+-   FixedLabel
+-   UserLabel
+-   IcdManagement
+-   LocalizationConfiguration
+
+The 12 commissioning-essential clusters (AccessControl,
+AdministratorCommissioning, BasicInformation, Binding, Descriptor,
+GeneralCommissioning, GeneralDiagnostics, GroupKeyManagement, Groups, Identify,
+NetworkCommissioning, OperationalCredentials) and all 17 casting-specific
+clusters are retained.
+
+### Updated cluster counts (post-phase 2)
+
+| Category                                | Count           | Change                |
+| --------------------------------------- | --------------- | --------------------- |
+| Infrastructure clusters (commissioning) | 12              | Unchanged             |
+| Casting clusters                        | 17              | Unchanged             |
+| Non-essential infrastructure (removed)  | 10              | Removed in phase 2    |
+| **Total in slim cluster file**          | **29 + shared** | Down from 39 + shared |
+| `.ipp` includes                         | ~116            | Down from ~157        |
+
+### Updated size comparison (arm64-v8a)
+
+| Metric                | Default build | Phase 1 optimized | Phase 2 optimized | Phase 2 reduction |
+| --------------------- | ------------- | ----------------- | ----------------- | ----------------- |
+| `libTvCastingApp.so`  | 18 MB         | 2.8 MB            | 2.6 MB            | 7 % vs phase 1    |
+| `libc++_shared.so`    | 8.9 MB        | 1.3 MB (static)   | 1.3 MB (static)   | —                 |
+| **Total native libs** | **26.9 MB**   | **2.8 MB**        | **2.6 MB**        | **~7 %**          |
+
+### Phase 2 GN arguments
+
+These arguments are passed automatically by `android.py` when building the
+`android-arm64-tv-casting-app-size-optimized` target:
+
+| Argument                          | Value    | Set by                                                    |
+| --------------------------------- | -------- | --------------------------------------------------------- |
+| `chip_data_model_extra_logging`   | `false`  | `android.py` (TV_CASTING_APP only)                        |
+| `enable_rtti`                     | `false`  | `android.py` (TV_CASTING_APP only)                        |
+| `CONFIG_BUILD_FOR_HOST_UNIT_TEST` | `0`      | `BUILD.gn` config defines (when `optimize_apk_size=true`) |
+| ICD client deps                   | excluded | `BUILD.gn` conditional (when `optimize_apk_size=true`)    |
+
+### Phase 2 property tests
+
+New test files in `examples/tv-casting-app/tests/`:
+
+| Test file                        | What it validates                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------------- |
+| `test_phase2_cluster_removal.py` | Removed clusters absent, retained clusters present, command metadata consistency  |
+| `test_phase2_zap_clusters.py`    | ZAP server-side disabled for removed clusters, enabled for commissioning clusters |
+| `test_phase2_android_py_args.py` | android.py passes phase 2 GN args for TV_CASTING_APP only                         |
+| `test_phase2_build_config.py`    | CHIPProjectAppConfig.h conditional, BUILD.gn ICD dep conditional                  |
+| `test_phase2_rtti_icd_safety.py` | No RTTI or ICD client usage in casting common C++ sources                         |
+
+---
+
+_Updated March 2026 with phase 2 optimizations: cluster trimming, extra logging,
+unit-test hooks, RTTI, and ICD removal._
+
+---
+
+## 7. Phase 3 Optimizations (~2.6 MB → ~2.3 MB estimated)
+
+Phase 2 reduced `libTvCastingApp.so` from 2.8 MB to 2.6 MB. Phase 3 targets an
+additional ~2.3 MB of `.o` file bloat identified through binary analysis of the
+size-optimized arm64 build. Four optimization areas were investigated; three are
+implemented and one is documented as future work.
+
+All changes are gated behind `optimize_apk_size=true`. Default builds and
+non-casting-app targets remain unaffected.
+
+### Phase 3 optimization summary
+
+| Optimization              | Mechanism                                                        | `.o` file savings | Status       |
+| ------------------------- | ---------------------------------------------------------------- | ----------------- | ------------ |
+| Cluster server exclusion  | `chip_data_model_overrides_dir` + `cluster-servers-override.gni` | ~1.1 MB           | Implemented  |
+| Slim Accessors.cpp        | `chip_data_model_overrides_dir` + `Accessors-override.cpp`       | ~826 KB           | Implemented  |
+| jsoncpp/jsontlv removal   | Conditional dep in `src/controller/java/BUILD.gn`                | ~350 KB           | Not feasible |
+| Controller code reduction | Requires controller library refactoring                          | ~1.3 MB           | Future work  |
+| **Total implemented**     |                                                                  | **~1.9 MB (.o)**  |              |
+
+The `.o` file savings represent uncompressed object file sizes before linking.
+After LTO (thin link-time optimization), ICF (identical code folding), and
+`--gc-sections` dead-code stripping, the actual `.so` reduction is smaller.
+Measured result: `libTvCastingApp.so` remains at 2.6 MB (same as phase 2). The
+linker was already stripping the unused cluster server code and accessor
+functions in earlier phases via `--gc-sections` and LTO. The phase 3 changes
+still provide value by reducing compile time, intermediate object file sizes,
+and making the build explicit about what's needed — preventing regressions if
+LTO/gc-sections behavior changes upstream.
+
+### 7.1 Cluster server exclusion (~1.1 MB .o savings)
+
+**Problem:** The `chip_data_model` GN template calls `zap_cluster_list.py` to
+discover ALL server-side cluster implementations from the `.matter` file. The
+casting app's `.matter` file declares ~44 clusters, but only ~13 need server
+implementations (12 commissioning + ContentAppObserver). The remaining ~31
+cluster server directories are compiled unnecessarily.
+
+**Mechanism:** The `chip_data_model_overrides_dir` GN argument in
+`src/app/common_flags.gni` points to a directory containing well-known override
+files. When set to a non-empty path, the `chip_data_model` template imports
+`cluster-servers-override.gni` from the override directory and uses its cluster
+list instead of calling `zap_cluster_list.py`. Both `public_deps` (cluster
+server sources) and `_app_config_dependent_sources` are scoped to the override
+clusters only.
+
+**Override file:**
+`examples/tv-casting-app/tv-casting-common/cluster-servers-override.gni` defines
+exactly 13 cluster server directories:
+
+-   `access-control-server`, `administrator-commissioning-server`,
+    `basic-information`, `bindings`, `descriptor`,
+    `general-commissioning-server`, `general-diagnostics-server`,
+    `group-key-management-server`, `groups-server`, `identify-server`,
+    `network-commissioning`, `operational-credentials-server`,
+    `content-app-observer`
+
+**Default behavior:** When `chip_data_model_overrides_dir` is empty (default),
+the template calls `zap_cluster_list.py` as before — no change for non-casting
+builds.
+
+### 7.2 Slim Accessors.cpp (~826 KB .o savings)
+
+**Problem:** `chip_data_model.gni` hardcodes the full
+`zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp`
+which contains attribute getter/setter functions for ALL ~200+ clusters. Only
+the 29 casting-relevant clusters' accessors are needed (12 commissioning + 17
+casting).
+
+**Mechanism:** The `chip_data_model_overrides_dir` GN argument in
+`src/app/common_flags.gni` points to a directory containing well-known override
+files. When set to a non-empty path, the `chip_data_model` template compiles
+`Accessors-override.cpp` from the override directory instead of the full
+generated Accessors.cpp.
+
+**Override file:**
+`examples/tv-casting-app/tv-casting-common/Accessors-override.cpp` is a
+hand-maintained slim file containing attribute accessor functions for only the
+29 casting-relevant clusters. It includes the same `Accessors.h` header and
+provides identical function signatures for the retained clusters.
+
+**Retained clusters (29):**
+
+-   **Commissioning (12):** AccessControl, AdministratorCommissioning,
+    BasicInformation, Binding, Descriptor, GeneralCommissioning,
+    GeneralDiagnostics, GroupKeyManagement, Groups, Identify,
+    NetworkCommissioning, OperationalCredentials
+-   **Casting (17):** AccountLogin, ApplicationBasic, ApplicationLauncher,
+    AudioOutput, Channel, ContentAppObserver, ContentControl, ContentLauncher,
+    KeypadInput, LevelControl, LowPower, MediaInput, MediaPlayback, Messages,
+    OnOff, TargetNavigator, WakeOnLan
+
+**Default behavior:** When `chip_data_model_overrides_dir` is empty (default),
+the full Accessors.cpp is compiled — no change for non-casting builds.
+
+### 7.3 jsoncpp/jsontlv removal (~350 KB — not feasible)
+
+**Problem:** `android_chip_im_jni` and the `jni` shared library in
+`src/controller/java/BUILD.gn` both depend on `src/lib/support/jsontlv`, which
+pulls in `jsoncpp` (~350 KB).
+
+**Investigation:** Initial analysis suggested the casting app does not use
+JSON-TLV conversion at runtime. However, build testing revealed that
+`AndroidCallbacks.cpp` and `AndroidInteractionClient.cpp` — both core files in
+`android_chip_im_jni` — call `JsonToTlv()`, `TlvToJson()`, and `ConvertTlvTag()`
+directly. These functions are used for:
+
+-   Converting command invoke payloads from JSON to TLV
+    (`AndroidInteractionClient.cpp`)
+-   Converting attribute/event report TLV to JSON for Java callbacks
+    (`AndroidCallbacks.cpp`)
+-   Converting write attribute payloads from JSON to TLV
+    (`AndroidInteractionClient.cpp`)
+
+These are core interaction model operations that the casting app uses at runtime
+for sending commands, reading attributes, and subscribing to events on the
+remote TV/player endpoint.
+
+**Conclusion:** The jsontlv dependency **cannot be removed** without also
+wrapping all call sites in `AndroidCallbacks.cpp` and
+`AndroidInteractionClient.cpp` with conditionals and providing alternative code
+paths — a significantly larger refactoring effort. The ~350 KB savings is
+documented as a future optimization opportunity that would require restructuring
+the JNI interaction model layer to separate JSON-based APIs from binary TLV-only
+APIs.
+
+### 7.4 Controller code reduction (~1.3 MB — future work)
+
+Setting `chip_support_commissioning_in_controller=false` for the casting app
+**will cause link failures**. The dependency chain is too entangled for a simple
+flag flip. A clean split requires restructuring the controller library, which is
+a larger refactoring effort suitable for a future phase.
+
+#### Dependency chain
+
+```
+libTvCastingApp.so (examples/tv-casting-app/android/BUILD.gn :jni)
+  └─ tv-casting-common (examples/tv-casting-app/tv-casting-common/BUILD.gn)
+       └─ ${chip_root}/src/controller  (src/controller/BUILD.gn :controller)
+```
+
+#### What the casting app uses from `src/controller`
+
+1. **`controller/CHIPCluster.h` (`ClusterBase`)** — Used by `BaseCluster.h` and
+   `MediaClusterBase` for sending commands, reading attributes, and subscribing
+   to the remote TV/player endpoint. In the `:interactions` source set, always
+   compiled regardless of `chip_support_commissioning_in_controller`.
+
+2. **`controller/CHIPCommissionableNodeController.h/.cpp`** — Used by
+   `CastingPlayerDiscovery` to discover casting targets. Calls
+   `DiscoverCommissioners()`, `StopDiscovery()`,
+   `RegisterDeviceDiscoveryDelegate()`, and `GetDiscoveredCommissioner()`.
+
+3. **`controller/DeviceDiscoveryDelegate.h`** — Header-only discovery delegate
+   interface. Always available.
+
+#### Why the flag flip breaks
+
+Setting `chip_support_commissioning_in_controller=false` excludes **all** `.cpp`
+files in the conditional, including two the casting app needs:
+
+-   `AbstractDnssdDiscoveryController.cpp` — base class of
+    `CommissionableNodeController`
+-   `CHIPCommissionableNodeController.cpp` — discovery of casting targets
+
+The linker fails with unresolved symbols for `DiscoverCommissioners()`,
+`GetDiscoveredCommissioner()`, `OnNodeDiscovered()`, etc.
+
+#### Files inside the conditional
+
+| File                                      | Size (approx.) | Needed by casting?   |
+| ----------------------------------------- | -------------- | -------------------- |
+| `AbstractDnssdDiscoveryController.cpp`    | small          | **YES** — base class |
+| `CHIPCommissionableNodeController.cpp`    | small          | **YES** — discovery  |
+| `AutoCommissioner.cpp`                    | medium         | No                   |
+| `CHIPDeviceControllerFactory.cpp`         | ~90 KB         | No                   |
+| `CommissioneeDeviceProxy.cpp`             | medium         | No                   |
+| `CommissionerDiscoveryController.cpp`     | medium         | No                   |
+| `CommissioningDelegate.cpp`               | medium         | No                   |
+| `ExampleOperationalCredentialsIssuer.cpp` | medium         | No                   |
+| `SetUpCodePairer.cpp`                     | medium         | No                   |
+| `CHIPDeviceController.cpp`                | ~970 KB        | No                   |
+| `CommissioningWindowOpener.cpp`           | ~167 KB        | No                   |
+| `CurrentFabricRemover.cpp`                | ~86 KB         | No                   |
+
+#### JNI layer analysis
+
+The casting app's `jni` shared library depends on
+`${chip_root}/src/controller/java:android_chip_im_jni` (interaction model JNI
+bindings), **not** on the full controller JNI (`libCHIPController.so`). The full
+controller JNI is deeply entangled with commissioner code
+(`AndroidDeviceControllerWrapper`, `CHIPDeviceController-JNI`, etc.), but the
+casting app does not use it. The problem is the direct dependency from
+`tv-casting-common` on `src/controller`.
+
+#### Future refactoring approach
+
+To achieve the ~1.3 MB savings, the controller library needs a finer-grained
+split:
+
+1. **Move discovery code to a separate `:discovery` source set** — Extract
+   `AbstractDnssdDiscoveryController.cpp` and
+   `CHIPCommissionableNodeController.cpp` into a new `:discovery` source set
+   that is always compiled.
+
+2. **Set `chip_support_commissioning_in_controller=false` after the split** —
+   With discovery code extracted, the remaining conditional files are all
+   commissioner-specific and can be safely excluded.
+
+3. **Estimated effort:** Medium — requires modifying `src/controller/BUILD.gn`,
+   updating `tv-casting-common/BUILD.gn` to depend on the split targets, and
+   verifying no transitive header dependencies pull in commissioner code. The
+   existing TODO comment in `BUILD.gn` notes that "these conditionals are NOT ok
+   and should have been solved with separate source sets."
+
+#### Estimated savings breakdown
+
+| File                              | Compiled size (arm64, -Os) | Status                                  |
+| --------------------------------- | -------------------------- | --------------------------------------- |
+| `CHIPDeviceController.cpp`        | ~970 KB                    | Excludable after split                  |
+| `CommissioningWindowOpener.cpp`   | ~167 KB                    | Excludable after split                  |
+| `CHIPDeviceControllerFactory.cpp` | ~90 KB                     | Excludable after split                  |
+| `CurrentFabricRemover.cpp`        | ~86 KB                     | Excludable after split                  |
+| `AutoCommissioner.cpp`            | ~50 KB (est.)              | Excludable after split                  |
+| Other commissioner files          | ~50 KB (est.)              | Excludable after split                  |
+| **Total potential savings**       | **~1.3 MB**                | Requires controller library refactoring |
+
+### Updated size comparison (arm64-v8a)
+
+| Metric                | Default build | Phase 1         | Phase 2         | Phase 3 (est.)  | Phase 3 reduction |
+| --------------------- | ------------- | --------------- | --------------- | --------------- | ----------------- |
+| `libTvCastingApp.so`  | 18 MB         | 2.8 MB          | 2.6 MB          | 2.6 MB          | 0 % vs phase 2    |
+| `libc++_shared.so`    | 8.9 MB        | 1.3 MB (static) | 1.3 MB (static) | 1.3 MB (static) | —                 |
+| **Total native libs** | **26.9 MB**   | **2.8 MB**      | **2.6 MB**      | **2.6 MB**      | **0 %**           |
+
+The phase 3 `.so` size is unchanged from phase 2. The ~1.9 MB of `.o` file
+savings from cluster server exclusion and slim Accessors.cpp were already being
+eliminated by the linker's `--gc-sections` and thin LTO in earlier phases. The
+phase 3 changes reduce compile time and intermediate object sizes, and make the
+build explicit about what's needed — preventing regressions if linker behavior
+changes upstream.
+
+### Phase 3 GN arguments
+
+All phase 3 overrides are controlled by the consolidated
+`chip_data_model_overrides_dir` argument, which is passed automatically by
+`android.py` when building the `android-arm64-tv-casting-app-size-optimized`
+target:
+
+| Argument                        | Value                                  | Set by                             |
+| ------------------------------- | -------------------------------------- | ---------------------------------- |
+| `chip_data_model_overrides_dir` | Path to `tv-casting-common/` directory | `android.py` (TV_CASTING_APP only) |
+
+When `chip_data_model_overrides_dir` is set, the build system looks for the
+following well-known filenames inside the directory and uses them as source
+overrides. When unset (empty string), all consumers fall back to the full
+zap-generated sources.
+
+| Well-known filename                         | Purpose                                     | Consumer                       |
+| ------------------------------------------- | ------------------------------------------- | ------------------------------ |
+| `cluster-objects-override.cpp`              | Slim cluster objects (~29 clusters)         | `src/app/common/BUILD.gn`      |
+| `CHIPAttributeTLVValueDecoder-override.cpp` | Slim attribute TLV decoder (18 clusters)    | `src/controller/java/BUILD.gn` |
+| `CHIPEventTLVValueDecoder-override.cpp`     | Slim event TLV decoder (18 clusters)        | `src/controller/java/BUILD.gn` |
+| `cluster-servers-override.gni`              | Cluster server directory list (13 clusters) | `src/app/chip_data_model.gni`  |
+| `Accessors-override.cpp`                    | Slim attribute accessors (29 clusters)      | `src/app/chip_data_model.gni`  |
+
+All GN arguments have inert defaults (empty string) so that non-casting builds
+are unaffected.
+
+### Phase 3 override files
+
+| File                           | Location             | Purpose                                                  |
+| ------------------------------ | -------------------- | -------------------------------------------------------- |
+| `cluster-servers-override.gni` | `tv-casting-common/` | Lists the 13 required cluster server directories         |
+| `Accessors-override.cpp`       | `tv-casting-common/` | Slim accessors for 29 casting-relevant clusters          |
+| `cluster-objects-override.cpp` | `tv-casting-common/` | (existing, phase 1) Slim cluster objects for 29 clusters |
+
+### Regenerating slim override files
+
+The slim override files can be regenerated from the full zap-generated sources
+using the `generate_slim_overrides.py` script. This is useful after upstream ZAP
+template changes modify the full generated files.
+
+```bash
+# From the repo root, after running `source scripts/activate.sh`:
+python3 examples/tv-casting-app/tv-casting-common/generate_slim_overrides.py \
+    examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml \
+    --output-dir examples/tv-casting-app/tv-casting-common/
+```
+
+The script reads `casting-cluster-config.yaml` which defines three cluster
+lists:
+
+-   `casting_clusters` (29 clusters) — used for `cluster-objects-override.cpp`
+    and `Accessors-override.cpp`
+-   `tlv_decoder_clusters` (18 clusters) — used for the slim TLV decoder files
+-   `cluster_servers` (13 directories) — used for `cluster-servers-override.gni`
+
+To add or remove clusters, edit the YAML config and re-run the script. The
+script produces byte-identical output when run with the same inputs
+(idempotent).
+
+### Phase 3 property tests
+
+Property-based tests for phase 3 are defined in the design document and validate
+the correctness of the new override mechanisms. They follow the same pattern as
+phase 1/2 tests in `examples/tv-casting-app/tests/`:
+
+| Property                              | What it validates                                                                       |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| Cluster server set membership         | Override list contains exactly the 13 required clusters, no extras, no duplicates       |
+| Slim accessors cluster set membership | Slim accessors file contains exactly the 29 casting clusters' namespaces                |
+| Slim accessors signature equivalence  | Function signatures in slim file match full Accessors.cpp for all retained clusters     |
+| Phase 3 args target isolation         | `android.py` sets phase 3 args only for TV_CASTING_APP; new GN args have inert defaults |
+
+Additional unit-level validations:
+
+| Validation                       | What it checks                                                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Override dir in GNI              | `common_flags.gni` declares `chip_data_model_overrides_dir` with empty default                                          |
+| Data model template conditionals | `chip_data_model.gni` has conditionals for accessors and cluster server overrides using `chip_data_model_overrides_dir` |
+| Default preservation             | Default builds (`optimize_apk_size=false`) are unaffected by all phase 3 changes                                        |
+
+### When to run phase 3 tests
+
+-   After modifying `Accessors-override.cpp` or `cluster-servers-override.gni`
+-   After changing `chip_data_model.gni`, `common_flags.gni`, `android.py`, or
+    `src/controller/java/BUILD.gn`
+-   Before pushing a commit that touches any phase 3 files
+
+```bash
+python -m pytest examples/tv-casting-app/tests/ -v
+```
+
+---
+
+_Updated April 2026 with Phase 3 optimizations: cluster server exclusion, slim
+Accessors.cpp, and controller code investigation. jsoncpp/jsontlv removal was
+investigated but found not feasible due to runtime usage in the JNI layer._

--- a/examples/tv-casting-app/DARWIN_SIZE_ANALYSIS.md
+++ b/examples/tv-casting-app/DARWIN_SIZE_ANALYSIS.md
@@ -10,8 +10,8 @@ version of the casting library into their apps.
 
 | Metric                           | Default build | Optimized build | Reduction |
 | -------------------------------- | ------------- | --------------- | --------- |
-| `libTvCastingCommon.a` (archive) | 210 MB        | 144 MB          | 31 %      |
-| `__TEXT` (actual code)           | 12.1 MB       | 2.8 MB          | 77 %      |
+| `libTvCastingCommon.a` (archive) | 184 MB        | 135 MB          | 27 %      |
+| `__TEXT` (actual code)           | 11.6 MB       | 2.7 MB          | 77 %      |
 | `__DATA`                         | 0.4 MB        | 0.3 MB          | 25 %      |
 
 The `.a` archive sizes (210 / 144 MB) include debug info, symbol tables, and
@@ -67,15 +67,17 @@ statically links the C++ standard library by default.
 
 ## 3. What the Darwin Build Already Optimizes
 
-The darwin `args.gni` already sets the slim cluster-objects override:
+The darwin `args.gni` already sets the override directory for slim source files:
 
 ```python
-chip_cluster_objects_source_override =
-    "${chip_root}/examples/tv-casting-app/tv-casting-common/casting-cluster-objects.cpp"
+chip_data_model_overrides_dir =
+    "${chip_root}/examples/tv-casting-app/tv-casting-common"
 ```
 
-This compiles only ~36 casting-relevant clusters instead of the full ~200+
-generated `cluster-objects.cpp`. This is the same slim file used by the Android
+This directs the build system to look for well-known override filenames in the
+`tv-casting-common/` directory. The slim `cluster-objects-override.cpp` compiles
+only ~36 casting-relevant clusters instead of the full ~200+ generated
+`cluster-objects.cpp`. This is the same slim file used by the Android
 size-optimized build.
 
 Additionally, the darwin casting bridge uses its own zap-generated Objective-C
@@ -222,7 +224,7 @@ bundles all transitive dependencies into a single `.a` file:
 
 -   Matter core (transport, crypto, secure channel, interaction model)
 -   Casting common C++ layer (CastingApp, CastingPlayer, Endpoint, etc.)
--   Cluster implementations (~36 via slim `casting-cluster-objects.cpp`)
+-   Cluster implementations (~36 via slim `cluster-objects-override.cpp`)
 -   App server, data model provider
 -   Darwin platform layer (BLE, DNS-SD via Bonjour, KeyValueStore)
 -   mbedTLS (crypto backend)
@@ -273,7 +275,7 @@ If you're building a new app (not migrating from the old API):
 | C++ stdlib              | Separate `libc++_shared.so` (or static)                     | Always statically linked by Apple toolchain                 |
 | Cluster API surface     | Java `ChipClusters.java` (all ~200+ clusters, shrunk by R8) | ObjC `MCClusterObjects` (9 casting clusters only)           |
 | TLV decoders            | C++ `CHIPAttributeTLVValueDecoder.cpp` (full or slim)       | ObjC zap-generated `MCAttributeObjects.mm` (already scoped) |
-| Slim cluster-objects    | ✅ via `chip_cluster_objects_source_override`               | ✅ via `chip_cluster_objects_source_override`               |
+| Slim cluster-objects    | ✅ via `chip_data_model_overrides_dir`                      | ✅ via `chip_data_model_overrides_dir`                      |
 | Legacy source exclusion | ✅ via `optimize_apk_size=true`                             | ✅ via `optimize_apk_size=true` (Release builds)            |
 | Build system            | GN → ninja → Gradle                                         | GN → ninja → Xcode                                          |
 
@@ -282,7 +284,7 @@ Android build because:
 
 1. The Objective-C cluster API is pre-scoped to casting clusters (no equivalent
    of the 200+ cluster `ChipClusters.java`)
-2. The slim `casting-cluster-objects.cpp` is already set in `args.gni`
+2. The slim `cluster-objects-override.cpp` is already set in `args.gni`
 3. There's no separate C++ stdlib shared library to worry about
 
 The main remaining opportunity is enabling `optimize_apk_size=true` to drop the
@@ -291,3 +293,84 @@ legacy chip-tool sources and their transitive dependencies.
 ---
 
 _March 2026 — Initial analysis of Darwin casting framework size._
+
+---
+
+## 9. Phase 2 Optimizations — Darwin Applicability
+
+Phase 2 of the APK size reduction effort introduces five additional
+optimizations for the Android size-optimized build. Some of these also apply to
+Darwin builds; others are Android-specific due to platform differences.
+
+### Optimizations that apply to Darwin
+
+| Optimization                   | Darwin applicability | Notes                                                                                                                                                                                                          |
+| ------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cluster trimming (10 clusters) | ✅ Applies           | The slim `cluster-objects-override.cpp` is shared between Android and Darwin. Removing 10 non-essential infrastructure clusters reduces code in `libTvCastingCommon.a` identically.                            |
+| ICD client removal             | ✅ Applies           | The `tv-casting-common/BUILD.gn` conditional excluding `icd/client:handler` and `icd/client:manager` applies to all platforms when `optimize_apk_size=true`. Darwin casting builds do not use ICD client APIs. |
+
+### Optimizations that are Android-specific
+
+| Optimization                                                             | Why it doesn't apply to Darwin                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Disable RTTI (`enable_rtti=false`)                                       | The Darwin Objective-C bridge (`MatterTvCastingBridge`) uses `typeid` in the ObjC-to-C++ interop layer. Disabling RTTI would break the bridge at compile time. RTTI is safe to disable only on Android where the JNI layer does not use `dynamic_cast` or `typeid`.                      |
+| Disable extra data-model logging (`chip_data_model_extra_logging=false`) | This GN arg is passed by `android.py` specifically for the `TV_CASTING_APP` target. Darwin builds use a separate build flow (Xcode + `chip_xcode_build_connector.sh`) and do not pass this argument. It could be added to `darwin/args.gni` in a future phase if desired.                |
+| Disable host unit-test hooks (`CONFIG_BUILD_FOR_HOST_UNIT_TEST=0`)       | The define override is applied via the `tv-casting-common/BUILD.gn` config block only when `optimize_apk_size=true`. While technically platform-agnostic, the primary motivation and testing is Android-focused. Darwin Release builds already strip test code via different mechanisms. |
+
+### Summary
+
+Of the five phase 2 optimizations, two (cluster trimming and ICD removal) are
+platform-agnostic and benefit Darwin builds automatically when
+`optimize_apk_size=true` is set. The remaining three (RTTI, extra logging,
+unit-test hooks) are Android-specific — RTTI cannot be disabled on Darwin due to
+`typeid` usage in the ObjC bridge, and the logging/test-hook flags are wired
+through the Android build pipeline.
+
+---
+
+_Updated March 2026 with phase 2 applicability notes for Darwin builds._
+
+---
+
+## 10. Phase 3 Optimizations — Darwin Applicability
+
+Phase 3 targets ~3.5 MB of additional binary bloat in the Android size-optimized
+build across four areas: cluster server exclusion, slim Accessors.cpp,
+jsoncpp/jsontlv removal, and controller code reduction. Some of these
+optimizations are platform-agnostic and can be adopted by Darwin builds; others
+are Android-specific.
+
+### Optimizations that apply to Darwin
+
+| Optimization             | Darwin applicability | How to enable                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cluster server exclusion | ✅ Applies           | The `chip_data_model_overrides_dir` GN arg is declared in `src/app/common_flags.gni` (platform-agnostic). Darwin builds set `chip_data_model_overrides_dir` in `darwin/args.gni` pointing to the `tv-casting-common/` directory, which contains `cluster-servers-override.gni` to compile only the 13 required cluster server implementations instead of all ~44 discovered from the `.matter` file. |
+| Slim Accessors.cpp       | ✅ Applies           | The `chip_data_model_overrides_dir` GN arg is declared in `src/app/common_flags.gni` (platform-agnostic). Darwin builds set `chip_data_model_overrides_dir` in `darwin/args.gni` pointing to the `tv-casting-common/` directory, which contains `Accessors-override.cpp` to compile only the 29 casting-relevant cluster accessors instead of the full ~200+ cluster Accessors.cpp.                  |
+
+Both override files are resolved automatically from the
+`chip_data_model_overrides_dir` already set in `darwin/args.gni`. No additional
+args.gni changes are needed since the override directory already contains all
+well-known override filenames (`cluster-objects-override.cpp`,
+`Accessors-override.cpp`, `cluster-servers-override.gni`, etc.).
+
+### Optimizations that are Android-specific
+
+| Optimization                                      | Why it doesn't apply to Darwin                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jsoncpp/jsontlv removal (~350 KB)                 | The jsontlv dependency is in `src/controller/java/BUILD.gn`, which is the Android JNI layer (`android_chip_im_jni` and the `jni` shared library). Darwin does not use the Java controller or JNI — the Objective-C bridge (`MatterTvCastingBridge`) has its own interaction path. This optimization has no effect on Darwin builds.                                                                                                                                                                         |
+| Controller code reduction (future work — ~1.3 MB) | The dependency chain analysis through the JNI layer (`AndroidDeviceControllerWrapper.cpp`, etc.) is Android-specific. The general finding that the casting app does not need commissioner code (`CHIPDeviceController.cpp`, `CommissioningWindowOpener.cpp`, etc.) applies to both platforms, but the JNI-layer refactoring required to cleanly split the controller library is an Android concern. Darwin builds could independently investigate excluding commissioner code through their own build flow. |
+
+### Summary
+
+Of the four phase 3 optimization areas, two (cluster server exclusion and slim
+Accessors.cpp) are platform-agnostic — they use the
+`chip_data_model_overrides_dir` GN arg declared in `src/app/common_flags.gni`
+and are adopted by Darwin builds via the override directory already set in
+`darwin/args.gni`. The jsoncpp/jsontlv removal is Android JNI-specific and does
+not apply to Darwin. The controller code reduction analysis identifies savings
+relevant to both platforms, but the implementation path is tied to the Android
+JNI dependency chain.
+
+---
+
+_Updated March 2026 with phase 3 applicability notes for Darwin builds._

--- a/examples/tv-casting-app/android/args.gni
+++ b/examples/tv-casting-app/android/args.gni
@@ -52,9 +52,7 @@ if (optimize_apk_size) {
   #   is_debug = false
   #   matter_enable_tracing_support = false
   #   use_static_libcxx = true
-  #   chip_tlv_decoder_attribute_source_override  (tv-casting-app only)
-  #   chip_tlv_decoder_event_source_override     (tv-casting-app only)
-  #   chip_cluster_objects_source_override        (tv-casting-app only)
+  #   chip_data_model_overrides_dir     (tv-casting-app only)
   #
   # The assignments below are kept for documentation and for any
   # build path that evaluates args.gni AFTER args.gn (e.g. a manual
@@ -62,18 +60,18 @@ if (optimize_apk_size) {
   chip_build_libshell = false
   optimize_for_size = true  # -Os (size) instead of -O2 (speed)
   symbol_level = 0  # -g0: no debug symbols
+  enable_rtti =
+      false  # Disable C++ RTTI to remove type_info and vtable overhead
 
-  # Slim TLV decoders covering only the 18 casting clusters.  These
-  # replace the full zap-generated decoders (~200+ clusters) at build
-  # time, keeping ChipClusters.java read/subscribe APIs functional
+  # Point the build at the override directory containing slim source
+  # files (cluster-objects, TLV decoders, accessors, cluster servers)
+  # covering only the ~36 casting-relevant clusters.  The build system
+  # resolves well-known filenames inside this directory automatically,
+  # replacing the full zap-generated sources (~200+ clusters) with slim
+  # versions that keep ChipClusters.java read/subscribe APIs functional
   # while reducing binary size.
-  chip_tlv_decoder_attribute_source_override = "${chip_root}/examples/tv-casting-app/tv-casting-common/casting-CHIPAttributeTLVValueDecoder.cpp"
-  chip_tlv_decoder_event_source_override = "${chip_root}/examples/tv-casting-app/tv-casting-common/casting-CHIPEventTLVValueDecoder.cpp"
-
-  # Compile only the ~36 casting-relevant clusters instead of the full
-  # generated cluster-objects.cpp (~200+ clusters).  This is the same
-  # slim file already used by Linux and Darwin builds.
-  chip_cluster_objects_source_override = "${chip_root}/examples/tv-casting-app/tv-casting-common/casting-cluster-objects.cpp"
+  chip_data_model_overrides_dir =
+      "${chip_root}/examples/tv-casting-app/tv-casting-common"
 } else {
   # Default development build: full debug features, fast compilation
   chip_build_libshell = true

--- a/examples/tv-casting-app/darwin/args.gni
+++ b/examples/tv-casting-app/darwin/args.gni
@@ -27,8 +27,11 @@ chip_project_config_include_dirs = [
 import(
     "${chip_root}/examples/tv-casting-app/tv-casting-common/tv-casting-common.gni")
 
-# Use slim cluster-objects: only the ~36 clusters a casting client needs.
-chip_cluster_objects_source_override = "${chip_root}/examples/tv-casting-app/tv-casting-common/casting-cluster-objects.cpp"
+# Use slim override sources: only the ~36 clusters a casting client needs.
+# The build system resolves well-known filenames inside this directory
+# automatically (cluster-objects, TLV decoders, accessors, cluster servers).
+chip_data_model_overrides_dir =
+    "${chip_root}/examples/tv-casting-app/tv-casting-common"
 
 if (optimize_apk_size) {
   # Size-optimized build: smaller framework, fewer debug features.

--- a/examples/tv-casting-app/tests/test_bug_condition_android_cluster_override.py
+++ b/examples/tv-casting-app/tests/test_bug_condition_android_cluster_override.py
@@ -1,20 +1,18 @@
 """
-Bug Condition Exploration Test — Property 1: Slim Cluster Override on Android
+Bug Condition Exploration Test — Property 1: Override Directory on Android
 
 Validates: Requirements 1.1, 2.1
 
 This test parses `examples/tv-casting-app/android/args.gni` and checks that
 when `optimize_apk_size = true`, the build configuration:
 
-  1. Sets `chip_cluster_objects_source_override` to the slim
-     `casting-cluster-objects.cpp` path (so only ~36 casting-relevant clusters
-     are compiled instead of all ~200+).
-  2. Sets `matter_enable_tlv_decoder_api = false` (so the Java TLV decoder
-     files that reference Decode() for every cluster are excluded, removing
-     the link-time dependency that blocks the slim override).
+  1. Sets `chip_data_model_overrides_dir` to the tv-casting-common directory
+     (so only ~36 casting-relevant clusters are compiled instead of all ~200+).
+     The directory-based override mechanism also handles TLV decoder overrides
+     via well-known filenames, eliminating the need for separate flags.
 
-EXPECTED on UNFIXED code: FAIL — the current `optimize_apk_size` block does
-NOT set either flag, confirming the bug exists.
+EXPECTED on FIXED code: PASS — the `optimize_apk_size` block sets
+`chip_data_model_overrides_dir` to the override directory.
 """
 
 import os
@@ -23,9 +21,9 @@ import re
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 # Helpers — lightweight GNI parser
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 ANDROID_ARGS_GNI = os.path.join(
@@ -36,7 +34,7 @@ SLIM_CLUSTER_FILE = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-cluster-objects.cpp",
+    "cluster-objects-override.cpp",
 )
 
 
@@ -53,10 +51,7 @@ def _strip_comments(text: str) -> str:
 
 def _extract_optimize_block(text: str) -> str:
     """
-    Extract the body of the first `if (optimize_apk_size)
-{
-    ...
-}` block.
+    Extract the body of the first `if (optimize_apk_size) { ... }` block.
 
     Uses a simple brace-depth counter — sufficient for the flat structure of
     args.gni files.
@@ -66,7 +61,7 @@ def _extract_optimize_block(text: str) -> str:
     if not match:
         return ""
 
-# Find the opening brace
+    # Find the opening brace
     start = stripped.index("{", match.end())
     depth = 1
     pos = start + 1
@@ -77,7 +72,7 @@ def _extract_optimize_block(text: str) -> str:
             depth -= 1
         pos += 1
 
-    return stripped[start + 1: pos - 1]
+    return stripped[start + 1:pos - 1]
 
 
 def _extract_assignment(block: str, var_name: str) -> str | None:
@@ -91,14 +86,9 @@ def _extract_assignment(block: str, var_name: str) -> str | None:
         return None
     return m.group(1).strip().rstrip(";").strip()
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-# Property - based test
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-
-# We use Hypothesis to parameterise over a(trivially small) strategy so the
-# test is formally a property - based test, but the real assertion is against the
-# concrete file on disk.The strategy generates a boolean flag that is always
-# True — representing `optimize_apk_size = true`.
+# ---------------------------------------------------------------------------
+# Property-based test
+# ---------------------------------------------------------------------------
 
 
 @given(optimize_apk_size=st.just(True))
@@ -113,51 +103,38 @@ def test_android_optimized_build_uses_slim_cluster_override(optimize_apk_size: b
 
     Property 1 (Bug Condition): For an Android build with
     `optimize_apk_size = true`, the GN args SHALL set
-    `chip_cluster_objects_source_override` to the slim
-    `casting-cluster-objects.cpp` AND set
-    `matter_enable_tlv_decoder_api = false`.
+    `chip_data_model_overrides_dir` to the tv-casting-common directory.
+    The directory-based override mechanism handles all source overrides
+    (cluster-objects, TLV decoders, accessors, cluster servers).
     """
     assert optimize_apk_size, "Test only applies when optimize_apk_size is true"
 
-# -- - Parse the android args.gni -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+    # --- Parse the android args.gni ---
     gni_text = _read_gni(ANDROID_ARGS_GNI)
     opt_block = _extract_optimize_block(gni_text)
     assert opt_block, (
         "Could not find `if (optimize_apk_size) { ... }` block in android/args.gni"
     )
 
-# -- - Assert 1 : chip_cluster_objects_source_override is set -- -- -- -- -- -- -- --
-    override_val = _extract_assignment(opt_block, "chip_cluster_objects_source_override")
+    # --- Assert 1: chip_data_model_overrides_dir is set ---
+    override_val = _extract_assignment(opt_block, "chip_data_model_overrides_dir")
     assert override_val is not None, (
-        "COUNTEREXAMPLE: `chip_cluster_objects_source_override` is NOT set inside "
+        "COUNTEREXAMPLE: `chip_data_model_overrides_dir` is NOT set inside "
         "the `optimize_apk_size` block of android/args.gni.  "
-        "The full generated cluster-objects.cpp (~200+ clusters) is still compiled "
+        "The full generated sources (~200+ clusters) are still compiled "
         "even when optimize_apk_size = true."
     )
 
-# The value should reference the slim casting - cluster - objects.cpp
-    assert "casting-cluster-objects.cpp" in override_val, (
-        f"COUNTEREXAMPLE: `chip_cluster_objects_source_override` is set to "
-        f"`{override_val}` which does not reference casting-cluster-objects.cpp"
-    )
-
-# -- - Assert 2 : matter_enable_tlv_decoder_api is false -- -- -- -- -- -- -- -- -- -- -
-    tlv_val = _extract_assignment(opt_block, "matter_enable_tlv_decoder_api")
-    assert tlv_val is not None, (
-        "COUNTEREXAMPLE: `matter_enable_tlv_decoder_api` is NOT set inside "
-        "the `optimize_apk_size` block of android/args.gni.  "
-        "The Java TLV decoders that reference Decode() for every cluster will "
-        "still be compiled, blocking use of the slim cluster override."
-    )
-    assert tlv_val == "false", (
-        f"COUNTEREXAMPLE: `matter_enable_tlv_decoder_api` is set to `{tlv_val}` "
-        f"instead of `false` — the TLV decoder dependency is not resolved."
+    # The value should reference the tv-casting-common directory
+    assert "tv-casting-common" in override_val, (
+        f"COUNTEREXAMPLE: `chip_data_model_overrides_dir` is set to "
+        f"`{override_val}` which does not reference tv-casting-common"
     )
 
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-# Allow running directly : python test_bug_condition_android_cluster_override.py
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
+# Allow running directly: python test_bug_condition_android_cluster_override.py
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     print("Running bug condition exploration test...")
     try:

--- a/examples/tv-casting-app/tests/test_cluster_set_membership.py
+++ b/examples/tv-casting-app/tests/test_cluster_set_membership.py
@@ -3,8 +3,8 @@ Property Test — Property 1: Casting cluster set membership (attribute & event 
 
 **Validates: Requirements 1.1, 2.1**
 
-This test parses `casting-CHIPAttributeTLVValueDecoder.cpp` and
-`casting-CHIPEventTLVValueDecoder.cpp` and verifies that the top-level switch
+This test parses `CHIPAttributeTLVValueDecoder-override.cpp` and
+`CHIPEventTLVValueDecoder-override.cpp` and verifies that the top-level switch
 in each contains case statements for exactly the 18 casting clusters — no more,
 no less.
 
@@ -28,14 +28,14 @@ SLIM_ATTR_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPAttributeTLVValueDecoder.cpp",
+    "CHIPAttributeTLVValueDecoder-override.cpp",
 )
 SLIM_EVENT_DECODER = os.path.join(
     REPO_ROOT,
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPEventTLVValueDecoder.cpp",
+    "CHIPEventTLVValueDecoder-override.cpp",
 )
 
 # ---------------------------------------------------------------------------
@@ -116,7 +116,7 @@ def test_each_expected_cluster_present_in_attribute_decoder(cluster):
 
     assert cluster in found_clusters, (
         f"Expected casting cluster `{cluster}` is missing from "
-        f"casting-CHIPAttributeTLVValueDecoder.cpp. "
+        f"CHIPAttributeTLVValueDecoder-override.cpp. "
         f"Found clusters: {sorted(found_clusters)}"
     )
 
@@ -138,7 +138,7 @@ def test_attribute_decoder_cluster_set_exact_match(dummy):
     found_clusters = _extract_top_level_cluster_cases(content)
 
     assert found_clusters == EXPECTED_CASTING_CLUSTERS, (
-        f"Cluster set mismatch in casting-CHIPAttributeTLVValueDecoder.cpp.\n"
+        f"Cluster set mismatch in CHIPAttributeTLVValueDecoder-override.cpp.\n"
         f"  Expected ({len(EXPECTED_CASTING_CLUSTERS)}): {sorted(EXPECTED_CASTING_CLUSTERS)}\n"
         f"  Found    ({len(found_clusters)}): {sorted(found_clusters)}\n"
         f"  Missing:  {sorted(EXPECTED_CASTING_CLUSTERS - found_clusters)}\n"
@@ -194,7 +194,7 @@ def test_each_expected_cluster_present_in_event_decoder(cluster):
 
     assert cluster in found_clusters, (
         f"Expected casting cluster `{cluster}` is missing from "
-        f"casting-CHIPEventTLVValueDecoder.cpp. "
+        f"CHIPEventTLVValueDecoder-override.cpp. "
         f"Found clusters: {sorted(found_clusters)}"
     )
 
@@ -216,7 +216,7 @@ def test_event_decoder_cluster_set_exact_match(dummy):
     found_clusters = _extract_top_level_cluster_cases(content)
 
     assert found_clusters == EXPECTED_CASTING_CLUSTERS, (
-        f"Cluster set mismatch in casting-CHIPEventTLVValueDecoder.cpp.\n"
+        f"Cluster set mismatch in CHIPEventTLVValueDecoder-override.cpp.\n"
         f"  Expected ({len(EXPECTED_CASTING_CLUSTERS)}): {sorted(EXPECTED_CASTING_CLUSTERS)}\n"
         f"  Found    ({len(found_clusters)}): {sorted(found_clusters)}\n"
         f"  Missing:  {sorted(EXPECTED_CASTING_CLUSTERS - found_clusters)}\n"

--- a/examples/tv-casting-app/tests/test_consolidated_android_py.py
+++ b/examples/tv-casting-app/tests/test_consolidated_android_py.py
@@ -1,18 +1,13 @@
 """
-Property Test — Property 6: android.py casting build args correctness
+Property Test — Property 3: android.py passes only the consolidated override arg
 
-Feature: casting-client-cluster-reduction (updated for consolidation)
-Property 6: android.py casting build args correctness
+Feature: consolidate-overrides-and-generation-script
 
 **Validates: Requirements 6.1, 6.2, 14.3**
 
-This test parses `scripts/build/builders/android.py` and verifies that the
-TV_CASTING_APP optimize_size block:
-
-1. Sets `chip_data_model_overrides_dir` to the tv-casting-common directory
-2. Does NOT set any of the 5 individual per-file override args
-3. Still sets `chip_data_model_extra_logging` to False
-4. Still sets `enable_rtti` to False
+Parse `android.py` and verify the TV_CASTING_APP optimize_size block sets
+`chip_data_model_overrides_dir` and does NOT set any of the 5 individual
+per-file override args.
 """
 
 import os
@@ -27,6 +22,18 @@ from hypothesis import strategies as st
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 ANDROID_PY = os.path.join(REPO_ROOT, "scripts", "build", "builders", "android.py")
+
+# ---------------------------------------------------------------------------
+# The 5 individual per-file override args that should NOT be set
+# ---------------------------------------------------------------------------
+
+REMOVED_OVERRIDE_ARGS = [
+    "chip_tlv_decoder_attribute_source_override",
+    "chip_tlv_decoder_event_source_override",
+    "chip_cluster_objects_source_override",
+    "chip_cluster_server_source_override",
+    "chip_accessors_source_override",
+]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -119,11 +126,11 @@ def _find_gn_arg_assignment(block: str, arg_name: str) -> str | None:
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_tv_casting_app_sets_overrides_dir(dummy):
+def test_tv_casting_app_sets_chip_data_model_overrides_dir(dummy):
     """
     **Validates: Requirements 6.1, 14.3**
 
-    Property 6a: For any size-optimized TV_CASTING_APP build, android.py
+    Property 3a: For a size-optimized TV_CASTING_APP build, android.py
     SHALL set `chip_data_model_overrides_dir` pointing to the
     tv-casting-common directory.
     """
@@ -134,7 +141,7 @@ def test_tv_casting_app_sets_overrides_dir(dummy):
     value = _find_gn_arg_assignment(casting_block, "chip_data_model_overrides_dir")
     assert value is not None, (
         '`gn_args["chip_data_model_overrides_dir"]` is not set in the '
-        "TV_CASTING_APP optimize_size block"
+        "TV_CASTING_APP optimize_size block of android.py"
     )
     assert "tv-casting-app/tv-casting-common" in value, (
         f'`gn_args["chip_data_model_overrides_dir"]` is set to {value}, '
@@ -143,26 +150,19 @@ def test_tv_casting_app_sets_overrides_dir(dummy):
 
 
 @given(
-    removed_arg=st.sampled_from([
-        "chip_tlv_decoder_attribute_source_override",
-        "chip_tlv_decoder_event_source_override",
-        "chip_cluster_objects_source_override",
-        "chip_cluster_server_source_override",
-        "chip_accessors_source_override",
-    ])
+    removed_arg=st.sampled_from(REMOVED_OVERRIDE_ARGS),
 )
 @settings(
     max_examples=100,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_tv_casting_app_does_not_set_individual_overrides(removed_arg):
+def test_tv_casting_app_does_not_set_individual_override_args(removed_arg):
     """
     **Validates: Requirements 6.2, 14.3**
 
-    Property 6b: For any size-optimized TV_CASTING_APP build, android.py
+    Property 3b: For a size-optimized TV_CASTING_APP build, android.py
     SHALL NOT set any of the 5 individual per-file override GN args.
-    These have been replaced by `chip_data_model_overrides_dir`.
     """
     content = _read_file(ANDROID_PY)
     opt_block = _extract_optimize_size_block(content)
@@ -176,86 +176,18 @@ def test_tv_casting_app_does_not_set_individual_overrides(removed_arg):
     )
 
 
-@given(dummy=st.just(True))
-@settings(
-    max_examples=1,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-    deadline=None,
-)
-def test_tv_casting_app_preserves_extra_logging_and_rtti(dummy):
-    """
-    **Validates: Requirements 6.1**
-
-    Property 6c: The TV_CASTING_APP optimize_size block SHALL still set
-    `chip_data_model_extra_logging = False` and `enable_rtti = False`.
-    """
-    content = _read_file(ANDROID_PY)
-    opt_block = _extract_optimize_size_block(content)
-    casting_block = _extract_tv_casting_app_block(opt_block)
-
-    extra_logging = _find_gn_arg_assignment(casting_block, "chip_data_model_extra_logging")
-    assert extra_logging is not None, (
-        '`gn_args["chip_data_model_extra_logging"]` is not set in the '
-        "TV_CASTING_APP optimize_size block"
-    )
-    assert extra_logging == "False", (
-        f'`gn_args["chip_data_model_extra_logging"]` is {extra_logging}, '
-        f"expected False"
-    )
-
-    rtti = _find_gn_arg_assignment(casting_block, "enable_rtti")
-    assert rtti is not None, (
-        '`gn_args["enable_rtti"]` is not set in the '
-        "TV_CASTING_APP optimize_size block"
-    )
-    assert rtti == "False", (
-        f'`gn_args["enable_rtti"]` is {rtti}, expected False'
-    )
-
-
-@given(dummy=st.just(True))
-@settings(
-    max_examples=1,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-    deadline=None,
-)
-def test_overrides_dir_uses_correct_gn_prefix(dummy):
-    """
-    **Validates: Requirements 6.1**
-
-    Property 6d: The `chip_data_model_overrides_dir` path SHALL use the
-    `//third_party/connectedhomeip/examples/` GN path prefix.
-    """
-    content = _read_file(ANDROID_PY)
-    opt_block = _extract_optimize_size_block(content)
-    casting_block = _extract_tv_casting_app_block(opt_block)
-
-    value = _find_gn_arg_assignment(casting_block, "chip_data_model_overrides_dir")
-    assert value is not None, (
-        '`gn_args["chip_data_model_overrides_dir"]` is not set'
-    )
-    assert "//third_party/connectedhomeip/examples/" in value, (
-        f'`gn_args["chip_data_model_overrides_dir"]` path does not use the '
-        f"expected `//third_party/connectedhomeip/examples/` GN prefix. Got: {value}"
-    )
-
-
 # ---------------------------------------------------------------------------
 # Allow running directly
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     import sys
 
-    print("Running android.py casting build args property tests...")
+    print("Running android.py consolidated arg property tests...")
     tests = [
-        ("6a: TV_CASTING_APP sets overrides dir",
-         test_tv_casting_app_sets_overrides_dir),
-        ("6b: TV_CASTING_APP does not set individual overrides",
-         test_tv_casting_app_does_not_set_individual_overrides),
-        ("6c: TV_CASTING_APP preserves extra logging and RTTI",
-         test_tv_casting_app_preserves_extra_logging_and_rtti),
-        ("6d: Overrides dir uses correct GN prefix",
-         test_overrides_dir_uses_correct_gn_prefix),
+        ("Property 3a: TV_CASTING_APP sets chip_data_model_overrides_dir",
+         test_tv_casting_app_sets_chip_data_model_overrides_dir),
+        ("Property 3b: TV_CASTING_APP does not set individual override args",
+         test_tv_casting_app_does_not_set_individual_override_args),
     ]
     all_passed = True
     for name, test_fn in tests:

--- a/examples/tv-casting-app/tests/test_consolidated_gn_overrides.py
+++ b/examples/tv-casting-app/tests/test_consolidated_gn_overrides.py
@@ -1,0 +1,188 @@
+"""
+Property Test — Property 2: GN files resolve all overrides from the override directory
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 3.1, 3.2, 4.1, 4.2, 5.1, 14.4**
+
+For each of the 5 well-known filenames, parse the corresponding GN consumer
+file and verify it references `chip_data_model_overrides_dir` in its
+conditional logic for selecting that source file, and falls back to the
+default full generated source when the override dir is empty.
+
+Well-known filenames and their consumers:
+- cluster-objects-override.cpp -> src/app/common/BUILD.gn
+- CHIPAttributeTLVValueDecoder-override.cpp -> src/controller/java/BUILD.gn
+- CHIPEventTLVValueDecoder-override.cpp -> src/controller/java/BUILD.gn
+- Accessors-override.cpp -> src/app/chip_data_model.gni
+- cluster-servers-override.gni -> src/app/chip_data_model.gni
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+# Consumer files
+COMMON_BUILD_GN = os.path.join(REPO_ROOT, "src", "app", "common", "BUILD.gn")
+JAVA_BUILD_GN = os.path.join(REPO_ROOT, "src", "controller", "java", "BUILD.gn")
+CHIP_DATA_MODEL_GNI = os.path.join(REPO_ROOT, "src", "app", "chip_data_model.gni")
+
+# ---------------------------------------------------------------------------
+# Well-known filenames and their consumer files
+# ---------------------------------------------------------------------------
+
+OVERRIDE_ENTRIES = [
+    ("cluster-objects-override.cpp", COMMON_BUILD_GN),
+    ("CHIPAttributeTLVValueDecoder-override.cpp", JAVA_BUILD_GN),
+    ("CHIPEventTLVValueDecoder-override.cpp", JAVA_BUILD_GN),
+    ("Accessors-override.cpp", CHIP_DATA_MODEL_GNI),
+    ("cluster-servers-override.gni", CHIP_DATA_MODEL_GNI),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Property-based test
+# ---------------------------------------------------------------------------
+
+
+@given(
+    override_entry=st.sampled_from(OVERRIDE_ENTRIES),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_gn_files_resolve_overrides_from_directory(override_entry):
+    """
+    **Validates: Requirements 3.1, 3.2, 4.1, 4.2, 5.1, 14.4**
+
+    Property 2: For any of the 5 well-known override filenames, the
+    corresponding GN consumer file SHALL reference
+    `chip_data_model_overrides_dir` in its conditional logic for selecting
+    that source file.
+    """
+    well_known_filename, consumer_file = override_entry
+
+    content = _read_file(consumer_file)
+    rel_path = os.path.relpath(consumer_file, REPO_ROOT)
+
+    # The consumer file must reference chip_data_model_overrides_dir
+    assert "chip_data_model_overrides_dir" in content, (
+        f"`{rel_path}` does not reference `chip_data_model_overrides_dir` "
+        f"at all — it should use the override directory for {well_known_filename}"
+    )
+
+    # The consumer file must reference the well-known filename
+    assert well_known_filename in content, (
+        f"`{rel_path}` does not reference `{well_known_filename}` — "
+        f"the override file should be used when chip_data_model_overrides_dir is set"
+    )
+
+    # Verify the conditional pattern: if (chip_data_model_overrides_dir != "")
+    conditional_pattern = r'if\s*\(\s*chip_data_model_overrides_dir\s*!=\s*""\s*\)'
+    assert re.search(conditional_pattern, content), (
+        f"`{rel_path}` does not contain the expected conditional "
+        f'`if (chip_data_model_overrides_dir != "")` — '
+        f"the override directory check is missing"
+    )
+
+    # Verify the well-known filename appears in a line that also references
+    # chip_data_model_overrides_dir (i.e., it's resolved from the directory)
+    dir_ref_pattern = (
+        r"chip_data_model_overrides_dir.*" + re.escape(well_known_filename)
+    )
+    assert re.search(dir_ref_pattern, content), (
+        f"`{rel_path}` references `{well_known_filename}` but not in "
+        f"combination with `chip_data_model_overrides_dir` — the file should "
+        f"be resolved from the override directory"
+    )
+
+
+@given(
+    override_entry=st.sampled_from([
+        ("cluster-objects-override.cpp", COMMON_BUILD_GN, "cluster-objects.cpp"),
+        ("CHIPAttributeTLVValueDecoder-override.cpp", JAVA_BUILD_GN,
+         "CHIPAttributeTLVValueDecoder.cpp"),
+        ("CHIPEventTLVValueDecoder-override.cpp", JAVA_BUILD_GN,
+         "CHIPEventTLVValueDecoder.cpp"),
+        ("Accessors-override.cpp", CHIP_DATA_MODEL_GNI, "Accessors.cpp"),
+    ]),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_gn_files_have_fallback_to_default_source(override_entry):
+    """
+    **Validates: Requirements 3.1, 4.1, 4.2, 5.1**
+
+    Property 2 (fallback): For each well-known override filename that has
+    a corresponding full generated source, the GN consumer SHALL have an
+    `else` branch that falls back to the default full generated source.
+    """
+    well_known_filename, consumer_file, fallback_filename = override_entry
+
+    content = _read_file(consumer_file)
+    rel_path = os.path.relpath(consumer_file, REPO_ROOT)
+
+    # The consumer file must contain the fallback filename in an else branch
+    assert fallback_filename in content, (
+        f"`{rel_path}` does not reference the fallback file "
+        f"`{fallback_filename}` — there should be an else branch that "
+        f"compiles the full generated source when chip_data_model_overrides_dir "
+        f"is empty"
+    )
+
+    # Verify there's an else clause after the override conditional
+    # (simple check: "} else {" appears in the file)
+    assert "} else {" in content or "} else if" in content, (
+        f"`{rel_path}` does not contain an else clause — the override "
+        f"conditional should have a fallback path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running GN override resolution property tests...")
+    tests = [
+        ("Property 2a: GN files resolve overrides from directory",
+         test_gn_files_resolve_overrides_from_directory),
+        ("Property 2b: GN files have fallback to default source",
+         test_gn_files_have_fallback_to_default_source),
+    ]
+    all_passed = True
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            all_passed = False
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/examples/tv-casting-app/tests/test_consolidated_removed_args.py
+++ b/examples/tv-casting-app/tests/test_consolidated_removed_args.py
@@ -1,0 +1,150 @@
+"""
+Property Test — Property 1: Removed GN args are not declared
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 2.6**
+
+For each of the 6 removed GN arguments, parse the corresponding `.gni` file
+and verify the arg is NOT in any `declare_args()` block.
+
+Removed args:
+- chip_tlv_decoder_attribute_source_override (was in config.gni)
+- chip_tlv_decoder_event_source_override (was in config.gni)
+- matter_enable_tlv_decoder_cpp (was in config.gni)
+- chip_cluster_objects_source_override (was in common_flags.gni)
+- chip_cluster_server_source_override (was in common_flags.gni)
+- chip_accessors_source_override (was in common_flags.gni)
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+CONFIG_GNI = os.path.join(REPO_ROOT, "build", "chip", "java", "config.gni")
+COMMON_FLAGS_GNI = os.path.join(REPO_ROOT, "src", "app", "common_flags.gni")
+
+# ---------------------------------------------------------------------------
+# Mapping: removed arg -> file it was declared in
+# ---------------------------------------------------------------------------
+
+REMOVED_ARGS_CONFIG_GNI = [
+    "chip_tlv_decoder_attribute_source_override",
+    "chip_tlv_decoder_event_source_override",
+    "matter_enable_tlv_decoder_cpp",
+]
+
+REMOVED_ARGS_COMMON_FLAGS_GNI = [
+    "chip_cluster_objects_source_override",
+    "chip_cluster_server_source_override",
+    "chip_accessors_source_override",
+]
+
+ALL_REMOVED_ARGS = [
+    ("chip_tlv_decoder_attribute_source_override", CONFIG_GNI),
+    ("chip_tlv_decoder_event_source_override", CONFIG_GNI),
+    ("matter_enable_tlv_decoder_cpp", CONFIG_GNI),
+    ("chip_cluster_objects_source_override", COMMON_FLAGS_GNI),
+    ("chip_cluster_server_source_override", COMMON_FLAGS_GNI),
+    ("chip_accessors_source_override", COMMON_FLAGS_GNI),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _extract_all_declare_args_blocks(text: str) -> list[str]:
+    """
+    Extract the bodies of ALL `declare_args() { ... }` blocks from a file.
+    Returns a list of block body strings.
+    """
+    blocks = []
+    pattern = r"declare_args\s*\(\s*\)\s*\{"
+    for m in re.finditer(pattern, text):
+        depth = 1
+        pos = m.end()
+        while pos < len(text) and depth > 0:
+            if text[pos] == "{":
+                depth += 1
+            elif text[pos] == "}":
+                depth -= 1
+            pos += 1
+        blocks.append(text[m.end():pos - 1])
+    return blocks
+
+
+def _arg_declared_in_blocks(blocks: list[str], arg_name: str) -> bool:
+    """
+    Check if `arg_name` appears as a declaration (assignment) in any of
+    the declare_args blocks.
+    """
+    pattern = rf"^\s*{re.escape(arg_name)}\s*="
+    for block in blocks:
+        if re.search(pattern, block, re.MULTILINE):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Property-based test
+# ---------------------------------------------------------------------------
+
+
+@given(
+    removed_arg_entry=st.sampled_from(ALL_REMOVED_ARGS),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_removed_gn_args_not_declared(removed_arg_entry):
+    """
+    **Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 2.6**
+
+    Property 1: For any of the 6 removed GN arguments, the argument SHALL
+    NOT appear as a declaration in its original `declare_args()` block.
+    """
+    arg_name, gni_file = removed_arg_entry
+
+    content = _read_file(gni_file)
+    blocks = _extract_all_declare_args_blocks(content)
+
+    assert not _arg_declared_in_blocks(blocks, arg_name), (
+        f"REGRESSION: `{arg_name}` is still declared in a declare_args() block "
+        f"in {os.path.relpath(gni_file, REPO_ROOT)} — it should have been "
+        f"removed as part of the consolidation to chip_data_model_overrides_dir"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running removed GN args property test...")
+    try:
+        test_removed_gn_args_not_declared()
+        print("  PASS: Property 1 — removed GN args not declared")
+    except AssertionError as e:
+        print(f"  FAIL: Property 1\n    {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"  ERROR: Property 1\n    {e}")
+        sys.exit(1)
+
+    sys.exit(0)

--- a/examples/tv-casting-app/tests/test_decode_logic_equivalence.py
+++ b/examples/tv-casting-app/tests/test_decode_logic_equivalence.py
@@ -29,7 +29,7 @@ SLIM_ATTR_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPAttributeTLVValueDecoder.cpp",
+    "CHIPAttributeTLVValueDecoder-override.cpp",
 )
 
 FULL_ATTR_DECODER = os.path.join(
@@ -46,7 +46,7 @@ SLIM_EVENT_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPEventTLVValueDecoder.cpp",
+    "CHIPEventTLVValueDecoder-override.cpp",
 )
 
 FULL_EVENT_DECODER = os.path.join(

--- a/examples/tv-casting-app/tests/test_gen_accessors.py
+++ b/examples/tv-casting-app/tests/test_gen_accessors.py
@@ -1,0 +1,221 @@
+"""
+Property Test — Property 6: Generation script Accessors extraction
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 9.7, 10.4**
+
+For any valid subset of cluster names from the full Accessors.cpp,
+the generation script SHALL produce a Accessors-override.cpp that
+contains exactly the namespace blocks for the specified clusters,
+and no namespace blocks for clusters not in the subset.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FULL_ACCESSORS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "attributes", "Accessors.cpp",
+)
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import _extract_cluster_namespace_blocks, generate_accessors  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Discover valid cluster names (those that actually have namespace blocks)
+# ---------------------------------------------------------------------------
+
+
+def _discover_accessor_cluster_names(source_path):
+    """Find cluster names that have top-level namespace blocks in Accessors.cpp.
+
+    We use the same extraction logic as the generation script to identify
+    which names are valid cluster-level namespaces (as opposed to attribute
+    namespaces nested inside clusters).
+    """
+    with open(source_path, "r") as f:
+        text = f.read()
+
+    # Use a large set of candidate names to discover which ones produce blocks
+    # We look for namespace X { patterns after namespace Clusters {
+    clusters_match = re.search(r'namespace\s+Clusters\s*\{', text)
+    if not clusters_match:
+        return []
+
+    # Find all namespace names that appear right after Clusters namespace
+    # at the top level (not nested inside another cluster namespace)
+    candidates = set()
+    ns_pattern = re.compile(r'^namespace\s+(\w+)\s*\{', re.MULTILINE)
+    for m in ns_pattern.finditer(text, clusters_match.end()):
+        name = m.group(1)
+        if name not in ("Attributes", "chip", "app", "Clusters"):
+            candidates.add(name)
+
+    # Filter to only names that the extraction function actually finds
+    # (i.e., names that produce non-empty blocks)
+    valid = []
+    for name in sorted(candidates):
+        blocks = _extract_cluster_namespace_blocks(text, [name])
+        if blocks:
+            valid.append(name)
+
+    return valid
+
+
+# Use the casting_clusters from the YAML config as our known-good cluster names
+# These are the ones the script is designed to work with
+CASTING_CLUSTERS = [
+    "AccessControl", "AdministratorCommissioning", "BasicInformation",
+    "Binding", "Descriptor", "GeneralCommissioning", "GeneralDiagnostics",
+    "GroupKeyManagement", "Groupcast", "Groups", "Identify",
+    "NetworkCommissioning", "OperationalCredentials",
+    "AccountLogin", "ApplicationBasic", "ApplicationLauncher",
+    "AudioOutput", "Channel", "ContentAppObserver", "ContentControl",
+    "ContentLauncher", "KeypadInput", "LevelControl", "LowPower",
+    "MediaInput", "MediaPlayback", "Messages", "OnOff",
+    "TargetNavigator", "WakeOnLan",
+]
+
+# Verify these are all valid
+_valid_set = set(_discover_accessor_cluster_names(FULL_ACCESSORS))
+ALL_ACCESSOR_CLUSTERS = [c for c in CASTING_CLUSTERS if c in _valid_set]
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+accessor_cluster_subsets = st.lists(
+    st.sampled_from(ALL_ACCESSOR_CLUSTERS),
+    min_size=1,
+    max_size=len(ALL_ACCESSOR_CLUSTERS),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_output_namespace_clusters(text):
+    """Extract top-level cluster names from the generated Accessors output.
+
+    Uses the same extraction logic as the generation script to identify
+    cluster namespace blocks, ensuring consistency.
+    """
+    clusters = set()
+    clusters_match = re.search(r'namespace\s+Clusters\s*\{', text)
+    if not clusters_match:
+        return clusters
+
+    end_match = re.search(r'}\s*//\s*namespace\s+Clusters', text, re.MULTILINE)
+    if not end_match:
+        return clusters
+
+    body = text[clusters_match.end():end_match.start()]
+
+    # Find namespace blocks at the top level by looking for patterns like:
+    # namespace X {  (preceded by start-of-body or } // namespace Y)
+    # We track brace depth: a namespace at depth 0 is a cluster namespace
+    depth = 0
+    i = 0
+    while i < len(body):
+        # Try to match a namespace declaration
+        m = re.match(r'namespace\s+(\w+)\s*\{', body[i:])
+        if m and depth == 0:
+            name = m.group(1)
+            if name not in ("Attributes", "chip", "app", "Clusters"):
+                clusters.add(name)
+            # Skip past the matched text but count the { we just saw
+            depth += 1
+            i += m.end()
+            continue
+
+        if body[i] == '{':
+            depth += 1
+        elif body[i] == '}':
+            depth -= 1
+
+        i += 1
+
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(subset=accessor_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_accessors_contains_only_requested_namespace_blocks(subset):
+    """
+    **Validates: Requirements 9.7, 10.4**
+
+    For any subset of cluster names, the generated Accessors file
+    SHALL contain namespace blocks only for those clusters.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "Accessors-override.cpp")
+        generate_accessors(FULL_ACCESSORS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        output_clusters = _extract_output_namespace_clusters(content)
+        requested = set(subset)
+
+        # All requested clusters should have namespace blocks
+        missing = requested - output_clusters
+        assert not missing, (
+            f"Missing namespace blocks for requested clusters: {missing}"
+        )
+
+        # No extra clusters should have namespace blocks
+        extra = output_clusters - requested
+        assert not extra, (
+            f"Namespace blocks found for clusters NOT in the subset: {extra}"
+        )
+
+
+@given(subset=accessor_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_accessors_wrapped_in_chip_app_clusters_namespaces(subset):
+    """
+    **Validates: Requirements 9.7, 10.4**
+
+    For any subset, the generated Accessors file SHALL wrap the cluster
+    namespace blocks inside namespace chip { namespace app { namespace Clusters { }.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "Accessors-override.cpp")
+        generate_accessors(FULL_ACCESSORS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert "namespace chip {" in content, "Output must contain namespace chip {"
+        assert "namespace app {" in content, "Output must contain namespace app {"
+        assert "namespace Clusters {" in content, "Output must contain namespace Clusters {"
+        assert "} // namespace Clusters" in content, "Output must close namespace Clusters"
+        assert "} // namespace app" in content, "Output must close namespace app"
+        assert "} // namespace chip" in content, "Output must close namespace chip"

--- a/examples/tv-casting-app/tests/test_gen_cluster_objects.py
+++ b/examples/tv-casting-app/tests/test_gen_cluster_objects.py
@@ -1,0 +1,152 @@
+"""
+Property Test — Property 4: Generation script cluster-objects extraction
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 9.4, 10.4**
+
+For any valid subset of cluster names from the full cluster-objects.cpp,
+the generation script SHALL produce a cluster-objects-override.cpp that
+contains exactly the #include <clusters/ClusterName/...> directives for
+the specified clusters (plus shared/Structs.ipp), and no includes for
+clusters not in the subset.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FULL_CLUSTER_OBJECTS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "cluster-objects.cpp",
+)
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import generate_cluster_objects  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Discover all cluster names from the full source
+# ---------------------------------------------------------------------------
+
+
+def _discover_cluster_names(source_path):
+    """Extract all unique cluster names from #include <clusters/X/...> lines."""
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.match(r'#include\s+<clusters/([^/]+)/', line)
+            if m and m.group(1) != "shared":
+                names.add(m.group(1))
+    return sorted(names)
+
+
+ALL_CLUSTER_NAMES = _discover_cluster_names(FULL_CLUSTER_OBJECTS)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+cluster_subsets = st.lists(
+    st.sampled_from(ALL_CLUSTER_NAMES),
+    min_size=1,
+    max_size=len(ALL_CLUSTER_NAMES),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_include_clusters(text):
+    """Extract cluster names from #include <clusters/X/...> lines in output."""
+    clusters = set()
+    for line in text.splitlines():
+        m = re.match(r'#include\s+<clusters/([^/]+)/', line)
+        if m:
+            clusters.add(m.group(1))
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(subset=cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_objects_includes_only_requested_clusters(subset):
+    """
+    **Validates: Requirements 9.4, 10.4**
+
+    For any subset of cluster names, the generated cluster-objects file
+    SHALL contain #include directives only for those clusters plus shared.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-objects-override.cpp")
+        generate_cluster_objects(FULL_CLUSTER_OBJECTS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        included_clusters = _extract_include_clusters(content)
+
+        # shared/Structs.ipp must always be present
+        assert "shared" in included_clusters, (
+            "Output must always include shared/Structs.ipp"
+        )
+
+        # Remove 'shared' for comparison
+        included_clusters.discard("shared")
+        requested = set(subset)
+
+        # All requested clusters should be present
+        missing = requested - included_clusters
+        assert not missing, (
+            f"Missing includes for requested clusters: {missing}"
+        )
+
+        # No extra clusters should be present
+        extra = included_clusters - requested
+        assert not extra, (
+            f"Includes found for clusters NOT in the subset: {extra}"
+        )
+
+
+@given(subset=cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_objects_always_includes_shared_structs(subset):
+    """
+    **Validates: Requirements 9.4, 10.4**
+
+    For any subset of cluster names, the generated cluster-objects file
+    SHALL always include shared/Structs.ipp.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-objects-override.cpp")
+        generate_cluster_objects(FULL_CLUSTER_OBJECTS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert "#include <clusters/shared/Structs.ipp>" in content, (
+            "Output must always include #include <clusters/shared/Structs.ipp>"
+        )

--- a/examples/tv-casting-app/tests/test_gen_cluster_servers_gni.py
+++ b/examples/tv-casting-app/tests/test_gen_cluster_servers_gni.py
@@ -1,0 +1,174 @@
+"""
+Property Test — Property 9: Generation script cluster-servers.gni output
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 12.1, 12.2, 12.3**
+
+For any list of server directory names, the generation script SHALL
+produce a cluster-servers-override.gni file containing a GN list variable
+cluster_server_override_dirs with exactly those directory names, formatted
+with the standard CHIP copyright header.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import generate_cluster_servers_gni  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Generate realistic server directory names
+KNOWN_SERVERS = [
+    "access-control-server",
+    "administrator-commissioning-server",
+    "basic-information",
+    "bindings",
+    "descriptor",
+    "general-commissioning-server",
+    "general-diagnostics-server",
+    "group-key-mgmt-server",
+    "groups-server",
+    "identify-server",
+    "network-commissioning",
+    "operational-credentials-server",
+    "content-app-observer",
+    "door-lock-server",
+    "fan-control-server",
+    "level-control",
+    "on-off-server",
+    "color-control-server",
+    "thermostat",
+    "window-covering-server",
+]
+
+server_lists = st.lists(
+    st.sampled_from(KNOWN_SERVERS),
+    min_size=1,
+    max_size=len(KNOWN_SERVERS),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_gni_list_entries(text):
+    """Extract directory names from the cluster_server_override_dirs GN list."""
+    # Find the list variable
+    m = re.search(r'cluster_server_override_dirs\s*=\s*\[', text)
+    if not m:
+        return None
+
+    # Find the closing bracket
+    bracket_start = text.index('[', m.start())
+    bracket_end = text.index(']', bracket_start)
+    list_body = text[bracket_start + 1:bracket_end]
+
+    # Extract quoted strings
+    entries = re.findall(r'"([^"]+)"', list_body)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(servers=server_lists)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_gni_contains_exactly_requested_servers(servers):
+    """
+    **Validates: Requirements 12.1, 12.2, 12.3**
+
+    The generated .gni file SHALL contain a cluster_server_override_dirs
+    variable with exactly the requested directory names.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-servers-override.gni")
+        generate_cluster_servers_gni(servers, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        entries = _extract_gni_list_entries(content)
+        assert entries is not None, (
+            "Output must contain cluster_server_override_dirs = [...]"
+        )
+
+        assert entries == servers, (
+            f"Expected servers {servers}, got {entries}"
+        )
+
+
+@given(servers=server_lists)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_gni_has_copyright_header(servers):
+    """
+    **Validates: Requirements 12.3**
+
+    The generated .gni file SHALL start with the standard CHIP copyright
+    header.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-servers-override.gni")
+        generate_cluster_servers_gni(servers, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert content.startswith("# Copyright"), (
+            "GNI output must start with the copyright header"
+        )
+        assert "Apache License" in content
+
+
+@given(servers=server_lists)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_gni_one_entry_per_line(servers):
+    """
+    **Validates: Requirements 12.3**
+
+    The generated .gni file SHALL have one directory entry per line.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-servers-override.gni")
+        generate_cluster_servers_gni(servers, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        # Each server should appear on its own line as "  \"server-name\","
+        for server in servers:
+            pattern = rf'^\s*"{re.escape(server)}",'
+            assert re.search(pattern, content, re.MULTILINE), (
+                f"Server '{server}' should appear on its own line"
+            )

--- a/examples/tv-casting-app/tests/test_gen_idempotency.py
+++ b/examples/tv-casting-app/tests/test_gen_idempotency.py
@@ -1,0 +1,246 @@
+"""
+Property Test — Property 7: Generation script idempotency
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 11.4**
+
+For any valid cluster configuration and the same full generated source
+files, running the generation script twice SHALL produce byte-identical
+output files.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FULL_CLUSTER_OBJECTS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "cluster-objects.cpp",
+)
+FULL_ATTR_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPAttributeTLVValueDecoder.cpp",
+)
+FULL_EVENT_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPEventTLVValueDecoder.cpp",
+)
+FULL_ACCESSORS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "attributes", "Accessors.cpp",
+)
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import (generate_accessors, generate_cluster_objects, generate_cluster_servers_gni,  # noqa: E402
+                                     generate_tlv_decoder)
+
+# ---------------------------------------------------------------------------
+# Discover cluster names from full sources
+# ---------------------------------------------------------------------------
+
+
+def _discover_cluster_names(source_path):
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.match(r'#include\s+<clusters/([^/]+)/', line)
+            if m and m.group(1) != "shared":
+                names.add(m.group(1))
+    return sorted(names)
+
+
+def _discover_tlv_cluster_names(source_path):
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.search(r'case\s+app::Clusters::(\w+)::Id:', line)
+            if m:
+                names.add(m.group(1))
+    return sorted(names)
+
+
+ALL_OBJ_CLUSTERS = _discover_cluster_names(FULL_CLUSTER_OBJECTS)
+ALL_ATTR_CLUSTERS = _discover_tlv_cluster_names(FULL_ATTR_DECODER)
+ALL_EVENT_CLUSTERS = _discover_tlv_cluster_names(FULL_EVENT_DECODER)
+
+SAMPLE_SERVERS = [
+    "access-control-server", "basic-information", "bindings",
+    "descriptor", "groups-server", "identify-server",
+]
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+obj_cluster_subsets = st.lists(
+    st.sampled_from(ALL_OBJ_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_OBJ_CLUSTERS), 20),
+    unique=True,
+)
+
+attr_cluster_subsets = st.lists(
+    st.sampled_from(ALL_ATTR_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_ATTR_CLUSTERS), 20),
+    unique=True,
+)
+
+event_cluster_subsets = st.lists(
+    st.sampled_from(ALL_EVENT_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_EVENT_CLUSTERS), 20),
+    unique=True,
+)
+
+server_subsets = st.lists(
+    st.sampled_from(SAMPLE_SERVERS),
+    min_size=1,
+    max_size=len(SAMPLE_SERVERS),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(subset=obj_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_objects_idempotent(subset):
+    """
+    **Validates: Requirements 11.4**
+
+    Running generate_cluster_objects twice with the same inputs
+    SHALL produce byte-identical output.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = os.path.join(tmpdir, "run1.cpp")
+        path2 = os.path.join(tmpdir, "run2.cpp")
+
+        generate_cluster_objects(FULL_CLUSTER_OBJECTS, subset, path1)
+        generate_cluster_objects(FULL_CLUSTER_OBJECTS, subset, path2)
+
+        with open(path1, "rb") as f1, open(path2, "rb") as f2:
+            assert f1.read() == f2.read(), (
+                "cluster-objects output is not idempotent"
+            )
+
+
+@given(subset=attr_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_attr_decoder_idempotent(subset):
+    """
+    **Validates: Requirements 11.4**
+
+    Running generate_tlv_decoder (attribute) twice with the same inputs
+    SHALL produce byte-identical output.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = os.path.join(tmpdir, "run1.cpp")
+        path2 = os.path.join(tmpdir, "run2.cpp")
+
+        generate_tlv_decoder(FULL_ATTR_DECODER, subset, path1, "attribute")
+        generate_tlv_decoder(FULL_ATTR_DECODER, subset, path2, "attribute")
+
+        with open(path1, "rb") as f1, open(path2, "rb") as f2:
+            assert f1.read() == f2.read(), (
+                "attribute TLV decoder output is not idempotent"
+            )
+
+
+@given(subset=event_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_event_decoder_idempotent(subset):
+    """
+    **Validates: Requirements 11.4**
+
+    Running generate_tlv_decoder (event) twice with the same inputs
+    SHALL produce byte-identical output.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = os.path.join(tmpdir, "run1.cpp")
+        path2 = os.path.join(tmpdir, "run2.cpp")
+
+        generate_tlv_decoder(FULL_EVENT_DECODER, subset, path1, "event")
+        generate_tlv_decoder(FULL_EVENT_DECODER, subset, path2, "event")
+
+        with open(path1, "rb") as f1, open(path2, "rb") as f2:
+            assert f1.read() == f2.read(), (
+                "event TLV decoder output is not idempotent"
+            )
+
+
+@given(subset=obj_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_accessors_idempotent(subset):
+    """
+    **Validates: Requirements 11.4**
+
+    Running generate_accessors twice with the same inputs
+    SHALL produce byte-identical output.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = os.path.join(tmpdir, "run1.cpp")
+        path2 = os.path.join(tmpdir, "run2.cpp")
+
+        generate_accessors(FULL_ACCESSORS, subset, path1)
+        generate_accessors(FULL_ACCESSORS, subset, path2)
+
+        with open(path1, "rb") as f1, open(path2, "rb") as f2:
+            assert f1.read() == f2.read(), (
+                "Accessors output is not idempotent"
+            )
+
+
+@given(servers=server_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_servers_gni_idempotent(servers):
+    """
+    **Validates: Requirements 11.4**
+
+    Running generate_cluster_servers_gni twice with the same inputs
+    SHALL produce byte-identical output.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = os.path.join(tmpdir, "run1.gni")
+        path2 = os.path.join(tmpdir, "run2.gni")
+
+        generate_cluster_servers_gni(servers, path1)
+        generate_cluster_servers_gni(servers, path2)
+
+        with open(path1, "rb") as f1, open(path2, "rb") as f2:
+            assert f1.read() == f2.read(), (
+                "cluster-servers.gni output is not idempotent"
+            )

--- a/examples/tv-casting-app/tests/test_gen_preamble.py
+++ b/examples/tv-casting-app/tests/test_gen_preamble.py
@@ -1,0 +1,280 @@
+"""
+Property Test — Property 8: Generation script output preamble
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 11.2, 11.3**
+
+For any valid cluster configuration, each generated slim file SHALL
+begin with the CHIP copyright header and SHALL contain the required
+#include directives for that file type.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FULL_CLUSTER_OBJECTS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "cluster-objects.cpp",
+)
+FULL_ATTR_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPAttributeTLVValueDecoder.cpp",
+)
+FULL_EVENT_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPEventTLVValueDecoder.cpp",
+)
+FULL_ACCESSORS = os.path.join(
+    REPO_ROOT, "zzz_generated", "app-common", "app-common",
+    "zap-generated", "attributes", "Accessors.cpp",
+)
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import (generate_accessors, generate_cluster_objects, generate_cluster_servers_gni,  # noqa: E402
+                                     generate_tlv_decoder)
+
+# ---------------------------------------------------------------------------
+# Discover cluster names
+# ---------------------------------------------------------------------------
+
+
+def _discover_cluster_names(source_path):
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.match(r'#include\s+<clusters/([^/]+)/', line)
+            if m and m.group(1) != "shared":
+                names.add(m.group(1))
+    return sorted(names)
+
+
+def _discover_tlv_cluster_names(source_path):
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.search(r'case\s+app::Clusters::(\w+)::Id:', line)
+            if m:
+                names.add(m.group(1))
+    return sorted(names)
+
+
+ALL_OBJ_CLUSTERS = _discover_cluster_names(FULL_CLUSTER_OBJECTS)
+ALL_ATTR_CLUSTERS = _discover_tlv_cluster_names(FULL_ATTR_DECODER)
+ALL_EVENT_CLUSTERS = _discover_tlv_cluster_names(FULL_EVENT_DECODER)
+
+SAMPLE_SERVERS = [
+    "access-control-server", "basic-information", "bindings",
+    "descriptor", "groups-server", "identify-server",
+]
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+obj_cluster_subsets = st.lists(
+    st.sampled_from(ALL_OBJ_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_OBJ_CLUSTERS), 15),
+    unique=True,
+)
+
+attr_cluster_subsets = st.lists(
+    st.sampled_from(ALL_ATTR_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_ATTR_CLUSTERS), 15),
+    unique=True,
+)
+
+event_cluster_subsets = st.lists(
+    st.sampled_from(ALL_EVENT_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_EVENT_CLUSTERS), 15),
+    unique=True,
+)
+
+server_subsets = st.lists(
+    st.sampled_from(SAMPLE_SERVERS),
+    min_size=1,
+    max_size=len(SAMPLE_SERVERS),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(subset=obj_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_objects_has_copyright_and_includes(subset):
+    """
+    **Validates: Requirements 11.2, 11.3**
+
+    The generated cluster-objects file SHALL start with the CHIP copyright
+    header and contain the required #include directive.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-objects-override.cpp")
+        generate_cluster_objects(FULL_CLUSTER_OBJECTS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        # Must start with copyright header
+        assert content.startswith("/*"), (
+            "Output must start with the CHIP copyright header (/*)"
+        )
+        assert "Copyright (c)" in content, (
+            "Output must contain copyright notice"
+        )
+        assert "Apache License" in content, (
+            "Output must contain Apache License reference"
+        )
+
+        # Must contain the required include
+        assert "#include <app-common/zap-generated/cluster-objects.h>" in content, (
+            "Output must include cluster-objects.h"
+        )
+
+
+@given(subset=attr_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_attr_decoder_has_copyright_and_includes(subset):
+    """
+    **Validates: Requirements 11.2, 11.3**
+
+    The generated attribute TLV decoder SHALL start with the CHIP copyright
+    header and contain the required #include directives.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPAttributeTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_ATTR_DECODER, subset, output_path, "attribute")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert content.startswith("/*"), (
+            "Output must start with the CHIP copyright header"
+        )
+        assert "Copyright (c)" in content
+        assert "Apache License" in content
+
+        # Required includes for attribute decoder
+        assert "#include <controller/java/CHIPAttributeTLVValueDecoder.h>" in content
+        assert "#include <app-common/zap-generated/cluster-objects.h>" in content
+        assert "#include <app-common/zap-generated/ids/Attributes.h>" in content
+        assert "#include <app-common/zap-generated/ids/Clusters.h>" in content
+        assert "#include <jni.h>" in content
+
+
+@given(subset=event_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_event_decoder_has_copyright_and_includes(subset):
+    """
+    **Validates: Requirements 11.2, 11.3**
+
+    The generated event TLV decoder SHALL start with the CHIP copyright
+    header and contain the required #include directives.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPEventTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_EVENT_DECODER, subset, output_path, "event")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert content.startswith("/*"), (
+            "Output must start with the CHIP copyright header"
+        )
+        assert "Copyright (c)" in content
+        assert "Apache License" in content
+
+        # Required includes for event decoder
+        assert "#include <controller/java/CHIPAttributeTLVValueDecoder.h>" in content
+        assert "#include <app-common/zap-generated/cluster-objects.h>" in content
+        assert "#include <app-common/zap-generated/ids/Clusters.h>" in content
+        assert "#include <app-common/zap-generated/ids/Events.h>" in content
+        assert "#include <jni.h>" in content
+
+
+@given(subset=obj_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_accessors_has_copyright_and_includes(subset):
+    """
+    **Validates: Requirements 11.2, 11.3**
+
+    The generated Accessors file SHALL start with the CHIP copyright
+    header and contain the required #include directives.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "Accessors-override.cpp")
+        generate_accessors(FULL_ACCESSORS, subset, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert content.startswith("/*"), (
+            "Output must start with the CHIP copyright header"
+        )
+        assert "Copyright (c)" in content
+        assert "Apache License" in content
+
+        # Required includes for Accessors
+        assert "#include <app-common/zap-generated/attributes/Accessors.h>" in content
+        assert "#include <app-common/zap-generated/attribute-type.h>" in content
+        assert "#include <app-common/zap-generated/ids/Attributes.h>" in content
+        assert "#include <app-common/zap-generated/ids/Clusters.h>" in content
+
+
+@given(servers=server_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_cluster_servers_gni_has_copyright(servers):
+    """
+    **Validates: Requirements 11.2**
+
+    The generated cluster-servers.gni SHALL start with the CHIP copyright
+    header (GNI format with # comments).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "cluster-servers-override.gni")
+        generate_cluster_servers_gni(servers, output_path)
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert content.startswith("# Copyright"), (
+            "GNI output must start with the copyright header"
+        )
+        assert "Apache License" in content

--- a/examples/tv-casting-app/tests/test_gen_tlv_decoder.py
+++ b/examples/tv-casting-app/tests/test_gen_tlv_decoder.py
@@ -1,0 +1,219 @@
+"""
+Property Test — Property 5: Generation script TLV decoder extraction
+
+Feature: consolidate-overrides-and-generation-script
+
+**Validates: Requirements 9.5, 9.6, 11.5**
+
+For any valid subset of cluster names from the full TLV decoder files,
+the generation script SHALL produce slim decoder files that contain
+exactly the case blocks for the specified clusters, plus a default case,
+and no case blocks for clusters not in the subset.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FULL_ATTR_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPAttributeTLVValueDecoder.cpp",
+)
+FULL_EVENT_DECODER = os.path.join(
+    REPO_ROOT, "src", "controller", "java", "zap-generated",
+    "CHIPEventTLVValueDecoder.cpp",
+)
+
+# Import the generation script
+sys.path.insert(0, os.path.join(REPO_ROOT, "examples", "tv-casting-app", "tv-casting-common"))
+from generate_slim_overrides import generate_tlv_decoder  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Discover all cluster names from the full source
+# ---------------------------------------------------------------------------
+
+
+def _discover_tlv_cluster_names(source_path):
+    """Extract unique cluster names from case app::Clusters::X::Id: lines."""
+    names = set()
+    with open(source_path, "r") as f:
+        for line in f:
+            m = re.search(r'case\s+app::Clusters::(\w+)::Id:', line)
+            if m:
+                names.add(m.group(1))
+    return sorted(names)
+
+
+ALL_ATTR_CLUSTERS = _discover_tlv_cluster_names(FULL_ATTR_DECODER)
+ALL_EVENT_CLUSTERS = _discover_tlv_cluster_names(FULL_EVENT_DECODER)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+attr_cluster_subsets = st.lists(
+    st.sampled_from(ALL_ATTR_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_ATTR_CLUSTERS), 30),
+    unique=True,
+)
+
+event_cluster_subsets = st.lists(
+    st.sampled_from(ALL_EVENT_CLUSTERS),
+    min_size=1,
+    max_size=min(len(ALL_EVENT_CLUSTERS), 30),
+    unique=True,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_case_clusters(text):
+    """Extract cluster names from case app::Clusters::X::Id: lines."""
+    clusters = set()
+    for m in re.finditer(r'case\s+app::Clusters::(\w+)::Id:', text):
+        clusters.add(m.group(1))
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Property tests — Attribute decoder
+# ---------------------------------------------------------------------------
+
+
+@given(subset=attr_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_attr_decoder_contains_only_requested_case_blocks(subset):
+    """
+    **Validates: Requirements 9.5, 11.5**
+
+    For any subset of cluster names, the generated attribute TLV decoder
+    SHALL contain case blocks only for those clusters.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPAttributeTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_ATTR_DECODER, subset, output_path, "attribute")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        case_clusters = _extract_case_clusters(content)
+        requested = set(subset)
+
+        # All requested clusters should have case blocks
+        missing = requested - case_clusters
+        assert not missing, (
+            f"Missing case blocks for requested clusters: {missing}"
+        )
+
+        # No extra clusters should have case blocks
+        extra = case_clusters - requested
+        assert not extra, (
+            f"Case blocks found for clusters NOT in the subset: {extra}"
+        )
+
+
+@given(subset=attr_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_attr_decoder_has_default_case(subset):
+    """
+    **Validates: Requirements 9.5, 11.5**
+
+    For any subset, the generated attribute decoder SHALL contain a
+    default: case with CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPAttributeTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_ATTR_DECODER, subset, output_path, "attribute")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert "default:" in content, "Output must contain a default: case"
+        assert "CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB" in content, (
+            "Output must contain CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB in default case"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property tests — Event decoder
+# ---------------------------------------------------------------------------
+
+
+@given(subset=event_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_event_decoder_contains_only_requested_case_blocks(subset):
+    """
+    **Validates: Requirements 9.6, 11.5**
+
+    For any subset of cluster names, the generated event TLV decoder
+    SHALL contain case blocks only for those clusters.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPEventTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_EVENT_DECODER, subset, output_path, "event")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        case_clusters = _extract_case_clusters(content)
+        requested = set(subset)
+
+        missing = requested - case_clusters
+        assert not missing, (
+            f"Missing case blocks for requested clusters: {missing}"
+        )
+
+        extra = case_clusters - requested
+        assert not extra, (
+            f"Case blocks found for clusters NOT in the subset: {extra}"
+        )
+
+
+@given(subset=event_cluster_subsets)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_event_decoder_has_default_case(subset):
+    """
+    **Validates: Requirements 9.6, 11.5**
+
+    For any subset, the generated event decoder SHALL contain a
+    default: case with CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "CHIPEventTLVValueDecoder-override.cpp")
+        generate_tlv_decoder(FULL_EVENT_DECODER, subset, output_path, "event")
+
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        assert "default:" in content, "Output must contain a default: case"
+        assert "CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB" in content, (
+            "Output must contain CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB in default case"
+        )

--- a/examples/tv-casting-app/tests/test_gn_conditional_source_selection.py
+++ b/examples/tv-casting-app/tests/test_gn_conditional_source_selection.py
@@ -1,17 +1,21 @@
 """
 Property Test — Property 5: GN conditional source selection
 
-**Validates: Requirements 3.3, 3.4, 3.5, 6.1, 6.2**
+**Validates: Requirements 4.1, 4.2, 5.1, 14.4**
 
 This test parses `src/controller/java/BUILD.gn` and verifies that the
-`if (matter_enable_tlv_decoder_cpp)` block contains conditional logic for
-both `chip_tlv_decoder_attribute_source_override` and
-`chip_tlv_decoder_event_source_override`, following the pattern:
+`android_chip_im_jni` source set contains conditional logic for both
+TLV decoder overrides using `chip_data_model_overrides_dir`, following
+the pattern:
 
-    if (override != "") { use override } else { use zap-generated }
+    if (chip_data_model_overrides_dir != "") { use override } else { use zap-generated }
 
-This ensures that non-empty overrides compile the slim file, while empty
-(default) overrides compile the full zap-generated decoder.
+This ensures that when the override directory is set, the slim files are
+compiled, and when it is empty (default), the full zap-generated decoders
+are compiled.
+
+After the consolidation, `matter_enable_tlv_decoder_cpp` has been removed
+and the TLV decoder block is unconditional.
 """
 
 import os
@@ -37,143 +41,66 @@ def _read_file(path: str) -> str:
         return f.read()
 
 
-def _extract_brace_block(text: str, start: int) -> str:
-    """
-    Given *text* and the index of an opening '{', return the content
-    between the braces (handling nested braces).
-    """
-    assert text[start] == "{", f"Expected '{{' at position {start}"
-    depth = 1
-    pos = start + 1
-    while pos < len(text) and depth > 0:
-        if text[pos] == "{":
-            depth += 1
-        elif text[pos] == "}":
-            depth -= 1
-        pos += 1
-    return text[start + 1: pos - 1]
-
-
-def _find_tlv_decoder_block(content: str) -> str:
-    """
-    Locate the `if (matter_enable_tlv_decoder_cpp)` block inside BUILD.gn
-    and return its body text.
-    """
-    pattern = r"if\s*\(\s*matter_enable_tlv_decoder_cpp\s*\)"
-    m = re.search(pattern, content)
-    assert m is not None, (
-        "Could not find `if (matter_enable_tlv_decoder_cpp)` in BUILD.gn"
-    )
-    brace_pos = content.index("{", m.end())
-    return _extract_brace_block(content, brace_pos)
-
-
-def _find_conditional_override(block: str, override_var: str, fallback_file: str):
-    """
-    Verify that *block* contains a conditional of the form:
-
-        if (<override_var> != "") {
-          sources += [ <override_var> ]
-        } else {
-          sources += [ "<fallback_file>" ]
-        }
-
-    Returns (if_body, else_body) strings for further inspection.
-    """
-    # Match the if-condition
-    pattern = rf'if\s*\(\s*{re.escape(override_var)}\s*!=\s*""\s*\)'
-    m = re.search(pattern, block)
-    assert m is not None, (
-        f"Could not find `if ({override_var} != \"\")` inside the "
-        f"matter_enable_tlv_decoder_cpp block"
-    )
-
-    # Extract the if-body
-    if_brace = block.index("{", m.end())
-    if_body = _extract_brace_block(block, if_brace)
-
-    # Find the else clause immediately after the if-block closing brace
-    after_if = if_brace + 1 + len(if_body) + 1  # skip past closing '}'
-    rest = block[after_if:]
-    else_match = re.match(r"\s*else\s*\{", rest)
-    assert else_match is not None, (
-        f"Could not find `else` clause after `if ({override_var} != \"\")` block"
-    )
-
-    else_brace = after_if + rest.index("{", else_match.start())
-    else_body = _extract_brace_block(block, else_brace)
-
-    return if_body, else_body
+# Override filenames paired with their zap-generated fallback filenames
+OVERRIDE_CONFIGS = [
+    ("CHIPAttributeTLVValueDecoder-override.cpp",
+     "zap-generated/CHIPAttributeTLVValueDecoder.cpp"),
+    ("CHIPEventTLVValueDecoder-override.cpp",
+     "zap-generated/CHIPEventTLVValueDecoder.cpp"),
+]
 
 
 # ---------------------------------------------------------------------------
 # Property-based tests
 # ---------------------------------------------------------------------------
 
-# Override arg names paired with their zap-generated fallback filenames
-OVERRIDE_CONFIGS = [
-    ("chip_tlv_decoder_attribute_source_override",
-     "zap-generated/CHIPAttributeTLVValueDecoder.cpp"),
-    ("chip_tlv_decoder_event_source_override",
-     "zap-generated/CHIPEventTLVValueDecoder.cpp"),
-]
-
 
 @given(
     override_config=st.sampled_from(OVERRIDE_CONFIGS),
-    dummy_path=st.text(
-        alphabet=st.characters(whitelist_categories=("L", "N", "P")),
-        min_size=1,
-        max_size=80,
-    ),
 )
 @settings(
     max_examples=100,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_gn_conditional_source_selection(override_config, dummy_path):
+def test_gn_conditional_source_selection(override_config):
     """
-    **Validates: Requirements 3.3, 3.4, 3.5, 6.1, 6.2**
+    **Validates: Requirements 4.1, 4.2, 14.4**
 
-    Property 5: For any non-empty value of the override arg, BUILD.gn SHALL
-    compile the override file instead of the zap-generated file. When the
-    override is empty (default), the zap-generated file SHALL be compiled.
+    Property 5: For any non-empty value of `chip_data_model_overrides_dir`,
+    BUILD.gn SHALL compile the override file instead of the zap-generated
+    file. When the override dir is empty (default), the zap-generated file
+    SHALL be compiled.
 
     This test:
-    1. Parses BUILD.gn and locates the matter_enable_tlv_decoder_cpp block
-    2. Verifies the conditional `if (override != "")` exists for each arg
-    3. Verifies the if-branch references the override variable
-    4. Verifies the else-branch references the zap-generated fallback
+    1. Parses BUILD.gn
+    2. Verifies the conditional `if (chip_data_model_overrides_dir != "")` exists
+    3. Verifies the override filename is referenced with the override dir
+    4. Verifies the fallback filename is present for the else branch
     """
-    override_var, fallback_file = override_config
+    override_filename, fallback_file = override_config
 
     content = _read_file(BUILD_GN)
-    block = _find_tlv_decoder_block(content)
 
-    # Verify the conditional pattern exists and extract bodies
-    if_body, else_body = _find_conditional_override(block, override_var, fallback_file)
-
-    # The if-body should reference the override variable (the dynamic path)
-    assert override_var in if_body, (
-        f"The if-branch for `{override_var} != \"\"` does not reference "
-        f"`{override_var}` — expected `sources += [ {override_var} ]`"
+    # Verify the conditional pattern exists
+    conditional_pattern = r'if\s*\(\s*chip_data_model_overrides_dir\s*!=\s*""\s*\)'
+    assert re.search(conditional_pattern, content), (
+        "Could not find `if (chip_data_model_overrides_dir != \"\")` in BUILD.gn"
     )
 
-    # The else-body should reference the zap-generated fallback file
-    assert fallback_file in else_body, (
-        f"The else-branch for `{override_var}` does not reference "
-        f"`{fallback_file}` — expected `sources += [ \"{fallback_file}\" ]`"
+    # The override filename should be referenced with chip_data_model_overrides_dir
+    dir_ref_pattern = (
+        r"chip_data_model_overrides_dir.*" + re.escape(override_filename)
+    )
+    assert re.search(dir_ref_pattern, content), (
+        f"BUILD.gn does not reference `{override_filename}` in combination "
+        f"with `chip_data_model_overrides_dir`"
     )
 
-    # The if-body should contain a sources += assignment
-    assert "sources +=" in if_body, (
-        f"The if-branch for `{override_var}` does not contain `sources +=`"
-    )
-
-    # The else-body should contain a sources += assignment
-    assert "sources +=" in else_body, (
-        f"The else-branch for `{override_var}` does not contain `sources +=`"
+    # The fallback file should be present
+    assert fallback_file in content, (
+        f"BUILD.gn does not reference the fallback file `{fallback_file}` — "
+        f"there should be an else branch for the default path"
     )
 
 
@@ -183,26 +110,25 @@ def test_gn_conditional_source_selection(override_config, dummy_path):
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_tlv_decoder_block_preserves_unconditional_elements(dummy):
+def test_tlv_decoder_unconditional_elements(dummy):
     """
-    **Validates: Requirements 3.5, 6.1, 6.2**
+    **Validates: Requirements 4.1, 4.2**
 
-    Verify that the matter_enable_tlv_decoder_cpp block still contains the
+    Verify that the android_chip_im_jni source set contains the
     unconditional elements: the USE_JAVA_TLV_ENCODE_DECODE define and the
-    CHIPTLVValueDecoder-JNI.cpp source. These must not be gated behind the
-    override conditionals.
+    CHIPTLVValueDecoder-JNI.cpp source. These are no longer gated behind
+    `matter_enable_tlv_decoder_cpp` (which has been removed).
     """
     content = _read_file(BUILD_GN)
-    block = _find_tlv_decoder_block(content)
 
-    assert "USE_JAVA_TLV_ENCODE_DECODE" in block, (
-        "The matter_enable_tlv_decoder_cpp block is missing the "
-        "`USE_JAVA_TLV_ENCODE_DECODE` define"
+    assert "USE_JAVA_TLV_ENCODE_DECODE" in content, (
+        "BUILD.gn is missing the `USE_JAVA_TLV_ENCODE_DECODE` define "
+        "in the android_chip_im_jni source set"
     )
 
-    assert "CHIPTLVValueDecoder-JNI.cpp" in block, (
-        "The matter_enable_tlv_decoder_cpp block is missing "
-        "`CHIPTLVValueDecoder-JNI.cpp` as an unconditional source"
+    assert "CHIPTLVValueDecoder-JNI.cpp" in content, (
+        "BUILD.gn is missing `CHIPTLVValueDecoder-JNI.cpp` as a source "
+        "in the android_chip_im_jni source set"
     )
 
 
@@ -212,22 +138,22 @@ def test_tlv_decoder_block_preserves_unconditional_elements(dummy):
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_both_override_conditionals_present(dummy):
+def test_matter_enable_tlv_decoder_cpp_removed(dummy):
     """
-    **Validates: Requirements 3.3, 3.4**
+    **Validates: Requirements 2.6, 14.2**
 
-    Verify that both override conditionals are present in the
-    matter_enable_tlv_decoder_cpp block — one for attributes, one for events.
+    Verify that `matter_enable_tlv_decoder_cpp` is no longer referenced
+    as a conditional in BUILD.gn. The flag has been removed and the TLV
+    decoder block is now unconditional.
     """
     content = _read_file(BUILD_GN)
-    block = _find_tlv_decoder_block(content)
 
-    for override_var, fallback_file in OVERRIDE_CONFIGS:
-        pattern = rf'if\s*\(\s*{re.escape(override_var)}\s*!=\s*""\s*\)'
-        assert re.search(pattern, block) is not None, (
-            f"Missing conditional for `{override_var}` in the "
-            f"matter_enable_tlv_decoder_cpp block"
-        )
+    pattern = r"if\s*\(\s*matter_enable_tlv_decoder_cpp\s*\)"
+    assert not re.search(pattern, content), (
+        "REGRESSION: `if (matter_enable_tlv_decoder_cpp)` is still present "
+        "in BUILD.gn — this conditional should have been removed as part of "
+        "the consolidation to chip_data_model_overrides_dir"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -238,12 +164,12 @@ if __name__ == "__main__":
 
     print("Running GN conditional source selection property tests...")
     tests = [
-        ("5a: GN conditional source selection",
+        ("5a: GN conditional source selection with overrides dir",
          test_gn_conditional_source_selection),
-        ("5b: Unconditional elements preserved",
-         test_tlv_decoder_block_preserves_unconditional_elements),
-        ("5c: Both override conditionals present",
-         test_both_override_conditionals_present),
+        ("5b: Unconditional TLV decoder elements preserved",
+         test_tlv_decoder_unconditional_elements),
+        ("5c: matter_enable_tlv_decoder_cpp removed from BUILD.gn",
+         test_matter_enable_tlv_decoder_cpp_removed),
     ]
     all_passed = True
     for name, test_fn in tests:

--- a/examples/tv-casting-app/tests/test_interface_compatibility.py
+++ b/examples/tv-casting-app/tests/test_interface_compatibility.py
@@ -4,9 +4,9 @@ Property Test — Property 3: Interface compatibility (attribute & event decoder
 **Validates: Requirements 1.3, 2.3**
 
 This test parses both the slim attribute decoder
-(`casting-CHIPAttributeTLVValueDecoder.cpp`) and the full zap-generated
+(`CHIPAttributeTLVValueDecoder-override.cpp`) and the full zap-generated
 decoder (`zap-generated/CHIPAttributeTLVValueDecoder.cpp`), as well as
-the slim event decoder (`casting-CHIPEventTLVValueDecoder.cpp`) and the
+the slim event decoder (`CHIPEventTLVValueDecoder-override.cpp`) and the
 full zap-generated event decoder (`zap-generated/CHIPEventTLVValueDecoder.cpp`),
 and verifies:
 
@@ -34,7 +34,7 @@ SLIM_ATTR_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPAttributeTLVValueDecoder.cpp",
+    "CHIPAttributeTLVValueDecoder-override.cpp",
 )
 
 FULL_ATTR_DECODER = os.path.join(
@@ -51,7 +51,7 @@ SLIM_EVENT_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPEventTLVValueDecoder.cpp",
+    "CHIPEventTLVValueDecoder-override.cpp",
 )
 
 FULL_EVENT_DECODER = os.path.join(

--- a/examples/tv-casting-app/tests/test_non_casting_error_handling.py
+++ b/examples/tv-casting-app/tests/test_non_casting_error_handling.py
@@ -3,7 +3,7 @@ Property Test — Property 2: Non-casting cluster error handling (attribute deco
 
 **Validates: Requirements 1.2, 5.3**
 
-This test parses `casting-CHIPAttributeTLVValueDecoder.cpp` and verifies that:
+This test parses `CHIPAttributeTLVValueDecoder-override.cpp` and verifies that:
 1. The top-level switch contains a `default:` case that sets
    `CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB`.
 2. The function returns `nullptr` after the switch (for the default case path).
@@ -30,7 +30,7 @@ SLIM_ATTR_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPAttributeTLVValueDecoder.cpp",
+    "CHIPAttributeTLVValueDecoder-override.cpp",
 )
 
 # ---------------------------------------------------------------------------
@@ -310,7 +310,7 @@ if __name__ == "__main__":
 #
 # **Validates: Requirements 2.2, 5.3**
 #
-# These tests parse `casting-CHIPEventTLVValueDecoder.cpp` and verify that:
+# These tests parse `CHIPEventTLVValueDecoder-override.cpp` and verify that:
 # 1. The top-level switch contains a `default:` case that sets
 #    `CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB`.
 # 2. The function returns `nullptr` after the switch (for the default case path).
@@ -322,7 +322,7 @@ SLIM_EVENT_DECODER = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-CHIPEventTLVValueDecoder.cpp",
+    "CHIPEventTLVValueDecoder-override.cpp",
 )
 
 # ---------------------------------------------------------------------------

--- a/examples/tv-casting-app/tests/test_phase2_android_py_args.py
+++ b/examples/tv-casting-app/tests/test_phase2_android_py_args.py
@@ -1,0 +1,247 @@
+"""
+Property Test — Property 6: android.py passes phase 2 args for TV_CASTING_APP only
+
+Feature: casting-apk-size-reduction-phase2, Property 6: android.py passes
+phase 2 args for TV_CASTING_APP only
+
+**Validates: Requirements 3.1, 5.1, 7.1, 7.2, 7.3, 8.2**
+
+This test parses `scripts/build/builders/android.py` and verifies that
+`chip_data_model_extra_logging` and `enable_rtti` are set to False within
+the TV_CASTING_APP + optimize_size scope, and are NOT set outside that scope.
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+ANDROID_PY = os.path.join(REPO_ROOT, "scripts", "build", "builders", "android.py")
+
+# Phase 2 GN args that must be set only for TV_CASTING_APP + optimize_size
+PHASE2_ARGS = [
+    ("chip_data_model_extra_logging", "False"),
+    ("enable_rtti", "False"),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _extract_optimize_size_block(content: str) -> str:
+    """
+    Extract the body of the `if self.optimize_size:` block from the
+    `generate()` method in android.py.
+    """
+    pattern = r"^(\s+)if self\.optimize_size:\s*$"
+    m = re.search(pattern, content, re.MULTILINE)
+    assert m is not None, (
+        "Could not find `if self.optimize_size:` in android.py"
+    )
+    indent = m.group(1)
+    block_indent = indent + "    "
+
+    lines = content[m.end():].split("\n")
+    block_lines = []
+    for line in lines:
+        if line.strip() == "":
+            block_lines.append(line)
+            continue
+        if line.startswith(block_indent):
+            block_lines.append(line)
+            continue
+        break
+
+    return "\n".join(block_lines)
+
+
+def _extract_tv_casting_app_block(optimize_block: str) -> str:
+    """
+    Extract the body of the `if self.app == AndroidApp.TV_CASTING_APP:`
+    block from within the optimize_size block.
+    """
+    pattern = r"^(\s+)if self\.app\s*==\s*AndroidApp\.TV_CASTING_APP:\s*$"
+    m = re.search(pattern, optimize_block, re.MULTILINE)
+    assert m is not None, (
+        "Could not find `if self.app == AndroidApp.TV_CASTING_APP:` "
+        "inside the optimize_size block"
+    )
+    indent = m.group(1)
+    block_indent = indent + "    "
+
+    lines = optimize_block[m.end():].split("\n")
+    block_lines = []
+    for line in lines:
+        if line.strip() == "":
+            block_lines.append(line)
+            continue
+        if line.startswith(block_indent):
+            block_lines.append(line)
+            continue
+        break
+
+    return "\n".join(block_lines)
+
+
+def _find_gn_arg_assignment(block: str, arg_name: str) -> str | None:
+    """
+    Find a `gn_args["<arg_name>"] = <value>` assignment in the block.
+    Returns the RHS value as a string, or None if not found.
+    """
+    pattern = (
+        rf'gn_args\[\s*"{re.escape(arg_name)}"\s*\]\s*=\s*'
+        r'(\([\s\S]*?\)|"[^"]*"|[^\n]+)'
+    )
+    m = re.search(pattern, block)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _remove_block(content: str, block_start_pattern: str) -> str:
+    """
+    Remove an indented block (the header line + all deeper-indented lines)
+    from content. Used to get the 'outside' portion of a scope.
+    """
+    m = re.search(block_start_pattern, content, re.MULTILINE)
+    if m is None:
+        return content
+
+    indent = m.group(1)
+    block_indent = indent + "    "
+    before = content[:m.start()]
+
+    lines = content[m.end():].split("\n")
+    after_lines = []
+    in_block = True
+    for line in lines:
+        if in_block:
+            if line.strip() == "" or line.startswith(block_indent):
+                continue
+            in_block = False
+        after_lines.append(line)
+
+    return before + "\n".join(after_lines)
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    phase2_arg=st.sampled_from(PHASE2_ARGS),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_phase2_args_set_in_tv_casting_app_optimize_block(phase2_arg):
+    """
+    **Validates: Requirements 3.1, 5.1, 7.1, 7.2**
+
+    Property 6a: For any phase 2 GN argument, android.py SHALL set that
+    argument within the TV_CASTING_APP block inside the optimize_size
+    conditional, with the value False.
+    """
+    arg_name, expected_value = phase2_arg
+
+    content = _read_file(ANDROID_PY)
+    opt_block = _extract_optimize_size_block(content)
+    casting_block = _extract_tv_casting_app_block(opt_block)
+
+    value = _find_gn_arg_assignment(casting_block, arg_name)
+    assert value is not None, (
+        f'`gn_args["{arg_name}"]` is not set in the '
+        f"TV_CASTING_APP optimize_size block"
+    )
+    assert value == expected_value, (
+        f'`gn_args["{arg_name}"]` is set to {value}, '
+        f"expected {expected_value}"
+    )
+
+
+@given(
+    phase2_arg=st.sampled_from([name for name, _ in PHASE2_ARGS]),
+)
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_phase2_args_not_set_outside_tv_casting_app_scope(phase2_arg):
+    """
+    **Validates: Requirements 7.3, 8.2**
+
+    Property 6b: For any phase 2 GN argument, android.py SHALL NOT set
+    that argument outside the TV_CASTING_APP + optimize_size scope.
+    This ensures non-casting-app targets are unaffected.
+    """
+    content = _read_file(ANDROID_PY)
+
+    # Get the optimize_size block and remove the TV_CASTING_APP sub-block
+    opt_block = _extract_optimize_size_block(content)
+    outside_casting = _remove_block(
+        opt_block,
+        r"^(\s+)if self\.app\s*==\s*AndroidApp\.TV_CASTING_APP:\s*$",
+    )
+
+    value = _find_gn_arg_assignment(outside_casting, phase2_arg)
+    assert value is None, (
+        f'`gn_args["{phase2_arg}"]` is set to {value} in the '
+        f"optimize_size block but OUTSIDE the TV_CASTING_APP scope — "
+        f"phase 2 args must only apply to TV_CASTING_APP"
+    )
+
+    # Also check the full file outside the optimize_size block
+    full_outside = _remove_block(
+        content,
+        r"^(\s+)if self\.optimize_size:\s*$",
+    )
+    value_outside = _find_gn_arg_assignment(full_outside, phase2_arg)
+    assert value_outside is None, (
+        f'`gn_args["{phase2_arg}"]` is set to {value_outside} '
+        f"OUTSIDE the optimize_size block entirely — "
+        f"phase 2 args must only apply when optimize_size is true"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running phase 2 android.py args property tests...")
+    tests = [
+        ("6a: Phase 2 args set in TV_CASTING_APP optimize block",
+         test_phase2_args_set_in_tv_casting_app_optimize_block),
+        ("6b: Phase 2 args not set outside TV_CASTING_APP scope",
+         test_phase2_args_not_set_outside_tv_casting_app_scope),
+    ]
+    all_passed = True
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            all_passed = False
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/examples/tv-casting-app/tests/test_phase2_build_config.py
+++ b/examples/tv-casting-app/tests/test_phase2_build_config.py
@@ -1,0 +1,316 @@
+"""
+Phase 2 Build Config Property Tests
+
+Feature: casting-apk-size-reduction-phase2
+
+Property 7: CONFIG_BUILD_FOR_HOST_UNIT_TEST is overridable
+**Validates: Requirements 4.1, 4.2**
+
+Property 8: ICD client deps are conditional on optimize_apk_size
+**Validates: Requirements 6.1, 6.2**
+
+This test verifies that:
+  - CHIPProjectAppConfig.h uses a #ifndef guard around
+    CONFIG_BUILD_FOR_HOST_UNIT_TEST so the build system can override it to 0.
+  - tv-casting-common/BUILD.gn wraps ICD client deps
+    (icd/client:handler, icd/client:manager) inside a !optimize_apk_size
+    conditional so they are excluded in size-optimized builds.
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+BUILD_GN_FILE = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "tv-casting-common",
+    "BUILD.gn",
+)
+
+CHIP_PROJECT_APP_CONFIG_FILE = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "tv-casting-common",
+    "include",
+    "CHIPProjectAppConfig.h",
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ICD_CLIENT_DEPS = [
+    "icd/client:handler",
+    "icd/client:manager",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    """Return the text content of a file."""
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _find_conditional_blocks(content: str, condition_pattern: str) -> list:
+    """Find all blocks guarded by a GN if-condition matching the pattern.
+
+    Returns a list of strings, each being the body of a matching if-block.
+    Handles nested braces.
+    """
+    blocks = []
+    # Match 'if (<condition_pattern>) {'
+    pattern = rf'if\s*\(\s*{re.escape(condition_pattern)}\s*\)\s*\{{'
+    for m in re.finditer(pattern, content):
+        start = m.end()
+        depth = 1
+        pos = start
+        while pos < len(content) and depth > 0:
+            if content[pos] == '{':
+                depth += 1
+            elif content[pos] == '}':
+                depth -= 1
+            pos += 1
+        blocks.append(content[start:pos - 1])
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Property 8: ICD client deps are conditional on optimize_apk_size
+# ---------------------------------------------------------------------------
+
+
+@given(dep=st.sampled_from(ICD_CLIENT_DEPS))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_icd_client_deps_inside_not_optimize_apk_size_block(dep: str):
+    """
+    **Validates: Requirements 6.1, 6.2**
+
+    Property 8: ICD client deps are conditional on optimize_apk_size
+
+    For any ICD client dependency (icd/client:handler, icd/client:manager),
+    the tv-casting-common/BUILD.gn SHALL include that dependency only inside
+    a !optimize_apk_size conditional block, ensuring it is excluded when
+    optimize_apk_size=true.
+    """
+    content = _read_file(BUILD_GN_FILE)
+
+    # The dep must appear inside an if (!optimize_apk_size) block
+    guarded_blocks = _find_conditional_blocks(content, "!optimize_apk_size")
+    dep_in_guarded = any(dep in block for block in guarded_blocks)
+
+    assert dep_in_guarded, (
+        f"FAIL: ICD client dependency '{dep}' is not inside an "
+        f"if (!optimize_apk_size) block in BUILD.gn. "
+        f"It must be conditional so it is excluded in size-optimized builds."
+    )
+
+
+def test_icd_client_deps_not_unconditional():
+    """
+    **Validates: Requirements 6.1, 6.2**
+
+    Property 8 (supplement): ICD client deps are NOT present unconditionally.
+
+    Verify that icd/client deps do not appear outside of any
+    !optimize_apk_size conditional block.
+    """
+    content = _read_file(BUILD_GN_FILE)
+    lines = content.split("\n")
+
+    # Find all !optimize_apk_size block line ranges
+    guarded_blocks = _find_conditional_blocks(content, "!optimize_apk_size")
+    guarded_text = "\n".join(guarded_blocks)
+
+    for dep in ICD_CLIENT_DEPS:
+        # Count total occurrences vs occurrences inside guarded blocks
+        total_count = content.count(dep)
+        guarded_count = guarded_text.count(dep)
+
+        assert total_count == guarded_count, (
+            f"FAIL: ICD client dependency '{dep}' appears {total_count} time(s) "
+            f"in BUILD.gn but only {guarded_count} time(s) inside "
+            f"!optimize_apk_size blocks. All occurrences must be conditional."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 7: CONFIG_BUILD_FOR_HOST_UNIT_TEST is overridable
+# ---------------------------------------------------------------------------
+
+
+def test_config_build_for_host_unit_test_has_ifndef_guard():
+    """
+    **Validates: Requirements 4.1, 4.2**
+
+    Property 7: CONFIG_BUILD_FOR_HOST_UNIT_TEST is overridable
+
+    The CHIPProjectAppConfig.h header SHALL define CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    using a #ifndef guard so that the build system can override it to 0 for
+    size-optimized builds while defaulting to 1 for standard builds.
+    """
+    content = _read_file(CHIP_PROJECT_APP_CONFIG_FILE)
+
+    # Check for the #ifndef / #define / #endif pattern
+    ifndef_pattern = (
+        r'#ifndef\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST\s*\n'
+        r'\s*#define\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST\s+\d+\s*\n'
+        r'\s*#endif'
+    )
+    match = re.search(ifndef_pattern, content)
+
+    assert match is not None, (
+        "FAIL: CONFIG_BUILD_FOR_HOST_UNIT_TEST in CHIPProjectAppConfig.h "
+        "does not use a #ifndef guard. Expected pattern:\n"
+        "  #ifndef CONFIG_BUILD_FOR_HOST_UNIT_TEST\n"
+        "  #define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1\n"
+        "  #endif"
+    )
+
+
+def test_config_build_for_host_unit_test_default_value_is_1():
+    """
+    **Validates: Requirements 4.2**
+
+    Property 7 (supplement): Default value is 1
+
+    The #define inside the #ifndef guard SHALL set
+    CONFIG_BUILD_FOR_HOST_UNIT_TEST to 1, preserving backward compatibility
+    for non-optimized builds.
+    """
+    content = _read_file(CHIP_PROJECT_APP_CONFIG_FILE)
+
+    # Extract the value from the guarded #define
+    pattern = (
+        r'#ifndef\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST\s*\n'
+        r'\s*#define\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST\s+(\d+)'
+    )
+    match = re.search(pattern, content)
+
+    assert match is not None, (
+        "FAIL: Could not find #ifndef-guarded #define for "
+        "CONFIG_BUILD_FOR_HOST_UNIT_TEST."
+    )
+
+    value = int(match.group(1))
+    assert value == 1, (
+        f"FAIL: CONFIG_BUILD_FOR_HOST_UNIT_TEST default value is {value}, "
+        f"expected 1. Non-optimized builds must default to 1."
+    )
+
+
+def test_config_build_for_host_unit_test_no_unguarded_define():
+    """
+    **Validates: Requirements 4.1, 4.2**
+
+    Property 7 (supplement): No unguarded #define
+
+    There SHALL NOT be an unguarded (bare) #define CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    in the header. All definitions must be inside a #ifndef guard.
+    """
+    content = _read_file(CHIP_PROJECT_APP_CONFIG_FILE)
+    lines = content.split("\n")
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if re.match(r'^#define\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST\b', stripped):
+            # This #define must be preceded by a #ifndef guard
+            if i > 0:
+                prev_line = lines[i - 1].strip()
+                assert re.match(
+                    r'^#ifndef\s+CONFIG_BUILD_FOR_HOST_UNIT_TEST', prev_line
+                ), (
+                    f"FAIL: Found unguarded #define CONFIG_BUILD_FOR_HOST_UNIT_TEST "
+                    f"at line {i + 1}. It must be inside a #ifndef guard."
+                )
+            else:
+                assert False, (
+                    "FAIL: #define CONFIG_BUILD_FOR_HOST_UNIT_TEST is on the "
+                    "first line with no preceding #ifndef guard."
+                )
+
+
+def test_build_gn_defines_config_build_for_host_unit_test_zero():
+    """
+    **Validates: Requirements 4.1**
+
+    Property 7 (supplement): BUILD.gn overrides CONFIG_BUILD_FOR_HOST_UNIT_TEST=0
+
+    The config("config") block in tv-casting-common/BUILD.gn SHALL add
+    CONFIG_BUILD_FOR_HOST_UNIT_TEST=0 to defines when optimize_apk_size is true.
+    """
+    content = _read_file(BUILD_GN_FILE)
+
+    # Find the optimize_apk_size block inside the config("config") section
+    # Look for defines += [ "CONFIG_BUILD_FOR_HOST_UNIT_TEST=0" ] inside
+    # an if (optimize_apk_size) block
+    optimize_blocks = _find_conditional_blocks(content, "optimize_apk_size")
+
+    found = any(
+        "CONFIG_BUILD_FOR_HOST_UNIT_TEST=0" in block
+        for block in optimize_blocks
+    )
+
+    assert found, (
+        "FAIL: BUILD.gn does not define CONFIG_BUILD_FOR_HOST_UNIT_TEST=0 "
+        "inside an if (optimize_apk_size) block. This is needed to override "
+        "the header default for size-optimized builds."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running phase 2 build config property tests...")
+    failed = False
+
+    tests = [
+        ("Property 8 - ICD deps conditional",
+         test_icd_client_deps_inside_not_optimize_apk_size_block),
+        ("Property 8 (supplement) - ICD deps not unconditional",
+         test_icd_client_deps_not_unconditional),
+        ("Property 7 - #ifndef guard",
+         test_config_build_for_host_unit_test_has_ifndef_guard),
+        ("Property 7 (supplement) - default value is 1",
+         test_config_build_for_host_unit_test_default_value_is_1),
+        ("Property 7 (supplement) - no unguarded define",
+         test_config_build_for_host_unit_test_no_unguarded_define),
+        ("Property 7 (supplement) - BUILD.gn override",
+         test_build_gn_defines_config_build_for_host_unit_test_zero),
+    ]
+
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            failed = True
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            failed = True
+
+    sys.exit(1 if failed else 0)

--- a/examples/tv-casting-app/tests/test_phase2_cluster_removal.py
+++ b/examples/tv-casting-app/tests/test_phase2_cluster_removal.py
@@ -1,0 +1,369 @@
+"""
+Phase 2 Cluster Removal Property Tests
+
+Feature: casting-apk-size-reduction-phase2
+
+Property 1: Removed clusters absent from slim cluster file
+**Validates: Requirements 1.1**
+
+Property 2: Retained clusters present in slim cluster file
+**Validates: Requirements 1.3, 1.4**
+
+Property 3: Command metadata consistency
+**Validates: Requirements 1.5**
+
+This test verifies that:
+  - The 11 non-essential infrastructure clusters removed in phase 2 do not
+    appear as #include lines in the slim cluster-objects-override.cpp.
+  - The 12 commissioning-essential clusters and 17 casting-specific clusters
+    are present, along with shared/Structs.ipp.
+  - Every cluster referenced in CommandNeedsTimedInvoke, CommandIsFabricScoped,
+    or CommandHasLargePayload also has .ipp includes in the file.
+
+The 11 removed clusters are:
+  EthernetNetworkDiagnostics, SoftwareDiagnostics, WiFiNetworkDiagnostics,
+  TimeSynchronization, TimeFormatLocalization, UnitLocalization, FixedLabel,
+  UserLabel, Groupcast, IcdManagement, LocalizationConfiguration
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+SLIM_CLUSTER_FILE = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "tv-casting-common",
+    "cluster-objects-override.cpp",
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REMOVED_CLUSTERS = [
+    "EthernetNetworkDiagnostics",
+    "SoftwareDiagnostics",
+    "WiFiNetworkDiagnostics",
+    "TimeSynchronization",
+    "TimeFormatLocalization",
+    "UnitLocalization",
+    "FixedLabel",
+    "UserLabel",
+    "IcdManagement",
+    "LocalizationConfiguration",
+]
+
+COMMISSIONING_CLUSTERS = [
+    "AccessControl",
+    "AdministratorCommissioning",
+    "BasicInformation",
+    "Binding",
+    "Descriptor",
+    "GeneralCommissioning",
+    "GeneralDiagnostics",
+    "GroupKeyManagement",
+    "Groupcast",
+    "Groups",
+    "Identify",
+    "NetworkCommissioning",
+    "OperationalCredentials",
+]
+
+CASTING_CLUSTERS = [
+    "AccountLogin",
+    "ApplicationBasic",
+    "ApplicationLauncher",
+    "AudioOutput",
+    "Channel",
+    "ContentAppObserver",
+    "ContentControl",
+    "ContentLauncher",
+    "KeypadInput",
+    "LevelControl",
+    "LowPower",
+    "MediaInput",
+    "MediaPlayback",
+    "Messages",
+    "OnOff",
+    "TargetNavigator",
+    "WakeOnLan",
+]
+
+RETAINED_CLUSTERS = COMMISSIONING_CLUSTERS + CASTING_CLUSTERS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str:
+    """Return the text content of a file."""
+    with open(path, "r") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(cluster=st.sampled_from(REMOVED_CLUSTERS))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_removed_clusters_absent_from_slim_cluster_file(cluster: str):
+    """
+    **Validates: Requirements 1.1**
+
+    Property 1: Removed clusters absent from slim cluster file
+
+    For any cluster name in the set of 11 removed clusters, the slim
+    cluster-objects-override.cpp SHALL NOT contain any
+    #include <clusters/{cluster}/...> lines.
+    """
+    content = _read_file(SLIM_CLUSTER_FILE)
+
+    # Find any #include lines referencing this cluster's directory
+    pattern = rf'#include\s+<clusters/{re.escape(cluster)}/'
+    matches = re.findall(pattern, content)
+
+    assert len(matches) == 0, (
+        f"FAIL: Found {len(matches)} #include line(s) for removed cluster "
+        f"'{cluster}' in cluster-objects-override.cpp. "
+        f"Phase 2 requires this cluster to be removed from the slim cluster file."
+    )
+
+
+@given(cluster=st.sampled_from(RETAINED_CLUSTERS))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_retained_clusters_present_in_slim_cluster_file(cluster: str):
+    """
+    **Validates: Requirements 1.3, 1.4**
+
+    Property 2: Retained clusters present in slim cluster file
+
+    For any cluster name in the set of 12 commissioning-essential clusters or
+    the set of 17 casting-specific clusters, the slim
+    cluster-objects-override.cpp SHALL contain #include lines referencing that
+    cluster directory.
+    """
+    content = _read_file(SLIM_CLUSTER_FILE)
+
+    pattern = rf'#include\s+<clusters/{re.escape(cluster)}/'
+    matches = re.findall(pattern, content)
+
+    assert len(matches) > 0, (
+        f"FAIL: No #include line(s) found for retained cluster "
+        f"'{cluster}' in cluster-objects-override.cpp. "
+        f"This cluster must be present in the slim cluster file."
+    )
+
+
+def test_shared_structs_ipp_present_in_slim_cluster_file():
+    """
+    **Validates: Requirements 1.3, 1.4**
+
+    Property 2 (supplement): shared/Structs.ipp present in slim cluster file
+
+    The slim cluster-objects-override.cpp SHALL contain the shared/Structs.ipp
+    include.
+    """
+    content = _read_file(SLIM_CLUSTER_FILE)
+
+    pattern = r'#include\s+<clusters/shared/Structs\.ipp>'
+    matches = re.findall(pattern, content)
+
+    assert len(matches) > 0, (
+        "FAIL: shared/Structs.ipp include not found in "
+        "cluster-objects-override.cpp. This include must be present."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3 helpers
+# ---------------------------------------------------------------------------
+
+# The three command metadata function names to scan for cluster references.
+_COMMAND_METADATA_FUNCTIONS = [
+    "CommandNeedsTimedInvoke",
+    "CommandIsFabricScoped",
+    "CommandHasLargePayload",
+]
+
+
+def _extract_command_metadata_clusters(content: str) -> list:
+    """Extract unique cluster names referenced in the command metadata functions.
+
+    Looks for ``Clusters::<Name>::Id`` patterns inside the bodies of
+    CommandNeedsTimedInvoke, CommandIsFabricScoped, and CommandHasLargePayload.
+    Returns a sorted deduplicated list of cluster names.
+    """
+    clusters = set()
+    for func_name in _COMMAND_METADATA_FUNCTIONS:
+        # Match the function body: starts at the function signature and ends
+        # at the next top-level closing brace followed by a blank line or EOF.
+        func_pattern = (
+            rf'bool\s+{func_name}\s*\([^)]*\)\s*\{{(.*?)\n\}}'
+        )
+        match = re.search(func_pattern, content, re.DOTALL)
+        if match:
+            body = match.group(1)
+            # Find all Clusters::XXX::Id references in the function body
+            refs = re.findall(r'Clusters::(\w+)::Id', body)
+            clusters.update(refs)
+    return sorted(clusters)
+
+
+def _get_included_cluster_dirs(content: str) -> set:
+    """Return the set of cluster directory names present as .ipp includes."""
+    return set(re.findall(r'#include\s+<clusters/(\w+)/', content))
+
+
+# Build the list of clusters referenced in command metadata at module load
+# so hypothesis can sample from it.
+_FILE_CONTENT = _read_file(SLIM_CLUSTER_FILE)
+_CMD_METADATA_CLUSTERS = _extract_command_metadata_clusters(_FILE_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Property 3 test
+# ---------------------------------------------------------------------------
+
+if _CMD_METADATA_CLUSTERS:
+    @given(cluster=st.sampled_from(_CMD_METADATA_CLUSTERS))
+    @settings(
+        max_examples=100,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+        deadline=None,
+    )
+    def test_command_metadata_clusters_have_ipp_includes(cluster: str):
+        """
+        **Validates: Requirements 1.5**
+
+        Property 3: Command metadata consistency
+
+        For any cluster ID referenced in CommandNeedsTimedInvoke,
+        CommandIsFabricScoped, or CommandHasLargePayload, the slim
+        cluster-objects-override.cpp SHALL also contain .ipp includes for
+        that cluster. No orphaned command metadata entries shall exist for
+        clusters whose .ipp files have been removed.
+        """
+        content = _read_file(SLIM_CLUSTER_FILE)
+        included_dirs = _get_included_cluster_dirs(content)
+
+        assert cluster in included_dirs, (
+            f"FAIL: Cluster '{cluster}' is referenced in a command metadata "
+            f"function (CommandNeedsTimedInvoke / CommandIsFabricScoped / "
+            f"CommandHasLargePayload) but has no .ipp includes in "
+            f"cluster-objects-override.cpp. This is an orphaned metadata entry."
+        )
+else:
+    def test_command_metadata_clusters_have_ipp_includes():
+        """
+        **Validates: Requirements 1.5**
+
+        Property 3: Command metadata consistency (vacuously true)
+
+        No cluster IDs are referenced in the command metadata functions,
+        so there are no orphaned entries to check.
+        """
+        pass
+
+
+def test_command_metadata_no_orphaned_entries():
+    """
+    **Validates: Requirements 1.5**
+
+    Property 3 (supplement): Deterministic check that ALL clusters in
+    command metadata functions have corresponding .ipp includes.
+    """
+    content = _read_file(SLIM_CLUSTER_FILE)
+    metadata_clusters = _extract_command_metadata_clusters(content)
+    included_dirs = _get_included_cluster_dirs(content)
+
+    orphaned = [c for c in metadata_clusters if c not in included_dirs]
+    assert len(orphaned) == 0, (
+        f"FAIL: Found orphaned command metadata entries for clusters "
+        f"without .ipp includes: {orphaned}. "
+        f"Remove these entries from CommandNeedsTimedInvoke / "
+        f"CommandIsFabricScoped / CommandHasLargePayload."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running phase 2 cluster removal property tests...")
+    failed = False
+    try:
+        test_removed_clusters_absent_from_slim_cluster_file()
+        print("  PASS: Property 1 - Removed clusters absent from slim cluster file")
+    except AssertionError as e:
+        print(f"  FAIL: Property 1\n    {e}")
+        failed = True
+    except Exception as e:
+        print(f"  ERROR: Property 1\n    {e}")
+        failed = True
+
+    try:
+        test_retained_clusters_present_in_slim_cluster_file()
+        print("  PASS: Property 2 - Retained clusters present in slim cluster file")
+    except AssertionError as e:
+        print(f"  FAIL: Property 2\n    {e}")
+        failed = True
+    except Exception as e:
+        print(f"  ERROR: Property 2\n    {e}")
+        failed = True
+
+    try:
+        test_shared_structs_ipp_present_in_slim_cluster_file()
+        print("  PASS: Property 2 (supplement) - shared/Structs.ipp present")
+    except AssertionError as e:
+        print(f"  FAIL: Property 2 (supplement)\n    {e}")
+        failed = True
+    except Exception as e:
+        print(f"  ERROR: Property 2 (supplement)\n    {e}")
+        failed = True
+
+    try:
+        test_command_metadata_clusters_have_ipp_includes()
+        print("  PASS: Property 3 - Command metadata clusters have .ipp includes")
+    except AssertionError as e:
+        print(f"  FAIL: Property 3\n    {e}")
+        failed = True
+    except Exception as e:
+        print(f"  ERROR: Property 3\n    {e}")
+        failed = True
+
+    try:
+        test_command_metadata_no_orphaned_entries()
+        print("  PASS: Property 3 (supplement) - No orphaned metadata entries")
+    except AssertionError as e:
+        print(f"  FAIL: Property 3 (supplement)\n    {e}")
+        failed = True
+    except Exception as e:
+        print(f"  ERROR: Property 3 (supplement)\n    {e}")
+        failed = True
+
+    sys.exit(1 if failed else 0)

--- a/examples/tv-casting-app/tests/test_phase2_rtti_icd_safety.py
+++ b/examples/tv-casting-app/tests/test_phase2_rtti_icd_safety.py
@@ -1,0 +1,204 @@
+"""
+Phase 2 RTTI & ICD Safety Property Tests
+
+Feature: casting-apk-size-reduction-phase2
+
+Property 9: No RTTI usage in casting common C++ sources
+**Validates: Requirements 5.3**
+
+Property 10: No ICD client API usage in casting common sources
+**Validates: Requirements 6.3**
+
+This test verifies that:
+  - No .cpp or .h file in tv-casting-common/ (excluding darwin/ bridge)
+    uses dynamic_cast or typeid operators, confirming RTTI can be safely
+    disabled for Android builds.
+  - No .cpp or .h file in tv-casting-common/core/ or tv-casting-common/support/
+    contains #include directives referencing icd/client/ headers, confirming
+    the ICD client dependencies can be safely removed.
+"""
+
+import os
+import re
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+TV_CASTING_COMMON_DIR = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "tv-casting-common",
+)
+
+CORE_DIR = os.path.join(TV_CASTING_COMMON_DIR, "core")
+SUPPORT_DIR = os.path.join(TV_CASTING_COMMON_DIR, "support")
+
+# ---------------------------------------------------------------------------
+# File collection helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_cpp_h_files(root_dir, exclude_dirs=None):
+    """Collect all .cpp and .h files under root_dir, excluding specified dirs."""
+    if exclude_dirs is None:
+        exclude_dirs = set()
+    files = []
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        # Skip excluded directories
+        dirnames[:] = [
+            d for d in dirnames
+            if os.path.join(dirpath, d) not in exclude_dirs
+        ]
+        for fname in filenames:
+            if fname.endswith(".cpp") or fname.endswith(".h"):
+                files.append(os.path.join(dirpath, fname))
+    return sorted(files)
+
+
+# ---------------------------------------------------------------------------
+# Build file lists
+# ---------------------------------------------------------------------------
+
+# Property 9: All .cpp/.h in tv-casting-common/ excluding darwin/ bridge
+# (darwin/ is at examples/tv-casting-app/darwin/, not under tv-casting-common/,
+# but we exclude it defensively in case the layout changes)
+_DARWIN_EXCLUDE = os.path.join(TV_CASTING_COMMON_DIR, "darwin")
+ALL_CASTING_COMMON_CPP_H = _collect_cpp_h_files(
+    TV_CASTING_COMMON_DIR, exclude_dirs={_DARWIN_EXCLUDE}
+)
+
+# Property 10: .cpp/.h in core/ and support/ only
+CORE_SUPPORT_CPP_H = _collect_cpp_h_files(CORE_DIR) + _collect_cpp_h_files(SUPPORT_DIR)
+
+# RTTI patterns: match dynamic_cast<...> or typeid(...) as C++ operators
+# Use word boundary to avoid matching inside comments or string literals
+# that happen to contain these as substrings of other identifiers.
+RTTI_PATTERN = re.compile(r'\bdynamic_cast\s*<|\btypeid\s*\(')
+
+# ICD client include pattern: #include with icd/client/ path
+ICD_CLIENT_INCLUDE_PATTERN = re.compile(r'#\s*include\s+[<"].*icd/client/.*[>"]')
+
+
+# ---------------------------------------------------------------------------
+# Property 9: No RTTI usage in casting common C++ sources
+# ---------------------------------------------------------------------------
+
+# Guard: hypothesis needs at least one element in sampled_from
+assert len(ALL_CASTING_COMMON_CPP_H) > 0, (
+    "No .cpp or .h files found in tv-casting-common/. "
+    "Check that the directory exists and contains source files."
+)
+
+
+@given(filepath=st.sampled_from(ALL_CASTING_COMMON_CPP_H))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_no_rtti_usage_in_casting_common(filepath):
+    """
+    **Validates: Requirements 5.3**
+
+    Property 9: No RTTI usage in casting common C++ sources
+
+    For any .cpp or .h file in tv-casting-common/ (excluding darwin/ bridge),
+    the file SHALL NOT contain dynamic_cast or typeid operators, confirming
+    RTTI can be safely disabled for Android builds.
+    """
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    # Strip single-line comments to reduce false positives
+    content_no_comments = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
+    # Strip multi-line comments
+    content_no_comments = re.sub(r'/\*.*?\*/', '', content_no_comments, flags=re.DOTALL)
+
+    matches = list(RTTI_PATTERN.finditer(content_no_comments))
+    rel_path = os.path.relpath(filepath, REPO_ROOT)
+
+    assert len(matches) == 0, (
+        f"FAIL: RTTI usage found in {rel_path}. "
+        f"Found {len(matches)} occurrence(s) of dynamic_cast or typeid. "
+        f"RTTI must not be used in casting common sources so that "
+        f"enable_rtti=false can be safely applied."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 10: No ICD client API usage in casting common sources
+# ---------------------------------------------------------------------------
+
+# Guard: hypothesis needs at least one element in sampled_from
+assert len(CORE_SUPPORT_CPP_H) > 0, (
+    "No .cpp or .h files found in tv-casting-common/core/ or support/. "
+    "Check that the directories exist and contain source files."
+)
+
+
+@given(filepath=st.sampled_from(CORE_SUPPORT_CPP_H))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_no_icd_client_includes_in_core_support(filepath):
+    """
+    **Validates: Requirements 6.3**
+
+    Property 10: No ICD client API usage in casting common sources
+
+    For any .cpp or .h file in tv-casting-common/core/ or
+    tv-casting-common/support/, the file SHALL NOT contain #include
+    directives referencing icd/client/ headers, confirming the ICD client
+    dependencies can be safely removed.
+    """
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    matches = list(ICD_CLIENT_INCLUDE_PATTERN.finditer(content))
+    rel_path = os.path.relpath(filepath, REPO_ROOT)
+
+    assert len(matches) == 0, (
+        f"FAIL: ICD client #include found in {rel_path}. "
+        f"Found {len(matches)} #include directive(s) referencing icd/client/ headers. "
+        f"ICD client APIs must not be used in casting common sources so that "
+        f"the ICD client dependencies can be safely removed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allow running directly
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+
+    print("Running phase 2 RTTI & ICD safety property tests...")
+    failed = False
+
+    tests = [
+        ("Property 9 - No RTTI usage", test_no_rtti_usage_in_casting_common),
+        ("Property 10 - No ICD client includes", test_no_icd_client_includes_in_core_support),
+    ]
+
+    for name, test_fn in tests:
+        try:
+            test_fn()
+            print(f"  PASS: {name}")
+        except AssertionError as e:
+            print(f"  FAIL: {name}\n    {e}")
+            failed = True
+        except Exception as e:
+            print(f"  ERROR: {name}\n    {e}")
+            failed = True
+
+    sys.exit(1 if failed else 0)

--- a/examples/tv-casting-app/tests/test_phase2_zap_clusters.py
+++ b/examples/tv-casting-app/tests/test_phase2_zap_clusters.py
@@ -1,0 +1,181 @@
+"""
+Phase 2 ZAP Cluster Property Tests
+
+Feature: casting-apk-size-reduction-phase2
+
+Property 4: ZAP server-side disabled for removed clusters
+**Validates: Requirements 2.1**
+
+Property 5: ZAP server-side enabled for commissioning clusters
+**Validates: Requirements 2.2**
+
+This test verifies that:
+  - For each of the 11 removed clusters, if a server-side entry exists in the
+    ZAP file it has "enabled": 0 (absence also counts as disabled).
+  - For each of the 12 commissioning-essential clusters, a server-side entry
+    exists with "enabled": 1.
+
+The 10 removed clusters (ZAP names use spaces):
+  Ethernet Network Diagnostics, Software Diagnostics,
+  Wi-Fi Network Diagnostics, Time Synchronization,
+  Time Format Localization, Unit Localization, Fixed Label, User Label,
+  ICD Management, Localization Configuration
+
+The 13 commissioning clusters (ZAP names use spaces):
+  Descriptor, Binding, Access Control, Basic Information,
+  General Commissioning, Network Commissioning, General Diagnostics,
+  Administrator Commissioning, Operational Credentials,
+  Group Key Management, Groupcast, Identify, Groups
+"""
+
+import json
+import os
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+ZAP_FILE = os.path.join(
+    REPO_ROOT,
+    "examples",
+    "tv-casting-app",
+    "tv-casting-common",
+    "tv-casting-app.zap",
+)
+
+# ---------------------------------------------------------------------------
+# Constants — ZAP cluster names use spaces, not PascalCase
+# ---------------------------------------------------------------------------
+
+REMOVED_CLUSTERS_ZAP = [
+    "Ethernet Network Diagnostics",
+    "Software Diagnostics",
+    "Wi-Fi Network Diagnostics",
+    "Time Synchronization",
+    "Time Format Localization",
+    "Unit Localization",
+    "Fixed Label",
+    "User Label",
+    "ICD Management",
+    "Localization Configuration",
+]
+
+COMMISSIONING_CLUSTERS_ZAP = [
+    "Descriptor",
+    "Binding",
+    "Access Control",
+    "Basic Information",
+    "General Commissioning",
+    "Network Commissioning",
+    "General Diagnostics",
+    "Administrator Commissioning",
+    "Operational Credentials",
+    "Group Key Management",
+    "Groupcast",
+    "Identify",
+    "Groups",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_zap() -> dict:
+    """Load and parse the ZAP JSON file."""
+    with open(ZAP_FILE, "r") as f:
+        return json.load(f)
+
+
+def _get_server_clusters(zap_data: dict) -> list[dict]:
+    """Return all server-side cluster entries across all endpoint types."""
+    clusters = []
+    for endpoint_type in zap_data.get("endpointTypes", []):
+        for cluster in endpoint_type.get("clusters", []):
+            if cluster.get("side") == "server":
+                clusters.append(cluster)
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Property 4: ZAP server-side disabled for removed clusters
+# ---------------------------------------------------------------------------
+
+
+@given(cluster_name=st.sampled_from(REMOVED_CLUSTERS_ZAP))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_zap_server_side_disabled_for_removed_clusters(cluster_name: str):
+    """
+    **Validates: Requirements 2.1**
+
+    Property 4: ZAP server-side disabled for removed clusters
+
+    For any cluster name in the set of 11 removed clusters, if the ZAP file
+    contains a server-side entry for that cluster, it SHALL have "enabled": 0.
+    Absence of a server-side entry also satisfies this property.
+    """
+    zap_data = _load_zap()
+    server_clusters = _get_server_clusters(zap_data)
+
+    matching = [c for c in server_clusters if c["name"] == cluster_name]
+
+    # If no server-side entry exists, the cluster is effectively disabled
+    if not matching:
+        return
+
+    for entry in matching:
+        assert entry.get("enabled") == 0, (
+            f"FAIL: Server-side cluster '{cluster_name}' has "
+            f"\"enabled\": {entry.get('enabled')} but should be 0 (disabled). "
+            f"Phase 2 requires this cluster to be disabled in the ZAP file."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 5: ZAP server-side enabled for commissioning clusters
+# ---------------------------------------------------------------------------
+
+
+@given(cluster_name=st.sampled_from(COMMISSIONING_CLUSTERS_ZAP))
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_zap_server_side_enabled_for_commissioning_clusters(cluster_name: str):
+    """
+    **Validates: Requirements 2.2**
+
+    Property 5: ZAP server-side enabled for commissioning clusters
+
+    For any cluster name in the set of 12 commissioning-essential clusters,
+    the ZAP file SHALL contain a server-side entry with "enabled": 1.
+    """
+    zap_data = _load_zap()
+    server_clusters = _get_server_clusters(zap_data)
+
+    matching = [c for c in server_clusters if c["name"] == cluster_name]
+
+    assert len(matching) > 0, (
+        f"FAIL: No server-side entry found for commissioning cluster "
+        f"'{cluster_name}' in tv-casting-app.zap. "
+        f"Commissioning clusters must have a server-side entry."
+    )
+
+    for entry in matching:
+        assert entry.get("enabled") == 1, (
+            f"FAIL: Server-side cluster '{cluster_name}' has "
+            f"\"enabled\": {entry.get('enabled')} but should be 1 (enabled). "
+            f"Commissioning clusters must remain enabled."
+        )

--- a/examples/tv-casting-app/tests/test_preservation_default_and_non_android.py
+++ b/examples/tv-casting-app/tests/test_preservation_default_and_non_android.py
@@ -1,26 +1,21 @@
 """
 Preservation Property Test -- Property 2: Default and Non-Android Builds Unchanged
 
-**Validates: Requirements 3.1, 3.2**
+**Validates: Requirements 14.1, 14.4**
 
 This test verifies that the baseline build configurations for default
 (non-optimized) Android builds and non-Android platforms (Linux, Darwin)
-remain unchanged. It follows observation-first methodology: the assertions
-encode the *current* state of the files so that any future change that
-accidentally regresses these configurations will be caught.
+remain unchanged after consolidation of override args into
+`chip_data_model_overrides_dir`.
 
-Observations (on UNFIXED code):
+Observations (on consolidated code):
 - android/args.gni default block: chip_build_libshell=true,
-  optimize_for_size=false, no chip_cluster_objects_source_override set,
-  no matter_enable_tlv_decoder_api set.
-- linux/args.gni: does NOT set chip_cluster_objects_source_override
-  unconditionally (set via host.py when chip_casting_simplified=true).
-- darwin/args.gni: chip_cluster_objects_source_override points to
-  casting-cluster-objects.cpp.
-- casting-cluster-objects.cpp exists and contains ~157 .ipp includes
-  spanning ~39 cluster directories plus the shared utilities directory.
-
-EXPECTED on UNFIXED code: ALL TESTS PASS -- confirms baseline to preserve.
+  optimize_for_size=false, no chip_data_model_overrides_dir set.
+- android/args.gni optimize_apk_size block: sets chip_data_model_overrides_dir.
+- linux/args.gni: does NOT set chip_data_model_overrides_dir unconditionally.
+- darwin/args.gni: chip_data_model_overrides_dir points to tv-casting-common/.
+- cluster-objects-override.cpp exists and contains ~117 .ipp includes
+  spanning ~29 cluster directories plus the shared utilities directory.
 """
 
 import os
@@ -51,7 +46,7 @@ SLIM_CLUSTER_FILE = os.path.join(
     "examples",
     "tv-casting-app",
     "tv-casting-common",
-    "casting-cluster-objects.cpp",
+    "cluster-objects-override.cpp",
 )
 
 # ---------------------------------------------------------------------------
@@ -115,6 +110,29 @@ def _extract_else_block(text: str) -> str:
     return stripped[else_body_start:epos - 1]
 
 
+def _extract_if_block(text: str) -> str:
+    """
+    Extract the body of the `if (optimize_apk_size)` block in args.gni.
+    """
+    stripped = _strip_comments(text)
+
+    match = re.search(r"if\s*\(\s*optimize_apk_size\s*\)", stripped)
+    if not match:
+        return ""
+
+    brace_start = stripped.index("{", match.end())
+    depth = 1
+    pos = brace_start + 1
+    while pos < len(stripped) and depth > 0:
+        if stripped[pos] == "{":
+            depth += 1
+        elif stripped[pos] == "}":
+            depth -= 1
+        pos += 1
+
+    return stripped[brace_start + 1:pos - 1]
+
+
 def _extract_top_level_assignment(text: str, var_name: str) -> str | None:
     """
     Return the RHS of a top-level `var_name = <value>` in *text*, or None.
@@ -152,13 +170,12 @@ def _unique_cluster_dirs(text: str) -> set:
 )
 def test_android_default_build_preserves_dev_flags(optimize_apk_size: bool):
     """
-    **Validates: Requirements 3.1**
+    **Validates: Requirements 14.1**
 
     Property 2a (Preservation): For an Android build with
     `optimize_apk_size = false` (the default), the build SHALL preserve
     `chip_build_libshell = true`, `optimize_for_size = false`, and SHALL NOT
-    set `chip_cluster_objects_source_override` or
-    `matter_enable_tlv_decoder_api`.
+    set `chip_data_model_overrides_dir`.
     """
     assert not optimize_apk_size, "This test covers the default (non-optimized) path"
 
@@ -193,23 +210,49 @@ def test_android_default_build_preserves_dev_flags(optimize_apk_size: bool):
         f"in the default build"
     )
 
-    # chip_cluster_objects_source_override should NOT be set in the else block
+    # chip_data_model_overrides_dir should NOT be set in the else block
     override_in_else = _extract_top_level_assignment(
-        else_block, "chip_cluster_objects_source_override"
+        else_block, "chip_data_model_overrides_dir"
     )
     assert override_in_else is None, (
-        f"REGRESSION: `chip_cluster_objects_source_override` is set to "
+        f"REGRESSION: `chip_data_model_overrides_dir` is set to "
         f"`{override_in_else}` in the default (else) block -- it should only "
-        f"be set in the optimize_apk_size block (if at all)"
+        f"be set in the optimize_apk_size block"
     )
 
-    # matter_enable_tlv_decoder_api should NOT be set in the else block
-    tlv_in_else = _extract_top_level_assignment(
-        else_block, "matter_enable_tlv_decoder_api"
+
+@given(optimize_apk_size=st.just(True))
+@settings(
+    max_examples=1,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=None,
+)
+def test_android_optimize_block_sets_overrides_dir(optimize_apk_size: bool):
+    """
+    **Validates: Requirements 14.1, 14.4**
+
+    Property 2a-opt (Preservation): For an Android build with
+    `optimize_apk_size = true`, the args.gni SHALL set
+    `chip_data_model_overrides_dir` pointing to the tv-casting-common directory.
+    """
+    assert optimize_apk_size, "This test covers the optimized path"
+
+    gni_text = _read_file(ANDROID_ARGS_GNI)
+    if_block = _extract_if_block(gni_text)
+    assert if_block, (
+        "Could not find the `if (optimize_apk_size)` block in android/args.gni"
     )
-    assert tlv_in_else is None, (
-        f"REGRESSION: `matter_enable_tlv_decoder_api` is set to `{tlv_in_else}` "
-        f"in the default (else) block -- it should not be overridden for dev builds"
+
+    override_val = _extract_top_level_assignment(
+        if_block, "chip_data_model_overrides_dir"
+    )
+    assert override_val is not None, (
+        "REGRESSION: `chip_data_model_overrides_dir` is not set in the "
+        "optimize_apk_size block of android/args.gni"
+    )
+    assert "tv-casting-common" in override_val, (
+        f"REGRESSION: `chip_data_model_overrides_dir` in the optimize_apk_size "
+        f"block is `{override_val}` -- expected it to reference tv-casting-common"
     )
 
 
@@ -219,30 +262,27 @@ def test_android_default_build_preserves_dev_flags(optimize_apk_size: bool):
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_non_android_builds_use_slim_cluster_override(platform: str):
+def test_non_android_builds_use_overrides_dir(platform: str):
     """
-    **Validates: Requirements 3.2**
+    **Validates: Requirements 14.4**
 
     Property 2b (Preservation): Darwin builds SHALL continue to
-    set `chip_cluster_objects_source_override` pointing to
-    `casting-cluster-objects.cpp`.
-
-    Linux builds set the override conditionally via host.py when
-    chip_casting_simplified=true, so it is NOT in linux/args.gni.
+    set `chip_data_model_overrides_dir` pointing to the tv-casting-common
+    directory.
     """
     gni_text = _read_file(DARWIN_ARGS_GNI)
     stripped = _strip_comments(gni_text)
 
     override_val = _extract_top_level_assignment(
-        stripped, "chip_cluster_objects_source_override"
+        stripped, "chip_data_model_overrides_dir"
     )
     assert override_val is not None, (
-        f"REGRESSION: `chip_cluster_objects_source_override` is not set in "
-        f"{platform}/args.gni -- the slim cluster override must remain active"
+        f"REGRESSION: `chip_data_model_overrides_dir` is not set in "
+        f"{platform}/args.gni -- the override directory must remain active"
     )
-    assert "casting-cluster-objects.cpp" in override_val, (
-        f"REGRESSION: `chip_cluster_objects_source_override` in {platform}/args.gni "
-        f"is `{override_val}` -- expected it to reference casting-cluster-objects.cpp"
+    assert "tv-casting-common" in override_val, (
+        f"REGRESSION: `chip_data_model_overrides_dir` in {platform}/args.gni "
+        f"is `{override_val}` -- expected it to reference tv-casting-common"
     )
 
 
@@ -252,27 +292,24 @@ def test_non_android_builds_use_slim_cluster_override(platform: str):
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_linux_args_gni_does_not_set_unconditional_cluster_override(dummy: bool):
+def test_linux_args_gni_does_not_set_unconditional_overrides_dir(dummy: bool):
     """
     **Validates: CI fix for linux-x64-tv-casting-app**
 
     Property 2b-linux: Linux args.gni SHALL NOT unconditionally set
-    chip_cluster_objects_source_override, because the legacy build path
+    chip_data_model_overrides_dir, because the legacy build path
     (chip_casting_simplified=false) needs the full cluster-objects.cpp.
-    The override is set conditionally via host.py when
-    chip_casting_simplified=true.
     """
     gni_text = _read_file(LINUX_ARGS_GNI)
     stripped = _strip_comments(gni_text)
 
     override_val = _extract_top_level_assignment(
-        stripped, "chip_cluster_objects_source_override"
+        stripped, "chip_data_model_overrides_dir"
     )
     assert override_val is None, (
-        f"REGRESSION: `chip_cluster_objects_source_override` is set unconditionally "
+        f"REGRESSION: `chip_data_model_overrides_dir` is set unconditionally "
         f"in linux/args.gni to `{override_val}` -- this breaks the legacy build path "
-        f"(chip_casting_simplified=false) which needs all clusters. The override "
-        f"should be set via host.py only when chip_casting_simplified=true."
+        f"(chip_casting_simplified=false) which needs all clusters."
     )
 
 
@@ -284,36 +321,32 @@ def test_linux_args_gni_does_not_set_unconditional_cluster_override(dummy: bool)
 )
 def test_casting_cluster_objects_file_exists_with_expected_includes(dummy: bool):
     """
-    **Validates: Requirements 3.2**
+    **Validates: Requirements 14.4**
 
-    Property 2c (Preservation): The slim `casting-cluster-objects.cpp` file
+    Property 2c (Preservation): The slim `cluster-objects-override.cpp` file
     SHALL exist and include .ipp files for the expected set of casting-relevant
-    and infrastructure clusters (~39 cluster directories plus shared utilities,
-    totalling ~157 .ipp includes).
+    and infrastructure clusters (~29 cluster directories plus shared utilities,
+    totalling ~117 .ipp includes).
     """
     assert os.path.isfile(SLIM_CLUSTER_FILE), (
-        f"REGRESSION: casting-cluster-objects.cpp not found at {SLIM_CLUSTER_FILE}"
+        f"REGRESSION: cluster-objects-override.cpp not found at {SLIM_CLUSTER_FILE}"
     )
 
     content = _read_file(SLIM_CLUSTER_FILE)
 
     # Count .ipp includes
     ipp_count = _count_ipp_includes(content)
-    # The file currently has ~157 .ipp includes. Allow a small tolerance
-    # (+-5) for minor cluster additions/removals, but catch large regressions
-    # like accidentally replacing with the full cluster-objects.cpp (~800+).
     assert 100 <= ipp_count <= 200, (
-        f"REGRESSION: casting-cluster-objects.cpp has {ipp_count} .ipp includes. "
-        f"Expected ~157 (between 100 and 200). If this is much larger, the slim "
+        f"REGRESSION: cluster-objects-override.cpp has {ipp_count} .ipp includes. "
+        f"Expected ~117 (between 100 and 200). If this is much larger, the slim "
         f"file may have been replaced with the full cluster-objects.cpp."
     )
 
     # Verify unique cluster directories
     cluster_dirs = _unique_cluster_dirs(content)
-    # Currently 39 cluster dirs + 'shared' = 40 total
     assert 30 <= len(cluster_dirs) <= 50, (
-        f"REGRESSION: casting-cluster-objects.cpp references {len(cluster_dirs)} "
-        f"unique cluster directories. Expected ~40 (between 30 and 50)."
+        f"REGRESSION: cluster-objects-override.cpp references {len(cluster_dirs)} "
+        f"unique cluster directories. Expected ~30 (between 30 and 50)."
     )
 
     # Verify key casting-specific clusters are present
@@ -337,7 +370,7 @@ def test_casting_cluster_objects_file_exists_with_expected_includes(dummy: bool)
     }
     missing = expected_casting_clusters - cluster_dirs
     assert not missing, (
-        f"REGRESSION: casting-cluster-objects.cpp is missing casting-specific "
+        f"REGRESSION: cluster-objects-override.cpp is missing casting-specific "
         f"clusters: {missing}"
     )
 
@@ -353,7 +386,7 @@ def test_casting_cluster_objects_file_exists_with_expected_includes(dummy: bool)
     }
     missing_infra = expected_infra_clusters - cluster_dirs
     assert not missing_infra, (
-        f"REGRESSION: casting-cluster-objects.cpp is missing infrastructure "
+        f"REGRESSION: cluster-objects-override.cpp is missing infrastructure "
         f"clusters: {missing_infra}"
     )
 
@@ -368,11 +401,13 @@ if __name__ == "__main__":
     tests = [
         ("2a: Android default build preserves dev flags",
          test_android_default_build_preserves_dev_flags),
-        ("2b: Darwin builds use slim cluster override",
-         test_non_android_builds_use_slim_cluster_override),
-        ("2b-linux: Linux args.gni does not set unconditional cluster override",
-         test_linux_args_gni_does_not_set_unconditional_cluster_override),
-        ("2c: casting-cluster-objects.cpp exists with expected includes",
+        ("2a-opt: Android optimize block sets overrides dir",
+         test_android_optimize_block_sets_overrides_dir),
+        ("2b: Darwin builds use overrides dir",
+         test_non_android_builds_use_overrides_dir),
+        ("2b-linux: Linux args.gni does not set unconditional overrides dir",
+         test_linux_args_gni_does_not_set_unconditional_overrides_dir),
+        ("2c: cluster-objects-override.cpp exists with expected includes",
          test_casting_cluster_objects_file_exists_with_expected_includes),
     ]
     all_passed = True

--- a/examples/tv-casting-app/tests/test_preservation_non_casting_builds.py
+++ b/examples/tv-casting-app/tests/test_preservation_non_casting_builds.py
@@ -1,22 +1,20 @@
 """
-Property Test — Property 5 + 6 preservation: Non-casting builds unchanged
+Property Test — Preservation: Non-casting builds unchanged
 
-Feature: casting-client-cluster-reduction
-Property 5+6 preservation: Non-casting builds unchanged
+Feature: consolidate-overrides-and-generation-script
+Preservation: Non-casting builds unchanged
 
-**Validates: Requirements 6.1, 6.2, 6.3, 6.4, 6.5**
+**Validates: Requirements 14.1, 14.2**
 
 This test verifies that the GN build configuration preserves correct defaults
-for non-casting builds:
+for non-casting builds after the consolidation of override args into
+`chip_data_model_overrides_dir`:
 
-1. `config.gni` still declares `matter_enable_tlv_decoder_cpp` with default `true`
-2. `config.gni` declares `chip_tlv_decoder_attribute_source_override` with default `""`
-3. `config.gni` declares `chip_tlv_decoder_event_source_override` with default `""`
-4. `args.gni` default block (else branch) does NOT set the override args
-5. `args.gni` default block does NOT set `matter_enable_tlv_decoder_cpp` to false
+1. `common_flags.gni` declares `chip_data_model_overrides_dir` with default `""`
+2. `args.gni` default block (else branch) does NOT set `chip_data_model_overrides_dir`
 
 These properties ensure that non-casting Android builds and non-Android builds
-remain completely unaffected by the slim decoder feature.
+remain completely unaffected by the override directory mechanism.
 """
 
 import os
@@ -25,17 +23,17 @@ import re
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 # Paths
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-CONFIG_GNI = os.path.join(REPO_ROOT, "build", "chip", "java", "config.gni")
+COMMON_FLAGS_GNI = os.path.join(REPO_ROOT, "src", "app", "common_flags.gni")
 ARGS_GNI = os.path.join(REPO_ROOT, "examples", "tv-casting-app", "android", "args.gni")
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 # Helpers
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 
 
 def _read_file(path: str) -> str:
@@ -50,36 +48,37 @@ def _strip_comments(text: str) -> str:
 
 def _extract_declare_args_block(text: str) -> str:
     r"""
-    Extract the body of the `declare_args()
-{
-    ...
-}
-` block from config.gni.""
-                        "
-    pattern = r "declare_args\s*\(\s*\)\s*\{" m           = re.search(pattern, text) assert m is not None,
-    "Could not find `declare_args()` in config.gni" depth = 1 pos =
-        m.end() while pos < len(text) and depth > 0 : if text[pos] == "{" : depth += 1 elif text[pos] == "}" : depth -= 1 pos +=
-    1 return text [m.end():pos - 1]
+    Extract the body of the `declare_args() { ... }` block.
+    """
+    pattern = r"declare_args\s*\(\s*\)\s*\{"
+    m = re.search(pattern, text)
+    assert m is not None, "Could not find `declare_args()` block"
+    depth = 1
+    pos = m.end()
+    while pos < len(text) and depth > 0:
+        if text[pos] == "{":
+            depth += 1
+        elif text[pos] == "}":
+            depth -= 1
+        pos += 1
+    return text[m.end():pos - 1]
 
-    def
-    _find_assignment_in_block(block : str, var_name : str) -> str |
-    None : ""
-           "
-           Find a `var_name = <value>` assignment in the block.Returns the RHS value as a string,
-    or
-    None if not found.""
-                      "
-    pattern = rf "^\s*{re.escape(var_name)}\s*=\s*(.+)" m = re.search(pattern, block, re.MULTILINE) if m
-    : return m.group(1)
-          .strip() return None
 
-              def _extract_else_block(text : str)
-          ->str : ""
-                  "
-                  Extract the body of the `
-}
-else
-{` block that follows the
+def _find_assignment_in_block(block: str, var_name: str) -> str | None:
+    """
+    Find a `var_name = <value>` assignment in the block. Returns the RHS
+    value as a string, or None if not found.
+    """
+    pattern = rf"^\s*{re.escape(var_name)}\s*=\s*(.+)"
+    m = re.search(pattern, block, re.MULTILINE)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _extract_else_block(text: str) -> str:
+    """
+    Extract the body of the `} else {` block that follows the
     `if (optimize_apk_size)` conditional in android/args.gni.
     """
     stripped = _strip_comments(text)
@@ -88,7 +87,7 @@ else
     if not match:
         return ""
 
-# Walk past the if - block's opening brace
+    # Walk past the if-block's opening brace
     brace_start = stripped.index("{", match.end())
     depth = 1
     pos = brace_start + 1
@@ -99,8 +98,8 @@ else
             depth -= 1
         pos += 1
 
-# pos is now just past the closing } of the if - block.
-# Look for `else {`
+    # pos is now just past the closing } of the if-block.
+    # Look for `else {`
     rest = stripped[pos:]
     else_match = re.search(r"else\s*\{", rest)
     if not else_match:
@@ -116,46 +115,45 @@ else
             depth -= 1
         epos += 1
 
-    return stripped[else_body_start: epos - 1]
+    return stripped[else_body_start:epos - 1]
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-# Property - based tests — config.gni declarations
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
+# Property-based tests — common_flags.gni declarations
+# ---------------------------------------------------------------------------
 
 
-@given(
-    override_arg=st.sampled_from([
-        "chip_tlv_decoder_attribute_source_override",
-        "chip_tlv_decoder_event_source_override",
-    ])
-)
+@given(dummy=st.just(True))
 @settings(
-    max_examples=100,
+    max_examples=1,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_config_gni_declares_override_args_with_empty_default(override_arg):
+def test_common_flags_gni_declares_chip_data_model_overrides_dir(dummy):
     """
-    **Validates: Requirements 6.1, 6.2**
+    **Validates: Requirements 14.1**
 
-    Property 5+6 preservation (a): config.gni SHALL declare both
-    `chip_tlv_decoder_attribute_source_override` and
-    `chip_tlv_decoder_event_source_override` with default empty string `""`.
-    When empty, the GN build compiles the full zap-generated decoders.
+    Preservation (a): common_flags.gni SHALL declare
+    `chip_data_model_overrides_dir` with default empty string `""`.
+    When empty, the GN build uses the full zap-generated sources.
     """
-    content = _read_file(CONFIG_GNI)
+    content = _read_file(COMMON_FLAGS_GNI)
     block = _extract_declare_args_block(content)
 
-    value = _find_assignment_in_block(block, override_arg)
+    value = _find_assignment_in_block(block, "chip_data_model_overrides_dir")
     assert value is not None, (
-        f"`{override_arg}` is not declared in the declare_args() block "
-        f"of config.gni"
+        "`chip_data_model_overrides_dir` is not declared in the "
+        "declare_args() block of common_flags.gni"
     )
-# The default should be an empty string : ""
+    # The default should be an empty string: ""
     assert value == '""', (
-        f"`{override_arg}` has default `{value}` instead of `\"\"` in "
-        f"config.gni — non-casting builds require the empty default"
+        f"`chip_data_model_overrides_dir` has default `{value}` instead of "
+        f'`""` in common_flags.gni — non-casting builds require the empty default'
     )
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests — args.gni default (else) block
+# ---------------------------------------------------------------------------
 
 
 @given(dummy=st.just(True))
@@ -164,54 +162,14 @@ def test_config_gni_declares_override_args_with_empty_default(override_arg):
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     deadline=None,
 )
-def test_config_gni_preserves_matter_enable_tlv_decoder_cpp_true(dummy):
+def test_args_gni_default_block_does_not_set_overrides_dir(dummy):
     """
-    **Validates: Requirements 6.5**
+    **Validates: Requirements 14.2**
 
-    Property 5+6 preservation (b): config.gni SHALL still declare
-    `matter_enable_tlv_decoder_cpp` with default `true`. This flag must
-    remain available for other use cases and default to enabling C++ TLV
-    decoding.
-    """
-    content = _read_file(CONFIG_GNI)
-    block = _extract_declare_args_block(content)
-
-    value = _find_assignment_in_block(block, "matter_enable_tlv_decoder_cpp")
-    assert value is not None, (
-        "`matter_enable_tlv_decoder_cpp` is not declared in the "
-        "declare_args() block of config.gni"
-    )
-    assert value == "true", (
-        f"`matter_enable_tlv_decoder_cpp` has default `{value}` instead of "
-        f"`true` in config.gni — this flag must default to true to preserve "
-        f"existing behavior for all non-casting builds"
-    )
-
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-# Property - based tests — args.gni default(else) block
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
-
-
-@given(
-    override_arg=st.sampled_from([
-        "chip_tlv_decoder_attribute_source_override",
-        "chip_tlv_decoder_event_source_override",
-    ])
-)
-@settings(
-    max_examples=100,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-    deadline=None,
-)
-def test_args_gni_default_block_does_not_set_override_args(override_arg):
-    """
-    **Validates: Requirements 6.3, 6.4**
-
-    Property 5+6 preservation (c): The default (else) block in args.gni
+    Preservation (b): The default (else) block in args.gni
     (when optimize_apk_size is false) SHALL NOT set
-    `chip_tlv_decoder_attribute_source_override` or
-    `chip_tlv_decoder_event_source_override`. Non-optimized builds must
-    use the full zap-generated decoders via the empty-string default.
+    `chip_data_model_overrides_dir`. Non-optimized builds must
+    use the full zap-generated sources via the empty-string default.
     """
     content = _read_file(ARGS_GNI)
     else_block = _extract_else_block(content)
@@ -220,59 +178,26 @@ def test_args_gni_default_block_does_not_set_override_args(override_arg):
         "in android/args.gni"
     )
 
-    value = _find_assignment_in_block(else_block, override_arg)
+    value = _find_assignment_in_block(else_block, "chip_data_model_overrides_dir")
     assert value is None, (
-        f"REGRESSION: `{override_arg}` is set to `{value}` in the default "
-        f"(else) block of args.gni — it should only be set in the "
-        f"optimize_apk_size block"
+        f"REGRESSION: `chip_data_model_overrides_dir` is set to `{value}` "
+        f"in the default (else) block of args.gni — it should only be set "
+        f"in the optimize_apk_size block"
     )
 
 
-@given(dummy=st.just(True))
-@settings(
-    max_examples=1,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-    deadline=None,
-)
-def test_args_gni_default_block_does_not_disable_tlv_decoder(dummy):
-    """
-    **Validates: Requirements 6.3, 6.5**
-
-    Property 5+6 preservation (d): The default (else) block in args.gni
-    SHALL NOT set `matter_enable_tlv_decoder_cpp` to false. Non-optimized
-    builds must keep C++ TLV decoding enabled (the config.gni default).
-    """
-    content = _read_file(ARGS_GNI)
-    else_block = _extract_else_block(content)
-    assert else_block, (
-        "Could not find the `else` block after `if (optimize_apk_size)` "
-        "in android/args.gni"
-    )
-
-    value = _find_assignment_in_block(else_block, "matter_enable_tlv_decoder_cpp")
-    assert value is None, (
-        f"REGRESSION: `matter_enable_tlv_decoder_cpp` is set to `{value}` "
-        f"in the default (else) block of args.gni — it should not be "
-        f"overridden for default development builds"
-    )
-
-
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 # Allow running directly
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     import sys
 
     print("Running preservation of non-casting builds property tests...")
     tests = [
-        ("5+6a: config.gni declares override args with empty default",
-         test_config_gni_declares_override_args_with_empty_default),
-        ("5+6b: config.gni preserves matter_enable_tlv_decoder_cpp = true",
-         test_config_gni_preserves_matter_enable_tlv_decoder_cpp_true),
-        ("5+6c: args.gni default block does not set override args",
-         test_args_gni_default_block_does_not_set_override_args),
-        ("5+6d: args.gni default block does not disable TLV decoder",
-         test_args_gni_default_block_does_not_disable_tlv_decoder),
+        ("a: common_flags.gni declares chip_data_model_overrides_dir with empty default",
+         test_common_flags_gni_declares_chip_data_model_overrides_dir),
+        ("b: args.gni default block does not set chip_data_model_overrides_dir",
+         test_args_gni_default_block_does_not_set_overrides_dir),
     ]
     all_passed = True
     for name, test_fn in tests:

--- a/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
@@ -1,0 +1,3391 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file Accessors-override.cpp
+ *
+ * Slim replacement for the full zap-generated Accessors.cpp that includes
+ * only the attribute accessor functions needed by the TV Casting App.
+ *
+ * This file is a hand-maintained subset of:
+ *   zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+ *
+ * It covers the 29 casting-relevant clusters:
+ *
+ *   Commissioning clusters (12):
+ *     Identify, Groups, Descriptor, Binding, AccessControl,
+ *     BasicInformation, OtaSoftwareUpdateProvider,
+ *     OtaSoftwareUpdateRequestor, GeneralCommissioning,
+ *     NetworkCommissioning, GeneralDiagnostics,
+ *     AdministratorCommissioning
+ *
+ *   Casting clusters (17):
+ *     OperationalCredentials, GroupKeyManagement, FixedLabel, UserLabel,
+ *     RelativeHumidityMeasurement, WakeOnLan, Channel, TargetNavigator,
+ *     MediaPlayback, MediaInput, LowPower, KeypadInput, ContentLauncher,
+ *     AudioOutput, ApplicationLauncher, ApplicationBasic,
+ *     ContentAppObserver
+ *
+ * All other clusters are omitted to reduce binary size (~826 KB savings).
+ * Function signatures and implementations are identical to the full
+ * generated file for the retained clusters.
+ */
+
+#include <app-common/zap-generated/attributes/Accessors.h>
+
+#include <app-common/zap-generated/attribute-type.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/attribute-table.h>
+#include <app/util/ember-strings.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <lib/support/odd-sized-integers.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+// ---------------------------------------------------------------------------
+// Commissioning clusters
+// ---------------------------------------------------------------------------
+
+namespace Identify {
+namespace Attributes {} // namespace Attributes
+} // namespace Identify
+
+namespace Groups {
+namespace Attributes {
+
+namespace NameSupport {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap> * value)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap>>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Groups::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace NameSupport
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Groups::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Groups::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace Groups
+
+namespace Descriptor {
+namespace Attributes {} // namespace Attributes
+} // namespace Descriptor
+
+namespace Binding {
+namespace Attributes {} // namespace Attributes
+} // namespace Binding
+
+namespace AccessControl {
+namespace Attributes {} // namespace Attributes
+} // namespace AccessControl
+
+namespace BasicInformation {
+namespace Attributes {} // namespace Attributes
+} // namespace BasicInformation
+
+namespace OtaSoftwareUpdateProvider {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateProvider::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateProvider::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace OtaSoftwareUpdateProvider
+
+namespace OtaSoftwareUpdateRequestor {
+namespace Attributes {
+
+namespace UpdatePossible {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, bool * value)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, bool value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BOOLEAN_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, bool value)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+}
+
+} // namespace UpdatePossible
+
+namespace UpdateState {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint,
+                                        chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum * value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum value,
+                                        MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_ENUM8_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::OtaSoftwareUpdateRequestor::UpdateStateEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_ENUM8_ATTRIBUTE_TYPE);
+}
+
+} // namespace UpdateState
+
+namespace UpdateStateProgress {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint8_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT8U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_INT8U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT8U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_INT8U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint8_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint8_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace UpdateStateProgress
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace OtaSoftwareUpdateRequestor
+
+namespace GeneralCommissioning {
+namespace Attributes {
+
+namespace TCAcceptedVersion {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace TCAcceptedVersion
+
+namespace TCMinRequiredVersion {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace TCMinRequiredVersion
+
+namespace TCAcknowledgements {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace TCAcknowledgements
+
+namespace TCAcknowledgementsRequired {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, bool * value)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace TCAcknowledgementsRequired
+
+namespace TCUpdateDeadline {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint32_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+} // namespace TCUpdateDeadline
+
+namespace RecoveryIdentifier {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableByteSpan & value)
+{
+    uint8_t zclString[8 + 1];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfStringLength(zclString);
+    if (length == NumericAttributeTraits<uint8_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 8, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[1], 8);
+    value.reduce_size(length);
+    return status;
+}
+
+} // namespace RecoveryIdentifier
+
+namespace NetworkRecoveryReason {
+
+Protocols::InteractionModel::Status
+Get(EndpointId endpoint, DataModel::Nullable<chip::app::Clusters::GeneralCommissioning::NetworkRecoveryReasonEnum> & value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::GeneralCommissioning::NetworkRecoveryReasonEnum>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+} // namespace NetworkRecoveryReason
+
+namespace IsCommissioningWithoutPower {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, bool * value)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace IsCommissioningWithoutPower
+
+} // namespace Attributes
+} // namespace GeneralCommissioning
+
+namespace NetworkCommissioning {
+namespace Attributes {} // namespace Attributes
+} // namespace NetworkCommissioning
+
+namespace GeneralDiagnostics {
+namespace Attributes {
+
+namespace TestEventTriggersEnabled {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, bool * value)
+{
+    using Traits = NumericAttributeTraits<bool>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace TestEventTriggersEnabled
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace FeatureMap
+
+} // namespace Attributes
+} // namespace GeneralDiagnostics
+
+namespace AdministratorCommissioning {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::AdministratorCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+} // namespace FeatureMap
+
+} // namespace Attributes
+} // namespace AdministratorCommissioning
+
+// ---------------------------------------------------------------------------
+// Casting clusters
+// ---------------------------------------------------------------------------
+
+namespace OperationalCredentials {
+namespace Attributes {} // namespace Attributes
+} // namespace OperationalCredentials
+
+namespace GroupKeyManagement {
+namespace Attributes {} // namespace Attributes
+} // namespace GroupKeyManagement
+
+namespace FixedLabel {
+namespace Attributes {} // namespace Attributes
+} // namespace FixedLabel
+
+namespace UserLabel {
+namespace Attributes {} // namespace Attributes
+} // namespace UserLabel
+
+namespace RelativeHumidityMeasurement {
+namespace Attributes {
+
+namespace MeasuredValue {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint16_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint16_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint16_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint16_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace Tolerance
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace RelativeHumidityMeasurement
+
+namespace WakeOnLan {
+namespace Attributes {
+
+namespace MACAddress {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableCharSpan & value)
+{
+    uint8_t zclString[12 + 1];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfStringLength(zclString);
+    if (length == NumericAttributeTraits<uint8_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 12, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[1], 12);
+    value.reduce_size(length);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value, MarkAttributeDirty markDirty)
+{
+
+    static_assert(12 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 12, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[12 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::WakeOnLan::Id, Id),
+                                 EmberAfWriteDataInput(zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value)
+{
+
+    static_assert(12 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 12, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[12 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace MACAddress
+
+namespace LinkLocalAddress {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableByteSpan & value)
+{
+    uint8_t zclString[16 + 1];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfStringLength(zclString);
+    if (length == NumericAttributeTraits<uint8_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 16, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(length);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::ByteSpan value, MarkAttributeDirty markDirty)
+{
+
+    static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 16, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[16 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::WakeOnLan::Id, Id),
+                                 EmberAfWriteDataInput(zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::ByteSpan value)
+{
+
+    static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 16, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[16 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace LinkLocalAddress
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::WakeOnLan::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::WakeOnLan::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::WakeOnLan::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::WakeOnLan::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::WakeOnLan::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::WakeOnLan::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace WakeOnLan
+
+namespace Channel {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Channel::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::Channel::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::Channel::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Channel::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::Channel::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::Channel::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace Channel
+
+namespace TargetNavigator {
+namespace Attributes {
+
+namespace CurrentTarget {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint8_t * value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::TargetNavigator::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::TargetNavigator::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT8U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::TargetNavigator::Id, Id, writable, ZCL_INT8U_ATTRIBUTE_TYPE);
+}
+
+} // namespace CurrentTarget
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::TargetNavigator::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::TargetNavigator::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::TargetNavigator::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::TargetNavigator::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::TargetNavigator::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::TargetNavigator::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace TargetNavigator
+
+namespace MediaPlayback {
+namespace Attributes {
+
+namespace CurrentState {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::app::Clusters::MediaPlayback::PlaybackStateEnum * value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::MediaPlayback::PlaybackStateEnum>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::MediaPlayback::PlaybackStateEnum value,
+                                        MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::MediaPlayback::PlaybackStateEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_ENUM8_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::MediaPlayback::PlaybackStateEnum value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::MediaPlayback::PlaybackStateEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_ENUM8_ATTRIBUTE_TYPE);
+}
+
+} // namespace CurrentState
+
+namespace StartTime {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace StartTime
+
+namespace Duration {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace Duration
+
+namespace PlaybackSpeed {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, float * value)
+{
+    using Traits = NumericAttributeTraits<float>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, float value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<float>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_SINGLE_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, float value)
+{
+    using Traits = NumericAttributeTraits<float>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_SINGLE_ATTRIBUTE_TYPE);
+}
+
+} // namespace PlaybackSpeed
+
+namespace SeekRangeEnd {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace SeekRangeEnd
+
+namespace SeekRangeStart {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (Traits::IsNullValue(temp))
+    {
+        value.SetNull();
+    }
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status SetNull(EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value,
+                                        MarkAttributeDirty markDirty)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint, markDirty);
+    }
+
+    return Set(endpoint, value.Value(), markDirty);
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
+} // namespace SeekRangeStart
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaPlayback::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace MediaPlayback
+
+namespace MediaInput {
+namespace Attributes {
+
+namespace CurrentInput {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint8_t * value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaInput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaInput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT8U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaInput::Id, Id, writable, ZCL_INT8U_ATTRIBUTE_TYPE);
+}
+
+} // namespace CurrentInput
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaInput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaInput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaInput::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaInput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaInput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaInput::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace MediaInput
+
+namespace LowPower {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::LowPower::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::LowPower::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::LowPower::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::LowPower::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::LowPower::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::LowPower::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace LowPower
+
+namespace KeypadInput {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::KeypadInput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::KeypadInput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::KeypadInput::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::KeypadInput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::KeypadInput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::KeypadInput::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace KeypadInput
+
+namespace ContentLauncher {
+namespace Attributes {
+
+namespace SupportedStreamingProtocols {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint,
+                                        chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap> * value)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap>>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ContentLauncher::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint,
+                                        chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap> value,
+                                        MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap>>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ContentLauncher::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint,
+                                        chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap> value)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ContentLauncher::SupportedProtocolsBitmap>>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ContentLauncher::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace SupportedStreamingProtocols
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ContentLauncher::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ContentLauncher::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ContentLauncher::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ContentLauncher::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ContentLauncher::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ContentLauncher::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace ContentLauncher
+
+namespace AudioOutput {
+namespace Attributes {
+
+namespace CurrentOutput {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint8_t * value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::AudioOutput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::AudioOutput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT8U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint8_t value)
+{
+    using Traits = NumericAttributeTraits<uint8_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::AudioOutput::Id, Id, writable, ZCL_INT8U_ATTRIBUTE_TYPE);
+}
+
+} // namespace CurrentOutput
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::AudioOutput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::AudioOutput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::AudioOutput::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::AudioOutput::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::AudioOutput::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::AudioOutput::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace AudioOutput
+
+namespace ApplicationLauncher {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationLauncher::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationLauncher::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace ApplicationLauncher
+
+namespace ApplicationBasic {
+namespace Attributes {
+
+namespace VendorName {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableCharSpan & value)
+{
+    uint8_t zclString[32 + 1];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfStringLength(zclString);
+    if (length == NumericAttributeTraits<uint8_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 32, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(length);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value, MarkAttributeDirty markDirty)
+{
+
+    static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 32, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[32 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value)
+{
+
+    static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 32, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[32 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace VendorName
+
+namespace VendorID {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::VendorId * value)
+{
+    using Traits = NumericAttributeTraits<chip::VendorId>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::VendorId value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::VendorId>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_VENDOR_ID_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::VendorId value)
+{
+    using Traits = NumericAttributeTraits<chip::VendorId>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, writable, ZCL_VENDOR_ID_ATTRIBUTE_TYPE);
+}
+
+} // namespace VendorID
+
+namespace ApplicationName {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableCharSpan & value)
+{
+    uint8_t zclString[256 + 2];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfLongStringLength(zclString);
+    if (length == NumericAttributeTraits<uint16_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 256, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[2], 256);
+    value.reduce_size(length);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value, MarkAttributeDirty markDirty)
+{
+
+    static_assert(256 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 256, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[256 + 2];
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
+    memcpy(&zclString[2], value.data(), value.size());
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(zclString, ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value)
+{
+
+    static_assert(256 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 256, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[256 + 2];
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
+    memcpy(&zclString[2], value.data(), value.size());
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ApplicationName
+
+namespace ProductID {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductID
+
+namespace Status {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum * value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum value,
+                                        MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_ENUM8_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum value)
+{
+    using Traits = NumericAttributeTraits<chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, writable, ZCL_ENUM8_ATTRIBUTE_TYPE);
+}
+
+} // namespace Status
+
+namespace ApplicationVersion {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::MutableCharSpan & value)
+{
+    uint8_t zclString[32 + 1];
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    size_t length = emberAfStringLength(zclString);
+    if (length == NumericAttributeTraits<uint8_t>::kNullValue)
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+
+    VerifyOrReturnError(value.size() == 32, Protocols::InteractionModel::Status::InvalidDataType);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(length);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value, MarkAttributeDirty markDirty)
+{
+
+    static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 32, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[32 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::CharSpan value)
+{
+
+    static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
+    VerifyOrReturnError(value.size() <= 32, Protocols::InteractionModel::Status::ConstraintError);
+    uint8_t zclString[32 + 1];
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ApplicationVersion
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ApplicationBasic::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace ApplicationBasic
+
+namespace ContentAppObserver {
+namespace Attributes {
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ContentAppObserver::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ContentAppObserver::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ContentAppObserver::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::ContentAppObserver::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ContentAppObserver::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::ContentAppObserver::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace ContentAppObserver
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
@@ -52,9 +52,9 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-table.h>
 #include <app/util/ember-strings.h>
+#include <app/util/odd-sized-integers.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <app/util/odd-sized-integers.h>
 
 namespace chip {
 namespace app {
@@ -64,7 +64,55 @@ namespace Clusters {
 // ---------------------------------------------------------------------------
 
 namespace Identify {
-namespace Attributes {} // namespace Attributes
+namespace Attributes {
+
+namespace IdentifyTime {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable                         = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status = emberAfReadAttribute(endpoint, Clusters::Identify::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::Identify::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::Identify::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace IdentifyTime
+
+} // namespace Attributes
 } // namespace Identify
 
 namespace Groups {
@@ -87,6 +135,34 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, chip::BitMask<chip:
     return status;
 }
 
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap> value,
+                                        MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap>>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::Groups::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP8_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap> value)
+{
+    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::Groups::NameSupportBitmap>>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::Groups::Id, Id, writable, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+}
+
 } // namespace NameSupport
 
 namespace FeatureMap {
@@ -104,6 +180,33 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::Groups::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::Groups::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace FeatureMap
@@ -480,6 +583,53 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
 
 namespace GeneralCommissioning {
 namespace Attributes {
+
+namespace Breadcrumb {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint64_t * value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::GeneralCommissioning::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+} // namespace Breadcrumb
 
 namespace TCAcceptedVersion {
 

--- a/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
@@ -54,7 +54,7 @@
 #include <app/util/ember-strings.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <lib/support/odd-sized-integers.h>
+#include <app/util/odd-sized-integers.h>
 
 namespace chip {
 namespace app {
@@ -629,26 +629,6 @@ Get(EndpointId endpoint, DataModel::Nullable<chip::app::Clusters::GeneralCommiss
 }
 
 } // namespace NetworkRecoveryReason
-
-namespace IsCommissioningWithoutPower {
-
-Protocols::InteractionModel::Status Get(EndpointId endpoint, bool * value)
-{
-    using Traits = NumericAttributeTraits<bool>;
-    Traits::StorageType temp;
-    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
-    Protocols::InteractionModel::Status status =
-        emberAfReadAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, readable, sizeof(temp));
-    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    *value = Traits::StorageToWorking(temp);
-    return status;
-}
-
-} // namespace IsCommissioningWithoutPower
 
 } // namespace Attributes
 } // namespace GeneralCommissioning

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -35,6 +35,7 @@ config("config") {
   }
 
   cflags = [ "-Wconversion" ]
+  defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=0" ]
 
   # Enable per-function and per-data sections so the linker's --gc-sections
   # can discard unreferenced code/data from the final .so.
@@ -45,9 +46,11 @@ config("config") {
       "-fvisibility=hidden",
       "-flto=thin",
     ]
-  }
 
-  defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=0" ]
+    # Disable host unit-test hooks to exclude test-only code paths
+    # (CASESession, ExchangeContext, FabricTable, MRP) from the binary.
+    defines += [ "CONFIG_BUILD_FOR_HOST_UNIT_TEST=0" ]
+  }
 }
 
 chip_data_model("tv-casting-common") {
@@ -158,10 +161,18 @@ chip_data_model("tv-casting-common") {
   ]
 
   deps = [
-    "${chip_root}/src/app/icd/client:handler",
-    "${chip_root}/src/app/icd/client:manager",
+    "${chip_root}/src/controller",
     "${chip_root}/third_party/inipp",
   ]
+
+  # ICD client deps are not directly used by tv-casting-common source files.
+  # Exclude them in size-optimized builds to reduce .so size.
+  if (!optimize_apk_size) {
+    deps += [
+      "${chip_root}/src/app/icd/client:handler",
+      "${chip_root}/src/app/icd/client:manager",
+    ]
+  }
 
   # These deps are pulled from chip-tool but not directly used by
   # tv-casting-common source files. Keep them in normal builds for

--- a/examples/tv-casting-app/tv-casting-common/CHIPAttributeTLVValueDecoder-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/CHIPAttributeTLVValueDecoder-override.cpp
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file casting-CHIPAttributeTLVValueDecoder.cpp
+ * @file CHIPAttributeTLVValueDecoder-override.cpp
  *
  * Slim attribute TLV decoder for the TV Casting App.
  * Contains DecodeAttributeValue() cases for ONLY the casting clusters.
@@ -33,7 +33,7 @@
  *   1. Copy its case block from zap-generated/CHIPAttributeTLVValueDecoder.cpp
  *   2. Add it to the switch statement below (keep alphabetical order)
  *   3. Update this cluster list
- *   4. Ensure the cluster's .ipp files are included in casting-cluster-objects.cpp
+ *   4. Ensure the cluster's .ipp files are included in cluster-objects-override.cpp
  */
 
 #include <controller/java/CHIPAttributeTLVValueDecoder.h>

--- a/examples/tv-casting-app/tv-casting-common/CHIPEventTLVValueDecoder-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/CHIPEventTLVValueDecoder-override.cpp
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file casting-CHIPEventTLVValueDecoder.cpp
+ * @file CHIPEventTLVValueDecoder-override.cpp
  *
  * Slim event TLV decoder for the TV Casting App.
  * Contains DecodeEventValue() cases for ONLY the casting clusters.
@@ -33,7 +33,7 @@
  *   1. Copy its case block from zap-generated/CHIPEventTLVValueDecoder.cpp
  *   2. Add it to the switch statement below (keep alphabetical order)
  *   3. Update this cluster list
- *   4. Ensure the cluster's .ipp files are included in casting-cluster-objects.cpp
+ *   4. Ensure the cluster's .ipp files are included in cluster-objects-override.cpp
  */
 
 #include <controller/java/CHIPAttributeTLVValueDecoder.h>

--- a/examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml
+++ b/examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Clusters for cluster-objects-override.cpp and Accessors-override.cpp.
+# Note: not all clusters have Accessors entries (e.g. Groupcast has
+# cluster-objects but no Accessors); the generator warns but proceeds.
+casting_clusters:
+    # Infrastructure
+    - AccessControl
+    - AdministratorCommissioning
+    - BasicInformation
+    - Binding
+    - Descriptor
+    - GeneralCommissioning
+    - GeneralDiagnostics
+    - GroupKeyManagement
+    - Groupcast
+    - Groups
+    - Identify
+    - NetworkCommissioning
+    - OperationalCredentials
+    # Casting-specific
+    - AccountLogin
+    - ApplicationBasic
+    - ApplicationLauncher
+    - AudioOutput
+    - Channel
+    - ContentAppObserver
+    - ContentControl
+    - ContentLauncher
+    - KeypadInput
+    - LevelControl
+    - LowPower
+    - MediaInput
+    - MediaPlayback
+    - Messages
+    - OnOff
+    - TargetNavigator
+    - WakeOnLan
+
+# Clusters for TLV decoder overrides
+tlv_decoder_clusters:
+    - AccountLogin
+    - ApplicationBasic
+    - ApplicationLauncher
+    - AudioOutput
+    - Binding
+    - Channel
+    - ContentAppObserver
+    - ContentControl
+    - ContentLauncher
+    - Descriptor
+    - KeypadInput
+    - LevelControl
+    - LowPower
+    - MediaInput
+    - MediaPlayback
+    - OnOff
+    - TargetNavigator
+    - WakeOnLan
+
+# Cluster server directories
+cluster_servers:
+    - access-control-server
+    - administrator-commissioning-server
+    - basic-information
+    - bindings
+    - descriptor
+    - general-commissioning-server
+    - general-diagnostics-server
+    - group-key-mgmt-server
+    - groups-server
+    - identify-server
+    - network-commissioning
+    - operational-credentials-server
+    - content-app-observer

--- a/examples/tv-casting-app/tv-casting-common/cluster-objects-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/cluster-objects-override.cpp
@@ -16,7 +16,7 @@
  */
 
 /**
- * @file casting-cluster-objects.cpp
+ * @file cluster-objects-override.cpp
  *
  * Slim replacement for the generated cluster-objects.cpp that only includes
  * the cluster implementations (Attributes/Commands/Events/Structs .ipp files)
@@ -60,16 +60,6 @@
 #include <clusters/Descriptor/Events.ipp>
 #include <clusters/Descriptor/Structs.ipp>
 
-#include <clusters/EthernetNetworkDiagnostics/Attributes.ipp>
-#include <clusters/EthernetNetworkDiagnostics/Commands.ipp>
-#include <clusters/EthernetNetworkDiagnostics/Events.ipp>
-#include <clusters/EthernetNetworkDiagnostics/Structs.ipp>
-
-#include <clusters/FixedLabel/Attributes.ipp>
-#include <clusters/FixedLabel/Commands.ipp>
-#include <clusters/FixedLabel/Events.ipp>
-#include <clusters/FixedLabel/Structs.ipp>
-
 #include <clusters/GeneralCommissioning/Attributes.ipp>
 #include <clusters/GeneralCommissioning/Commands.ipp>
 #include <clusters/GeneralCommissioning/Events.ipp>
@@ -90,20 +80,10 @@
 #include <clusters/Groups/Events.ipp>
 #include <clusters/Groups/Structs.ipp>
 
-#include <clusters/IcdManagement/Attributes.ipp>
-#include <clusters/IcdManagement/Commands.ipp>
-#include <clusters/IcdManagement/Events.ipp>
-#include <clusters/IcdManagement/Structs.ipp>
-
 #include <clusters/Identify/Attributes.ipp>
 #include <clusters/Identify/Commands.ipp>
 #include <clusters/Identify/Events.ipp>
 #include <clusters/Identify/Structs.ipp>
-
-#include <clusters/LocalizationConfiguration/Attributes.ipp>
-#include <clusters/LocalizationConfiguration/Commands.ipp>
-#include <clusters/LocalizationConfiguration/Events.ipp>
-#include <clusters/LocalizationConfiguration/Structs.ipp>
 
 #include <clusters/NetworkCommissioning/Attributes.ipp>
 #include <clusters/NetworkCommissioning/Commands.ipp>
@@ -114,36 +94,6 @@
 #include <clusters/OperationalCredentials/Commands.ipp>
 #include <clusters/OperationalCredentials/Events.ipp>
 #include <clusters/OperationalCredentials/Structs.ipp>
-
-#include <clusters/SoftwareDiagnostics/Attributes.ipp>
-#include <clusters/SoftwareDiagnostics/Commands.ipp>
-#include <clusters/SoftwareDiagnostics/Events.ipp>
-#include <clusters/SoftwareDiagnostics/Structs.ipp>
-
-#include <clusters/TimeFormatLocalization/Attributes.ipp>
-#include <clusters/TimeFormatLocalization/Commands.ipp>
-#include <clusters/TimeFormatLocalization/Events.ipp>
-#include <clusters/TimeFormatLocalization/Structs.ipp>
-
-#include <clusters/TimeSynchronization/Attributes.ipp>
-#include <clusters/TimeSynchronization/Commands.ipp>
-#include <clusters/TimeSynchronization/Events.ipp>
-#include <clusters/TimeSynchronization/Structs.ipp>
-
-#include <clusters/UnitLocalization/Attributes.ipp>
-#include <clusters/UnitLocalization/Commands.ipp>
-#include <clusters/UnitLocalization/Events.ipp>
-#include <clusters/UnitLocalization/Structs.ipp>
-
-#include <clusters/UserLabel/Attributes.ipp>
-#include <clusters/UserLabel/Commands.ipp>
-#include <clusters/UserLabel/Events.ipp>
-#include <clusters/UserLabel/Structs.ipp>
-
-#include <clusters/WiFiNetworkDiagnostics/Attributes.ipp>
-#include <clusters/WiFiNetworkDiagnostics/Commands.ipp>
-#include <clusters/WiFiNetworkDiagnostics/Events.ipp>
-#include <clusters/WiFiNetworkDiagnostics/Structs.ipp>
 
 // ---------------------------------------------------------------------------
 // Casting-specific clusters
@@ -332,25 +282,6 @@ bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
         case Clusters::OperationalCredentials::Commands::UpdateNOC::Id:
         case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id:
         case Clusters::OperationalCredentials::Commands::SetVIDVerificationStatement::Id:
-            return true;
-        default:
-            return false;
-        }
-    }
-    case Clusters::TimeSynchronization::Id: {
-        switch (aCommand)
-        {
-        case Clusters::TimeSynchronization::Commands::SetTrustedTimeSource::Id:
-            return true;
-        default:
-            return false;
-        }
-    }
-    case Clusters::IcdManagement::Id: {
-        switch (aCommand)
-        {
-        case Clusters::IcdManagement::Commands::RegisterClient::Id:
-        case Clusters::IcdManagement::Commands::UnregisterClient::Id:
             return true;
         default:
             return false;

--- a/examples/tv-casting-app/tv-casting-common/cluster-servers-override.gni
+++ b/examples/tv-casting-app/tv-casting-common/cluster-servers-override.gni
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cluster server override for the casting app's size-optimized build.
+# 12 commissioning-essential + 1 casting-specific (content-app-observer).
+#
+# When chip_data_model_overrides_dir points to this directory, the
+# chip_data_model template imports this file and uses this list instead
+# of auto-discovering cluster server directories via zap_cluster_list.py.
+# This excludes
+# ~31 unused server implementations, saving ~1.1 MB in the binary.
+
+cluster_server_override_dirs = [
+  "access-control-server",
+  "administrator-commissioning-server",
+  "basic-information",
+  "bindings",
+  "descriptor",
+  "general-commissioning-server",
+  "general-diagnostics-server",
+  "group-key-mgmt-server",
+  "groups-server",
+  "identify-server",
+  "network-commissioning",
+  "operational-credentials-server",
+  "content-app-observer",
+]

--- a/examples/tv-casting-app/tv-casting-common/generate_slim_overrides.py
+++ b/examples/tv-casting-app/tv-casting-common/generate_slim_overrides.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generation script for TV Casting App slim override files.
+
+Parses full zap-generated source files and extracts only the sections
+needed by the casting-relevant clusters, producing slim override files
+that reduce binary size.
+
+Usage:
+    python3 generate_slim_overrides.py <cluster-config.yaml> [--output-dir <dir>] [--chip-root <dir>]
+"""
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import yaml
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CHIP_COPYRIGHT_HEADER = """\
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */"""
+
+
+CHIP_COPYRIGHT_HEADER_ALL_RIGHTS = """\
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */"""
+
+GNI_COPYRIGHT_HEADER = """\
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License."""
+
+
+# ---------------------------------------------------------------------------
+# CLI and YAML parsing (Task 8.1)
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None):
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate slim override files for the TV Casting App."
+    )
+    parser.add_argument(
+        "config",
+        help="Path to the cluster config YAML file (e.g. casting-cluster-config.yaml)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory to write generated files (default: current directory)",
+    )
+    parser.add_argument(
+        "--chip-root",
+        default=None,
+        help="Path to the CHIP SDK root directory (for finding full generated source files)",
+    )
+    return parser.parse_args(argv)
+
+
+def load_config(config_path):
+    """Load and validate the cluster config YAML file.
+
+    Returns a dict with keys: casting_clusters, tlv_decoder_clusters, cluster_servers.
+    """
+    if not os.path.isfile(config_path):
+        logger.error("config file not found: %s", config_path)
+        sys.exit(1)
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except yaml.YAMLError:
+        logger.exception("invalid YAML in %s", config_path)
+        sys.exit(1)
+
+    if not isinstance(config, dict):
+        logger.error("config file must be a YAML mapping, got %s", type(config).__name__)
+        sys.exit(1)
+
+    casting_clusters = config.get("casting_clusters", [])
+    tlv_decoder_clusters = config.get("tlv_decoder_clusters", [])
+    cluster_servers = config.get("cluster_servers", [])
+
+    if not isinstance(casting_clusters, list):
+        logger.error("'casting_clusters' must be a list")
+        sys.exit(1)
+    if not isinstance(tlv_decoder_clusters, list):
+        logger.error("'tlv_decoder_clusters' must be a list")
+        sys.exit(1)
+    if not isinstance(cluster_servers, list):
+        logger.error("'cluster_servers' must be a list")
+        sys.exit(1)
+
+    return {
+        "casting_clusters": casting_clusters,
+        "tlv_decoder_clusters": tlv_decoder_clusters,
+        "cluster_servers": cluster_servers,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cluster-objects extraction (Task 8.2)
+# ---------------------------------------------------------------------------
+
+def _extract_cluster_name_from_include(line):
+    """Extract the cluster name from an #include <clusters/ClusterName/...> line.
+
+    Returns the cluster name string, or None if the line doesn't match.
+    """
+    m = re.match(r'#include\s+<clusters/([^/]+)/', line)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _extract_command_function_case_blocks(full_text, func_name, cluster_names):
+    """Extract case blocks for the given clusters from a Command* function.
+
+    Parses the function body's switch statement and returns only the case
+    blocks for clusters in cluster_names. Returns the full function text
+    with only matching case blocks.
+    """
+    cluster_set = set(cluster_names)
+
+    # Find the function in the text
+    func_pattern = re.compile(
+        r'^bool\s+' + re.escape(func_name) + r'\s*\(ClusterId\s+aCluster,\s*CommandId\s+aCommand\)',
+        re.MULTILINE
+    )
+    match = func_pattern.search(full_text)
+    if not match:
+        return None
+
+    # Find the opening brace of the function
+    brace_pos = full_text.index('{', match.end())
+
+    # Extract the full function body using brace balancing
+    depth = 0
+    func_end = brace_pos
+    for i in range(brace_pos, len(full_text)):
+        if full_text[i] == '{':
+            depth += 1
+        elif full_text[i] == '}':
+            depth -= 1
+            if depth == 0:
+                func_end = i + 1
+                break
+
+    func_body = full_text[brace_pos:func_end]
+
+    # Parse case blocks: case Clusters::ClusterName::Id: { ... }
+    case_pattern = re.compile(r'case\s+Clusters::(\w+)::Id:\s*\{')
+    case_blocks = []
+
+    for case_match in case_pattern.finditer(func_body):
+        cluster_name = case_match.group(1)
+        # Find the start of the line containing the case statement
+        line_start = func_body.rfind('\n', 0, case_match.start())
+        block_start = line_start + 1 if line_start >= 0 else case_match.start()
+        # Extract the full case block using brace balancing
+        brace_start = func_body.index('{', case_match.end() - 1)
+        depth = 0
+        block_end = brace_start
+        for i in range(brace_start, len(func_body)):
+            if func_body[i] == '{':
+                depth += 1
+            elif func_body[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    block_end = i + 1
+                    break
+
+        if cluster_name in cluster_set:
+            case_blocks.append(func_body[block_start:block_end])
+
+    return case_blocks
+
+
+def _reindent_case_block(block_text):
+    """Re-indent a case block to have consistent 4-space indentation.
+
+    The case keyword should be at 4-space indent (inside a switch inside a function).
+    All other lines maintain their relative indentation to the case line.
+    """
+    block_lines = block_text.splitlines()
+    if not block_lines:
+        return ""
+
+    # Find the indentation of the first line (the case line)
+    first_line = block_lines[0]
+    current_indent = len(first_line) - len(first_line.lstrip())
+
+    # Target indent for case is 4 spaces
+    target_indent = 4
+    indent_diff = target_indent - current_indent
+
+    result_lines = []
+    for line in block_lines:
+        if line.strip() == "":
+            result_lines.append("")
+        else:
+            line_indent = len(line) - len(line.lstrip())
+            new_indent = max(0, line_indent + indent_diff)
+            result_lines.append(" " * new_indent + line.lstrip())
+
+    return "\n".join(result_lines)
+
+
+def generate_cluster_objects(full_source_path, casting_clusters, output_path):
+    """Generate cluster-objects-override.cpp from the full cluster-objects.cpp.
+
+    Extracts #include directives for casting clusters, plus shared/Structs.ipp,
+    and the three Command* functions with only casting-relevant case blocks.
+    """
+    if not os.path.isfile(full_source_path):
+        logger.error("full cluster-objects.cpp not found: %s", full_source_path)
+        sys.exit(1)
+
+    with open(full_source_path) as f:
+        full_text = f.read()
+
+    full_lines = full_text.splitlines()
+
+    cluster_set = set(casting_clusters)
+    matched_clusters = set()
+
+    # Collect all #include <clusters/...> lines
+    include_lines = []
+    for line in full_lines:
+        name = _extract_cluster_name_from_include(line)
+        if name is not None:
+            if name == "shared":
+                # Always include shared/Structs.ipp — we'll add it at the end
+                continue
+            if name in cluster_set:
+                include_lines.append(line)
+                matched_clusters.add(name)
+
+    # Warn about unmatched clusters
+    for cluster in casting_clusters:
+        if cluster not in matched_clusters:
+            logger.warning("cluster '%s' not found in %s", cluster, full_source_path)
+
+    # Extract Command* function case blocks
+    timed_blocks = _extract_command_function_case_blocks(full_text, "CommandNeedsTimedInvoke", casting_clusters)
+    scoped_blocks = _extract_command_function_case_blocks(full_text, "CommandIsFabricScoped", casting_clusters)
+    large_blocks = _extract_command_function_case_blocks(full_text, "CommandHasLargePayload", casting_clusters)
+
+    # Build output
+    lines = []
+    lines.append(CHIP_COPYRIGHT_HEADER)
+    lines.append("")
+    lines.append("#include <app-common/zap-generated/cluster-objects.h>")
+    lines.append("")
+
+    # Add includes grouped by cluster (sorted for determinism)
+    for line in include_lines:
+        lines.append(line)
+
+    # Always add shared/Structs.ipp
+    lines.append("")
+    lines.append("#include <clusters/shared/Structs.ipp>")
+
+    # Add Command* functions
+    lines.append("")
+    lines.append("namespace chip {")
+    lines.append("namespace app {")
+    lines.append("")
+
+    # CommandNeedsTimedInvoke
+    lines.append("bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)")
+    lines.append("{")
+    lines.append("    switch (aCluster)")
+    lines.append("    {")
+    if timed_blocks:
+        for block in timed_blocks:
+            lines.append(_reindent_case_block(block))
+    lines.append("    default:")
+    lines.append("        break;")
+    lines.append("    }")
+    lines.append("    return false;")
+    lines.append("}")
+    lines.append("")
+
+    # CommandIsFabricScoped
+    lines.append("bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)")
+    lines.append("{")
+    lines.append("    switch (aCluster)")
+    lines.append("    {")
+    if scoped_blocks:
+        for block in scoped_blocks:
+            lines.append(_reindent_case_block(block))
+    lines.append("    default:")
+    lines.append("        break;")
+    lines.append("    }")
+    lines.append("    return false;")
+    lines.append("}")
+    lines.append("")
+
+    # CommandHasLargePayload
+    lines.append("bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand)")
+    lines.append("{")
+    if large_blocks:
+        lines.append("    switch (aCluster)")
+        lines.append("    {")
+        for block in large_blocks:
+            lines.append(_reindent_case_block(block))
+        lines.append("    default:")
+        lines.append("        break;")
+        lines.append("    }")
+    else:
+        lines.append("    // None of the casting-relevant clusters have commands flagged as large payload.")
+        lines.append("    (void) aCluster;")
+        lines.append("    (void) aCommand;")
+    lines.append("    return false;")
+    lines.append("}")
+    lines.append("")
+    lines.append("} // namespace app")
+    lines.append("} // namespace chip")
+    lines.append("")
+
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# TLV decoder extraction (Task 8.3)
+# ---------------------------------------------------------------------------
+
+def _extract_switch_case_blocks(full_text, cluster_names):
+    """Extract case blocks from the outer switch(mClusterId) for given clusters.
+
+    Uses brace-balanced extraction to capture complete case blocks including
+    all nested code. Returns a list of (cluster_name, block_text) tuples.
+    """
+    cluster_set = set(cluster_names)
+    results = []
+
+    # Pattern for outer case blocks: case app::Clusters::ClusterName::Id: {
+    case_pattern = re.compile(r'(\s*case\s+app::Clusters::(\w+)::Id:\s*\{)')
+
+    for match in case_pattern.finditer(full_text):
+        cluster_name = match.group(2)
+        if cluster_name not in cluster_set:
+            continue
+
+        # Find the opening brace of this case block
+        block_start = match.start()
+        brace_pos = full_text.index('{', match.end() - 1)
+
+        # Brace-balanced extraction
+        depth = 0
+        block_end = brace_pos
+        for i in range(brace_pos, len(full_text)):
+            if full_text[i] == '{':
+                depth += 1
+            elif full_text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    block_end = i + 1
+                    break
+
+        # Capture through the "break;" after the closing brace
+        rest = full_text[block_end:block_end + 50]
+        break_match = re.match(r'\s*\n\s*break;\s*\n', rest)
+        if break_match:
+            block_end += break_match.end()
+
+        block_text = full_text[block_start:block_end]
+        results.append((cluster_name, block_text))
+
+    return results
+
+
+def generate_tlv_decoder(full_source_path, cluster_names, output_path, decoder_type):
+    """Generate a slim TLV decoder file (attribute or event).
+
+    Args:
+        full_source_path: Path to the full zap-generated decoder .cpp
+        cluster_names: List of cluster names to include
+        output_path: Path to write the slim decoder
+        decoder_type: "attribute" or "event"
+    """
+    if not os.path.isfile(full_source_path):
+        logger.error("full TLV decoder not found: %s", full_source_path)
+        sys.exit(1)
+
+    with open(full_source_path) as f:
+        full_text = f.read()
+
+    case_blocks = _extract_switch_case_blocks(full_text, cluster_names)
+    matched_clusters = {name for name, _ in case_blocks}
+
+    # Warn about unmatched clusters
+    for cluster in cluster_names:
+        if cluster not in matched_clusters:
+            logger.warning("cluster '%s' not found in %s", cluster, full_source_path)
+
+    if decoder_type == "attribute":
+        error_macro = "CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB"
+        func_sig = "jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVReader & aReader, CHIP_ERROR * aError)"
+        path_field = "mClusterId"
+        includes = [
+            "#include <controller/java/CHIPAttributeTLVValueDecoder.h>",
+            "",
+            "#include <app-common/zap-generated/cluster-objects.h>",
+            "#include <app-common/zap-generated/ids/Attributes.h>",
+            "#include <app-common/zap-generated/ids/Clusters.h>",
+            "#include <app/data-model/DecodableList.h>",
+            "#include <app/data-model/Decode.h>",
+            "#include <jni.h>",
+            "#include <lib/support/JniReferences.h>",
+            "#include <lib/support/JniTypeWrappers.h>",
+            "#include <lib/support/TypeTraits.h>",
+        ]
+    else:
+        error_macro = "CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB"
+        func_sig = "jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & aReader, CHIP_ERROR * aError)"
+        path_field = "mClusterId"
+        includes = [
+            "#include <controller/java/CHIPAttributeTLVValueDecoder.h>",
+            "",
+            "#include <app-common/zap-generated/cluster-objects.h>",
+            "#include <app-common/zap-generated/ids/Clusters.h>",
+            "#include <app-common/zap-generated/ids/Events.h>",
+            "#include <app/data-model/DecodableList.h>",
+            "#include <app/data-model/Decode.h>",
+            "#include <jni.h>",
+            "#include <lib/support/JniReferences.h>",
+            "#include <lib/support/JniTypeWrappers.h>",
+            "#include <lib/support/TypeTraits.h>",
+        ]
+
+    lines = []
+    lines.append(CHIP_COPYRIGHT_HEADER_ALL_RIGHTS)
+    lines.append("")
+    for inc in includes:
+        lines.append(inc)
+    lines.append("")
+    lines.append("namespace chip {")
+    lines.append("")
+    lines.append(func_sig)
+    lines.append("{")
+    lines.append("    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();")
+    lines.append("    CHIP_ERROR err = CHIP_NO_ERROR;")
+    lines.append("")
+    lines.append("    switch (aPath." + path_field + ")")
+    lines.append("    {")
+
+    # Add case blocks
+    for cluster_name, block_text in case_blocks:
+        # The block_text already has proper indentation from the source
+        for bline in block_text.splitlines():
+            lines.append(bline)
+
+    # Add default case
+    lines.append("    default:")
+    lines.append(f"        *aError = {error_macro};")
+    lines.append("        break;")
+    lines.append("    }")
+    lines.append("    return nullptr;")
+    lines.append("}")
+    lines.append("")
+    lines.append("} // namespace chip")
+    lines.append("")
+
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Accessors extraction (Task 8.4)
+# ---------------------------------------------------------------------------
+
+def _extract_cluster_namespace_blocks(full_text, cluster_names):
+    """Extract namespace ClusterName { ... } blocks from inside namespace Clusters {.
+
+    Uses brace-balanced extraction. Returns a list of (cluster_name, block_text) tuples.
+    """
+    cluster_set = set(cluster_names)
+    results = []
+
+    # Find the start of namespace Clusters {
+    clusters_ns_match = re.search(r'namespace\s+Clusters\s*\{', full_text)
+    if not clusters_ns_match:
+        return results
+
+    search_start = clusters_ns_match.end()
+
+    # Find all top-level namespace blocks inside Clusters
+    # Pattern: namespace ClusterName {
+    ns_pattern = re.compile(r'^(namespace\s+(\w+)\s*\{)', re.MULTILINE)
+
+    for match in ns_pattern.finditer(full_text, search_start):
+        cluster_name = match.group(2)
+
+        # Skip non-cluster namespaces (Attributes, etc. are nested)
+        if cluster_name in ("Attributes", "chip", "app"):
+            continue
+
+        if cluster_name not in cluster_set:
+            continue
+
+        # Find the opening brace
+        brace_pos = full_text.index('{', match.end() - 1)
+
+        # Brace-balanced extraction for the namespace block
+        depth = 0
+        block_end = brace_pos
+        for i in range(brace_pos, len(full_text)):
+            if full_text[i] == '{':
+                depth += 1
+            elif full_text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    block_end = i + 1
+                    break
+
+        # Capture the closing comment: } // namespace ClusterName
+        rest = full_text[block_end:block_end + 100]
+        comment_match = re.match(r'\s*//\s*namespace\s+\w+\s*\n?', rest)
+        if comment_match:
+            block_end += comment_match.end()
+
+        block_text = full_text[match.start():block_end]
+        results.append((cluster_name, block_text))
+
+    return results
+
+
+def generate_accessors(full_source_path, casting_clusters, output_path):
+    """Generate Accessors-override.cpp from the full Accessors.cpp.
+
+    Extracts namespace blocks for casting clusters.
+    """
+    if not os.path.isfile(full_source_path):
+        logger.error("full Accessors.cpp not found: %s", full_source_path)
+        sys.exit(1)
+
+    with open(full_source_path) as f:
+        full_text = f.read()
+
+    namespace_blocks = _extract_cluster_namespace_blocks(full_text, casting_clusters)
+    matched_clusters = {name for name, _ in namespace_blocks}
+
+    # Warn about unmatched clusters
+    for cluster in casting_clusters:
+        if cluster not in matched_clusters:
+            logger.warning("cluster '%s' not found in %s", cluster, full_source_path)
+
+    lines = []
+    lines.append(CHIP_COPYRIGHT_HEADER)
+    lines.append("")
+    lines.append("#include <app-common/zap-generated/attributes/Accessors.h>")
+    lines.append("")
+    lines.append("#include <app-common/zap-generated/attribute-type.h>")
+    lines.append("#include <app-common/zap-generated/ids/Attributes.h>")
+    lines.append("#include <app-common/zap-generated/ids/Clusters.h>")
+    lines.append("#include <app/util/attribute-table.h>")
+    lines.append("#include <app/util/ember-strings.h>")
+    lines.append("#include <lib/core/CHIPEncoding.h>")
+    lines.append("#include <lib/support/logging/CHIPLogging.h>")
+    lines.append("#include <lib/support/odd-sized-integers.h>")
+    lines.append("")
+    lines.append("namespace chip {")
+    lines.append("namespace app {")
+    lines.append("namespace Clusters {")
+    lines.append("")
+
+    for cluster_name, block_text in namespace_blocks:
+        lines.append(block_text)
+        lines.append("")
+
+    lines.append("} // namespace Clusters")
+    lines.append("} // namespace app")
+    lines.append("} // namespace chip")
+    lines.append("")
+
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Cluster-servers.gni generation (Task 8.5)
+# ---------------------------------------------------------------------------
+
+def generate_cluster_servers_gni(cluster_servers, output_path):
+    """Generate cluster-servers-override.gni from the cluster_servers list."""
+    lines = []
+    lines.append(GNI_COPYRIGHT_HEADER)
+    lines.append("")
+    lines.append("cluster_server_override_dirs = [")
+    for server in cluster_servers:
+        lines.append(f'  "{server}",')
+    lines.append("]")
+    lines.append("")
+
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    config = load_config(args.config)
+    output_dir = args.output_dir
+    chip_root = args.chip_root
+
+    # If chip_root not specified, try to infer from the config file location
+    if chip_root is None:
+        # Assume config is at examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml
+        # So chip_root is 4 levels up
+        config_dir = os.path.dirname(os.path.abspath(args.config))
+        chip_root = os.path.normpath(os.path.join(config_dir, "..", "..", ".."))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    casting_clusters = config["casting_clusters"]
+    tlv_decoder_clusters = config["tlv_decoder_clusters"]
+    cluster_servers = config["cluster_servers"]
+
+    # Full source paths
+    cluster_objects_path = os.path.join(
+        chip_root, "zzz_generated", "app-common", "app-common",
+        "zap-generated", "cluster-objects.cpp"
+    )
+    attr_decoder_path = os.path.join(
+        chip_root, "src", "controller", "java", "zap-generated",
+        "CHIPAttributeTLVValueDecoder.cpp"
+    )
+    event_decoder_path = os.path.join(
+        chip_root, "src", "controller", "java", "zap-generated",
+        "CHIPEventTLVValueDecoder.cpp"
+    )
+    accessors_path = os.path.join(
+        chip_root, "zzz_generated", "app-common", "app-common",
+        "zap-generated", "attributes", "Accessors.cpp"
+    )
+
+    # Generate each file
+    logger.info("Generating cluster-objects-override.cpp ...")
+    generate_cluster_objects(
+        cluster_objects_path,
+        casting_clusters,
+        os.path.join(output_dir, "cluster-objects-override.cpp"),
+    )
+
+    logger.info("Generating CHIPAttributeTLVValueDecoder-override.cpp ...")
+    generate_tlv_decoder(
+        attr_decoder_path,
+        tlv_decoder_clusters,
+        os.path.join(output_dir, "CHIPAttributeTLVValueDecoder-override.cpp"),
+        "attribute",
+    )
+
+    logger.info("Generating CHIPEventTLVValueDecoder-override.cpp ...")
+    generate_tlv_decoder(
+        event_decoder_path,
+        tlv_decoder_clusters,
+        os.path.join(output_dir, "CHIPEventTLVValueDecoder-override.cpp"),
+        "event",
+    )
+
+    logger.info("Generating Accessors-override.cpp ...")
+    generate_accessors(
+        accessors_path,
+        casting_clusters,
+        os.path.join(output_dir, "Accessors-override.cpp"),
+    )
+
+    logger.info("Generating cluster-servers-override.gni ...")
+    generate_cluster_servers_gni(
+        cluster_servers,
+        os.path.join(output_dir, "cluster-servers-override.gni"),
+    )
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -87,7 +87,9 @@
 #define MATTER_BINDING_TABLE_SIZE 64
 
 // Enable some test-only interaction model APIs.
+#ifndef CONFIG_BUILD_FOR_HOST_UNIT_TEST
 #define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
+#endif
 
 #define CHIP_ENABLE_ROTATING_DEVICE_ID 1
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -974,32 +974,6 @@ cluster BasicInformation = 40 {
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
-/** Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for the units in which values are conveyed in communication to a
-      user. As such, Nodes that visually or audibly convey measurable values to the user need a
-      mechanism by which they can be configured to use a user’s preferred unit. */
-cluster UnitLocalization = 45 {
-  revision 2;
-
-  enum TempUnitEnum : enum8 {
-    kFahrenheit = 0;
-    kCelsius = 1;
-    kKelvin = 2;
-  }
-
-  bitmap Feature : bitmap32 {
-    kTemperatureUnit = 0x1;
-  }
-
-  attribute access(write: manage) optional TempUnitEnum temperatureUnit = 0;
-  provisional readonly attribute optional TempUnitEnum supportedTemperatureUnits[] = 1;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-}
-
 /** This cluster is used to manage global aspects of the Commissioning flow. */
 cluster GeneralCommissioning = 48 {
   revision 2;
@@ -1407,159 +1381,6 @@ cluster GeneralDiagnostics = 51 {
   command TimeSnapshot(): TimeSnapshotResponse = 1;
   /** Request a variable length payload response. */
   command access(invoke: manage) PayloadTestRequest(PayloadTestRequestRequest): PayloadTestResponse = 3;
-}
-
-/** The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems. */
-cluster SoftwareDiagnostics = 52 {
-  revision 1;
-
-  bitmap Feature : bitmap32 {
-    kWatermarks = 0x1;
-  }
-
-  struct ThreadMetricsStruct {
-    int64u id = 0;
-    optional char_string<8> name = 1;
-    optional int32u stackFreeCurrent = 2;
-    optional int32u stackFreeMinimum = 3;
-    optional int32u stackSize = 4;
-  }
-
-  info event SoftwareFault = 0 {
-    int64u id = 0;
-    optional char_string name = 1;
-    optional long_octet_string faultRecording = 2;
-  }
-
-  readonly attribute optional ThreadMetricsStruct threadMetrics[] = 0;
-  readonly attribute optional int64u currentHeapFree = 1;
-  readonly attribute optional int64u currentHeapUsed = 2;
-  readonly attribute optional int64u currentHeapHighWatermark = 3;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  /** This command is used to reset the high watermarks for heap and stack memory. */
-  command access(invoke: manage) ResetWatermarks(): DefaultSuccess = 0;
-}
-
-/** The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems. */
-cluster WiFiNetworkDiagnostics = 54 {
-  revision 1;
-
-  enum AssociationFailureCauseEnum : enum8 {
-    kUnknown = 0;
-    kAssociationFailed = 1;
-    kAuthenticationFailed = 2;
-    kSsidNotFound = 3;
-  }
-
-  enum ConnectionStatusEnum : enum8 {
-    kConnected = 0;
-    kNotConnected = 1;
-  }
-
-  enum SecurityTypeEnum : enum8 {
-    kUnspecified = 0;
-    kNone = 1;
-    kWEP = 2 [spec_name = "WEP"];
-    kWPA = 3 [spec_name = "WPA"];
-    kWPA2 = 4 [spec_name = "WPA2"];
-    kWPA3 = 5 [spec_name = "WPA3"];
-  }
-
-  enum WiFiVersionEnum : enum8 {
-    kA = 0;
-    kB = 1;
-    kG = 2;
-    kN = 3;
-    kAc = 4;
-    kAx = 5;
-    kAh = 6;
-  }
-
-  bitmap Feature : bitmap32 {
-    kPacketCounts = 0x1;
-    kErrorCounts = 0x2;
-  }
-
-  info event Disconnection = 0 {
-    int16u reasonCode = 0;
-  }
-
-  info event AssociationFailure = 1 {
-    AssociationFailureCauseEnum associationFailureCause = 0;
-    int16u status = 1;
-  }
-
-  info event ConnectionStatus = 2 {
-    ConnectionStatusEnum connectionStatus = 0;
-  }
-
-  readonly attribute nullable octet_string<6> bssid = 0;
-  readonly attribute nullable SecurityTypeEnum securityType = 1;
-  readonly attribute nullable WiFiVersionEnum wiFiVersion = 2;
-  readonly attribute nullable int16u channelNumber = 3;
-  readonly attribute nullable int8s rssi = 4;
-  readonly attribute optional nullable int32u beaconLostCount = 5;
-  readonly attribute optional nullable int32u beaconRxCount = 6;
-  readonly attribute optional nullable int32u packetMulticastRxCount = 7;
-  readonly attribute optional nullable int32u packetMulticastTxCount = 8;
-  readonly attribute optional nullable int32u packetUnicastRxCount = 9;
-  readonly attribute optional nullable int32u packetUnicastTxCount = 10;
-  readonly attribute optional nullable int64u currentMaxRate = 11;
-  readonly attribute optional nullable int64u overrunCount = 12;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  /** This command is used to reset the count attributes. */
-  command ResetCounts(): DefaultSuccess = 0;
-}
-
-/** The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems. */
-cluster EthernetNetworkDiagnostics = 55 {
-  revision 1;
-
-  enum PHYRateEnum : enum8 {
-    kRate10M = 0;
-    kRate100M = 1;
-    kRate1G = 2;
-    kRate25G = 3 [spec_name = "Rate2_5G"];
-    kRate5G = 4;
-    kRate10G = 5;
-    kRate40G = 6;
-    kRate100G = 7;
-    kRate200G = 8;
-    kRate400G = 9;
-  }
-
-  bitmap Feature : bitmap32 {
-    kPacketCounts = 0x1;
-    kErrorCounts = 0x2;
-  }
-
-  readonly attribute optional nullable PHYRateEnum PHYRate = 0;
-  readonly attribute optional nullable boolean fullDuplex = 1;
-  readonly attribute optional int64u packetRxCount = 2;
-  readonly attribute optional int64u packetTxCount = 3;
-  readonly attribute optional int64u txErrCount = 4;
-  readonly attribute optional int64u collisionCount = 5;
-  readonly attribute optional int64u overrunCount = 6;
-  readonly attribute optional nullable boolean carrierDetect = 7;
-  readonly attribute optional int64u timeSinceReset = 8;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  /** This command is used to reset the count attributes. */
-  command access(invoke: manage) ResetCounts(): DefaultSuccess = 0;
 }
 
 /** Commands to trigger a Node to allow a new Administrator to commission it. */
@@ -3014,12 +2835,6 @@ endpoint 0 {
     ram      attribute clusterRevision default = 5;
   }
 
-  server cluster UnitLocalization {
-    callback attribute temperatureUnit;
-    ram      attribute featureMap default = 0x1;
-    ram      attribute clusterRevision default = 1;
-  }
-
   server cluster GeneralCommissioning {
     ram      attribute breadcrumb default = 0x0000000000000000;
     callback attribute basicCommissioningInfo;
@@ -3074,52 +2889,6 @@ endpoint 0 {
     handle command TestEventTrigger;
     handle command TimeSnapshot;
     handle command TimeSnapshotResponse;
-  }
-
-  server cluster SoftwareDiagnostics {
-    callback attribute threadMetrics;
-    callback attribute currentHeapFree;
-    callback attribute currentHeapUsed;
-    callback attribute currentHeapHighWatermark;
-    callback attribute featureMap;
-    callback attribute clusterRevision;
-  }
-
-  server cluster WiFiNetworkDiagnostics {
-    emits event Disconnection;
-    emits event AssociationFailure;
-    emits event ConnectionStatus;
-    callback attribute bssid;
-    callback attribute securityType;
-    callback attribute wiFiVersion;
-    callback attribute channelNumber;
-    callback attribute rssi;
-    callback attribute beaconLostCount;
-    callback attribute beaconRxCount;
-    callback attribute packetMulticastRxCount;
-    callback attribute packetMulticastTxCount;
-    callback attribute packetUnicastRxCount;
-    callback attribute packetUnicastTxCount;
-    callback attribute currentMaxRate;
-    callback attribute overrunCount;
-    ram      attribute featureMap default = 3;
-    ram      attribute clusterRevision default = 1;
-  }
-
-  server cluster EthernetNetworkDiagnostics {
-    callback attribute PHYRate;
-    callback attribute fullDuplex;
-    callback attribute packetRxCount;
-    callback attribute packetTxCount;
-    callback attribute txErrCount;
-    callback attribute collisionCount;
-    callback attribute overrunCount;
-    callback attribute carrierDetect;
-    callback attribute timeSinceReset;
-    ram      attribute featureMap default = 3;
-    ram      attribute clusterRevision default = 1;
-
-    handle command ResetCounts;
   }
 
   server cluster AdministratorCommissioning {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -968,7 +968,7 @@
           "mfgCode": null,
           "define": "UNIT_LOCALIZATION_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "attributes": [
             {
               "name": "TemperatureUnit",
@@ -1663,7 +1663,7 @@
           "mfgCode": null,
           "define": "SOFTWARE_DIAGNOSTICS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "attributes": [
             {
               "name": "ThreadMetrics",
@@ -1769,7 +1769,7 @@
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "attributes": [
             {
               "name": "BSSID",
@@ -2042,7 +2042,7 @@
           "mfgCode": null,
           "define": "ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "ResetCounts",

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -460,33 +460,24 @@ class AndroidBuilder(Builder):
                 gn_args["matter_enable_tracing_support"] = False
                 gn_args["use_static_libcxx"] = True
 
-                # TV Casting App size optimizations: compile only the
-                # ~36 casting-relevant clusters instead of the full
-                # generated cluster-objects.cpp, and use slim TLV
-                # decoder source overrides covering only the 18
-                # casting clusters so that ChipClusters.java
-                # read/subscribe APIs remain functional at runtime.
-                # These must be passed as explicit GN build args
+                # TV Casting App size optimizations: point the build at
+                # the override directory containing slim source files
+                # (cluster-objects, TLV decoders, accessors, cluster
+                # servers) covering only the ~36 casting-relevant
+                # clusters.  The build system resolves well-known
+                # filenames inside this directory automatically.
+                # This must be passed as an explicit GN build arg
                 # because args.gni is evaluated inside default_args
                 # (before args.gn is applied), so the
                 # if (optimize_apk_size) conditional there cannot see
                 # the args.gn value.
                 if self.app == AndroidApp.TV_CASTING_APP:
-                    gn_args["chip_cluster_objects_source_override"] = (
+                    gn_args["chip_data_model_overrides_dir"] = (
                         "//third_party/connectedhomeip/examples/"
-                        "tv-casting-app/tv-casting-common/"
-                        "casting-cluster-objects.cpp"
+                        "tv-casting-app/tv-casting-common"
                     )
-                    gn_args["chip_tlv_decoder_attribute_source_override"] = (
-                        "//third_party/connectedhomeip/examples/"
-                        "tv-casting-app/tv-casting-common/"
-                        "casting-CHIPAttributeTLVValueDecoder.cpp"
-                    )
-                    gn_args["chip_tlv_decoder_event_source_override"] = (
-                        "//third_party/connectedhomeip/examples/"
-                        "tv-casting-app/tv-casting-common/"
-                        "casting-CHIPEventTLVValueDecoder.cpp"
-                    )
+                    gn_args["chip_data_model_extra_logging"] = False
+                    gn_args["enable_rtti"] = False
             gn_args.update(self.app.AppGnArgs())
 
             args_str = ""

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -507,8 +507,8 @@ class HostBuilder(GnBuilder):
             self.extra_gn_options.append(f'chip_casting_simplified={str(chip_casting_simplified).lower()}')
             if chip_casting_simplified:
                 self.extra_gn_options.append(
-                    'chip_cluster_objects_source_override='
-                    '"${chip_root}/examples/tv-casting-app/tv-casting-common/casting-cluster-objects.cpp"'
+                    'chip_data_model_overrides_dir='
+                    '"${chip_root}/examples/tv-casting-app/tv-casting-common"'
                 )
 
         if terms_and_conditions_required is not None:

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -201,8 +201,14 @@ template("chip_data_model") {
       "${_app_root}/util/binding-table.h",
       "${_app_root}/util/generic-callback-stubs.cpp",
       "${_app_root}/util/privilege-storage.cpp",
-      "${chip_root}/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp",
     ]
+
+    if (chip_data_model_overrides_dir != "") {
+      sources += [ "${chip_data_model_overrides_dir}/Accessors-override.cpp" ]
+    } else {
+      sources += [ "${chip_root}/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp" ]
+    }
+
     sources += codegen_data_model_SOURCES
 
     if (!chip_build_controller_dynamic_server) {
@@ -216,7 +222,14 @@ template("chip_data_model") {
       ]
     }
 
-    if (defined(invoker.zap_file)) {
+    if (chip_data_model_overrides_dir != "") {
+      # Use the override .gni file to get the cluster server list instead
+      # of auto-discovering from the .zap file via zap_cluster_list.py.
+      # This allows applications to compile only the cluster server
+      # implementations they actually need.
+      import("${chip_data_model_overrides_dir}/cluster-servers-override.gni")
+      _cluster_sources = cluster_server_override_dirs
+    } else if (defined(invoker.zap_file)) {
       _zap_file = rebase_path(invoker.zap_file, root_build_dir)
       _script_args = [
         "--zap_file",

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -50,8 +50,9 @@ static_library("cluster-objects") {
 
   sources = [ "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.h" ]
 
-  if (chip_cluster_objects_source_override != "") {
-    sources += [ chip_cluster_objects_source_override ]
+  if (chip_data_model_overrides_dir != "") {
+    sources +=
+        [ "${chip_data_model_overrides_dir}/cluster-objects-override.cpp" ]
   } else {
     sources +=
         [ "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.cpp" ]

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -46,11 +46,13 @@ declare_args() {
   # application/platform specific layer
   chip_config_enable_groupcast = false
 
-  # Optional path to a replacement cluster-objects.cpp source file.
-  # When set, the cluster-objects static library compiles this file instead
-  # of the full generated cluster-objects.cpp, allowing applications to
-  # include only the cluster implementations they actually need.
-  # The replacement file must provide the same translation-unit contract
-  # (i.e. include the necessary .ipp files and the shared/Structs.ipp).
-  chip_cluster_objects_source_override = ""
+  # Optional path to a directory containing well-known override source
+  # files for the data model. When set to a non-empty path, the build
+  # system looks for files like cluster-objects-override.cpp,
+  # Accessors-override.cpp, cluster-servers-override.gni,
+  # CHIPAttributeTLVValueDecoder-override.cpp, and
+  # CHIPEventTLVValueDecoder-override.cpp inside this directory and
+  # compiles them instead of the full zap-generated sources.
+  # When empty (default), the full generated sources are used.
+  chip_data_model_overrides_dir = ""
 }

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -65,21 +65,19 @@ source_set("android_chip_im_jni") {
     "CHIPInteractionClient-JNI.h",
   ]
 
-  if (matter_enable_tlv_decoder_cpp) {
-    defines = [ "USE_JAVA_TLV_ENCODE_DECODE" ]
-    sources += [ "CHIPTLVValueDecoder-JNI.cpp" ]
+  defines = [ "USE_JAVA_TLV_ENCODE_DECODE" ]
+  sources += [ "CHIPTLVValueDecoder-JNI.cpp" ]
 
-    if (chip_tlv_decoder_attribute_source_override != "") {
-      sources += [ chip_tlv_decoder_attribute_source_override ]
-    } else {
-      sources += [ "zap-generated/CHIPAttributeTLVValueDecoder.cpp" ]
-    }
-
-    if (chip_tlv_decoder_event_source_override != "") {
-      sources += [ chip_tlv_decoder_event_source_override ]
-    } else {
-      sources += [ "zap-generated/CHIPEventTLVValueDecoder.cpp" ]
-    }
+  if (chip_data_model_overrides_dir != "") {
+    sources += [
+      "${chip_data_model_overrides_dir}/CHIPAttributeTLVValueDecoder-override.cpp",
+      "${chip_data_model_overrides_dir}/CHIPEventTLVValueDecoder-override.cpp",
+    ]
+  } else {
+    sources += [
+      "zap-generated/CHIPAttributeTLVValueDecoder.cpp",
+      "zap-generated/CHIPEventTLVValueDecoder.cpp",
+    ]
   }
 
   deps = [


### PR DESCRIPTION
#### Summary


* feat(tv-casting-app): Phase 2 APK size reduction (2.8 MB → 2.6 MB)

Remove 10 non-essential infrastructure clusters from the slim casting-cluster-objects.cpp and disable their server-side definitions in tv-casting-app.zap and tv-casting-app.matter. Disable extra data-model logging, host unit-test hooks, and RTTI for size-optimized builds. Make ICD client dependencies conditional on optimize_apk_size.

Cluster changes:
- Remove .ipp includes for 10 clusters: EthernetNetworkDiagnostics, SoftwareDiagnostics, WiFiNetworkDiagnostics, TimeSynchronization, TimeFormatLocalization, UnitLocalization, FixedLabel, UserLabel, IcdManagement, LocalizationConfiguration
- Retain Groupcast (required by InteractionModelEngine.cpp)
- Remove orphaned CommandIsFabricScoped entries for TimeSynchronization and IcdManagement
- Disable server-side ZAP/matter definitions for removed clusters

Build flag changes (optimize_apk_size=true only):
- chip_data_model_extra_logging=false via android.py
- enable_rtti=false via android.py and args.gni
- CONFIG_BUILD_FOR_HOST_UNIT_TEST=0 via BUILD.gn defines
- ICD client deps excluded via BUILD.gn conditional
- Add src/controller as direct dep (was transitive via ICD)

Measured results (arm64-v8a):
- Android: libTvCastingApp.so 2.8 MB -> 2.6 MB (-7%)
- Darwin: __TEXT 2.8 MB -> 2.7 MB (cluster trimming only)

* feat(casting): Add phase 3 build scoping for cluster servers and accessors

Add explicit build scoping for the TV Casting App size-optimized build:

- chip_cluster_server_source_override: compile only 13 cluster server dirs (12 commissioning + content-app-observer) instead of all ~44 discovered from the .matter file
- chip_accessors_source_override: compile only 29 casting-relevant cluster accessors instead of the full ~200+ cluster Accessors.cpp
- casting-cluster-servers.gni: override list for cluster servers
- casting-Accessors.cpp: slim accessors for 29 clusters

Both overrides follow the same pattern as the existing chip_cluster_objects_source_override from phase 2. All changes are gated behind optimize_apk_size=true; default builds are unaffected.

Measured result: libTvCastingApp.so remains at 2.6 MB (arm64-v8a) because LTO and --gc-sections were already stripping the excluded code. The overrides reduce compile time and intermediate .o sizes, and prevent regressions if linker behavior changes upstream.

Also documents jsoncpp/jsontlv removal as not feasible (JNI interaction model layer uses it at runtime) and controller library split as future work (~1.3 MB potential, requires BUILD.gn refactor).

* refactor(casting): Consolidate 5+ GN override args into chip_data_model_overrides_dir

Replace chip_cluster_objects_source_override,
chip_cluster_server_source_override, chip_accessors_source_override, chip_tlv_decoder_attribute_source_override,
chip_tlv_decoder_event_source_override, and matter_enable_tlv_decoder_cpp with a single chip_data_model_overrides_dir directory-based argument.

When set to a non-empty path, the build system looks for well-known filenames (casting-cluster-objects.cpp, casting-Accessors.cpp, casting-cluster-servers.gni, casting-CHIPAttributeTLVValueDecoder.cpp, casting-CHIPEventTLVValueDecoder.cpp) inside the directory and uses them as source overrides. When empty (default), all consumers fall back to the full zap-generated sources.

Also adds generate_slim_overrides.py and casting-cluster-config.yaml for regenerating slim override files from full zap-generated sources.

Updates android.py, both args.gni files, all GN consumers, docs, and property tests. 76/76 tests pass.

* address CI

* fix(casting): Add trailing newline to tv-casting-app.matter

ZAP codegen produces an extra trailing newline that was missing from the committed file, causing the ZAP consistency CI check to fail.

* fix(build): Update host.py to use chip_data_model_overrides_dir

The old chip_cluster_objects_source_override arg was removed in this PR but host.py still referenced it, which would cause GN "unused args" failures for chip_casting_simplified=true host builds.

* fix(ci): Exclude casting-Accessors.cpp from ember lint checks

casting-Accessors.cpp is a subset of the generated Accessors.cpp (which is already excluded). Add it to both emberAfReadAttribute and emberAfWriteAttribute exclusion lists.

* refactor(build): Rename override files to generic, app-neutral names

Rename casting-specific filenames in src/ build references to generic names so the override mechanism is reusable by any app:
- casting-cluster-objects.cpp → cluster-objects-override.cpp
- casting-Accessors.cpp → Accessors-override.cpp
- casting-cluster-servers.gni → cluster-servers-override.gni
- casting-CHIPAttributeTLVValueDecoder.cpp → CHIPAttributeTLVValueDecoder-override.cpp
- casting-CHIPEventTLVValueDecoder.cpp → CHIPEventTLVValueDecoder-override.cpp

Also removes hardcoded cluster counts from YAML comments to reduce maintenance burden.

Addresses review feedback from andy31415.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* fix: Address review feedback from andy31415

- Merge duplicate chip_data_model_overrides_dir conditionals in src/controller/java/BUILD.gn
- Fix Groupcast misclassification: move from REMOVED to COMMISSIONING in test_phase2_zap_clusters.py (matches casting-cluster-config.yaml)
- Add note in yaml explaining why Groupcast has no Accessors entry
- Replace all print() with logging module in generate_slim_overrides.py

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* fix: Use named logger instead of root logger to satisfy ruff LOG015

---------


(cherry picked from commit 20eabcdfbaf0e5509de5496b8cb03f68894be544)

#### Testing

build, android