### PR TITLE
[Logs] Change log level of verbose log

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -254,7 +254,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     //
     // Legend that can be used to decode this log line can be found in README.md
     //
-    ChipLogProgress(
+    ChipLogDetail(
         ExchangeManager,
         ">>> [E:" ChipLogFormatExchangeId " S:%u M:" ChipLogFormatMessageCounter "%s] (%s) Msg RX %s --- Type %s (%s:%s) (B:%u)",
         ChipLogValueExchangeIdFromReceivedHeader(payloadHeader), session->SessionIdForLogging(), packetHeader.GetMessageCounter(),

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -396,7 +396,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
     //
     // Legend that can be used to decode this log line can be found in messaging/README.md
     //
-    ChipLogProgress(ExchangeManager,
+    ChipLogDetail(ExchangeManager,
                     "<<< [E:%s S:%u M:" ChipLogFormatMessageCounter "%s] (%s) Msg TX %s [%s] --- Type %s (%s:%s) (B:%u)",
                     exchangeStr, sessionHandle->SessionIdForLogging(), packetHeader.GetMessageCounter(), ackBuf,
                     Transport::GetSessionTypeString(sessionHandle), sourceDestinationStr, addressStr, typeStr, protocolName,

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -397,10 +397,10 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
     // Legend that can be used to decode this log line can be found in messaging/README.md
     //
     ChipLogDetail(ExchangeManager,
-                    "<<< [E:%s S:%u M:" ChipLogFormatMessageCounter "%s] (%s) Msg TX %s [%s] --- Type %s (%s:%s) (B:%u)",
-                    exchangeStr, sessionHandle->SessionIdForLogging(), packetHeader.GetMessageCounter(), ackBuf,
-                    Transport::GetSessionTypeString(sessionHandle), sourceDestinationStr, addressStr, typeStr, protocolName,
-                    msgTypeName, static_cast<unsigned>(message->TotalLength()));
+                  "<<< [E:%s S:%u M:" ChipLogFormatMessageCounter "%s] (%s) Msg TX %s [%s] --- Type %s (%s:%s) (B:%u)", exchangeStr,
+                  sessionHandle->SessionIdForLogging(), packetHeader.GetMessageCounter(), ackBuf,
+                  Transport::GetSessionTypeString(sessionHandle), sourceDestinationStr, addressStr, typeStr, protocolName,
+                  msgTypeName, static_cast<unsigned>(message->TotalLength()));
 #endif
 
     preparedMessage = EncryptedPacketBufferHandle::MarkEncrypted(std::move(message));


### PR DESCRIPTION
#### Summary
During commissioning, there is a lot of logs produce as it should be. However when one reduce the log level from `detail` to `Progress`, the console is still swamped with logs of disputable value. 


As such this PR changes the log level of two of the most dense log produce from `Progress` to `Detail` in an effort to obtain cleaner log when the `Detail` level is disabled

#### Related issues
None

#### Testing
Tested locally with a MG24
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
