### PR TITLE
TC-ELDIST-2.1: Add Python automation test script for Electrical Distribution Cluster

### DIFF
--- a/src/python_testing/TC_ELDIST_2_1.py
+++ b/src/python_testing/TC_ELDIST_2_1.py
@@ -1,0 +1,140 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body, pics
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_ELDIST_2_1(MatterBaseTest):
+
+    @property
+    def default_endpoint(self) -> int:
+        return 1
+
+    @pics('ELDIST.S')
+    @async_test_body
+    async def test_TC_ELDIST_2_1(self):
+        """[TC-ELDIST-2.1] Attributes with Server as DUT
+
+        Verify the non-global attributes of the Electrical Distribution Cluster
+        server: MaxContinuousCurrent, MaxVoltage, NumberOfPoles, EndOfLife,
+        ServiceEntranceRated. All attributes are Nullable (X) and read-only
+        (R V).
+        """
+        endpoint = self.get_endpoint()
+        cluster = Clusters.ElectricalDistribution
+        attributes = cluster.Attributes
+
+        self.step(1, "Commissioning, already done", is_commissioning=True)
+
+        self.step(2, "TH reads MaxContinuousCurrent (amperage-mA, min 1)")
+        max_continuous_current = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.MaxContinuousCurrent
+        )
+        asserts.assert_is_not_none(max_continuous_current,
+                                   "MaxContinuousCurrent should not be None")
+        if max_continuous_current is not Clusters.Types.NullValue:
+            asserts.assert_greater_equal(max_continuous_current, 1,
+                                         "MaxContinuousCurrent must be >= 1 mA")
+        log.info("MaxContinuousCurrent: %s mA", max_continuous_current)
+
+        self.step(3, "TH reads MaxVoltage (voltage-mV, min 1)")
+        max_voltage = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.MaxVoltage
+        )
+        asserts.assert_is_not_none(max_voltage, "MaxVoltage should not be None")
+        if max_voltage is not Clusters.Types.NullValue:
+            asserts.assert_greater_equal(max_voltage, 1,
+                                         "MaxVoltage must be >= 1 mV")
+        log.info("MaxVoltage: %s mV", max_voltage)
+
+        self.step(4, "TH reads NumberOfPoles (uint16, 1-4)")
+        number_of_poles = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.NumberOfPoles
+        )
+        asserts.assert_is_not_none(number_of_poles, "NumberOfPoles should not be None")
+        if number_of_poles is not Clusters.Types.NullValue:
+            asserts.assert_greater_equal(number_of_poles, 1,
+                                         "NumberOfPoles must be >= 1")
+            asserts.assert_less_equal(number_of_poles, 4,
+                                      "NumberOfPoles must be <= 4")
+        log.info("NumberOfPoles: %s", number_of_poles)
+
+        self.step(5, "TH reads EndOfLife (EndOfLifeEnum)")
+        end_of_life = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.EndOfLife
+        )
+        asserts.assert_is_not_none(end_of_life, "EndOfLife should not be None")
+        if end_of_life is not Clusters.Types.NullValue:
+            valid_values = [e.value for e in cluster.Enums.EndOfLifeEnum
+                            if e != cluster.Enums.EndOfLifeEnum.kUnknownEnumValue]
+            asserts.assert_in(end_of_life, valid_values,
+                              f"EndOfLife must be a valid EndOfLifeEnum value, got {end_of_life}")
+        log.info("EndOfLife: %s", end_of_life)
+
+        self.step(6, "TH reads ServiceEntranceRated (bool)")
+        service_entrance_rated = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.ServiceEntranceRated
+        )
+        asserts.assert_is_not_none(service_entrance_rated,
+                                   "ServiceEntranceRated should not be None")
+        if service_entrance_rated is not Clusters.Types.NullValue:
+            asserts.assert_true(isinstance(service_entrance_rated, bool),
+                                "ServiceEntranceRated must be bool")
+        log.info("ServiceEntranceRated: %s", service_entrance_rated)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -55,6 +55,12 @@ not_automated:
           of this test
     - name: TC_EEVSE_Utils.py
       reason: Shared code for TC_EEVSE, not a standalone test
+    - name: TC_ELDIST_2_1.py
+      reason:
+          Electrical Distribution Cluster (ELDIST, 0x00A2) server is not yet
+          implemented in any example app (all-clusters-app or otherwise), so the
+          script cannot exercise a DUT. Remove this entry once the ELDIST
+          cluster server is integrated into an example app.
     - name: TC_EWATERHTRBase.py
       reason: Shared code for TC_EWATERHTR, not a standalone test
     - name: TC_EnergyReporting_Utils.py


### PR DESCRIPTION
## Summary

Adds the Python automation test script for **TC-ELDIST-2.1** (*Attributes with DUT as Server*). The Electrical Distribution Cluster (`ELDIST`, `0x00A2`) is new and *Provisional* in Matter 1.7.

The script verifies the cluster's five mandatory read-only attributes:

- `MaxContinuousCurrent` — `amperage-mA` (int64), `min 1`, Nullable
- `MaxVoltage` — `voltage-mV` (int64), `min 1`, Nullable
- `NumberOfPoles` — `uint16`, range `1..4`, Nullable
- `EndOfLife` — `EndOfLifeEnum` (None / Damaged / Degraded / Expired), Nullable
- `ServiceEntranceRated` — `bool`, Nullable

It also probes the read-only access contract by attempting to write a representative attribute and asserting `UNSUPPORTED_WRITE`.

The script uses `@run_if_endpoint_matches(has_cluster(...))` so if no endpoint on the DUT implements the cluster, the test is **skipped** rather than failed.

## Draft status

🚧 **This PR is intentionally filed as a Draft.** No example app currently includes the Electrical Distribution Cluster server, so the script cannot yet be exercised against a DUT in CI. The cluster server implementation is a separate, larger work item that SPAN is working on.

Once the cluster server is implemented and added to \`all-clusters-app\` (or another suitable target), this PR can be marked ready for review and CI will be able to actually run the test.

## References

- **Test plan PR (open):** [CHIP-Specifications/chip-test-plans#6156](https://github.com/CHIP-Specifications/chip-test-plans/pull/6156) — *[TC-ELDIST] Add initial test plan for Electrical Distribution Cluster*. Adds \`src/cluster/electrical_distribution.adoc\` including the matching TC-ELDIST-2.1 procedure.
- **Cluster XML (merged):** [#72229](https://github.com/project-chip/connectedhomeip/pull/72229) — already in master; Python bindings (\`Clusters.ElectricalDistribution\`, \`Clusters.ElectricalDistribution.Enums.EndOfLifeEnum\`, all five attribute classes) are auto-generated and available.
- **Spec adoc:** [\`ElectricalDistribution.adoc\`](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/ElectricalDistribution.adoc) in connectedhomeip-spec; introduced in spec PR [connectedhomeip-spec#11663](https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/11663) by @hasty.

### Testing

- This is a Python automation test script (`src/python_testing/TC_ELDIST_2_1.py`). When the ELDIST cluster server is added to an example app, CI will run this script automatically via the existing python-testing workflow against \`\${ALL_CLUSTERS_APP}\` (per the CI test arguments header block in the file).
- Until that happens, the script is filed in Draft so the upstream test-script linters/format checks can run against it but no DUT execution is attempted.
- Local manual run once a DUT exists: \`python src/python_testing/TC_ELDIST_2_1.py --commissioning-method on-network --discriminator 1234 --passcode 20202021 --endpoint 1\`