### PR TITLE
Increase Linux C++ Lambda Event Size to Cover LP64 Architectures

### DIFF
--- a/src/platform/Linux/CHIPPlatformConfig.h
+++ b/src/platform/Linux/CHIPPlatformConfig.h
@@ -64,6 +64,15 @@ using CHIP_CONFIG_PERSISTED_STORAGE_KEY_TYPE = const char *;
 #define CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS 1
 #endif // CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS
 
+// Increase C++ lambda event size to accommodate larger local captures
+// for connman-based Connectivity Manager network management
+// implementation, particularly on [I]LP64 architectures in which
+// pointers are double the size of those on [I]LP32 architectures.
+
+#ifndef CHIP_CONFIG_LAMBDA_EVENT_SIZE
+#define CHIP_CONFIG_LAMBDA_EVENT_SIZE (48)
+#endif // CHIP_CONFIG_LAMBDA_EVENT_SIZE
+
 // ==================== Security Configuration Overrides ====================
 
 #ifndef CHIP_CONFIG_KVS_PATH


### PR DESCRIPTION
#### Summary

Per #42516 and [this overview](https://github.com/user-attachments/files/25854289/Matter.ConnectivityManager.Linux.Platform.Refactoring.html), this continues the work and  increases the Linux C++ lambda event size to 48 bytes to accommodate larger local captures for connman-based _Connectivity Manager_ network management implementation (see draft #43538), particularly on [I]LP64 architectures (such as x86_64 or aarch64) in which pointers are double the size of those on [I]LP32 architectures (i686 or arm).

#### Related issues

#42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.4 Apple "Home" app with **both** a _connman_ **and** _wpa_supplicant_ implementation using this infrastructure.