### PR TITLE
[Python tests] Improve timeout mechanism for Subprocess

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/apps.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/apps.py
@@ -88,7 +88,9 @@ class IcdAppServerSubprocess(AppServerSubprocess):
 
     def pause(self, check_state: bool = True):
         if check_state and self.paused:
-            raise ValueError("ICD TH Server unexpectedly is already paused")
+            raise RuntimeError("ICD TH Server unexpectedly is already paused")
+        if self.p is None:
+            raise RuntimeError("ICD TH Server process is not started")
         if not self.paused:
             # Stop (halt) the ICD server process by sending a SIGTOP signal.
             self.p.send_signal(signal.SIGSTOP)
@@ -97,6 +99,8 @@ class IcdAppServerSubprocess(AppServerSubprocess):
     def resume(self, check_state: bool = True):
         if check_state and not self.paused:
             raise ValueError("ICD TH Server unexpectedly is already running")
+        if self.p is None:
+            raise RuntimeError("ICD TH Server process is not started")
         if self.paused:
             # Resume (continue) the ICD server process by sending a SIGCONT signal.
             self.p.send_signal(signal.SIGCONT)
@@ -220,7 +224,11 @@ class OTAProviderSubprocess(AppServerSubprocess):
                 self._err_log_file = None
 
     def kill(self):
-        self.p.send_signal(signal.SIGKILL)
+        if self.p is None:
+            raise RuntimeError("OTAProviderSubprocess is not started")
+        self.p.kill()
 
     def get_pid(self) -> int:
+        if self.p is None:
+            raise RuntimeError("OTAProviderSubprocess is not started")
         return self.p.pid

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/apps.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/apps.py
@@ -98,7 +98,7 @@ class IcdAppServerSubprocess(AppServerSubprocess):
 
     def resume(self, check_state: bool = True):
         if check_state and not self.paused:
-            raise ValueError("ICD TH Server unexpectedly is already running")
+            raise RuntimeError("ICD TH Server unexpectedly is already running")
         if self.p is None:
             raise RuntimeError("ICD TH Server process is not started")
         if self.paused:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -212,7 +212,7 @@ class Subprocess(threading.Thread):
         self.p.kill()
         self.join(self.TERMINATION_TIMEOUT_S)
         if self.is_alive() or self.p.poll() is None:
-            LOGGER.warning("Subprocess did not kill within timeout. We may be leaving a zombie process")
+            LOGGER.warning("Failed to kill subprocess within timeout. We may be leaving a zombie process")
 
     def wait(self, timeout: float = DEFAULT_TIMEOUT_S) -> int | None:
         """Wait for the subprocess to finish."""

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -205,13 +205,13 @@ class Subprocess(threading.Thread):
 
         self.p.terminate()
         self.join(self.TERMINATION_TIMEOUT_S)
-        if not self.is_alive() and self.p.poll() is not None:
+        if not self.is_alive() and self.returncode is not None:
             return
 
         LOGGER.warning("Subprocess or controller thread did not terminate within timeout. Killing the process instead")
         self.p.kill()
         self.join(self.TERMINATION_TIMEOUT_S)
-        if self.is_alive() or self.p.poll() is None:
+        if self.is_alive() or self.returncode is not None:
             LOGGER.warning("Failed to kill subprocess within timeout. We may be leaving a zombie process")
 
     def wait(self, timeout: float = DEFAULT_TIMEOUT_S) -> int | None:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -179,7 +179,7 @@ class Subprocess(threading.Thread):
             # Terminate the process, so the Python interpreter will not hang on the join call in our thread entry point in case of
             # Python process termination (not-caught exception).
             self.p.terminate()
-            raise TimeoutError("Expected output '%r' not found within %s seconds", expected_output, timeout)
+            raise TimeoutError(f"Expected output '{expected_output!r}' not found within {timeout} seconds")
 
     def send(self, message: str, end: str = "\n", expected_output: str | re.Pattern | None = None,
              timeout: float = DEFAULT_TIMEOUT_S) -> None:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -21,15 +21,12 @@ import sys
 import threading
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import BinaryIO, Callable, Optional, Union
+from typing import BinaryIO, Callable, Self
 
 LOGGER = logging.getLogger(__name__)
 
 
-def forward_f(f_in: BinaryIO,
-              f_out: BinaryIO,
-              cb: Optional[Callable[[bytes, bool], bytes]] = None,
-              is_stderr: bool = False):
+def forward_f(f_in: BinaryIO, f_out: BinaryIO, cb: Callable[[bytes, bool], bytes] | None = None, is_stderr: bool = False) -> None:
     """Forward f_in to f_out.
 
     This function can optionally post-process received lines using a callback
@@ -57,13 +54,13 @@ class SubprocessInfo:
     wrapper: tuple[str, ...] = ()
     args: tuple[str, ...] = ()
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.path = pathlib.Path(self.path)
 
-    def with_args(self, *args: str):
+    def with_args(self, *args: str) -> Self:
         return replace(self, args=self.args + tuple(args))
 
-    def wrap_with(self, *args: str):
+    def wrap_with(self, *args: str) -> Self:
         return replace(self, wrapper=tuple(args) + self.wrapper)
 
     def to_cmd(self) -> list[str]:
@@ -73,10 +70,8 @@ class SubprocessInfo:
 class Subprocess(threading.Thread):
     """Run a subprocess in a thread."""
 
-    def __init__(self, program: str, *args,
-                 output_cb: Optional[Callable[[bytes, bool], bytes]] = None,
-                 f_stdout: BinaryIO = sys.stdout.buffer,
-                 f_stderr: BinaryIO = sys.stderr.buffer):
+    def __init__(self, program: str, *args: str, output_cb: Callable[[bytes, bool], bytes] | None = None,
+                 f_stdout: BinaryIO = sys.stdout.buffer, f_stderr: BinaryIO = sys.stderr.buffer) -> None:
         """Initialize the subprocess.
 
         Args:
@@ -96,31 +91,32 @@ class Subprocess(threading.Thread):
         self.output_cb = output_cb
         self.f_stdout = f_stdout
         self.f_stderr = f_stderr
-        self.output_match: Optional[re.Pattern] = None
-        self.returncode = None
+        self.output_match: re.Pattern | None = None
+        self.returncode: int | None = None
+        self.p: subprocess.Popen | None = None
 
-    def set_output_match(self, pattern: Union[str, re.Pattern]):
+    def set_output_match(self, pattern: str | re.Pattern) -> None:
         if isinstance(pattern, str):
             self.output_match = re.compile(re.escape(pattern.encode()))
         else:
             self.output_match = pattern
 
-    def _check_output(self, line: bytes, is_stderr: bool):
+    def _check_output(self, line: bytes, is_stderr: bool) -> bytes:
         if self.output_match is not None and self.output_match.search(line):
             self.event.set()
         if self.output_cb is not None:
             line = self.output_cb(line, is_stderr)
         return line
 
-    def run(self):
+    def run(self) -> None:
         """Thread entry point."""
 
         command = [self.program] + list(self.args)
 
         LOGGER.info("RUN: %s", shlex.join(command))
         self.p = None
-        forwarding_stdout_thread = None
-        forwarding_stderr_thread = None
+        forwarding_stdout_thread: threading.Thread | None = None
+        forwarding_stderr_thread: threading.Thread | None = None
         try:
             self.p = subprocess.Popen(command,
                                       stdin=subprocess.PIPE,
@@ -160,9 +156,7 @@ class Subprocess(threading.Thread):
             if forwarding_stderr_thread is not None:
                 forwarding_stderr_thread.join()
 
-    def start(self,
-              expected_output: Optional[Union[str, re.Pattern]] = None,
-              timeout: Optional[float] = None):
+    def start(self, expected_output: str | re.Pattern | None = None, timeout: float | None = None) -> None:
         """Start a subprocess and optionally wait for a specific output."""
 
         if expected_output is not None:
@@ -182,29 +176,32 @@ class Subprocess(threading.Thread):
                 raise TimeoutError("Expected output '%r' not found within %s seconds" % (expected_output, timeout))
             self.expected_output = None
 
-    def send(self, message: str, end: str = "\n",
-             expected_output: Optional[Union[str, re.Pattern]] = None,
-             timeout: float = 300):
+    def send(self, message: str, end: str = "\n", expected_output: str | re.Pattern | None = None,
+             timeout: float = 300) -> None:
         """Send a message to a process and optionally wait for a response."""
 
         if expected_output is not None:
             self.set_output_match(expected_output)
             self.event.clear()
 
+        if self.p is None:
+            raise RuntimeError(f'Process "{self.program}" has not been started yet')
+        assert self.p.stdin is not None, "Subprocess should have stdin pipe."
         self.p.stdin.write((message + end).encode())
         self.p.stdin.flush()
 
-        if expected_output is not None:
-            if self.event.wait(timeout) is False:
-                raise TimeoutError("Expected output not found")
-            self.expected_output = None
+        if expected_output is not None and not self.event.wait(timeout):
+            raise TimeoutError("Expected output not found")
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Terminate the subprocess and wait for it to finish."""
+        if self.p is None:
+            return
+
         self.p.terminate()
         self.join()
 
-    def wait(self, timeout: Optional[float] = None) -> Optional[int]:
+    def wait(self, timeout: float | None = None) -> int | None:
         """Wait for the subprocess to finish."""
         self.join(timeout)
         return self.returncode

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -211,7 +211,7 @@ class Subprocess(threading.Thread):
         LOGGER.warning("Subprocess or controller thread did not terminate within timeout. Killing the process instead")
         self.p.kill()
         self.join(self.TERMINATION_TIMEOUT_S)
-        if self.is_alive() or self.returncode is not None:
+        if self.is_alive() or self.returncode is None:
             LOGGER.warning("Failed to kill subprocess within timeout. We may be leaving a zombie process")
 
     def wait(self, timeout: float = DEFAULT_TIMEOUT_S) -> int | None:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -83,7 +83,7 @@ class Subprocess(threading.Thread):
             f_stdout: The file to forward the stdout to.
             f_stderr: The file to forward the stderr to.
         """
-        super().__init__()
+        super().__init__(daemon=True)
         self.event = threading.Event()
         self.event_started = threading.Event()
         self.program = program
@@ -127,12 +127,11 @@ class Subprocess(threading.Thread):
 
             # Forward stdout and stderr with a tag attached.
             forwarding_stdout_thread = threading.Thread(
-                target=forward_f,
-                args=(self.p.stdout, self.f_stdout, self._check_output))
+                target=forward_f, args=(self.p.stdout, self.f_stdout, self._check_output), daemon=True)
             forwarding_stdout_thread.start()
+
             forwarding_stderr_thread = threading.Thread(
-                target=forward_f,
-                args=(self.p.stderr, self.f_stderr, self._check_output, True))
+                target=forward_f, args=(self.p.stderr, self.f_stderr, self._check_output, True), daemon=True)
             forwarding_stderr_thread.start()
 
         except Exception:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -179,7 +179,7 @@ class Subprocess(threading.Thread):
             # Terminate the process, so the Python interpreter will not hang on the join call in our thread entry point in case of
             # Python process termination (not-caught exception).
             self.p.terminate()
-            raise TimeoutError(f"Expected output '{expected_output!r}' not found within {timeout} seconds")
+            raise TimeoutError(f"Expected output {expected_output!r} not found within {timeout} seconds")
 
     def send(self, message: str, end: str = "\n", expected_output: str | re.Pattern | None = None,
              timeout: float = DEFAULT_TIMEOUT_S) -> None:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -70,6 +70,9 @@ class SubprocessInfo:
 class Subprocess(threading.Thread):
     """Run a subprocess in a thread."""
 
+    DEFAULT_TIMEOUT_S: float = 300.0
+    TERMINATION_TIMEOUT_S: float = 5.0
+
     def __init__(self, program: str, *args: str, output_cb: Callable[[bytes, bool], bytes] | None = None,
                  f_stdout: BinaryIO = sys.stdout.buffer, f_stderr: BinaryIO = sys.stderr.buffer) -> None:
         """Initialize the subprocess.
@@ -150,12 +153,16 @@ class Subprocess(threading.Thread):
                 self.returncode = -1
 
             if forwarding_stdout_thread is not None:
-                forwarding_stdout_thread.join()
+                forwarding_stdout_thread.join(self.TERMINATION_TIMEOUT_S)
+                if forwarding_stdout_thread.is_alive():
+                    LOGGER.warning("Forwarding stdout thread did not finish within timeout")
 
             if forwarding_stderr_thread is not None:
-                forwarding_stderr_thread.join()
+                forwarding_stderr_thread.join(self.TERMINATION_TIMEOUT_S)
+                if forwarding_stderr_thread.is_alive():
+                    LOGGER.warning("Forwarding stderr thread did not finish within timeout")
 
-    def start(self, expected_output: str | re.Pattern | None = None, timeout: float | None = None) -> None:
+    def start(self, expected_output: str | re.Pattern | None = None, timeout: float = DEFAULT_TIMEOUT_S) -> None:
         """Start a subprocess and optionally wait for a specific output."""
 
         if expected_output is not None:
@@ -165,18 +172,17 @@ class Subprocess(threading.Thread):
         super().start()
         # Wait for the thread to start, so the self.p attribute is available.
         self.event_started.wait()
+        if self.p is None:
+            raise RuntimeError("Subprocess failed to start")
 
-        if expected_output is not None:
-            if self.event.wait(timeout) is False:
-                # Terminate the process, so the Python interpreter will not
-                # hang on the join call in our thread entry point in case of
-                # Python process termination (not-caught exception).
-                self.p.terminate()
-                raise TimeoutError("Expected output '%r' not found within %s seconds" % (expected_output, timeout))
-            self.expected_output = None
+        if expected_output is not None and not self.event.wait(timeout):
+            # Terminate the process, so the Python interpreter will not hang on the join call in our thread entry point in case of
+            # Python process termination (not-caught exception).
+            self.p.terminate()
+            raise TimeoutError("Expected output '%r' not found within %s seconds", expected_output, timeout)
 
     def send(self, message: str, end: str = "\n", expected_output: str | re.Pattern | None = None,
-             timeout: float = 300) -> None:
+             timeout: float = DEFAULT_TIMEOUT_S) -> None:
         """Send a message to a process and optionally wait for a response."""
 
         if expected_output is not None:
@@ -198,9 +204,17 @@ class Subprocess(threading.Thread):
             return
 
         self.p.terminate()
-        self.join()
+        self.join(self.TERMINATION_TIMEOUT_S)
+        if not self.is_alive() and self.p.poll() is not None:
+            return
 
-    def wait(self, timeout: float | None = None) -> int | None:
+        LOGGER.warning("Subprocess or controller thread did not terminate within timeout. Killing the process instead")
+        self.p.kill()
+        self.join(self.TERMINATION_TIMEOUT_S)
+        if self.is_alive() or self.p.poll() is None:
+            LOGGER.warning("Subprocess did not kill within timeout. We may be leaving a zombie process")
+
+    def wait(self, timeout: float = DEFAULT_TIMEOUT_S) -> int | None:
         """Wait for the subprocess to finish."""
         self.join(timeout)
         return self.returncode


### PR DESCRIPTION
#### Summary

This PR improves timeout mechanism for `Subprocess` in Python tests. Hopefully this will give more explicit error reports and less CI hangs.

- Disallow no timeout (`timeout=None`).
- Set a default timeout for `start()` and `wait()` to 300 s.
- Set a default termination timer to 5 s.
- Add logger messages in case timeout was reached.
- Make `Subprocess` threads daemonic, as they don't manage any resources, and may block Python from exiting.
- Add additional `kill()` stage for process termination.

Other changes:
- Minor typing and formatting polishing in the module.
- Remove unneeded `expected_output` field.

#### Related issues

There are hangs in CI as mentioned in #72143. One is actually happening in #72206, and with the current state it's tricky to easily debug.

#### Testing

Local run of Python tests.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
