### PR TITLE
[Tooling]: generate.py: Create Rename Destination Directory before Renaming

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -403,10 +403,11 @@ def main():
             srcDir = f'{cmdLineArgs.outputDir}/{src}'
             if not os.path.exists(srcDir):
                 continue
-            print(f"Moving files from {srcDir} INTO {cmdLineArgs.outputDir}/{dest}")
-            # move all files
+            destDir = os.path.join(cmdLineArgs.outputDir, dest)
+            os.makedirs(destDir, exist_ok=True)
+            print(f"Moving files from {srcDir} INTO {destDir}")
             for name in glob.glob(f'{srcDir}/*'):
-                os.rename(name, f'{cmdLineArgs.outputDir}/{dest}/{os.path.basename(name)}')
+                os.replace(name, os.path.join(destDir, os.path.basename(name)))
             os.rmdir(srcDir)
 
     if cmdLineArgs.prettify_output:


### PR DESCRIPTION
#### Summary

Fixes #72263.

The _Pm2.5_ to _Pm25_ post-processing rename in `scripts/tools/zap/generate.py` (workaround for project-chip/zap#1569) fails with `FileNotFoundError` on the first invocation against a clean output tree because `os.rename(src, dst)` requires the destination's parent directory to exist. This change creates that directory before entering the rename loop.

##### Change

A three-line change: hoist `f'{cmdLineArgs.outputDir}/{dest}'` into a `destDir` local, call `os.makedirs(destDir, exist_ok=True)` before the loop, and reuse the local in the print statement and rename target.

##### Backtrace before Fix

```
Moving files from ${BuildRoot}/results/arm/gnu-toolchain/12.3.1/release/matter/zap-generated/common/../../clusters/Pm2.5ConcentrationMeasurement INTO ${BuildRoot}/results/arm/gnu-toolchain/12.3.1/release/matter/zap-generated/common/../../clusters/Pm25ConcentrationMeasurement
Traceback (most recent call last):
  File "${BuildRoot}/third_party/matter/repo/scripts/tools/zap/generate.py", line 431, in <module>
    main()
  File "${BuildRoot}/third_party/matter/repo/scripts/tools/zap/generate.py", line 413, in main
    os.rename(name, f'{cmdLineArgs.outputDir}/{dest}/{os.path.basename(name)}')
FileNotFoundError: [Errno 2] No such file or directory: '${BuildRoot}/results/arm/gnu-toolchain/12.3.1/release/matter/zap-generated/common/../../clusters/Pm2.5ConcentrationMeasurement/EnumsCheck.h' -> '${BuildRoot}/results/arm/gnu-toolchain/12.3.1/release/matter/zap-generated/common/../../clusters/Pm25ConcentrationMeasurement/EnumsCheck.h'
make: *** [Makefile:358: .build/Makefile/arm/gnu-toolchain/12.3.1/release/.matter-zap-common-gen.stamp] Error 1
Moving files from .../matter/zap-generated/common/../../clusters/Pm2.5ConcentrationMeasurement INTO .../matter/zap-generated/common/../../clusters/Pm25ConcentrationMeasurement
Traceback (most recent call last):
File ".../scripts/tools/zap/generate.py", line 431, in <module>
main()
File ".../scripts/tools/zap/generate.py", line 413, in main
os.rename(name, f'{cmdLineArgs.outputDir}/{dest}/{os.path.basename(name)}')
FileNotFoundError: [Errno 2] No such file or directory: '.../Pm2.5ConcentrationMeasurement/EnumsCheck.h' -> '.../Pm25ConcentrationMeasurement/EnumsCheck.h'
make: *** [Makefile:358: ....matter-zap-common-gen.stamp] Error 1
```

##### Behavior after Fix

First invocation against a clean output tree succeeds. Subsequent invocations are unaffected (idempotent via `exist_ok=True`). No change to upstream `zap` behavior or to any generated artifact's contents: only the post-processing rename now reaches a clean exit.

#### Related issues

Fixes: #72263 
Relate: project-chip/zap#1569

#### Testing

Local rebuild on a clean output tree:

* **Before:** `make` fails at the `templates.json` invocation as shown in the backtrace above.
* **After:** both `app-templates.json` and `templates.json` `zap-cli` invocations complete; the `clusters/Pm25ConcentrationMeasurement/` directory is populated as expected and the `clusters/Pm2.5ConcentrationMeasurement/` directory is correctly removed by the existing `os.rmdir(srcDir)` at the end of the loop.