### PR TITLE
[Infineon]HSM Matter SDK Code Improvement and Bug Fixes

### DIFF
--- a/docs/platforms/infineon/infineon_trustm_provisioning.md
+++ b/docs/platforms/infineon/infineon_trustm_provisioning.md
@@ -30,9 +30,7 @@ can be used to perform provisioning by following the steps mentioned below.
 
 ```
  $ cd linux-optiga-trust-m/
- $ git checkout provider_dev
- $ git submodule update -f
- $ ./provider_installation_script.sh
+ $ ./trustm_installation_script.sh
 ```
 
 -   Run the script to generate Matter test DAC for lock-app using the public key
@@ -64,4 +62,19 @@ and test CD into OPTIGA&trade; Trust M Arbitrary OID 0xF1E0._
 
 For certificate claim and OPTIGA&trade; Trust M MTR provisioning, please refer
 to our
-[README for Late-stage Provisioning](https://github.com/Infineon/linux-optiga-trust-m/blob/provider_dev/scripts/matter_provisioning/README.md#certificate-claiming)
+[README for Late-stage Provisioning](https://github.com/Infineon/linux-optiga-trust-m/tree/master/scripts/matter_provisioning#certificate-claiming)
+
+To provision OPTIGA&trade; Trust M for HMAC usage in the Matter SDK, run the script below:
+
+```
+$ cd scripts/matter_provisioning/
+$ ./matter_HMAC_provisioning.sh
+```
+
+To provision OPTIGA&trade; Trust M for HKDF usage in the Matter SDK, run the script below:
+
+```
+$ cd scripts/matter_provisioning/
+$ ./matter_HKDF_provisioning.sh
+```
+

--- a/docs/platforms/infineon/infineon_trustm_provisioning.md
+++ b/docs/platforms/infineon/infineon_trustm_provisioning.md
@@ -64,17 +64,18 @@ For certificate claim and OPTIGA&trade; Trust M MTR provisioning, please refer
 to our
 [README for Late-stage Provisioning](https://github.com/Infineon/linux-optiga-trust-m/tree/master/scripts/matter_provisioning#certificate-claiming)
 
-To provision OPTIGA&trade; Trust M for HMAC usage in the Matter SDK, run the script below:
+To provision OPTIGA&trade; Trust M for HMAC usage in the Matter SDK, run the
+script below:
 
 ```
 $ cd scripts/matter_provisioning/
 $ ./matter_HMAC_provisioning.sh
 ```
 
-To provision OPTIGA&trade; Trust M for HKDF usage in the Matter SDK, run the script below:
+To provision OPTIGA&trade; Trust M for HKDF usage in the Matter SDK, run the
+script below:
 
 ```
 $ cd scripts/matter_provisioning/
 $ ./matter_HKDF_provisioning.sh
 ```
-

--- a/examples/lock-app/infineon/psoc6/README.md
+++ b/examples/lock-app/infineon/psoc6/README.md
@@ -14,8 +14,8 @@ An example showing the use of Matter on the Infineon CY8CKIT-062S2-43012 board.
             -   [Notes](#notes)
         -   [Cluster control](#cluster-control)
         -   [Factory Reset](#factory-reset)
-    -   [Building with Optiga Trust M as HSM](#building-with-optiga-trust-m-as-hsm)
-        -   [Optiga Trust M Provisioning](#optiga-trust-m-provisioning)
+    -   [Building with OPTIGA™ Trust M as HSM](#building-with-optiga-trust-m-as-hsm)
+        -   [OPTIGA™ Trust M Provisioning](#optiga-trust-m-provisioning)
     -   [OTA Software Update](#ota-software-update)
 
 <hr>
@@ -140,7 +140,7 @@ commands. These power cycle the BlueTooth hardware and disable BR/EDR mode.
 -   Pressing the button again within 5 seconds will cancel the factory reset of
     the board.
 
-## Building with Optiga Trust M as HSM
+## Building with OPTIGA™ Trust M as HSM
 
 Infineon Hardware Security Module-OPTIGA™ Trust M is a high-end security
 solution that provides an anchor of trust for connecting IoT devices to the
@@ -171,7 +171,7 @@ cloud, giving every IoT device its own unique identity.
 -   Proceed to OPTIGA™ Trust M Provisioning section to complete the credential
     storage into HSM.
 
-### Optiga Trust M Provisioning
+### OPTIGA™ Trust M Provisioning
 
 For the description of OPTIGA™ Trust M Provisioning with test DAC generation
 and PAI and CD storage, please refer to

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -160,7 +160,7 @@ static void InitServer(intptr_t context)
 {
     // Initialize device attestation config before server init so Operational
     // Credentials sees the configured provider during cluster construction.
-  #if defined(ENABLE_DEVICE_ATTESTATION) && !ENABLE_TRUSTM_RANDOM
+#if defined(ENABLE_DEVICE_ATTESTATION) && !ENABLE_TRUSTM_RANDOM
     // Pre-seed the CTR-DRBG here, in the CHIP event loop task, before BLE
     // advertising starts.
     {

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -157,7 +157,7 @@ static void InitServer(intptr_t context)
 {
     // Initialize device attestation config before server init so Operational
     // Credentials sees the configured provider during cluster construction.
-#if defined(ENABLE_DEVICE_ATTESTATION) && !ENABLE_TRUSTM_RANDOM
+#if ENABLE_DEVICE_ATTESTATION && !ENABLE_TRUSTM_RANDOM
     // Pre-seed the CTR-DRBG here, in the CHIP event loop task, before BLE
     // advertising starts.
     {

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -50,6 +50,10 @@
 #include <DeviceAttestationCredsExampleTrustM.h>
 #endif
 
+#if !ENABLE_TRUSTM_RANDOM
+#include <crypto/CHIPCryptoPAL.h>
+#endif
+
 /* OTA related includes */
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
@@ -156,6 +160,33 @@ static void InitServer(intptr_t context)
 {
     // Initialize device attestation config before server init so Operational
     // Credentials sees the configured provider during cluster construction.
+  #if defined(ENABLE_DEVICE_ATTESTATION) && !ENABLE_TRUSTM_RANDOM
+    // Pre-seed the CTR-DRBG here, in the CHIP event loop task, before BLE
+    // advertising starts.
+    {
+        uint8_t seed_buf[16];
+        CHIP_ERROR seed_err = chip::Crypto::DRBG_get_bytes(seed_buf, sizeof(seed_buf));
+        if (seed_err != CHIP_NO_ERROR)
+        {
+            PSOC6_LOG("DRBG pre-seed failed");
+            appError(seed_err);
+        }
+        memset(seed_buf, 0, sizeof(seed_buf));
+    }
+#endif
+
+#if ENABLE_DEVICE_ATTESTATION
+    // Pre-load PAI, DAC and CD certs from TrustM into RAM before Server::Init()
+    {
+        CHIP_ERROR cert_err = chip::Credentials::Examples::PreloadTrustMAttestationCerts();
+        if (cert_err != CHIP_NO_ERROR)
+        {
+            PSOC6_LOG("TrustM cert preload failed");
+            appError(cert_err);
+        }
+    }
+#endif
+
 #if ENABLE_DEVICE_ATTESTATION
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleTrustMDACProvider());
 #else
@@ -166,10 +197,10 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
-    TEMPORARY_RETURN_IGNORED chip::Server::GetInstance().Init(initParams);
-
-    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+
+    TEMPORARY_RETURN_IGNORED chip::Server::GetInstance().Init(initParams);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     GetAppTask().InitOTARequestor();

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -47,8 +47,8 @@
 #include <app/clusters/identify-server/identify-server.h>
 
 #if ENABLE_DEVICE_ATTESTATION
-#include <DeviceAttestationCredsExampleTrustM.h>
 #include <CHIPCryptoPALHsm_config_trustm.h>
+#include <DeviceAttestationCredsExampleTrustM.h>
 #endif
 
 /* OTA related includes */

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -50,8 +50,6 @@
 #include <DeviceAttestationCredsExampleTrustM.h>
 #endif
 
-#include <CHIPCryptoPALHsm_config_trustm.h>
-
 #if !ENABLE_TRUSTM_RANDOM
 #include <crypto/CHIPCryptoPAL.h>
 #endif

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -48,10 +48,7 @@
 
 #if ENABLE_DEVICE_ATTESTATION
 #include <DeviceAttestationCredsExampleTrustM.h>
-#endif
-
-#if !ENABLE_TRUSTM_RANDOM
-#include <crypto/CHIPCryptoPAL.h>
+#include <CHIPCryptoPALHsm_config_trustm.h>
 #endif
 
 /* OTA related includes */

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -50,6 +50,8 @@
 #include <DeviceAttestationCredsExampleTrustM.h>
 #endif
 
+#include <CHIPCryptoPALHsm_config_trustm.h>
+
 #if !ENABLE_TRUSTM_RANDOM
 #include <crypto/CHIPCryptoPAL.h>
 #endif
@@ -171,7 +173,7 @@ static void InitServer(intptr_t context)
             PSOC6_LOG("DRBG pre-seed failed");
             appError(seed_err);
         }
-        memset(seed_buf, 0, sizeof(seed_buf));
+        chip::Crypto::ClearSecretData(seed_buf, sizeof(seed_buf));
     }
 #endif
 

--- a/src/platform/Infineon/PSOC6/BUILD.gn
+++ b/src/platform/Infineon/PSOC6/BUILD.gn
@@ -82,6 +82,7 @@ static_library("PSOC6") {
 }
 
 source_set("logging") {
+  defines = [ "PSOC6_LOG_ENABLED=1" ]
   deps = [
     "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/platform/logging:headers",

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
@@ -414,8 +414,8 @@ static EntropyContext * get_entropy_context()
         gsEntropyContext.mEntropy.source_count = 0;
 
         // Register TrustM as the only strong entropy source for CHIP's DRBG.
-        (void) mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr,
-                                          MBEDTLS_CTR_DRBG_ENTROPY_LEN, MBEDTLS_ENTROPY_SOURCE_STRONG);
+        (void) mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr, MBEDTLS_CTR_DRBG_ENTROPY_LEN,
+                                          MBEDTLS_ENTROPY_SOURCE_STRONG);
 #endif
 
         gsEntropyContext.mInitialized = true;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
@@ -21,6 +21,8 @@
  */
 
 #include "CHIPCryptoPAL.h"
+#include "CHIPCryptoPALHsm_config_trustm.h"
+#include "CHIPCryptoPALHsm_utils_trustm.h"
 
 #include <type_traits>
 
@@ -406,12 +408,23 @@ static EntropyContext * get_entropy_context()
         mbedtls_entropy_init(&gsEntropyContext.mEntropy);
         mbedtls_ctr_drbg_init(&gsEntropyContext.mDRBGCtxt);
 
+#if !ENABLE_TRUSTM_RANDOM
+        // mbedtls_entropy_init() auto-registers mbedtls_hardware_poll (PSoC6
+        // TRNG) because MBEDTLS_ENTROPY_HARDWARE_ALT is defined globally.
+        gsEntropyContext.mEntropy.source_count = 0;
+
+        // Register TrustM as the only strong entropy source for CHIP's DRBG.
+        (void) mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr,
+                                          MBEDTLS_CTR_DRBG_ENTROPY_LEN, MBEDTLS_ENTROPY_SOURCE_STRONG);
+#endif
+
         gsEntropyContext.mInitialized = true;
     }
 
     return &gsEntropyContext;
 }
 
+#if !ENABLE_TRUSTM_RANDOM
 static mbedtls_ctr_drbg_context * get_drbg_context()
 {
     EntropyContext * const context = get_entropy_context();
@@ -432,6 +445,7 @@ static mbedtls_ctr_drbg_context * get_drbg_context()
 
     return drbgCtxt;
 }
+#endif // !ENABLE_TRUSTM_RANDOM
 
 CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t threshold)
 {
@@ -446,6 +460,7 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
     return CHIP_NO_ERROR;
 }
 
+#if !ENABLE_TRUSTM_RANDOM
 CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 {
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -459,6 +474,7 @@ CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 
     return CHIP_NO_ERROR;
 }
+#endif // !ENABLE_TRUSTM_RANDOM
 
 static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
 {

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
@@ -413,9 +413,16 @@ static EntropyContext * get_entropy_context()
         // TRNG) because MBEDTLS_ENTROPY_HARDWARE_ALT is defined globally.
         gsEntropyContext.mEntropy.source_count = 0;
 
-        // Register TrustM as the only strong entropy source for CHIP's DRBG.
-        (void) mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr, MBEDTLS_CTR_DRBG_ENTROPY_LEN,
-                                          MBEDTLS_ENTROPY_SOURCE_STRONG);
+        // Register TrustM as a strong entropy source for CHIP's DRBG.
+        const int entropy_err = mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr,
+                                                           MBEDTLS_CTR_DRBG_ENTROPY_LEN, MBEDTLS_ENTROPY_SOURCE_STRONG);
+        if (entropy_err != 0)
+        {
+            ChipLogError(Crypto, "Failed to register TrustM entropy source: %d", entropy_err);
+            mbedtls_entropy_free(&gsEntropyContext.mEntropy);
+            mbedtls_ctr_drbg_free(&gsEntropyContext.mDRBGCtxt);
+            return nullptr;
+        }
 #endif
 
         gsEntropyContext.mInitialized = true;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
@@ -409,10 +409,6 @@ static EntropyContext * get_entropy_context()
         mbedtls_ctr_drbg_init(&gsEntropyContext.mDRBGCtxt);
 
 #if !ENABLE_TRUSTM_RANDOM
-        // mbedtls_entropy_init() auto-registers mbedtls_hardware_poll (PSoC6
-        // TRNG) because MBEDTLS_ENTROPY_HARDWARE_ALT is defined globally.
-        gsEntropyContext.mEntropy.source_count = 0;
-
         // Register TrustM as a strong entropy source for CHIP's DRBG.
         const int entropy_err = mbedtls_entropy_add_source(&gsEntropyContext.mEntropy, trustm_entropy_source, nullptr,
                                                            MBEDTLS_CTR_DRBG_ENTROPY_LEN, MBEDTLS_ENTROPY_SOURCE_STRONG);

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HKDF_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HKDF_trustm.cpp
@@ -48,12 +48,6 @@ CHIP_ERROR HKDF_sha::HKDF_SHA256(const uint8_t * secret, const size_t secret_len
     uint16_t out_length_u16    = static_cast<uint16_t>(out_length);
     uint16_t secret_length_u16 = static_cast<uint16_t>(secret_length);
 
-    if (salt_length > 64 || info_length > 80 || secret_length > 256 || out_length > 768)
-    {
-        /* Length not supported by trustm. Rollback to SW */
-        return HKDF_SHA256_H(secret, secret_length, salt, salt_length, info, info_length, out_buffer, out_length);
-    }
-
     // Salt is optional
     if (salt_length > 0)
     {
@@ -65,11 +59,19 @@ CHIP_ERROR HKDF_sha::HKDF_SHA256(const uint8_t * secret, const size_t secret_len
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    if (salt_length > 64 || info_length > 80 || secret_length > 256 || out_length > 768)
+    {
+        /* Length not supported by trustm. Rollback to SW */
+        return HKDF_SHA256_H(secret, secret_length, salt, salt_length, info, info_length, out_buffer, out_length);
+    }
+
     // Trust M init
-    trustm_Open();
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     // Write the secret key
-    write_data(TRUSTM_HKDF_OID_KEY, secret, secret_length_u16);
+    return_status = write_data(TRUSTM_HKDF_OID_KEY, secret, secret_length_u16);
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     return_status = OPTIGA_LIB_BUSY;
 
@@ -81,6 +83,7 @@ CHIP_ERROR HKDF_sha::HKDF_SHA256(const uint8_t * secret, const size_t secret_len
 exit:
     if (error != CHIP_NO_ERROR)
     {
+        ClearSecretData(out_buffer, out_length);
         trustm_close();
     }
     return error;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
@@ -48,27 +48,29 @@ CHIP_ERROR HMAC_sha::HMAC_SHA256(const uint8_t * key, size_t key_length, const u
     uint32_t message_length_u32 = static_cast<uint32_t>(message_length);
     uint32_t out_length_u32     = static_cast<uint32_t>(out_length);
 
-    if (key_length > 64)
-    {
-        return HMAC_sha::HMAC_SHA256_h(key, key_length, message, message_length, out_buffer, out_length);
-    }
+    VerifyOrReturnError(key != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(key_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(message != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(message_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(key != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (key_length > 64)
+    {
+        return HMAC_SHA256_h(key, key_length, message, message_length, out_buffer, out_length);
+    }
 
     // Trust M init
-    trustm_Open();
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     // Update the secret key
-    write_data(TRUSTM_HMAC_OID_KEY, key, key_length_u16);
+    return_status = write_data(TRUSTM_HMAC_OID_KEY, key, key_length_u16);
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     // Start HMAC operation
     return_status = OPTIGA_LIB_BUSY;
 
-    // What is the max length supported ?
     return_status = hmac_sha256(OPTIGA_HMAC_SHA_256, message, message_length_u32, out_buffer, &out_length_u32);
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
@@ -77,6 +79,7 @@ CHIP_ERROR HMAC_sha::HMAC_SHA256(const uint8_t * key, size_t key_length, const u
 exit:
     if (error != CHIP_NO_ERROR)
     {
+        ClearSecretData(out_buffer, out_length);
         trustm_close();
     }
     return error;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR HMAC_sha::HMAC_SHA256(const uint8_t * key, size_t key_length, const u
     VerifyOrReturnError(message != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(message_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > CHIP_CRYPTO_HASH_LEN_BYTES, CHIP_ERROR_INVALID_ARGUMENT);
 
     if (key_length > 64)
     {

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_HMAC_trustm.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR HMAC_sha::HMAC_SHA256(const uint8_t * key, size_t key_length, const u
     VerifyOrReturnError(message != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(message_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(out_length > CHIP_CRYPTO_HASH_LEN_BYTES, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length >= CHIP_CRYPTO_HASH_LEN_BYTES, CHIP_ERROR_INVALID_ARGUMENT);
 
     if (key_length > 64)
     {

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
@@ -46,8 +46,6 @@
 
 const uint8_t kTlvHeader = 2;
 
-// Define keyid
-uint32_t keyid = 0;
 namespace chip {
 namespace Crypto {
 
@@ -85,12 +83,13 @@ static CHIP_ERROR get_trustm_keyid_from_keypair(const P256KeypairContext mKeypai
         return CHIP_ERROR_INTERNAL;
     }
 
-    *key_id += (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]) | (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET + 1] << 8);
+    *key_id = (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]) | (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET + 1] << 8);
     return CHIP_NO_ERROR;
 }
 
 P256Keypair::~P256Keypair()
 {
+    uint32_t keyid = 0;
     if (CHIP_NO_ERROR != get_trustm_keyid_from_keypair(mKeypair, &keyid))
     {
         Clear();
@@ -120,31 +119,24 @@ CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
     }
     else
     {
-#if !ENABLE_TRUSTM_NOC_KEYGEN
         error = Initialize_H(this, &mPublicKey, &mKeypair);
         if (CHIP_NO_ERROR == error)
         {
             mInitialized = true;
         }
         return error;
-#else
-        // Add the logic to use different keyid
-        keyid = TRUSTM_NODE_OID_KEY_START;
-        // Trust M ECC 256 Key Gen
-        ChipLogDetail(Crypto, "Generating NIST256 key in TrustM !");
-        key_usage = (optiga_key_usage_t) (OPTIGA_KEY_USAGE_SIGN | OPTIGA_KEY_USAGE_AUTHENTICATION);
-#endif //! ENABLE_TRUSTM_NOC_KEYGEN
     }
     // Trust M init
-    trustm_Open();
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     return_status = trustm_ecc_keygen(keyid, key_usage, OPTIGA_ECC_CURVE_NIST_P_256, pubkey, &pubKeyLen);
 
     // Add signature length
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     /* Set the public key */
-    VerifyOrReturnError((size_t) pubKeyLen > NIST256_HEADER_OFFSET, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(((size_t) pubKeyLen - NIST256_HEADER_OFFSET) <= kP256_PublicKey_Length, CHIP_ERROR_INTERNAL);
+    VerifyOrExit((size_t) pubKeyLen > NIST256_HEADER_OFFSET, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(((size_t) pubKeyLen - NIST256_HEADER_OFFSET) <= kP256_PublicKey_Length, error = CHIP_ERROR_INTERNAL);
     memcpy((void *) Uint8::to_const_uchar(public_key), pubkey + NIST256_HEADER_OFFSET, pubKeyLen - NIST256_HEADER_OFFSET);
 
     memcpy(&mKeypair.mBytes[0], trustm_magic_no, sizeof(trustm_magic_no));
@@ -181,9 +173,11 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P
     VerifyOrReturnError(msg != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(msg_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     // Trust M Init
-    trustm_Open();
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     // Hash to get the digest
-    Hash_SHA256(msg, msg_length, &digest[0]);
+    error = Hash_SHA256(msg, msg_length, &digest[0]);
+    SuccessOrExit(error);
 
     if (keyid == OPTIGA_KEY_ID_E0F0)
     {
@@ -194,17 +188,9 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P
     }
     else
     {
-#if !ENABLE_TRUSTM_NOC_KEYGEN
         // Use the mbedtls based method
-        ChipLogDetail(Crypto, "ECDSA sing msg mbedtls");
+        ChipLogDetail(Crypto, "ECDSA sign msg mbedtls");
         return ECDSA_sign_msg_H(&mKeypair, msg, msg_length, out_signature);
-#else
-        if (keyid == OPTIGA_KEY_ID_E0F2)
-        {
-            ChipLogDetail(Crypto, "TrustM: ECDSA_sign_msg");
-            return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F2, digest, digest_length, signature_trustm, &signature_trustm_len);
-        }
-#endif //! ENABLE_TRUSTM_NOC_KEYGEN
     }
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
@@ -213,7 +199,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P
 
     SuccessOrExit(error);
 
-    out_signature.SetLength(2 * kP256_FE_Length);
+    SuccessOrExit(error = out_signature.SetLength(2 * kP256_FE_Length));
 
     error = CHIP_NO_ERROR;
 
@@ -238,21 +224,27 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     }
 
     ChipLogDetail(Crypto, "TrustM: ECDH_derive_secret");
-    trustm_Open();
 
     const uint8_t * const rem_pubKey = Uint8::to_const_uchar(remote_public_key);
     const size_t rem_pubKeyLen       = remote_public_key.Length();
-
     uint8_t remote_key[68];
     uint8_t header[3] = { 0x03, 0x42, 0x00 };
 
-    memcpy(remote_key, &header, 3);
-    memcpy(remote_key + 3, rem_pubKey, rem_pubKeyLen);
-
-    return_status = trustm_ecdh_derive_secret(OPTIGA_KEY_ID_E100, (uint8_t *) remote_key, (uint16_t) rem_pubKeyLen + 3,
-                                              out_secret.Bytes(), (uint8_t) secret_length);
+    return_status = trustm_Open();
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
-    out_secret.SetLength(secret_length);
+
+    VerifyOrExit(rem_pubKeyLen <= (sizeof(remote_key) - sizeof(header)), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(secret_length <= UINT8_MAX, error = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    memcpy(remote_key, &header, sizeof(header));
+    memcpy(remote_key + sizeof(header), rem_pubKey, rem_pubKeyLen);
+
+    return_status = trustm_ecdh_derive_secret(static_cast<optiga_key_id_t>(TRUSTM_ECDH_OID_KEY), (uint8_t *) remote_key,
+                                                  static_cast<uint16_t>(rem_pubKeyLen + sizeof(header)), out_secret.Bytes(),
+                                                  static_cast<uint8_t>(secret_length));
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
+
     error = CHIP_NO_ERROR;
 
 exit:
@@ -275,22 +267,30 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, si
     size_t signature_trustm_len                               = sizeof(signature_trustm);
     MutableByteSpan out_der_sig_span(signature_trustm, signature_trustm_len);
 
-    uint8_t hash_length_u8 = static_cast<uint8_t>(hash_length);
-
     VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(hash_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(hash_length <= UINT8_MAX, CHIP_ERROR_INVALID_ARGUMENT);
+
+
+    uint8_t hash_length_u8 = static_cast<uint8_t>(hash_length);
+
     ChipLogDetail(Crypto, "TrustM: ECDSA_validate_hash_signature");
 
     // Trust M init
-    trustm_Open();
-    error = EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    error = EcdsaRawSignatureToAsn1(kP256_FE_Length,
+                                    ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
                                     out_der_sig_span);
     SuccessOrExit(error);
 
     signature_trustm_len = out_der_sig_span.size();
+    VerifyOrExit(signature_trustm_len <= UINT16_MAX, error = CHIP_ERROR_INTERNAL);
     // ECC verify
-    return_status = trustm_ecdsa_verify((uint8_t *) hash, hash_length_u8, (uint8_t *) signature_trustm, signature_trustm_len,
-                                        (uint8_t *) bytes, (uint8_t) kP256_PublicKey_Length);
+    return_status = trustm_ecdsa_verify((uint8_t *) hash, hash_length_u8, (uint8_t *) signature_trustm,
+                                        static_cast<uint16_t>(signature_trustm_len), (uint8_t *) bytes,
+                                        (uint8_t) kP256_PublicKey_Length);
+
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     error = CHIP_NO_ERROR;
@@ -327,7 +327,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     bbuf.Put(mKeypair.mBytes, kP256_PrivateKey_Length);
     VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    output.SetLength(bbuf.Needed());
+    ReturnErrorOnFailure(output.SetLength(bbuf.Needed()));
 
     return CHIP_NO_ERROR;
 }
@@ -383,7 +383,6 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, size
     uint8_t digest_length = sizeof(digest);
     MutableByteSpan out_der_sig_span(signature_trustm, signature_trustm_len);
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
-    uint16_t signature_trustm_len_u16 = static_cast<uint16_t>(signature_trustm_len);
 
     VerifyOrReturnError(msg != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(msg_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
@@ -391,19 +390,23 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, size
     ChipLogDetail(Crypto, "TrustM: ECDSA_validate_msg_signature");
 
     // Trust M init
-    trustm_Open();
+    return_status = trustm_Open();
+    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     error = EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
                                     out_der_sig_span);
     SuccessOrExit(error);
 
     signature_trustm_len = out_der_sig_span.size();
+    VerifyOrExit(signature_trustm_len <= UINT16_MAX, error = CHIP_ERROR_INTERNAL);
     // Hash to get the digest
     memset(&digest[0], 0, sizeof(digest));
-    Hash_SHA256(msg, msg_length, &digest[0]);
+    error = Hash_SHA256(msg, msg_length, &digest[0]);
+    SuccessOrExit(error);
     // ECC verify
-    return_status = trustm_ecdsa_verify(digest, digest_length, (uint8_t *) signature_trustm, signature_trustm_len_u16,
-                                        (uint8_t *) bytes, (uint8_t) kP256_PublicKey_Length);
+    return_status = trustm_ecdsa_verify(digest, digest_length, (uint8_t *) signature_trustm,
+                                        static_cast<uint16_t>(signature_trustm_len), (uint8_t *) bytes,
+                                        (uint8_t) kP256_PublicKey_Length);
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     error = CHIP_NO_ERROR;
@@ -416,171 +419,12 @@ exit:
 #endif
 }
 
-static void add_tlv(uint8_t * buf, size_t buf_index, uint8_t tag, size_t len, uint8_t * val)
-{
-    buf[buf_index++] = tag;
-    buf[buf_index++] = (uint8_t) len;
-    if (len > 0 && val != NULL)
-    {
-        memcpy(&buf[buf_index], val, len);
-        buf_index = buf_index + len;
-    }
-}
-
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) const
 {
-    CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
-    optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
-
-    uint8_t data_to_hash[128]     = { 0 };
-    size_t data_to_hash_len       = sizeof(data_to_hash);
-    uint8_t pubkey[128]           = { 0 };
-    size_t pubKeyLen              = 0;
-    uint8_t digest[32]            = { 0 };
-    uint8_t digest_length         = sizeof(digest);
-    uint8_t signature_trustm[128] = { 0 };
-    uint16_t signature_len        = sizeof(signature_trustm);
-
-    size_t csr_index    = 0;
-    size_t buffer_index = data_to_hash_len;
-
-    // Dummy value
-    uint8_t organisation_oid[3] = { 0x55, 0x04, 0x0a };
-
-    // Version  ::=  INTEGER  {  v1(0), v2(1), v3(2)  }
-    uint8_t version[3]       = { 0x02, 0x01, 0x00 };
-    uint8_t signature_oid[8] = { 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02 };
-    uint8_t nist256_header[] = { 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
-                                 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00 };
-
     VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
 
-    if (CHIP_NO_ERROR != get_trustm_keyid_from_keypair(mKeypair, &keyid))
-    {
-        ChipLogDetail(Crypto, "NewCertificateSigningRequest : Host");
-        return NewCertificateSigningRequest_H(&mKeypair, csr, csr_length);
-    }
-    ChipLogDetail(Crypto, "NewCertificateSigningRequest: TrustM");
-
-    // No extensions are copied
-    buffer_index -= kTlvHeader;
-    add_tlv(data_to_hash, buffer_index, (ASN1_CONSTRUCTED | ASN1_CONTEXT_SPECIFIC), 0, NULL);
-
-    // Copy public key (with header)
-    {
-        P256PublicKey & public_key = const_cast<P256PublicKey &>(Pubkey());
-
-        VerifyOrExit((sizeof(nist256_header) + public_key.Length()) <= sizeof(pubkey), error = CHIP_ERROR_INTERNAL);
-
-        memcpy(pubkey, nist256_header, sizeof(nist256_header));
-        pubKeyLen = pubKeyLen + sizeof(nist256_header);
-
-        memcpy((pubkey + pubKeyLen), Uint8::to_uchar(public_key), public_key.Length());
-        pubKeyLen = pubKeyLen + public_key.Length();
-    }
-
-    buffer_index -= pubKeyLen;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    memcpy((void *) &data_to_hash[buffer_index], pubkey, pubKeyLen);
-
-    // Copy subject (in the current implementation only organisation name info is added) and organisation OID
-    buffer_index -= (kTlvHeader + sizeof(SUBJECT_STR) - 1);
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, ASN1_UTF8_STRING, sizeof(SUBJECT_STR) - 1, (uint8_t *) SUBJECT_STR);
-
-    buffer_index -= (kTlvHeader + sizeof(organisation_oid));
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, ASN1_OID, sizeof(organisation_oid), organisation_oid);
-
-    // Add length
-    buffer_index -= kTlvHeader;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, (ASN1_CONSTRUCTED | ASN1_SEQUENCE),
-            ((2 * kTlvHeader) + (sizeof(SUBJECT_STR) - 1) + sizeof(organisation_oid)), NULL);
-
-    buffer_index -= kTlvHeader;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, (ASN1_CONSTRUCTED | ASN1_SET),
-            ((3 * kTlvHeader) + (sizeof(SUBJECT_STR) - 1) + sizeof(organisation_oid)), NULL);
-
-    buffer_index -= kTlvHeader;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, (ASN1_CONSTRUCTED | ASN1_SEQUENCE),
-            ((4 * kTlvHeader) + (sizeof(SUBJECT_STR) - 1) + sizeof(organisation_oid)), NULL);
-
-    buffer_index -= 3;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    memcpy((void *) &data_to_hash[buffer_index], version, sizeof(version));
-
-    buffer_index -= kTlvHeader;
-    VerifyOrExit(buffer_index > 0, error = CHIP_ERROR_INTERNAL);
-    add_tlv(data_to_hash, buffer_index, (ASN1_CONSTRUCTED | ASN1_SEQUENCE), (data_to_hash_len - buffer_index - kTlvHeader), NULL);
-
-    // TLV data is created by copying from backwards. move it to start of buffer.
-    data_to_hash_len = (data_to_hash_len - buffer_index);
-    memmove(data_to_hash, (data_to_hash + buffer_index), data_to_hash_len);
-
-    // Hash to get the digest
-    memset(&digest[0], 0, sizeof(digest));
-    error = Hash_SHA256(data_to_hash, data_to_hash_len, digest);
-    SuccessOrExit(error);
-
-    // Trust M Init
-    trustm_Open();
-
-    // Sign on hash
-    return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F2, digest, digest_length, signature_trustm, &signature_len);
-
-    VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit((csr_index + 3) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    csr[csr_index++] = (ASN1_CONSTRUCTED | ASN1_SEQUENCE);
-    if ((data_to_hash_len + 14 + kTlvHeader + signature_len) >= 0x80)
-    {
-        csr[csr_index++] = 0x81;
-    }
-    csr[csr_index++] = (uint8_t) (data_to_hash_len + 14 + kTlvHeader + signature_len);
-
-    VerifyOrExit((csr_index + data_to_hash_len) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    memcpy((csr + csr_index), data_to_hash, data_to_hash_len);
-    csr_index = csr_index + data_to_hash_len;
-
-    // ECDSA SHA256 Signature OID TLV ==> 1 + 1 + len(signature_oid) (8)
-    // ASN_NULL ==> 1 + 1
-    VerifyOrExit((csr_index + kTlvHeader) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    add_tlv(csr, csr_index, (ASN1_CONSTRUCTED | ASN1_SEQUENCE), 0x0C, NULL);
-    csr_index = csr_index + kTlvHeader;
-
-    VerifyOrExit((csr_index + sizeof(signature_oid) + kTlvHeader) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    add_tlv(csr, csr_index, ASN1_OID, sizeof(signature_oid), signature_oid);
-    csr_index = csr_index + kTlvHeader + sizeof(signature_oid);
-
-    VerifyOrExit((csr_index + kTlvHeader) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    add_tlv(csr, csr_index, ASN1_NULL, 0x00, NULL);
-    csr_index = csr_index + kTlvHeader;
-
-    VerifyOrExit((csr_index + kTlvHeader) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    csr[csr_index++] = ASN1_BIT_STRING;
-    csr[csr_index++] = (uint8_t) ((signature_trustm[0] != 0) ? (signature_len + 1) : (signature_len));
-
-    if (signature_trustm[0] != 0)
-    {
-        VerifyOrExit(csr_index <= csr_length, error = CHIP_ERROR_INTERNAL);
-        csr[csr_index++] = 0x00;
-        // Increament total count by 1
-        csr[2]++;
-    }
-    VerifyOrExit((csr_index + signature_len) <= csr_length, error = CHIP_ERROR_INTERNAL);
-    memcpy(&csr[csr_index], signature_trustm, signature_len);
-
-    csr_length = (csr_index + signature_len);
-
-    error = CHIP_NO_ERROR;
-exit:
-    if (error != CHIP_NO_ERROR)
-    {
-        trustm_close();
-    }
-    return error;
+    ChipLogDetail(Crypto, "NewCertificateSigningRequest : Host");
+    return NewCertificateSigningRequest_H(&mKeypair, csr, csr_length);
 }
 
 } // namespace Crypto

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
@@ -240,8 +240,8 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     memcpy(remote_key + sizeof(header), rem_pubKey, rem_pubKeyLen);
 
     return_status = trustm_ecdh_derive_secret(static_cast<optiga_key_id_t>(TRUSTM_ECDH_OID_KEY), (uint8_t *) remote_key,
-                                                  static_cast<uint16_t>(rem_pubKeyLen + sizeof(header)), out_secret.Bytes(),
-                                                  static_cast<uint8_t>(secret_length));
+                                              static_cast<uint16_t>(rem_pubKeyLen + sizeof(header)), out_secret.Bytes(),
+                                              static_cast<uint8_t>(secret_length));
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     SuccessOrExit(error = out_secret.SetLength(secret_length));
 
@@ -271,7 +271,6 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, si
     VerifyOrReturnError(hash_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(hash_length <= UINT8_MAX, CHIP_ERROR_INVALID_ARGUMENT);
 
-
     uint8_t hash_length_u8 = static_cast<uint8_t>(hash_length);
 
     ChipLogDetail(Crypto, "TrustM: ECDSA_validate_hash_signature");
@@ -279,18 +278,16 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, si
     // Trust M init
     return_status = trustm_Open();
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
-    error = EcdsaRawSignatureToAsn1(kP256_FE_Length,
-                                    ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
+    error = EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
                                     out_der_sig_span);
     SuccessOrExit(error);
 
     signature_trustm_len = out_der_sig_span.size();
     VerifyOrExit(signature_trustm_len <= UINT16_MAX, error = CHIP_ERROR_INTERNAL);
     // ECC verify
-    return_status = trustm_ecdsa_verify((uint8_t *) hash, hash_length_u8, (uint8_t *) signature_trustm,
-                                        static_cast<uint16_t>(signature_trustm_len), (uint8_t *) bytes,
-                                        (uint8_t) kP256_PublicKey_Length);
-
+    return_status =
+        trustm_ecdsa_verify((uint8_t *) hash, hash_length_u8, (uint8_t *) signature_trustm,
+                            static_cast<uint16_t>(signature_trustm_len), (uint8_t *) bytes, (uint8_t) kP256_PublicKey_Length);
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     error = CHIP_NO_ERROR;
@@ -404,9 +401,9 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, size
     error = Hash_SHA256(msg, msg_length, &digest[0]);
     SuccessOrExit(error);
     // ECC verify
-    return_status = trustm_ecdsa_verify(digest, digest_length, (uint8_t *) signature_trustm,
-                                        static_cast<uint16_t>(signature_trustm_len), (uint8_t *) bytes,
-                                        (uint8_t) kP256_PublicKey_Length);
+    return_status =
+        trustm_ecdsa_verify(digest, digest_length, (uint8_t *) signature_trustm, static_cast<uint16_t>(signature_trustm_len),
+                            (uint8_t *) bytes, (uint8_t) kP256_PublicKey_Length);
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
     error = CHIP_NO_ERROR;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
@@ -235,6 +235,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
 
     VerifyOrExit(rem_pubKeyLen <= (sizeof(remote_key) - sizeof(header)), error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(secret_length <= UINT8_MAX, error = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrExit(secret_length <= out_secret.Capacity(), error = CHIP_ERROR_BUFFER_TOO_SMALL);
 
     memcpy(remote_key, &header, sizeof(header));
     memcpy(remote_key + sizeof(header), rem_pubKey, rem_pubKeyLen);

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_config_trustm.h
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_config_trustm.h
@@ -34,11 +34,15 @@
 
 /*
  * Enable trustm for HKDF SHA256
+ * Ensure that TRUSTM_HKDF_OID_KEY is provisioned before enabling this option
+ * refer to /docs/platforms/infineon/infineon_trustm_provisioning.md for more details.
  */
 #define ENABLE_TRUSTM_HKDF_SHA256 0
 
 /*
  * Enable trustm for HMAC SHA256
+ * Ensure that TRUSTM_HMAC_OID_KEY is provisioned before enabling this option
+ * refer to /docs/platforms/infineon/infineon_trustm_provisioning.md for more details.
  */
 #define ENABLE_TRUSTM_HMAC_SHA256 0
 
@@ -48,6 +52,8 @@
 #define ENABLE_TRUSTM_DEVICE_ATTESTATION 1
 
 /*
- * Enable trustm for NOC key-pair generation
+ * Enable trustm for Random Number Generation (DRBG)
+ * Disabled: TrustM is registered as an entropy source for the mbedtls CTR-DRBG
+ * via add_entropy_source() in PlatformManagerImpl::_InitChipStack().
  */
-#define ENABLE_TRUSTM_NOC_KEYGEN 0
+#define ENABLE_TRUSTM_RANDOM 1

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_rng_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_rng_trustm.cpp
@@ -27,34 +27,60 @@
 #include "optiga_crypt.h"
 #include "optiga_lib_types.h"
 #include <lib/core/CHIPEncoding.h>
+#include <stdint.h>
+#include <string.h>
+
+#if ENABLE_TRUSTM_RANDOM
 
 namespace chip {
 namespace Crypto {
+
+namespace {
+// Trust M optiga_crypt_rng requires a minimum of 8 bytes per request.
+constexpr uint16_t kTrustMRngMin = 8;
+} // namespace
 
 CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 {
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
+    ChipLogDetail(Crypto, "Random Number: Using TrustM for Random Number Generation !");
+
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length <= UINT16_MAX, CHIP_ERROR_INVALID_ARGUMENT);
+
     // Trust M init
-    trustm_Open();
-
-    ChipLogDetail(Crypto, "Random Number: Using TrustM for Rondom Number Generate !");
-    return_status = optiga_crypt_rng(out_buffer, out_length);
-
+    return_status = trustm_Open();
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
+
+    if (out_length < kTrustMRngMin)
+    {
+        uint8_t scratch[kTrustMRngMin];
+        return_status = optiga_crypt_rng(scratch, kTrustMRngMin);
+        VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
+        memcpy(out_buffer, scratch, out_length);
+        ClearSecretData(scratch, sizeof(scratch));
+    }
+    else
+    {
+        return_status = optiga_crypt_rng(out_buffer, static_cast<uint16_t>(out_length));
+        VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    }
 
     error = CHIP_NO_ERROR;
 
 exit:
     if (error != CHIP_NO_ERROR)
     {
+        ClearSecretData(out_buffer, out_length);
         trustm_close();
     }
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 } // namespace Crypto
 } // namespace chip
+
+#endif // ENABLE_TRUSTM_RANDOM

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -74,7 +74,7 @@ void vApplicationTickHook(void) {}
     if (OPTIGA_LIB_SUCCESS != optiga_lib_status)                                                                                   \
     {                                                                                                                              \
         ret = optiga_lib_status;                                                                                                   \
-        ChipLogError(Crypto, "Error: 0x%02X", optiga_lib_status);                                                                           \
+        ChipLogError(Crypto, "Error: 0x%02X", optiga_lib_status);                                                                  \
         break;                                                                                                                     \
     }
 
@@ -116,7 +116,7 @@ optiga_lib_status_t trustm_Open(void)
 {
     uint16_t dOptigaOID = 0xE0C4;
     // Maximum Power, Minimum Current limitation
-    uint8_t cCurrentLimit = 15;
+    uint8_t cCurrentLimit             = 15;
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
     if (!trustm_isOpen)
@@ -181,7 +181,7 @@ optiga_lib_status_t trustm_Open(void)
                 OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
                 OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-                return_status     = optiga_util_write_data(me_util, dOptigaOID, OPTIGA_UTIL_ERASE_AND_WRITE, 0, &cCurrentLimit, 1);
+                return_status = optiga_util_write_data(me_util, dOptigaOID, OPTIGA_UTIL_ERASE_AND_WRITE, 0, &cCurrentLimit, 1);
                 if (OPTIGA_LIB_SUCCESS != return_status)
                 {
                     ChipLogError(Crypto, "optiga_util_write_data api returns error %02X", return_status);
@@ -264,7 +264,7 @@ void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t
         OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-        return_status     = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
+        return_status = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_util_read_data api returns error %02X", return_status);
@@ -322,7 +322,7 @@ optiga_lib_status_t write_data(uint16_t optiga_oid, const uint8_t * p_data, uint
         OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_FULL_PROTECTION);
 #endif
-        return_status     = optiga_util_write_data(me_util, optiga_oid, OPTIGA_UTIL_ERASE_AND_WRITE, 0, p_data, length);
+        return_status = optiga_util_write_data(me_util, optiga_oid, OPTIGA_UTIL_ERASE_AND_WRITE, 0, p_data, length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_util_write_data api returns error %02X", return_status);
@@ -352,7 +352,7 @@ void write_metadata(uint16_t optiga_oid, const uint8_t * p_data, uint8_t length)
         OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_FULL_PROTECTION);
 #endif
-        return_status     = optiga_util_write_metadata(me_util, optiga_oid, p_data, length);
+        return_status = optiga_util_write_metadata(me_util, optiga_oid, p_data, length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_util_write_metadata api returns error %02X", return_status);
@@ -379,8 +379,8 @@ optiga_lib_status_t deriveKey_HKDF(const uint8_t * salt, uint16_t salt_length, c
         OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
 #endif
-        return_status     = optiga_crypt_hkdf(me_crypt, OPTIGA_HKDF_SHA_256, TRUSTM_HKDF_OID_KEY, /* Input secret OID */
-                                              salt, salt_length, info, info_length, derived_key_length, TRUE, derived_key);
+        return_status = optiga_crypt_hkdf(me_crypt, OPTIGA_HKDF_SHA_256, TRUSTM_HKDF_OID_KEY, /* Input secret OID */
+                                          salt, salt_length, info, info_length, derived_key_length, TRUE, derived_key);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_crypt_hkdf api returns error %02X", return_status);
@@ -526,7 +526,7 @@ optiga_lib_status_t optiga_crypt_rng(uint8_t * random_data, uint16_t random_data
         OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-        return_status     = optiga_crypt_random(me_crypt, OPTIGA_RNG_TYPE_DRNG, random_data, random_data_length);
+        return_status = optiga_crypt_random(me_crypt, OPTIGA_RNG_TYPE_DRNG, random_data, random_data_length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_crypt_random api error %02X", return_status);
@@ -592,7 +592,7 @@ void trustmGetKey(uint16_t optiga_oid, uint8_t * pubkey, uint16_t * pubkeyLen)
         OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-        return_status     = optiga_util_read_data(me_util, optiga_oid, offset, pubkey, pubkeyLen);
+        return_status = optiga_util_read_data(me_util, optiga_oid, offset, pubkey, pubkeyLen);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_util_read_data api error %02X", return_status);
@@ -647,7 +647,7 @@ optiga_lib_status_t trustm_ecdsa_sign(optiga_key_id_t optiga_key_id, uint8_t * d
         OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
 #endif
-        return_status     = optiga_crypt_ecdsa_sign(me_crypt, digest, digest_length, optiga_key_id, signature, signature_length);
+        return_status = optiga_crypt_ecdsa_sign(me_crypt, digest, digest_length, optiga_key_id, signature, signature_length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_crypt_ecdsa_sign api error %02X", return_status);
@@ -714,8 +714,8 @@ optiga_lib_status_t trustm_ecdsa_verify(uint8_t * digest, uint8_t digest_length,
         OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-        return_status     = optiga_crypt_ecdsa_verify(me_crypt, digest, digest_length, signature, signature_length,
-                                                      OPTIGA_CRYPT_HOST_DATA, &public_key_details);
+        return_status = optiga_crypt_ecdsa_verify(me_crypt, digest, digest_length, signature, signature_length,
+                                                  OPTIGA_CRYPT_HOST_DATA, &public_key_details);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_crypt_ecdsa_verify api error %02X", return_status);
@@ -754,7 +754,7 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
         OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
 #endif
-        return_status     = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
+        return_status = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_util_read_data api error %02X", return_status);
@@ -797,7 +797,7 @@ optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uin
         OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
         OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
 #endif
-        return_status     = optiga_crypt_ecdh(me_crypt, optiga_key_id, &public_key_details, TRUE, shared_secret);
+        return_status = optiga_crypt_ecdh(me_crypt, optiga_key_id, &public_key_details, TRUE, shared_secret);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             ChipLogError(Crypto, "optiga_crypt_ecdh api error %02X", return_status);

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -31,6 +31,7 @@
 #include "optiga_util.h"
 #include "pal.h"
 #include "pal_ifx_i2c_config.h"
+#include "pal_os_datastore.h"
 #include "pal_os_event.h"
 #include "pal_os_memory.h"
 #include "pal_os_timer.h"
@@ -38,6 +39,10 @@
 
 optiga_crypt_t * me_crypt = NULL;
 optiga_util_t * me_util   = NULL;
+
+const uint8_t trustm_magic_no[4] = IFX_CRYPTO_KEY_MAGIC;
+const uint8_t DA_KEY_ID[2]       = { 0xF0, 0xE0 }; // OID --> 0xE0F0
+
 static bool trustm_isOpen = false;
 #define ENABLE_HMAC_MULTI_STEP (0)
 #define OPTIGA_UTIL_DER_BITSTRING_TAG (0x03)
@@ -64,11 +69,12 @@ void vApplicationTickHook(void) {}
     }                                                                                                                              \
     while (optiga_lib_status == OPTIGA_LIB_BUSY)                                                                                   \
     {                                                                                                                              \
+        pal_os_timer_delay_in_milliseconds(1);                                                                                     \
     }                                                                                                                              \
     if (OPTIGA_LIB_SUCCESS != optiga_lib_status)                                                                                   \
     {                                                                                                                              \
         ret = optiga_lib_status;                                                                                                   \
-        printf("Error: 0x%02X \r\n", optiga_lib_status);                                                                           \
+        ChipLogError(Crypto, "Error: 0x%02X", optiga_lib_status);                                                                           \
         break;                                                                                                                     \
     }
 
@@ -106,15 +112,15 @@ static void optiga_crypt_callback(void * context, optiga_lib_status_t return_sta
  * trustm_Open()
  **********************************************************************/
 static bool init = false;
-void trustm_Open(void)
+optiga_lib_status_t trustm_Open(void)
 {
     uint16_t dOptigaOID = 0xE0C4;
     // Maximum Power, Minimum Current limitation
     uint8_t cCurrentLimit = 15;
+    optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
     if (!trustm_isOpen)
     {
-        optiga_lib_status_t return_status;
         do
         {
             // Create Optiga crypt instance
@@ -123,12 +129,13 @@ void trustm_Open(void)
                 me_crypt = optiga_crypt_create(0, optiga_crypt_callback, NULL);
                 if (NULL == me_crypt)
                 {
+                    return_status = OPTIGA_CRYPT_ERROR;
                     break;
                 }
             }
             else
             {
-                printf("Error: me_crypt already initialised\n");
+                ChipLogDetail(Crypto, "me_crypt already initialised");
             }
             // Create Optiga Util instance
             if (me_util == NULL)
@@ -136,12 +143,13 @@ void trustm_Open(void)
                 me_util = optiga_util_create(0, optiga_util_callback, NULL);
                 if (NULL == me_util)
                 {
+                    return_status = OPTIGA_UTIL_ERROR;
                     break;
                 }
             }
             else
             {
-                printf("Error: me_crypt already initialised\n");
+                ChipLogDetail(Crypto, "me_util already initialised");
             }
             /**
              * Open the application on OPTIGA which is a precondition to perform any other operations
@@ -151,7 +159,7 @@ void trustm_Open(void)
             return_status     = optiga_util_open_application(me_util, 0); // skip restore
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
-                printf("optiga_util_open_application api returns error %02X\n", return_status);
+                ChipLogError(Crypto, "optiga_util_open_application api returns error %02X", return_status);
                 break;
             }
             // Wait until the optiga_util_open_application is completed
@@ -160,7 +168,7 @@ void trustm_Open(void)
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
                 // optiga_util_open_application failed
-                printf("optiga_util_open_application failed\n");
+                ChipLogError(Crypto, "optiga_util_open_application failed");
                 break;
             }
             trustm_isOpen = true;
@@ -169,23 +177,35 @@ void trustm_Open(void)
             if (!init)
             {
                 optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+                OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+                OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
+#endif
                 return_status     = optiga_util_write_data(me_util, dOptigaOID, OPTIGA_UTIL_ERASE_AND_WRITE, 0, &cCurrentLimit, 1);
                 if (OPTIGA_LIB_SUCCESS != return_status)
                 {
-                    printf("optiga_util_write_data api returns error %02X\n", return_status);
+                    ChipLogError(Crypto, "optiga_util_write_data api returns error %02X", return_status);
                     break;
                 }
                 WAIT_FOR_COMPLETION(return_status);
                 if (OPTIGA_LIB_SUCCESS != return_status)
                 {
-                    printf("optiga_util_write_data returns error\n");
+                    ChipLogError(Crypto, "optiga_util_write_data returns error");
                     break;
                 }
                 // Set init to true
                 init = true;
             }
+
         } while (0);
     }
+    // Trust M is already open, return success
+    else
+    {
+        return_status = OPTIGA_LIB_SUCCESS;
+    }
+
+    return return_status;
 }
 
 void trustm_close(void)
@@ -202,7 +222,7 @@ void trustm_close(void)
         return_status     = optiga_util_close_application(me_util, 0);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_util_close_application api returns error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_close_application api returns error %02X", return_status);
             break;
         }
 
@@ -211,7 +231,7 @@ void trustm_close(void)
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             // optiga_util_close_application failed
-            printf("optiga_util_close_application failed\n");
+            ChipLogError(Crypto, "optiga_util_close_application failed");
             break;
         }
 
@@ -229,7 +249,7 @@ void trustm_close(void)
 void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t * cert_pem_length)
 {
     size_t ifx_cert_b64_len = 0;
-    uint8_t ifx_cert_b64_temp[1200];
+    uint8_t ifx_cert_b64_temp[1400];
     uint16_t offset_to_write = 0, offset_to_read = 0;
     uint16_t size_to_copy = 0;
     optiga_lib_status_t return_status;
@@ -240,24 +260,31 @@ void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status     = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_util_read_data api returns error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_read_data api returns error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_data returns error
-            printf("read_certificate_from_optiga failed\n");
+            ChipLogError(Crypto, "read_certificate_from_optiga failed");
             break;
         }
         // convert to PEM format
         // If the first byte is TLS Identity Tag, than we need to skip 9 first bytes
         offset_to_read = ifx_cert_hex[0] == 0xc0 ? 9 : 0;
-        mbedtls_base64_encode((unsigned char *) ifx_cert_b64_temp, sizeof(ifx_cert_b64_temp), &ifx_cert_b64_len,
-                              ifx_cert_hex + offset_to_read, ifx_cert_hex_len - offset_to_read);
+        if (mbedtls_base64_encode((unsigned char *) ifx_cert_b64_temp, sizeof(ifx_cert_b64_temp), &ifx_cert_b64_len,
+                                  ifx_cert_hex + offset_to_read, ifx_cert_hex_len - offset_to_read) != 0)
+        {
+            ChipLogError(Crypto, "read_certificate_from_optiga: base64 encode failed");
+            break;
+        }
 
         memcpy(cert_pem, "-----BEGIN CERTIFICATE-----\n", 28);
         offset_to_write += 28;
@@ -284,28 +311,34 @@ void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t
     } while (0);
 }
 
-void write_data(uint16_t optiga_oid, const uint8_t * p_data, uint16_t length)
+optiga_lib_status_t write_data(uint16_t optiga_oid, const uint8_t * p_data, uint16_t length)
 {
-    optiga_lib_status_t return_status;
+    optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status     = optiga_util_write_data(me_util, optiga_oid, OPTIGA_UTIL_ERASE_AND_WRITE, 0, p_data, length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_util_write_data api returns error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_write_data api returns error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
 
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("write_data failed\n");
+            ChipLogError(Crypto, "write_data failed");
             return_status = optiga_lib_status;
             break;
         }
     } while (0);
+
+    return return_status;
 }
 
 void write_metadata(uint16_t optiga_oid, const uint8_t * p_data, uint8_t length)
@@ -315,16 +348,20 @@ void write_metadata(uint16_t optiga_oid, const uint8_t * p_data, uint8_t length)
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status     = optiga_util_write_metadata(me_util, optiga_oid, p_data, length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_util_write_metadata api returns error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_write_metadata api returns error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_util_write_metadata failed\n");
+            ChipLogError(Crypto, "optiga_util_write_metadata failed");
             break;
         }
     } while (0);
@@ -338,17 +375,21 @@ optiga_lib_status_t deriveKey_HKDF(const uint8_t * salt, uint16_t salt_length, c
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status     = optiga_crypt_hkdf(me_crypt, OPTIGA_HKDF_SHA_256, TRUSTM_HKDF_OID_KEY, /* Input secret OID */
                                               salt, salt_length, info, info_length, derived_key_length, TRUE, derived_key);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_crypt_hkdf api returns error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_hkdf api returns error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            printf("optiga_crypt_hkdf failed\n");
+            ChipLogError(Crypto, "optiga_crypt_hkdf failed");
             break;
         }
     } while (0);
@@ -372,7 +413,7 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
                 // optiga_crypt_hmac returns error !!!
-                printf("optiga_crypt_hmac api error %02X\n", return_status);
+                ChipLogError(Crypto, "optiga_crypt_hmac api error %02X", return_status);
                 break;
             }
 
@@ -380,7 +421,7 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
                 // optiga_crypt_hmac returns error !!!
-                printf("optiga_crypt_hmac returns error\n");
+                ChipLogError(Crypto, "optiga_crypt_hmac returns error");
                 break;
             }
         }
@@ -394,14 +435,14 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
                 // optiga_crypt_hmac returns error !!!
-                printf("optiga_crypt_hmac_start api error %02X\n", return_status);
+                ChipLogError(Crypto, "optiga_crypt_hmac_start api error %02X", return_status);
                 break;
             }
             WAIT_FOR_COMPLETION(return_status);
             if (OPTIGA_LIB_SUCCESS != return_status)
             {
                 // optiga_crypt_hmac_start returns error !!!
-                printf("optiga_crypt_hmac_start returns error\n");
+                ChipLogError(Crypto, "optiga_crypt_hmac_start returns error");
                 break;
             }
             remainingLen = input_data_length - MAX_MAC_DATA_LEN;
@@ -418,7 +459,7 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
                     if (OPTIGA_LIB_SUCCESS != return_status)
                     {
                         // optiga_crypt_hmac_update returns error !!!
-                        printf("optiga_crypt_hmac_update api error %02X\n", return_status);
+                        ChipLogError(Crypto, "optiga_crypt_hmac_update api error %02X", return_status);
                         break;
                     }
                     WAIT_FOR_COMPLETION(return_status);
@@ -426,7 +467,7 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
                     if (OPTIGA_LIB_SUCCESS != return_status)
                     {
                         // optiga_crypt_hmac_update returns error !!!
-                        printf("optiga_crypt_hmac_update returns error\n");
+                        ChipLogError(Crypto, "optiga_crypt_hmac_update returns error");
                         break;
                     }
                 }
@@ -440,14 +481,14 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
                     if (OPTIGA_LIB_SUCCESS != return_status)
                     {
                         // optiga_crypt_hmac_finalize returns error !!!
-                        printf("optiga_crypt_hmac_finalize api error %02X\n", return_status);
+                        ChipLogError(Crypto, "optiga_crypt_hmac_finalize api error %02X", return_status);
                         break;
                     }
                     WAIT_FOR_COMPLETION(return_status);
                     if (OPTIGA_LIB_SUCCESS != return_status)
                     {
                         // optiga_crypt_hmac_finalize returns error !!!
-                        printf("optiga_crypt_hmac_finalize returns error\n");
+                        ChipLogError(Crypto, "optiga_crypt_hmac_finalize returns error");
                         break;
                     }
                 }
@@ -459,14 +500,14 @@ optiga_lib_status_t hmac_sha256(optiga_hmac_type_t type, const uint8_t * input_d
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             // optiga_crypt_hmac returns error !!!
-            printf("optiga_crypt_hmac api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_hmac api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
             // optiga_crypt_hmac returns error !!!
-            printf("optiga_crypt_hmac returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_hmac returns error");
             break;
         }
 #endif
@@ -481,18 +522,20 @@ optiga_lib_status_t optiga_crypt_rng(uint8_t * random_data, uint16_t random_data
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status     = optiga_crypt_random(me_crypt, OPTIGA_RNG_TYPE_DRNG, random_data, random_data_length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_random returns error !!!
-            printf("optiga_crypt_random api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_random api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_random failed
-            printf("optiga_crypt_random returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_random returns error");
             break;
         }
     } while (0);
@@ -513,24 +556,29 @@ optiga_lib_status_t trustm_ecc_keygen(uint16_t optiga_key_id, uint8_t key_type, 
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status =
             optiga_crypt_ecc_generate_keypair(me_crypt, curve_id, key_type, FALSE, &optiga_key_id, (pubkey + i), pubkey_length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecc_generate_keypair api returns error !!!
-            printf("optiga_crypt_ecc_generate_keypair api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_ecc_generate_keypair api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecc_generate_keypair returns error !!!
-            printf("optiga_crypt_ecc_generate_keypair returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_ecc_generate_keypair returns error");
             break;
         }
     } while (0);
 
-    *pubkey_length += sizeof(header256);
+    if (OPTIGA_LIB_SUCCESS == return_status)
+    {
+        *pubkey_length += sizeof(header256);
+    }
     return return_status;
 }
 void trustmGetKey(uint16_t optiga_oid, uint8_t * pubkey, uint16_t * pubkeyLen)
@@ -540,18 +588,20 @@ void trustmGetKey(uint16_t optiga_oid, uint8_t * pubkey, uint16_t * pubkeyLen)
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status     = optiga_util_read_data(me_util, optiga_oid, offset, pubkey, pubkeyLen);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_data api returns error !!!
-            printf("optiga_util_read_data api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_read_data api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_pubkey returns error !!!
-            printf("optiga_util_read_pubkey returns error\n");
+            ChipLogError(Crypto, "optiga_util_read_pubkey returns error");
             break;
         }
     } while (0);
@@ -565,18 +615,20 @@ optiga_lib_status_t trustm_hash(uint8_t * msg, uint16_t msg_length, uint8_t * di
         hash_data_host.buffer = msg;
         hash_data_host.length = msg_length;
         optiga_lib_status     = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status = optiga_crypt_hash(me_crypt, OPTIGA_HASH_TYPE_SHA_256, OPTIGA_CRYPT_HOST_DATA, &hash_data_host, digest);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_hash api returns error !!!
-            printf("optiga_crypt_hash api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_hash api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_hash api returns error !!!
-            printf("optiga_crypt_hash returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_hash returns error");
             break;
         }
     } while (0);
@@ -591,18 +643,20 @@ optiga_lib_status_t trustm_ecdsa_sign(optiga_key_id_t optiga_key_id, uint8_t * d
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status     = optiga_crypt_ecdsa_sign(me_crypt, digest, digest_length, optiga_key_id, signature, signature_length);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecdsa_sign api returns error !!!
-            printf("optiga_crypt_ecdsa_sign api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_ecdsa_sign api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecdsa_sign returns error !!!
-            printf("optiga_crypt_ecdsa_sign returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_ecdsa_sign returns error");
             break;
         }
         for (i = (*signature_length - 1); i >= 0; i--)
@@ -656,19 +710,21 @@ optiga_lib_status_t trustm_ecdsa_verify(uint8_t * digest, uint8_t digest_length,
         }
 
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status     = optiga_crypt_ecdsa_verify(me_crypt, digest, digest_length, signature, signature_length,
                                                       OPTIGA_CRYPT_HOST_DATA, &public_key_details);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecdsa_verify api returns error !!!
-            printf("optiga_crypt_ecdsa_verify api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_ecdsa_verify api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecdsa_verify returns error !!!
-            printf("optiga_crypt_ecdsa_verify returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_ecdsa_verify returns error");
             break;
         }
     } while (0);
@@ -685,22 +741,29 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
     uint8_t ifx_cert_hex[1024];
     uint16_t ifx_cert_hex_len = sizeof(ifx_cert_hex);
 
-    trustm_Open();
+    return_status = trustm_Open();
     do
     {
+        if (OPTIGA_LIB_SUCCESS != return_status)
+        {
+            ChipLogError(Crypto, "trustm_Open failed %02X", return_status);
+            break;
+        }
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        OPTIGA_UTIL_SET_COMMS_PROTOCOL_VERSION(me_util, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_UTIL_SET_COMMS_PROTECTION_LEVEL(me_util, OPTIGA_COMMS_NO_PROTECTION);
+#endif
         return_status     = optiga_util_read_data(me_util, optiga_oid, 0, ifx_cert_hex, &ifx_cert_hex_len);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_data api returns error !!!
-            printf("optiga_util_read_data api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_util_read_data api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_data failed
-            printf("trustmGetCertificate failed\n");
+            ChipLogError(Crypto, "trustmGetCertificate failed");
             break;
         }
         memcpy(buf, ifx_cert_hex, ifx_cert_hex_len);
@@ -721,7 +784,7 @@ optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uin
                                               uint8_t * shared_secret, uint8_t shared_secret_length)
 {
     optiga_lib_status_t return_status;
-    static public_key_from_host_t public_key_details = {
+    public_key_from_host_t public_key_details = {
         (uint8_t *) public_key,
         public_key_length,
         (uint8_t) OPTIGA_ECC_CURVE_NIST_P_256,
@@ -729,18 +792,21 @@ optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uin
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
+#ifdef OPTIGA_COMMS_SHIELDED_CONNECTION
+        // ECDH uses a private key: protect the command and the response (shared secret).
+        OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+        OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_FULL_PROTECTION);
+#endif
         return_status     = optiga_crypt_ecdh(me_crypt, optiga_key_id, &public_key_details, TRUE, shared_secret);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_util_read_data api returns error !!!
-            printf("optiga_crypt_ecdh api error %02X\n", return_status);
+            ChipLogError(Crypto, "optiga_crypt_ecdh api error %02X", return_status);
             break;
         }
         WAIT_FOR_COMPLETION(return_status);
         if (OPTIGA_LIB_SUCCESS != return_status)
         {
-            // optiga_crypt_ecdh returns error !!!
-            printf("optiga_crypt_ecdh returns error\n");
+            ChipLogError(Crypto, "optiga_crypt_ecdh returns error");
             break;
         }
     } while (0);
@@ -748,61 +814,43 @@ optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uin
     return return_status;
 }
 
-optiga_lib_status_t trustm_PBKDF2_HMAC(const unsigned char * salt, size_t slen, unsigned int iteration_count, uint32_t key_length,
-                                       unsigned char * output)
+#if !ENABLE_TRUSTM_RANDOM
+#include <mbedtls/entropy.h>
+
+// mbedtls entropy callback: called by CTR-DRBG at seed/reseed time only,
+// not on every DRBG_get_bytes() invocation. Pulls hardware entropy from TrustM.
+int trustm_entropy_source(void * /* data */, unsigned char * output, size_t len, size_t * olen)
 {
-    optiga_lib_status_t return_status;
-    uint8_t md1[32];
-    uint32_t md1_len = sizeof(md1);
-    uint8_t work[32];
-    uint32_t work_len = sizeof(work);
+    ChipLogProgress(Crypto, "TrustM entropy source called (requested %u bytes)", (unsigned) len);
+    // optiga_crypt_rng minimum is 8 bytes; maximum is 256 bytes per call.
+    constexpr uint16_t kMin = 8;
+    constexpr uint16_t kMax = 256;
+    *olen                   = 0;
 
-    unsigned char * out_p = output;
-    do
+    if (trustm_Open() != OPTIGA_LIB_SUCCESS)
     {
-        // Calculate U1, U1 ends up in work
-        optiga_lib_status = OPTIGA_LIB_BUSY;
-        return_status =
-            optiga_crypt_hmac(me_crypt, OPTIGA_HMAC_SHA_256, TRUSTM_HMAC_OID_KEY, salt, (uint32_t) slen, work, &work_len);
-        if (OPTIGA_LIB_SUCCESS != return_status)
+        return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
+    }
+
+    while (len > 0)
+    {
+        uint16_t chunk = (len > kMax) ? kMax : static_cast<uint16_t>(len);
+        if (chunk < kMin)
+            chunk = kMin;
+
+        uint8_t scratch[kMax];
+        optiga_lib_status_t status = optiga_crypt_rng(scratch, chunk);
+        if (status != OPTIGA_LIB_SUCCESS)
         {
-            // optiga_crypt_hmac api returns error !!!
-            printf("optiga_crypt_hmac api 1 error %02X\n", return_status);
-            break;
-        }
-        WAIT_FOR_COMPLETION(return_status);
-        if (OPTIGA_LIB_SUCCESS != return_status)
-        {
-            printf("optiga_crypt_hmac 1 returns error\n");
-            break;
-        }
-        memcpy(md1, work, md1_len);
-        for (unsigned int i = 1; i < iteration_count; i++)
-        {
-            optiga_lib_status = OPTIGA_LIB_BUSY;
-            // Calculated subsequent U, which ends up in md1
-            return_status = optiga_crypt_hmac(me_crypt, OPTIGA_HMAC_SHA_256, TRUSTM_HMAC_OID_KEY, md1, md1_len, md1, &md1_len);
-            if (OPTIGA_LIB_SUCCESS != return_status)
-            {
-                // optiga_crypt_hmac api returns error !!!
-                printf("optiga_crypt_hmac api 2 error %02X\n", return_status);
-                break;
-            }
-            WAIT_FOR_COMPLETION(return_status);
-            if (OPTIGA_LIB_SUCCESS != return_status)
-            {
-                printf("optiga_crypt_hmac 2 returns error\n");
-                break;
-            }
-            // U1 xor U2
-            for (int j = 0; j < (int) md1_len; j++)
-            {
-                work[j] ^= md1[j];
-            }
+            return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
         }
 
-        memcpy(out_p, work, key_length);
-    } while (0);
-
-    return return_status;
+        size_t copy = (chunk > len) ? len : chunk;
+        memcpy(output, scratch, copy);
+        output += copy;
+        *olen += copy;
+        len -= copy;
+    }
+    return 0;
 }
+#endif // !ENABLE_TRUSTM_RANDOM

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -787,8 +787,7 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
         }
         if (ifx_cert_hex_len > buffer_capacity)
         {
-            ChipLogError(Crypto, "trustmGetCertificate: buffer too small (have %u, need %u)", buffer_capacity,
-                         ifx_cert_hex_len);
+            ChipLogError(Crypto, "trustmGetCertificate: buffer too small (have %u, need %u)", buffer_capacity, ifx_cert_hex_len);
             return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
         memcpy(buf, ifx_cert_hex, ifx_cert_hex_len);

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -873,6 +873,7 @@ int trustm_entropy_source(void * /* data */, unsigned char * output, size_t len,
 
         size_t copy = (chunk > len) ? len : chunk;
         memcpy(output, scratch, copy);
+        mbedtls_platform_zeroize(scratch, sizeof(scratch));
         output += copy;
         *olen += copy;
         len -= copy;

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -58,9 +58,9 @@ static bool trustm_isOpen = false;
 
 /* This is a place from which we can poll the status of operation */
 
-void vApplicationTickHook(void);
+extern "C" void vApplicationTickHook(void);
 
-void vApplicationTickHook(void) {}
+extern "C" void vApplicationTickHook(void) {}
 
 #define WAIT_FOR_COMPLETION(ret)                                                                                                   \
     if (OPTIGA_LIB_SUCCESS != ret)                                                                                                 \
@@ -218,29 +218,36 @@ void trustm_close(void)
          * Close the application on OPTIGA after all the operations are executed
          * using optiga_util_close_application
          */
-        optiga_lib_status = OPTIGA_LIB_BUSY;
-        return_status     = optiga_util_close_application(me_util, 0);
-        if (OPTIGA_LIB_SUCCESS != return_status)
+        if (me_util != NULL)
         {
-            ChipLogError(Crypto, "optiga_util_close_application api returns error %02X", return_status);
-            break;
+            optiga_lib_status = OPTIGA_LIB_BUSY;
+            return_status     = optiga_util_close_application(me_util, 0);
+            if (OPTIGA_LIB_SUCCESS != return_status)
+            {
+                ChipLogError(Crypto, "optiga_util_close_application api returns error %02X", return_status);
+                break;
+            }
+
+            WAIT_FOR_COMPLETION(return_status);
+
+            if (OPTIGA_LIB_SUCCESS != return_status)
+            {
+                // optiga_util_close_application failed
+                ChipLogError(Crypto, "optiga_util_close_application failed");
+                break;
+            }
+
+            optiga_util_destroy(me_util);
+            me_util = NULL;
         }
 
-        WAIT_FOR_COMPLETION(return_status);
-
-        if (OPTIGA_LIB_SUCCESS != return_status)
+        if (me_crypt != NULL)
         {
-            // optiga_util_close_application failed
-            ChipLogError(Crypto, "optiga_util_close_application failed");
-            break;
+            optiga_crypt_destroy(me_crypt);
+            me_crypt = NULL;
         }
 
-        // destroy util and crypt instances
-        optiga_util_destroy(me_util);
-        optiga_crypt_destroy(me_crypt);
         pal_os_event_destroy(NULL);
-        me_util       = NULL;
-        me_crypt      = NULL;
         trustm_isOpen = false;
         return_status = OPTIGA_LIB_SUCCESS;
     } while (0);
@@ -256,7 +263,6 @@ void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t
 
     uint8_t ifx_cert_hex[1024];
     uint16_t ifx_cert_hex_len = sizeof(ifx_cert_hex);
-
     do
     {
         optiga_lib_status = OPTIGA_LIB_BUSY;
@@ -276,9 +282,19 @@ void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t
             ChipLogError(Crypto, "read_certificate_from_optiga failed");
             break;
         }
+        if (ifx_cert_hex_len == 0)
+        {
+            ChipLogError(Crypto, "read_certificate_from_optiga: empty certificate");
+            break;
+        }
         // convert to PEM format
         // If the first byte is TLS Identity Tag, than we need to skip 9 first bytes
         offset_to_read = ifx_cert_hex[0] == 0xc0 ? 9 : 0;
+        if (ifx_cert_hex_len < offset_to_read)
+        {
+            ChipLogError(Crypto, "read_certificate_from_optiga: certificate length too short");
+            break;
+        }
         if (mbedtls_base64_encode((unsigned char *) ifx_cert_b64_temp, sizeof(ifx_cert_b64_temp), &ifx_cert_b64_len,
                                   ifx_cert_hex + offset_to_read, ifx_cert_hex_len - offset_to_read) != 0)
         {
@@ -738,6 +754,9 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(buflen != nullptr, CHIP_ERROR_INTERNAL);
 
+    const uint16_t buffer_capacity = *buflen;
+    VerifyOrReturnError(buffer_capacity > 0, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     uint8_t ifx_cert_hex[1024];
     uint16_t ifx_cert_hex_len = sizeof(ifx_cert_hex);
 
@@ -765,6 +784,12 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
         {
             ChipLogError(Crypto, "trustmGetCertificate failed");
             break;
+        }
+        if (ifx_cert_hex_len > buffer_capacity)
+        {
+            ChipLogError(Crypto, "trustmGetCertificate: buffer too small (have %u, need %u)", buffer_capacity,
+                         ifx_cert_hex_len);
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
         memcpy(buf, ifx_cert_hex, ifx_cert_hex_len);
         *buflen = ifx_cert_hex_len;
@@ -816,6 +841,7 @@ optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uin
 
 #if !ENABLE_TRUSTM_RANDOM
 #include <mbedtls/entropy.h>
+#include <mbedtls/platform_util.h>
 
 // mbedtls entropy callback: called by CTR-DRBG at seed/reseed time only,
 // not on every DRBG_get_bytes() invocation. Pulls hardware entropy from TrustM.
@@ -842,6 +868,7 @@ int trustm_entropy_source(void * /* data */, unsigned char * output, size_t len,
         optiga_lib_status_t status = optiga_crypt_rng(scratch, chunk);
         if (status != OPTIGA_LIB_SUCCESS)
         {
+            mbedtls_platform_zeroize(scratch, sizeof(scratch));
             return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
         }
 

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.cpp
@@ -31,7 +31,6 @@
 #include "optiga_util.h"
 #include "pal.h"
 #include "pal_ifx_i2c_config.h"
-#include "pal_os_datastore.h"
 #include "pal_os_event.h"
 #include "pal_os_memory.h"
 #include "pal_os_timer.h"

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
@@ -36,7 +36,6 @@
 extern "C" {
 #endif
 
-
 #define TRUSTM_HKDF_OID_KEY (0xF1D8)
 #define TRUSTM_HMAC_OID_KEY (0xF1D9)
 #define TRUSTM_P256_PUBKEY_OID_KEY (0xF1DA)

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
@@ -36,8 +36,6 @@
 extern "C" {
 #endif
 
-extern optiga_crypt_t * p_local_crypt;
-extern optiga_util_t * p_local_util;
 
 #define TRUSTM_HKDF_OID_KEY (0xF1D8)
 #define TRUSTM_HMAC_OID_KEY (0xF1D9)
@@ -50,12 +48,12 @@ extern optiga_util_t * p_local_util;
         0xA0, 0x10, 0xA0, 0x10                                                                                                     \
     }
 
-static const uint8_t trustm_magic_no[] = IFX_CRYPTO_KEY_MAGIC;
-static const uint8_t DA_KEY_ID[]       = { 0xF0, 0xE0 }; // OID --> 0xE0F0
+extern const uint8_t trustm_magic_no[4];
+extern const uint8_t DA_KEY_ID[2]; // OID --> 0xE0F0
 /* Open session to trustm */
-void trustm_Open(void);
+optiga_lib_status_t trustm_Open(void);
 void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t * cert_pem_length);
-void write_data(uint16_t optiga_oid, const uint8_t * p_data, uint16_t length);
+optiga_lib_status_t write_data(uint16_t optiga_oid, const uint8_t * p_data, uint16_t length);
 void write_metadata(uint16_t optiga_oid, const uint8_t * p_data, uint8_t length);
 void trustmGetKey(uint16_t optiga_oid, uint8_t * pubkey, uint16_t * pubKeyLen);
 optiga_lib_status_t deriveKey_HKDF(const uint8_t * salt, uint16_t salt_length, const uint8_t * info, uint16_t info_length,
@@ -67,7 +65,7 @@ optiga_lib_status_t trustm_ecc_keygen(uint16_t optiga_key_id, uint8_t key_type, 
 optiga_lib_status_t trustm_hash(uint8_t * msg, uint16_t msg_length, uint8_t * digest, uint8_t digest_length);
 optiga_lib_status_t trustm_ecdsa_sign(optiga_key_id_t optiga_key_id, uint8_t * digest, uint8_t digest_length, uint8_t * signature,
                                       uint16_t * signature_length);
-void ecc_public_key_in_bit(const uint8_t * q_buffer, uint8_t q_length, uint8_t * pub_key_buffer, uint16_t pub_key_length);
+void ecc_pub_key_bit(uint8_t * q_buffer, uint8_t q_length, uint8_t * pub_key_buffer, uint16_t * pub_key_length);
 optiga_lib_status_t trustm_ecdsa_verify(uint8_t * digest, uint8_t digest_length, uint8_t * signature, uint16_t signature_length,
                                         uint8_t * ecc_pubkey, uint8_t ecc_pubkey_length);
 /* Close session to trustm */
@@ -76,8 +74,11 @@ CHIP_ERROR trustmGetCertificate(uint16_t optiga_oid, uint8_t * buf, uint16_t * b
 optiga_lib_status_t trustm_ecdh_derive_secret(optiga_key_id_t optiga_key_id, uint8_t * public_key, uint16_t public_key_length,
                                               uint8_t * shared_secret, uint8_t shared_secret_length);
 optiga_lib_status_t optiga_crypt_rng(uint8_t * random_data, uint16_t random_data_length);
-optiga_lib_status_t trustm_PBKDF2_HMAC(const unsigned char * salt, size_t slen, unsigned int iteration_count, uint32_t key_length,
-                                       unsigned char * output);
+#if !ENABLE_TRUSTM_RANDOM
+// mbedtls entropy source callback backed by TrustM hardware RNG.
+// Signature matches mbedtls_entropy_f_source_ptr.
+int trustm_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPAL_HostFallBack.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPAL_HostFallBack.cpp
@@ -247,7 +247,7 @@ CHIP_ERROR ECDH_derive_secret_H(P256KeypairContext * mKeypair, const P256PublicK
 
     result = mbedtls_mpi_write_binary(&mpi_secret, out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, secret_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-    out_secret.SetLength(secret_length);
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
 
 exit:
     keypair = nullptr;
@@ -413,7 +413,7 @@ CHIP_ERROR Serialize_H(const P256KeypairContext mKeypair, const P256PublicKey mP
     bbuf.Put(privkey, sizeof(privkey));
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    output.SetLength(bbuf.Needed());
+    SuccessOrExit(error = output.SetLength(bbuf.Needed()));
 
 exit:
     ClearSecretData(privkey, sizeof(privkey));

--- a/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
+++ b/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
@@ -36,6 +36,14 @@ namespace Examples {
 
 namespace {
 
+// Attestation cert caches — populated once by PreloadTrustMAttestationCerts().
+static uint8_t  gPAICertBuf[1024];
+static uint16_t gPAICertLen = 0;
+static uint8_t  gDACCertBuf[1024];
+static uint16_t gDACCertLen = 0;
+static uint8_t  gCDBuf[1024];
+static uint16_t gCDLen      = 0;
+
 class ExampleTrustMDACProvider : public DeviceAttestationCredentialsProvider
 {
 public:
@@ -48,6 +56,8 @@ public:
 
 CHIP_ERROR ExampleTrustMDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
 {
+    if (gDACCertLen > 0)
+        return CopySpanToMutableSpan(ByteSpan(gDACCertBuf, gDACCertLen), out_dac_buffer);
     uint16_t buflen = (uint16_t) out_dac_buffer.size();
     ChipLogDetail(Crypto, "Get DAC certificate from trustm");
     ReturnErrorOnFailure(trustmGetCertificate(DEV_ATTESTATION_CERT_ID, out_dac_buffer.data(), &buflen));
@@ -57,6 +67,8 @@ CHIP_ERROR ExampleTrustMDACProvider::GetDeviceAttestationCert(MutableByteSpan & 
 
 CHIP_ERROR ExampleTrustMDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
 {
+    if (gPAICertLen > 0)
+        return CopySpanToMutableSpan(ByteSpan(gPAICertBuf, gPAICertLen), out_pai_buffer);
     uint16_t buflen = (uint16_t) out_pai_buffer.size();
     ChipLogDetail(Crypto, "Get PAI certificate from trustm");
     ReturnErrorOnFailure(trustmGetCertificate(PAI_CERT_ID, out_pai_buffer.data(), &buflen));
@@ -85,6 +97,8 @@ CHIP_ERROR ExampleTrustMDACProvider::GetCertificationDeclaration(MutableByteSpan
     //-> dac_origin_product_id is not present
     size_t buflen = out_cd_buffer.size();
     ChipLogDetail(Crypto, "Get certificate declaration from trustm");
+    if (gCDLen > 0)
+        return CopySpanToMutableSpan(ByteSpan(gCDBuf, gCDLen), out_cd_buffer);
     ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, out_cd_buffer.data(), (uint16_t *) &buflen));
     out_cd_buffer.reduce_size(buflen);
     return CHIP_NO_ERROR;
@@ -111,7 +125,7 @@ CHIP_ERROR ExampleTrustMDACProvider::SignWithDeviceAttestationKey(const ByteSpan
     VerifyOrReturnError(IsSpanUsable(message_to_sign), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_signature_buffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    serialized_keypair.SetLength(Crypto::kP256_PublicKey_Length + Crypto::kP256_PrivateKey_Length);
+    ReturnErrorOnFailure(serialized_keypair.SetLength(Crypto::kP256_PublicKey_Length + Crypto::kP256_PrivateKey_Length));
 
     memset(serialized_keypair.Bytes(), 0, Crypto::kP256_PublicKey_Length);
     memcpy(serialized_keypair.Bytes() + Crypto::kP256_PublicKey_Length, trustm_magic_no, sizeof(trustm_magic_no));
@@ -131,6 +145,23 @@ DeviceAttestationCredentialsProvider * GetExampleTrustMDACProvider()
     static ExampleTrustMDACProvider example_dac_provider;
 
     return &example_dac_provider;
+}
+
+CHIP_ERROR PreloadTrustMAttestationCerts()
+{
+    // Read PAI, DAC, and CD from TrustM into RAM before BLE advertising starts.
+    gPAICertLen = sizeof(gPAICertBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(PAI_CERT_ID, gPAICertBuf, &gPAICertLen));
+
+    gDACCertLen = sizeof(gDACCertBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(DEV_ATTESTATION_CERT_ID, gDACCertBuf, &gDACCertLen));
+
+    gCDLen = sizeof(gCDBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, gCDBuf, &gCDLen));
+
+    ChipLogProgress(Crypto, "TrustM attestation certs preloaded (PAI=%u DAC=%u CD=%u bytes)",
+                    gPAICertLen, gDACCertLen, gCDLen);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Examples

--- a/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
+++ b/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
@@ -37,12 +37,12 @@ namespace Examples {
 namespace {
 
 // Attestation cert caches — populated once by PreloadTrustMAttestationCerts().
-static uint8_t  gPAICertBuf[1024];
+static uint8_t gPAICertBuf[1024];
 static uint16_t gPAICertLen = 0;
-static uint8_t  gDACCertBuf[1024];
+static uint8_t gDACCertBuf[1024];
 static uint16_t gDACCertLen = 0;
-static uint8_t  gCDBuf[1024];
-static uint16_t gCDLen      = 0;
+static uint8_t gCDBuf[1024];
+static uint16_t gCDLen = 0;
 
 class ExampleTrustMDACProvider : public DeviceAttestationCredentialsProvider
 {
@@ -159,8 +159,7 @@ CHIP_ERROR PreloadTrustMAttestationCerts()
     gCDLen = sizeof(gCDBuf);
     ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, gCDBuf, &gCDLen));
 
-    ChipLogProgress(Crypto, "TrustM attestation certs preloaded (PAI=%u DAC=%u CD=%u bytes)",
-                    gPAICertLen, gDACCertLen, gCDLen);
+    ChipLogProgress(Crypto, "TrustM attestation certs preloaded (PAI=%u DAC=%u CD=%u bytes)", gPAICertLen, gDACCertLen, gCDLen);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
+++ b/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
@@ -149,15 +149,22 @@ DeviceAttestationCredentialsProvider * GetExampleTrustMDACProvider()
 
 CHIP_ERROR PreloadTrustMAttestationCerts()
 {
+    gPAICertLen = 0;
+    gDACCertLen = 0;
+    gCDLen      = 0;
+
     // Read PAI, DAC, and CD from TrustM into RAM before BLE advertising starts.
-    gPAICertLen = sizeof(gPAICertBuf);
-    ReturnErrorOnFailure(trustmGetCertificate(PAI_CERT_ID, gPAICertBuf, &gPAICertLen));
+    uint16_t len = sizeof(gPAICertBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(PAI_CERT_ID, gPAICertBuf, &len));
+    gPAICertLen = len;
 
-    gDACCertLen = sizeof(gDACCertBuf);
-    ReturnErrorOnFailure(trustmGetCertificate(DEV_ATTESTATION_CERT_ID, gDACCertBuf, &gDACCertLen));
+    len = sizeof(gDACCertBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(DEV_ATTESTATION_CERT_ID, gDACCertBuf, &len));
+    gDACCertLen = len;
 
-    gCDLen = sizeof(gCDBuf);
-    ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, gCDBuf, &gCDLen));
+    len = sizeof(gCDBuf);
+    ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, gCDBuf, &len));
+    gCDLen = len;
 
     ChipLogProgress(Crypto, "TrustM attestation certs preloaded (PAI=%u DAC=%u CD=%u bytes)", gPAICertLen, gDACCertLen, gCDLen);
     return CHIP_NO_ERROR;

--- a/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
+++ b/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.cpp
@@ -95,11 +95,11 @@ CHIP_ERROR ExampleTrustMDACProvider::GetCertificationDeclaration(MutableByteSpan
     //-> certification_type = 0
     //-> dac_origin_vendor_id is not present
     //-> dac_origin_product_id is not present
-    size_t buflen = out_cd_buffer.size();
+    uint16_t buflen = static_cast<uint16_t>(out_cd_buffer.size());
     ChipLogDetail(Crypto, "Get certificate declaration from trustm");
     if (gCDLen > 0)
         return CopySpanToMutableSpan(ByteSpan(gCDBuf, gCDLen), out_cd_buffer);
-    ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, out_cd_buffer.data(), (uint16_t *) &buflen));
+    ReturnErrorOnFailure(trustmGetCertificate(CERT_DECLARATION_ID, out_cd_buffer.data(), &buflen));
     out_cd_buffer.reduce_size(buflen);
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.h
+++ b/src/platform/Infineon/crypto/trustm/DeviceAttestationCredsExampleTrustM.h
@@ -31,6 +31,13 @@ namespace Examples {
  */
 DeviceAttestationCredentialsProvider * GetExampleTrustMDACProvider();
 
+/**
+ * @brief Pre-load PAI, DAC and CD certs from TrustM into RAM.
+ *
+ */
+
+CHIP_ERROR PreloadTrustMAttestationCerts();
+
 } // namespace Examples
 } // namespace Credentials
 } // namespace chip

--- a/third_party/infineon/psoc6/BUILD.gn
+++ b/third_party/infineon/psoc6/BUILD.gn
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
 import("//build_overrides/psoc6.gni")
+import("${chip_root}/src/crypto/crypto.gni")
 import("${psoc6_sdk_build_root}/psoc6_sdk.gni")
 
 declare_args() {
@@ -64,6 +66,10 @@ config("psoc6_sdk_config") {
   foreach(def, mtb_json_local.defines) {
     # Strip off leading -D part
     defines += [ string_replace(def, "-D", "", 1) ]
+  }
+
+  if (chip_crypto == "platform") {
+    defines += [ "CHIP_TRUSTM_DA=1" ]
   }
 
   # Pull out static libs (.a files) from generated json

--- a/third_party/infineon/psoc6/psoc6_sdk/configs/FreeRTOSConfig.h
+++ b/third_party/infineon/psoc6/psoc6_sdk/configs/FreeRTOSConfig.h
@@ -76,7 +76,7 @@ extern uint32_t SystemCoreClock;
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK 0
 
-#ifdef ENABLE_HSM_DEVICE_ATTESTATION
+#ifdef CHIP_TRUSTM_DA
 #define configUSE_TICK_HOOK 1
 #else
 #define configUSE_TICK_HOOK 0
@@ -97,12 +97,17 @@ extern uint32_t SystemCoreClock;
 /* Co-routine related definitions. */
 #define configUSE_CO_ROUTINES 0
 #define configMAX_CO_ROUTINE_PRIORITIES 2
-
 /* Software timer related definitions. */
 #define configUSE_TIMERS 1
 #define configTIMER_TASK_PRIORITY 2
+/* Increased for OPTIGA Trust M shielded connection (mbedTLS AES-CCM in timer task). */
+#ifdef CHIP_TRUSTM_DA
+#define configTIMER_QUEUE_LENGTH 32
+#define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 20)
+#else
 #define configTIMER_QUEUE_LENGTH 10
 #define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 6)
+#endif
 
 /* Queue Creation Fix to not use static queue */
 #define LWIP_FREERTOS_USE_STATIC_TCPIP_QUEUE 0

--- a/third_party/infineon/psoc6/psoc6_sdk/configs/optiga_lib_config_mtb.h
+++ b/third_party/infineon/psoc6/psoc6_sdk/configs/optiga_lib_config_mtb.h
@@ -102,7 +102,7 @@ extern "C" {
 /** @brief OPTIGA COMMS shielded connection feature.
  *         To disable the feature, undefine the macro
  */
-#define OPTIGA_COMMS_SHIELDED_CONNECTION
+//#define OPTIGA_COMMS_SHIELDED_CONNECTION
 
 /** @brief Default reset protection level for OPTIGA CRYPT and UTIL APIs */
 #define OPTIGA_COMMS_DEFAULT_PROTECTION_LEVEL OPTIGA_COMMS_NO_PROTECTION


### PR DESCRIPTION
#### Summary
1)DRBG_get_bytes() previously returned CHIP_NO_ERROR unconditionally regardless of the underlying optiga_crypt_rng()status. 
2)Added upper limit check on out_length upper limit 
3)Added return status for trustm_Open() and write_data()
4)Removed the Trust M NOC related code
5)Pre-loaded Trust M Attestation Certs
6)Added Trust M as Entropy source by default for mbedtls_entropy_add_source() when ENABLE_TRUSTM_RANDOM = 0 7)WAIT_FOR_COMPLETION yields with pal_os_timer_delay_in_milliseconds(1) while Trust M is busy instead of spinning the calling task. 
8)Removed unused function trustm_PBKDF2_HMAC()
9)Increased buffer size for read_certificate_from_optiga() to cater for larger certificate size. 
10)Added Shielded Connection protection level options which can be configured by the user's application.

#### Testing
Manually tested on PSoC6 + OPTIGA Trust M:
Commissioning and post-commissioning operation with ENABLE_TRUSTM_RANDOM=1 and =0. Shielded connection enabled (OPTIGA_COMMS_SHIELDED_CONNECTION)




