### PR TITLE
[Slack CI notifications] add more details

### DIFF
--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -61,8 +61,11 @@ runs:
 
         EXTRA_TEXT=""
         if [[ -n "$EXTRA_FILE" && -f "$EXTRA_FILE" ]]; then
-          CONTENT=$(head -n 2 "$EXTRA_FILE" | tr '\n' ' ' | sed -e 's/  */ /g' -e 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          CONTENT=$(head -n 2 "$EXTRA_FILE" | tr '\n' ' ' | sed -e 's/  */ /g' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e 's/@//g')
           if [[ -n "$CONTENT" ]]; then
+            if [[ ${#CONTENT} -gt 300 ]]; then
+              CONTENT="${CONTENT:0:300}..."
+            fi
             EXTRA_TEXT="\n*Failed Tests:* ${CONTENT}"
           fi
         fi

--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -7,7 +7,7 @@ inputs:
   job-name:
     description: 'The display name of the job'
     required: false
-    default: ${{ github.job }}
+    default: ''
   job-details:
     description: 'Extra matrix or job details'
     required: false
@@ -24,7 +24,7 @@ runs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         REF_NAME: ${{ github.ref_name }}
-        JOB_NAME: ${{ inputs['job-name'] }}
+        JOB_NAME: ${{ inputs['job-name'] || github.job }}
         JOB_DETAILS: ${{ inputs['job-details'] }}
         EXTRA_FILE: ${{ inputs['extra-details-file'] }}
         SERVER_URL: ${{ github.server_url }}
@@ -61,7 +61,7 @@ runs:
 
         EXTRA_TEXT=""
         if [[ -n "$EXTRA_FILE" && -f "$EXTRA_FILE" ]]; then
-          CONTENT=$(head -n 2 "$EXTRA_FILE" | tr '\n' ' ' | sed 's/  */ /g' | xargs)
+          CONTENT=$(head -n 2 "$EXTRA_FILE" | tr '\n' ' ' | sed -e 's/  */ /g' -e 's/^[[:space:]]*//;s/[[:space:]]*$//')
           if [[ -n "$CONTENT" ]]; then
             EXTRA_TEXT="\n*Failed Tests:* ${CONTENT}"
           fi

--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -4,6 +4,18 @@ inputs:
   slack-webhook:
     description: 'The Slack Webhook URL'
     required: false
+  job-name:
+    description: 'The display name of the job'
+    required: false
+    default: ${{ github.job }}
+  job-details:
+    description: 'Extra matrix or job details'
+    required: false
+    default: ''
+  extra-details-file:
+    description: 'Path to a file containing additional compact information to append'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -12,7 +24,9 @@ runs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         REF_NAME: ${{ github.ref_name }}
-        JOB_NAME: ${{ github.job }}
+        JOB_NAME: ${{ inputs['job-name'] }}
+        JOB_DETAILS: ${{ inputs['job-details'] }}
+        EXTRA_FILE: ${{ inputs['extra-details-file'] }}
         SERVER_URL: ${{ github.server_url }}
         REPOSITORY: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
@@ -38,15 +52,28 @@ runs:
 
         # 4. Send the Slack notification
         RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
-        
-        # WARNING: If adding user-controlled variables (like commit messages) in the future,
-        # do not manually interpolate them into the JSON body. Use a proper encoder (like jq) to prevent injection.
-        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨\n*Job:* ${JOB_NAME}\n*Run Details:* <${RUN_URL}|View Pipeline Logs>"
-        
+
+        if [[ -n "$JOB_DETAILS" ]]; then
+          JOB_TEXT="${JOB_NAME} (${JOB_DETAILS})"
+        else
+          JOB_TEXT="${JOB_NAME}"
+        fi
+
+        EXTRA_TEXT=""
+        if [[ -n "$EXTRA_FILE" && -f "$EXTRA_FILE" ]]; then
+          CONTENT=$(head -n 2 "$EXTRA_FILE" | tr '\n' ' ' | sed 's/  */ /g' | xargs)
+          if [[ -n "$CONTENT" ]]; then
+            EXTRA_TEXT="\n*Failed Tests:* ${CONTENT}"
+          fi
+        fi
+
+        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨\n*Job:* ${JOB_TEXT}\n*Run Details:* <${RUN_URL}|View Pipeline Logs>${EXTRA_TEXT}"
+
+        JSON_PAYLOAD=$(python3 -c 'import json, sys; print(json.dumps({"text": sys.argv[1]}))' "$PAYLOAD_TEXT")
+
         curl -sS -X POST -H 'Content-type: application/json' \
           --connect-timeout 5 \
           --max-time 10 \
           --retry 3 \
-          --data-binary @- "$SLACK_WEBHOOK" <<EOF
-        {"text":"${PAYLOAD_TEXT}"}
-        EOF
+          -d "$JSON_PAYLOAD" "$SLACK_WEBHOOK"
+

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -82,6 +82,8 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "Build framework"
+                job-details: "${{ matrix.os }}, ${{ matrix.options.flavor }}"
     tests:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
@@ -148,3 +150,5 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "Run framework tests"
+                job-details: "${{ matrix.os }}, ${{ matrix.options.flavor }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -565,7 +565,7 @@ jobs:
                       echo ""
                       echo ">>> $f"
                       ./scripts/run_in_build_env.sh \
-                        "scripts/tests/run_test_suite.py summarize --summary-file $f" || true
+                        "scripts/tests/run_test_suite.py summarize --summary-file $f --compact-failures-file test-summaries/compact-failures.txt" || true
                   done
             - name: Upload test run summaries
               uses: actions/upload-artifact@v7
@@ -611,6 +611,9 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "Test Suites - Linux"
+                job-details: "${{ matrix.build_variant }}"
+                extra-details-file: "test-summaries/compact-failures.txt"
     test_suites_darwin:
         name: Test Suites - Darwin
 
@@ -817,6 +820,9 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "Test Suites - Darwin"
+                job-details: "${{ matrix.os }}, ${{ matrix.arch }}, ${{ matrix.build_variant }}"
+                extra-details-file: "test-summaries/compact-failures.txt"
     repl_tests_linux_build:
         name: REPL Tests - Linux (BUILD)
 
@@ -1073,6 +1079,8 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "REPL Tests - Linux (BUILD)"
+                job-details: "${{ matrix.build_variant }}"
     repl_tests_linux_run:
         name: REPL Tests - Linux (RUN)
         needs: repl_tests_linux_build
@@ -1235,7 +1243,7 @@ jobs:
               run: |
                   [ -f test-summaries/python-tests.json ] && \
                     scripts/run_in_python_env.sh out/venv \
-                      'src/python_testing/execute_python_tests.py summarize --summary-file test-summaries/python-tests.json' || true
+                      'src/python_testing/execute_python_tests.py summarize --summary-file test-summaries/python-tests.json --compact-failures-file test-summaries/compact-failures.txt' || true
             - name: Upload python test summary
               uses: actions/upload-artifact@v7
               if: ${{ matrix.filter != '' && always() }}
@@ -1294,6 +1302,9 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "REPL Tests - Linux (RUN)"
+                job-details: "${{ matrix.filter }}"
+                extra-details-file: "test-summaries/compact-failures.txt"
     repl_tests_linux_report:
       name: REPL Tests - Linux (REPORT RESULTS)
       needs: repl_tests_linux_run
@@ -1366,6 +1377,7 @@ jobs:
             uses: ./.github/actions/notify-slack-failure
             with:
               slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+              job-name: "Deploy to GitHub Pages"
     repl_tests_darwin:
         name: REPL Tests - Darwin (Build Only)
         strategy:
@@ -1454,3 +1466,5 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+                job-name: "REPL Tests - Darwin (Build Only)"
+                job-details: "${{ matrix.os }}, ${{ matrix.arch }}, ${{ matrix.build_variant }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -768,7 +768,7 @@ jobs:
                       echo ""
                       echo ">>> $f"
                       ./scripts/run_in_build_env.sh \
-                        "scripts/tests/run_test_suite.py summarize --summary-file $f" || true
+                        "scripts/tests/run_test_suite.py summarize --summary-file $f --compact-failures-file test-summaries/compact-failures.txt" || true
                   done
             - name: Upload test run summaries
               uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -562,6 +562,7 @@ jobs:
               run: |
                   for f in test-summaries/*.json; do
                       [ -f "$f" ] || continue
+                      [[ "$f" == *"purposeful-failures"* ]] && continue
                       echo ""
                       echo ">>> $f"
                       ./scripts/run_in_build_env.sh \
@@ -765,6 +766,7 @@ jobs:
               run: |
                   for f in test-summaries/*.json; do
                       [ -f "$f" ] || continue
+                      [[ "$f" == *"purposeful-failures"* ]] && continue
                       echo ""
                       echo ">>> $f"
                       ./scripts/run_in_build_env.sh \

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -703,10 +703,10 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int, app_path: li
     help='Path to output a compact, comma-separated list of failed test names.',
 )
 def cmd_summarize(summary_file: Path, top_slowest: int, show_all: bool, compact_failures_file: Path | None) -> None:
-    RunSummary.from_json(summary_file).print_summary(top_slowest=top_slowest, show_all=show_all)
+    summary = RunSummary.from_json(summary_file)
+    summary.print_summary(top_slowest=top_slowest, show_all=show_all)
 
     if compact_failures_file:
-        summary = RunSummary.from_json(summary_file)
         failed_results = tuple(r for r in summary.results if r.status == TestStatus.FAILED)
         if failed_results:
             existing = set()

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -713,8 +713,8 @@ def cmd_summarize(summary_file: Path, top_slowest: int, show_all: bool, compact_
             if compact_failures_file.exists():
                 content = compact_failures_file.read_text().strip()
                 if content:
-                    existing = set(n.strip() for n in content.split(","))
-            new_names = [Path(r.name).stem for r in failed_results]
+                    existing = {n.strip() for n in content.split(",") if n.strip()}
+            new_names = [r.name for r in failed_results]
             all_names = sorted(existing.union(new_names))
             compact_failures_file.parent.mkdir(parents=True, exist_ok=True)
             compact_failures_file.write_text(", ".join(all_names) + "\n")

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -34,7 +34,7 @@ from chiptest.accessories import AppsRegister
 from chiptest.concurrency.work_queue import CancellableQueue
 from chiptest.glob_matcher import GlobMatcher
 from chiptest.log_config import LOG_LEVELS, LogConfig, LogMessageCounter
-from chiptest.results import ResultError, ResultProcessingThread, RunSummary, TestResult
+from chiptest.results import ResultError, ResultProcessingThread, RunSummary, TestResult, TestStatus
 from chiptest.runner import Executor, SubprocessKind
 from chiptest.status import PeriodicStatusThread
 from chiptest.test_definition import TEST_THREAD_DATASET, SubprocessInfoRepo, TestDefinition, TestRunTime, TestTag
@@ -696,8 +696,28 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int, app_path: li
     '--show-all',
     is_flag=True,
     help='Show statistics of all tests for all iterations.')
-def cmd_summarize(summary_file: Path, top_slowest: int, show_all: bool) -> None:
+@click.option(
+    '--compact-failures-file',
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help='Path to output a compact, comma-separated list of failed test names.',
+)
+def cmd_summarize(summary_file: Path, top_slowest: int, show_all: bool, compact_failures_file: Path | None) -> None:
     RunSummary.from_json(summary_file).print_summary(top_slowest=top_slowest, show_all=show_all)
+
+    if compact_failures_file:
+        summary = RunSummary.from_json(summary_file)
+        failed_results = tuple(r for r in summary.results if r.status == TestStatus.FAILED)
+        if failed_results:
+            existing = set()
+            if compact_failures_file.exists():
+                content = compact_failures_file.read_text().strip()
+                if content:
+                    existing = set(n.strip() for n in content.split(","))
+            new_names = [Path(r.name).stem for r in failed_results]
+            all_names = sorted(existing.union(new_names))
+            compact_failures_file.parent.mkdir(parents=True, exist_ok=True)
+            compact_failures_file.write_text(", ".join(all_names) + "\n")
 
 
 # On Linux, allow an execution shell to be prepared

--- a/src/python_testing/execute_python_tests.py
+++ b/src/python_testing/execute_python_tests.py
@@ -321,8 +321,8 @@ def cmd_summarize(summary_file: Path, top_slowest: int, compact_failures_file: P
         if compact_failures_file.exists():
             content = compact_failures_file.read_text().strip()
             if content:
-                existing = set(n.strip() for n in content.split(","))
-        new_names = [Path(r["name"]).stem for r in failed_results]
+                existing = {n.strip() for n in content.split(",") if n.strip()}
+        new_names = [r["name"].removesuffix(".py") for r in failed_results]
         all_names = sorted(existing.union(new_names))
         compact_failures_file.parent.mkdir(parents=True, exist_ok=True)
         compact_failures_file.write_text(", ".join(all_names) + "\n")

--- a/src/python_testing/execute_python_tests.py
+++ b/src/python_testing/execute_python_tests.py
@@ -278,7 +278,13 @@ def cmd_run(search_directory, env_file, keep_going, dry_run: bool, glob: list[st
     type=click.IntRange(min=1),
     help='Number of slowest tests to include in the timing table.',
 )
-def cmd_summarize(summary_file: Path, top_slowest: int) -> None:
+@click.option(
+    '--compact-failures-file',
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help='Path to output a compact, comma-separated list of failed test names.',
+)
+def cmd_summarize(summary_file: Path, top_slowest: int, compact_failures_file: Path | None) -> None:
     raw = json.loads(summary_file.read_text())
     results: list[dict] = raw.get("results", [])
 
@@ -309,6 +315,17 @@ def cmd_summarize(summary_file: Path, top_slowest: int) -> None:
             print(f"  {'✗  ' + r['name']:<60} {r['duration_seconds']:>9.2f}s")
     else:
         print("\n  No failures recorded.")
+
+    if compact_failures_file and failed_results:
+        existing = set()
+        if compact_failures_file.exists():
+            content = compact_failures_file.read_text().strip()
+            if content:
+                existing = set(n.strip() for n in content.split(","))
+        new_names = [Path(r["name"]).stem for r in failed_results]
+        all_names = sorted(existing.union(new_names))
+        compact_failures_file.parent.mkdir(parents=True, exist_ok=True)
+        compact_failures_file.write_text(", ".join(all_names) + "\n")
 
     slowest = sorted(
         [r for r in results if r["status"] != "dry_run"],


### PR DESCRIPTION
#### Summary

Add more details to slack notifications:
  - actual job name 
  - for tests where we have detailed summary, report those (i.e. we will say what test failed)

#### Testing

This infra is unfortunately _not_ made for testing. This is bot-generated so likely ok. I would see about refactoring for testability in a separate PR. We need to have some sample failures to do that and maybe mock failing workflows (e.g. something that I trigger manually or via a test failure label).