### PR TITLE
[doc] ESP32 VS Code build - Fix missing argument for bootstrap.sh (#72184)

### DIFF
--- a/docs/platforms/esp32/vs_code_development.md
+++ b/docs/platforms/esp32/vs_code_development.md
@@ -41,7 +41,7 @@ For Espressif esp32 devices:
 1. Source esp-idf : `source /opt/espressif/esp-idf/export.sh`
 
 1. Activate matter :
-   `cd /workspaces/connectedhomeip && source scripts/bootstrap.sh && source scripts/activate.sh`
+   `cd /workspaces/connectedhomeip && source scripts/bootstrap.sh -p all,esp32 && source scripts/activate.sh`
 
 1. Confirm that the device is accessible : `ls -l /dev/ttyUSB*`
 


### PR DESCRIPTION
#### Summary

I was unable to build any esp32 platform example code, in the VS Code, without this.

All the steps for the Linux platform work for me after adding these arguments.

Note: same arguments are mentioned in this [Setup ESP-IDF and Matter Environment - Bootstrap Matter environment](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/esp32/setup_idf_chip.md#bootstrap-matter-environment) doc.

#### Related issues

Fixes / answers: #72184

#### Testing

Verified by following manual [steps for preparing build env and building examples/bridge-app/esp32 in VS Code](https://project-chip.github.io/connectedhomeip-doc/platforms/esp32/vs_code_development.html#linux).

#### Readability checklist
