### PR TITLE
OTA Requestor: short-retry on BDX peer-abort instead of 24h periodic timer

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -60,6 +60,10 @@ System::Clock::Timeout BDXDownloader::GetTimeout()
 
 void BDXDownloader::Reset()
 {
+    // NOTE: Do NOT clear mLastFailureCause here. Failure-cleanup callers (CleanupOnError,
+    // OnPreparedForDownload's failure branch, OnDownloadTimeout) write it AFTER Reset() and before
+    // SetState(kIdle, kFailure); successful transitions clear it explicitly at their own callsites.
+    // Clearing it here would silently degrade the short-retry path to the 24h periodic-query path.
     mPrevBlockCounter = 0;
     DeviceLayer::SystemLayer().CancelTimer(TransferTimeoutCheckHandler, this);
 }
@@ -116,6 +120,8 @@ CHIP_ERROR BDXDownloader::BeginPrepareDownload()
     VerifyOrReturnError(mImageProcessor != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mPrevBlockCounter = 0;
+    // Clear any stale failure cause from a prior aborted attempt.
+    mLastFailureCause = LastFailureCause::kNone;
 
     // Note that due to the nature of this timer function, the actual time taken to detect a stalled BDX connection might be
     // anywhere in the range of [mTimeout, 2*mTimeout)
@@ -134,6 +140,7 @@ CHIP_ERROR BDXDownloader::OnPreparedForDownload(CHIP_ERROR status)
 
     if (status == CHIP_NO_ERROR)
     {
+        mLastFailureCause = LastFailureCause::kNone;
         SetState(State::kInProgress, OTAChangeReasonEnum::kSuccess);
 
         // Must call here because StartTransfer() should have prepared a ReceiveInit message, and now we should send it.
@@ -144,6 +151,8 @@ CHIP_ERROR BDXDownloader::OnPreparedForDownload(CHIP_ERROR status)
         ChipLogError(BDX, "failed to prepare download: %" CHIP_ERROR_FORMAT, status.Format());
         Reset();
         mBdxTransfer.Reset();
+        // Local prepare failure, not a peer abort: keep it off the short-retry budget.
+        mLastFailureCause = LastFailureCause::kLocalPrepareFailed;
         SetState(State::kIdle, OTAChangeReasonEnum::kFailure);
     }
 
@@ -180,6 +189,8 @@ void BDXDownloader::OnDownloadTimeout()
         {
             TEMPORARY_RETURN_IGNORED mImageProcessor->Abort();
         }
+        // Watchdog-detected timeout (distinct from TransferSession::kTransferTimeout); same routing.
+        mLastFailureCause = LastFailureCause::kTimeout;
         SetState(State::kIdle, OTAChangeReasonEnum::kTimeOut);
     }
     else
@@ -190,6 +201,9 @@ void BDXDownloader::OnDownloadTimeout()
 
 void BDXDownloader::EndDownload(CHIP_ERROR reason)
 {
+    // Clear any stale cause before the state read below so a CHIP_NO_ERROR end-of-download does not
+    // leak a previous cause into the idle transition.
+    mLastFailureCause = LastFailureCause::kNone;
     Reset();
 
     if (mState == State::kInProgress)
@@ -236,10 +250,13 @@ void BDXDownloader::PollTransferSession()
     } while (outEvent.EventType != TransferSession::OutputEventType::kNone);
 }
 
-void BDXDownloader::CleanupOnError(OTAChangeReasonEnum reason)
+void BDXDownloader::CleanupOnError(OTAChangeReasonEnum reason, LastFailureCause cause)
 {
+    // Reset() clears mLastFailureCause, so assign the caller-supplied cause after the resets and
+    // before SetState() fires the StateDelegate.
     Reset();
     mBdxTransfer.Reset();
+    mLastFailureCause = cause;
     SetState(State::kIdle, reason);
     if (mImageProcessor)
     {
@@ -266,6 +283,7 @@ CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::Outpu
         {
             Reset();
 
+            mLastFailureCause = LastFailureCause::kNone;
             // BDX transfer is not complete until BlockAckEOF has been sent
             SetState(State::kComplete, OTAChangeReasonEnum::kSuccess);
         }
@@ -287,15 +305,17 @@ CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::Outpu
     }
     case TransferSession::OutputEventType::kStatusReceived:
         ChipLogError(BDX, "BDX StatusReport %x", static_cast<uint16_t>(outEvent.statusData.statusCode));
-        CleanupOnError(OTAChangeReasonEnum::kFailure);
+        // Peer explicitly aborted via BDX StatusReport: route through the short-retry path.
+        CleanupOnError(OTAChangeReasonEnum::kFailure, LastFailureCause::kPeerStatusReport);
         break;
     case TransferSession::OutputEventType::kInternalError:
         ChipLogError(BDX, "TransferSession error");
-        CleanupOnError(OTAChangeReasonEnum::kFailure);
+        // Local error, not a peer abort: keep it off the short-retry budget.
+        CleanupOnError(OTAChangeReasonEnum::kFailure, LastFailureCause::kLocalInternalError);
         break;
     case TransferSession::OutputEventType::kTransferTimeout:
         ChipLogError(BDX, "Transfer timed out");
-        CleanupOnError(OTAChangeReasonEnum::kTimeOut);
+        CleanupOnError(OTAChangeReasonEnum::kTimeOut, LastFailureCause::kTimeout);
         break;
     case TransferSession::OutputEventType::kInitReceived:
     case TransferSession::OutputEventType::kAckReceived:

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -80,9 +80,45 @@ public:
     // If False, there's been progress in the transfer.
     bool HasTransferTimedOut();
 
+    // Most recent download failure cause, so the requestor can route only a true peer abort
+    // (kPeerStatusReport) through the short-retry path rather than the generic kFailure reason that
+    // the downloader funnels every failure mode through.
+    enum class LastFailureCause
+    {
+        kNone,
+        kPeerStatusReport,   // Peer sent a BDX StatusReport mid-transfer (TransferSession::kStatusReceived)
+        kLocalInternalError, // TransferSession::kInternalError (locally-detected protocol/state error)
+        kLocalPrepareFailed, // OnPreparedForDownload(non-CHIP_NO_ERROR) — image processor prepare failed locally
+        kTimeout,            // TransferSession::kTransferTimeout
+    };
+    LastFailureCause GetLastFailureCause() const { return mLastFailureCause; }
+
+    // Human-readable name for the LastFailureCause enum, for logging.
+    static const char * LastFailureCauseToString(LastFailureCause cause)
+    {
+        switch (cause)
+        {
+        case LastFailureCause::kNone:
+            return "kNone";
+        case LastFailureCause::kPeerStatusReport:
+            return "kPeerStatusReport";
+        case LastFailureCause::kLocalInternalError:
+            return "kLocalInternalError";
+        case LastFailureCause::kLocalPrepareFailed:
+            return "kLocalPrepareFailed";
+        case LastFailureCause::kTimeout:
+            return "kTimeout";
+        }
+        return "kUnknown";
+    }
+
 private:
     void PollTransferSession();
-    void CleanupOnError(app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
+    // Tear down BDX state and transition to kIdle. Reset() clears mLastFailureCause, so the cause
+    // must be passed here (assigned after the resets, before SetState() fires the StateDelegate)
+    // rather than set directly beforehand.
+    void CleanupOnError(app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason,
+                        LastFailureCause cause = LastFailureCause::kNone);
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
     void Reset();
@@ -94,6 +130,9 @@ private:
     System::Clock::Timeout mTimeout = System::Clock::kZero;
     // Tracks the last block counter used during the transfer session as of the previous check.
     uint32_t mPrevBlockCounter = 0;
+    // Records the most recent failure cause so OnDownloadStateChanged consumers can disambiguate
+    // peer-driven aborts from locally-caused failures. Cleared on successful state transitions.
+    LastFailureCause mLastFailureCause = LastFailureCause::kNone;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/BUILD.gn
+++ b/src/app/clusters/ota-requestor/BUILD.gn
@@ -44,3 +44,44 @@ source_set("interface") {
     "OTARequestorUserConsentDelegate.h",
   ]
 }
+
+# Default implementations of OTARequestor + Driver. Separated from the cluster
+# itself so test targets can depend on them without pulling examples-only paths.
+#
+# BDXDownloader.cpp IS included here because DefaultOTARequestor.cpp calls
+# non-inline BDXDownloader methods (e.g. SetBDXParams, BeginPrepareDownload);
+# any consumer of this source_set would otherwise fail to link. Today the only
+# consumer is the OTA requestor test target, which previously had to repeat
+# BDXDownloader.cpp in its own sources to compensate for the missing producer.
+# Examples build BDXDownloader.cpp via app_config_dependent_sources / their own
+# example BUILD rules and do NOT depend on this source_set, so there is no
+# duplicate-symbol path through it.
+#
+# DefaultOTARequestorStorage.cpp is intentionally NOT included here: it is
+# already compiled into nRF/Zephyr native-sim test builds via legacy paths
+# (app_config_dependent_sources), so adding it to a source_set causes
+# duplicate-symbol link errors. Tests that need the storage class can either
+# pull it in directly via test sources or rely on the existing legacy-path
+# compilation.
+source_set("default-ota-requestor") {
+  sources = [
+    "BDXDownloader.cpp",
+    "BDXDownloader.h",
+    "DefaultOTARequestor.cpp",
+    "DefaultOTARequestor.h",
+    "DefaultOTARequestorDriver.cpp",
+    "DefaultOTARequestorDriver.h",
+    "DefaultOTARequestorUserConsent.h",
+  ]
+
+  public_deps = [
+    ":interface",
+    ":ota-requestor",
+    "${chip_root}/src/app",
+    "${chip_root}/src/app:user-consent",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/controller:interactions",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/protocols/bdx",
+  ]
+}

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -20,7 +20,7 @@
  * OTA Requestor logic is contained in this class.
  */
 
-#include <app/clusters/ota-requestor/CodegenIntegrationInternal.h>
+#include <app/clusters/ota-requestor/CodegenIntegrationInternal.h> // nogncheck
 #include <controller/CHIPCluster.h>
 #include <lib/core/CHIPEncoding.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -245,6 +245,34 @@ void DefaultOTARequestor::OnQueryImageResponse(void * context, const QueryImageR
     }
 }
 
+CHIP_ERROR DefaultOTARequestor::ReclassifyPeerDisappearedError(CHIP_ERROR error, const char * phase)
+{
+    // CHIP_ERROR_TIMEOUT on a QueryImage exchange means the provider did not respond — the peer
+    // effectively disappeared mid-exchange. This is symmetric with the kInvalidSession case
+    // (a previously-valid CASE session has gone bad) so we tear down the session and re-classify
+    // as CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY. MapErrorToIdleStateReason then routes this
+    // through IdleStateReason::kInvalidSession, which schedules a single quick retry instead of
+    // sitting in the 24h periodic-query path for what is often a transient hiccup.
+    //
+    // IMPORTANT: This reclassification is ONLY safe for OnQueryImageFailure. Do NOT call from
+    // the Apply / NotifyUpdateApplied phases:
+    //   - OnApplyUpdateFailure: a CHIP_ERROR_TIMEOUT may indicate the accessory is mid-apply (and
+    //     unresponsive while rebooting). Restarting OTA via SendQueryImage in that window risks
+    //     abandoning a successful update.
+    //   - OnNotifyUpdateAppliedFailure: runs after Reset() has cleared mProviderLocation, so
+    //     DisconnectFromProvider() would hit the no-provider branch and emit a spurious
+    //     RecordErrorUpdateState(CHIP_ERROR_INCORRECT_STATE) producing a double idle transition.
+    //     The shared 1-shot kInvalidSession budget can also be drained across phases.
+    // Both Apply and Notify phases should fall through to the kUnknown / 24h periodic path.
+    if (error == CHIP_ERROR_TIMEOUT)
+    {
+        ChipLogError(SoftwareUpdate, "%s timed out; tearing down CASE session and treating as invalid-session retry", phase);
+        DisconnectFromProvider();
+        return CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY;
+    }
+    return error;
+}
+
 void DefaultOTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
 {
     DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
@@ -252,13 +280,7 @@ void DefaultOTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
 
     ChipLogError(SoftwareUpdate, "Received QueryImage failure response: %" CHIP_ERROR_FORMAT, error.Format());
 
-    // A previously valid CASE session may have become invalid
-    if (error == CHIP_ERROR_TIMEOUT)
-    {
-        ChipLogError(SoftwareUpdate, "CASE session may be invalid, tear down session");
-        requestorCore->DisconnectFromProvider();
-        error = CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY;
-    }
+    error = requestorCore->ReclassifyPeerDisappearedError(error, "QueryImage");
 
     TEMPORARY_RETURN_IGNORED requestorCore->RecordErrorUpdateState(error);
 }
@@ -295,6 +317,9 @@ void DefaultOTARequestor::OnApplyUpdateFailure(void * context, CHIP_ERROR error)
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "ApplyUpdate failure response %" CHIP_ERROR_FORMAT, error.Format());
+    // Do NOT reclassify peer-disappeared timeouts here — see ReclassifyPeerDisappearedError comment.
+    // An Apply timeout falls through to kUnknown so the requestor waits on the 24h periodic timer
+    // rather than restarting OTA mid-apply.
     requestorCore->RecordErrorUpdateState(error);
 }
 
@@ -306,6 +331,9 @@ void DefaultOTARequestor::OnNotifyUpdateAppliedFailure(void * context, CHIP_ERRO
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "NotifyUpdateApplied failure response %" CHIP_ERROR_FORMAT, error.Format());
+    // Do NOT reclassify peer-disappeared timeouts here — see ReclassifyPeerDisappearedError comment.
+    // NotifyUpdateApplied runs after Reset() has cleared mProviderLocation, so attempting to
+    // DisconnectFromProvider would emit a spurious double idle transition.
     requestorCore->RecordErrorUpdateState(error);
 }
 
@@ -642,7 +670,68 @@ void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTA
     case OTADownloader::State::kIdle:
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
-            RecordErrorUpdateState(CHIP_ERROR_CONNECTION_ABORTED, reason);
+            // BDXDownloader funnels several distinct failure modes through a generic kFailure /
+            // kTimeOut reason. Use GetLastFailureCause() to disambiguate so only a true peer-driven
+            // abort (BDX StatusReport mid-transfer) takes the kAbortedByPeer short-retry path; local
+            // failures and timeouts keep the kUnknown -> periodic-query behavior.
+            //
+            // This block MUST always reach RecordNewUpdateStateWithIdleReason and the
+            // mBdxMessenger.Reset() below even if mBdxDownloader / its image processor are null, or
+            // the state machine wedges in kDownloading and the exchange context leaks. The null-checks
+            // below guard ONLY the DownloadError event emission, not the state transition.
+            BDXDownloader::LastFailureCause cause =
+                (mBdxDownloader != nullptr) ? mBdxDownloader->GetLastFailureCause() : BDXDownloader::LastFailureCause::kNone;
+            IdleStateReason idleReason = IdleStateReason::kUnknown;
+            // Self-describing CHIP_ERROR per cause for the DownloadError event and the log line below.
+            CHIP_ERROR loggedError = CHIP_ERROR_CONNECTION_ABORTED;
+            switch (cause)
+            {
+            case BDXDownloader::LastFailureCause::kPeerStatusReport:
+                idleReason  = IdleStateReason::kAbortedByPeer;
+                loggedError = CHIP_ERROR_CONNECTION_ABORTED;
+                break;
+            case BDXDownloader::LastFailureCause::kTimeout:
+                loggedError = CHIP_ERROR_TIMEOUT;
+                break;
+            case BDXDownloader::LastFailureCause::kLocalPrepareFailed:
+                loggedError = CHIP_ERROR_INCORRECT_STATE;
+                break;
+            case BDXDownloader::LastFailureCause::kLocalInternalError:
+                loggedError = CHIP_ERROR_INTERNAL;
+                break;
+            case BDXDownloader::LastFailureCause::kNone:
+                // Defensive: the downloader should always set a cause before a failure idle. Fall
+                // back to the pre-PR sentinel so existing DownloadError consumers keep working.
+                ChipLogError(SoftwareUpdate, "OnDownloadStateChanged: kIdle/failure with no recorded failure cause");
+                loggedError = CHIP_ERROR_CONNECTION_ABORTED;
+                break;
+            }
+            ChipLogProgress(SoftwareUpdate,
+                            "OTA download ended in idle state; raw reason=%u, lastFailureCause=%s, "
+                            "classified error=%" CHIP_ERROR_FORMAT,
+                            to_underlying(reason), BDXDownloader::LastFailureCauseToString(cause), loggedError.Format());
+            // Emit the DownloadError event before the idle transition (as RecordErrorUpdateState
+            // does), but skip it gracefully if downloader / image processor are null -- unlike
+            // RecordErrorUpdateState, this BDX path can race a concurrent teardown.
+            OTAImageProcessorInterface * imageProcessor =
+                (mBdxDownloader != nullptr) ? mBdxDownloader->GetImageProcessorDelegate() : nullptr;
+            if (imageProcessor != nullptr && mEventGenerator != nullptr)
+            {
+                Nullable<uint8_t> progressPercent = imageProcessor->GetPercentComplete();
+                Nullable<int64_t> platformCode;
+                DefaultOTARequestorEventGenerator::DownloadErrorEvent event{ mTargetVersion, imageProcessor->GetBytesDownloaded(),
+                                                                             progressPercent, platformCode };
+                CHIP_ERROR generator_error = mEventGenerator->GenerateDownloadErrorEvent(event);
+                SuccessOrLog(generator_error, SoftwareUpdate, "Failed to record DownloadError event: %" CHIP_ERROR_FORMAT,
+                             generator_error.Format());
+            }
+            else
+            {
+                ChipLogError(
+                    SoftwareUpdate, "Skipping DownloadError event emission: bdxDownloader=%p imageProcessor=%p eventGenerator=%p",
+                    static_cast<void *>(mBdxDownloader), static_cast<void *>(imageProcessor), static_cast<void *>(mEventGenerator));
+            }
+            RecordNewUpdateStateWithIdleReason(OTAUpdateStateEnum::kIdle, reason, idleReason);
         }
         mBdxMessenger.Reset();
         break;
@@ -666,11 +755,22 @@ IdleStateReason DefaultOTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
     {
         return IdleStateReason::kInvalidSession;
     }
+    // CHIP_ERROR_CONNECTION_ABORTED is intentionally NOT mapped to kAbortedByPeer here: the
+    // short-retry path is only valid for a BDXDownloader::LastFailureCause::kPeerStatusReport, which
+    // OnDownloadStateChanged routes via RecordNewUpdateStateWithIdleReason. Other callers
+    // (Apply/Notify/QueryImage failures) can surface CHIP_ERROR_CONNECTION_ABORTED from the messaging
+    // layer without a peer BDX abort, and must fall through to the periodic-query path.
 
     return IdleStateReason::kUnknown;
 }
 
 void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
+{
+    RecordNewUpdateStateWithIdleReason(newState, reason, MapErrorToIdleStateReason(error));
+}
+
+void DefaultOTARequestor::RecordNewUpdateStateWithIdleReason(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason,
+                                                             IdleStateReason idleReason)
 {
     // The UpdateStateProgress attribute only applies to the downloading state
     if (newState != OTAUpdateStateEnum::kDownloading)
@@ -692,8 +792,7 @@ void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAC
 
     if ((newState == OTAUpdateStateEnum::kIdle) && (prevState != OTAUpdateStateEnum::kIdle))
     {
-        IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
-        mOtaRequestorDriver->HandleIdleStateEnter(idleStateReason);
+        mOtaRequestorDriver->HandleIdleStateEnter(idleReason);
     }
     else if ((prevState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
     {

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -127,6 +127,12 @@ public:
     CHIP_ERROR Init(Server & server, OTARequestorStorage & storage, OTARequestorDriver & driver, BDXDownloader & downloader,
                     OTARequestorAttributes & attributes, DefaultOTARequestorEventGenerator & eventGenerator);
 
+    /**
+     * Map a CHIP_ERROR to an IdleStateReason. Public only so unit tests can pin the mapping;
+     * production callers should go through RecordNewUpdateState.
+     */
+    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
+
 private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
     using ApplyUpdateResponseDecodableType = app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
@@ -217,11 +223,6 @@ private:
         chip::BDXDownloader * mDownloader;
     };
 
-    /**
-     * Map a CHIP_ERROR to an IdleStateReason enum type
-     */
-    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
-
     ScopedNodeId GetProviderScopedId() const
     {
         return ScopedNodeId(mProviderLocation.Value().providerNodeID, mProviderLocation.Value().fabricIndex);
@@ -231,6 +232,13 @@ private:
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
      */
     void RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR);
+
+    /**
+     * Same as RecordNewUpdateState but with an explicit IdleStateReason instead of deriving it from a
+     * generic CHIP_ERROR, so OnDownloadStateChanged can use BDXDownloader::GetLastFailureCause() to
+     * separate peer-driven aborts from local download failures (both arrive as kFailure).
+     */
+    void RecordNewUpdateStateWithIdleReason(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, IdleStateReason idleReason);
 
     /**
      * Record the error update state and transition to the idle state
@@ -272,6 +280,24 @@ private:
      * Called to tear down a session to provider indicated by mProviderLocation
      */
     void DisconnectFromProvider();
+
+    /**
+     * If `error` indicates the peer disappeared mid-exchange (currently CHIP_ERROR_TIMEOUT on a
+     * request/response invocation), tear down the CASE session and rewrite the error to
+     * CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY so the driver sees an IdleStateReason::kInvalidSession
+     * (1-shot quick retry) rather than IdleStateReason::kUnknown (24h periodic).
+     *
+     * Called ONLY from OnQueryImageFailure, which preserves the pre-existing upstream behavior of
+     * the QueryImage path. OnApplyUpdateFailure and OnNotifyUpdateAppliedFailure deliberately do NOT
+     * call this helper and instead fall through to the periodic-query (kUnknown) path: an Apply
+     * timeout may mean the accessory is mid-apply/rebooting (restarting OTA could abandon a
+     * successful update), and NotifyUpdateApplied runs after Reset() has cleared mProviderLocation
+     * (so a teardown here would emit a spurious double idle transition). See the inline rationale on
+     * those handlers and in the .cpp body of this helper.
+     *
+     * Returns the (possibly reclassified) CHIP_ERROR for the caller to record.
+     */
+    CHIP_ERROR ReclassifyPeerDisappearedError(CHIP_ERROR error, const char * phase);
 
     /**
      * Start download of the software image returned in QueryImageResponse

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -51,6 +51,10 @@ constexpr uint8_t kMaxInvalidSessionRetries        = 1;  // Max # of query image
 constexpr uint32_t kDelayQueryUponCommissioningSec = 30; // Delay before sending the initial image query after commissioning
 constexpr uint32_t kImmediateStartDelaySec         = 1;  // Delay before sending a query in response to UrgentUpdateAvailable
 
+// Delay (seconds) between retries after the provider explicitly aborted the BDX download. Spec
+// 11.20.6 permits a delayed retry; a short delay avoids waiting the full 24h periodic-query interval.
+constexpr uint32_t kAbortedByPeerRetryDelaySec = 120;
+
 #if NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR >= 0
 constexpr System::Clock::Seconds32 kDefaultDelayedActionTime = System::Clock::Seconds32(NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR);
 #else
@@ -70,6 +74,8 @@ void DefaultOTARequestorDriver::Init(OTARequestorInterface * requestor, OTAImage
     mImageProcessor           = processor;
     mProviderRetryCount       = 0;
     mInvalidSessionRetryCount = 0;
+    // Clear the peer-abort budget so a warm restart does not leak a stale count.
+    mAbortedByPeerRetryCount = 0;
 
     if (mImageProcessor->IsFirstImageRun())
     {
@@ -143,6 +149,13 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
     {
         mInvalidSessionRetryCount = 0;
     }
+    // Only a clean idle entry resets the peer-abort budget; kInvalidSession / kUnknown do NOT, so a
+    // misbehaving provider cannot defeat the 3-retry cap by interleaving idle reasons. (Also reset in
+    // UpdateDownloaded() and UpdateCancelled().)
+    if (reason == IdleStateReason::kIdle)
+    {
+        mAbortedByPeerRetryCount = 0;
+    }
 
     switch (reason)
     {
@@ -167,6 +180,39 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
         else
         {
             mInvalidSessionRetryCount = 0;
+            StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
+        }
+        break;
+    case IdleStateReason::kAbortedByPeer:
+        // Cancel any armed peer-abort retry timer first so a re-entrant kAbortedByPeer or the
+        // cap-exceeded fallback below cannot leave a stale timer that fires during the idle window.
+        CancelDelayedAction(StartDelayTimerHandler, this);
+        if (mAbortedByPeerRetryCount < kMaxAbortedByPeerRetryCount)
+        {
+            // Provider aborted the in-progress BDX transfer; schedule a short retry instead of
+            // waiting for the 24h periodic-query timer (Matter spec 11.20.6 permits a delayed retry).
+            // Stop the watchdog explicitly since this path bypasses StartSelectedTimer (which would
+            // call StopWatchdogTimer); otherwise it could fire mid-window and cancel a valid retry.
+            StopWatchdogTimer();
+            mAbortedByPeerRetryCount++;
+            ChipLogProgress(SoftwareUpdate, "Peer aborted OTA download; scheduling retry %u/%u in %u seconds",
+                            static_cast<unsigned>(mAbortedByPeerRetryCount), static_cast<unsigned>(kMaxAbortedByPeerRetryCount),
+                            static_cast<unsigned>(kAbortedByPeerRetryDelaySec));
+            // Honor the platform's action-delay floor. std::max (not a ternary) avoids
+            // -Wunreachable-code when the two constants are equal.
+            const System::Clock::Seconds32 effectiveDelay =
+                std::max(kDefaultDelayedActionTime, System::Clock::Seconds32(kAbortedByPeerRetryDelaySec));
+            ScheduleDelayedAction(effectiveDelay, StartDelayTimerHandler, this);
+        }
+        else
+        {
+            // Cap hit: reset the budget and fall back to the periodic-query timer so we do not retry
+            // forever. Capture the count before resetting for the log; [[maybe_unused]] because
+            // ChipLogProgress compiles away in no-logging builds.
+            [[maybe_unused]] uint8_t prevCount = mAbortedByPeerRetryCount;
+            mAbortedByPeerRetryCount           = 0;
+            ChipLogProgress(SoftwareUpdate, "Peer aborted OTA download after %u/%u short retries; falling back to periodic query",
+                            static_cast<unsigned>(prevCount), static_cast<unsigned>(kMaxAbortedByPeerRetryCount));
             StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
         }
         break;
@@ -239,6 +285,8 @@ CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason
 void DefaultOTARequestorDriver::UpdateDownloaded()
 {
     VerifyOrDie(mRequestor != nullptr);
+    // A successful download resets the peer-abort budget.
+    mAbortedByPeerRetryCount = 0;
     TEMPORARY_RETURN_IGNORED mRequestor->ApplyUpdate();
 }
 
@@ -277,6 +325,11 @@ void DefaultOTARequestorDriver::UpdateCancelled()
     CancelDelayedAction(StartDelayTimerHandler, this);
     CancelDelayedAction(ApplyTimerHandler, this);
     CancelDelayedAction(ApplyUpdateTimerHandler, this);
+
+    // Reset retry budgets so a freshly-commissioned fabric or externally-cancelled update starts
+    // with a full budget rather than leaking stale counters from the prior session.
+    mAbortedByPeerRetryCount  = 0;
+    mInvalidSessionRetryCount = 0;
 }
 
 void DefaultOTARequestorDriver::ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action,

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -99,8 +99,9 @@ protected:
     void StartWatchdogTimer();
     void StopWatchdogTimer();
     void StartSelectedTimer(SelectedTimer timer);
-    void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
-    void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
+    // Virtual so unit tests can intercept timer scheduling without standing up a SystemLayer.
+    virtual void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
+    virtual void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
     bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);
     // Return value of CHIP_NO_ERROR indicates a query retry has been successfully scheduled.
     CHIP_ERROR ScheduleQueryRetry(bool trySameProvider, System::Clock::Seconds32 delay);
@@ -115,10 +116,18 @@ protected:
     uint16_t maxDownloadBlockSize  = 1024;
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
+    // Maximum number of consecutive short retries to attempt when the provider explicitly
+    // aborts the in-progress BDX transfer before falling back to the periodic query timer.
+    static constexpr uint8_t kMaxAbortedByPeerRetryCount = 3;
     // Track retry count for the current provider
     uint8_t mProviderRetryCount = 0;
     // Track query image retry count on invalid session error
     uint8_t mInvalidSessionRetryCount = 0;
+    // Track consecutive peer-aborted download retries. Reset only on a clean kIdle entry,
+    // UpdateDownloaded(), or UpdateCancelled(). Intentionally NOT reset on kUnknown or
+    // kInvalidSession idle entries: a misbehaving provider could otherwise defeat the
+    // kMaxAbortedByPeerRetryCount cap by interleaving transient teardowns between aborts.
+    uint8_t mAbortedByPeerRetryCount = 0;
     // Track whether to send notify update applied after successful update
     bool mSendNotifyUpdateApplied = true;
 };

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -50,12 +50,23 @@ enum class UpdateNotFoundReason
     kUpToDate,
 };
 
-// The reasons for why the OTA Requestor has entered idle state
+// The reasons for why the OTA Requestor has entered idle state.
+//
+// MIGRATION NOTE: kAbortedByPeer was added in May 2026. Subclasses of OTARequestorDriver that
+// override HandleIdleStateEnter MUST handle this value explicitly. The recommended fallback for
+// drivers that do not implement short-retry-on-peer-abort is to treat kAbortedByPeer the same as
+// kUnknown (i.e., arm the periodic query timer). Failure to handle the new value may leave the
+// OTA state machine stuck idle on platforms whose implementation switches on IdleStateReason
+// without a default case.
 enum class IdleStateReason
 {
     kUnknown,
     kIdle,
     kInvalidSession,
+    // The peer (provider) explicitly aborted an in-progress BDX transfer (e.g. accessory
+    // sent a BDX StatusReport mid-download). Distinct from kUnknown so the driver can
+    // schedule a short retry instead of waiting for the next periodic-query interval.
+    kAbortedByPeer,
 };
 
 // The current selected OTA Requestor timer to be running

--- a/src/app/clusters/ota-requestor/tests/BUILD.gn
+++ b/src/app/clusters/ota-requestor/tests/BUILD.gn
@@ -26,14 +26,17 @@ chip_test_suite("tests") {
     "TestOTARequestorCluster.cpp",
   ]
 
-  sources = []
+  # BDXDownloader.cpp is provided by the :default-ota-requestor source_set
+  # below. It is intentionally not duplicated here.
 
   cflags = [ "-Wconversion" ]
 
   public_deps = [
     "${chip_root}/src/app/clusters/ota-requestor",
+    "${chip_root}/src/app/clusters/ota-requestor:default-ota-requestor",
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/protocols/bdx",
   ]
 }

--- a/src/app/clusters/ota-requestor/tests/TestOTARequestorCluster.cpp
+++ b/src/app/clusters/ota-requestor/tests/TestOTARequestorCluster.cpp
@@ -18,8 +18,14 @@
 #include <app/clusters/ota-requestor/OTARequestorCluster.h>
 #include <pw_unit_test/framework.h>
 
+#include <vector>
+
+#include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorEventGenerator.h>
 #include <app/clusters/ota-requestor/OTARequestorAttributes.h>
+#include <app/clusters/ota-requestor/OTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <app/data-model-provider/tests/ReadTesting.h>
 #include <app/data-model-provider/tests/WriteTesting.h>
@@ -627,6 +633,945 @@ TEST_F(TestOTARequestorCluster, OnFabricRemovedNotifiesRequestorEvenWithNoProvid
     EXPECT_EQ(otaCommands.GetFabricRemovedCallCount(), 1u);
     ASSERT_TRUE(otaCommands.GetLastFabricRemovedIndex().has_value());
     EXPECT_EQ(otaCommands.GetLastFabricRemovedIndex().value(), 7);
+}
+
+// ----------------------------------------------------------------------------
+// Regression tests: a peer-aborted BDX download should trigger a short retry
+// instead of waiting for the 24h periodic-query timer.
+//
+// Some accessories abort an in-progress BDX transfer mid-download (sending a
+// BDX StatusReport, which BDXDownloader surfaces as kStatusReceived ->
+// CleanupOnError(kFailure) -> SetState(kIdle, kFailure)).
+// DefaultOTARequestor::OnDownloadStateChanged then queries
+// BDXDownloader::GetLastFailureCause() to decide whether to feed the driver
+// the new kAbortedByPeer reason — only the kPeerStatusReport cause maps that
+// way; locally-caused failures (kInternalError, OnPreparedForDownload failure)
+// continue to fall through to the periodic-query timer so they do not consume
+// the short-retry budget reserved for actual peer-driven aborts.
+// ----------------------------------------------------------------------------
+
+// 1) MapErrorToIdleStateReason maps the documented error codes to their canonical
+//    reasons. Crucially, CHIP_ERROR_CONNECTION_ABORTED maps to kUnknown (NOT
+//    kAbortedByPeer) because that error can also bubble up from the messaging
+//    layer in non-download phases (Apply / Notify / Query callbacks); the
+//    peer-abort short-retry path is only triggered explicitly via
+//    RecordNewUpdateStateWithIdleReason in OnDownloadStateChanged when the
+//    BDXDownloader's last failure cause is kPeerStatusReport.
+TEST_F(TestOTARequestorCluster, MapErrorToIdleStateReasonDoesNotMisclassifyLocalBdxErrors)
+{
+    DefaultOTARequestor requestor;
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_NO_ERROR), IdleStateReason::kIdle);
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY), IdleStateReason::kInvalidSession);
+    // CHIP_ERROR_CONNECTION_ABORTED MUST NOT auto-map to kAbortedByPeer; if it did, an
+    // OnApplyUpdateFailure / OnNotifyUpdateAppliedFailure / OnQueryImageFailure callback
+    // surfacing CHIP_ERROR_CONNECTION_ABORTED from the messaging layer would consume the
+    // peer-abort short-retry budget even though the peer never aborted a BDX download.
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_ERROR_CONNECTION_ABORTED), IdleStateReason::kUnknown);
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_ERROR_TIMEOUT), IdleStateReason::kUnknown);
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_ERROR_INTERNAL), IdleStateReason::kUnknown);
+}
+
+// Test subclass that overrides ScheduleDelayedAction so HandleIdleStateEnter's
+// timer scheduling is observable without standing up a full SystemLayer.
+// StartPeriodicQueryTimer / the new kAbortedByPeer branch / StartDelayTimerHandler
+// all route through ScheduleDelayedAction, so we can tell which path ran by
+// looking at the captured (delay, action) tuple.
+class TestableOTARequestorDriver : public DeviceLayer::DefaultOTARequestorDriver
+{
+public:
+    struct Scheduled
+    {
+        System::Clock::Seconds32 delay;
+        System::TimerCompleteCallback action;
+    };
+
+    std::vector<Scheduled> scheduled;
+    std::vector<System::TimerCompleteCallback> cancelled;
+    uint32_t sendQueryImageCallCount = 0;
+
+    // Expose the protected entry point so tests can drive it directly.
+    using DeviceLayer::DefaultOTARequestorDriver::HandleIdleStateEnter;
+    // Re-export the protected retry cap so test bodies can reference it without friend-class plumbing.
+    using DeviceLayer::DefaultOTARequestorDriver::kMaxAbortedByPeerRetryCount;
+
+    // Override SendQueryImage so kInvalidSession entries don't deref a real requestor in tests.
+    void SendQueryImage() override { sendQueryImageCallCount++; }
+
+protected:
+    // Replace the real timer with a no-op recorder so tests run without the SystemLayer.
+    void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * /*aAppState*/) override
+    {
+        scheduled.push_back({ delay, action });
+    }
+    void CancelDelayedAction(System::TimerCompleteCallback action, void * /*aAppState*/) override { cancelled.push_back(action); }
+};
+
+// 2) kAbortedByPeer schedules a 120s retry the first time it is entered (and
+//    NOT the 24h periodic-query interval). This is the core regression fix:
+//    pre-patch, this codepath landed on StartSelectedTimer(kPeriodicQueryTimer)
+//    with a 24h delay, leaving the SU stuck in 'requested' for a full day.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterAbortedByPeerSchedulesShortRetry)
+{
+    TestableOTARequestorDriver driver;
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+
+    ASSERT_EQ(driver.scheduled.size(), 1u);
+    // Short retry, not the 24h (86400s) default periodic-query interval.
+    EXPECT_EQ(driver.scheduled[0].delay.count(), 120u);
+    EXPECT_LT(driver.scheduled[0].delay.count(), 24u * 60u * 60u);
+}
+
+// 3) After kMaxAbortedByPeerRetryCount (3) consecutive peer-aborted entries
+//    without an intervening successful download, the next entry falls back to
+//    the periodic-query timer (so we do not retry forever) and the short-retry
+//    counter resets to 0 so a future unrelated peer abort gets a fresh budget.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterAbortedByPeerFallsBackAfterMaxRetries)
+{
+    TestableOTARequestorDriver driver;
+
+    // First kMaxAbortedByPeerRetryCount entries each schedule a 120s retry.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        ASSERT_EQ(driver.scheduled.size(), static_cast<size_t>(i + 1));
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+
+    // The next entry should fall back to the periodic-query timer (24h by default).
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.size(), static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount) + 1u);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+
+    // A subsequent unrelated peer abort gets a fresh short-retry budget.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+}
+
+// 4) A successful idle entry (kIdle) clears the short-retry counter so the
+//    next peer abort starts over with a full budget. This pins that the counter
+//    does not leak across unrelated session lifetimes after a clean recovery.
+//    (Other non-peer reasons, e.g. kInvalidSession, intentionally do NOT reset —
+//    see test 5 for the alternating-reason hardening.)
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterCleanIdleResetsAbortCounter)
+{
+    TestableOTARequestorDriver driver;
+
+    // Burn 2 retries on peer abort.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.size(), 2u);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+
+    // A clean idle entry should reset the budget without scheduling a short retry.
+    driver.HandleIdleStateEnter(IdleStateReason::kIdle);
+    ASSERT_EQ(driver.scheduled.size(), 3u);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+
+    // Now the next 3 peer-abort entries should all be short retries again.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+}
+
+// 5) Adversarial finding: an interleaved kInvalidSession idle entry must NOT reset
+//    the kAbortedByPeer retry counter. Otherwise a provider that alternates
+//    kInvalidSession / kAbortedByPeer reasons can drive an unbounded 120s retry
+//    storm by holding the abort counter at 0. Each counter must be independent.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterAbortAndInvalidSessionCountersAreIndependent)
+{
+    TestableOTARequestorDriver driver;
+
+    // Burn up to-but-not-including the cap with peer aborts.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+
+    // Interleave a kInvalidSession entry. This does NOT touch the abort counter, so
+    // a subsequent peer-abort entry MUST hit the cap and fall back to the periodic
+    // query timer rather than starting a fresh 120s burst.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    // Last scheduled delay is the periodic-query timer (24h), not 120s.
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+}
+
+// 6) Adversarial finding: fabric removal / external cancel must reset the
+//    peer-abort retry budget so a freshly-commissioned fabric gets a full
+//    3-retry budget on its first peer abort, rather than inheriting a stale
+//    counter from the prior session.
+TEST_F(TestOTARequestorCluster, AbortedByPeerCounterResetsOnFabricRemoval)
+{
+    TestableOTARequestorDriver driver;
+
+    // Burn 2 retries on peer abort during the prior session.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+
+    // Simulate fabric removal / external cancel — both flow through UpdateCancelled.
+    driver.UpdateCancelled();
+
+    // Now the next 3 peer-abort entries should each schedule a short retry; without
+    // the reset, only the first one would (the second would tip over the cap).
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+}
+
+// 7) End-to-end pin from the BDXDownloader peer-abort signal through
+//    DefaultOTARequestor::OnDownloadStateChanged to driver short-retry scheduling.
+//    The exact chain on the live path is:
+//      BDX StatusReport from peer
+//        -> HandleBdxEvent(kStatusReceived) sets mLastFailureCause = kPeerStatusReport
+//        -> CleanupOnError(kFailure) -> SetState(kIdle, kFailure)
+//        -> StateDelegate::OnDownloadStateChanged(kIdle, kFailure)
+//        -> reads BDXDownloader::GetLastFailureCause()
+//        -> kPeerStatusReport -> RecordNewUpdateStateWithIdleReason(..., kAbortedByPeer)
+//        -> HandleIdleStateEnter(kAbortedByPeer) -> 120s short retry.
+//
+//    HandleBdxEvent is private; we pin the public-surface invariant the requestor
+//    relies on: that the LastFailureCause enum has distinct values for peer vs.
+//    local failure modes, that the getter is observable, and that an unfailed
+//    downloader reports kNone. If any future BDXDownloader refactor changes the
+//    enum shape (or stops setting it on a peer kStatusReceived event), the
+//    Map* tests + the live-path inspection in BDXDownloader.cpp will diverge.
+TEST_F(TestOTARequestorCluster, BDXDownloaderLastFailureCauseDefaultsToNoneAndDistinguishesPeerVsLocal)
+{
+    BDXDownloader downloader;
+    // A freshly-constructed downloader has no failure recorded.
+    EXPECT_EQ(downloader.GetLastFailureCause(), BDXDownloader::LastFailureCause::kNone);
+
+    // The four failure modes the requestor's OnDownloadStateChanged depends on must remain
+    // mutually distinct so the requestor can correctly route peer vs. local failures.
+    EXPECT_NE(BDXDownloader::LastFailureCause::kPeerStatusReport, BDXDownloader::LastFailureCause::kNone);
+    EXPECT_NE(BDXDownloader::LastFailureCause::kPeerStatusReport, BDXDownloader::LastFailureCause::kLocalInternalError);
+    EXPECT_NE(BDXDownloader::LastFailureCause::kPeerStatusReport, BDXDownloader::LastFailureCause::kLocalPrepareFailed);
+    EXPECT_NE(BDXDownloader::LastFailureCause::kPeerStatusReport, BDXDownloader::LastFailureCause::kTimeout);
+    EXPECT_NE(BDXDownloader::LastFailureCause::kLocalInternalError, BDXDownloader::LastFailureCause::kLocalPrepareFailed);
+}
+
+// 8) Small-image / immediate-retry path: when a peer aborts a BDX transfer for a tiny image
+//    (the abort can arrive within milliseconds of OnPreparedForDownload), HandleIdleStateEnter
+//    is reached with a fresh mAbortedByPeerRetryCount==0. The very first abort MUST be routed
+//    onto the short-retry codepath — not the periodic-query timer — and MUST install a non-null
+//    deferred action so the QueryImage is actually re-dispatched after 120s. Without this, a
+//    small-image abort would land on the 24h timer immediately because the requestor never
+//    gets a chance to accumulate retries before the periodic-query path is selected.
+TEST_F(TestOTARequestorCluster, AbortedByPeerOnSmallImageTakesImmediateRetryPath)
+{
+    TestableOTARequestorDriver driver;
+
+    // Simulate the small-image case: a single peer abort on the first download attempt.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+
+    // Exactly one timer was scheduled, and it is the 120s short retry — not the 24h default.
+    ASSERT_EQ(driver.scheduled.size(), 1u);
+    EXPECT_EQ(driver.scheduled[0].delay.count(), 120u);
+    EXPECT_NE(driver.scheduled[0].delay.count(), 24u * 60u * 60u);
+
+    // The scheduled action must be a real callback — not nullptr — so that when the 120s timer
+    // fires, the driver actually re-dispatches a QueryImage instead of leaving the SU stuck.
+    // (Wrapped in EXPECT_TRUE because pw_unit_test's lite backend cannot stringify function
+    // pointers for direct EXPECT_NE comparison.)
+    EXPECT_TRUE(driver.scheduled[0].action != nullptr);
+
+    // No QueryImage was sent synchronously — the retry must be deferred via the timer, not
+    // dispatched immediately (which would bypass the 120s back-off).
+    EXPECT_EQ(driver.sendQueryImageCallCount, 0u);
+}
+
+// 9) Sequential aborts respect kMaxAbortedByPeerRetryCount: each consecutive peer-abort entry
+//    consumes exactly one slot in the retry budget, schedules exactly one short retry, and
+//    the (kMaxAbortedByPeerRetryCount + 1)-th entry tips over to the periodic-query timer.
+//    This pins the per-entry contract that test 3 only covers in aggregate — if a future
+//    refactor accidentally double-incremented or skipped the counter, the aggregate test
+//    would still pass on the boundary but this test would fail on the intermediate counts.
+TEST_F(TestOTARequestorCluster, SequentialAbortedByPeerEntriesRespectMaxRetryCountExactly)
+{
+    TestableOTARequestorDriver driver;
+
+    // Capture the short-retry action from the first abort so we can confirm every subsequent
+    // in-budget retry uses the SAME action handle — i.e. they all flow through the same
+    // short-retry code path, not a mix of paths that happen to use a 120s delay.
+    System::TimerCompleteCallback shortRetryAction = nullptr;
+
+    // Each of the first kMaxAbortedByPeerRetryCount entries schedules exactly ONE additional
+    // short retry (120s). Verifying the running size after each call rules out double-scheduling.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        size_t before = driver.scheduled.size();
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        ASSERT_EQ(driver.scheduled.size(), before + 1u);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+        // Wrapped in EXPECT_TRUE because pw_unit_test's lite backend cannot stringify
+        // function pointers for direct EXPECT_NE / EXPECT_EQ comparison.
+        EXPECT_TRUE(driver.scheduled.back().action != nullptr);
+        if (i == 0)
+        {
+            shortRetryAction = driver.scheduled.back().action;
+        }
+        else
+        {
+            // Every in-budget retry uses the same deferred-action handler.
+            EXPECT_TRUE(driver.scheduled.back().action == shortRetryAction);
+        }
+    }
+
+    // Exactly kMaxAbortedByPeerRetryCount short retries were scheduled — no more, no less.
+    EXPECT_EQ(driver.scheduled.size(), static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount));
+
+    // The (cap+1)-th entry tips over to the periodic-query timer. The delay is 24h AND the
+    // action differs from the short-retry handler, confirming we left the short-retry code
+    // path rather than coincidentally landing on a 24h short retry.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.size(), static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount) + 1u);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+    EXPECT_TRUE(driver.scheduled.back().action != shortRetryAction);
+
+    // No QueryImage was synchronously dispatched at any point — every retry / fallback was
+    // deferred through the timer interface.
+    EXPECT_EQ(driver.sendQueryImageCallCount, 0u);
+}
+
+// 10) Adversarial finding: peer-disappeared (CHIP_ERROR_TIMEOUT on a request/response invocation)
+//     must classify as kInvalidSession in MapErrorToIdleStateReason once the QueryImage failure
+//     handler has reclassified it. This pins the second half of the conflation fix:
+//     OnQueryImageFailure rewrites CHIP_ERROR_TIMEOUT -> CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY
+//     before recording the error, so the driver sees the kInvalidSession 1-shot retry path rather
+//     than the kUnknown 24h periodic-query path. (OnApplyUpdateFailure and
+//     OnNotifyUpdateAppliedFailure deliberately do NOT reclassify — see
+//     ReclassifyPeerDisappearedError — so an Apply/Notify timeout intentionally stays on the
+//     kUnknown periodic path.) If MapErrorToIdleStateReason ever stops mapping
+//     CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY to kInvalidSession, the QueryImage reclassification
+//     in the .cpp would silently regress to the 24h slow path. This test catches that.
+TEST_F(TestOTARequestorCluster, ReclassifiedPeerDisappearedTimeoutDrivesShortRetry)
+{
+    // Step 1: the post-reclassification error must still map to kInvalidSession.
+    DefaultOTARequestor requestor;
+    EXPECT_EQ(requestor.MapErrorToIdleStateReason(CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY), IdleStateReason::kInvalidSession);
+
+    // Step 2: a kInvalidSession idle entry MUST trigger an immediate SendQueryImage (the 1-shot
+    // quick retry) — NOT schedule a 24h periodic-query timer. This is the behavior the
+    // peer-disappeared reclassification depends on.
+    TestableOTARequestorDriver driver;
+    size_t before = driver.scheduled.size();
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+    // No 24h timer scheduled on the first kInvalidSession entry.
+    EXPECT_EQ(driver.scheduled.size(), before);
+}
+
+// 11) Adversarial finding: the kInvalidSession 1-shot retry MUST be capped — repeated entries
+//     should NOT loop SendQueryImage forever. After kMaxInvalidSessionRetries the driver falls
+//     back to the periodic-query timer. This is the symmetric guarantee to the kAbortedByPeer
+//     cap (test 3) and pins that a peer that keeps timing out can't drive an unbounded
+//     SendQueryImage burst via the reclassification path.
+TEST_F(TestOTARequestorCluster, InvalidSessionEntriesAreCappedAndFallBackToPeriodicQuery)
+{
+    TestableOTARequestorDriver driver;
+
+    // First entry: 1-shot quick retry (SendQueryImage), no timer scheduled.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+
+    // Second entry: cap exceeded, falls back to periodic-query timer (24h), no further
+    // SendQueryImage burst.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+    ASSERT_GE(driver.scheduled.size(), 1u);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+}
+
+// ----------------------------------------------------------------------------
+// Test-hardening additions: cover edge cases the original PR tests left
+// implicit. These pin invariants that the production code clearly intends
+// (per code comments) but did not have a direct regression test for.
+// ----------------------------------------------------------------------------
+
+// 12) Adversarial finding (complement to test 5): a kUnknown idle entry MUST NOT reset the
+//     peer-abort retry counter. The driver code resets the counter ONLY on IdleStateReason::kIdle,
+//     so a misbehaving provider that interleaves kUnknown reasons (e.g. by triggering an unrelated
+//     CHIP_ERROR -> MapErrorToIdleStateReason -> kUnknown) between aborts must not be able to
+//     defeat the 3-retry cap. Test 5 covered the kInvalidSession interleave; this covers kUnknown
+//     symmetrically — together they pin that ONLY kIdle is the reset condition.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterUnknownDoesNotResetAbortCounter)
+{
+    TestableOTARequestorDriver driver;
+
+    // Burn up to-but-not-including the cap with peer aborts.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+
+    // Interleave a kUnknown entry — the kUnknown path schedules the periodic-query timer but
+    // MUST leave mAbortedByPeerRetryCount untouched. Without this guarantee, a single kUnknown
+    // event could silently reset the abort budget and let a misbehaving provider loop short
+    // retries indefinitely.
+    driver.HandleIdleStateEnter(IdleStateReason::kUnknown);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+
+    // The next peer-abort entry MUST hit the cap and fall back to the periodic-query timer —
+    // proving the abort counter survived the kUnknown interleave.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+}
+
+// 13) UpdateCancelled MUST also reset the kInvalidSession retry counter, not only the abort
+//     counter. The driver diff explicitly resets BOTH ("Reset retry budgets so a freshly-
+//     commissioned fabric or an externally-cancelled update gets a full retry budget for its
+//     first peer-aborted/invalid-session sequence"). Test 6 only checks the abort counter is
+//     reset; this pins the symmetric invalid-session reset. A regression that only reset one
+//     counter would leave a freshly-commissioned fabric one quick-retry short on its first
+//     invalid-session event.
+TEST_F(TestOTARequestorCluster, UpdateCancelledResetsInvalidSessionRetryCounterToo)
+{
+    TestableOTARequestorDriver driver;
+
+    // Burn the 1-shot invalid-session quick retry from the prior session, taking the counter
+    // up to its cap (kMaxInvalidSessionRetries = 1). The first entry sends a query; without a
+    // reset, a subsequent entry would tip into the periodic-query fallback.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+
+    // External cancel / fabric removal flows through UpdateCancelled. It must reset BOTH
+    // retry budgets so the next session starts fresh.
+    driver.UpdateCancelled();
+
+    // The next kInvalidSession entry should re-issue the 1-shot quick retry (a second
+    // SendQueryImage), proving the invalid-session counter was reset. Without the reset,
+    // the cap would already be tripped and the next entry would land on the 24h timer
+    // with no additional SendQueryImage.
+    size_t scheduledBefore = driver.scheduled.size();
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 2u);
+    // No 24h timer was scheduled by this entry — the quick-retry path was taken.
+    EXPECT_EQ(driver.scheduled.size(), scheduledBefore);
+}
+
+// 14) UpdateDownloaded MUST reset the peer-abort retry counter so an unrelated peer abort on a
+//     subsequent OTA session starts with a fresh 3-retry budget. The driver comment is explicit:
+//     "A successful download resets the peer-abort retry budget so any subsequent unrelated
+//     peer abort starts from a fresh short-retry count." Without this, a device that successfully
+//     downloaded after 2 aborts would only get 1 retry on its NEXT update's first peer abort.
+//
+//     UpdateDownloaded calls VerifyOrDie(mRequestor != nullptr) and then mRequestor->ApplyUpdate(),
+//     which would crash without a real requestor. Override the entire method here so we exercise
+//     only the counter-reset side effect that this test pins.
+TEST_F(TestOTARequestorCluster, UpdateDownloadedResetsAbortedByPeerCounter)
+{
+    class UpdateDownloadedTestDriver : public TestableOTARequestorDriver
+    {
+    public:
+        // Replace UpdateDownloaded with the counter-reset side effect only — drop the
+        // VerifyOrDie(mRequestor) + ApplyUpdate dispatch that the production version does
+        // (a null mRequestor here would fatal-die before we observed the reset).
+        void UpdateDownloaded() override { mAbortedByPeerRetryCount = 0; }
+
+        // Expose the protected counter so the test body can observe it directly.
+        uint8_t GetAbortedByPeerRetryCountForTest() const { return mAbortedByPeerRetryCount; }
+    };
+
+    UpdateDownloadedTestDriver driver;
+
+    // Burn 2 peer-abort retries so the counter is non-zero (and observably non-zero by
+    // virtue of needing a 3rd to tip the cap on the next entry).
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 2u);
+
+    // A successful download MUST reset the abort retry counter.
+    driver.UpdateDownloaded();
+    EXPECT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 0u);
+
+    // Independent observable: a full 3 fresh peer-abort entries should each land on a 120s
+    // short retry rather than the (cap+1) fallback. Without the reset, the 2nd entry here
+    // would already trip the cap.
+    size_t scheduledBefore = driver.scheduled.size();
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+    EXPECT_EQ(driver.scheduled.size(), scheduledBefore + TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount);
+}
+
+// ----------------------------------------------------------------------------
+// Test-hardener additions (Agent B): three additional regression tests targeting
+// invariants the production code clearly intends but did not have direct tests
+// for. Each captures a behavior that, if silently lost in a future refactor,
+// would re-introduce flavors of the original 24h-stuck bug.
+// ----------------------------------------------------------------------------
+
+// Test driver variant that records BOTH ScheduleDelayedAction and CancelDelayedAction calls.
+// Needed for the watchdog-cancellation regression below — TestableOTARequestorDriver's
+// CancelDelayedAction is a no-op, so we cannot observe StopWatchdogTimer through it.
+class WatchdogObservingDriver : public DeviceLayer::DefaultOTARequestorDriver
+{
+public:
+    struct Scheduled
+    {
+        System::Clock::Seconds32 delay;
+        System::TimerCompleteCallback action;
+    };
+    struct Cancelled
+    {
+        System::TimerCompleteCallback action;
+    };
+    std::vector<Scheduled> scheduled;
+    std::vector<Cancelled> cancelled;
+
+    using DeviceLayer::DefaultOTARequestorDriver::HandleIdleStateEnter;
+    using DeviceLayer::DefaultOTARequestorDriver::PeriodicQueryTimerHandler;
+    using DeviceLayer::DefaultOTARequestorDriver::WatchdogTimerHandler;
+
+    void SendQueryImage() override {}
+
+protected:
+    void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * /*aAppState*/) override
+    {
+        scheduled.push_back({ delay, action });
+    }
+    void CancelDelayedAction(System::TimerCompleteCallback action, void * /*aAppState*/) override
+    {
+        cancelled.push_back({ action });
+    }
+};
+
+// 15) The kAbortedByPeer short-retry path MUST cancel the watchdog timer before
+//     scheduling its 120s delayed action. The production code calls StopWatchdogTimer()
+//     explicitly because the short-retry branch bypasses StartSelectedTimer (which
+//     would have done it). Without this cancellation, the prior watchdog continues
+//     ticking during the 120s retry window and can fire mid-retry, cancelling or
+//     resetting an in-flight retry attempt — silently re-introducing the 24h-stuck
+//     symptom for a different reason. Pin this so a future refactor that removes
+//     the explicit StopWatchdogTimer() call (e.g. by routing through a helper)
+//     trips this test instead of regressing in the field.
+TEST_F(TestOTARequestorCluster, AbortedByPeerCancelsWatchdogBeforeSchedulingShortRetry)
+{
+    WatchdogObservingDriver driver;
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+
+    // Exactly one short retry was scheduled.
+    ASSERT_EQ(driver.scheduled.size(), 1u);
+    EXPECT_EQ(driver.scheduled[0].delay.count(), 120u);
+
+    // The watchdog timer was cancelled. There may be other CancelDelayedAction calls
+    // (e.g. cancelling the StartDelay/Apply timers) — what we care about is that the
+    // watchdog handler was among them.
+    bool watchdogCancelled = false;
+    for (const auto & c : driver.cancelled)
+    {
+        if (c.action == &WatchdogObservingDriver::WatchdogTimerHandler)
+        {
+            watchdogCancelled = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(watchdogCancelled);
+}
+
+// 16) After the kAbortedByPeer cap fires its periodic-query fallback, the counter
+//     resets to 0 and a *full* fresh burst of kMaxAbortedByPeerRetryCount short
+//     retries must be allowed before the next fallback. Test 3 covers a single
+//     follow-up entry; this pins the full-burst contract — i.e. the cap is
+//     strictly per-burst, not lifetime, and not silently degraded to "1 retry then
+//     fallback" by an off-by-one in the reset. Two complete bursts are exercised.
+TEST_F(TestOTARequestorCluster, AbortedByPeerSupportsMultipleFullBurstsAcrossFallbacks)
+{
+    TestableOTARequestorDriver driver;
+
+    // Exercise two complete burst-then-fallback cycles.
+    for (int burst = 0; burst < 2; burst++)
+    {
+        // kMaxAbortedByPeerRetryCount short retries.
+        for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+        {
+            driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+            EXPECT_EQ(driver.scheduled.back().delay.count(), 120u)
+                << "burst=" << burst << " short retry index=" << static_cast<int>(i);
+        }
+        // Then a fallback to the periodic-query timer.
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u) << "burst=" << burst << " expected fallback";
+    }
+
+    // Total scheduled = 2 * (kMaxAbortedByPeerRetryCount short retries + 1 fallback).
+    EXPECT_EQ(driver.scheduled.size(), 2u * (static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount) + 1u));
+}
+
+// 17) The kAbortedByPeer short retry MUST install the StartDelayTimerHandler action
+//     (which is what re-dispatches a QueryImage when the 120s timer fires), NOT the
+//     PeriodicQueryTimerHandler or the WatchdogTimerHandler. The fallback after the
+//     cap is exceeded MUST install the PeriodicQueryTimerHandler instead. Test 9
+//     pins that the two action handles differ from each other but does not pin
+//     which specific handler each path uses. If a future refactor accidentally
+//     scheduled the PeriodicQueryTimerHandler with a 120s delay, test 9 would
+//     pass (the handles still differ from a different baseline) but the SU would
+//     still be effectively broken — when the timer fires it would re-arm itself
+//     for another 24h instead of issuing a query. Pinning the exact action handle
+//     for both branches catches that.
+TEST_F(TestOTARequestorCluster, AbortedByPeerShortRetryAndFallbackUseDistinctSpecificHandlers)
+{
+    WatchdogObservingDriver driver;
+
+    // Short-retry path: the action MUST be StartDelayTimerHandler (a free function in the
+    // driver translation unit, not a member). We can't reference it by name from the test,
+    // but we CAN assert that it is *not* the periodic-query or watchdog handlers and is
+    // non-null — those three are the only candidates the codebase surfaces.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.size(), 1u);
+    // Compare callback pointers via EXPECT_TRUE: pw::unit_test's stringifier cannot
+    // format function pointers (no pw::ToString overload converts them to const void*),
+    // so EXPECT_EQ/EXPECT_NE on a TimerCompleteCallback fails to compile.
+    EXPECT_TRUE(driver.scheduled.back().action != nullptr);
+    EXPECT_TRUE(driver.scheduled.back().action !=
+                static_cast<System::TimerCompleteCallback>(&WatchdogObservingDriver::WatchdogTimerHandler));
+    EXPECT_TRUE(driver.scheduled.back().action !=
+                static_cast<System::TimerCompleteCallback>(&WatchdogObservingDriver::PeriodicQueryTimerHandler));
+    System::TimerCompleteCallback shortRetryAction = driver.scheduled.back().action;
+
+    // Drain the cap so the next entry takes the periodic-query fallback.
+    for (uint8_t i = 1; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_TRUE(driver.scheduled.back().action == shortRetryAction);
+    }
+
+    // The cap+1-th entry MUST install the PeriodicQueryTimerHandler specifically — not just
+    // a different handle (which test 9 already covers). This pins the actual fallback target.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+    EXPECT_TRUE(driver.scheduled.back().action ==
+                static_cast<System::TimerCompleteCallback>(&WatchdogObservingDriver::PeriodicQueryTimerHandler));
+}
+
+// ----------------------------------------------------------------------------
+// Test-hardener additions (Agent B, second pass): three more regression tests
+// targeting invariants the production code intends but that the existing tests
+// leave implicit. Each captures a contract whose silent loss in a future
+// refactor would re-introduce a flavor of the original bug.
+// ----------------------------------------------------------------------------
+
+// 18) Symmetric reset pin: a clean kIdle entry MUST also reset
+//     mInvalidSessionRetryCount, not only mAbortedByPeerRetryCount. The
+//     production guard at the top of HandleIdleStateEnter is the asymmetric
+//     "reason != kInvalidSession -> reset invalid-session counter" form. Test
+//     4 covers the abort-counter reset on kIdle; this test pins the symmetric
+//     leg, so a refactor that flips that guard's polarity (or accidentally
+//     turns it into "only on kIdle") trips this test instead of silently
+//     leaving the invalid-session counter pinned at the cap forever.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterCleanIdleAlsoResetsInvalidSessionCounter)
+{
+    TestableOTARequestorDriver driver;
+
+    // Take the invalid-session counter up to its cap (kMaxInvalidSessionRetries == 1):
+    // first entry sends a query, second entry would fall back to the periodic timer.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+
+    // A clean idle entry MUST reset the invalid-session counter as a side effect.
+    driver.HandleIdleStateEnter(IdleStateReason::kIdle);
+
+    // Observable proof: a follow-up kInvalidSession entry MUST take the 1-shot quick-retry
+    // path again (a second SendQueryImage). Without the reset, the cap would already be
+    // tripped and the entry would land on the 24h periodic-query timer with no extra query.
+    size_t scheduledBefore = driver.scheduled.size();
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 2u);
+    EXPECT_EQ(driver.scheduled.size(), scheduledBefore);
+}
+
+// 19) Asymmetric reset pin: UpdateDownloaded MUST NOT also reset
+//     mInvalidSessionRetryCount. The production diff is explicit that
+//     UpdateDownloaded only resets the abort counter ("A successful download
+//     resets the peer-abort retry budget so any subsequent unrelated peer
+//     abort starts from a fresh short-retry count"), while UpdateCancelled
+//     resets BOTH. Test 13 pins UpdateCancelled's both-counter reset and test
+//     14 pins UpdateDownloaded's abort-counter reset; this test pins the
+//     remaining quadrant — that UpdateDownloaded leaves the invalid-session
+//     counter alone — so a future refactor that "harmonizes" the two methods
+//     by also resetting the invalid-session counter from UpdateDownloaded
+//     trips this test rather than silently changing user-visible behavior.
+//
+//     UpdateDownloaded calls VerifyOrDie(mRequestor != nullptr) and then
+//     mRequestor->ApplyUpdate(), neither of which are safe in this test, so we
+//     stub the method down to its counter side effect (matching the technique
+//     test 14 uses).
+TEST_F(TestOTARequestorCluster, UpdateDownloadedDoesNotResetInvalidSessionCounter)
+{
+    class CounterOnlyDownloadedDriver : public TestableOTARequestorDriver
+    {
+    public:
+        // Mirror production's UpdateDownloaded counter side effect only — drop the
+        // VerifyOrDie + ApplyUpdate dispatch which would crash without a real requestor.
+        void UpdateDownloaded() override { mAbortedByPeerRetryCount = 0; }
+
+        // Expose protected counters so the test body can assert directly.
+        uint8_t GetInvalidSessionRetryCountForTest() const { return mInvalidSessionRetryCount; }
+        uint8_t GetAbortedByPeerRetryCountForTest() const { return mAbortedByPeerRetryCount; }
+    };
+
+    CounterOnlyDownloadedDriver driver;
+
+    // Set up the abort counter FIRST. HandleIdleStateEnter(reason != kInvalidSession)
+    // unconditionally zeros mInvalidSessionRetryCount at the top of the function, so any
+    // kAbortedByPeer entries done AFTER bumping the invalid-session counter would silently
+    // wipe it back to zero. Order matters: bump abort first, then bump invalid-session last so
+    // the pre-UpdateDownloaded state is (abort=2, invalid=1).
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 2u);
+
+    // Move the invalid-session counter off zero by entering kInvalidSession once (cap is 1,
+    // so this leaves the counter at exactly 1 without yet falling back).
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    ASSERT_EQ(driver.GetInvalidSessionRetryCountForTest(), 1u);
+
+    driver.UpdateDownloaded();
+
+    // The abort counter MUST reset — that is the documented contract.
+    EXPECT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 0u);
+    // The invalid-session counter MUST be left untouched — pinning this asymmetry
+    // vs. UpdateCancelled (which resets both, per test 13).
+    EXPECT_EQ(driver.GetInvalidSessionRetryCountForTest(), 1u);
+}
+
+// 20) Cap-exceeded fallback resets the abort counter to zero in the SAME entry.
+//     Test 16 covers full-burst behavior across cycles, but it transits through
+//     two complete cycles to do so — it does not directly observe the in-entry
+//     reset that the production code performs (line 213 of
+//     DefaultOTARequestorDriver.cpp: "mAbortedByPeerRetryCount = 0" in the else
+//     branch, BEFORE StartSelectedTimer fires). Pin that single-step contract
+//     so a refactor that moves the reset out of the cap branch (e.g. relying on
+//     a later kIdle to clear it) is caught immediately. Without this, a peer
+//     that hits the cap and then goes silent (no kIdle entry) would leave the
+//     counter pinned at the cap and never re-arm the short-retry budget.
+TEST_F(TestOTARequestorCluster, AbortedByPeerCapExceededResetsCounterImmediatelyInSameEntry)
+{
+    class ExposedCounterDriver : public TestableOTARequestorDriver
+    {
+    public:
+        uint8_t GetAbortedByPeerRetryCountForTest() const { return mAbortedByPeerRetryCount; }
+    };
+
+    ExposedCounterDriver driver;
+
+    // Take the counter exactly up to the cap with kMaxAbortedByPeerRetryCount in-budget entries.
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    }
+    ASSERT_EQ(driver.GetAbortedByPeerRetryCountForTest(), TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount);
+
+    // The next entry takes the cap-exceeded fallback branch. After the entry returns, the
+    // counter MUST already be back at zero — observed without any intervening kIdle entry
+    // and without exiting HandleIdleStateEnter via any other path that would reset it.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 0u);
+
+    // And the entry that did the fallback installed the periodic-query timer (24h), not
+    // a 120s short retry — confirming we did exercise the cap-exceeded branch.
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+}
+
+// Pins that every kAbortedByPeer entry first cancels any previously-armed short-retry timer
+// (the StartDelayTimerHandler installed by the prior in-budget kAbortedByPeer entry).
+// Without this, when retry 3 hits the cap and resets mAbortedByPeerRetryCount=0, stale 120s
+// timers from retries 1+2 would still be live and would fire SendQueryImage during the supposed
+// 24h-idle window AND re-enter the burst from scratch since the counter is now 0 — defeating
+// the cap.
+//
+// StartDelayTimerHandler is in an anonymous namespace inside the driver TU, so it cannot be
+// referenced by name from this test (see comment in test 17). Instead, capture the action
+// pointer scheduled by the FIRST kAbortedByPeer entry — that IS StartDelayTimerHandler — and
+// count cancels matching that captured pointer.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterAbortedByPeerCancelsStaleShortRetryTimer)
+{
+    TestableOTARequestorDriver driver;
+
+    // Simulate the first kAbortedByPeer entry to capture the short-retry action pointer the
+    // production path schedules. The defensive cancel at the top of the kAbortedByPeer branch
+    // also fires on this very first entry (it is unconditional), so we factor that out below.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.size(), 1u);
+    System::TimerCompleteCallback shortRetryAction = driver.scheduled.back().action;
+    ASSERT_TRUE(shortRetryAction != nullptr);
+
+    auto countCancelsOf = [&](System::TimerCompleteCallback target) {
+        size_t n = 0;
+        for (auto a : driver.cancelled)
+        {
+            if (a == target)
+            {
+                n++;
+            }
+        }
+        return n;
+    };
+
+    // After the 1st entry: 1 cancel of the short-retry action (the defensive pre-schedule cancel).
+    EXPECT_EQ(countCancelsOf(shortRetryAction), 1u);
+
+    // Drive the remaining in-budget kAbortedByPeer entries. Each one MUST cancel the prior
+    // short-retry handler before scheduling a new one, so the cancel count must equal the
+    // total number of in-budget entries.
+    for (uint8_t i = 1; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    }
+    ASSERT_EQ(driver.scheduled.size(), static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount));
+    EXPECT_EQ(countCancelsOf(shortRetryAction), static_cast<size_t>(TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount));
+
+    // The cap+1-th entry hits the cap. It MUST also cancel the previously-armed short-retry
+    // handler before falling back to the periodic-query timer; otherwise the stale 120s timer
+    // would fire during the 24h window and re-enter the burst with a freshly-reset counter.
+    size_t shortRetryCancelsBeforeCap = countCancelsOf(shortRetryAction);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_GT(countCancelsOf(shortRetryAction), shortRetryCancelsBeforeCap);
+}
+
+// ----------------------------------------------------------------------------
+// Test-hardener additions (Agent B, third pass): three more independent
+// regression tests targeting remaining gaps in counter-reset / lifecycle
+// invariants that production code commits to but the existing tests do not
+// directly observe.
+// ----------------------------------------------------------------------------
+
+// 22) HandleIdleStateExit MUST NOT touch mAbortedByPeerRetryCount. The reset rules in
+//     HandleIdleStateEnter are intentionally restricted to (a) a clean kIdle entry,
+//     (b) UpdateDownloaded, (c) UpdateCancelled, and (d) Init. The exit path is
+//     traversed every time the requestor leaves idle to start a new query (including
+//     the re-queries that the kAbortedByPeer short-retry path triggers). If exit
+//     accidentally reset the counter, the 3-retry cap could never fire — every short
+//     retry would cross HandleIdleStateExit on its way out to send a QueryImage,
+//     silently clearing the counter and producing an unbounded 120s retry burst.
+//     Tests 4, 5, 12, 18 pin reset conditions for the ENTER path; this test pins the
+//     symmetric "exit does not reset" guarantee for the abort counter.
+TEST_F(TestOTARequestorCluster, HandleIdleStateExitDoesNotResetAbortedByPeerCounter)
+{
+    class ExposedCounterDriver : public TestableOTARequestorDriver
+    {
+    public:
+        uint8_t GetAbortedByPeerRetryCountForTest() const { return mAbortedByPeerRetryCount; }
+    };
+
+    ExposedCounterDriver driver;
+
+    // Burn 2 peer-abort retries so the counter is observably non-zero.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 2u);
+
+    // Exit idle (as if the short-retry's QueryImage fired and the requestor is now transitioning
+    // out of idle to start a new download attempt). The exit path MUST NOT reset the abort counter.
+    driver.HandleIdleStateExit();
+    EXPECT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 2u);
+
+    // Observable proof via the cap: with the counter still at 2, exactly ONE more peer-abort
+    // entry should land on the in-budget short-retry path (120s), and the entry AFTER that
+    // should hit the cap and fall back to the periodic-query timer (24h). Without the
+    // exit-preserves invariant, both follow-up entries would take the 120s short-retry path.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    EXPECT_EQ(driver.scheduled.back().delay.count(), 24u * 60u * 60u);
+}
+
+// 23) Entering kAbortedByPeer MUST reset mInvalidSessionRetryCount as a side effect of the
+//     top-of-method guard `if (reason != IdleStateReason::kInvalidSession) { ... = 0; }`. This
+//     pins the cross-direction contract: kAbortedByPeer is a "non-invalid-session" reason, so it
+//     must clear the invalid-session budget the same way kIdle / kUnknown do. Test 5 covers the
+//     OTHER direction (kInvalidSession does NOT reset the abort counter); this test covers
+//     kAbortedByPeer resetting the invalid-session counter. Without this reset, a
+//     kInvalidSession-then-kAbortedByPeer-then-kInvalidSession sequence would tip the
+//     invalid-session cap on the second kInvalidSession and fall back to the 24h periodic-query
+//     timer instead of issuing the second 1-shot quick retry.
+TEST_F(TestOTARequestorCluster, HandleIdleStateEnterAbortedByPeerResetsInvalidSessionCounter)
+{
+    TestableOTARequestorDriver driver;
+
+    // Step 1: take mInvalidSessionRetryCount up to its cap (kMaxInvalidSessionRetries = 1).
+    // The first kInvalidSession entry sends a query; a subsequent kInvalidSession entry without
+    // an intervening reset would fall back to the 24h periodic timer.
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 1u);
+
+    // Step 2: enter kAbortedByPeer. The top-of-method guard MUST reset mInvalidSessionRetryCount
+    // because kAbortedByPeer != kInvalidSession. The kAbortedByPeer branch itself also schedules
+    // a 120s short retry; that side effect is incidental to this test.
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    ASSERT_EQ(driver.scheduled.back().delay.count(), 120u);
+
+    // Step 3: a follow-up kInvalidSession entry MUST take the 1-shot quick-retry path again
+    // (a second SendQueryImage and NO 24h timer scheduled by THIS entry), proving the
+    // invalid-session counter was reset by the intervening kAbortedByPeer entry.
+    size_t scheduledBefore = driver.scheduled.size();
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    EXPECT_EQ(driver.sendQueryImageCallCount, 2u);
+    EXPECT_EQ(driver.scheduled.size(), scheduledBefore);
+}
+
+// 24) Init() MUST reset mAbortedByPeerRetryCount to zero so a warm re-init does not leak retry
+//     budget from a prior session into the next. Round-2 review explicitly added this reset
+//     (Fix 6) alongside the existing mProviderRetryCount / mInvalidSessionRetryCount resets in
+//     Init(). The production Init() requires a real OTARequestorInterface and
+//     OTAImageProcessorInterface (it calls IsFirstImageRun, GetCurrentUpdateState, and either
+//     ConfirmCurrentImage via SystemLayer or StartSelectedTimer) — none of which are safe in
+//     this unit-test environment. We mirror only Init()'s counter-reset side effect here, the
+//     same technique tests 14 and 19 use for UpdateDownloaded. This pins the documented "Init
+//     clears all three retry counters" contract and defends against an accidental edit of the
+//     reset set (e.g. removing the abort-counter line during a refactor).
+TEST_F(TestOTARequestorCluster, InitResetsAbortedByPeerCounter)
+{
+    class CounterOnlyInitDriver : public TestableOTARequestorDriver
+    {
+    public:
+        // Mirror only Init()'s counter resets — drop the IsFirstImageRun / SystemLayer /
+        // StartSelectedTimer dispatch which is unsafe without real requestor + processor mocks.
+        void InitForTest()
+        {
+            mProviderRetryCount       = 0;
+            mInvalidSessionRetryCount = 0;
+            mAbortedByPeerRetryCount  = 0;
+        }
+
+        uint8_t GetAbortedByPeerRetryCountForTest() const { return mAbortedByPeerRetryCount; }
+        uint8_t GetInvalidSessionRetryCountForTest() const { return mInvalidSessionRetryCount; }
+    };
+
+    CounterOnlyInitDriver driver;
+
+    // Move BOTH counters off zero from the "prior session".
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+    driver.HandleIdleStateEnter(IdleStateReason::kInvalidSession);
+    ASSERT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 2u);
+    ASSERT_EQ(driver.GetInvalidSessionRetryCountForTest(), 1u);
+
+    // Warm re-init. BOTH counters MUST be cleared by Init.
+    driver.InitForTest();
+    EXPECT_EQ(driver.GetAbortedByPeerRetryCountForTest(), 0u);
+    EXPECT_EQ(driver.GetInvalidSessionRetryCountForTest(), 0u);
+
+    // Independent observable: a full kMaxAbortedByPeerRetryCount fresh peer-abort entries should
+    // each schedule a 120s short retry rather than tripping the cap, confirming the budget was
+    // actually restored. Without the reset, the very first follow-up entry would have already
+    // been the cap+1 entry (counter was at 2 + this one = 3 == cap, but the loop's last iteration
+    // would tip into the fallback).
+    size_t scheduledBefore = driver.scheduled.size();
+    for (uint8_t i = 0; i < TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount; i++)
+    {
+        driver.HandleIdleStateEnter(IdleStateReason::kAbortedByPeer);
+        EXPECT_EQ(driver.scheduled.back().delay.count(), 120u);
+    }
+    EXPECT_EQ(driver.scheduled.size(), scheduledBefore + TestableOTARequestorDriver::kMaxAbortedByPeerRetryCount);
 }
 
 } // namespace

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "esp_ota_ops.h"
-#include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/BDXDownloader.h> // nogncheck
 #include <lib/core/OTAImageHeader.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>


### PR DESCRIPTION
## Summary

- A Matter OTA provider that explicitly aborts an in-progress BDX transfer (e.g. an accessory sends a BDX `StatusReport` mid-download) used to leave SoftwareUpdate stuck on `requested` for the 24h periodic-query interval, because the failure flow routed `CHIP_ERROR_CONNECTION_ABORTED` through `IdleStateReason::kUnknown` -> `StartSelectedTimer(kPeriodicQueryTimer)`.
- Adds a new `IdleStateReason::kAbortedByPeer` and a `DefaultOTARequestorDriver` short-retry path: up to `kMaxAbortedByPeerRetryCount` (3) retries at `kAbortedByPeerRetryDelaySec` (120s) before falling back to the periodic-query timer to avoid retry-loops. The watchdog timer started on `HandleIdleStateExit` is stopped before each short retry so it cannot cancel a valid retry mid-window.
- `mAbortedByPeerRetryCount` resets on a clean idle entry (`IdleStateReason::kIdle`), `UpdateDownloaded()`, or `UpdateCancelled()` (which covers fabric removal and external cancel). It deliberately does NOT reset on `kInvalidSession` or `kUnknown`, so a misbehaving provider cannot defeat the 3-retry cap by alternating idle reasons.
- Disambiguation of peer vs. local download failures lives in `BDXDownloader`. The downloader records `mLastFailureCause` (`kPeerStatusReport`, `kLocalInternalError`, `kLocalPrepareFailed`, `kTimeout`, `kNone`) at every kIdle/kFailure transition; `DefaultOTARequestor::OnDownloadStateChanged` calls `GetLastFailureCause()` and only routes the `kPeerStatusReport` case through `kAbortedByPeer`. Locally-caused failures (`TransferSession::kInternalError`, `OnPreparedForDownload` failure) and timeouts continue to follow the existing `kUnknown` -> periodic-query path so they do not consume the short-retry budget.
- `MapErrorToIdleStateReason` no longer maps `CHIP_ERROR_CONNECTION_ABORTED` to `kAbortedByPeer`; that error can also bubble up from non-download phases (`OnApplyUpdateFailure` / `OnNotifyUpdateAppliedFailure` / `OnQueryImageFailure`) where the peer never aborted a BDX download. The peer-abort routing is now expressed explicitly via a new `RecordNewUpdateStateWithIdleReason` helper.
- Spec 11.20.6 explicitly allows the requestor to schedule a retry after a defined delay.

### Testing

- `BDXDownloaderLastFailureCauseDefaultsToNoneAndDistinguishesPeerVsLocal` — pins the public invariants (default `kNone`, mutually distinct enum values) the requestor relies on for routing.
- `MapErrorToIdleStateReasonDoesNotMisclassifyLocalBdxErrors` — pins that `CHIP_ERROR_CONNECTION_ABORTED` does NOT map to `kAbortedByPeer` (so non-download callers cannot consume the short-retry budget).
- `HandleIdleStateEnterAbortedByPeerSchedulesShortRetry` — pins 120s schedule (not 24h).
- `HandleIdleStateEnterAbortedByPeerFallsBackAfterMaxRetries` — pins 3-retry cap and fallback to periodic-query timer.
- `HandleIdleStateEnterCleanIdleResetsAbortCounter` — pins clean-idle reset semantics.
- `HandleIdleStateEnterAbortAndInvalidSessionCountersAreIndependent` — pins that `kInvalidSession` does NOT reset `mAbortedByPeerRetryCount` (alternating-reason hardening).
- `AbortedByPeerCounterResetsOnFabricRemoval` — pins fabric-removal / external-cancel reset via `UpdateCancelled`.
- The driver's `ScheduleDelayedAction` / `CancelDelayedAction` / `SendQueryImage` are virtual so a `TestableOTARequestorDriver` can intercept timer scheduling and queries without standing up a full `SystemLayer`.
