### PR TITLE
[TC-DRLK-2.2/2.3] Fix UnboundLocalError on invalid PIN generation and MaxPINCodeLength failure message

### DIFF
--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -191,7 +191,7 @@ class DRLK_COMMON:
             self.print_step("4c", "TH reads MaxPINCodeLength attribute and saves the value")
             max_pin_code_length = await self.read_and_verify_pincode_length(
                 attribute=Clusters.DoorLock.Attributes.MaxPINCodeLength,
-                failure_message="MinPINCodeLength attribute must be between 0 to 255"
+                failure_message="MaxPINCodeLength attribute must be between 0 to 255"
             )
             self.print_step("4d", "Generate credential data and store as pin_code,Th sends SetCredential command"
                                   "using pin_code")
@@ -230,12 +230,13 @@ class DRLK_COMMON:
                     self.print_step("6a", "TH verifies that RequirePINforRemoteOperation is TRUE")
                     asserts.assert_true(requirePinForRemoteOperation_dut, "RequirePINforRemoteOperation is expected to be TRUE")
         # generate InvalidPincode
-        while True:
-            invalidPincodeString = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
-            invalidPincode = bytes(invalidPincodeString, "ascii")
-            if invalidPincodeString != pin_code:
-                break
-        log.info(" pin_code=%s, Invalid PinCode=%s" % (pin_code, invalidPincodeString))
+        if self.check_pics("DRLK.S.F00"):
+            while True:
+                invalidPincodeString = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
+                invalidPincode = bytes(invalidPincodeString, "ascii")
+                if invalidPincodeString != pin_code:
+                    break
+            log.info(" pin_code=%s, Invalid PinCode=%s" % (pin_code, invalidPincodeString))
         if self.check_pics("DRLK.S.F00") and self.check_pics(lockUnlockCmdRspPICS) and self.check_pics("DRLK.S.A0033"):
             self.print_step("7", "TH sends %s Command to the DUT with an invalid PINCode" % lockUnlockText)
             command = lockUnlockCommand(PINCode=invalidPincode)


### PR DESCRIPTION
#### Summary

Two bugs in `drlk_2_x_common.py` (`DRLK_COMMON.run_drlk_test_common`) that affect TC-DRLK-2.2 and TC-DRLK-2.3 when the PIN credential feature (DRLK.S.F00) is disabled on the DUT:

**Bug 1 — `UnboundLocalError` crash on invalid PIN generation**

`max_pin_code_length` and `min_pin_code_length` are only assigned inside the `if self.check_pics("DRLK.S.F00")` block (step 4b/4c), but the `while True` loop that uses them to generate `invalidPincode` was sitting unconditionally
outside that block. When `DRLK.S.F00 = FALSE`, the variables are never assigned and the test crashes:

Fix: guard the `while True` invalid-pincode generation block under the same
`if self.check_pics("DRLK.S.F00")` condition.

**Bug 2 — Wrong `failure_message` string in step 4c (copy/paste error)**

Step 4c reads the `MaxPINCodeLength` attribute but the assertion failure
message incorrectly said `"MinPINCodeLength attribute must be between 0 to
255"`. Fixed to `"MaxPINCodeLength attribute must be between 0 to 255"`.

#### Related issues

Fix for CCB: https://zigbeecertifiedproducts.knackhq.com/zigbee-alliance-ccb-tool/#home/ccbs/ccbdetails2/6a0c306457112ce6b5d24552/


#### Testing

Tested in RPI platform

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
