### PR TITLE
[Messaging] Honor peer SAT in MRP retransmit backoff for ICDs

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -540,21 +540,30 @@ void ReliableMessageMgr::SetAdditionalMRPBackoffTime(const Optional<System::Cloc
 
 void ReliableMessageMgr::CalculateNextRetransTime(RetransTableEntry & entry)
 {
-    System::Clock::Timeout baseTimeout = System::Clock::Timeout(0);
-    const auto sessionHandle           = entry.ec->GetSessionHandle();
+    const auto sessionHandle = entry.ec->GetSessionHandle();
 
-    // Check if we have received at least one application-level message
-    if (entry.ec->HasReceivedAtLeastOneMessage())
-    {
-        // If we have received at least one message, assume peer is active and use ActiveRetransTimeout
-        baseTimeout = sessionHandle->GetRemoteMRPConfig().mActiveRetransTimeout;
-    }
-    else
-    {
-        // If we haven't received at least one message
-        // Choose active/idle timeout from PeerActiveMode of session per 4.11.2.1. Retransmissions.
-        baseTimeout = sessionHandle->GetMRPBaseTimeout();
-    }
+    // Per Matter Core spec §4.11.2.1 Retransmissions: choose the Active or Idle
+    // base timeout based on the peer's CURRENT activity mode at the moment we
+    // schedule the retransmit. The peer may have been Active when it last sent
+    // us a message in this exchange, but transitioned back to Idle once its
+    // Session Active Threshold (SAT) elapsed.
+    //
+    // For Intermittently Connected Devices (ICDs) where SAI ≪ SII, an earlier
+    // shortcut here pinned to ActiveRetransTimeout (SAI) for the remainder of
+    // the exchange as soon as one message had been received. That caused every
+    // subsequent retransmit to be scheduled well inside the peer's sleep
+    // window, defeating reliable delivery. A common failure mode is CASE Sigma3
+    // to a sleepy device: the just-received Sigma2 marks the exchange "has
+    // received a message", so Sigma3 retransmits were spaced on SAI-derived
+    // backoff (sub-second to a few seconds) instead of the SII-derived spacing
+    // the ICD actually polls on (multiple seconds), and the device never
+    // observed any of them.
+    //
+    // GetMRPBaseTimeout() re-evaluates IsPeerActive() against SAT on every
+    // call, returning ActiveRetransTimeout (SAI) while the peer is in its
+    // Active window and IdleRetransTimeout (SII) afterward, which is the
+    // behavior the spec actually prescribes.
+    System::Clock::Timeout baseTimeout = sessionHandle->GetMRPBaseTimeout();
 
     System::Clock::Timeout backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry.sendCount);
     entry.nextRetransTime          = System::SystemClock().GetMonotonicTimestamp() + backoff;

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1654,6 +1654,374 @@ TEST_F(TestReliableMessageProtocol, CheckIsPeerActiveNotInitiator)
     EXPECT_EQ(loopback.mSentMessageCount, 5u);
 }
 
+// =============================================================================
+// ICD-aware MRP retransmit backoff tests
+//
+// These exercise ReliableMessageMgr::CalculateNextRetransTime's choice of base
+// timeout (Active vs Idle) for an exchange where the peer is an Intermittently
+// Connected Device (ICD) advertising a Session Active Threshold (SAT) much
+// shorter than its Slow Idle Interval (SII).
+//
+// Per Matter Core spec §4.11.2.1 Retransmissions and §4.12 Intermittently
+// Connected Devices, the controller must spread retransmissions on the Idle
+// interval (SII) once the peer has dropped out of its Active window — even if
+// the local exchange has received messages from the peer earlier in the
+// exchange.
+//
+// Bug being guarded:
+//   A prior shortcut in CalculateNextRetransTime pinned to mActiveRetransTimeout
+//   (SAI) for the rest of the exchange as soon as HasReceivedAtLeastOneMessage()
+//   was true. For an ICD whose SAT < first-retx-backoff that meant every retx
+//   landed inside the peer's sleep window and reliable delivery silently failed
+//   (e.g. CASE Sigma3 to a sleepy Thread accessory).
+//
+// Test pattern (modeled after CheckIsPeerActiveNotInitiator above):
+//   Each test sends with kExpectResponse, drops one or more sends, then lets
+//   the retransmit succeed so the exchange closes naturally before TearDown.
+//   This avoids leaving an exchange in a "waiting for response" state, which
+//   would trip CancelResponseTimer through a torn-down SessionManager during
+//   shutdown.
+// =============================================================================
+
+namespace {
+
+// Helper: build an ICD-like peer MRP config.
+//
+//   SII = 1500 ms — Idle retx baseline; tests probing the post-SAT path
+//                    assert retx fires no sooner than this (after margin).
+//   SAI =  100 ms — Active retx baseline; tests of the pre-SAT-expiry path
+//                    assert retx fires well under this baseline + jitter.
+//   sat — Session Active Threshold; varied per test so we can stay inside
+//         the Active window or step outside it.
+ReliableMessageProtocolConfig MakeICDLikeMRPConfig(System::Clock::Milliseconds16 sat)
+{
+    return ReliableMessageProtocolConfig(1500_ms32, // mIdleRetransTimeout (SII)
+                                         100_ms32,  // mActiveRetransTimeout (SAI)
+                                         sat        // mActiveThresholdTime (SAT)
+    );
+}
+
+// Wall-clock tolerance for backoff timing assertions. MRP backoff adds up to
+// ~25% jitter on top of the (margin-adjusted) base, so a 50 ms lower-bound
+// margin keeps the tests stable on slow CI runners while still cleanly
+// distinguishing SAI- and SII-derived retx spacing.
+//
+// All tests in this file that consume these constants force the additional
+// MRP sender boost to 0 via ReliableMessageMgr::SetAdditionalMRPBackoffTime.
+// The platform default (CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST = 1500ms
+// on OpenThread/non-Linux, 0 elsewhere) would otherwise shift these bounds
+// in a platform-dependent way.
+constexpr System::Clock::Milliseconds32 kMrpTimingMargin = 50_ms32;
+
+// SII-derived lower bound for "this retx was scheduled on Idle". Bottom of
+// the jitter range for SII × margin × backoff^0 — for our SII=1500ms config
+// (with sender boost forced to 0), the minimum is at least SII itself.
+constexpr System::Clock::Milliseconds32 kIdleRetxMinElapsed = 1500_ms32;
+
+// Upper fence for "this retx was scheduled on Active". With our SAI=100ms
+// config and sender boost forced to 0, an Active retx fires within a few
+// hundred ms of the original send; 1200 ms gives plenty of room for jitter
+// and CI noise while remaining well below kIdleRetxMinElapsed (1500 ms) so
+// the two regimes can't be confused.
+constexpr System::Clock::Milliseconds32 kActiveRetxMaxElapsed = 1200_ms32;
+
+} // namespace
+
+/**
+ * Verifies that once the peer's Session Active Threshold has elapsed, the
+ * responder's retransmissions of a subsequent reliable message are spaced on
+ * the IDLE interval (SII), even though the exchange has received at least one
+ * message from the peer earlier.
+ *
+ * Pattern:
+ *   1) Alice (initiator) sends EchoRequest to Bob with kExpectResponse.
+ *   2) Bob's exchange receives it; mockReceiver retains the exchange so we
+ *      can drive a response from it later. Bob's exchange now has
+ *      HasReceivedAtLeastOneMessage() = true, and Bob's session for Alice
+ *      has fresh mLastPeerActivityTime.
+ *   3) We configure Bob's view of Alice as an ICD-like sleepy peer with
+ *      SAT=50ms, and wait 200ms — well past SAT. IsPeerActive() for Alice
+ *      on Bob's session is now false.
+ *   4) Bob sends EchoResponse back to Alice; loopback drops it once.
+ *   5) Bob's MRP must schedule the retx on the Idle interval (SII=1500ms),
+ *      not the Active interval (SAI=100ms). The retx is allowed to succeed,
+ *      Alice receives the response, and the exchange closes naturally.
+ *   6) Verify timing: measured retx elapsed >= SII floor minus margin.
+ *   7) Verify clean shutdown: retransmit table is empty and Alice's
+ *      delegate observed the EchoResponse.
+ */
+TEST_F(TestReliableMessageProtocol, CheckICDPeerRetxUsesIdleBackoffAfterSATExpiry)
+{
+    // Force the additional MRP sender boost to 0 for the duration of this test so the timing
+    // bounds below are independent of the platform default (CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST
+    // is 1500ms on OpenThread/non-Linux, 0 elsewhere). Reset at the bottom of the test.
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(MakeOptional(System::Clock::Timeout(0)));
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    EXPECT_FALSE(buffer.IsNull());
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    MockAppDelegate mockReceiver(*this);
+    err = GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &mockReceiver);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    MockAppDelegate mockSender(*this);
+    ExchangeContext * exchange = NewExchangeToAlice(&mockSender);
+    ASSERT_NE(exchange, nullptr);
+
+    ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+    ASSERT_NE(rm, nullptr);
+
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+    auto & loopback               = GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+
+    mockReceiver.mRetainExchange = true;
+    mockSender.mRetainExchange   = true;
+
+    // 1) Alice → Bob, expecting a response. Clean delivery — Bob acks via the
+    //    EchoResponse we drive in step 4.
+    err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kExpectResponse));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    DrainAndServiceIO();
+    ASSERT_NE(mockReceiver.mExchange, nullptr);
+    EXPECT_TRUE(mockReceiver.mExchange->HasReceivedAtLeastOneMessage());
+
+    // 2) Configure Bob's session view of Alice as an ICD-like sleepy peer.
+    mockReceiver.mExchange->GetSessionHandle()->AsSecureSession()->SetRemoteSessionParameters(
+        MakeICDLikeMRPConfig(50_ms16 /* SAT */));
+
+    // 3) Step past SAT so IsPeerActive() returns false on Bob's session.
+    GetIOContext().DriveIOUntil(200_ms32, [&] { return false; });
+    DrainAndServiceIO();
+    EXPECT_FALSE(mockReceiver.mExchange->GetSessionHandle()->AsSecureSession()->IsPeerActive());
+
+    mockReceiver.mRetainExchange = false;
+    mockSender.mRetainExchange   = false;
+
+    // 4) Bob sends EchoResponse; loopback drops it once. The retx is allowed
+    //    to succeed on the second send.
+    buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    EXPECT_FALSE(buffer.IsNull());
+    loopback.mNumMessagesToDrop      = 1;
+    uint32_t sentCountBeforeResponse = loopback.mSentMessageCount;
+
+    System::Clock::Timestamp txTime = System::SystemClock().GetMonotonicTimestamp();
+    err                             = mockReceiver.mExchange->SendMessage(Echo::MsgType::EchoResponse, std::move(buffer));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    EXPECT_EQ(loopback.mDroppedMessageCount, 1u);
+    EXPECT_EQ(loopback.mSentMessageCount, sentCountBeforeResponse + 1u);
+    // After Bob's EchoResponse drop, the retransmit table holds Bob's entry
+    // plus (typically) Alice's prior EchoRequest entry whose piggybacked ack
+    // was carried on the dropped EchoResponse. Don't pin the exact count.
+    EXPECT_GE(rm->TestGetCountRetransTable(), 1);
+
+    // 5) Wait long enough for the SII-derived retx to fire AND complete. We
+    //    poll until the message-count grows past the post-send baseline; in
+    //    the bug we'd see this in well under 200 ms (SAI-derived), in the
+    //    fixed path the soonest possible time is ~kIdleRetxMinElapsed.
+    GetIOContext().DriveIOUntil(3000_ms32, [&] { return mockSender.IsOnMessageReceivedCalled; });
+    DrainAndServiceIO();
+
+    System::Clock::Timestamp now              = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Milliseconds64 elapsedMs64 = now - txTime;
+    auto elapsedMs                            = System::Clock::Milliseconds32(static_cast<uint32_t>(elapsedMs64.count()));
+    ChipLogProgress(Test, "ICD retx fired and was delivered at %" PRIu32 "ms (expected >= %" PRIu32 "ms)", elapsedMs.count(),
+                    (kIdleRetxMinElapsed - kMrpTimingMargin).count());
+
+    // 6) Timing assertion.
+    EXPECT_TRUE(mockSender.IsOnMessageReceivedCalled);
+    EXPECT_GE(elapsedMs.count(), (kIdleRetxMinElapsed - kMrpTimingMargin).count());
+
+    // 7) Clean shutdown: nothing should remain in the retransmit table.
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(NullOptional);
+}
+
+/**
+ * Inverse of the test above. Verifies that the SAI-fast-path is still in
+ * effect when the peer IS within its Active window: retx is spaced on SAI,
+ * not SII. Guards against an over-broad fix that always uses SII regardless
+ * of peer state.
+ */
+TEST_F(TestReliableMessageProtocol, CheckICDPeerRetxUsesActiveBackoffWithinSATWindow)
+{
+    // Force the additional MRP sender boost to 0 (see CheckICDPeerRetxUsesIdleBackoffAfterSATExpiry
+    // for rationale). Reset at the bottom of the test.
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(MakeOptional(System::Clock::Timeout(0)));
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    EXPECT_FALSE(buffer.IsNull());
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    MockAppDelegate mockReceiver(*this);
+    err = GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &mockReceiver);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    MockAppDelegate mockSender(*this);
+    ExchangeContext * exchange = NewExchangeToAlice(&mockSender);
+    ASSERT_NE(exchange, nullptr);
+
+    ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+    ASSERT_NE(rm, nullptr);
+
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+    auto & loopback               = GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+
+    mockReceiver.mRetainExchange = true;
+    mockSender.mRetainExchange   = true;
+
+    err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kExpectResponse));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    DrainAndServiceIO();
+    ASSERT_NE(mockReceiver.mExchange, nullptr);
+    EXPECT_TRUE(mockReceiver.mExchange->HasReceivedAtLeastOneMessage());
+
+    // ICD-like config but with a LARGE SAT (2 seconds) so the peer stays
+    // Active for the entire test.
+    mockReceiver.mExchange->GetSessionHandle()->AsSecureSession()->SetRemoteSessionParameters(
+        MakeICDLikeMRPConfig(2000_ms16 /* SAT — well above the test runtime */));
+    EXPECT_TRUE(mockReceiver.mExchange->GetSessionHandle()->AsSecureSession()->IsPeerActive());
+
+    mockReceiver.mRetainExchange = false;
+    mockSender.mRetainExchange   = false;
+
+    buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    EXPECT_FALSE(buffer.IsNull());
+    loopback.mNumMessagesToDrop      = 1;
+    uint32_t sentCountBeforeResponse = loopback.mSentMessageCount;
+
+    System::Clock::Timestamp txTime = System::SystemClock().GetMonotonicTimestamp();
+    err                             = mockReceiver.mExchange->SendMessage(Echo::MsgType::EchoResponse, std::move(buffer));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    EXPECT_EQ(loopback.mDroppedMessageCount, 1u);
+    EXPECT_EQ(loopback.mSentMessageCount, sentCountBeforeResponse + 1u);
+    EXPECT_GE(rm->TestGetCountRetransTable(), 1);
+
+    // Drive IO until the retx completes; expected well below the Idle floor.
+    GetIOContext().DriveIOUntil(kActiveRetxMaxElapsed, [&] { return mockSender.IsOnMessageReceivedCalled; });
+    DrainAndServiceIO();
+
+    System::Clock::Timestamp now              = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Milliseconds64 elapsedMs64 = now - txTime;
+    auto elapsedMs                            = System::Clock::Milliseconds32(static_cast<uint32_t>(elapsedMs64.count()));
+    ChipLogProgress(Test, "Active retx fired and was delivered at %" PRIu32 "ms (expected <= %" PRIu32 "ms)", elapsedMs.count(),
+                    kActiveRetxMaxElapsed.count());
+
+    EXPECT_TRUE(mockSender.IsOnMessageReceivedCalled);
+    EXPECT_LE(elapsedMs.count(), kActiveRetxMaxElapsed.count());
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(NullOptional);
+}
+
+/**
+ * Exchange has NOT received any messages yet (HasReceivedAtLeastOneMessage =
+ * false), AND the test has explicitly stepped past SAT so IsPeerActive()
+ * returns false. Under those conditions the retx must be scheduled on the
+ * IDLE interval. Confirms the pre-existing else-branch behavior survives the
+ * simplification — the pre-fix shortcut never fired here either (it required
+ * HasReceivedAtLeastOneMessage to be true), but the post-fix code path now
+ * handles all retx scheduling, so this case still needs to be pinned.
+ *
+ * Alice sends a reliable EchoRequest (without kExpectResponse, so no
+ * response timer is left dangling at TearDown). Loopback drops the first
+ * attempt. The retransmit is allowed to succeed, Bob's MRP standalone ack
+ * reaches Alice and clears her retransmit entry. The retransmit table
+ * draining is the success signal; total elapsed time-to-drain must be
+ * >= the SII-derived floor.
+ */
+TEST_F(TestReliableMessageProtocol, CheckPeerRetxUsesIdleBackoffWhenNoMessagesReceived)
+{
+    // Force the additional MRP sender boost to 0 (see CheckICDPeerRetxUsesIdleBackoffAfterSATExpiry
+    // for rationale). Reset at the bottom of the test.
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(MakeOptional(System::Clock::Timeout(0)));
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    EXPECT_FALSE(buffer.IsNull());
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    MockAppDelegate mockReceiver(*this);
+    err = GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &mockReceiver);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    MockAppDelegate mockSender(*this);
+    ExchangeContext * exchange = NewExchangeToAlice(&mockSender);
+    ASSERT_NE(exchange, nullptr);
+
+    // ICD-like config with a very short SAT so we can step past it cheaply. SecureSession
+    // initializes mLastPeerActivityTime to the session-creation timestamp, so a fresh session
+    // is implicitly Active for SAT milliseconds even before the first received message. The
+    // test's premise — Idle backoff for an exchange with no prior receives — only holds once
+    // SAT has elapsed against that initial timestamp.
+    exchange->GetSessionHandle()->AsSecureSession()->SetRemoteSessionParameters(MakeICDLikeMRPConfig(50_ms16 /* SAT */));
+
+    // Step past SAT so IsPeerActive() returns false on the sending session.
+    GetIOContext().DriveIOUntil(150_ms32, [&] { return false; });
+    DrainAndServiceIO();
+    EXPECT_FALSE(exchange->GetSessionHandle()->AsSecureSession()->IsPeerActive());
+
+    ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+    ASSERT_NE(rm, nullptr);
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+    auto & loopback               = GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 1;
+    loopback.mDroppedMessageCount = 0;
+
+    // The exchange has NOT received any messages from the peer (`HasReceivedAtLeastOneMessage`
+    // is false), and SAT has elapsed so the session is Idle. The pre-fix code's shortcut path
+    // didn't apply here (it required `HasReceivedAtLeastOneMessage` to be true), so this case
+    // already behaved correctly; the test pins that behavior under the simplified code path.
+    EXPECT_FALSE(exchange->HasReceivedAtLeastOneMessage());
+
+    System::Clock::Timestamp txTime = System::SystemClock().GetMonotonicTimestamp();
+    // No kExpectResponse: Alice does not need (and must not leave dangling) a
+    // response timer for this test. Bob receives the EchoRequest, sends a
+    // standalone ack, and the exchange tears down naturally once the ack
+    // clears Alice's MRP retransmit entry.
+    err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    EXPECT_EQ(loopback.mDroppedMessageCount, 1u);
+    EXPECT_GE(rm->TestGetCountRetransTable(), 1);
+
+    // Drive IO until Bob's standalone ack has reached Alice and her entry has
+    // been cleared (retransmit table drains to 0). With Idle spacing the
+    // retx fires no sooner than ~kIdleRetxMinElapsed, plus the small ack
+    // round-trip; in the buggy SAI path it would fire in well under 200 ms.
+    GetIOContext().DriveIOUntil(3000_ms32, [&] { return rm->TestGetCountRetransTable() == 0; });
+    DrainAndServiceIO();
+
+    System::Clock::Timestamp now              = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Milliseconds64 elapsedMs64 = now - txTime;
+    auto elapsedMs                            = System::Clock::Milliseconds32(static_cast<uint32_t>(elapsedMs64.count()));
+    ChipLogProgress(Test, "Initial Idle retx drained at %" PRIu32 "ms (expected >= %" PRIu32 "ms)", elapsedMs.count(),
+                    (kIdleRetxMinElapsed - kMrpTimingMargin).count());
+
+    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+    EXPECT_GE(elapsedMs.count(), (kIdleRetxMinElapsed - kMrpTimingMargin).count());
+
+    ReliableMessageMgr::SetAdditionalMRPBackoffTime(NullOptional);
+}
+
 TEST_F(TestReliableMessageProtocol, CheckLostStandaloneAck)
 {
     /**


### PR DESCRIPTION
### Problem

`ReliableMessageMgr::CalculateNextRetransTime` short-circuits to `mActiveRetransTimeout` (SAI) for the rest of the exchange as soon as `ExchangeContext::HasReceivedAtLeastOneMessage()` is true. The else branch already does the spec-correct thing — call `GetMRPBaseTimeout()`, which evaluates `IsPeerActive()` against the peer's Session Active Threshold — but it only runs before the first received message.

For a peer that is an Intermittently Connected Device (ICD) advertising something like `SII=6000, SAI=1200, SAT=1000`, this means every retx scheduled after we receive the first message in an exchange uses an SAI-derived backoff (sub-second to ~3.5s after margin/jitter/sender boost) instead of the SII-derived backoff (multiple seconds) the device actually polls on. Every retransmit lands inside the peer's sleep window, the peer never observes them, and reliable delivery silently fails.

The most visible failure mode is **CASE Sigma3 to a sleepy device**:

- Initiator sends Sigma1 → peer sends Sigma2 → initiator sends Sigma3.
- Receiving Sigma2 flips `HasReceivedAtLeastOneMessage()` to true.
- Initiator's Sigma3 retransmits are now spaced on SAI backoff.
- Peer's SAT elapses ~1s after Sigma2; peer drops to its SII polling cadence.
- All four retx fire inside sleep windows; peer keeps retransmitting the same Sigma2 because it never received our piggybacked ack on Sigma3 (nor any of our standalone acks, which are spaced the same way).
- MRP exhausts retries, CASE session times out in `kSentSigma3`, the pairing flow surfaces a generic timeout error to the application.

This reproduces against multiple sleepy Thread ICD designs from unrelated vendors, which makes it clearly a controller-side bug rather than per-device firmware.

### Fix

Remove the shortcut. Always use `GetMRPBaseTimeout()`. The Active vs Idle decision is made on every retx schedule call against the peer's current `IsPeerActive()` state — which is precisely what spec §4.11.2.1 prescribes. No other call sites or public APIs touched; the behavior change is observed only by ICD peers where SAT < first-retx backoff.

### Testing

Three new tests in `src/messaging/tests/TestReliableMessageProtocol.cpp`, each modeled on the existing `CheckIsPeerActiveNotInitiator` pattern — drop one or more sends, let the retransmit succeed, observe the sender delegate, then assert the retransmit table drains cleanly:

- **`CheckICDPeerRetxUsesIdleBackoffAfterSATExpiry`** — core regression. Peer is configured `SII=1500ms, SAI=100ms, SAT=50ms`. Receiver gets a message (Active), test waits past SAT, sends a reliable response, drops it once. The retx is then allowed to succeed; total time-to-delivery is asserted >= the SII-derived floor (~1.5s), which is well above any SAI-derived spacing (~100-200ms) that would indicate the bug.
- **`CheckICDPeerRetxUsesActiveBackoffWithinSATWindow`** — guards against an over-broad fix. Same config but `SAT=2000ms`, so peer stays Active for the test duration. Retx-and-delivery must complete in well under 1.2s (SAI-fast), not on SII spacing.
- **`CheckPeerRetxUsesIdleBackoffWhenNoMessagesReceived`** — covers the pre-existing else-branch behavior under the simplified code path. New exchange, no prior receives → retx spaced on Idle interval since `IsPeerActive()` returns false on a fresh session.

The existing `CheckIsPeerActiveNotInitiator` test continues to pass: its `ActiveRetransTimeout=100ms` scenario runs in sub-second time, the peer remains within its (default 4s) SAT window throughout, and `GetMRPBaseTimeout()` returns `mActiveRetransTimeout` — matching the prior shortcut's behavior.

### Spec references

- Matter Core spec §4.11.2.1 Retransmissions
- Matter Core spec §4.12 Intermittently Connected Devices

### Open review questions

1. **Approach** — removing the `HasReceivedAtLeastOneMessage()` shortcut entirely, vs. layering an additional `IsPeerActive()` check on top of it. The shortcut existed for "we know the peer is alive" reasons; the spec language argues that doesn't override per-retx Active/Idle re-evaluation.
2. **Test design** — wall-clock timing thresholds are tuned for stability on CI runners (`kMrpTimingMargin = 50ms`). Reviewers may want to suggest mock-clock alternatives if Pigweed test infra supports them in this directory.
3. **Spec interpretation** — confirming that "Active/Idle decision is per-retx-schedule" is the spec-correct reading.

