### PR TITLE
[Silabs] Bugfix: Series3 default credentials address.

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -47,6 +47,9 @@ extern void setNvm3End(uint32_t addr);
 #endif
 
 extern uint8_t linker_nvm_end[];
+#ifdef _SILICON_LABS_32B_SERIES_3
+extern uint8_t linker_static_secure_tokens_begin; // Defined by the linker script
+#endif
 
 using namespace chip::Credentials;
 using namespace chip::DeviceLayer::Internal;
@@ -164,6 +167,10 @@ CHIP_ERROR Storage::Initialize(uint32_t flash_addr, uint32_t flash_size)
 #ifndef SLI_SI91X_MCU_INTERFACE
         base_addr = (flash_addr + flash_size - FLASH_PAGE_SIZE);
 #endif // SLI_SI91X_MCU_INTERFACE
+#ifdef _SILICON_LABS_32B_SERIES_3
+        uint32_t tokenStartAddr = reinterpret_cast<uint32_t>(&linker_static_secure_tokens_begin);
+        base_addr               = tokenStartAddr + FLASH_PAGE_SIZE;
+#endif
         TEMPORARY_RETURN_IGNORED chip::DeviceLayer::Silabs::GetPlatform().FlashInit();
 #ifdef SL_PROVISION_GENERATOR
         setNvm3End(base_addr);


### PR DESCRIPTION
#### Summary

In Series3, the secure tokens are stored at the beginning of the last page of flash, corrupting the Matter credentials, which are stored in the location.
A [migration function exist ](https://github.com/SiliconLabsSoftware/matter_sdk/blob/e7f323dac29792c8889d38e1cc5d296aefd77b5a/src/platform/silabs/MigrationManager.cpp#L180)to move existing credentials to avoid the conflict. However, the migration is run only once, when the devices runs for the first time. If the first run is executed before provisioning, the certificates are not moved, and become corrupted.
This fix sets the default credentials address to the location set by the migration manager, so the migration is no longer needed in new devices.

#### Related issues

[MATTER-5847](https://jira.silabs.com/browse/MATTER-5847)

#### Testing

Tested on BRD4408A (Six301):
* Device erased
* Matter app flashed (one-time migration runs, no credentials to move)
* Device provisioned (custom discriminator, new address is used)
* Matter app flashed again (certificates not moved)
* Device provisioned successfully (using custom discriminator)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
