### PR TITLE
[slack ci notify] Update \n with space for slack notifications

### DIFF
--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -70,7 +70,7 @@ runs:
           fi
         fi
 
-        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨 *Job:* ${JOB_TEXT} *Run Details:* <${RUN_URL}|View Pipeline Logs>${EXTRA_TEXT}"
+        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨 *Job:* ${JOB_TEXT} *Run Details:* <${RUN_URL}|View Pipeline Logs>${EXTRA_TEXT:-}"
 
         JSON_PAYLOAD=$(python3 -c 'import json, sys; print(json.dumps({"text": sys.argv[1]}))' "$PAYLOAD_TEXT")
 

--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -66,11 +66,11 @@ runs:
             if [[ ${#CONTENT} -gt 300 ]]; then
               CONTENT="${CONTENT:0:300}..."
             fi
-            EXTRA_TEXT="\n*Failed Tests:* ${CONTENT}"
+            EXTRA_TEXT=" *Failed Tests:* ${CONTENT}"
           fi
         fi
 
-        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨\n*Job:* ${JOB_TEXT}\n*Run Details:* <${RUN_URL}|View Pipeline Logs>${EXTRA_TEXT}"
+        PAYLOAD_TEXT="🚨 *CI Failure Alert* 🚨 *Job:* ${JOB_TEXT} *Run Details:* <${RUN_URL}|View Pipeline Logs>${EXTRA_TEXT}"
 
         JSON_PAYLOAD=$(python3 -c 'import json, sys; print(json.dumps({"text": sys.argv[1]}))' "$PAYLOAD_TEXT")
 


### PR DESCRIPTION
#### Summary

I considered actually supporting \n, however in practice I quite like the slack one-liner (to use less vertical space).
So replaced \n with ' '.

#### Testing

Trivial change. We currently have no testing infra for slack notifications.