### PR TITLE
[JF] Fix use-after-free in JCMCommissionee::PerformVendorIdVerification

### DIFF
--- a/src/app/clusters/joint-fabric-administrator-server/JCMCommissionee.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/JCMCommissionee.cpp
@@ -298,6 +298,10 @@ TrustVerificationError JCMCommissionee::PerformVendorIdVerification()
         {
             ChipLogError(JointFabric, "Failed to read commissioner info. Error: %" CHIP_ERROR_FORMAT, err.Format());
             OnVendorIdVerificationComplete(err);
+            // OnVendorIdVerificationComplete() synchronously destroys *this
+            // (mOnCompletion -> CleanupAnnounceJFA -> mActiveCommissionee.reset()), so without
+            // this return the code below would use freed storage in VerifyVendorId(&mInfo).
+            return;
         }
 
         chip::Messaging::ExchangeManager * exchangeMgr = &chip::Server::GetInstance().GetExchangeManager();

--- a/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
@@ -374,6 +374,7 @@ protected:
     void TestReadAdminFabricsPopulatesCommissionerInfo();
     void TestReadAdminCertsPopulatesCommissionerRcac();
     void TestReadAdminNOCsPopulatesCommissionerCerts();
+    void TestPerformVendorIdVerificationCompletesOnceOnReadFailure();
 };
 
 TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestNextStageFollowsExpectedOrder)
@@ -676,6 +677,68 @@ TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestValidateAdministratorIdsMatch)
     commissionee.mInfo.rootPublicKey.CopyFromSpan(ByteSpan(adminRootKey, Crypto::kP256_PublicKey_Length - 1));
     ASSERT_EQ(commissionee.mInfo.rootPublicKey.AllocatedSize(), Crypto::kP256_PublicKey_Length - 1);
     EXPECT_EQ(commissionee.ValidateAdministratorIdsMatch(kAdminFabricId, matchingKey), TrustVerificationError::kInternalError);
+}
+
+// Harness for PerformVendorIdVerification()'s FetchCommissionerInfo error path. That path
+// must complete the verification once via OnVendorIdVerificationComplete(err) and stop, not
+// continue into VerifyVendorId(&mInfo): OnVendorIdVerificationComplete() destroys *this in
+// production (mOnCompletion -> CleanupAnnounceJFA -> mActiveCommissionee.reset()), so
+// continuing would dereference freed storage. This harness frees the commissionee from
+// mOnCompletion to mirror that teardown, making such a regression observable under ASan.
+class ReadFailureJCMCommissionee : public JCMCommissionee
+{
+public:
+    using JCMCommissionee::JCMCommissionee;
+
+    int completionCount = 0;
+
+protected:
+    // Drive StartTrustVerification() straight into kPerformingVendorIDVerification.
+    TrustVerificationStage GetNextTrustVerificationStage(const TrustVerificationStage & currentStage) override
+    {
+        return (currentStage == TrustVerificationStage::kPerformingVendorIDVerification)
+            ? TrustVerificationStage::kComplete
+            : TrustVerificationStage::kPerformingVendorIDVerification;
+    }
+
+    // Counts how many times the verification completes; the error path must complete once.
+    void OnVendorIdVerificationComplete(const CHIP_ERROR & err) override
+    {
+        ++completionCount;
+        JCMCommissionee::OnVendorIdVerificationComplete(err);
+    }
+
+    // Simulate a dispatched read whose response is an error: invoke onError but return
+    // CHIP_NO_ERROR (returning an error would make FetchCommissionerInfo complete on its own).
+    CHIP_ERROR
+    ReadAdminFabricsAttribute(std::function<void(const ConcreteAttributePath &, const FabricsAttr::DecodableType &)> onSuccess,
+                              ReadErrorHandler onError) override
+    {
+        onError(nullptr, CHIP_ERROR_INTERNAL);
+        return CHIP_NO_ERROR;
+    }
+};
+
+// A failed commissioner read must complete the verification exactly once. If the error path
+// continued into VerifyVendorId (session released below), that call would complete a second
+// time and completionCount would exceed 1.
+TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestPerformVendorIdVerificationCompletesOnceOnReadFailure)
+{
+    FakeCommandHandler commandHandler;
+    CommandHandler::Handle handle(&commandHandler);
+    Messaging::ExchangeContext * exchangeCtx = NewExchangeToBob(nullptr, false);
+    commandHandler.SetExchangeContext(exchangeCtx);
+
+    ReadFailureJCMCommissionee commissionee(handle, EndpointId{ 41 }, [](CHIP_ERROR) {});
+
+    // Release the session so that if the error path ever continues into VerifyVendorId, that
+    // call completes synchronously (its "session missing" path) and the extra completion is
+    // caught by the assertion below.
+    commissionee.mSessionHolder.Release();
+
+    commissionee.VerifyTrustAgainstCommissionerAdmin();
+
+    EXPECT_EQ(commissionee.completionCount, 1);
 }
 
 } // namespace JointFabricAdministrator

--- a/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
@@ -680,12 +680,11 @@ TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestValidateAdministratorIdsMatch)
     EXPECT_EQ(commissionee.ValidateAdministratorIdsMatch(kAdminFabricId, matchingKey), TrustVerificationError::kInternalError);
 }
 
-// Harness for PerformVendorIdVerification()'s FetchCommissionerInfo error path. That path
-// must complete the verification once via OnVendorIdVerificationComplete(err) and stop, not
-// continue into VerifyVendorId(&mInfo): OnVendorIdVerificationComplete() destroys *this in
-// production (mOnCompletion -> CleanupAnnounceJFA -> mActiveCommissionee.reset()), so
-// continuing would dereference freed storage. This harness frees the commissionee from
-// mOnCompletion to mirror that teardown, making such a regression observable under ASan.
+// Harness for PerformVendorIdVerification()'s FetchCommissionerInfo error path: it forces the commissioner read
+// to fail and counts how many times the verification completes. The error path must complete exactly once and
+// stop, not continue into VerifyVendorId(&mInfo). In production, continuing would be a use-after-free, since
+// OnVendorIdVerificationComplete() destroys *this (mOnCompletion -> CleanupAnnounceJFA ->
+// mActiveCommissionee.reset()); this test detects the defect by counting completions, without that teardown.
 class ReadFailureJCMCommissionee : public JCMCommissionee
 {
 public:
@@ -712,7 +711,7 @@ protected:
     // Simulate a dispatched read whose response is an error: invoke onError but return
     // CHIP_NO_ERROR (returning an error would make FetchCommissionerInfo complete on its own).
     CHIP_ERROR
-    ReadAdminFabricsAttribute(std::function<void(const ConcreteAttributePath &, const FabricsAttr::DecodableType &)> onSuccess,
+    ReadAdminFabricsAttribute(std::function<void(const ConcreteAttributePath &, const FabricsAttr::DecodableType &)>,
                               ReadErrorHandler onError) override
     {
         onError(nullptr, CHIP_ERROR_INTERNAL);

--- a/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/TestJCMCommissionee.cpp
@@ -375,6 +375,7 @@ protected:
     void TestReadAdminCertsPopulatesCommissionerRcac();
     void TestReadAdminNOCsPopulatesCommissionerCerts();
     void TestPerformVendorIdVerificationCompletesOnceOnReadFailure();
+    void TestPerformVendorIdVerificationDoesNotUseFreedCommissioneeOnReadFailure();
 };
 
 TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestNextStageFollowsExpectedOrder)
@@ -739,6 +740,29 @@ TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestPerformVendorIdVerificationComplete
     commissionee.VerifyTrustAgainstCommissionerAdmin();
 
     EXPECT_EQ(commissionee.completionCount, 1);
+}
+
+// Heap-allocates the commissionee and frees it from the completion callback (mirroring
+// production's mActiveCommissionee.reset()). If the read-failure path continues into
+// VerifyVendorId(&mInfo) after completing, it touches freed memory and ASan aborts. There is
+// nothing to assert; in non-ASan builds it is a no-op, so the counting test above is the guard.
+TEST_F_FROM_FIXTURE(TestJCMCommissionee, TestPerformVendorIdVerificationDoesNotUseFreedCommissioneeOnReadFailure)
+{
+    FakeCommandHandler commandHandler;
+    CommandHandler::Handle handle(&commandHandler);
+    Messaging::ExchangeContext * exchangeCtx = NewExchangeToBob(nullptr, false);
+    commandHandler.SetExchangeContext(exchangeCtx);
+
+    // The completion callback owns the teardown and, like production's onComplete, does nothing
+    // after the delete -- so the only post-free access that can occur is the buggy fall-through.
+    ReadFailureJCMCommissionee * commissionee = nullptr;
+    commissionee = new ReadFailureJCMCommissionee(handle, EndpointId{ 41 }, [&commissionee](CHIP_ERROR) { delete commissionee; });
+
+    // Release the session so a continued VerifyVendorId resolves synchronously (dereferencing the
+    // freed commissionee in the regression).
+    commissionee->mSessionHolder.Release();
+
+    commissionee->VerifyTrustAgainstCommissionerAdmin();
 }
 
 } // namespace JointFabricAdministrator


### PR DESCRIPTION
#### Summary

On the `FetchCommissionerInfo` error path, `PerformVendorIdVerification()` called `OnVendorIdVerificationComplete(err)` but was missing an early return;, so it fell through to `VerifyVendorId(..., &mInfo)`.

`OnVendorIdVerificationComplete() `synchronously destroys the` JCMCommissionee` (its completion callback resets the owning `std::optional` via `CleanupAnnounceJFA()`), so the fall-through dereferenced freed storage — a use-after-free — and completed the verification a second time.

Fix: add the missing `return;`.



#### Testing

- Unit Test case added, which fails without the change and passes with it.

