### PR TITLE
EDE: add optional Electrical Protection Alarm cluster include

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1660,10 +1660,10 @@ limitations under the License.
         <scope>Endpoint</scope>
         <clusters>
             <include cluster="Electrical Distribution" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Electrical Protection Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Power Topology" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <!-- TODO: Add Electrical Protection Alarm (Provisional, Optional per spec) once https://github.com/project-chip/connectedhomeip/pull/72249 lands -->
         </clusters>
     </deviceType>
     <deviceType>


### PR DESCRIPTION
#### Summary

Adds the Electrical Protection Alarm (EPALM, 0x00A3) cluster reference to the Electrical Distribution Enclosure (EDE, 0x0517) device-type entry in `matter-devices.xml`.

This is the follow-on to the TODO comment landed in #72232 ("Add Electrical Distribution Enclosure device type (0x0517) registration"), now unblocked since the EPALM cluster XML merged in #72249.

Per the spec, EPALM on EDE is conformance `P, O` (Provisional, Optional). Per Hasty Granbery in EMTT discussion, provisional clusters are by definition optional, so the include uses `server="false" serverLocked="false"` — matches what Alchemy would generate, and matches Optional conformance for the cluster on this device type.

The TODO XML comment from #72232 is removed; the EPALM include is inserted in alphabetical order between Electrical Distribution and Identify, matching the convention used by Alchemy-generated `matter-devices.xml` output.

#### Related issues

Follows #72232 (Electrical Distribution Enclosure device-type registration — merged) and #72249 (Electrical Protection Alarm cluster XML — merged). N/A otherwise.

#### Testing

XML change is metadata only (one new `<include cluster=>` line in `matter-devices.xml`). The container regen (`chip-build:194` with the standard `zap_templates.yaml` workflow recipe) produced no downstream file changes — the cluster-include addition affects only the ZAP build's device-type-conformance metadata, not any generated C++/Java/Kotlin/Darwin/Python code.

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short (1 line)
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase