### PR TITLE
[Support] Add CharSpanToStdString helper for safe span→std::string copies

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -263,6 +263,7 @@ static_library("support") {
     "BytesToHex.h",
     "CHIPCounter.h",
     "CHIPMemString.h",
+    "CharSpanToStdString.h",
     "CommonIterator.h",
     "CommonPersistentData.h",
     "DLLUtil.h",

--- a/src/lib/support/CharSpanToStdString.h
+++ b/src/lib/support/CharSpanToStdString.h
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <lib/support/Span.h>
+
+namespace chip {
+
+/**
+ *  @brief Convert a CharSpan to an owning std::string.
+ *
+ *  Handles a default-constructed (`data()==nullptr`, `size()==0`) span without invoking
+ *  `std::string(nullptr, 0)`, which is undefined behavior per the C++ standard. Both default
+ *  spans and spans with `size()==0` but a non-null pointer produce an empty string; non-empty
+ *  spans copy `size()` bytes verbatim.
+ *
+ *  Lives in its own header so `lib/support/Span.h` can stay free of `<string>` (it is included
+ *  by core SDK headers compiled for embedded targets where `std::string` is undesirable).
+ *  Callers that already pull `<string>` (e.g. controller / app / Darwin code) can include this
+ *  header to deduplicate the otherwise-repeated
+ *  `span.empty() ? std::string() : std::string(span.data(), span.size())` idiom.
+ */
+inline std::string CharSpanToStdString(CharSpan span)
+{
+    return span.empty() ? std::string() : std::string(span.data(), span.size());
+}
+
+} // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -42,6 +42,7 @@ chip_test_suite("tests") {
     "TestCHIPCounter.cpp",
     "TestCHIPMem.cpp",
     "TestCHIPMemString.cpp",
+    "TestCharSpanToStdString.cpp",
     "TestDefer.cpp",
     "TestErrorStr.cpp",
     "TestFixedBuffer.cpp",

--- a/src/lib/support/tests/TestCharSpanToStdString.cpp
+++ b/src/lib/support/tests/TestCharSpanToStdString.cpp
@@ -74,8 +74,8 @@ TEST(TestCharSpanToStdString, ResultIsIndependentOfSourceSpan)
 {
     // The helper returns an owning std::string. Mutating the source buffer or letting it go
     // out of scope must not affect the returned string.
-    char buf[] = "original";
+    char buf[]         = "original";
     std::string result = CharSpanToStdString(CharSpan(buf, sizeof(buf) - 1));
-    buf[0] = 'X'; // modify source after copy
+    buf[0]             = 'X'; // modify source after copy
     EXPECT_EQ(result, "original");
 }

--- a/src/lib/support/tests/TestCharSpanToStdString.cpp
+++ b/src/lib/support/tests/TestCharSpanToStdString.cpp
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <cstring>
+#include <string>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/CharSpanToStdString.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
+
+TEST(TestCharSpanToStdString, EmptyDefaultSpanProducesEmptyString)
+{
+    // Default-constructed CharSpan has data()==nullptr, size()==0. The naive
+    // std::string(span.data(), span.size()) on this is undefined behavior; the helper must
+    // return an empty std::string instead.
+    CharSpan defaultSpan{};
+    std::string result = CharSpanToStdString(defaultSpan);
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(result.size(), 0u);
+}
+
+TEST(TestCharSpanToStdString, EmptyNonNullSpanProducesEmptyString)
+{
+    // A CharSpan with a non-null pointer but size()==0 is also valid input; the helper
+    // returns an empty string in that case too (the size==0 short-circuit applies regardless
+    // of pointer-nullness).
+    const char buf[] = "ignored";
+    CharSpan empty(buf, 0);
+    std::string result = CharSpanToStdString(empty);
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(result.size(), 0u);
+}
+
+TEST(TestCharSpanToStdString, NonEmptySpanIsCopiedVerbatim)
+{
+    const char source[] = "device-supplied-debug";
+    CharSpan span(source, sizeof(source) - 1);
+    std::string result = CharSpanToStdString(span);
+    EXPECT_EQ(result, source);
+    EXPECT_EQ(result.size(), sizeof(source) - 1);
+}
+
+TEST(TestCharSpanToStdString, EmbeddedNulIsPreserved)
+{
+    // CharSpan is byte-counted, not nul-terminated. The helper must copy the full size,
+    // including any embedded nul bytes, rather than treating them as terminators.
+    const char source[] = { 'a', 'b', '\0', 'c', 'd' };
+    CharSpan span(source, sizeof(source));
+    std::string result = CharSpanToStdString(span);
+    EXPECT_EQ(result.size(), sizeof(source));
+    EXPECT_EQ(std::memcmp(result.data(), source, sizeof(source)), 0);
+}
+
+TEST(TestCharSpanToStdString, ResultIsIndependentOfSourceSpan)
+{
+    // The helper returns an owning std::string. Mutating the source buffer or letting it go
+    // out of scope must not affect the returned string.
+    char buf[] = "original";
+    std::string result = CharSpanToStdString(CharSpan(buf, sizeof(buf) - 1));
+    buf[0] = 'X'; // modify source after copy
+    EXPECT_EQ(result, "original");
+}


### PR DESCRIPTION
The repo has 10+ sites copying a `CharSpan` into a `std::string` with the inline pattern `std::string(span.data(), span.size())`. On a default-constructed span (`data()==nullptr`, `size()==0`) that pattern is technically undefined behavior — `std::string(nullptr, 0)` is unspecified per the C++ standard, even though libc++/libstdc++ happen to handle it in practice.

This adds `chip::CharSpanToStdString` in a new `lib/support/CharSpanToStdString.h`:

```cpp
inline std::string CharSpanToStdString(CharSpan span)
{
    return span.empty() ? std::string() : std::string(span.data(), span.size());
}
```

### Why a new header

The helper needs `<string>`, but `lib/support/Span.h` is currently `<string>`-free and is pulled in by core SDK headers compiled for embedded targets where `std::string` is undesirable. Adding `<string>` to `Span.h` would propagate the include unconditionally. A small dedicated header lets callers that already pull `<string>` (controller, app, Darwin) opt in.

### Scope

This PR only adds the helper and unit tests. Existing call sites that match the pattern can be migrated incrementally in follow-up PRs as their files are touched. Suggested by @bzbarsky-apple as a follow-up to #72228.

### Testing

`src/lib/support/tests/TestCharSpanToStdString.cpp`:

- `EmptyDefaultSpanProducesEmptyString` — default-constructed `CharSpan` (`data()==nullptr`) returns an empty `std::string` without invoking `std::string(nullptr, 0)`.
- `EmptyNonNullSpanProducesEmptyString` — non-null pointer with `size()==0` also produces an empty string.
- `NonEmptySpanIsCopiedVerbatim` — full-content span copy.
- `EmbeddedNulIsPreserved` — byte-counted copy preserves embedded `\0`.
- `ResultIsIndependentOfSourceSpan` — confirms the result is owning, not a view.
