### PR TITLE
chip-tool (linux) : Add "nfc-ethernet" pairing mode

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -199,6 +199,14 @@ public:
         PairingCommand("nfc-wifi", PairingMode::Nfc, PairingNetworkType::WiFi, credsIssuerConfig)
     {}
 };
+
+class PairNfcEthernet : public PairingCommand
+{
+public:
+    PairNfcEthernet(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("nfc-ethernet", PairingMode::Nfc, PairingNetworkType::None, credsIssuerConfig)
+    {}
+};
 #endif // CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 
 class PairSoftAP : public PairingCommand
@@ -283,6 +291,7 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
         make_unique<PairNfcThread>(credsIssuerConfig),
         make_unique<PairNfcWiFi>(credsIssuerConfig),
+        make_unique<PairNfcEthernet>(credsIssuerConfig),
 #endif // CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
         make_unique<PairSoftAP>(credsIssuerConfig),
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -58,7 +58,7 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
-    void SetNetworkSetupNeeded(bool needed) { mNeedsNetworkSetup = needed; }
+    void SetNetworkSetupNeeded(bool needed) override { mNeedsNetworkSetup = needed; }
 
 protected:
     virtual void CleanupCommissioning();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2640,7 +2640,10 @@ CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningIn
             {
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Ethernet. endpointid = %u", path.mEndpointId);
                 info.network.eth.endpoint = path.mEndpointId;
-                mDefaultCommissioner->SetNetworkSetupNeeded(false);
+                if (mDefaultCommissioner != nullptr)
+                {
+                    mDefaultCommissioner->SetNetworkSetupNeeded(false);
+                }
             }
         }
         return CHIP_NO_ERROR;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2640,6 +2640,7 @@ CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningIn
             {
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Ethernet. endpointid = %u", path.mEndpointId);
                 info.network.eth.endpoint = path.mEndpointId;
+                mDefaultCommissioner->SetNetworkSetupNeeded(false);
             }
         }
         return CHIP_NO_ERROR;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -900,6 +900,7 @@ public:
     virtual void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate * operationalCredentialsDelegate) = 0;
     virtual CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy)       = 0;
     virtual CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningReport report)                        = 0;
+    virtual void SetNetworkSetupNeeded(bool needed)                                                                 = 0;
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -352,7 +352,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverNFC()
     VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
                         ChipLogError(Controller, "Error, Long discriminator is required"));
     chip::Nfc::NFCTag::Identifier identifier{};
-    identifier.discriminator = payload.discriminator.GetLongValue();
+    identifier.discriminator                  = payload.discriminator.GetLongValue();
     Nfc::NFCReaderTransport * readerTransport = DeviceLayer::Internal::NFCCommissioningMgr().GetNFCReaderTransport();
     if (!readerTransport)
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -351,7 +351,8 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverNFC()
     const SetupDiscriminator connDiscriminator(payload.discriminator);
     VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
                         ChipLogError(Controller, "Error, Long discriminator is required"));
-    chip::Nfc::NFCTag::Identifier identifier  = { .discriminator = payload.discriminator.GetLongValue() };
+    chip::Nfc::NFCTag::Identifier identifier{};
+    identifier.discriminator = payload.discriminator.GetLongValue();
     Nfc::NFCReaderTransport * readerTransport = DeviceLayer::Internal::NFCCommissioningMgr().GetNFCReaderTransport();
     if (!readerTransport)
     {


### PR DESCRIPTION
#### Summary

This PR add nfc-ethernet pairing mode in chip-tool linux.

It also fixes an issue about mNeedsNetworkSetup, visible when doing NFC commissioning of an Ethernet device.
The issue is due to this code:

```
    mNeedsNetworkSetup = mNeedsNetworkSetup || (transportType == Transport::Type::kBle);
#if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
    mNeedsNetworkSetup = mNeedsNetworkSetup || (transportType == Transport::Type::kNfc);
#endif
#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
    mNeedsNetworkSetup = mNeedsNetworkSetup || (transportType == Transport::Type::kWiFiPAF);
#endif
```

The lines about BLE and WiFiPAF are "ok" (I would rather say acceptable): When BLE or WiFiPAF is present, that's fair to consider that a Network should be configured.

However, we the line about NFC is not correct: The presence of NTL is not sufficient to know if a Network should be configured. On Ethernet devices with NTL, this lead to mNeedsNetworkSetup = true, which is not correct.

#### Testing

Tested that "nfc-ethernet" pairing mode is working with chip-tool (on a raspberry)