### PR TITLE
Chef m5 fix - operational credentials error

### DIFF
--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -162,10 +162,12 @@ void InitServer(intptr_t)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
-    chip::Server::GetInstance().Init(initParams);
 
     // Device Attestation & Onboarding codes
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
+
+    chip::Server::GetInstance().Init(initParams);
+
     sWiFiNetworkCommissioningInstance.Init();
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
 

--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -166,7 +166,10 @@ void InitServer(intptr_t)
     // Device Attestation & Onboarding codes
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
-    chip::Server::GetInstance().Init(initParams);
+    if (chip::Server::GetInstance().Init(initParams) != CHIP_NO_ERROR)
+    {
+        ChipLogError(Shell, "chip::Server::GetInstance().Init(initParams) failed");
+    }
 
     sWiFiNetworkCommissioningInstance.Init();
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();

--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -166,10 +166,7 @@ void InitServer(intptr_t)
     // Device Attestation & Onboarding codes
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
-    if (chip::Server::GetInstance().Init(initParams) != CHIP_NO_ERROR)
-    {
-        ChipLogError(Shell, "chip::Server::GetInstance().Init(initParams) failed");
-    }
+    LogErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     sWiFiNetworkCommissioningInstance.Init();
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();


### PR DESCRIPTION
#### Summary

Generic switch chef app failed to commission on M5 stack. Error -
```
Endpoint=0 Cluster=0x0000_003E Command=0x0000_0002 status 0x01 (no additional context)
```

#### Testing

Flashed on m5 and commissioned device.