### PR TITLE
[devcontainer] Add vscode user to dialout group

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,7 +61,7 @@ RUN (getent passwd $USER_UID && userdel -f $(getent passwd $USER_UID | cut -d: -
     && (getent passwd $USERNAME && userdel -f $USERNAME || true) \
     && (getent group $USERNAME && groupdel -f $USERNAME || true) \
     && groupadd -g $USER_GID $USERNAME \
-    && useradd --no-log-init -s /bin/bash -u $USER_UID -g $USER_GID -G docker,sudo -m $USERNAME \
+    && useradd --no-log-init -s /bin/bash -u $USER_UID -g $USER_GID -G docker,sudo,dialout -m $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && :


### PR DESCRIPTION
#### Summary

Ensures the vscode user can access serial devices inside the container. Without membership in the dialout group, flashing ESP32 targets fails:

    $ idf.py -p /dev/ttyACM0 flash
    Error: Invalid value for '-p' / '--port': Path '/dev/ttyACM0' is not readable.

Device permissions confirm the issue:

    $ ls -l /dev/ttyACM0
    crw-rw---- 1 root dialout ...

And the vscode user is not a member of dialout:

    $ groups
    vscode sudo docker

Adding the user to the dialout group resolves the flashing failure.

#### Related issues

#72184 

#### Testing

Manual verification whether the vscode user is added to the dialout group - when I reopened VS Code in rebuilt container.

#### Readability checklist
