### PR TITLE
Fix `matter-devices.xml` inconsistencies with spec

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1063,12 +1063,6 @@ limitations under the License.
             </include>
             <include cluster="Identify" client="false" server="false" clientLocked="true"
                 serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="WebRTC Transport Provider" client="true" server="true"
                 clientLocked="true" serverLocked="true"></include>
             <include cluster="WebRTC Transport Requestor" client="true" server="true"
@@ -1099,16 +1093,8 @@ limitations under the License.
             </include>
             <include cluster="Identify" client="false" server="false" clientLocked="true"
                 serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="Push AV Stream Transport" client="false" server="false"
                 clientLocked="true" serverLocked="false"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="WebRTC Transport Provider" client="false" server="true"
                 clientLocked="false" serverLocked="true"></include>
             <include cluster="WebRTC Transport Requestor" client="true" server="false"
@@ -1129,8 +1115,6 @@ limitations under the License.
             <endpoint conformance="O">
                 <deviceType id="0x0107" name="Occupancy Sensor">
                     <clusters>
-                        <include cluster="Boolean State Configuration" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
                         <include cluster="Identify" client="false" server="true" clientLocked="true"
                             serverLocked="true"></include>
                         <include cluster="Occupancy Sensing" client="false" server="true"
@@ -1154,16 +1138,8 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
                 serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="Push AV Stream Transport" client="false" server="false"
                 clientLocked="true" serverLocked="false"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="WebRTC Transport Provider" client="false" server="true"
                 clientLocked="false" serverLocked="true"></include>
             <include cluster="WebRTC Transport Requestor" client="true" server="false"
@@ -1212,18 +1188,8 @@ limitations under the License.
                         </include>
                         <include cluster="Identify" client="false" server="false"
                             clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Power Source" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
                         <include cluster="Push AV Stream Transport" client="false" server="false"
                             clientLocked="true" serverLocked="false"></include>
-                        <include cluster="TLS Certificate Management" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
-                        <include cluster="TLS Client Management" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Time Synchronization" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
                         <include cluster="WebRTC Transport Provider" client="false" server="true"
                             clientLocked="false" serverLocked="true"></include>
                         <include cluster="WebRTC Transport Requestor" client="true" server="false"
@@ -1295,16 +1261,8 @@ limitations under the License.
                             clientLocked="true" serverLocked="false"></include>
                         <include cluster="Occupancy Sensing" client="false" server="false"
                             clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Power Source" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
                         <include cluster="Push AV Stream Transport" client="false" server="false"
                             clientLocked="true" serverLocked="false"></include>
-                        <include cluster="TLS Certificate Management" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
-                        <include cluster="TLS Client Management" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Time Synchronization" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
                         <include cluster="WebRTC Transport Provider" client="false" server="true"
                             clientLocked="false" serverLocked="true"></include>
                         <include cluster="WebRTC Transport Requestor" client="true" server="false"
@@ -1359,10 +1317,6 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
                 serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
             <include cluster="Zone Management" client="false" server="false" clientLocked="true"
                 serverLocked="false"></include>
         </clusters>
@@ -1408,8 +1362,6 @@ limitations under the License.
             <include cluster="TLS Certificate Management" client="false" server="false"
                 clientLocked="false" serverLocked="true"></include>
             <include cluster="TLS Client Management" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false"
                 clientLocked="false" serverLocked="true"></include>
             <include cluster="WebRTC Transport Provider" client="true" server="false"
                 clientLocked="true" serverLocked="true"></include>
@@ -1838,8 +1790,6 @@ limitations under the License.
         <clusters>
             <include cluster="Meter Identification" client="false" server="true" clientLocked="true"
                 serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1855,8 +1805,6 @@ limitations under the License.
             <include cluster="Descriptor" client="false" server="true" clientLocked="true"
                 serverLocked="true"></include>
             <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
                 serverLocked="true"></include>
         </clusters>
     </deviceType>
@@ -2168,8 +2116,6 @@ limitations under the License.
                 serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
             <include cluster="Illuminance Measurement" client="false" server="true"
                 clientLocked="true" serverLocked="true">
                 <requireAttribute>ILLUM_MEASURED_VALUE</requireAttribute>
@@ -2207,8 +2153,6 @@ limitations under the License.
                 serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
             <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true"
                 serverLocked="true">
                 <requireAttribute>OCCUPANCY</requireAttribute>
@@ -2554,27 +2498,6 @@ limitations under the License.
                 serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
-                serverLocked="false">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
-                <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
-                <requireCommand>AddScene</requireCommand>
-                <requireCommand>AddSceneResponse</requireCommand>
-                <requireCommand>ViewScene</requireCommand>
-                <requireCommand>ViewSceneResponse</requireCommand>
-                <requireCommand>RemoveScene</requireCommand>
-                <requireCommand>RemoveSceneResponse</requireCommand>
-                <requireCommand>RemoveAllScenes</requireCommand>
-                <requireCommand>RemoveAllScenesResponse</requireCommand>
-                <requireCommand>StoreScene</requireCommand>
-                <requireCommand>StoreSceneResponse</requireCommand>
-                <requireCommand>RecallScene</requireCommand>
-                <requireCommand>GetSceneMembership</requireCommand>
-                <requireCommand>GetSceneMembershipResponse</requireCommand>
-            </include>
             <include cluster="Groups" client="false" server="false" clientLocked="true"
                 serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
@@ -2591,8 +2514,6 @@ limitations under the License.
             </include>
             <include cluster="Thermostat" client="false" server="true" clientLocked="true"
                 serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false"
-                clientLocked="false" serverLocked="false"></include>
             <include cluster="Thermostat User Interface Configuration" client="false" server="false"
                 clientLocked="true" serverLocked="false"></include>
             <include cluster="Fan Control" client="false" server="false" clientLocked="false"
@@ -2686,7 +2607,7 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Low Power" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false"
+            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
             <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
@@ -2727,7 +2648,7 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Low Power" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false"
+            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
             <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
                 serverLocked="false"></include>
@@ -2766,7 +2687,7 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Level Control" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false"
+            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
             <include cluster="Channel" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
@@ -2817,7 +2738,7 @@ limitations under the License.
                 serverLocked="false"></include>
             <include cluster="Level Control" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false"
+            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
             <include cluster="Channel" client="true" server="false" clientLocked="false"
                 serverLocked="false"></include>
@@ -2843,14 +2764,6 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
-                <requireAttribute>IDENTIFY_TIME</requireAttribute>
-                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
-                <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
-                <requireCommand>TriggerEffect</requireCommand>
-            </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true"
                 serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
@@ -2874,14 +2787,6 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
-                <requireAttribute>IDENTIFY_TIME</requireAttribute>
-                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
-                <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
-                <requireCommand>TriggerEffect</requireCommand>
-            </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true"
                 serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
@@ -2923,14 +2828,6 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
-                <requireAttribute>IDENTIFY_TIME</requireAttribute>
-                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
-                <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
-                <requireCommand>TriggerEffect</requireCommand>
-            </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true"
                 serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
@@ -3014,8 +2911,6 @@ limitations under the License.
                 clientLocked="true" serverLocked="false"></include>
             <include cluster="Carbon Monoxide Concentration Measurement" client="false"
                 server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true"
                 serverLocked="true"></include>
         </clusters>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -22,10 +22,14 @@ limitations under the License.
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0xFFF10001</deviceId>
         <clusters lockOthers="true">
-            <include cluster="Proxy Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Proxy Discovery" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Proxy Valid" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Pulse Width Modulation" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Proxy Configuration" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Proxy Discovery" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Proxy Valid" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Pulse Width Modulation" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -38,10 +42,12 @@ limitations under the License.
         <class>Node</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Access Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Access Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>ACL</requireAttribute>
             </include>
-            <include cluster="Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Basic Information" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DATA_MODEL_REVISION</requireAttribute>
                 <requireAttribute>VENDOR_NAME</requireAttribute>
                 <requireAttribute>VENDOR_ID</requireAttribute>
@@ -54,33 +60,51 @@ limitations under the License.
                 <requireAttribute>SOFTWARE_VERSION</requireAttribute>
                 <requireAttribute>SOFTWARE_VERSION_STRING</requireAttribute>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="General Commissioning" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <requireCommand>SetRegulatoryConfig</requireCommand>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Group Key Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Administrator Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Operational Credentials" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Localization Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Format Localization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Unit Localization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Power Source Configuration" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Group Key Management" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Network Commissioning" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Administrator Commissioning" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Operational Credentials" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Localization Configuration" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Format Localization" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Unit Localization" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>UP_TIME</requireAttribute>
             </include>
-            <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Software Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Software Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ethernet Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="ICD Management" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="LITS" name="LongIdleTimeSupport">
                         <otherwiseConform>
@@ -104,13 +128,15 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -123,10 +149,14 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Electrical Energy Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Electrical Power Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Power Topology" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Electrical Energy Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Electrical Power Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -139,14 +169,17 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="OTA Software Update Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Requestor" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="true" server="false"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -159,14 +192,17 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Requestor" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Requestor" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -179,13 +215,15 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Actions" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Actions" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -198,17 +236,21 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Bridged Device Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Bridged Device Basic Information" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <requireAttribute>REACHABLE</requireAttribute>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Power Source Configuration" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -221,11 +263,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Humidistat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Water Tank Level Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Humidistat" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Water Tank Level Monitoring" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -238,19 +285,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -263,7 +313,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="false" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -281,7 +332,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -299,7 +351,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -322,7 +375,8 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -336,22 +390,26 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -364,7 +422,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -382,7 +441,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -400,7 +460,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -423,7 +484,8 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -437,19 +499,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmable Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -462,7 +527,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -480,7 +546,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -498,7 +565,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -521,7 +589,8 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Color Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="CT" name="ColorTemperature">
                         <mandatoryConform></mandatoryConform>
@@ -556,19 +625,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Color Temperature Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -581,7 +653,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -599,7 +672,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -617,7 +691,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -640,7 +715,8 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Color Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="HS" name="HueSaturation">
                         <optionalConform></optionalConform>
@@ -691,19 +767,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -716,7 +795,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -734,7 +814,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -752,7 +833,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -787,19 +869,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -812,7 +897,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -830,7 +916,8 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -848,7 +935,8 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -884,23 +972,29 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Plug-in Unit</superset>
         <clusters>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                     <feature code="OO" name="OnOff"></feature>
                 </features>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                 </features>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireCommand>CopyScene</requireCommand>
             </include>
         </clusters>
@@ -916,23 +1010,29 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmable Plug-in Unit</superset>
         <clusters>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                     <feature code="OO" name="OnOff"></feature>
                 </features>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                 </features>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireCommand>CopyScene</requireCommand>
             </include>
         </clusters>
@@ -947,8 +1047,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false"
+                server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot">
@@ -959,12 +1061,18 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Provider" client="true" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="TLS Certificate Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="WebRTC Transport Provider" client="true" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -977,7 +1085,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Stream Management" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot">
@@ -988,14 +1097,22 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="TLS Certificate Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="TLS Client Management" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="WebRTC Transport Provider" client="false" server="true"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1012,32 +1129,47 @@ limitations under the License.
             <endpoint conformance="O">
                 <deviceType id="0x0107" name="Occupancy Sensor">
                     <clusters>
-                        <include cluster="Boolean State Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Boolean State Configuration" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true"
+                            serverLocked="true"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
         </endpointComposition>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false"
+                server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot"></feature>
                     <feature code="VDO" name="Video"></feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="TLS Certificate Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="TLS Certificate Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="TLS Client Management" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="WebRTC Transport Provider" client="false" server="true"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1054,8 +1186,10 @@ limitations under the License.
             <endpoint conformance="M" constraint="min 1">
                 <deviceType id="0x000F" name="Generic Switch">
                     <clusters>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true">
+                        <include cluster="Identify" client="false" server="true" clientLocked="true"
+                            serverLocked="true"></include>
+                        <include cluster="Switch" client="false" server="true" clientLocked="true"
+                            serverLocked="true">
                             <features>
                                 <feature code="MS" name="MomentarySwitch"></feature>
                             </features>
@@ -1066,24 +1200,36 @@ limitations under the License.
             <endpoint conformance="M" constraint="1">
                 <deviceType id="0x0142" name="Camera">
                     <clusters>
-                        <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+                        <include cluster="Camera AV Settings User Level Management" client="false"
+                            server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Camera AV Stream Management" client="false" server="true"
+                            clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="ADO" name="Audio"></feature>
                                 <feature code="SNP" name="Snapshot"></feature>
                                 <feature code="VDO" name="Video"></feature>
                             </features>
                         </include>
-                        <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="TLS Certificate Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="TLS Client Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Power Source" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Push AV Stream Transport" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="TLS Certificate Management" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="TLS Client Management" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Time Synchronization" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Provider" client="false" server="true"
+                            clientLocked="false" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Requestor" client="true" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Zone Management" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
@@ -1103,11 +1249,14 @@ limitations under the License.
             <endpoint conformance="M" constraint="min 1">
                 <deviceType id="0x0100" name="On/Off Light">
                     <clusters>
-                        <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                        <include cluster="Groups" client="false" server="true" clientLocked="true"
+                            serverLocked="true"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true"
+                            serverLocked="true">
                             <requireCommand>TriggerEffect</requireCommand>
                         </include>
-                        <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                        <include cluster="Level Control" client="false" server="false"
+                            clientLocked="true" serverLocked="false">
                             <requireAttribute>CURRENT_LEVEL</requireAttribute>
                             <requireAttribute>MAX_LEVEL</requireAttribute>
                             <requireAttribute>MIN_LEVEL</requireAttribute>
@@ -1116,37 +1265,52 @@ limitations under the License.
                                 <feature code="OO" name="OnOff"></feature>
                             </features>
                         </include>
-                        <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-                        <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                        <include cluster="Occupancy Sensing" client="false" server="false"
+                            clientLocked="false" serverLocked="true"></include>
+                        <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                            serverLocked="true">
                             <features>
                                 <feature code="LT" name="Lighting"></feature>
                             </features>
                         </include>
-                        <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Scenes Management" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
             <endpoint conformance="M" constraint="1">
                 <deviceType id="0x0142" name="Camera">
                     <clusters>
-                        <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+                        <include cluster="Camera AV Settings User Level Management" client="false"
+                            server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Camera AV Stream Management" client="false" server="true"
+                            clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="ADO" name="Audio"></feature>
                                 <feature code="SNP" name="Snapshot"></feature>
                                 <feature code="VDO" name="Video"></feature>
                             </features>
                         </include>
-                        <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="TLS Certificate Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="TLS Client Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Power Source" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Push AV Stream Transport" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="TLS Certificate Management" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="TLS Client Management" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Time Synchronization" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Provider" client="false" server="true"
+                            clientLocked="false" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Requestor" client="true" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Zone Management" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
@@ -1166,16 +1330,21 @@ limitations under the License.
             <endpoint conformance="O">
                 <deviceType id="0x0107" name="Occupancy Sensor">
                     <clusters>
-                        <include cluster="Boolean State Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Boolean State Configuration" client="false" server="false"
+                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true"
+                            serverLocked="true"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="true"
+                            clientLocked="true" serverLocked="true"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
         </endpointComposition>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false"
+                server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio">
                         <disallowConform></disallowConform>
@@ -1186,11 +1355,16 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1203,8 +1377,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Chime" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Chime" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1217,18 +1393,30 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Power Source" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="TLS Certificate Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Camera AV Settings User Level Management" client="false"
+                server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Power Source" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="TLS Certificate Management" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="TLS Client Management" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Provider" client="true" server="false"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1240,10 +1428,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Chime" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Chime" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Switch" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="MS" name="MomentarySwitch"></feature>
                 </features>
@@ -1260,11 +1452,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Service Area" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Ambient Context Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Service Area" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Ambient Context Sensing" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1277,13 +1474,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Closure Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Closure Control" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1296,8 +1496,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Closure Dimension" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Closure Dimension" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
                 </features>
@@ -1314,11 +1516,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Closure Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Closure Dimension" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Closure Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Closure Dimension" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1331,23 +1538,27 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1360,7 +1571,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1380,13 +1592,15 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireCommand>Off</requireCommand>
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Pump Configuration and Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Pump Configuration and Control" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <requireAttribute>MAX_PRESSURE</requireAttribute>
                 <requireAttribute>MAX_SPEED</requireAttribute>
                 <requireAttribute>MAX_FLOW</requireAttribute>
@@ -1395,11 +1609,16 @@ limitations under the License.
                 <requireAttribute>Capacity</requireAttribute>
                 <requireAttribute>OperationMode</requireAttribute>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="false"></include>
+            <include cluster="Pressure Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="false"></include>
+            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1412,22 +1631,26 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1440,7 +1663,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1460,7 +1684,8 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1474,22 +1699,26 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Light Switch</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1502,7 +1731,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1522,8 +1752,10 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1537,22 +1769,26 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmer Switch</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1565,7 +1801,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -1581,9 +1818,12 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Color Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1596,8 +1836,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Meter Identification" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Meter Identification" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1610,9 +1852,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1625,9 +1870,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Commodity Price" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Commodity Tariff" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Commodity Price" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Commodity Tariff" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>TAG_LIST</requireAttribute>
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
@@ -1645,8 +1893,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Commodity Metering" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Commodity Metering" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1712,29 +1962,39 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Scenes Management" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Illuminance Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Groups" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Scenes Management" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Color Control" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Illuminance Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1747,23 +2007,27 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="false" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1776,7 +2040,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1796,12 +2061,18 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Pump Configuration and Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Pump Configuration and Control" client="true" server="false"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Pressure Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1814,22 +2085,27 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Fixed Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="User Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Switch" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Fixed Label" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="User Label" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1842,20 +2118,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>STATE_VALUE</requireAttribute>
             </include>
         </clusters>
@@ -1870,24 +2149,29 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Illuminance Measurement" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Illuminance Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <requireAttribute>ILLUM_MEASURED_VALUE</requireAttribute>
                 <requireAttribute>ILLUM_MIN_MEASURED_VALUE</requireAttribute>
                 <requireAttribute>ILLUM_MAX_MEASURED_VALUE</requireAttribute>
@@ -1904,24 +2188,29 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>OCCUPANCY</requireAttribute>
                 <requireAttribute>OCCUPANCY_SENSOR_TYPE</requireAttribute>
             </include>
@@ -1937,20 +2226,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1963,20 +2255,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Pressure Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Pressure Measurement" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1989,20 +2284,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Flow Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Flow Measurement" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2015,20 +2313,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Relative Humidity Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2041,27 +2342,35 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Color Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Color Control" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2074,20 +2383,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Door Lock" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="USR" name="User">
                         <mandatoryConform>
@@ -2110,7 +2422,8 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2123,17 +2436,21 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Door Lock" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Door Lock" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2146,39 +2463,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
-                <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
-                <requireCommand>AddScene</requireCommand>
-                <requireCommand>AddSceneResponse</requireCommand>
-                <requireCommand>ViewScene</requireCommand>
-                <requireCommand>ViewSceneResponse</requireCommand>
-                <requireCommand>RemoveScene</requireCommand>
-                <requireCommand>RemoveSceneResponse</requireCommand>
-                <requireCommand>RemoveAllScenes</requireCommand>
-                <requireCommand>RemoveAllScenesResponse</requireCommand>
-                <requireCommand>StoreScene</requireCommand>
-                <requireCommand>StoreSceneResponse</requireCommand>
-                <requireCommand>RecallScene</requireCommand>
-                <requireCommand>GetSceneMembership</requireCommand>
-                <requireCommand>GetSceneMembershipResponse</requireCommand>
-            </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2191,15 +2491,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Window Covering" client="false" server="true" clientLocked="true" serverLocked="true">
-                <features>
-                    <feature code="ABS" name="AbsolutePosition">
-                        <mandatoryConform>
-                            <condition name="Zigbee"></condition>
-                        </mandatoryConform>
-                    </feature>
-                </features>
-            </include>
+            <include cluster="Window Covering" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2212,32 +2505,28 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="false"
+                serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Window Covering" client="true" server="false" clientLocked="true" serverLocked="true">
-                <features>
-                    <feature code="ABS" name="AbsolutePosition">
-                        <mandatoryConform>
-                            <condition name="Zigbee"></condition>
-                        </mandatoryConform>
-                    </feature>
-                </features>
-            </include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Window Covering" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2250,23 +2539,27 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -2286,7 +2579,8 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2299,13 +2593,20 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Time Synchronization" client="false" server="false"
+                clientLocked="false" serverLocked="false"></include>
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false"
+                clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2318,19 +2619,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2343,7 +2647,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2356,30 +2661,43 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="false">
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Application Launcher" client="false" server="true"
+                clientLocked="false" serverLocked="false">
                 <features>
                     <feature code="AP" name="ApplicationPlatform">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Media Input" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Audio Output" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Low Power" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Account Login" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Content Launcher" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Media Input" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Audio Output" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Low Power" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Account Login" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Content Launcher" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2392,21 +2710,31 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Media Input" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Audio Output" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Low Power" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Media Input" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Audio Output" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Low Power" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Wake on LAN" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2419,29 +2747,45 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="false" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Content Launcher" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Keypad Input" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Account Login" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Channel" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Target Navigator" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Media Input" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Low Power" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Audio Output" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Application Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Application Basic" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Media Playback" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Content Launcher" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Keypad Input" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Account Login" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Channel" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Target Navigator" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Media Input" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Low Power" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Audio Output" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Application Launcher" client="true" server="false"
+                clientLocked="false" serverLocked="false"></include>
+            <include cluster="Application Basic" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2454,28 +2798,43 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="false" serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Content Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Keypad Input" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Account Login" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Channel" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Target Navigator" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Media Input" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Low Power" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Audio Output" client="true" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Application Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Playback" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Content Launcher" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Keypad Input" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Account Login" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Wake on LAN" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Channel" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Target Navigator" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Media Input" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Low Power" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Audio Output" client="true" server="false" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Application Launcher" client="true" server="false"
+                clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2488,21 +2847,25 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2515,33 +2878,43 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Application Basic" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="true">
+            <include cluster="Application Basic" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Application Launcher" client="false" server="true"
+                clientLocked="false" serverLocked="true">
                 <features>
                     <feature code="AP" name="ApplicationPlatform">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Account Login" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Content Launcher" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Account Login" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Content Launcher" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2554,20 +2927,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Mode Select" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Mode Select" client="false" server="true" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2580,12 +2956,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
@@ -2596,14 +2974,22 @@ limitations under the License.
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2616,18 +3002,26 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Smoke CO Alarm" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Monoxide Concentration Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Smoke CO Alarm" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Monoxide Concentration Measurement" client="false"
+                server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2640,16 +3034,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="HEPA Filter Monitoring" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Activated Carbon Filter Monitoring" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="HEPA Filter Monitoring" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Activated Carbon Filter Monitoring" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2662,25 +3062,40 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Air Quality" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Monoxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Dioxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Nitrogen Dioxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Ozone Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Formaldehyde Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM1 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM2.5 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM10 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Radon Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Total Volatile Organic Compounds Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Air Quality" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Monoxide Concentration Measurement" client="false"
+                server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Dioxide Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Nitrogen Dioxide Concentration Measurement" client="false"
+                server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ozone Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Formaldehyde Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM1 Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM2.5 Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM10 Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Radon Concentration Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Total Volatile Organic Compounds Concentration Measurement"
+                client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2693,25 +3108,32 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Dishwasher Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Dishwasher Alarm" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2733,8 +3155,10 @@ limitations under the License.
             </endpoint>
         </endpointComposition>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2747,9 +3171,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="WND" name="Wind">
                         <disallowConform></disallowConform>
@@ -2759,9 +3186,12 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Microwave Oven Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Microwave Oven Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Microwave Oven Mode" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Microwave Oven Control" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2780,16 +3210,20 @@ limitations under the License.
             </endpoint>
         </endpointComposition>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false"
+                server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Refrigerator Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Refrigerator Alarm" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2802,25 +3236,32 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Laundry Washer Controls" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2833,25 +3274,32 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Dryer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Laundry Dryer Controls" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2864,11 +3312,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="HEPA Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Activated Carbon Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="HEPA Filter Monitoring" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Activated Carbon Filter Monitoring" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="RCK" name="Rocking">
                         <disallowConform></disallowConform>
@@ -2893,12 +3346,18 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="RVC Run Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="RVC Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Service Area" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="RVC Run Mode" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="RVC Operational State" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Service Area" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2911,24 +3370,30 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false"
+                server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Oven Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Oven Mode" client="false" server="false" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Oven Cavity Operational State" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Oven Cavity Operational State" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2941,10 +3406,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2957,9 +3426,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Valve Configuration and Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Valve Configuration and Control" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2972,10 +3444,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2988,10 +3464,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3004,10 +3484,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Network Directory" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Wi-Fi Network Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Border Router Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Thread Network Directory" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Wi-Fi Network Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Border Router Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3020,9 +3504,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Border Router Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Border Router Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3032,23 +3519,27 @@ limitations under the License.
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0xFFF10003</deviceId>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Color Control" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Color Control" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
@@ -3116,7 +3607,8 @@ limitations under the License.
                 <requireCommand>StepColorTemperature</requireCommand>
                 <requireCommand>StopMoveStep</requireCommand>
             </include>
-            <include cluster="Door Lock" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Door Lock" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireCommand>LockDoor</requireCommand>
                 <requireCommand>UnlockDoor</requireCommand>
                 <requireCommand>SetUser</requireCommand>
@@ -3129,7 +3621,8 @@ limitations under the License.
                 <requireCommand>SetCredentialStatusResponse</requireCommand>
                 <requireCommand>ClearCredential</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -3142,7 +3635,8 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Level Control" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Level Control" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -3153,13 +3647,15 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="On/Off" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireCommand>Off</requireCommand>
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="true" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes Management" client="true" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -3179,7 +3675,8 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3192,16 +3689,21 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Network Commissioning" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ethernet Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3214,8 +3716,10 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Joint Fabric Datastore" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Joint Fabric Administrator" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Joint Fabric Datastore" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Joint Fabric Administrator" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3227,9 +3731,12 @@ limitations under the License.
         <deviceId editable="false">0x0078</deviceId>
         <revision editable="false">1</revision>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <features>
                     <feature code="OFFONLY" name="OffOnly">
                         <mandatoryConform></mandatoryConform>
@@ -3247,16 +3754,20 @@ limitations under the License.
         <deviceId editable="false">0x0077</deviceId>
         <revision editable="false">2</revision>
         <clusters lockOthers="true">
-            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <features>
                     <feature code="OFFONLY" name="OffOnly">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="true" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3268,11 +3779,16 @@ limitations under the License.
         <deviceId editable="false">0x050C</deviceId>
         <revision editable="false">2</revision>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Energy EVSE" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Energy EVSE Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true"
+                serverLocked="false"></include>
+            <include cluster="Energy EVSE" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Energy EVSE Mode" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3285,8 +3801,10 @@ limitations under the License.
         <revision editable="false">2</revision>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Device Energy Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Device Energy Management Mode" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Device Energy Management" client="false" server="true"
+                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Device Energy Management Mode" client="false" server="true"
+                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3299,24 +3817,28 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CONTROL_SEQUENCE_OF_OPERATION</requireAttribute>
                 <requireAttribute>LOCAL_TEMPERATURE</requireAttribute>
                 <requireAttribute>SYSTEM_MODE</requireAttribute>
                 <requireCommand>SetpointRaiseLower</requireCommand>
             </include>
-            <include cluster="Water Heater Management" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Water Heater Management" client="false" server="true"
+                clientLocked="true" serverLocked="true">
                 <requireAttribute>BOOST_STATE</requireAttribute>
                 <requireAttribute>HEATER_TYPES</requireAttribute>
                 <requireAttribute>HEAT_DEMAND</requireAttribute>
@@ -3325,7 +3847,8 @@ limitations under the License.
                 <requireCommand>Boost</requireCommand>
                 <requireCommand>CancelBoost</requireCommand>
             </include>
-            <include cluster="Water Heater Mode" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Water Heater Mode" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CURRENT_MODE</requireAttribute>
                 <requireAttribute>SUPPORTED_MODES</requireAttribute>
                 <requireCommand>ChangeToMode</requireCommand>
@@ -3343,18 +3866,21 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Thermostat" client="true" server="false" clientLocked="false" serverLocked="true">
+            <include cluster="Thermostat" client="true" server="false" clientLocked="false"
+                serverLocked="true">
                 <requireAttribute>CONTROL_SEQUENCE_OF_OPERATION</requireAttribute>
                 <requireAttribute>LOCAL_TEMPERATURE</requireAttribute>
                 <requireAttribute>SYSTEM_MODE</requireAttribute>
@@ -3372,13 +3898,15 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
@@ -3395,13 +3923,15 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
@@ -3418,12 +3948,18 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thermostat" client="true" server="false" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Identify" client="true" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Scenes Management" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Thermostat" client="true" server="false" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Identify" client="true" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Groups" client="true" server="false" clientLocked="false"
+                serverLocked="true"></include>
+            <include cluster="Scenes Management" client="true" server="false" clientLocked="false"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3436,10 +3972,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Soil Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false"
+                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Soil Measurement" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3452,9 +3992,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Proximity Ranging" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
+                serverLocked="true"></include>
+            <include cluster="Proximity Ranging" client="false" server="true" clientLocked="true"
+                serverLocked="true">
                 <requireAttribute>RANGING_CAPABILITIES</requireAttribute>
                 <requireAttribute>SESSION_IDS</requireAttribute>
                 <requireCommand>StartRangingRequest</requireCommand>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -985,8 +985,10 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
+            <include cluster="Chime" client="true" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
             <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
@@ -1293,7 +1295,6 @@ limitations under the License.
             <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Closure Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
             <include cluster="Closure Dimension" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
@@ -1621,6 +1622,8 @@ limitations under the License.
         <clusters>
             <include cluster="Commodity Metering" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Electrical Energy Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Electrical Power Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2440,6 +2443,7 @@ limitations under the License.
             <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="false"></include>
             <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
             <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Content App Observer" client="false" server="false" clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2895,6 +2899,7 @@ limitations under the License.
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Thread Network Directory" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Wi-Fi Network Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Thread Border Router Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2422,8 +2422,6 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Time Synchronization" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2449,8 +2447,6 @@ limitations under the License.
             </include>
             <include cluster="Door Lock" client="true" server="false" clientLocked="true"
                 serverLocked="true"></include>
-            <include cluster="Time Synchronization" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -22,14 +22,10 @@ limitations under the License.
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0xFFF10001</deviceId>
         <clusters lockOthers="true">
-            <include cluster="Proxy Configuration" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Proxy Discovery" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Proxy Valid" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Pulse Width Modulation" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Proxy Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Proxy Discovery" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Proxy Valid" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Pulse Width Modulation" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -42,12 +38,10 @@ limitations under the License.
         <class>Node</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Access Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Access Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ACL</requireAttribute>
             </include>
-            <include cluster="Basic Information" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DATA_MODEL_REVISION</requireAttribute>
                 <requireAttribute>VENDOR_NAME</requireAttribute>
                 <requireAttribute>VENDOR_ID</requireAttribute>
@@ -60,51 +54,33 @@ limitations under the License.
                 <requireAttribute>SOFTWARE_VERSION</requireAttribute>
                 <requireAttribute>SOFTWARE_VERSION_STRING</requireAttribute>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="General Commissioning" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>SetRegulatoryConfig</requireCommand>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Synchronization" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Group Key Management" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Network Commissioning" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Administrator Commissioning" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Operational Credentials" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Localization Configuration" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time Format Localization" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Unit Localization" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Group Key Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Administrator Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Operational Credentials" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Localization Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Time Format Localization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Unit Localization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>UP_TIME</requireAttribute>
             </include>
-            <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Software Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Ethernet Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="ICD Management" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Software Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="LITS" name="LongIdleTimeSupport">
                         <otherwiseConform>
@@ -128,15 +104,13 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -149,14 +123,10 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Power Topology" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Electrical Energy Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Electrical Power Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Electrical Energy Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Electrical Power Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -169,17 +139,14 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="OTA Software Update Requestor" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Provider" client="true" server="false"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -192,17 +159,14 @@ limitations under the License.
         <class>Utility</class>
         <scope>Node</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="OTA Software Update Provider" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Requestor" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Requestor" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -215,15 +179,13 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Actions" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Actions" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -236,21 +198,17 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Bridged Device Basic Information" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Bridged Device Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>REACHABLE</requireAttribute>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Power Source" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Power Source" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -263,16 +221,11 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Humidistat" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Water Tank Level Monitoring" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Humidistat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Water Tank Level Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -285,22 +238,19 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -313,8 +263,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="false" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -332,8 +281,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -351,8 +299,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -375,8 +322,7 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -390,26 +336,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -422,8 +364,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -441,8 +382,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -460,8 +400,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -484,8 +423,7 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -499,22 +437,19 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmable Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -527,8 +462,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -546,8 +480,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -565,8 +498,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -589,8 +521,7 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Color Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="CT" name="ColorTemperature">
                         <mandatoryConform></mandatoryConform>
@@ -625,22 +556,19 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Color Temperature Light</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -653,8 +581,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -672,8 +599,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -691,8 +617,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -715,8 +640,7 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="Color Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="HS" name="HueSaturation">
                         <optionalConform></optionalConform>
@@ -767,22 +691,19 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -795,8 +716,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -814,8 +734,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -833,8 +752,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -869,22 +787,19 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -897,8 +812,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -916,8 +830,7 @@ limitations under the License.
                 <requireCommand>CopyScene</requireCommand>
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting">
                         <mandatoryConform></mandatoryConform>
@@ -935,8 +848,7 @@ limitations under the License.
                 <requireCommand>OnWithRecallGlobalScene</requireCommand>
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="OO" name="OnOff">
                         <mandatoryConform></mandatoryConform>
@@ -972,29 +884,23 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Plug-in Unit</superset>
         <clusters>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                     <feature code="OO" name="OnOff"></feature>
                 </features>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                 </features>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireCommand>CopyScene</requireCommand>
             </include>
         </clusters>
@@ -1010,29 +916,23 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmable Plug-in Unit</superset>
         <clusters>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                     <feature code="OO" name="OnOff"></feature>
                 </features>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="LT" name="Lighting"></feature>
                 </features>
             </include>
-            <include cluster="Scenes Management" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireCommand>CopyScene</requireCommand>
             </include>
         </clusters>
@@ -1047,10 +947,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false"
-                server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot">
@@ -1061,12 +959,9 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="WebRTC Transport Provider" client="true" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="WebRTC Transport Provider" client="true" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1079,8 +974,7 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Stream Management" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot">
@@ -1091,14 +985,10 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="WebRTC Transport Provider" client="false" server="true"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1115,37 +1005,27 @@ limitations under the License.
             <endpoint conformance="O">
                 <deviceType id="0x0107" name="Occupancy Sensor">
                     <clusters>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true"
-                            serverLocked="true"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
         </endpointComposition>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false"
-                server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio"></feature>
                     <feature code="SNP" name="Snapshot"></feature>
                     <feature code="VDO" name="Video"></feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="WebRTC Transport Provider" client="false" server="true"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="true" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1162,10 +1042,8 @@ limitations under the License.
             <endpoint conformance="M" constraint="min 1">
                 <deviceType id="0x000F" name="Generic Switch">
                     <clusters>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true"
-                            serverLocked="true"></include>
-                        <include cluster="Switch" client="false" server="true" clientLocked="true"
-                            serverLocked="true">
+                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="MS" name="MomentarySwitch"></feature>
                             </features>
@@ -1176,26 +1054,19 @@ limitations under the License.
             <endpoint conformance="M" constraint="1">
                 <deviceType id="0x0142" name="Camera">
                     <clusters>
-                        <include cluster="Camera AV Settings User Level Management" client="false"
-                            server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Camera AV Stream Management" client="false" server="true"
-                            clientLocked="true" serverLocked="true">
+                        <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="ADO" name="Audio"></feature>
                                 <feature code="SNP" name="Snapshot"></feature>
                                 <feature code="VDO" name="Video"></feature>
                             </features>
                         </include>
-                        <include cluster="Identify" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Push AV Stream Transport" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="WebRTC Transport Provider" client="false" server="true"
-                            clientLocked="false" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Requestor" client="true" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Zone Management" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
@@ -1215,14 +1086,11 @@ limitations under the License.
             <endpoint conformance="M" constraint="min 1">
                 <deviceType id="0x0100" name="On/Off Light">
                     <clusters>
-                        <include cluster="Groups" client="false" server="true" clientLocked="true"
-                            serverLocked="true"></include>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true"
-                            serverLocked="true">
+                        <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                             <requireCommand>TriggerEffect</requireCommand>
                         </include>
-                        <include cluster="Level Control" client="false" server="false"
-                            clientLocked="true" serverLocked="false">
+                        <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
                             <requireAttribute>CURRENT_LEVEL</requireAttribute>
                             <requireAttribute>MAX_LEVEL</requireAttribute>
                             <requireAttribute>MIN_LEVEL</requireAttribute>
@@ -1231,44 +1099,33 @@ limitations under the License.
                                 <feature code="OO" name="OnOff"></feature>
                             </features>
                         </include>
-                        <include cluster="Occupancy Sensing" client="false" server="false"
-                            clientLocked="false" serverLocked="true"></include>
-                        <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                            serverLocked="true">
+                        <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+                        <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="LT" name="Lighting"></feature>
                             </features>
                         </include>
-                        <include cluster="Scenes Management" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
             <endpoint conformance="M" constraint="1">
                 <deviceType id="0x0142" name="Camera">
                     <clusters>
-                        <include cluster="Camera AV Settings User Level Management" client="false"
-                            server="false" clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Camera AV Stream Management" client="false" server="true"
-                            clientLocked="true" serverLocked="true">
+                        <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                             <features>
                                 <feature code="ADO" name="Audio"></feature>
                                 <feature code="SNP" name="Snapshot"></feature>
                                 <feature code="VDO" name="Video"></feature>
                             </features>
                         </include>
-                        <include cluster="Identify" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Push AV Stream Transport" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="WebRTC Transport Provider" client="false" server="true"
-                            clientLocked="false" serverLocked="true"></include>
-                        <include cluster="WebRTC Transport Requestor" client="true" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Zone Management" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="WebRTC Transport Provider" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+                        <include cluster="WebRTC Transport Requestor" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
@@ -1288,21 +1145,16 @@ limitations under the License.
             <endpoint conformance="O">
                 <deviceType id="0x0107" name="Occupancy Sensor">
                     <clusters>
-                        <include cluster="Boolean State Configuration" client="false" server="false"
-                            clientLocked="true" serverLocked="false"></include>
-                        <include cluster="Identify" client="false" server="true" clientLocked="true"
-                            serverLocked="true"></include>
-                        <include cluster="Occupancy Sensing" client="false" server="true"
-                            clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Boolean State Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+                        <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+                        <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
                     </clusters>
                 </deviceType>
             </endpoint>
         </endpointComposition>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false"
-                server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="ADO" name="Audio">
                         <disallowConform></disallowConform>
@@ -1313,12 +1165,9 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1331,10 +1180,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Chime" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Chime" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1347,28 +1194,17 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Camera AV Settings User Level Management" client="false"
-                server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Camera AV Stream Management" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Power Source" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Push AV Stream Transport" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="TLS Certificate Management" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="TLS Client Management" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Provider" client="true" server="false"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="WebRTC Transport Requestor" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Zone Management" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Camera AV Settings User Level Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Camera AV Stream Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Power Source" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Push AV Stream Transport" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="TLS Certificate Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="TLS Client Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="WebRTC Transport Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Zone Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1380,14 +1216,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Chime" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Switch" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Chime" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="MS" name="MomentarySwitch"></feature>
                 </features>
@@ -1404,16 +1236,11 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Service Area" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Ambient Context Sensing" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Service Area" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Ambient Context Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1426,16 +1253,13 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Closure Control" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Closure Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
                 </features>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1448,10 +1272,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Closure Dimension" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Closure Dimension" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
                 </features>
@@ -1468,16 +1290,11 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Closure Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Closure Dimension" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Closure Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Closure Dimension" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1490,27 +1307,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1523,8 +1336,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1544,15 +1356,13 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireCommand>Off</requireCommand>
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Pump Configuration and Control" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Pump Configuration and Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>MAX_PRESSURE</requireAttribute>
                 <requireAttribute>MAX_SPEED</requireAttribute>
                 <requireAttribute>MAX_FLOW</requireAttribute>
@@ -1561,16 +1371,11 @@ limitations under the License.
                 <requireAttribute>Capacity</requireAttribute>
                 <requireAttribute>OperationMode</requireAttribute>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="false"></include>
-            <include cluster="Pressure Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="false"></include>
-            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1583,26 +1388,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1615,8 +1416,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1636,8 +1436,7 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1651,26 +1450,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>On/Off Light Switch</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1683,8 +1478,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1704,10 +1498,8 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1721,26 +1513,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <superset>Dimmer Switch</superset>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1753,8 +1541,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -1770,12 +1557,9 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Color Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1788,8 +1572,7 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Meter Identification" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Meter Identification" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1802,10 +1585,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1818,12 +1599,9 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Commodity Price" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Commodity Tariff" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Commodity Price" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Commodity Tariff" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>TAG_LIST</requireAttribute>
                 <features>
                     <feature code="TAGLIST" name="TagList"></feature>
@@ -1841,10 +1619,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Commodity Metering" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Commodity Metering" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1910,39 +1686,29 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Scenes Management" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Color Control" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Illuminance Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Scenes Management" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Illuminance Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1955,27 +1721,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="false" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -1988,8 +1750,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -2009,18 +1770,12 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Pump Configuration and Control" client="true" server="false"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Pressure Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Pump Configuration and Control" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2033,27 +1788,22 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Switch" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Fixed Label" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="User Label" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Fixed Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="User Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2066,23 +1816,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>STATE_VALUE</requireAttribute>
             </include>
         </clusters>
@@ -2097,27 +1844,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Illuminance Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Illuminance Measurement" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ILLUM_MEASURED_VALUE</requireAttribute>
                 <requireAttribute>ILLUM_MIN_MEASURED_VALUE</requireAttribute>
                 <requireAttribute>ILLUM_MAX_MEASURED_VALUE</requireAttribute>
@@ -2134,27 +1877,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>OCCUPANCY</requireAttribute>
                 <requireAttribute>OCCUPANCY_SENSOR_TYPE</requireAttribute>
             </include>
@@ -2170,23 +1909,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Temperature Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2199,23 +1935,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Pressure Measurement" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Pressure Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2228,23 +1961,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Flow Measurement" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Flow Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2257,23 +1987,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Relative Humidity Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2286,35 +2013,27 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Color Control" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Color Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2327,23 +2046,20 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Door Lock" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="USR" name="User">
                         <mandatoryConform>
@@ -2378,19 +2094,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Door Lock" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Door Lock" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2403,22 +2116,19 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2431,8 +2141,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Window Covering" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Window Covering" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2445,28 +2154,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="false"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="false" serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Window Covering" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Window Covering" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2479,27 +2183,23 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2512,18 +2212,12 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Thermostat User Interface Configuration" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false"
-                clientLocked="false" serverLocked="true"></include>
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2536,22 +2230,19 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -2564,8 +2255,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2578,43 +2268,30 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true"
-                clientLocked="false" serverLocked="false">
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="false">
                 <features>
                     <feature code="AP" name="ApplicationPlatform">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Media Input" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Audio Output" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Low Power" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Account Login" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Content Launcher" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Media Input" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Audio Output" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Low Power" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Account Login" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Content Launcher" client="false" server="true" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2627,31 +2304,21 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Media Input" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Audio Output" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Low Power" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Media Input" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Audio Output" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Low Power" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Wake On LAN" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2664,45 +2331,29 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="false" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Content Launcher" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Keypad Input" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Account Login" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Channel" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Target Navigator" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Media Input" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Low Power" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Audio Output" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Application Launcher" client="true" server="false"
-                clientLocked="false" serverLocked="false"></include>
-            <include cluster="Application Basic" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Media Playback" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Content Launcher" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Keypad Input" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Account Login" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Channel" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Target Navigator" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Input" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Low Power" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Audio Output" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Application Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Application Basic" client="true" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2715,43 +2366,28 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Binding" client="false" server="true" clientLocked="false" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Media Playback" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Content Launcher" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Keypad Input" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Account Login" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="true" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Level Control" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Channel" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Target Navigator" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Media Input" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Low Power" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Audio Output" client="true" server="false" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Application Launcher" client="true" server="false"
-                clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Playback" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Content Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Keypad Input" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Account Login" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Level Control" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Wake On LAN" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Channel" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Target Navigator" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Input" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Low Power" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Audio Output" client="true" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Application Launcher" client="true" server="false" clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2764,17 +2400,14 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Level Control" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Level Control" client="false" server="true" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2787,35 +2420,26 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Application Basic" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Keypad Input" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true"
-                clientLocked="false" serverLocked="true">
+            <include cluster="Application Basic" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="true">
                 <features>
                     <feature code="AP" name="ApplicationPlatform">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Account Login" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Content Launcher" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Media Playback" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Target Navigator" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
-            <include cluster="Channel" client="false" server="true" clientLocked="false"
-                serverLocked="false"></include>
+            <include cluster="Account Login" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Content Launcher" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Target Navigator" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2828,15 +2452,13 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Mode Select" client="false" server="true" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Mode Select" client="false" server="true" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2849,14 +2471,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
@@ -2867,22 +2487,14 @@ limitations under the License.
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Scenes Management" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Thermostat User Interface Configuration" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2895,24 +2507,17 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Smoke CO Alarm" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Monoxide Concentration Measurement" client="false"
-                server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Smoke CO Alarm" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Monoxide Concentration Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2925,22 +2530,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="HEPA Filter Monitoring" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Activated Carbon Filter Monitoring" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="HEPA Filter Monitoring" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Activated Carbon Filter Monitoring" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2953,40 +2552,25 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Air Quality" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Relative Humidity Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Monoxide Concentration Measurement" client="false"
-                server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Carbon Dioxide Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Nitrogen Dioxide Concentration Measurement" client="false"
-                server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Ozone Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Formaldehyde Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM1 Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM2.5 Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="PM10 Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Radon Concentration Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Total Volatile Organic Compounds Concentration Measurement"
-                client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Air Quality" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Relative Humidity Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Monoxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Carbon Dioxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Nitrogen Dioxide Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ozone Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Formaldehyde Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM1 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM2.5 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="PM10 Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Radon Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Total Volatile Organic Compounds Concentration Measurement" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2999,32 +2583,25 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Dishwasher Alarm" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Dishwasher Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3046,10 +2623,8 @@ limitations under the License.
             </endpoint>
         </endpointComposition>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3062,12 +2637,9 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="WND" name="Wind">
                         <disallowConform></disallowConform>
@@ -3077,12 +2649,9 @@ limitations under the License.
                     </feature>
                 </features>
             </include>
-            <include cluster="Microwave Oven Mode" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Microwave Oven Control" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Microwave Oven Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Microwave Oven Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3101,20 +2670,16 @@ limitations under the License.
             </endpoint>
         </endpointComposition>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false"
-                server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Refrigerator Alarm" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Refrigerator Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3127,32 +2692,25 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Controls" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Laundry Washer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3165,32 +2723,25 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="DF" name="DeadFrontBehavior">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Laundry Dryer Controls" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Control" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Operational State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Laundry Dryer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3203,16 +2754,11 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="HEPA Filter Monitoring" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Activated Carbon Filter Monitoring" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="HEPA Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Activated Carbon Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="RCK" name="Rocking">
                         <disallowConform></disallowConform>
@@ -3237,18 +2783,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="RVC Run Mode" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="RVC Operational State" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Service Area" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="RVC Run Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="RVC Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Service Area" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3261,30 +2801,24 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false"
-                server="false" clientLocked="true" serverLocked="false">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Oven Mode" client="false" server="false" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Oven Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OO" name="OnOff">
                         <disallowConform></disallowConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Oven Cavity Operational State" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Oven Cavity Operational State" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3297,14 +2831,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3317,12 +2847,9 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Valve Configuration and Control" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Valve Configuration and Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3335,14 +2862,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3355,14 +2878,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3375,14 +2894,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Thread Network Directory" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Wi-Fi Network Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Border Router Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Network Directory" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Wi-Fi Network Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Border Router Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3395,12 +2910,9 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thread Border Router Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thread Border Router Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3410,27 +2922,23 @@ limitations under the License.
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0xFFF10003</deviceId>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
                 <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
-            <include cluster="Color Control" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Color Control" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
@@ -3498,8 +3006,7 @@ limitations under the License.
                 <requireCommand>StepColorTemperature</requireCommand>
                 <requireCommand>StopMoveStep</requireCommand>
             </include>
-            <include cluster="Door Lock" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Door Lock" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>LockDoor</requireCommand>
                 <requireCommand>UnlockDoor</requireCommand>
                 <requireCommand>SetUser</requireCommand>
@@ -3512,8 +3019,7 @@ limitations under the License.
                 <requireCommand>SetCredentialStatusResponse</requireCommand>
                 <requireCommand>ClearCredential</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>
@@ -3526,8 +3032,7 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Level Control" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Level Control" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -3538,15 +3043,13 @@ limitations under the License.
                 <requireCommand>StepWithOnOff</requireCommand>
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
-            <include cluster="On/Off" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="On/Off" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireCommand>Off</requireCommand>
                 <requireCommand>On</requireCommand>
                 <requireCommand>Toggle</requireCommand>
             </include>
-            <include cluster="Scenes Management" client="true" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Scenes Management" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -3566,8 +3069,7 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="Temperature Measurement" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3580,21 +3082,16 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Network Commissioning" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Ethernet Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Thread Network Diagnostics" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3607,10 +3104,8 @@ limitations under the License.
         <class>Utility</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Joint Fabric Datastore" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Joint Fabric Administrator" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
+            <include cluster="Joint Fabric Datastore" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Joint Fabric Administrator" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3622,12 +3117,9 @@ limitations under the License.
         <deviceId editable="false">0x0078</deviceId>
         <revision editable="false">1</revision>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
                     <feature code="OFFONLY" name="OffOnly">
                         <mandatoryConform></mandatoryConform>
@@ -3645,20 +3137,16 @@ limitations under the License.
         <deviceId editable="false">0x0077</deviceId>
         <revision editable="false">2</revision>
         <clusters lockOthers="true">
-            <include cluster="On/Off" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="false">
                 <features>
                     <feature code="OFFONLY" name="OffOnly">
                         <mandatoryConform></mandatoryConform>
                     </feature>
                 </features>
             </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Control" client="false" server="true" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Control" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3670,16 +3158,11 @@ limitations under the License.
         <deviceId editable="false">0x050C</deviceId>
         <revision editable="false">2</revision>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="false" server="false" clientLocked="true"
-                serverLocked="false"></include>
-            <include cluster="Energy EVSE" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Energy EVSE Mode" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Energy EVSE" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Energy EVSE Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3692,10 +3175,8 @@ limitations under the License.
         <revision editable="false">2</revision>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Device Energy Management" client="false" server="true"
-                clientLocked="true" serverLocked="true"></include>
-            <include cluster="Device Energy Management Mode" client="false" server="true"
-                clientLocked="true" serverLocked="false"></include>
+            <include cluster="Device Energy Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Device Energy Management Mode" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3708,28 +3189,24 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Thermostat" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CONTROL_SEQUENCE_OF_OPERATION</requireAttribute>
                 <requireAttribute>LOCAL_TEMPERATURE</requireAttribute>
                 <requireAttribute>SYSTEM_MODE</requireAttribute>
                 <requireCommand>SetpointRaiseLower</requireCommand>
             </include>
-            <include cluster="Water Heater Management" client="false" server="true"
-                clientLocked="true" serverLocked="true">
+            <include cluster="Water Heater Management" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>BOOST_STATE</requireAttribute>
                 <requireAttribute>HEATER_TYPES</requireAttribute>
                 <requireAttribute>HEAT_DEMAND</requireAttribute>
@@ -3738,8 +3215,7 @@ limitations under the License.
                 <requireCommand>Boost</requireCommand>
                 <requireCommand>CancelBoost</requireCommand>
             </include>
-            <include cluster="Water Heater Mode" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Water Heater Mode" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CURRENT_MODE</requireAttribute>
                 <requireAttribute>SUPPORTED_MODES</requireAttribute>
                 <requireCommand>ChangeToMode</requireCommand>
@@ -3757,21 +3233,18 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
             </include>
-            <include cluster="Thermostat" client="true" server="false" clientLocked="false"
-                serverLocked="true">
+            <include cluster="Thermostat" client="true" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>CONTROL_SEQUENCE_OF_OPERATION</requireAttribute>
                 <requireAttribute>LOCAL_TEMPERATURE</requireAttribute>
                 <requireAttribute>SYSTEM_MODE</requireAttribute>
@@ -3789,15 +3262,13 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
@@ -3814,15 +3285,13 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
                 <requireAttribute>SERVER_LIST</requireAttribute>
             </include>
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="false">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
@@ -3839,18 +3308,12 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Thermostat" client="true" server="false" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Identify" client="true" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Groups" client="true" server="false" clientLocked="false"
-                serverLocked="true"></include>
-            <include cluster="Scenes Management" client="true" server="false" clientLocked="false"
-                serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thermostat" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Scenes Management" client="true" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3863,14 +3326,10 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Temperature Measurement" client="false" server="false"
-                clientLocked="true" serverLocked="false"></include>
-            <include cluster="Soil Measurement" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Soil Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -3883,12 +3342,9 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true"
-                serverLocked="true"></include>
-            <include cluster="Proximity Ranging" client="false" server="true" clientLocked="true"
-                serverLocked="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Proximity Ranging" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>RANGING_CAPABILITIES</requireAttribute>
                 <requireAttribute>SESSION_IDS</requireAttribute>
                 <requireCommand>StartRangingRequest</requireCommand>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -186,6 +186,7 @@ limitations under the License.
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
             <include cluster="Actions" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Commissioner Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -209,6 +210,7 @@ limitations under the License.
             </include>
             <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Power Source" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Administrator Commissioning" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>


### PR DESCRIPTION
#### Summary

  Cross-checked `matter-devices.xml` against `data_model/1.6/device_types/` and removed cluster requirements not present in the spec
 - Removed condition-based cluster requirements (Time Sync, TLS, Power Source) from individual devices, as they belong on the Root Node endpoint. 
- Removed cluster requirements which are not supported by the current spec (i. e. Scenes Management from WindowCovering and WindowCoveringController device types)
- Fixed "Wake on LAN" to "Wake On LAN" to match the spec. 
#### Related issues
Fixes #72465

#### Testing
 CI passes
