### PR TITLE
[Silabs] Update device type revision for lighting app, cluster revision for concentration measurement and regen zap

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
@@ -2332,7 +2332,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
@@ -1917,7 +1917,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
@@ -2014,7 +2014,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -5809,7 +5809,7 @@ cluster OccupancySensing = 1030 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/all-clusters-app/realtek/data_model/all-clusters-app.matter
+++ b/examples/all-clusters-app/realtek/data_model/all-clusters-app.matter
@@ -6699,7 +6699,7 @@ cluster OccupancySensing = 1030 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -2185,7 +2185,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
@@ -1937,7 +1937,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/chef/devices/rootnode_contactsensor_lightsensor_occupancysensor_temperaturesensor_pressuresensor_flowsensor_humiditysensor_airqualitysensor_powersource_367e7cea91.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lightsensor_occupancysensor_temperaturesensor_pressuresensor_flowsensor_humiditysensor_airqualitysensor_powersource_367e7cea91.matter
@@ -1958,7 +1958,7 @@ cluster OccupancySensing = 1030 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
+++ b/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
@@ -1909,7 +1909,7 @@ cluster RelativeHumidityMeasurement = 1029 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -2455,7 +2455,7 @@ cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type ma_rootdevice = 22, version 4;
+  device type ma_rootdevice = 22, version 5;
   device type ma_otarequestor = 18, version 1;
 
   binding cluster OtaSoftwareUpdateProvider;
@@ -2718,7 +2718,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_extendedcolorlight = 269, version 4;
+  device type ma_extendedcolorlight = 269, version 5;
 
 
   server cluster Identify {

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -61,7 +61,7 @@
         }
       ],
       "deviceVersions": [
-        4,
+        5,
         1
       ],
       "deviceIdentifiers": [
@@ -3821,7 +3821,7 @@
         }
       ],
       "deviceVersions": [
-        4
+        5
       ],
       "deviceIdentifiers": [
         269

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -2721,7 +2721,7 @@ cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type ma_rootdevice = 22, version 4;
+  device type ma_rootdevice = 22, version 5;
   device type ma_otarequestor = 18, version 1;
 
   binding cluster OtaSoftwareUpdateProvider;
@@ -2959,7 +2959,7 @@ endpoint 0 {
 }
 endpoint 1 {
   device type ma_powersource = 17, version 1;
-  device type ma_extendedcolorlight = 269, version 4;
+  device type ma_extendedcolorlight = 269, version 5;
 
 
   server cluster Identify {

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -61,7 +61,7 @@
         }
       ],
       "deviceVersions": [
-        4,
+        5,
         1
       ],
       "deviceIdentifiers": [
@@ -3247,7 +3247,7 @@
         }
       ],
       "deviceVersions": [
-        4,
+        5,
         1
       ],
       "deviceIdentifiers": [

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -30,7 +30,7 @@ Git:
     <define>CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <globalAttribute side="either" code="0xFFFD" value="5"/>
     <features>
       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
         <optionalConform choice="a" more="true" min="1"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8334,7 +8334,7 @@ cluster OccupancySensing = 1030 {
 
 /** Attributes for reporting carbon monoxide concentration measurements */
 cluster CarbonMonoxideConcentrationMeasurement = 1036 {
-  revision 3;
+  revision 5;
 
   shared enum LevelValueEnum : enum8 {
     kUnknown = 0;


### PR DESCRIPTION
#### Summary
- Updated the device type revision to 5 for lighting app ZAP (both thread and wifi) and regenerated the matter file.
- Updated the cluster revision to 5 for concentration measurement cluster in the XML file - `src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml`, following v1.6 specs.
- Regenerated the ZAP files using:
```
python3 scripts/tools/zap_regen_all.py
```

#### Related issues
N/A

#### Testing
CI Tests

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
