### PR TITLE
[CI] Fix flaky NXP FreeRTOS example build (runner disk exhaustion)

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -116,6 +116,8 @@ jobs:
                       --target nxp-rw61x-freertos-thermostat-wifi-se05x-factory \
                       build \
                   "
+            - name: clean build
+              run: rm -rf ./out
             - name: Build RW61X thermostat ethernet example app
               run: |
                   scripts/run_in_build_env.sh "\


### PR DESCRIPTION
### Problem

The `Build example - NXP` / `FREERTOS` job intermittently fails on the **RW61X thermostat ethernet** build (`nxp-rw61x-freertos-thermostat-ethernet-frdm`). All 478 objects compile clean, then the final archive step dies with runner `ENOSPC`:

```
##[warning]You are running out of disk space ... Free space left: 8 MB
arm-none-eabi-ar: unable to copy file 'lib/libCHIP.a'; reason: No space left on device
ninja: build stopped
```

This is transient GitHub-hosted-runner disk exhaustion, not a code error (master is green).

### Root cause

Every build step in the FreeRTOS job is bracketed by a `clean build` / `rm -rf ./out` step **except one**: the job builds the RW61X thermostat OTBR step (two targets: `...thread-wifi-ota-factory` + `...wifi-se05x-factory`) and then immediately builds the RW61X ethernet target with no intervening cleanup. `out/` from the OTBR step (two targets' worth) is still on disk when the ethernet target links, and the final `ar` copy of `libCHIP.a` runs out of space.

### Fix

Add the missing `clean build` (`rm -rf ./out`) step between the OTBR build and the ethernet build, matching the existing cleanup pattern already used between every other build in this job. No new mechanism introduced — just closing the one gap.

(Note: the repo's `maximize-runner-disk` action is a no-op here because this job runs inside the `chip-build-nxp` container without `/runner-root-volume` mounted, so reusing it would require a riskier volume-mount change. The in-job `rm -rf ./out` pattern is the idiomatic fix for this workflow.)

### Testing

- Validated the workflow YAML parses cleanly.
- Change is a minimal, self-consistent edit: it reuses the identical `clean build` / `rm -rf ./out` step already present at four other points in the same job, so behavior is well-understood. CI on this PR exercises the full FreeRTOS matrix end-to-end with the cleanup in place.