### PR TITLE
[CI] Fix flaky Ameba example build (parallel-target configure race)

### DIFF
--- a/scripts/build/builders/ameba.py
+++ b/scripts/build/builders/ameba.py
@@ -12,11 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import os
 from enum import Enum, auto
 
 from runner.runner import Runner
 from .builder import Builder, BuilderOutput, OutDirLock, lock_output_dir
+
+# All Ameba targets delegate generation to the same Realtek SDK tree
+# ($AMEBA_PATH/project/realtek_amebaD_va0_example/GCC-RELEASE), whose configure
+# step (asdk/config.cmake's configure_file + the 'linux' GEN_OS scratch dir) is
+# shared across applications rather than scoped to the per-target output_dir.
+# When several Ameba targets generate in parallel they race on this shared tree,
+# producing nondeterministic failures such as
+# "mkdir: cannot create directory 'linux': File exists" and
+# "CMake Error at asdk/config.cmake:20 (configure_file): No such file or
+# directory", which leaves no build.ninja behind. Serialize generation on this
+# constant key (compilation still runs in parallel, each in its own output_dir).
+AMEBA_SDK_GENERATE_LOCK_KEY = 'ameba:realtek_amebaD_va0_example/GCC-RELEASE'
 
 
 class AmebaBoard(Enum):
@@ -74,8 +87,14 @@ class AmebaBuilder(Builder):
         cmd += ' '.join([self.root, 'ninja', self.output_dir,
                         self.app.ExampleName])
 
-        self._Execute(['bash', '-c', cmd],
-                      title='Generating ' + self.identifier)
+        # Serialize the Realtek SDK configure step across all Ameba targets: they
+        # share one SDK tree, so concurrent generation races on it (see
+        # AMEBA_SDK_GENERATE_LOCK_KEY). lock_dir() handles a None lock gracefully.
+        shared_lock = self.output_dir_lock.lock_dir(AMEBA_SDK_GENERATE_LOCK_KEY) \
+            if self.output_dir_lock is not None else contextlib.nullcontext()
+        with shared_lock:
+            self._Execute(['bash', '-c', cmd],
+                          title='Generating ' + self.identifier)
 
     @lock_output_dir
     def _build(self):


### PR DESCRIPTION
### Problem

The Ameba example workflow (`.github/workflows/examples-ameba.yaml`) builds three targets in a single `build_examples.py` invocation:

```
--target ameba-amebad-all-clusters
--target ameba-amebad-all-clusters-minimal
--target ameba-amebad-light
```

`build_examples.py` runs the `generate()` step for these targets **in parallel** (`Context.Generate()` uses a `ThreadPoolExecutor`). Each Ameba target's `generate()` shells out to the Realtek SDK's `$AMEBA_PATH/project/realtek_amebaD_va0_example/GCC-RELEASE/build.sh`, which configures **one SDK tree shared across all applications** — it is not scoped to the per-target `output_dir`.

The existing `@lock_output_dir` decorator keys its lock on `self.output_dir`, which is distinct per target, so it provides **no** mutual exclusion for the shared SDK tree. Concurrent generation therefore races on it:

```
mkdir: cannot create directory 'linux': File exists
CMake Error at asdk/config.cmake:20 (configure_file):
    No such file or directory  (asdk/CMakeLists.txt:72)
```

A racing configure leaves no `build.ninja` behind, so the subsequent compile fails with `ninja: error: loading 'build.ninja'`. The failing target **rotates between runs** (nondeterministic) and `master` is green, confirming a timing-dependent parallel-configure race rather than a real build break.

### Fix

Serialize **only** the Realtek SDK configure step across Ameba targets by acquiring the shared `OutDirLock` on a constant key (`AMEBA_SDK_GENERATE_LOCK_KEY`) around the `build.sh` invocation in `AmebaBuilder.generate()` (`scripts/build/builders/ameba.py`). The lock infrastructure already exists; this just locks on a key that is the *same* for all three targets (the shared SDK tree) instead of the per-target `output_dir`.

Compilation (`ninja` in `_build`) still runs fully in parallel, each in its own `output_dir`, so CI throughput is preserved — only the short, contended configure step is serialized.

### Testing

- `python3 -m py_compile scripts/build/builders/ameba.py` — passes.
- AST parse / style checks pass (lines within the repo's 132-char limit; no trailing whitespace).
- The change uses only the pre-existing `OutDirLock.lock_dir()` API (re-entrant, keyed by string, and a no-op when the lock is `None`), so non-parallel single-target builds are unaffected.
- CI: this PR re-runs the `Build example - Ameba` workflow, which exercises the exact three-target parallel build that was flaking. Several green runs (vs. the previous rotating failures) validate the fix.