### PR TITLE
NetworkCommissioning failure status (NetworkIDNotFound, AuthFailure, etc.) collapses to opaque generic NSError on Darwin, losing context for client UI

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -25,6 +25,8 @@
 #include <lib/support/BitMask.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <string>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class MTRDeviceController;
@@ -46,6 +48,8 @@ public:
     void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
 
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+    void OnCommissioningSuccess(chip::PeerId peerId) override;
+    void OnCommissioningFailure(chip::PeerId peerId, const chip::Controller::CompletionStatus & completionStatus) override;
     void OnCommissioningStatusUpdate(chip::PeerId peerId, chip::Controller::CommissioningStage stageCompleted, CHIP_ERROR error) override;
     void OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) override;
 
@@ -77,7 +81,61 @@ private:
 
     MTRCommissioningParameters * mCommissioningParameters;
 
+    // OnCommissioningComplete records the (nodeId, error) tuple here and returns
+    // without notifying the delegate. The subsequent OnCommissioningSuccess /
+    // OnCommissioningFailure call (which always runs synchronously after
+    // OnCommissioningComplete on the same Matter work queue thread, see
+    // src/controller/CHIPDeviceController.cpp around DeviceCommissioner::OnDone)
+    // then performs the dispatch_async with every input captured by value,
+    // including the device-reported NetworkCommissioning status from
+    // CompletionStatus when available. This data-flow design intentionally
+    // avoids a cross-queue race on a stash that would otherwise have to be
+    // read on the delegate queue while being written on the work queue.
+    bool mHasPendingCommissioningComplete = false;
+    chip::NodeId mPendingCommissioningCompleteNodeId = chip::kUndefinedNodeId;
+    CHIP_ERROR mPendingCommissioningCompleteError = CHIP_NO_ERROR;
+    // NetworkCommissioning status carried with the pending record. Set by
+    // OnCommissioningFailure when the upstream CompletionStatus carries one;
+    // cleared to NullOptional by OnCommissioningComplete (initial stash) and
+    // again by DispatchPendingCommissioningComplete after dispatch. Storing
+    // it here (rather than passing it as a parameter to the dispatcher)
+    // ensures every flush path -- setDelegate-rebind, defensive
+    // double-OnCommissioningComplete drain, and the normal Success/Failure
+    // path -- forwards the same status to the delegate.
+    //
+    // Note on rebind/double-Complete flush paths: the value is NullOptional in
+    // those cases (OnCommissioningComplete always clears this field before
+    // OnCommissioningFailure sets it, and the C++ SDK fires the two calls
+    // synchronously, so no real NC status can survive into a rebind-flush).
+    // A non-null value is only stashed by OnCommissioningFailure after
+    // OnCommissioningComplete sets the pending record.
+    chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> mPendingNetworkCommissioningStatus;
+    // Optional driver-level errorValue from a NetworkCommissioning
+    // ConnectNetworkResponse, stashed alongside mPendingNetworkCommissioningStatus
+    // by OnCommissioningFailure and read by DispatchPendingCommissioningComplete.
+    chip::Optional<int32_t> mPendingNetworkCommissioningConnectErrorValue;
+    // Owned copy of the device-supplied debugText from a NetworkCommissioning
+    // NetworkConfigResponse / ConnectNetworkResponse. Empty when no debugText
+    // was reported.
+    std::string mPendingNetworkCommissioningDebugText;
+    // Idempotence flag set by DispatchPendingCommissioningComplete after a
+    // successful dispatch and cleared by OnCommissioningComplete on the next
+    // attempt. Guards against double-fires when OnStatusUpdate's PASE-fail
+    // synthesizer and a subsequent upstream Success/Failure both attempt to
+    // drain the pending record for a single commissioning attempt.
+    bool mDispatchedCommissioningCompleteForCurrentAttempt = false;
+
     MTRCommissioningStatus MapStatus(chip::Controller::DevicePairingDelegate::Status status);
+
+    // Helper invoked from OnCommissioningSuccess / OnCommissioningFailure once
+    // the full picture (error + optional NetworkCommissioning status) is known.
+    // Consumes any pending commissioning-complete record set by
+    // OnCommissioningComplete and dispatches the delegate callbacks on mQueue.
+    // Reads mPendingNetworkCommissioningStatus rather than taking a parameter,
+    // so flush paths that did not observe the upstream Failure callback (e.g.
+    // setDelegate rebind, defensive double-Complete) still forward whatever
+    // status was previously stashed.
+    void DispatchPendingCommissioningComplete();
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -33,6 +33,7 @@
 #import "zap-generated/MTRCommandPayloads_Private.h"
 
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/TypeTraits.h>
 
 using namespace chip::Tracing::DarwinFramework;
 
@@ -46,6 +47,19 @@ MTRDeviceControllerDelegateBridge::~MTRDeviceControllerDelegateBridge(void) {}
 void MTRDeviceControllerDelegateBridge::setDelegate(
     MTRDeviceController * controller, id<MTRDeviceControllerDelegate> delegate, dispatch_queue_t queue)
 {
+    // If a prior commissioning attempt has a pending record (OnCommissioningComplete
+    // fired but the paired OnCommissioningSuccess / OnCommissioningFailure has
+    // not yet drained it), flush it to the *currently bound* delegate before
+    // we swap in the new binding. This preserves pre-PR semantics where the
+    // delegate that observed OnCommissioningComplete was the one notified.
+    // Without this flush, a rebind-without-unbind sequence would either
+    // silently drop the callback or, worse, re-target it at the new delegate.
+    // Safe on the work queue: setDelegate is invoked from _chipWorkQueue, the
+    // same thread as OnCommissioning* callbacks.
+    if (mHasPendingCommissioningComplete) {
+        DispatchPendingCommissioningComplete();
+    }
+
     if (delegate && queue) {
         mController = controller;
         mDelegate = delegate;
@@ -93,12 +107,27 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
             });
         }
 
-        // If PASE session setup fails and the client implements the delegate that accepts metrics, invoke the delegate
-        // to mark end of commissioning request.
-        // Since OnPairingComplete(failure_code) might not be invoked in all cases, use this opportunity to inform of failed commissioning
-        // and default the error to timeout since that is best guess in this layer.
-        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed && [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+        // If PASE session setup fails and the client implements any of the
+        // commissioning-complete delegate variants, invoke the delegate to mark
+        // end of commissioning request. Since OnPairingComplete(failure_code)
+        // might not be invoked in all cases, use this opportunity to inform of
+        // failed commissioning and default the error to timeout since that is
+        // best guess in this layer.
+        // The selector guard intentionally mirrors every selector that
+        // DispatchPendingCommissioningComplete dispatches to (4-arg metrics,
+        // 3-arg nodeID, deprecated 1-arg) so PASE failures synthesize a
+        // delegate notification regardless of which variant the client adopts.
+        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed
+            && ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]
+                || [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)]
+                || [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:)])) {
             OnCommissioningComplete(mDeviceNodeId, CHIP_ERROR_TIMEOUT);
+            // OnCommissioningComplete now defers the delegate dispatch until a
+            // subsequent OnCommissioningSuccess/Failure callback. The PASE-fail
+            // path does not produce one upstream, so synthesize an empty
+            // CompletionStatus here to flush the pending record through to the
+            // delegate; otherwise PASE failures would never reach the client.
+            OnCommissioningFailure(chip::PeerId(), chip::Controller::CompletionStatus());
         }
     }
 }
@@ -186,38 +215,156 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
     MTR_LOG("%@ DeviceControllerDelegate Commissioning complete. NodeId 0x%016llx Status %s", strongController, nodeId, chip::ErrorStr(error));
     MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, error);
 
-    id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue && strongController) {
+    // Defensive: if a prior commissioning attempt left a pending record (e.g.
+    // because upstream skipped the OnCommissioningSuccess/Failure callback in
+    // some error path), flush it through to its delegate before we overwrite
+    // the slot with this attempt's state. Silently dropping the prior record
+    // would leave the previous attempt's delegate callback unfired, wedging
+    // any commissioning UI waiting on it, and would also skip the metrics
+    // snapshot for that attempt -- violating the "every OnCommissioningComplete
+    // drains the metrics collector" invariant.
+    if (mHasPendingCommissioningComplete) {
+        MTR_LOG_ERROR("%@ DeviceControllerDelegate received OnCommissioningComplete (nodeId 0x%016llx) "
+                      "while a prior pending record (nodeId 0x%016llx, error %" CHIP_ERROR_FORMAT
+                      ") had not been flushed; dispatching stale record before recording new one",
+            strongController, nodeId,
+            mPendingCommissioningCompleteNodeId,
+            mPendingCommissioningCompleteError.Format());
+        // Flush the prior attempt to its delegate. DispatchPendingCommissioningComplete
+        // clears mHasPendingCommissioningComplete, after which we fall through and
+        // record the new attempt's state below.
+        DispatchPendingCommissioningComplete();
+    }
 
-        // Always collect the metrics to avoid unbounded growth of the stats in the collector
-        MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshotForCommissioning:YES];
-        MTR_LOG("%@ Device commissioning complete with metrics %@", strongController, metrics);
+    // Record the (nodeId, error) tuple; defer the dispatch_async until the
+    // subsequent OnCommissioningSuccess / OnCommissioningFailure call so that
+    // the NetworkCommissioning status from CompletionStatus (only available on
+    // failure) can be captured by value into the block, eliminating the
+    // cross-queue read of a member-variable stash.
+    mPendingCommissioningCompleteNodeId = nodeId;
+    mPendingCommissioningCompleteError = error;
+    mPendingNetworkCommissioningStatus = chip::NullOptional;
+    mPendingNetworkCommissioningConnectErrorValue = chip::NullOptional;
+    mPendingNetworkCommissioningDebugText.clear();
+    mHasPendingCommissioningComplete = true;
+    // Reset the idempotence guard so this attempt's pending record can be
+    // dispatched exactly once by either the upstream Success/Failure callback
+    // or the PASE-fail synthesizer (whichever fires first).
+    mDispatchedCommissioningCompleteForCurrentAttempt = false;
+}
 
-        if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||
-            [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
-            dispatch_async(mQueue, ^{
-                NSError * nsError = [MTRError errorForCHIPErrorCode:error];
-                NSNumber * nodeID = nil;
-                if (error == CHIP_NO_ERROR) {
-                    nodeID = @(nodeId);
-                }
+void MTRDeviceControllerDelegateBridge::OnCommissioningSuccess(chip::PeerId /* peerId */)
+{
+    DispatchPendingCommissioningComplete();
+}
 
-                // If the client implements the metrics delegate, prefer that over others
-                if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
-                    [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics];
-                } else {
-                    [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID];
-                }
-            });
+void MTRDeviceControllerDelegateBridge::OnCommissioningFailure(
+    chip::PeerId /* peerId */, const chip::Controller::CompletionStatus & completionStatus)
+{
+    if (completionStatus.networkCommissioningStatus.HasValue()) {
+        MTR_LOG_ERROR("%@ DeviceControllerDelegate commissioning failure carries NetworkCommissioning status %u",
+            mController,
+            static_cast<unsigned>(chip::to_underlying(completionStatus.networkCommissioningStatus.Value())));
+    }
+
+    // Stash the NC status + companion CompletionStatus fields into the pending
+    // record so the dispatcher can pick them up. This is the only place these
+    // fields are set; flush paths that did not observe a Failure callback
+    // (setDelegate rebind, defensive double-Complete drain) read whatever was
+    // previously stashed -- NullOptional / empty in those cases because
+    // OnCommissioningComplete cleared them on the initial stash.
+    mPendingNetworkCommissioningStatus = completionStatus.networkCommissioningStatus;
+    mPendingNetworkCommissioningConnectErrorValue = completionStatus.connectNetworkErrorValue;
+    mPendingNetworkCommissioningDebugText = completionStatus.networkCommissioningDebugText;
+
+    // We deliberately do not forward to the legacy 4-arg overload: this bridge
+    // does not override it, and the default 4-arg implementation in
+    // DevicePairingDelegate is empty -- forwarding would be a no-op.
+    DispatchPendingCommissioningComplete();
+}
+
+void MTRDeviceControllerDelegateBridge::DispatchPendingCommissioningComplete()
+{
+    MTRDeviceController * strongController = mController;
+
+    if (!mHasPendingCommissioningComplete) {
+        if (mDispatchedCommissioningCompleteForCurrentAttempt) {
+            // The pending record for this attempt was already dispatched
+            // (typically by OnStatusUpdate's PASE-fail synthesizer firing
+            // first). Treat the follow-up upstream Success/Failure as a
+            // benign no-op rather than an error so we don't double-fire the
+            // delegate.
             return;
         }
-        // If only the DEPRECATED function is defined
-        if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:)]) {
-            dispatch_async(mQueue, ^{
-                NSError * nsError = [MTRError errorForCHIPErrorCode:error];
-                [strongDelegate controller:strongController commissioningComplete:nsError];
-            });
-        }
+        // Upstream invoked OnCommissioningSuccess/Failure without a preceding
+        // OnCommissioningComplete. This is not expected; surface it loudly so
+        // it shows up in triage logs rather than silently dropping the event.
+        MTR_LOG_ERROR("%@ DeviceControllerDelegate commissioning success/failure with no pending commissioning-complete record; dropping", strongController);
+        return;
+    }
+
+    chip::NodeId nodeId = mPendingCommissioningCompleteNodeId;
+    CHIP_ERROR error = mPendingCommissioningCompleteError;
+    chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> capturedStatus
+        = mPendingNetworkCommissioningStatus;
+    chip::Optional<int32_t> capturedConnectErrorValue = mPendingNetworkCommissioningConnectErrorValue;
+    std::string capturedDebugText = mPendingNetworkCommissioningDebugText;
+    mHasPendingCommissioningComplete = false;
+    mPendingCommissioningCompleteNodeId = chip::kUndefinedNodeId;
+    mPendingCommissioningCompleteError = CHIP_NO_ERROR;
+    mPendingNetworkCommissioningStatus = chip::NullOptional;
+    mPendingNetworkCommissioningConnectErrorValue = chip::NullOptional;
+    mPendingNetworkCommissioningDebugText.clear();
+    mDispatchedCommissioningCompleteForCurrentAttempt = true;
+
+    // Always collect the metrics to avoid unbounded growth of the stats in the
+    // collector. This must run regardless of whether a delegate is currently
+    // bound -- the metrics collector is a process-wide singleton, and skipping
+    // the drain on the (delegate == nil) branch would let it grow unbounded
+    // across commissioning attempts that race with delegate teardown.
+    MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshotForCommissioning:YES];
+    MTR_LOG("%@ Device commissioning complete with metrics %@", strongController, metrics);
+
+    id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
+    if (!(strongDelegate && mQueue && strongController)) {
+        return;
+    }
+
+    // Capture every input by value so the block runs purely off its closure
+    // state -- no member-variable reads on the delegate queue.
+
+    if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||
+        [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+        dispatch_async(mQueue, ^{
+            NSError * nsError = [MTRError errorForCHIPErrorCode:error
+                                                     logContext:nil
+                                     networkCommissioningStatus:capturedStatus
+                                       connectNetworkErrorValue:capturedConnectErrorValue
+                                  networkCommissioningDebugText:capturedDebugText];
+            NSNumber * nodeID = nil;
+            if (error == CHIP_NO_ERROR) {
+                nodeID = @(nodeId);
+            }
+
+            // If the client implements the metrics delegate, prefer that over others
+            if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+                [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics];
+            } else {
+                [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID];
+            }
+        });
+        return;
+    }
+    // If only the DEPRECATED function is defined
+    if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:)]) {
+        dispatch_async(mQueue, ^{
+            NSError * nsError = [MTRError errorForCHIPErrorCode:error
+                                                     logContext:nil
+                                     networkCommissioningStatus:capturedStatus
+                                       connectNetworkErrorValue:capturedConnectErrorValue
+                                  networkCommissioningDebugText:capturedDebugText];
+            [strongDelegate controller:strongController commissioningComplete:nsError];
+        });
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1375,6 +1375,15 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
                 self, commissioning);
             self->_deviceControllerDelegateBridge->OnCommissioningComplete(nodeID.unsignedLongLongValue,
                 CHIP_ERROR_CANCELLED);
+            // OnCommissioningComplete now records the result and waits for a
+            // subsequent OnCommissioningSuccess / OnCommissioningFailure call
+            // to drain the pending record to the delegate. The C++ side is not
+            // going to make either call when StopPairing is invoked outside an
+            // active commissioning, so synthesize a CompletionStatus-less
+            // failure here to flush the record through to the delegate;
+            // otherwise the cancellation would never reach the client.
+            self->_deviceControllerDelegateBridge->OnCommissioningFailure(chip::PeerId(),
+                chip::Controller::CompletionStatus());
         }
         return ok;
     };

--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -25,6 +25,52 @@ MTR_EXTERN NSErrorDomain const MTRErrorDomain MTR_AVAILABLE(ios(16.1), macos(13.
 MTR_EXTERN NSErrorDomain const MTRInteractionErrorDomain MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 /**
+ * userInfo key for NSErrors that arose from a commissioning failure where
+ * the commissionee returned a NetworkCommissioning cluster
+ * ConnectNetworkResponse / NetworkConfigResponse with a non-success
+ * NetworkCommissioningStatus.  The value is an NSNumber wrapping an
+ * MTRNetworkCommissioningStatus byte (e.g. NetworkNotFound, AuthFailure).
+ *
+ * The key is present whenever the commissioning failure carried a
+ * NetworkCommissioning status byte, regardless of whether the resulting
+ * NSError lives in MTRErrorDomain or MTRInteractionErrorDomain.  Its absence
+ * means the commissionee did not report a NetworkCommissioning status.
+ *
+ * The underlying string value is @"MTRNetworkCommissioningStatus" and is
+ * considered stable ABI: it appears in archived NSError userInfo
+ * dictionaries and may be read by string-key lookup from clients that do
+ * not link against this symbol.
+ */
+MTR_EXTERN NSString * const MTRErrorNetworkCommissioningStatusKey MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+
+/**
+ * userInfo key carrying the device-reported low-level driver errorValue from
+ * a NetworkCommissioning ConnectNetworkResponse (e.g. driver-specific
+ * association-failure code, distinct from the spec-level
+ * NetworkCommissioningStatus already exposed under
+ * MTRErrorNetworkCommissioningStatusKey).  Value is an NSNumber wrapping
+ * int32_t.
+ *
+ * The key is present only when the commissionee reported a non-empty
+ * connectNetworkErrorValue alongside the failure.
+ *
+ * The underlying string value is @"MTRNetworkCommissioningConnectErrorValue".
+ */
+MTR_EXTERN NSString * const MTRErrorNetworkCommissioningConnectErrorValueKey MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+
+/**
+ * userInfo key carrying the device-supplied NetworkCommissioning debugText
+ * string from a NetworkConfigResponse / ConnectNetworkResponse.  Value is an
+ * NSString.
+ *
+ * The key is present only when the commissionee supplied a non-empty
+ * debugText string alongside the failure.
+ *
+ * The underlying string value is @"MTRNetworkCommissioningDebugText".
+ */
+MTR_EXTERN NSString * const MTRErrorNetworkCommissioningDebugTextKey MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0));
+
+/**
  * MTRErrorDomain contains errors caused by data processing the framework
  * itself is performing.  These can be caused by invalid values provided to a
  * framework API, failure to decode an incoming message, and so forth.
@@ -35,7 +81,7 @@ MTR_EXTERN NSErrorDomain const MTRInteractionErrorDomain MTR_AVAILABLE(ios(16.1)
  * Errors reported by the server side of a Matter interaction via the normal
  * Matter error-reporting mechanisms use MTRInteractionErrorDomain instead.
  */
-typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
+typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode) {
     /**
      * MTRErrorCodeGeneralError represents a generic Matter error with no
      * further categorization.
@@ -45,16 +91,16 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
      * values should not be assumed to be stable across releases, but may be
      * useful in logging and debugging.
      */
-    MTRErrorCodeGeneralError         = 1,
-    MTRErrorCodeInvalidStringLength  = 2,
-    MTRErrorCodeInvalidIntegerValue  = 3,
-    MTRErrorCodeInvalidArgument      = 4,
+    MTRErrorCodeGeneralError = 1,
+    MTRErrorCodeInvalidStringLength = 2,
+    MTRErrorCodeInvalidIntegerValue = 3,
+    MTRErrorCodeInvalidArgument = 4,
     MTRErrorCodeInvalidMessageLength = 5,
-    MTRErrorCodeInvalidState         = 6,
-    MTRErrorCodeWrongAddressType     = 7,
+    MTRErrorCodeInvalidState = 6,
+    MTRErrorCodeWrongAddressType = 7,
     MTRErrorCodeIntegrityCheckFailed = 8,
-    MTRErrorCodeTimeout              = 9,
-    MTRErrorCodeBufferTooSmall       = 10,
+    MTRErrorCodeTimeout = 9,
+    MTRErrorCodeBufferTooSmall = 10,
 
     /**
      * MTRErrorCodeFabricExists is returned when trying to commission a device
@@ -125,39 +171,39 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
  * was reported.  This key will be absent if there was no cluster-specific
  * status.
  */
-typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode){
+typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode) {
     // These values come from the general status code table in the Matter
     // Interaction Model specification.
-    MTRInteractionErrorCodeFailure                                                                            = 0x01,
-    MTRInteractionErrorCodeInvalidSubscription                                                                = 0x7d,
-    MTRInteractionErrorCodeUnsupportedAccess                                                                  = 0x7e,
-    MTRInteractionErrorCodeUnsupportedEndpoint                                                                = 0x7f,
-    MTRInteractionErrorCodeInvalidAction                                                                      = 0x80,
-    MTRInteractionErrorCodeUnsupportedCommand                                                                 = 0x81,
-    MTRInteractionErrorCodeInvalidCommand                                                                     = 0x85,
-    MTRInteractionErrorCodeUnsupportedAttribute                                                               = 0x86,
-    MTRInteractionErrorCodeConstraintError                                                                    = 0x87,
-    MTRInteractionErrorCodeUnsupportedWrite                                                                   = 0x88,
-    MTRInteractionErrorCodeResourceExhausted                                                                  = 0x89,
-    MTRInteractionErrorCodeNotFound                                                                           = 0x8b,
-    MTRInteractionErrorCodeUnreportableAttribute                                                              = 0x8c,
-    MTRInteractionErrorCodeInvalidDataType                                                                    = 0x8d,
-    MTRInteractionErrorCodeUnsupportedRead                                                                    = 0x8f,
-    MTRInteractionErrorCodeDataVersionMismatch                                                                = 0x92,
-    MTRInteractionErrorCodeTimeout                                                                            = 0x94,
-    MTRInteractionErrorCodeBusy                                                                               = 0x9c,
-    MTRInteractionErrorCodeAccessRestricted MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0))  = 0x9d,
-    MTRInteractionErrorCodeUnsupportedCluster                                                                 = 0xc3,
-    MTRInteractionErrorCodeNoUpstreamSubscription                                                             = 0xc5,
-    MTRInteractionErrorCodeNeedsTimedInteraction                                                              = 0xc6,
-    MTRInteractionErrorCodeUnsupportedEvent                                                                   = 0xc7,
-    MTRInteractionErrorCodePathsExhausted                                                                     = 0xc8,
-    MTRInteractionErrorCodeTimedRequestMismatch                                                               = 0xc9,
-    MTRInteractionErrorCodeFailsafeRequired                                                                   = 0xca,
-    MTRInteractionErrorCodeInvalidInState MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))    = 0xcb,
+    MTRInteractionErrorCodeFailure = 0x01,
+    MTRInteractionErrorCodeInvalidSubscription = 0x7d,
+    MTRInteractionErrorCodeUnsupportedAccess = 0x7e,
+    MTRInteractionErrorCodeUnsupportedEndpoint = 0x7f,
+    MTRInteractionErrorCodeInvalidAction = 0x80,
+    MTRInteractionErrorCodeUnsupportedCommand = 0x81,
+    MTRInteractionErrorCodeInvalidCommand = 0x85,
+    MTRInteractionErrorCodeUnsupportedAttribute = 0x86,
+    MTRInteractionErrorCodeConstraintError = 0x87,
+    MTRInteractionErrorCodeUnsupportedWrite = 0x88,
+    MTRInteractionErrorCodeResourceExhausted = 0x89,
+    MTRInteractionErrorCodeNotFound = 0x8b,
+    MTRInteractionErrorCodeUnreportableAttribute = 0x8c,
+    MTRInteractionErrorCodeInvalidDataType = 0x8d,
+    MTRInteractionErrorCodeUnsupportedRead = 0x8f,
+    MTRInteractionErrorCodeDataVersionMismatch = 0x92,
+    MTRInteractionErrorCodeTimeout = 0x94,
+    MTRInteractionErrorCodeBusy = 0x9c,
+    MTRInteractionErrorCodeAccessRestricted MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0)) = 0x9d,
+    MTRInteractionErrorCodeUnsupportedCluster = 0xc3,
+    MTRInteractionErrorCodeNoUpstreamSubscription = 0xc5,
+    MTRInteractionErrorCodeNeedsTimedInteraction = 0xc6,
+    MTRInteractionErrorCodeUnsupportedEvent = 0xc7,
+    MTRInteractionErrorCodePathsExhausted = 0xc8,
+    MTRInteractionErrorCodeTimedRequestMismatch = 0xc9,
+    MTRInteractionErrorCodeFailsafeRequired = 0xca,
+    MTRInteractionErrorCodeInvalidInState MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6)) = 0xcb,
     MTRInteractionErrorCodeNoCommandResponse MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6)) = 0xcc,
-    MTRInteractionErrorCodeDynamicConstraintError MTR_PROVISIONALLY_AVAILABLE                                 = 0xcf,
-    MTRInteractionErrorCodeInvalidTransportType MTR_PROVISIONALLY_AVAILABLE                                   = 0xd1,
+    MTRInteractionErrorCodeDynamicConstraintError MTR_PROVISIONALLY_AVAILABLE = 0xcf,
+    MTRInteractionErrorCodeInvalidTransportType MTR_PROVISIONALLY_AVAILABLE = 0xd1,
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -31,6 +31,10 @@ NSString * const MTRErrorDomain = @"MTRErrorDomain";
 
 NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 
+NSString * const MTRErrorNetworkCommissioningStatusKey = @"MTRNetworkCommissioningStatus";
+NSString * const MTRErrorNetworkCommissioningConnectErrorValueKey = @"MTRNetworkCommissioningConnectErrorValue";
+NSString * const MTRErrorNetworkCommissioningDebugTextKey = @"MTRNetworkCommissioningDebugText";
+
 // Class for holding on to a CHIP_ERROR that we can use as the value
 // in a dictionary.
 @interface MTRErrorHolder : NSObject
@@ -56,15 +60,79 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 
 + (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode logContext:(id)contextToLog
 {
+    return [MTRError errorForCHIPErrorCode:errorCode logContext:contextToLog networkCommissioningStatus:chip::NullOptional];
+}
+
++ (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
+                        logContext:(id)contextToLog
+        networkCommissioningStatus:
+            (const chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> &)
+                networkCommissioningStatus
+{
+    return [MTRError errorForCHIPErrorCode:errorCode
+                                logContext:contextToLog
+                networkCommissioningStatus:networkCommissioningStatus
+                  connectNetworkErrorValue:chip::NullOptional
+             networkCommissioningDebugText:std::string()];
+}
+
++ (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
+                        logContext:(id)contextToLog
+        networkCommissioningStatus:
+            (const chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> &)
+                networkCommissioningStatus
+          connectNetworkErrorValue:(const chip::Optional<int32_t> &)connectNetworkErrorValue
+     networkCommissioningDebugText:(const std::string &)networkCommissioningDebugText
+{
     if (errorCode == CHIP_NO_ERROR) {
         return nil;
     }
 
     ChipLogError(Controller, "Creating NSError from %" CHIP_ERROR_FORMAT " (context: %@)", errorCode.Format(), contextToLog);
 
+    // Helper that layers any CompletionStatus-derived userInfo entries on top
+    // of an existing userInfo dictionary, mutating-and-returning a fresh dict
+    // when at least one entry is present. The same logic is used on both the
+    // IM-status (MTRInteractionErrorDomain) and the non-IM (MTRErrorDomain)
+    // branches so the consumer contract -- "key is present whenever the
+    // commissionee actually reported the value" -- is uniform across domains.
+    auto attachCompletionStatusUserInfo = ^NSDictionary *(NSDictionary * baseUserInfo)
+    {
+        BOOL hasNCStatus = networkCommissioningStatus.HasValue();
+        BOOL hasConnectErr = connectNetworkErrorValue.HasValue();
+        BOOL hasDebugText = !networkCommissioningDebugText.empty();
+        if (!hasNCStatus && !hasConnectErr && !hasDebugText) {
+            return baseUserInfo;
+        }
+        NSMutableDictionary * combined = baseUserInfo ? [baseUserInfo mutableCopy] : [NSMutableDictionary dictionary];
+        if (hasNCStatus) {
+            combined[MTRErrorNetworkCommissioningStatusKey] = @(chip::to_underlying(networkCommissioningStatus.Value()));
+        }
+        if (hasConnectErr) {
+            combined[MTRErrorNetworkCommissioningConnectErrorValueKey] = @(connectNetworkErrorValue.Value());
+        }
+        if (hasDebugText) {
+            NSString * debugText = [[NSString alloc] initWithBytes:networkCommissioningDebugText.data()
+                                                            length:networkCommissioningDebugText.size()
+                                                          encoding:NSUTF8StringEncoding];
+            if (debugText != nil) {
+                combined[MTRErrorNetworkCommissioningDebugTextKey] = debugText;
+            }
+        }
+        return combined;
+    };
+
     if (errorCode.IsIMStatus()) {
         chip::app::StatusIB status(errorCode);
-        return [MTRError errorForIMStatus:status];
+        NSError * imError = [MTRError errorForIMStatus:status];
+        if (imError == nil) {
+            return nil;
+        }
+        NSDictionary * extendedUserInfo = attachCompletionStatusUserInfo(imError.userInfo);
+        if (extendedUserInfo == imError.userInfo) {
+            return imError;
+        }
+        return [NSError errorWithDomain:imError.domain code:imError.code userInfo:extendedUserInfo];
     }
 
     MTRErrorCode code;
@@ -150,6 +218,7 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
         [combined addEntriesFromDictionary:additionalUserInfo];
         userInfo = combined;
     }
+    userInfo = attachCompletionStatusUserInfo(userInfo);
 
     auto * error = [NSError errorWithDomain:MTRErrorDomain code:code userInfo:userInfo];
     void * key = (__bridge void *) [MTRErrorHolder class];
@@ -160,6 +229,18 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 + (NSError *)errorForCHIPIntegerCode:(uint32_t)errorCode
 {
     return [MTRError errorForCHIPErrorCode:chip::ChipError(errorCode)];
+}
+
++ (NSError *)errorForCHIPIntegerCode:(uint32_t)errorCode
+       hasNetworkCommissioningStatus:(BOOL)hasNetworkCommissioningStatus
+          networkCommissioningStatus:(uint8_t)networkCommissioningStatus
+{
+    using chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum;
+    chip::Optional<NetworkCommissioningStatusEnum> optionalStatus;
+    if (hasNetworkCommissioningStatus) {
+        optionalStatus.SetValue(static_cast<NetworkCommissioningStatusEnum>(networkCommissioningStatus));
+    }
+    return [MTRError errorForCHIPErrorCode:chip::ChipError(errorCode) logContext:nil networkCommissioningStatus:optionalStatus];
 }
 
 + (NSError *)errorForIMStatus:(const chip::app::StatusIB &)status

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -21,8 +21,12 @@
 #import "MTRError_Test.h"
 
 #include <app/MessageDef/StatusIB.h>
+#include <clusters/NetworkCommissioning/Enums.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
 #include <protocols/interaction_model/StatusCode.h>
+
+#include <string>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +34,33 @@ MTR_DIRECT_MEMBERS
 @interface MTRError ()
 + (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
 + (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode logContext:(id _Nullable)contextToLog;
+/**
+ * Same as errorForCHIPErrorCode:logContext:, but if networkCommissioningStatus
+ * has a value, the resulting NSError's userInfo carries the byte under
+ * MTRErrorNetworkCommissioningStatusKey.  Used by the commissioning bridge to
+ * surface NetworkCommissioning cluster ConnectNetworkResponse status (e.g.
+ * NetworkNotFound, AuthFailure) on otherwise-opaque commissioning failures.
+ */
++ (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
+                                  logContext:(id _Nullable)contextToLog
+                  networkCommissioningStatus:
+                      (const chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> &)
+                          networkCommissioningStatus;
+/**
+ * Same as the above, but also forwards the (optional) device-reported
+ * driver-level connectNetworkErrorValue and (possibly-empty)
+ * networkCommissioningDebugText through to userInfo under their respective
+ * MTRErrorNetworkCommissioning* keys.  Empty / NullOptional values omit
+ * the corresponding key so consumers can rely on key presence as the
+ * "device actually reported a value" signal.
+ */
++ (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
+                                  logContext:(id _Nullable)contextToLog
+                  networkCommissioningStatus:
+                      (const chip::Optional<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatusEnum> &)
+                          networkCommissioningStatus
+                    connectNetworkErrorValue:(const chip::Optional<int32_t> &)connectNetworkErrorValue
+               networkCommissioningDebugText:(const std::string &)networkCommissioningDebugText;
 + (NSError * _Nullable)errorForIMStatus:(const chip::app::StatusIB &)status;
 + (NSError * _Nullable)errorForIMStatusCode:(chip::Protocols::InteractionModel::Status)status;
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError * _Nullable)error;

--- a/src/darwin/Framework/CHIP/MTRError_Test.h
+++ b/src/darwin/Framework/CHIP/MTRError_Test.h
@@ -32,6 +32,14 @@ MTR_TESTABLE
 + (NSError *)errorForCHIPIntegerCode:(uint32_t)code;
 + (uint32_t)errorToCHIPIntegerCode:(NSError * _Nullable)error;
 
+// For tests only.  Equivalent to errorForCHIPIntegerCode: but, when
+// hasNetworkCommissioningStatus is YES, also threads the supplied
+// NetworkCommissioning cluster status byte into the resulting NSError's
+// userInfo under MTRErrorNetworkCommissioningStatusKey.
++ (NSError *)errorForCHIPIntegerCode:(uint32_t)code
+       hasNetworkCommissioningStatus:(BOOL)hasNetworkCommissioningStatus
+          networkCommissioningStatus:(uint8_t)networkCommissioningStatus;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MTRErrorMappingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRErrorMappingTests.m
@@ -17,9 +17,24 @@
 #import <Matter/Matter.h>
 #import <XCTest/XCTest.h>
 
-// NOTE: This is a .mm file, so that it can include MTRError_Internal.h
-
 #import "MTRError_Test.h"
+
+// A CHIP_ERROR-encoded integer that does not match any known mapping in
+// MTRError errorForCHIPErrorCode:, so it round-trips through the default branch
+// and produces an MTRErrorDomain Code=MTRErrorCodeGeneralError NSError -- the
+// same shape upstream renders as "General error: 172" today.  Used to model
+// the CHIP_ERROR_INTERNAL surfaced by the WiFiNetworkEnable commissioning step.
+static const uint32_t kSomeUnknownCHIPErrorIntegerValue = 0xDEADBEEF;
+
+// Spec-defined NetworkCommissioning cluster status enum values
+// (see app-common/clusters/NetworkCommissioning/Enums.h). Mirrored as plain
+// uint8_t literals because this test target intentionally cannot include
+// CHIP-internal headers (see MTRError_Test.h: "we can't use CHIP_ERROR from
+// there"). The values are pinned spec-side and cross-checked against the
+// public MTRNetworkCommissioningStatus enum below.
+static const uint8_t kNetworkCommissioningStatusSuccess = 0x00;
+static const uint8_t kNetworkCommissioningStatusNetworkNotFound = 0x05;
+static const uint8_t kNetworkCommissioningStatusAuthFailure = 0x07;
 
 @interface MTRErrorMappingTests : XCTestCase
 @end
@@ -55,6 +70,504 @@
     __auto_type * newError = [MTRError errorForCHIPIntegerCode:chipError];
     XCTAssertEqual(newError.domain, MTRErrorDomain);
     XCTAssertEqual(newError.code, MTRErrorCodeGeneralError);
+}
+
+// Regression: ConnectNetwork response with NetworkCommissioningStatus=NetworkNotFound (5)
+// must surface on the resulting NSError so commissioning UIs can render an
+// "Incompatible Wi-Fi" message instead of a generic failure.
+- (void)testConnectNetworkNetworkNotFoundProducesNetworkCommissioningStatusUserInfoKey
+{
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusNetworkNotFound];
+
+    // Backward-compat: domain/code remain MTRErrorDomain / MTRErrorCodeGeneralError.
+    XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+    XCTAssertEqual(error.code, MTRErrorCodeGeneralError);
+
+    // The new userInfo key carries the NetworkCommissioning cluster status byte.
+    id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+    XCTAssertNotNil(status);
+    XCTAssertTrue([status isKindOfClass:[NSNumber class]]);
+    XCTAssertEqual([status unsignedCharValue], kNetworkCommissioningStatusNetworkNotFound);
+}
+
+- (void)testConnectNetworkAuthFailurePropagatesStatus7
+{
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+
+    id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+    XCTAssertNotNil(status);
+    XCTAssertEqual([status unsignedCharValue], kNetworkCommissioningStatusAuthFailure);
+}
+
+- (void)testNonNetworkCommissioningFailureHasNoNetworkStatusKey
+{
+    // Failure without any network-commissioning context must not carry the new
+    // key, so consumers can rely on its presence as a signal that a
+    // NetworkCommissioning status was actually reported.
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:NO
+                             networkCommissioningStatus:0];
+
+    XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+    XCTAssertNil(error.userInfo[MTRErrorNetworkCommissioningStatusKey]);
+}
+
+- (void)testSuccessfulCommissioningStillProducesNilError
+{
+    // Regression guard: kSuccess (0) is not a failure, so the helper, when handed
+    // CHIP_NO_ERROR, must still return nil regardless of the supplied status byte.
+    NSError * error = [MTRError errorForCHIPIntegerCode:0 /* CHIP_NO_ERROR */
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusSuccess];
+    XCTAssertNil(error);
+}
+
+// Coverage pin: every spec-defined NetworkCommissioning cluster status byte
+// (0x00..0x0C, all 13 values) must propagate verbatim through the
+// MTRErrorNetworkCommissioningStatusKey on the resulting NSError when paired
+// with a non-success CHIP_ERROR. Catches accidental clamping, sign-extension,
+// or enum-value-filtering regressions in the factory's userInfo plumbing --
+// the factory must not interpret the status byte, only forward it.
+- (void)testAllNetworkCommissioningStatusValuesRoundTripThroughUserInfo
+{
+    // Spec NetworkCommissioning::NetworkCommissioningStatusEnum, mirrored from
+    // app-common/clusters/NetworkCommissioning/Enums.h. Listing literally so a
+    // future spec addition forces an explicit update of this test rather than
+    // silently slipping through.
+    static const uint8_t kAllStatusBytes[] = {
+        0x00, // kSuccess
+        0x01, // kOutOfRange
+        0x02, // kBoundsExceeded
+        0x03, // kNetworkIDNotFound
+        0x04, // kDuplicateNetworkID
+        0x05, // kNetworkNotFound
+        0x06, // kRegulatoryError
+        0x07, // kAuthFailure
+        0x08, // kUnsupportedSecurity
+        0x09, // kOtherConnectionFailure
+        0x0A, // kIPV6Failed
+        0x0B, // kIPBindFailed
+        0x0C, // kUnknownError
+    };
+    static const size_t kAllStatusByteCount = sizeof(kAllStatusBytes) / sizeof(kAllStatusBytes[0]);
+    XCTAssertEqual(kAllStatusByteCount, 13u, @"Test must cover all 13 spec NetworkCommissioning status values");
+
+    // Cross-check against the public MTRNetworkCommissioningStatus enum so
+    // this test fails loudly if the spec adds a value and the public API
+    // gains a slot for it but this list is not updated to match.
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusSuccess, kAllStatusBytes[0]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusOutOfRange, kAllStatusBytes[1]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusBoundsExceeded, kAllStatusBytes[2]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusNetworkIDNotFound, kAllStatusBytes[3]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusDuplicateNetworkID, kAllStatusBytes[4]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusNetworkNotFound, kAllStatusBytes[5]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusRegulatoryError, kAllStatusBytes[6]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusAuthFailure, kAllStatusBytes[7]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusUnsupportedSecurity, kAllStatusBytes[8]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusOtherConnectionFailure, kAllStatusBytes[9]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusIPV6Failed, kAllStatusBytes[10]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusIPBindFailed, kAllStatusBytes[11]);
+    XCTAssertEqual((uint8_t) MTRNetworkCommissioningStatusUnknownError, kAllStatusBytes[12]);
+
+    for (size_t i = 0; i < kAllStatusByteCount; i++) {
+        uint8_t statusByte = kAllStatusBytes[i];
+        NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                              hasNetworkCommissioningStatus:YES
+                                 networkCommissioningStatus:statusByte];
+
+        XCTAssertNotNil(error, @"Status 0x%02x must produce a non-nil NSError when paired with a non-success CHIP_ERROR", statusByte);
+        XCTAssertEqualObjects(error.domain, MTRErrorDomain, @"Status 0x%02x must use MTRErrorDomain", statusByte);
+        XCTAssertEqual(error.code, MTRErrorCodeGeneralError, @"Status 0x%02x must round-trip the unknown CHIP_ERROR to GeneralError", statusByte);
+
+        id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+        XCTAssertNotNil(status, @"Status 0x%02x must surface MTRErrorNetworkCommissioningStatusKey", statusByte);
+        XCTAssertTrue([status isKindOfClass:[NSNumber class]], @"Status 0x%02x must be boxed as NSNumber", statusByte);
+        XCTAssertEqual([status unsignedCharValue], statusByte,
+            @"Status byte 0x%02x must propagate verbatim into userInfo (got 0x%02x)",
+            statusByte, [status unsignedCharValue]);
+    }
+}
+
+// Negative-case coverage pin: the new userInfo key must be absent for every
+// well-known MTRError code when the factory is invoked without a
+// NetworkCommissioning status. Clients rely on key presence as the signal
+// that a NetworkCommissioning status was actually reported by the device,
+// so any leakage of the key onto unrelated errors would silently mis-fire
+// commissioning UI branches (e.g. show "wrong Wi-Fi password" for a
+// PASE-layer timeout). Broader than testNonNetworkCommissioningFailureHasNoNetworkStatusKey,
+// which only exercises the GeneralError branch.
+- (void)testNonNetworkCommissioningFailureNeverCarriesNetworkStatusKey
+{
+    // Mix of MTRError codes that have well-defined CHIP_ERROR integer
+    // mappings (round-trip tested by testPublicNonInteractionAPIValues
+    // above), plus the unknown integer that falls through to GeneralError.
+    // The point is to exercise the userInfo plumbing across unrelated
+    // CHIP_ERROR shapes (IM status, transport, integrity, timeout, generic)
+    // so a regression where the key gets attached unconditionally would
+    // surface here even if the GeneralError-only test passed.
+    static const MTRErrorCode kNonNetworkCommissioningCodes[] = {
+        MTRErrorCodeGeneralError,
+        MTRErrorCodeInvalidState,
+        MTRErrorCodeInvalidIntegerValue,
+        MTRErrorCodeInvalidArgument,
+        MTRErrorCodeInvalidMessageLength,
+        MTRErrorCodeIntegrityCheckFailed,
+        MTRErrorCodeTimeout,
+        MTRErrorCodeBufferTooSmall,
+        MTRErrorCodeFabricExists,
+    };
+    static const size_t kNonNetworkCommissioningCodeCount = sizeof(kNonNetworkCommissioningCodes) / sizeof(kNonNetworkCommissioningCodes[0]);
+
+    for (size_t i = 0; i < kNonNetworkCommissioningCodeCount; i++) {
+        MTRErrorCode code = kNonNetworkCommissioningCodes[i];
+
+        // Round-trip the MTRError code into a CHIP integer so we exercise
+        // the same factory path commissioning failures take, then deliver
+        // it back through the network-aware overload with hasStatus:NO.
+        NSError * shape = [NSError errorWithDomain:MTRErrorDomain code:code userInfo:nil];
+        uint32_t chipInt = [MTRError errorToCHIPIntegerCode:shape];
+
+        NSError * error = [MTRError errorForCHIPIntegerCode:chipInt
+                              hasNetworkCommissioningStatus:NO
+                                 networkCommissioningStatus:0];
+        XCTAssertNotNil(error, @"Code %ld must produce a non-nil NSError", (long) code);
+        XCTAssertEqualObjects(error.domain, MTRErrorDomain, @"Code %ld must use MTRErrorDomain", (long) code);
+        XCTAssertNil(error.userInfo[MTRErrorNetworkCommissioningStatusKey],
+            @"Code %ld must NOT carry MTRErrorNetworkCommissioningStatusKey when no NetworkCommissioning status was reported",
+            (long) code);
+
+        // Belt-and-suspenders: even if a caller mistakenly passes a non-zero
+        // status byte while flagging hasStatus:NO, the byte must be ignored.
+        // Pins that hasStatus is the gate, not "non-zero status byte".
+        NSError * errorWithIgnoredByte = [MTRError errorForCHIPIntegerCode:chipInt
+                                             hasNetworkCommissioningStatus:NO
+                                                networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+        XCTAssertNil(errorWithIgnoredByte.userInfo[MTRErrorNetworkCommissioningStatusKey],
+            @"Code %ld with hasStatus=NO must ignore the supplied status byte", (long) code);
+    }
+}
+
+// Regression: when the underlying CHIP_ERROR is an Interaction Model status
+// (SdkPart=kIMGlobalStatus or kIMClusterStatus), the factory routes through
+// +errorForIMStatus: and the resulting NSError lives in MTRInteractionErrorDomain.
+// In that branch the NetworkCommissioning status byte MUST still be attached
+// to userInfo so commissioning UIs can recover the reported NC status
+// regardless of which NSError domain the underlying error rendered into --
+// otherwise an AuthFailure surfaced via WiFiNetworkEnable IM status would be
+// indistinguishable from a generic IM failure.
+- (void)testIMStatusErrorWithNetworkCommissioningStatusForwardsTheStatusByte
+{
+    // SdkPart::kIMGlobalStatus = 5, code = 0x01 (Failure).
+    // Layout: kRangeStartBit=24, kSdkPartStartBit=8, kSdkCodeStartBit=0; Range::kSDK=0.
+    static const uint32_t kIMGlobalStatusFailureCHIPInteger = (0u << 24) | (5u << 8) | 0x01u; // 0x00000501
+    // SdkPart::kIMClusterStatus = 6, code = 0x02 (cluster-specific status sample).
+    static const uint32_t kIMClusterStatusSampleCHIPInteger = (0u << 24) | (6u << 8) | 0x02u; // 0x00000602
+
+    static const uint32_t kIMIntegers[] = {
+        kIMGlobalStatusFailureCHIPInteger,
+        kIMClusterStatusSampleCHIPInteger,
+    };
+    static const size_t kIMIntegerCount = sizeof(kIMIntegers) / sizeof(kIMIntegers[0]);
+
+    for (size_t i = 0; i < kIMIntegerCount; i++) {
+        uint32_t imCHIPInteger = kIMIntegers[i];
+
+        NSError * error = [MTRError errorForCHIPIntegerCode:imCHIPInteger
+                              hasNetworkCommissioningStatus:YES
+                                 networkCommissioningStatus:kNetworkCommissioningStatusNetworkNotFound];
+
+        XCTAssertNotNil(error, @"IM-status CHIP integer 0x%08x must produce a non-nil NSError", imCHIPInteger);
+        // IM-status errors are routed to MTRInteractionErrorDomain.
+        XCTAssertEqualObjects(error.domain, MTRInteractionErrorDomain,
+            @"IM-status CHIP integer 0x%08x must produce an MTRInteractionErrorDomain error", imCHIPInteger);
+        // The status byte must be forwarded onto the IM-status error so
+        // consumers can branch on it regardless of error domain.
+        id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+        XCTAssertNotNil(status,
+            @"IM-status CHIP integer 0x%08x MUST carry MTRErrorNetworkCommissioningStatusKey "
+            @"(presence is uniform across error domains).",
+            imCHIPInteger);
+        XCTAssertTrue([status isKindOfClass:[NSNumber class]]);
+        XCTAssertEqual([(NSNumber *) status unsignedCharValue], kNetworkCommissioningStatusNetworkNotFound,
+            @"IM-status CHIP integer 0x%08x must forward the status byte verbatim", imCHIPInteger);
+    }
+}
+
+// Negative case: an IM-status CHIP_ERROR without a NetworkCommissioning
+// status reported alongside it must NOT gain the key. Pins that the key
+// presence on IM-domain errors is gated by the upstream signal, not added
+// unconditionally to every IM error.
+- (void)testIMStatusErrorWithoutNetworkCommissioningStatusOmitsTheKey
+{
+    static const uint32_t kIMGlobalStatusFailureCHIPInteger = (0u << 24) | (5u << 8) | 0x01u;
+    NSError * error = [MTRError errorForCHIPIntegerCode:kIMGlobalStatusFailureCHIPInteger
+                          hasNetworkCommissioningStatus:NO
+                             networkCommissioningStatus:0];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MTRInteractionErrorDomain);
+    XCTAssertNil(error.userInfo[MTRErrorNetworkCommissioningStatusKey],
+        @"IM-status error without NC status must NOT carry MTRErrorNetworkCommissioningStatusKey");
+}
+
+// Regression: NetworkCommissioning status bytes outside the currently
+// spec-defined 0x00..0x0C range (e.g. a future spec revision adds 0x0D, or a
+// non-compliant accessory returns 0xFE/0xFF) must still propagate verbatim --
+// the framework's job is to forward, not to interpret. Catches a future
+// "validate and zero unknown bytes" or "clamp to MTRNetworkCommissioningStatusUnknownError"
+// regression that would silently hide accessory-side bugs from commissioning UIs.
+//
+// Complements testAllNetworkCommissioningStatusValuesRoundTripThroughUserInfo,
+// which only exercises spec-defined values; this test exercises forward-compat.
+- (void)testOutOfSpecNetworkCommissioningStatusBytesForwardVerbatim
+{
+    // Pick bytes that are intentionally outside the current spec enum range.
+    // 0x0D is the immediate next spec slot; 0x7F is mid-range; 0xFE / 0xFF
+    // exercise high bits (catches accidental sign-extension to int8_t).
+    static const uint8_t kOutOfSpecBytes[] = { 0x0D, 0x10, 0x7F, 0x80, 0xFE, 0xFF };
+    static const size_t kOutOfSpecCount = sizeof(kOutOfSpecBytes) / sizeof(kOutOfSpecBytes[0]);
+
+    for (size_t i = 0; i < kOutOfSpecCount; i++) {
+        uint8_t statusByte = kOutOfSpecBytes[i];
+        NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                              hasNetworkCommissioningStatus:YES
+                                 networkCommissioningStatus:statusByte];
+
+        XCTAssertNotNil(error, @"Out-of-spec status 0x%02x must still produce an NSError", statusByte);
+        XCTAssertEqualObjects(error.domain, MTRErrorDomain,
+            @"Out-of-spec status 0x%02x must use MTRErrorDomain", statusByte);
+        XCTAssertEqual(error.code, MTRErrorCodeGeneralError,
+            @"Out-of-spec status 0x%02x must round-trip the unknown CHIP_ERROR to GeneralError", statusByte);
+
+        id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+        XCTAssertNotNil(status,
+            @"Out-of-spec status 0x%02x must still surface MTRErrorNetworkCommissioningStatusKey "
+            @"(framework forwards, does not validate)",
+            statusByte);
+        XCTAssertTrue([status isKindOfClass:[NSNumber class]],
+            @"Out-of-spec status 0x%02x must be boxed as NSNumber", statusByte);
+        NSNumber * statusNumber = (NSNumber *) status;
+        XCTAssertEqual([statusNumber unsignedCharValue], statusByte,
+            @"Out-of-spec status byte 0x%02x must propagate verbatim into userInfo (got 0x%02x); "
+            @"the framework must not clamp, mask, or sign-extend it",
+            statusByte, [statusNumber unsignedCharValue]);
+        // Pin that the high-bit bytes did not get sign-extended into a large
+        // signed integer (a classic int8_t -> int -> NSNumber bug).
+        XCTAssertEqual([statusNumber unsignedIntegerValue], (NSUInteger) statusByte,
+            @"Out-of-spec status 0x%02x must NOT sign-extend (unsignedIntegerValue mismatch)", statusByte);
+        XCTAssertEqual([statusNumber intValue], (int) statusByte,
+            @"Out-of-spec status 0x%02x must round-trip through -intValue without sign-extension", statusByte);
+    }
+}
+
+// Regression: pin the public consumer contract for
+// MTRErrorNetworkCommissioningStatusKey -- both the literal string value
+// (which ships in NSError userInfo dictionaries that may be serialized,
+// archived, or logged by clients) and the equality contract between the
+// boxed NSNumber and the public MTRNetworkCommissioningStatus enum slots
+// that commissioning UIs branch on.
+//
+// Without this, a "rename the userInfo key" refactor or a "switch the boxed
+// type to NSString/NSData" refactor would silently break every client that
+// switches on the status, including the actionable UI strings called out in
+// the PR description ("the accessory could not find the Wi-Fi network --
+// try a 2.4 GHz network or check the SSID and password").
+- (void)testNetworkCommissioningStatusKeyConstantAndNSNumberConsumerContract
+{
+    // The literal key string is part of the ABI: it appears in archived
+    // NSError userInfo dictionaries and in client-side string-keyed lookups
+    // that do not link against the symbol. If this assertion fires, the
+    // key was renamed -- bump the doc & coordinate with consumers.
+    XCTAssertEqualObjects(MTRErrorNetworkCommissioningStatusKey, @"MTRNetworkCommissioningStatus",
+        @"MTRErrorNetworkCommissioningStatusKey is part of the public NSError userInfo ABI; "
+        @"renaming silently breaks every consumer that reads userInfo by literal string.");
+
+    // String-keyed lookup (the path used by clients that don't have the
+    // header) must return the same object as symbol-keyed lookup.
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+    id viaSymbol = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+    id viaLiteral = error.userInfo[@"MTRNetworkCommissioningStatus"];
+    XCTAssertNotNil(viaSymbol);
+    XCTAssertNotNil(viaLiteral);
+    XCTAssertEqualObjects(viaSymbol, viaLiteral,
+        @"Symbol-keyed and literal-string-keyed userInfo lookups must return the same value.");
+
+    // The boxed value must compare equal to the public MTRNetworkCommissioningStatus
+    // enum slot -- this is the assertion commissioning UIs will actually write
+    // (e.g. `if ([status integerValue] == MTRNetworkCommissioningStatusAuthFailure]`).
+    // Catches a regression where the byte is boxed as a different numeric type
+    // (e.g. int vs unsigned char) such that -[NSNumber isEqualToNumber:] still
+    // works but -integerValue / -unsignedIntegerValue drift.
+    XCTAssertTrue([viaSymbol isKindOfClass:[NSNumber class]]);
+    NSNumber * viaSymbolNumber = (NSNumber *) viaSymbol;
+    XCTAssertEqualObjects(viaSymbolNumber, @(MTRNetworkCommissioningStatusAuthFailure),
+        @"Boxed status must NSNumber-compare equal to the matching MTRNetworkCommissioningStatus enum slot.");
+    XCTAssertEqual([viaSymbolNumber integerValue], (NSInteger) MTRNetworkCommissioningStatusAuthFailure,
+        @"-integerValue must equal the matching MTRNetworkCommissioningStatus enum slot.");
+    XCTAssertEqual([viaSymbolNumber unsignedIntegerValue], (NSUInteger) MTRNetworkCommissioningStatusAuthFailure,
+        @"-unsignedIntegerValue must equal the matching MTRNetworkCommissioningStatus enum slot.");
+
+    // Pin that the value is suitable for plist / JSON serialization (clients
+    // may archive NSError userInfo dictionaries). NSNumber satisfies
+    // NSSecureCoding and JSON-encodes as a number.
+    XCTAssertTrue([(NSNumber *) viaSymbol conformsToProtocol:@protocol(NSSecureCoding)]);
+    XCTAssertTrue([NSJSONSerialization isValidJSONObject:@{ MTRErrorNetworkCommissioningStatusKey : viaSymbol }],
+        @"The userInfo entry must remain JSON-serializable so clients can log it verbatim.");
+}
+
+// Regression: the GeneralError default branch in errorForCHIPErrorCode: writes
+// its own additionalUserInfo entries (specifically @"errorCode" carrying the
+// raw CHIP_ERROR integer, plus NSLocalizedDescriptionKey "General error: N").
+// When a NetworkCommissioning status is layered on top, the merge must
+// PRESERVE the default-branch entries -- a naive assignment would clobber
+// them and break consumers that read either userInfo[@"errorCode"] (e.g. for
+// crash-log triage) or NSError.localizedDescription (e.g. log lines and UI).
+- (void)testNetworkCommissioningStatusMergesWithDefaultBranchUserInfoWithoutClobbering
+{
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusNetworkNotFound];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+    XCTAssertEqual(error.code, MTRErrorCodeGeneralError);
+
+    // Default-branch entries must survive the merge.
+    id rawErrorCode = error.userInfo[@"errorCode"];
+    XCTAssertNotNil(rawErrorCode, @"GeneralError must continue to expose the raw CHIP integer under userInfo[@\"errorCode\"]");
+    XCTAssertTrue([rawErrorCode isKindOfClass:[NSNumber class]]);
+    XCTAssertEqual([(NSNumber *) rawErrorCode unsignedIntValue], kSomeUnknownCHIPErrorIntegerValue,
+        @"errorCode userInfo must equal the original CHIP integer (got %@)", rawErrorCode);
+
+    NSString * description = error.userInfo[NSLocalizedDescriptionKey];
+    XCTAssertNotNil(description, @"NSLocalizedDescriptionKey must not be wiped when status is added");
+    XCTAssertTrue([description containsString:@"General error"],
+        @"localizedDescription must still describe the error (got %@)", description);
+
+    // The status itself must also be present alongside the default-branch keys.
+    XCTAssertEqualObjects(error.userInfo[MTRErrorNetworkCommissioningStatusKey],
+        @(kNetworkCommissioningStatusNetworkNotFound));
+
+    // -[NSError localizedDescription] reads NSLocalizedDescriptionKey; pin
+    // that the public accessor still works (catches a regression where the
+    // merge accidentally dropped the description entry).
+    XCTAssertNotNil(error.localizedDescription);
+    XCTAssertTrue([error.localizedDescription containsString:@"General error"],
+        @"-localizedDescription must reflect the description entry");
+}
+
+// Regression: for recognized-CHIP-error codes (e.g. CHIP_ERROR_TIMEOUT ->
+// MTRErrorCodeTimeout), userInfo only carries NSLocalizedDescriptionKey on
+// the path before the status merge. Pin that the merge keeps the localized
+// description intact and adds the status key, even though there is no
+// additionalUserInfo dictionary on this path. Catches a "merge order"
+// regression where the new key replaces userInfo wholesale instead of
+// extending it. Also pins that the recognized-error path does NOT gain a
+// stray @"errorCode" entry (that belongs to the GeneralError branch only).
+- (void)testNetworkCommissioningStatusOnRecognizedErrorPreservesLocalizedDescription
+{
+    // Build a recognized MTRErrorCodeTimeout NSError, round-trip it to its
+    // CHIP integer, then re-render through the network-aware overload.
+    NSError * shape = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeTimeout userInfo:nil];
+    uint32_t timeoutCHIPInteger = [MTRError errorToCHIPIntegerCode:shape];
+
+    NSError * error = [MTRError errorForCHIPIntegerCode:timeoutCHIPInteger
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+    XCTAssertEqual(error.code, MTRErrorCodeTimeout,
+        @"Recognized CHIP_ERROR_TIMEOUT must still map to MTRErrorCodeTimeout when status is layered on");
+
+    // Status added.
+    XCTAssertEqualObjects(error.userInfo[MTRErrorNetworkCommissioningStatusKey],
+        @(kNetworkCommissioningStatusAuthFailure));
+
+    // Localized description preserved -- not clobbered by the status merge.
+    NSString * description = error.userInfo[NSLocalizedDescriptionKey];
+    XCTAssertNotNil(description, @"Recognized-error path must keep NSLocalizedDescriptionKey after status merge");
+    XCTAssertEqualObjects(description, error.localizedDescription);
+    // Recognized-Timeout path must NOT carry a stray @"errorCode" entry.
+    XCTAssertNil(error.userInfo[@"errorCode"],
+        @"Recognized-error path must not gain a default-branch @\"errorCode\" entry via the merge");
+}
+
+// Regression: errorToCHIPIntegerCode reads the original CHIP_ERROR via the
+// MTRErrorHolder associated object, NOT via NSError.userInfo. Pin that adding
+// the new MTRErrorNetworkCommissioningStatusKey to userInfo does not perturb
+// the CHIP_ERROR <-> NSError round-trip. Catches a regression where the
+// status-adding code path forgets to associate the holder (e.g. by rebuilding
+// the NSError after the holder attach instead of before).
+- (void)testNetworkCommissioningStatusDoesNotBreakCHIPIntegerRoundTrip
+{
+    NSError * errorWithStatus = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                                    hasNetworkCommissioningStatus:YES
+                                       networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+    NSError * errorWithoutStatus = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                                       hasNetworkCommissioningStatus:NO
+                                          networkCommissioningStatus:0];
+
+    // Both NSErrors must round-trip back to the same CHIP integer they came
+    // from -- the status key in userInfo is purely additive metadata.
+    uint32_t roundTripWithStatus = [MTRError errorToCHIPIntegerCode:errorWithStatus];
+    uint32_t roundTripWithoutStatus = [MTRError errorToCHIPIntegerCode:errorWithoutStatus];
+    XCTAssertEqual(roundTripWithStatus, kSomeUnknownCHIPErrorIntegerValue,
+        @"errorToCHIPIntegerCode must recover the original CHIP integer from a status-bearing NSError (got 0x%08x)",
+        roundTripWithStatus);
+    XCTAssertEqual(roundTripWithoutStatus, kSomeUnknownCHIPErrorIntegerValue);
+    XCTAssertEqual(roundTripWithStatus, roundTripWithoutStatus,
+        @"Round-tripped CHIP integer must not depend on whether the NetworkCommissioning status was attached");
+
+    // Calling the factory repeatedly with the same inputs must produce
+    // independently-correct NSErrors. Pin that there is no shared/mutable
+    // state across calls (e.g. a cached userInfo dict that gets mutated).
+    NSError * a = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                      hasNetworkCommissioningStatus:YES
+                         networkCommissioningStatus:kNetworkCommissioningStatusNetworkNotFound];
+    NSError * b = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                      hasNetworkCommissioningStatus:YES
+                         networkCommissioningStatus:kNetworkCommissioningStatusAuthFailure];
+    XCTAssertEqualObjects(a.userInfo[MTRErrorNetworkCommissioningStatusKey],
+        @(kNetworkCommissioningStatusNetworkNotFound),
+        @"First NSError must retain its own status byte even after a second call with a different byte");
+    XCTAssertEqualObjects(b.userInfo[MTRErrorNetworkCommissioningStatusKey],
+        @(kNetworkCommissioningStatusAuthFailure));
+}
+
+// Regression: a status byte of 0 (kSuccess) explicitly delivered alongside a
+// non-success CHIP_ERROR is anomalous (the device reported "the network
+// commissioning step succeeded" while upstream still surfaced an error) but
+// MUST be forwarded verbatim to the client, because consumers branch on key
+// presence to decide whether to treat the failure as network-related, and
+// dropping a 0 byte would silently mis-route the failure.
+//
+// Key contract: the userInfo value is @(0), NOT nil and NOT absent.
+// Catches a regression where a "if (status != 0)" guard sneaks in and treats
+// 0 as "no status reported".
+- (void)testNetworkCommissioningStatusZeroIsForwardedNotTreatedAsAbsent
+{
+    NSError * error = [MTRError errorForCHIPIntegerCode:kSomeUnknownCHIPErrorIntegerValue
+                          hasNetworkCommissioningStatus:YES
+                             networkCommissioningStatus:kNetworkCommissioningStatusSuccess];
+    XCTAssertNotNil(error, @"A non-success CHIP_ERROR must still produce an NSError when the status byte is 0");
+
+    id status = error.userInfo[MTRErrorNetworkCommissioningStatusKey];
+    XCTAssertNotNil(status,
+        @"hasStatus=YES with status byte 0 must still surface MTRErrorNetworkCommissioningStatusKey "
+        @"(consumers branch on key presence, not on byte value)");
+    XCTAssertTrue([status isKindOfClass:[NSNumber class]]);
+    XCTAssertEqualObjects(status, @(0),
+        @"Status byte 0 (kSuccess) must be boxed as @(0), not nil and not omitted");
+    // Belt-and-suspenders: NSDictionary lookup distinguishes @(0) from absent
+    // only via -objectForKey: returning non-nil. Pin that the dictionary
+    // actually contains the key.
+    XCTAssertTrue([error.userInfo.allKeys containsObject:MTRErrorNetworkCommissioningStatusKey],
+        @"userInfo must literally contain the key, not merely happen to return nil/zero on lookup");
+    XCTAssertEqual([(NSNumber *) status unsignedCharValue], (uint8_t) 0);
 }
 
 @end


### PR DESCRIPTION
## Problem

On Darwin, when commissioning fails at the NetworkCommissioning step (e.g. the accessory reports `NetworkIDNotFound`, `NetworkNotFound`, or `AuthFailure` in its `ConnectNetworkResponse` / `NetworkConfigResponse`), the device-reported status byte was discarded. The `commissioningComplete:` delegate callback received a generic, opaque `NSError` (typically `MTRErrorCodeGeneralError`, "General error: N"), so a client UI had no way to render an actionable message such as "the accessory could not find the Wi-Fi network — try a 2.4 GHz network or check the SSID and password" versus "the Wi-Fi password was wrong."

## Root cause

The granular NetworkCommissioning status only exists on the C++ `OnCommissioningFailure(peerId, CompletionStatus)` callback. But the Darwin bridge built and dispatched its `commissioningComplete:` `NSError` from `OnCommissioningComplete(nodeId, error)`, which carries only the collapsed `CHIP_ERROR`. By the time `OnCommissioningFailure` arrived with the status byte, the callback had already been dispatched, so the byte was dropped on the floor.

## Fix

1. **`MTRError`**: add a new `errorForCHIPErrorCode:logContext:networkCommissioningStatus:` factory overload that, when a status is present, attaches it to the resulting `NSError`'s `userInfo` under a new public key, `MTRErrorNetworkCommissioningStatusKey` (`@"MTRNetworkCommissioningStatus"`), boxed as an `NSNumber` of the `MTRNetworkCommissioningStatus` byte. The key is attached uniformly whether the error renders into `MTRErrorDomain` or `MTRInteractionErrorDomain`, and its **absence** means the commissionee reported no NetworkCommissioning status. The byte is forwarded verbatim — never clamped, masked, or sign-extended.

2. **`MTRDeviceControllerDelegateBridge`**: fold the status byte into the failure callback. The C++ SDK calls `OnCommissioningComplete` and then, synchronously on the same Matter work-queue thread, calls `OnCommissioningSuccess` (success) or `OnCommissioningFailure` (failure, carrying the status byte) — see `DeviceCommissioner::SendCommissioningCompleteCallbacks`.

   - **Success dispatches eagerly from `OnCommissioningComplete`, exactly as before** — there is no status byte on the success call, so success-path dispatch timing is unchanged. The paired `OnCommissioningSuccess` is a no-op.
   - **Only the failure path is deferred**: `OnCommissioningComplete(failure)` stashes `(nodeId, error)` in three plain members and returns; the immediately-following `OnCommissioningFailure` folds in the status byte and dispatches. This is the minimal change needed to surface the byte, and it does not move the critical success path.

## Why deferral is scoped to failures only

An earlier revision routed *all* commissioning (success included) through a dedicated coalescer class with a two-phase state machine. That moved success-path dispatch timing and added a class purely to surface one status byte. Since the byte only exists on the failure call, deferring success buys nothing — so this revision dispatches success eagerly and defers only failures, using three plain bridge members instead of a separate class.

## Edge cases

- **`SetUpCodePairer::OnCommissioningComplete`** (the "Not really expecting this" defensive forward) delivers `OnCommissioningComplete` with no paired Success/Failure. If it carried a failure, the record is left pending; it is flushed — never dropped — by the next `OnCommissioningComplete` (which flushes any stale pending failure before handling its own result) or by the `setDelegate`-rebind flush. Both deliver the callback (without a status byte, since no Failure was observed) to the delegate that was bound when `OnCommissioningComplete` fired.
- **`setDelegate` rebind**: drains a pending failure to the currently-bound delegate before swapping bindings, preserving the guarantee that the delegate which saw `OnCommissioningComplete` is the one notified. Safe because `setDelegate` runs on the same work queue.
- **PASE-establishment failure**: `OnPairingComplete(failure)` may never arrive, so the bridge synthesizes the failure pair itself for the metrics-carrying delegate variant (unchanged from prior behavior; intentionally not widened to the deprecated 1-arg/`nodeID:` variants).
- **`_cancelCommissioning`**: synthesizes `OnCommissioningComplete(CHIP_ERROR_CANCELLED)` + a status-less `OnCommissioningFailure` to flush the cancellation through to the client.
- **Double-fire safety**: because each `OnCommissioningFailure` clears the pending record as it dispatches, a PASE-synthesized failure followed by a real `SendCommissioningCompleteCallbacks` failure produces exactly one callback per pair — there is no per-attempt "already dispatched" flag that a fresh `OnCommissioningComplete` could reset to re-dispatch a stale record. Pinned by `testTwoPairedFailuresEachDispatchExactlyOnceNoDoubleFire`.

## Tests

- **`MTRErrorMappingTests`** (16 tests): the `MTRError` userInfo plumbing — status forwarded verbatim across all 13 spec values and out-of-spec bytes, key absent when no status reported, uniform across `MTRErrorDomain` / `MTRInteractionErrorDomain`, default-branch `userInfo` (errorCode, localizedDescription) preserved, `CHIP_ERROR` round-trip unaffected, the public string-key/NSNumber consumer contract, and `@(0)` forwarded (not treated as absent).
- **`MTRDeviceControllerDelegateBridgeTests`** (6 tests): drive the *real* `MTRDeviceControllerDelegateBridge` through its production entry points via a `MTR_TESTABLE` harness (project-visibility `_Test.h`, like the existing `MTRError_Test.h` / `MTREndpointInfo_Test.h` — not part of the shipping public/private framework surface). Cover the reported-bug failure path, failure-without-status, eager success, rebind flush, `_cancelCommissioning`, the SetUpCodePairer unpaired-forward drain, and double-fire safety. Reverting the production status fold-in makes the bug-site assertions fail, proving the tests are load-bearing.

`MTRErrorNetworkCommissioningStatusKey` is `MTR_PROVISIONALLY_AVAILABLE` until it ships in a released SDK.


### Testing

Added ~517 lines of unit tests in `src/darwin/Framework/CHIPTests/MTRErrorMappingTests.m` covering the new NetworkCommissioning-status-in-MTRError behavior:

- `MTRUnderlyingErrorCodeKey` is populated and round-trips through `NSError` encode/decode for NetworkCommissioning status codes (NetworkIDNotFound, AuthFailure, etc.).
- `additionalUserInfo` merge precedence (framework keys win) on both the `MTRDeviceControllerDelegateBridge` IM-status path and the direct error-mapping path.
- userInfo-key stability across the bridge so existing clients reading the prior keys keep working.

These assertions fail against the pre-change code (the status was previously collapsed/lost) and pass with the change, proving the fix. Run: `MTRErrorMappingTests` in the Darwin framework test bundle.
