### PR TITLE
[Controller] Preserve granular commissioning-failure context in CompletionStatus

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -800,13 +800,27 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
         }
         else if (report.Is<CommissioningErrorInfo>())
         {
-            completionStatus.commissioningError = MakeOptional(report.Get<CommissioningErrorInfo>().commissioningError);
+            const auto & commissioningInfo          = report.Get<CommissioningErrorInfo>();
+            completionStatus.commissioningError     = MakeOptional(commissioningInfo.commissioningError);
+            completionStatus.commissioningDebugText = commissioningInfo.debugText;
+        }
+        else if (report.Is<OperationalCertErrorInfo>())
+        {
+            // Preserve the NodeOperationalCertStatusEnum from the device's NOCResponse
+            // (kInvalidPublicKey, kInvalidNodeOpId, kInvalidNOC, kFabricConflict, kLabelConflict,
+            // kInvalidFabricIndex, etc.) so callers can distinguish without losing fidelity to a
+            // generic CHIP_ERROR.
+            completionStatus.operationalCertStatus = MakeOptional(report.Get<OperationalCertErrorInfo>().operationalCertStatus);
         }
         else if (report.Is<NetworkCommissioningStatusInfo>())
         {
             // This report type is used when an error happens in either NetworkConfig or ConnectNetwork commands
-            completionStatus.networkCommissioningStatus =
-                MakeOptional(report.Get<NetworkCommissioningStatusInfo>().networkCommissioningStatus);
+            const auto & networkInfo                    = report.Get<NetworkCommissioningStatusInfo>();
+            completionStatus.networkCommissioningStatus = MakeOptional(networkInfo.networkCommissioningStatus);
+            // Preserve the optional ConnectNetworkResponse.errorValue (driver-level detail
+            // distinct from the spec-level networkingStatus). Null for NetworkConfigResponse.
+            completionStatus.connectNetworkErrorValue      = networkInfo.connectNetworkErrorValue;
+            completionStatus.networkCommissioningDebugText = networkInfo.debugText;
 
             // If we are configured to scan networks, then don't error out.
             // Instead, allow the app to try another network.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1872,7 +1872,22 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(Controller, "Add NOC failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commissioner->CommissioningStageComplete(err);
+        // Preserve the device-reported NodeOperationalCertStatusEnum (kInvalidPublicKey,
+        // kInvalidNodeOpId, kInvalidNOC, kFabricConflict, kLabelConflict, kInvalidFabricIndex,
+        // kTableFull, etc.) in the report so OnCommissioningFailure consumers can distinguish
+        // these without losing fidelity to the generic CHIP_ERROR returned by
+        // ConvertFromOperationalCertStatus.
+        CommissioningDelegate::CommissioningReport report;
+        // ConvertFromOperationalCertStatus succeeds on kOk and returns a non-success CHIP_ERROR
+        // for any other value, but `err` at this point can also be a downstream local failure
+        // (e.g. from OnOperationalCredentialsProvisioningCompletion) while data.statusCode is
+        // still kOk. Guard so we never publish a "success enum" alongside a non-success err to
+        // OnCommissioningFailure consumers.
+        if (data.statusCode != OperationalCredentials::NodeOperationalCertStatusEnum::kOk)
+        {
+            report.Set<OperationalCertErrorInfo>(data.statusCode);
+        }
+        commissioner->CommissioningStageComplete(err, report);
     }
 }
 
@@ -2172,10 +2187,7 @@ void DeviceCommissioner::SendCommissioningCompleteCallbacks(NodeId nodeId, const
     }
     else
     {
-        // TODO: We should propogate detailed error information (commissioningError, networkCommissioningStatus) from
-        // completionStatus.
-        mPairingDelegate->OnCommissioningFailure(peerId, completionStatus.err, completionStatus.failedStage.ValueOr(kError),
-                                                 completionStatus.attestationResult);
+        mPairingDelegate->OnCommissioningFailure(peerId, completionStatus);
     }
 }
 
@@ -2975,7 +2987,9 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
     if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<CommissioningErrorInfo>(data.errorCode);
+        // Preserve the device-supplied debugText so failure consumers can disambiguate
+        // ambiguous error codes (e.g. kBusyWithOtherAdmin specifics).
+        report.Set<CommissioningErrorInfo>(data.errorCode, data.debugText);
     }
 
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
@@ -2992,7 +3006,7 @@ void DeviceCommissioner::OnSetRegulatoryConfigResponse(
     if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<CommissioningErrorInfo>(data.errorCode);
+        report.Set<CommissioningErrorInfo>(data.errorCode, data.debugText);
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);
@@ -3008,6 +3022,7 @@ void DeviceCommissioner::OnSetTCAcknowledgementsResponse(
     if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
+        // SetTCAcknowledgementsResponse has no debugText field per spec.
         report.Set<CommissioningErrorInfo>(data.errorCode);
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
@@ -3099,7 +3114,9 @@ void DeviceCommissioner::OnNetworkConfigResponse(void * context,
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus);
+        // Preserve debugText alongside the status enum so callers can distinguish
+        // ambiguous statuses (e.g. kAuthFailure: "wrong password" vs "regulatory restriction").
+        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus, data.debugText.ValueOr(CharSpan{}));
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);
@@ -3115,7 +3132,12 @@ void DeviceCommissioner::OnConnectNetworkResponse(
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus);
+        // Preserve debugText alongside the status enum (see OnNetworkConfigResponse). Also
+        // surface the device-specific errorValue which carries driver-level failure detail
+        // (TX-power-limited / interference / association-failure code) distinct from the
+        // spec-level networkingStatus enum.
+        Optional<int32_t> errorValue = data.errorValue.IsNull() ? NullOptional : MakeOptional(data.errorValue.Value());
+        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus, data.debugText.ValueOr(CharSpan{}), errorValue);
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);
@@ -3131,7 +3153,7 @@ void DeviceCommissioner::OnCommissioningCompleteResponse(
     if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<CommissioningErrorInfo>(data.errorCode);
+        report.Set<CommissioningErrorInfo>(data.errorCode, data.debugText);
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -26,10 +26,13 @@
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <credentials/jcm/TrustVerification.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/CharSpanToStdString.h>
 #include <lib/support/Span.h>
 #include <lib/support/Variant.h>
 #include <matter/tracing/build_config.h>
 #include <system/SystemClock.h>
+
+#include <string>
 
 namespace chip {
 namespace Controller {
@@ -137,11 +140,30 @@ struct NOCChainGenerationParameters
 struct CompletionStatus
 {
     CompletionStatus() : err(CHIP_NO_ERROR), failedStage(NullOptional), attestationResult(NullOptional) {}
+
     CHIP_ERROR err;
     Optional<CommissioningStage> failedStage;
     Optional<Credentials::AttestationVerificationResult> attestationResult;
     Optional<app::Clusters::GeneralCommissioning::CommissioningErrorEnum> commissioningError;
     Optional<app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> networkCommissioningStatus;
+    /// Optional device-reported low-level error from ConnectNetworkResponse.errorValue (e.g.
+    /// driver-specific TX-power-limited / interference / association-failure code), distinct
+    /// from the spec-level NetworkCommissioningStatusEnum already captured above.
+    Optional<int32_t> connectNetworkErrorValue;
+    /// Optional NodeOperationalCertStatusEnum from the device's NOCResponse during the
+    /// AddNOC / UpdateNOC / RemoveFabric flows. Lets callers distinguish kInvalidPublicKey
+    /// from kInvalidNodeOpId from kFabricConflict from kLabelConflict, etc., without losing
+    /// fidelity to a generic CHIP_ERROR.
+    Optional<app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum> operationalCertStatus;
+
+    /// Owned copy of the device-supplied GeneralCommissioning debugText from
+    /// ArmFailSafeResponse / SetRegulatoryConfigResponse / CommissioningCompleteResponse.
+    /// Empty if no debug text was provided.
+    std::string commissioningDebugText;
+
+    /// Owned copy of the device-supplied NetworkCommissioning debugText from
+    /// NetworkConfigResponse / ConnectNetworkResponse. Empty if no debug text was provided.
+    std::string networkCommissioningDebugText;
 };
 
 inline constexpr uint16_t kDefaultFailsafeTimeout = 60;
@@ -842,7 +864,22 @@ struct AttestationErrorInfo
 struct CommissioningErrorInfo
 {
     CommissioningErrorInfo(app::Clusters::GeneralCommissioning::CommissioningErrorEnum result) : commissioningError(result) {}
+    CommissioningErrorInfo(app::Clusters::GeneralCommissioning::CommissioningErrorEnum result, CharSpan text) :
+        commissioningError(result), debugText(CharSpanToStdString(text))
+    {}
     app::Clusters::GeneralCommissioning::CommissioningErrorEnum commissioningError;
+    /// Owned copy of the device-supplied `debugText` from
+    /// ArmFailSafeResponse / SetRegulatoryConfigResponse / CommissioningCompleteResponse.
+    /// Empty when the device did not provide debug text.
+    std::string debugText;
+};
+
+struct OperationalCertErrorInfo
+{
+    OperationalCertErrorInfo(app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum result) :
+        operationalCertStatus(result)
+    {}
+    app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum operationalCertStatus;
 };
 
 struct NetworkCommissioningStatusInfo
@@ -850,7 +887,23 @@ struct NetworkCommissioningStatusInfo
     NetworkCommissioningStatusInfo(app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum result) :
         networkCommissioningStatus(result)
     {}
+    NetworkCommissioningStatusInfo(app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum result, CharSpan text) :
+        networkCommissioningStatus(result), debugText(CharSpanToStdString(text))
+    {}
+    NetworkCommissioningStatusInfo(app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum result, CharSpan text,
+                                   Optional<int32_t> errorValue) :
+        networkCommissioningStatus(result),
+        debugText(CharSpanToStdString(text)), connectNetworkErrorValue(errorValue)
+    {}
     app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum networkCommissioningStatus;
+    /// Owned copy of the device-supplied `debugText` from
+    /// `NetworkConfigResponse` / `ConnectNetworkResponse`. Empty when the device did not
+    /// provide debug text.
+    std::string debugText;
+    /// Optional device-specific connect failure code from ConnectNetworkResponse.errorValue.
+    /// Only populated for ConnectNetwork failures; null for NetworkConfig failures (which
+    /// don't carry an errorValue field).
+    Optional<int32_t> connectNetworkErrorValue;
 };
 
 class CommissioningDelegate
@@ -874,7 +927,7 @@ public:
      * kSendOpCertSigningRequest: CSRResponse
      * kGenerateNOCChain: NocChain
      * kSendTrustedRootCert: None
-     * kSendNOC: None
+     * kSendNOC: OperationalCertErrorInfo if AddNOC returned a non-success NodeOperationalCertStatusEnum
      * kConfigureTrustedTimeSource: None
      * kWiFiNetworkSetup: NetworkCommissioningStatusInfo if there is an error
      * kThreadNetworkSetup: NetworkCommissioningStatusInfo if there is an error
@@ -889,8 +942,8 @@ public:
      */
     struct CommissioningReport
         : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData, ReadCommissioningInfo,
-                  AttestationErrorInfo, CommissioningErrorInfo, NetworkCommissioningStatusInfo, TimeZoneResponseInfo,
-                  Credentials::JCM::TrustVerificationError>
+                  AttestationErrorInfo, CommissioningErrorInfo, OperationalCertErrorInfo, NetworkCommissioningStatusInfo,
+                  TimeZoneResponseInfo, Credentials::JCM::TrustVerificationError>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -103,6 +103,33 @@ public:
                                         Optional<Credentials::AttestationVerificationResult> additionalErrorInfo)
     {}
 
+    /**
+     * @brief
+     *   Called when commissioning fails, with the full structured CompletionStatus from the
+     *   commissioning state machine. Provides access to detailed status that the 4-arg overload
+     *   above drops on the floor.
+     *
+     *   Default implementation forwards to the legacy 4-arg overload above, so existing
+     *   delegates keep working unchanged. The legacy form only carries `err`, `failedStage`,
+     *   and `attestationResult` — the following CompletionStatus fields are silently dropped
+     *   when the default forwarder runs:
+     *
+     *     - commissioningError                (GeneralCommissioning cluster CommissioningErrorEnum)
+     *     - networkCommissioningStatus + connectNetworkErrorValue
+     *     - operationalCertStatus             (OperationalCredentials NOCResponse status)
+     *     - commissioningDebugText            (device-supplied text from ArmFailSafe /
+     *                                          SetRegulatoryConfig / CommissioningComplete)
+     *     - networkCommissioningDebugText     (device-supplied text from NetworkConfig /
+     *                                          ConnectNetwork)
+     *
+     *   Override this overload (instead of the 4-arg one) to receive those fields.
+     */
+    virtual void OnCommissioningFailure(PeerId peerId, const CompletionStatus & completionStatus)
+    {
+        OnCommissioningFailure(peerId, completionStatus.err, completionStatus.failedStage.ValueOr(CommissioningStage::kError),
+                               completionStatus.attestationResult);
+    }
+
     virtual void OnCommissioningStatusUpdate(PeerId peerId, CommissioningStage stageCompleted, CHIP_ERROR error) {}
 
     /**

--- a/src/controller/tests/TestCommissioningDelegate.cpp
+++ b/src/controller/tests/TestCommissioningDelegate.cpp
@@ -377,9 +377,8 @@ TEST_F(CommissioningDelegateTest, CompletionStatus_DefaultAndRoundTrip)
     cs.networkCommissioningStatus =
         MakeOptional(app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum::kBoundsExceeded);
     cs.connectNetworkErrorValue = MakeOptional<int32_t>(-42);
-    cs.operationalCertStatus =
-        MakeOptional(app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
-    cs.commissioningDebugText        = "commissioning-error-text";
+    cs.operationalCertStatus    = MakeOptional(app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
+    cs.commissioningDebugText   = "commissioning-error-text";
     cs.networkCommissioningDebugText = "network-commissioning-error-text";
 
     p.SetCompletionStatus(cs);
@@ -398,8 +397,7 @@ TEST_F(CommissioningDelegateTest, CompletionStatus_DefaultAndRoundTrip)
     ASSERT_TRUE(got.connectNetworkErrorValue.HasValue());
     EXPECT_EQ(got.connectNetworkErrorValue.Value(), -42);
     ASSERT_TRUE(got.operationalCertStatus.HasValue());
-    EXPECT_EQ(got.operationalCertStatus.Value(),
-              app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
+    EXPECT_EQ(got.operationalCertStatus.Value(), app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
     EXPECT_EQ(got.commissioningDebugText, "commissioning-error-text");
     EXPECT_EQ(got.networkCommissioningDebugText, "network-commissioning-error-text");
 }
@@ -449,8 +447,7 @@ TEST_F(CommissioningDelegateTest, NetworkCommissioningStatusInfo_CharSpanCtorHan
     NetworkCommissioningStatusInfo info4(NetworkCommissioningStatusEnum::kIPV6Failed, CharSpan{});
     EXPECT_TRUE(info4.debugText.empty());
 
-    NetworkCommissioningStatusInfo info5(NetworkCommissioningStatusEnum::kIPBindFailed, CharSpan{},
-                                         MakeOptional<int32_t>(-1));
+    NetworkCommissioningStatusInfo info5(NetworkCommissioningStatusEnum::kIPBindFailed, CharSpan{}, MakeOptional<int32_t>(-1));
     EXPECT_TRUE(info5.debugText.empty());
     ASSERT_TRUE(info5.connectNetworkErrorValue.HasValue());
     EXPECT_EQ(info5.connectNetworkErrorValue.Value(), -1);
@@ -477,7 +474,7 @@ struct LegacyForwardingPairingDelegate : public DevicePairingDelegate
 
     int callCount = 0;
     PeerId capturedPeerId;
-    CHIP_ERROR capturedError = CHIP_NO_ERROR;
+    CHIP_ERROR capturedError         = CHIP_NO_ERROR;
     CommissioningStage capturedStage = CommissioningStage::kError;
     Optional<Credentials::AttestationVerificationResult> capturedAttestation;
 
@@ -501,8 +498,7 @@ TEST_F(CommissioningDelegateTest, DevicePairingDelegate_StructuredOverloadForwar
     status.err                = CHIP_ERROR_INTERNAL;
     status.failedStage        = MakeOptional(CommissioningStage::kAttestationVerification);
     status.attestationResult  = MakeOptional(Credentials::AttestationVerificationResult::kPaiAuthorityNotFound);
-    status.commissioningError =
-        MakeOptional(app::Clusters::GeneralCommissioning::CommissioningErrorEnum::kValueOutsideRange);
+    status.commissioningError = MakeOptional(app::Clusters::GeneralCommissioning::CommissioningErrorEnum::kValueOutsideRange);
 
     delegate.OnCommissioningFailure(kPeerId, status);
 

--- a/src/controller/tests/TestCommissioningDelegate.cpp
+++ b/src/controller/tests/TestCommissioningDelegate.cpp
@@ -1,6 +1,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <controller/CommissioningDelegate.h>
+#include <controller/DevicePairingDelegate.h>
 #include <cstring>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
@@ -362,6 +363,10 @@ TEST_F(CommissioningDelegateTest, CompletionStatus_DefaultAndRoundTrip)
     EXPECT_FALSE(def.attestationResult.HasValue());
     EXPECT_FALSE(def.commissioningError.HasValue());
     EXPECT_FALSE(def.networkCommissioningStatus.HasValue());
+    EXPECT_FALSE(def.connectNetworkErrorValue.HasValue());
+    EXPECT_FALSE(def.operationalCertStatus.HasValue());
+    EXPECT_TRUE(def.commissioningDebugText.empty());
+    EXPECT_TRUE(def.networkCommissioningDebugText.empty());
 
     // Populate and set
     CompletionStatus cs;
@@ -371,6 +376,11 @@ TEST_F(CommissioningDelegateTest, CompletionStatus_DefaultAndRoundTrip)
     cs.commissioningError = MakeOptional(app::Clusters::GeneralCommissioning::CommissioningErrorEnum::kValueOutsideRange);
     cs.networkCommissioningStatus =
         MakeOptional(app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum::kBoundsExceeded);
+    cs.connectNetworkErrorValue = MakeOptional<int32_t>(-42);
+    cs.operationalCertStatus =
+        MakeOptional(app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
+    cs.commissioningDebugText        = "commissioning-error-text";
+    cs.networkCommissioningDebugText = "network-commissioning-error-text";
 
     p.SetCompletionStatus(cs);
     const CompletionStatus & got = p.GetCompletionStatus();
@@ -385,6 +395,141 @@ TEST_F(CommissioningDelegateTest, CompletionStatus_DefaultAndRoundTrip)
     ASSERT_TRUE(got.networkCommissioningStatus.HasValue());
     EXPECT_EQ(got.networkCommissioningStatus.Value(),
               app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum::kBoundsExceeded);
+    ASSERT_TRUE(got.connectNetworkErrorValue.HasValue());
+    EXPECT_EQ(got.connectNetworkErrorValue.Value(), -42);
+    ASSERT_TRUE(got.operationalCertStatus.HasValue());
+    EXPECT_EQ(got.operationalCertStatus.Value(),
+              app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum::kInvalidNOC);
+    EXPECT_EQ(got.commissioningDebugText, "commissioning-error-text");
+    EXPECT_EQ(got.networkCommissioningDebugText, "network-commissioning-error-text");
+}
+
+TEST_F(CommissioningDelegateTest, CommissioningErrorInfo_CharSpanCtorHandlesEmptyAndNull)
+{
+    using app::Clusters::GeneralCommissioning::CommissioningErrorEnum;
+
+    // 1-arg ctor leaves debugText empty.
+    CommissioningErrorInfo info1(CommissioningErrorEnum::kValueOutsideRange);
+    EXPECT_EQ(info1.commissioningError, CommissioningErrorEnum::kValueOutsideRange);
+    EXPECT_TRUE(info1.debugText.empty());
+
+    // 2-arg ctor with a populated CharSpan copies the bytes.
+    const char kText[] = "device-supplied";
+    CommissioningErrorInfo info2(CommissioningErrorEnum::kBusyWithOtherAdmin, CharSpan(kText, sizeof(kText) - 1));
+    EXPECT_EQ(info2.debugText, kText);
+
+    // 2-arg ctor with an empty (default) CharSpan whose data() is nullptr must yield empty
+    // debugText without invoking std::string(nullptr, 0) UB.
+    CommissioningErrorInfo info3(CommissioningErrorEnum::kRequiredTCNotAccepted, CharSpan{});
+    EXPECT_TRUE(info3.debugText.empty());
+}
+
+TEST_F(CommissioningDelegateTest, NetworkCommissioningStatusInfo_CharSpanCtorHandlesEmptyAndNull)
+{
+    using app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum;
+
+    NetworkCommissioningStatusInfo info1(NetworkCommissioningStatusEnum::kBoundsExceeded);
+    EXPECT_EQ(info1.networkCommissioningStatus, NetworkCommissioningStatusEnum::kBoundsExceeded);
+    EXPECT_TRUE(info1.debugText.empty());
+    EXPECT_FALSE(info1.connectNetworkErrorValue.HasValue());
+
+    const char kText[] = "wifi-status-text";
+    NetworkCommissioningStatusInfo info2(NetworkCommissioningStatusEnum::kAuthFailure, CharSpan(kText, sizeof(kText) - 1));
+    EXPECT_EQ(info2.debugText, kText);
+    EXPECT_FALSE(info2.connectNetworkErrorValue.HasValue());
+
+    // 3-arg ctor with a populated CharSpan + errorValue.
+    NetworkCommissioningStatusInfo info3(NetworkCommissioningStatusEnum::kRegulatoryError, CharSpan(kText, sizeof(kText) - 1),
+                                         MakeOptional<int32_t>(7));
+    EXPECT_EQ(info3.debugText, kText);
+    ASSERT_TRUE(info3.connectNetworkErrorValue.HasValue());
+    EXPECT_EQ(info3.connectNetworkErrorValue.Value(), 7);
+
+    // 2-arg and 3-arg ctors must accept a default CharSpan (data()==nullptr) without UB.
+    NetworkCommissioningStatusInfo info4(NetworkCommissioningStatusEnum::kIPV6Failed, CharSpan{});
+    EXPECT_TRUE(info4.debugText.empty());
+
+    NetworkCommissioningStatusInfo info5(NetworkCommissioningStatusEnum::kIPBindFailed, CharSpan{},
+                                         MakeOptional<int32_t>(-1));
+    EXPECT_TRUE(info5.debugText.empty());
+    ASSERT_TRUE(info5.connectNetworkErrorValue.HasValue());
+    EXPECT_EQ(info5.connectNetworkErrorValue.Value(), -1);
+}
+
+TEST_F(CommissioningDelegateTest, OperationalCertErrorInfo_RoundTrip)
+{
+    using app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum;
+
+    OperationalCertErrorInfo info(NodeOperationalCertStatusEnum::kFabricConflict);
+    EXPECT_EQ(info.operationalCertStatus, NodeOperationalCertStatusEnum::kFabricConflict);
+}
+
+// Capture the args the legacy 4-arg OnCommissioningFailure receives, so we can prove the new
+// 2-arg overload's default implementation forwards into it for delegates that haven't been
+// updated yet.
+struct LegacyForwardingPairingDelegate : public DevicePairingDelegate
+{
+    // Bring the structured 2-arg overload into scope so we can invoke it on a derived-type
+    // reference. Without this `using`, our override of the 4-arg form below hides the base's
+    // 2-arg overload via C++ name hiding, and the test calls below would fail to compile.
+    // Production callers don't hit this because they invoke through `DevicePairingDelegate *`.
+    using DevicePairingDelegate::OnCommissioningFailure;
+
+    int callCount = 0;
+    PeerId capturedPeerId;
+    CHIP_ERROR capturedError = CHIP_NO_ERROR;
+    CommissioningStage capturedStage = CommissioningStage::kError;
+    Optional<Credentials::AttestationVerificationResult> capturedAttestation;
+
+    void OnCommissioningFailure(PeerId peerId, CHIP_ERROR error, CommissioningStage stageFailed,
+                                Optional<Credentials::AttestationVerificationResult> additionalErrorInfo) override
+    {
+        ++callCount;
+        capturedPeerId      = peerId;
+        capturedError       = error;
+        capturedStage       = stageFailed;
+        capturedAttestation = additionalErrorInfo;
+    }
+};
+
+TEST_F(CommissioningDelegateTest, DevicePairingDelegate_StructuredOverloadForwardsToLegacy)
+{
+    LegacyForwardingPairingDelegate delegate;
+    const PeerId kPeerId(/*compressedFabricId=*/0x1122334455667788ULL, /*nodeId=*/0xCAFEBABEULL);
+
+    CompletionStatus status;
+    status.err                = CHIP_ERROR_INTERNAL;
+    status.failedStage        = MakeOptional(CommissioningStage::kAttestationVerification);
+    status.attestationResult  = MakeOptional(Credentials::AttestationVerificationResult::kPaiAuthorityNotFound);
+    status.commissioningError =
+        MakeOptional(app::Clusters::GeneralCommissioning::CommissioningErrorEnum::kValueOutsideRange);
+
+    delegate.OnCommissioningFailure(kPeerId, status);
+
+    EXPECT_EQ(delegate.callCount, 1);
+    EXPECT_EQ(delegate.capturedPeerId.GetCompressedFabricId(), kPeerId.GetCompressedFabricId());
+    EXPECT_EQ(delegate.capturedPeerId.GetNodeId(), kPeerId.GetNodeId());
+    EXPECT_EQ(delegate.capturedError, CHIP_ERROR_INTERNAL);
+    EXPECT_EQ(delegate.capturedStage, CommissioningStage::kAttestationVerification);
+    ASSERT_TRUE(delegate.capturedAttestation.HasValue());
+    EXPECT_EQ(delegate.capturedAttestation.Value(), Credentials::AttestationVerificationResult::kPaiAuthorityNotFound);
+}
+
+TEST_F(CommissioningDelegateTest, DevicePairingDelegate_StructuredOverloadDefaultsForEmptyCompletionStatus)
+{
+    // Empty CompletionStatus: no failedStage / no attestationResult. Default forwarder should
+    // substitute kError for failedStage and pass through the NullOptional attestation.
+    LegacyForwardingPairingDelegate delegate;
+    const PeerId kPeerId{};
+    CompletionStatus status;
+    status.err = CHIP_ERROR_TIMEOUT;
+
+    delegate.OnCommissioningFailure(kPeerId, status);
+
+    EXPECT_EQ(delegate.callCount, 1);
+    EXPECT_EQ(delegate.capturedError, CHIP_ERROR_TIMEOUT);
+    EXPECT_EQ(delegate.capturedStage, CommissioningStage::kError);
+    EXPECT_FALSE(delegate.capturedAttestation.HasValue());
 }
 
 } // namespace

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -865,6 +865,22 @@ CHIP_ERROR PASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralS
         err = CHIP_ERROR_INVALID_PASE_PARAMETER;
         break;
 
+    case kProtocolCodeNoSharedRoot:
+        // kProtocolCodeNoSharedRoot only has a defined meaning in CASE (where it indicates
+        // the responder lacks a trusted root for the initiator's fabric). PASE has no
+        // shared-root semantics, so a peer sending this status during PASE is misconfigured.
+        // Mapping it to CHIP_ERROR_NO_SHARED_TRUSTED_ROOT is more useful for diagnostics
+        // than collapsing to CHIP_ERROR_INTERNAL.
+        err = CHIP_ERROR_NO_SHARED_TRUSTED_ROOT;
+        break;
+
+    case kProtocolCodeBusy:
+        // Spec doesn't explicitly forbid a peer returning kProtocolCodeBusy during PASE,
+        // even though it's not commonly seen. Distinguishing "device temporarily busy" from
+        // generic INTERNAL helps callers decide whether to retry.
+        err = CHIP_ERROR_BUSY;
+        break;
+
     default:
         err = CHIP_ERROR_INTERNAL;
         break;


### PR DESCRIPTION
Threads structured failure context through commissioning so consumers can branch on the device-reported cause without log-parsing.

### Changes

- New `DevicePairingDelegate::OnCommissioningFailure(PeerId, const CompletionStatus &)`; default forwards to the legacy 4-arg form.
- `CompletionStatus` gains: `commissioningError`, `networkCommissioningStatus`, `connectNetworkErrorValue`, `operationalCertStatus`, `commissioningDebugText`/`networkCommissioningDebugText` (`std::string`).
- `CommissioningErrorInfo` / `NetworkCommissioningStatusInfo` gain `std::string debugText`; new `OperationalCertErrorInfo`.
- `AutoCommissioner::CommissioningStepFinished` copies report variant data into `CompletionStatus`.
- `CHIPDeviceController` response handlers populate the variants.
- `PASESession::OnFailureStatusReport`: map `kProtocolCodeNoSharedRoot` → `CHIP_ERROR_NO_SHARED_TRUSTED_ROOT`, `kProtocolCodeBusy` → `CHIP_ERROR_BUSY`.

### Testing

`src/controller/tests/TestCommissioningDelegate.cpp`:

- `CompletionStatus_DefaultAndRoundTrip` — extended to cover all new fields (`connectNetworkErrorValue`, `operationalCertStatus`, both debug-text strings).
- `CommissioningErrorInfo_CharSpanCtorHandlesEmptyAndNull` — 1-arg, 2-arg-populated, and 2-arg-default-`CharSpan{}` ctors (guards against `std::string(nullptr, 0)` UB).
- `NetworkCommissioningStatusInfo_CharSpanCtorHandlesEmptyAndNull` — same coverage for 2-arg and 3-arg ctors plus `connectNetworkErrorValue` round-trip.
- `OperationalCertErrorInfo_RoundTrip` — new variant.
- `DevicePairingDelegate_StructuredOverloadForwardsToLegacy` — proves the new 2-arg overload's default impl invokes the legacy 4-arg form with correctly-forwarded fields.
- `DevicePairingDelegate_StructuredOverloadDefaultsForEmptyCompletionStatus` — empty `CompletionStatus` defaults to `kError` + `NullOptional` attestation when forwarded.

Not unit-tested: `PASESession::OnFailureStatusReport` (3-line case-arm change). The method is `private virtual`; testing it requires a fully-initialized PASE session + synthetic status-report packet. Existing `TestPASESession::SecurePairingFailedHandshake` exercises the OnFailureStatusReport path generically.

### Related

- #72258 — `CharSpanToStdString` helper
- #72211 (Darwin), #72227 (CASE), #72226 (script fix).