### PR TITLE
[Inet] Add deferred IPv6 binding for UDPEndPointImplOT initialization

### DIFF
--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -37,6 +37,9 @@ using DeviceLayer::Internal::MapOpenThreadError;
 
 otInstance * globalOtInstance;
 
+// Single deferred endpoint — there is only one OT-based UDP endpoint (the Thread operational port).
+static UDPEndPointImplOT * sDeferredEndpoint = nullptr;
+
 namespace {
 // We want to reserve space for an IPPacketInfo in our buffer, but it needs to
 // be 4-byte aligned.  We ensure the alignment by masking off the low bits of
@@ -127,6 +130,22 @@ void UDPEndPointImplOT::handleUdpReceive(void * aContext, otMessage * aMessage, 
 CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & address, uint16_t port,
                                        [[maybe_unused]] InterfaceId interface)
 {
+#if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    // OT still not ready — defer the bind and return success so Server::Init() can proceed.
+    // CompleteDeferredOTBinds() must be called after OT is initialized.
+    if (mOTInstance == nullptr)
+    {
+        if (!mDeferredBind)
+        {
+            mDeferredAddr    = address;
+            mDeferredPort    = port;
+            mDeferredBind    = true;
+            sDeferredEndpoint = this;
+        }
+        return CHIP_NO_ERROR;
+    }
+#endif
+
     otError err = OT_ERROR_NONE;
     otSockAddr listenSockAddr;
 
@@ -242,6 +261,29 @@ CHIP_ERROR UDPEndPointImplOT::BindInterfaceImpl(IPAddressType addressType, Inter
     (void) addressType;
     (void) interfaceId;
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
+{
+    UDPEndPointImplOT * ep = sDeferredEndpoint;
+    sDeferredEndpoint      = nullptr;
+
+    if (ep == nullptr || !ep->mDeferredBind)
+        return CHIP_NO_ERROR;
+
+    ep->mOTInstance  = otInst;
+    globalOtInstance = otInst;
+
+    CHIP_ERROR err = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mBoundIntfId);
+    if (err == CHIP_NO_ERROR)
+    {
+        ep->mDeferredBind = false;
+    }
+    else
+    {
+        ChipLogError(Inet, "CompleteDeferredOTBinds: bind failed: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    return err;
 }
 
 CHIP_ERROR UDPEndPointImplOT::SendMsgImpl(const IPPacketInfo * aPktInfo, System::PacketBufferHandle && msg)

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -139,7 +139,9 @@ CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & a
         {
             mDeferredAddr     = address;
             mDeferredPort     = port;
+            mDeferredIntfId   = interface;
             mDeferredBind     = true;
+            mNextDeferred     = sDeferredEndpoint;
             sDeferredEndpoint = this;
         }
         return CHIP_NO_ERROR;
@@ -263,27 +265,61 @@ CHIP_ERROR UDPEndPointImplOT::BindInterfaceImpl(IPAddressType addressType, Inter
     return CHIP_NO_ERROR;
 }
 
+UDPEndPointImplOT::~UDPEndPointImplOT()
+{
+    if (mDeferredBind)
+    {
+        if (sDeferredEndpoint == this)
+        {  
+            sDeferredEndpoint = mNextDeferred;  
+        }  
+        else
+        {  
+            UDPEndPointImplOT * curr = sDeferredEndpoint;  
+            while (curr != nullptr && curr->mNextDeferred != this)  
+            {  
+                curr = curr->mNextDeferred;  
+            }  
+            if (curr != nullptr)  
+            {  
+                curr->mNextDeferred = mNextDeferred;  
+            }  
+        }  
+        mDeferredBind = false;  
+        mNextDeferred = nullptr;  
+    }  
+}
+
 CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
 {
+    globalOtInstance = otInst;
+    CHIP_ERROR finalErr = CHIP_NO_ERROR;
+
     UDPEndPointImplOT * ep = sDeferredEndpoint;
     sDeferredEndpoint      = nullptr;
 
-    if (ep == nullptr || !ep->mDeferredBind)
-        return CHIP_NO_ERROR;
-
-    ep->mOTInstance  = otInst;
-    globalOtInstance = otInst;
-
-    CHIP_ERROR err = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mBoundIntfId);
-    if (err == CHIP_NO_ERROR)
+    while (ep != nullptr)
     {
-        ep->mDeferredBind = false;
+        UDPEndPointImplOT * next = ep->mNextDeferred;
+        ep->mNextDeferred = nullptr;
+
+        if (ep->mDeferredBind)
+        {
+            ep->mOTInstance = otInst;
+            CHIP_ERROR err = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
+            if (err == CHIP_NO_ERROR)
+            {
+                ep->mDeferredBind = false;
+            }
+            else
+            {
+                ChipLogError(Inet, "CompleteDeferredOTBinds: bind failed: %" CHIP_ERROR_FORMAT, err.Format());
+                finalErr = err;
+            }
+        }
+        ep = next;
     }
-    else
-    {
-        ChipLogError(Inet, "CompleteDeferredOTBinds: bind failed: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-    return err;
+    return finalErr;
 }
 
 CHIP_ERROR UDPEndPointImplOT::SendMsgImpl(const IPPacketInfo * aPktInfo, System::PacketBufferHandle && msg)

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -37,7 +37,7 @@ using DeviceLayer::Internal::MapOpenThreadError;
 
 otInstance * globalOtInstance;
 
-// Single deferred endpoint — there is only one OT-based UDP endpoint (the Thread operational port).
+// Head of the deferred endpoints list.
 static UDPEndPointImplOT * sDeferredEndpoint = nullptr;
 
 namespace {
@@ -135,11 +135,11 @@ CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & a
     // CompleteDeferredOTBinds() must be called after OT is initialized.
     if (mOTInstance == nullptr)
     {
+        mDeferredAddr   = address;
+        mDeferredPort   = port;
+        mDeferredIntfId = interface;
         if (!mDeferredBind)
         {
-            mDeferredAddr     = address;
-            mDeferredPort     = port;
-            mDeferredIntfId   = interface;
             mDeferredBind     = true;
             mNextDeferred     = sDeferredEndpoint;
             sDeferredEndpoint = this;
@@ -295,29 +295,23 @@ CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
     globalOtInstance    = otInst;
     CHIP_ERROR finalErr = CHIP_NO_ERROR;
 
-    UDPEndPointImplOT * ep = sDeferredEndpoint;
-    sDeferredEndpoint      = nullptr;
-
-    while (ep != nullptr)
+    while (sDeferredEndpoint  != nullptr)
     {
-        UDPEndPointImplOT * next = ep->mNextDeferred;
-        ep->mNextDeferred        = nullptr;
+        UDPEndPointImplOT * ep = sDeferredEndpoint;
+        sDeferredEndpoint      = ep->mNextDeferred;
+        ep->mNextDeferred      = nullptr;
 
         if (ep->mDeferredBind)
         {
             ep->mOTInstance = otInst;
             CHIP_ERROR err  = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
-            if (err == CHIP_NO_ERROR)
-            {
-                ep->mDeferredBind = false;
-            }
-            else
+            ep->mDeferredBind = false;
+            if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Inet, "CompleteDeferredOTBinds: bind failed: %" CHIP_ERROR_FORMAT, err.Format());
                 finalErr = err;
             }
         }
-        ep = next;
     }
     return finalErr;
 }

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -130,7 +130,7 @@ void UDPEndPointImplOT::handleUdpReceive(void * aContext, otMessage * aMessage, 
 CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & address, uint16_t port,
                                        [[maybe_unused]] InterfaceId interface)
 {
-#if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     // OT still not ready — defer the bind and return success so Server::Init() can proceed.
     // CompleteDeferredOTBinds() must be called after OT is initialized.
     if (mOTInstance == nullptr)

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -295,7 +295,7 @@ CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
     globalOtInstance    = otInst;
     CHIP_ERROR finalErr = CHIP_NO_ERROR;
 
-    while (sDeferredEndpoint  != nullptr)
+    while (sDeferredEndpoint != nullptr)
     {
         UDPEndPointImplOT * ep = sDeferredEndpoint;
         sDeferredEndpoint      = ep->mNextDeferred;
@@ -303,8 +303,8 @@ CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
 
         if (ep->mDeferredBind)
         {
-            ep->mOTInstance = otInst;
-            CHIP_ERROR err  = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
+            ep->mOTInstance   = otInst;
+            CHIP_ERROR err    = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
             ep->mDeferredBind = false;
             if (err != CHIP_NO_ERROR)
             {

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -137,9 +137,9 @@ CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & a
     {
         if (!mDeferredBind)
         {
-            mDeferredAddr    = address;
-            mDeferredPort    = port;
-            mDeferredBind    = true;
+            mDeferredAddr     = address;
+            mDeferredPort     = port;
+            mDeferredBind     = true;
             sDeferredEndpoint = this;
         }
         return CHIP_NO_ERROR;

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -270,29 +270,29 @@ UDPEndPointImplOT::~UDPEndPointImplOT()
     if (mDeferredBind)
     {
         if (sDeferredEndpoint == this)
-        {  
-            sDeferredEndpoint = mNextDeferred;  
-        }  
+        {
+            sDeferredEndpoint = mNextDeferred;
+        }
         else
-        {  
-            UDPEndPointImplOT * curr = sDeferredEndpoint;  
-            while (curr != nullptr && curr->mNextDeferred != this)  
-            {  
-                curr = curr->mNextDeferred;  
-            }  
-            if (curr != nullptr)  
-            {  
-                curr->mNextDeferred = mNextDeferred;  
-            }  
-        }  
-        mDeferredBind = false;  
-        mNextDeferred = nullptr;  
-    }  
+        {
+            UDPEndPointImplOT * curr = sDeferredEndpoint;
+            while (curr != nullptr && curr->mNextDeferred != this)
+            {
+                curr = curr->mNextDeferred;
+            }
+            if (curr != nullptr)
+            {
+                curr->mNextDeferred = mNextDeferred;
+            }
+        }
+        mDeferredBind = false;
+        mNextDeferred = nullptr;
+    }
 }
 
 CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
 {
-    globalOtInstance = otInst;
+    globalOtInstance    = otInst;
     CHIP_ERROR finalErr = CHIP_NO_ERROR;
 
     UDPEndPointImplOT * ep = sDeferredEndpoint;
@@ -301,12 +301,12 @@ CHIP_ERROR UDPEndPointImplOT::CompleteDeferredOTBinds(otInstance * otInst)
     while (ep != nullptr)
     {
         UDPEndPointImplOT * next = ep->mNextDeferred;
-        ep->mNextDeferred = nullptr;
+        ep->mNextDeferred        = nullptr;
 
         if (ep->mDeferredBind)
         {
             ep->mOTInstance = otInst;
-            CHIP_ERROR err = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
+            CHIP_ERROR err  = ep->IPv6Bind(ep->mSocket, ep->mDeferredAddr, ep->mDeferredPort, ep->mDeferredIntfId);
             if (err == CHIP_NO_ERROR)
             {
                 ep->mDeferredBind = false;

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -74,8 +74,8 @@ private:
     bool mDeferredBind = false;
     IPAddress mDeferredAddr;
     uint16_t mDeferredPort = 0;
-    InterfaceId mDeferredIntfId;  
-    UDPEndPointImplOT * mNextDeferred = nullptr;  
+    InterfaceId mDeferredIntfId;
+    UDPEndPointImplOT * mNextDeferred = nullptr;
 };
 
 using UDPEndPointImpl = UDPEndPointImplOT;

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -49,6 +49,10 @@ public:
     CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
     CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
 
+    // Complete any deferred IPv6 binds for endpoints whose OT instance was null at bind time.
+    // Call this after OpenThread is initialized (e.g. in non-concurrent commissioning mode).
+    static CHIP_ERROR CompleteDeferredOTBinds(otInstance * otInst);
+
 private:
     // UDPEndPoint overrides.
     CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
@@ -64,6 +68,11 @@ private:
     InterfaceId mBoundIntfId;
     uint16_t mBoundPort;
     otUdpSocket mSocket;
+
+    // State for deferred bind (used when OT instance is not yet initialized)
+    bool mDeferredBind   = false;
+    IPAddress mDeferredAddr;
+    uint16_t mDeferredPort = 0;
 };
 
 using UDPEndPointImpl = UDPEndPointImplOT;

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -70,7 +70,7 @@ private:
     otUdpSocket mSocket;
 
     // State for deferred bind (used when OT instance is not yet initialized)
-    bool mDeferredBind   = false;
+    bool mDeferredBind = false;
     IPAddress mDeferredAddr;
     uint16_t mDeferredPort = 0;
 };

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -40,6 +40,7 @@ public:
     UDPEndPointImplOT(EndPointManager<UDPEndPoint> & endPointManager) :
         UDPEndPoint(endPointManager), mBoundIntfId(InterfaceId::Null())
     {}
+    ~UDPEndPointImplOT() override;
 
     // UDPEndPoint overrides.
     InterfaceId GetBoundInterface() const override;
@@ -73,6 +74,8 @@ private:
     bool mDeferredBind = false;
     IPAddress mDeferredAddr;
     uint16_t mDeferredPort = 0;
+    InterfaceId mDeferredIntfId;  
+    UDPEndPointImplOT * mNextDeferred = nullptr;  
 };
 
 using UDPEndPointImpl = UDPEndPointImplOT;


### PR DESCRIPTION
#### Summary

For matter over thread non-concurrent commissioning flow, OT instance may not initialize when Server::Init() call BindImpl. 
Store the bind parameters first and let Server::Init() complete. Then complete the actual otUdpBind via CompleteDeferredOTBinds() once OT is up.

#### Related issues

NA

#### Testing

Complete non-concurrent commissioning test via CHIPTool for Realtek examples.