### PR TITLE
Add Electrical Distribution Enclosure device type (0x0517) registration

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1659,7 +1659,7 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Electrical Distribution" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Electrical Distribution" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1659,10 +1659,11 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <include cluster="Electrical Distribution" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Electrical Distribution" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <!-- TODO: Add Electrical Protection Alarm (Provisional, Optional per spec) once https://github.com/project-chip/connectedhomeip/pull/72249 lands -->
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1650,6 +1650,22 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-electrical-distribution-enclosure</name>
+        <domain>CHIP</domain>
+        <typeName>Electrical Distribution Enclosure</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0517</deviceId>
+        <revision editable="false">1</revision>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Electrical Distribution" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-control-bridge</name>
         <domain>CHIP</domain>
         <typeName>Control Bridge</typeName>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7209,6 +7209,7 @@ typedef NS_ENUM(uint32_t, MTRDeviceTypeIDType) {
     MTRDeviceTypeIDTypeMeterReferencePointID MTR_PROVISIONALLY_AVAILABLE = 0x00000512,
     MTRDeviceTypeIDTypeElectricalEnergyTariffID MTR_PROVISIONALLY_AVAILABLE = 0x00000513,
     MTRDeviceTypeIDTypeElectricalMeterID MTR_PROVISIONALLY_AVAILABLE = 0x00000514,
+    MTRDeviceTypeIDTypeElectricalDistributionEnclosureID MTR_PROVISIONALLY_AVAILABLE = 0x00000517,
     MTRDeviceTypeIDTypeControlBridgeID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000840,
     MTRDeviceTypeIDTypeOnOffSensorID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000850,
 } MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2));

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -115,6 +115,7 @@ static /* constexpr */ const MTRDeviceTypeData knownDeviceTypes[] = {
     { 0x00000512, MTRDeviceTypeClass::Simple, @"Meter Reference Point" },
     { 0x00000513, MTRDeviceTypeClass::Simple, @"Electrical Energy Tariff" },
     { 0x00000514, MTRDeviceTypeClass::Simple, @"Electrical Meter" },
+    { 0x00000517, MTRDeviceTypeClass::Simple, @"Electrical Distribution Enclosure" },
     { 0x00000840, MTRDeviceTypeClass::Simple, @"Control Bridge" },
     { 0x00000850, MTRDeviceTypeClass::Simple, @"On/Off Sensor" },
 };

--- a/zzz_generated/app-common/devices/Ids.h
+++ b/zzz_generated/app-common/devices/Ids.h
@@ -299,6 +299,9 @@ constexpr uint8_t kElectricalEnergyTariffDeviceTypeRevision = 1;
 constexpr DeviceTypeId kElectricalMeterDeviceTypeId  = 0x00000514;
 constexpr uint8_t kElectricalMeterDeviceTypeRevision = 1;
 
+constexpr DeviceTypeId kElectricalDistributionEnclosureDeviceTypeId  = 0x00000517;
+constexpr uint8_t kElectricalDistributionEnclosureDeviceTypeRevision = 1;
+
 constexpr DeviceTypeId kControlBridgeDeviceTypeId  = 0x00000840;
 constexpr uint8_t kControlBridgeDeviceTypeRevision = 3;
 

--- a/zzz_generated/app-common/devices/Types.h
+++ b/zzz_generated/app-common/devices/Types.h
@@ -484,6 +484,11 @@ constexpr DataModel::DeviceTypeEntry kElectricalMeter = {
     .deviceTypeRevision = kElectricalMeterDeviceTypeRevision,
 };
 
+constexpr DataModel::DeviceTypeEntry kElectricalDistributionEnclosure = {
+    .deviceTypeId       = kElectricalDistributionEnclosureDeviceTypeId,
+    .deviceTypeRevision = kElectricalDistributionEnclosureDeviceTypeRevision,
+};
+
 constexpr DataModel::DeviceTypeEntry kControlBridge = {
     .deviceTypeId       = kControlBridgeDeviceTypeId,
     .deviceTypeRevision = kControlBridgeDeviceTypeRevision,

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -7613,6 +7613,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Electrical Energy Tariff";
     case 0x00000514:
         return "Electrical Meter";
+    case 0x00000517:
+        return "Electrical Distribution Enclosure";
     case 0x00000840:
         return "Control Bridge";
     case 0x00000850:


### PR DESCRIPTION
#### Summary

Adds the Electrical Distribution Enclosure (EDE, 0x0517) device type registration for Matter 1.7. EDE is a Simple device type representing an electrical breaker panel, intended to be composed with child Electrical Circuit Breaker (0x0516) endpoints.

The EDE entry includes the spec-mandatory clusters:

- Identify (Optional)
- On/Off (Optional)
- Power Topology (Mandatory)
- Electrical Distribution (Provisional / Mandatory) — added by #72229 (merged)

The Electrical Protection Alarm cluster, which is Provisional/Optional on EDE per the spec, is intentionally omitted from this PR pending its upstream cluster definition (separate PR forthcoming from another contributor). It will be added as a follow-on once that cluster lands.

#### Commit structure

After rebase onto current master (now that #72229 is merged), this PR contains 3 commits — total 6 files changed, ~28 lines added:

- `3ce63c9` — `matter-devices.xml` addition for EDE
- `cc40130` — regen artifacts for EDE device type (4 files in `zzz_generated/app-common/devices/` and `src/darwin/Framework/CHIP/zap-generated/`)
- `5f5e911` — chip-tool `DeviceTypeIdToText` map entry for 0x0517

#### Related issues

Follows #72229 (Electrical Distribution cluster XML, merged 2026-05-29). N/A otherwise.

#### Testing

Generated entirely from upstream-merged spec adocs via Alchemy. No new server code or test scripts. Regen artifacts produced in `chip-build:194` container per the upstream `zap_templates.yaml` workflow recipe.

#### Readability checklist

- [x] PR title is descriptive
- [x] "When in Rome..." rule (coding style)
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history (one force-push was required to rebase onto master after #72229 merged)
- [x] CI time didn't increase