### PR TITLE
[Feature] Use chip-tool fabrics for python tests

### DIFF
--- a/src/controller/python/matter/CertificateAuthority.py
+++ b/src/controller/python/matter/CertificateAuthority.py
@@ -155,7 +155,6 @@ class CertificateAuthority:
                 # If we're here, it's likely because we're loading .ini files
                 caList[str(self._caIndex)] = replFabricEntry
             elif (replFabricEntry not in caList[str(self._caIndex)]):
-                LOGGER.warning(self._caIndex)
                 caList[str(self._caIndex)].append(replFabricEntry)
 
             self._persistentStorage.SetKey(key='caList', value=caList)

--- a/src/controller/python/matter/CertificateAuthority.py
+++ b/src/controller/python/matter/CertificateAuthority.py
@@ -151,7 +151,11 @@ class CertificateAuthority:
         if (caList is not None):
             replFabricEntry = {'fabricId': fabricId, 'vendorId': vendorId}
 
-            if (replFabricEntry not in caList[str(self._caIndex)]):
+            if (caList[str(self._caIndex)] == {}):
+                # If we're here, it's likely because we're loading .ini files
+                caList[str(self._caIndex)] = replFabricEntry
+            elif (replFabricEntry not in caList[str(self._caIndex)]):
+                LOGGER.warning(self._caIndex)
                 caList[str(self._caIndex)].append(replFabricEntry)
 
             self._persistentStorage.SetKey(key='caList', value=caList)

--- a/src/controller/python/matter/storage/__init__.py
+++ b/src/controller/python/matter/storage/__init__.py
@@ -317,6 +317,26 @@ class PersistentStorageINI(PersistentStorageBase):
     This persistent storage is compatible with the chip-tool implementation.
     """
 
+    def _caKeysWithNocaListRewrite(self, data: dict, sdkData: dict):
+        """Creates a caList entry if the keys are present
+
+        This typically occurs when chip-tool is used to commission the device.
+        """
+        caKeys = set()
+        for key in sdkData:
+            if match := _caKeyMatch.fullmatch(key):
+                caKeys.add(int(match.group(2)))
+
+        caListRewritten = data.get('caList', {})
+        if caKeys:
+            for key in caKeys:
+                if key not in caListRewritten:
+                    LOGGER.warning("Keys detected for index %d, creating empty caList entry", key)
+                    caListRewritten[str(key)] = {}
+
+        data['caList'] = caListRewritten
+        return data, sdkData
+
     class ConfigParser(ConfigParser):
         """Parser that preserves key case and does not use interpolation."""
 
@@ -357,6 +377,7 @@ class PersistentStorageINI(PersistentStorageBase):
                 config.read(chipToolFabricStoragePath)
                 for key, value in config.items('Default'):
                     sdkData[key] = value
+            data, sdkData = self._caKeysWithNocaListRewrite(data, sdkData)
         except Exception as ex:
             LOGGER.critical("Could not load configuration from INI file: %s", ex)
         super().__init__(data, sdkData)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -49,14 +49,15 @@ class MatterStackState:
         if not hasattr(builtins, "chipStack"):
             matter.native.Init(bluetoothAdapter=config.ble_controller)
             if config.chip_tool_common_storage_path is not None and config.chip_tool_fabric_storage_path is not None:
-                persistent_storage=PersistentStorageINI(config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path)
+                persistent_storage = PersistentStorageINI(
+                    config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path)
             else:
-                persistent_storage=PersistentStorageJSON(config.storage_path)
+                persistent_storage = PersistentStorageJSON(config.storage_path)
             self._we_initialized_the_stack = True
         else:
             self._we_initialized_the_stack = False
 
-        self._init_stack(already_initialized = not self._we_initialized_the_stack, persistent_storage=persistent_storage)
+        self._init_stack(already_initialized=not self._we_initialized_the_stack, persistent_storage=persistent_storage)
 
     def _init_stack(self, already_initialized: bool, persistent_storage: PersistentStorage | None = None):
         if already_initialized:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 import matter
 from matter.ChipStack import ChipStack
-from matter.storage import PersistentStorage, PersistentStorageJSON
+from matter.storage import PersistentStorage, PersistentStorageINI, PersistentStorageJSON
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -47,9 +47,14 @@ class MatterStackState:
 
         if not hasattr(builtins, "chipStack"):
             matter.native.Init(bluetoothAdapter=config.ble_controller)
-            if config.storage_path is None:
-                raise ValueError("Must have configured a MatterTestConfig.storage_path")
-            self._init_stack(already_initialized=False, persistentStorage=PersistentStorageJSON(config.storage_path))
+            if config.chip_tool_common_storage_path is not None and config.chip_tool_fabric_storage_path is not None:
+                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageINI(
+                    config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path))
+            elif config.storage_path is not None:
+                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageJSON(config.storage_path))
+            else:
+                raise ValueError(
+                    "Must have configured either a MatterTestConfig.storage_path or MatterTestConfig.chip_tool_common/fabric_storage_path")
             self._we_initialized_the_stack = True
         else:
             self._init_stack(already_initialized=True)
@@ -60,7 +65,7 @@ class MatterStackState:
             self._chip_stack = builtins.chipStack
             LOGGER.warning(
                 "Re-using existing ChipStack object found in current interpreter: "
-                "storage path %s will be ignored!", self._config.storage_path
+                "specified storage will be ignored!"
             )
             # TODO: Warn that storage will not follow what we set in config
         else:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -48,16 +48,16 @@ class MatterStackState:
         if not hasattr(builtins, "chipStack"):
             matter.native.Init(bluetoothAdapter=config.ble_controller)
             if config.chip_tool_common_storage_path is not None and config.chip_tool_fabric_storage_path is not None:
-                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageINI(
+                self._init_stack(already_initialized=False, persistent_storage=PersistentStorageINI(
                     config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path))
             else:
-                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageJSON(config.storage_path))
+                self._init_stack(already_initialized=False, persistent_storage=PersistentStorageJSON(config.storage_path))
             self._we_initialized_the_stack = True
         else:
             self._init_stack(already_initialized=True)
             self._we_initialized_the_stack = False
 
-    def _init_stack(self, already_initialized: bool, **kwargs):
+    def _init_stack(self, already_initialized: bool, persistent_storage: PersistentStorage | None = None):
         if already_initialized:
             self._chip_stack = builtins.chipStack
             LOGGER.warning(
@@ -65,8 +65,8 @@ class MatterStackState:
                 "specified storage will be ignored!"
             )
             # TODO: Warn that storage will not follow what we set in config
-        else:
-            self._chip_stack = ChipStack(**kwargs)
+        elif persistent_storage:
+            self._chip_stack = ChipStack(persistent_storage)
             builtins.chipStack = self._chip_stack
 
         matter.logging.RedirectToPythonLogging()
@@ -78,7 +78,7 @@ class MatterStackState:
         if (len(self._certificate_authority_manager.activeCaList) == 0):
             LOGGER.warning(
                 "Didn't find any CertificateAuthorities in storage -- creating a new CertificateAuthority + FabricAdmin...")
-            ca = self._certificate_authority_manager.NewCertificateAuthority()
+            ca = self._certificate_authority_manager.NewCertificateAuthority(caIndex=self._config.root_of_trust_index)
             ca.maximizeCertChains = self._config.maximize_cert_chains
             ca.certificateValidityPeriodSec = self._config.certificate_validity_period
             ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=self._config.fabric_id)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -78,7 +78,7 @@ class MatterStackState:
         if (len(self._certificate_authority_manager.activeCaList) == 0):
             LOGGER.warning(
                 "Didn't find any CertificateAuthorities in storage -- creating a new CertificateAuthority + FabricAdmin...")
-            ca = self._certificate_authority_manager.NewCertificateAuthority(caIndex=self._config.root_of_trust_index)
+            ca = self._certificate_authority_manager.NewCertificateAuthority()
             ca.maximizeCertChains = self._config.maximize_cert_chains
             ca.certificateValidityPeriodSec = self._config.certificate_validity_period
             ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=self._config.fabric_id)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -45,17 +45,18 @@ class MatterStackState:
     def __init__(self, config: 'MatterTestConfig'):
         self._config = config
 
+        persistent_storage = None
         if not hasattr(builtins, "chipStack"):
             matter.native.Init(bluetoothAdapter=config.ble_controller)
             if config.chip_tool_common_storage_path is not None and config.chip_tool_fabric_storage_path is not None:
-                self._init_stack(already_initialized=False, persistent_storage=PersistentStorageINI(
-                    config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path))
+                persistent_storage=PersistentStorageINI(config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path)
             else:
-                self._init_stack(already_initialized=False, persistent_storage=PersistentStorageJSON(config.storage_path))
+                persistent_storage=PersistentStorageJSON(config.storage_path)
             self._we_initialized_the_stack = True
         else:
-            self._init_stack(already_initialized=True)
             self._we_initialized_the_stack = False
+
+        self._init_stack(already_initialized = not self._we_initialized_the_stack, persistent_storage=persistent_storage)
 
     def _init_stack(self, already_initialized: bool, persistent_storage: PersistentStorage | None = None):
         if already_initialized:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_stack_state.py
@@ -50,11 +50,8 @@ class MatterStackState:
             if config.chip_tool_common_storage_path is not None and config.chip_tool_fabric_storage_path is not None:
                 self._init_stack(already_initialized=False, persistentStorage=PersistentStorageINI(
                     config.chip_tool_common_storage_path, config.chip_tool_fabric_storage_path))
-            elif config.storage_path is not None:
-                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageJSON(config.storage_path))
             else:
-                raise ValueError(
-                    "Must have configured either a MatterTestConfig.storage_path or MatterTestConfig.chip_tool_common/fabric_storage_path")
+                self._init_stack(already_initialized=False, persistentStorage=PersistentStorageJSON(config.storage_path))
             self._we_initialized_the_stack = True
         else:
             self._init_stack(already_initialized=True)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
@@ -24,9 +24,9 @@ from matter.testing.defaults import TestingDefaults
 
 @dataclass
 class MatterTestConfig:
-    storage_path: Optional[pathlib.Path] = pathlib.Path(".")
-    chip_tool_common_storage_path: Optional[pathlib.Path] = None
-    chip_tool_fabric_storage_path: Optional[pathlib.Path] = None
+    storage_path: pathlib.Path | None = pathlib.Path(".")
+    chip_tool_common_storage_path: pathlib.Path | None = None
+    chip_tool_fabric_storage_path: pathlib.Path | None = None
     logs_path: pathlib.Path = pathlib.Path(".")
     paa_trust_store_path: pathlib.Path | None = None
     ble_controller: int | None = None

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
@@ -24,7 +24,9 @@ from matter.testing.defaults import TestingDefaults
 
 @dataclass
 class MatterTestConfig:
-    storage_path: pathlib.Path = pathlib.Path(".")
+    storage_path: Optional[pathlib.Path] = None
+    chip_tool_common_storage_path: Optional[pathlib.Path] = None
+    chip_tool_fabric_storage_path: Optional[pathlib.Path] = None
     logs_path: pathlib.Path = pathlib.Path(".")
     paa_trust_store_path: pathlib.Path | None = None
     ble_controller: int | None = None

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
@@ -24,7 +24,7 @@ from matter.testing.defaults import TestingDefaults
 
 @dataclass
 class MatterTestConfig:
-    storage_path: Optional[pathlib.Path] = None
+    storage_path: Optional[pathlib.Path] = pathlib.Path(".")
     chip_tool_common_storage_path: Optional[pathlib.Path] = None
     chip_tool_fabric_storage_path: Optional[pathlib.Path] = None
     logs_path: pathlib.Path = pathlib.Path(".")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -781,6 +781,9 @@ def convert_args_to_matter_config(args: argparse.Namespace):
         if not (args.chip_tool_common_storage_path and args.chip_tool_fabric_storage_path):
             LOGGER.error("Error: One must specify both chip-tool common and chip-tool fabric storage paths")
             sys.exit(1)
+        elif args.storage_path is not None:
+            LOGGER.error("Error: Cannot specify both --storage-path and chip-tool storage paths")
+            sys.exit(1)
         else:
             config.chip_tool_common_storage_path = pathlib.Path(args.chip_tool_common_storage_path)
             config.chip_tool_fabric_storage_path = pathlib.Path(args.chip_tool_fabric_storage_path)
@@ -968,10 +971,10 @@ def matter_test_args_parser() -> argparse.ArgumentParser:
     basic_group.add_argument('--storage-path', action="store", type=pathlib.Path,
                              metavar="PATH", help="Location for persisted storage of instance")
     basic_group.add_argument(
-        "--chip-tool-common-storage-path", metavar="PATH",
+        "--chip-tool-common-storage-path", metavar="PATH", action="store", type=pathlib.Path,
         help="path to chip-tool common persistent storage configuration file (INI format)")
     basic_group.add_argument(
-        "--chip-tool-fabric-storage-path", metavar="PATH",
+        "--chip-tool-fabric-storage-path", metavar="PATH", action="store", type=pathlib.Path,
         help="path to chip-tool fabric persistent storage configuration file (INI format)")
     basic_group.add_argument('--logs-path', action="store", type=pathlib.Path, metavar="PATH", help="Location for test logs")
     paa_path_default = get_default_paa_trust_store(pathlib.Path.cwd())

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -777,7 +777,16 @@ def convert_args_to_matter_config(args: argparse.Namespace):
     if not populate_commissioning_args(args, config):
         sys.exit(1)
 
-    config.storage_path = pathlib.Path(TestingDefaults.STORAGE_PATH) if args.storage_path is None else args.storage_path
+    if args.chip_tool_common_storage_path or args.chip_tool_fabric_storage_path:
+        if not (args.chip_tool_common_storage_path and args.chip_tool_fabric_storage_path):
+            LOGGER.error("Error: One must specify both chip-tool common and chip-tool fabric storage paths")
+            sys.exit(1)
+        else:
+            config.chip_tool_common_storage_path = pathlib.Path(args.chip_tool_common_storage_path)
+            config.chip_tool_fabric_storage_path = pathlib.Path(args.chip_tool_fabric_storage_path)
+    else:
+        config.storage_path = pathlib.Path(
+            TestingDefaults.STORAGE_PATH) if args.storage_path is None else pathlib.Path(args.storage_path)
     config.logs_path = pathlib.Path(TestingDefaults.LOG_PATH) if args.logs_path is None else args.logs_path
     config.paa_trust_store_path = args.paa_trust_store_path
     config.ble_controller = args.ble_controller
@@ -958,6 +967,12 @@ def matter_test_args_parser() -> argparse.ArgumentParser:
                              help="Where to trace (e.g perfetto, perfetto:path, json:log, json:path)")
     basic_group.add_argument('--storage-path', action="store", type=pathlib.Path,
                              metavar="PATH", help="Location for persisted storage of instance")
+    basic_group.add_argument(
+        "--chip-tool-common-storage-path", metavar="PATH",
+        help="path to chip-tool common persistent storage configuration file (INI format)")
+    basic_group.add_argument(
+        "--chip-tool-fabric-storage-path", metavar="PATH",
+        help="path to chip-tool fabric persistent storage configuration file (INI format)")
     basic_group.add_argument('--logs-path', action="store", type=pathlib.Path, metavar="PATH", help="Location for test logs")
     paa_path_default = get_default_paa_trust_store(pathlib.Path.cwd())
     basic_group.add_argument('--paa-trust-store-path', action="store", type=pathlib.Path, metavar="PATH", default=paa_path_default,

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -781,15 +781,13 @@ def convert_args_to_matter_config(args: argparse.Namespace):
         if not (args.chip_tool_common_storage_path and args.chip_tool_fabric_storage_path):
             LOGGER.error("Error: One must specify both chip-tool common and chip-tool fabric storage paths")
             sys.exit(1)
-        elif args.storage_path is not None:
+        if args.storage_path is not None:
             LOGGER.error("Error: Cannot specify both --storage-path and chip-tool storage paths")
             sys.exit(1)
-        else:
-            config.chip_tool_common_storage_path = pathlib.Path(args.chip_tool_common_storage_path)
-            config.chip_tool_fabric_storage_path = pathlib.Path(args.chip_tool_fabric_storage_path)
+        config.chip_tool_common_storage_path = pathlib.Path(args.chip_tool_common_storage_path)
+        config.chip_tool_fabric_storage_path = pathlib.Path(args.chip_tool_fabric_storage_path)
     else:
-        config.storage_path = pathlib.Path(
-            TestingDefaults.STORAGE_PATH) if args.storage_path is None else pathlib.Path(args.storage_path)
+        config.storage_path = pathlib.Path(args.storage_path or TestingDefaults.STORAGE_PATH)
     config.logs_path = pathlib.Path(TestingDefaults.LOG_PATH) if args.logs_path is None else args.logs_path
     config.paa_trust_store_path = args.paa_trust_store_path
     config.ble_controller = args.ble_controller


### PR DESCRIPTION
#### Summary

Allows python tests to use fabrics generated by chip-tool via the `chip_tool_config.ini` and `chip_tool_config.[example CA].ini` storage files, as opposed to the `.json` files created/used by the python framework. This builds on work done here: https://github.com/project-chip/connectedhomeip/pull/40588 that allowed the python REPL to use the same storage files.

Adds two new arguments to base python tests:

```
  --chip-tool-common-storage-path PATH
                        path to chip-tool common persistent storage configuration file (INI format)
  --chip-tool-fabric-storage-path PATH
                        path to chip-tool fabric persistent storage configuration file (INI format)
```

Example usage:

First, commission a device using the chip-tool:

Start device:
```
./out/linux-x64-all-clusters-no-ble-clang-boringssl/chip-all-clusters-app --KVS kvs1 --discriminator 1234
```

In a separate shell:
```
./out/linux-x64-chip-tool/chip-tool pairing onnetwork 0x12344321 20202021
```

**Note**

Just commissioning the device is not sufficient to fully populate the two `.ini` files for loading by python tests. It is recommended to run a YAML test against the device, after which the `chip_tool_config.ini` will contain the necessary caList section:

```
[REPL]
caList = {"0":[{"fabricId":1,"vendorId":65521}]}
```

Example of running a YAML test:
```
./scripts/tests/chipyaml/chiptool.py tests TestOperationalState --server_path ./out/linux-x64-chip-tool/chip-tool
```

After these steps, you can then run a python test on the same fabric on which you previously commissioned the device.

Example:
```
python3 src/python_testing/TC_ACE_1_2.py --chip-tool-common-storage-path /tmp/chip_tool_config.ini --chip-tool-fabric-storage-path /tmp/chip_tool_config.alpha.ini
```

#### Testing

The above steps were used to verify the behavior. Python tests _without_ the new arguments were used to verify a lack of regressions.
