### PR TITLE
[camera-controller] Make liveview stop's --video-stream-id optional

### DIFF
--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -212,6 +212,18 @@ v4l2-ctl -d /dev/video0 --list-formats-ext
 Wave your hand in front of the camera to trigger live view; a video window will
 appear, confirming that the stream is active.
 
+4. To stop the active live view stream, use the `liveview stop` command. The
+   `--video-stream-id` flag is optional; when omitted, the controller stops the
+   stream it is currently tracking for that node.
+
+```
+# Stop the current live view on node 1
+liveview stop 1
+
+# Specify the stream ID when it is not tracked (e.g. after a restart)
+liveview stop 1 --video-stream-id <video-stream-id>
+```
+
 ### 4. Running the Video Recording Upload Demo
 
 The Push AV Server acts as the recording destination (like a cloud service) for

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
@@ -55,10 +55,9 @@ CHIP_ERROR LiveViewStopCommand::RunCommand()
         auto activeStreamId = camera::DeviceManager::Instance().GetActiveLiveViewStreamId(mPeerNodeId);
         if (!activeStreamId.has_value())
         {
-            ChipLogError(Camera,
-                         "No active LiveView stream tracked for node 0x" ChipLogFormatX64
-                         "; please pass video-stream-id explicitly",
-                         ChipLogValueX64(mPeerNodeId));
+            ChipLogError(
+                Camera, "No active LiveView stream tracked for node 0x" ChipLogFormatX64 "; please pass video-stream-id explicitly",
+                ChipLogValueX64(mPeerNodeId));
             return CHIP_ERROR_NOT_FOUND;
         }
         effectiveStreamId = activeStreamId.value();

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
@@ -45,7 +45,28 @@ CHIP_ERROR LiveViewStopCommand::RunCommand()
 {
     ChipLogProgress(Camera, "Run LiveViewStopCommand");
 
-    camera::DeviceManager::Instance().StopVideoStream(mVideoStreamID);
+    uint16_t effectiveStreamId = 0;
+    if (mVideoStreamID.HasValue())
+    {
+        effectiveStreamId = mVideoStreamID.Value();
+    }
+    else
+    {
+        auto activeStreamId = camera::DeviceManager::Instance().GetActiveLiveViewStreamId(mPeerNodeId);
+        if (!activeStreamId.has_value())
+        {
+            ChipLogError(Camera,
+                         "No active LiveView stream tracked for node 0x" ChipLogFormatX64
+                         "; please pass video-stream-id explicitly",
+                         ChipLogValueX64(mPeerNodeId));
+            return CHIP_ERROR_NOT_FOUND;
+        }
+        effectiveStreamId = activeStreamId.value();
+        ChipLogProgress(Camera, "Using active LiveView stream id %u for node 0x" ChipLogFormatX64, effectiveStreamId,
+                        ChipLogValueX64(mPeerNodeId));
+    }
 
-    return camera::DeviceManager::Instance().DeallocateVideoStream(mPeerNodeId, mVideoStreamID);
+    camera::DeviceManager::Instance().StopVideoStream(effectiveStreamId);
+
+    return camera::DeviceManager::Instance().DeallocateVideoStream(mPeerNodeId, effectiveStreamId);
 }

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.h
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.h
@@ -63,5 +63,5 @@ public:
 
 private:
     chip::NodeId mPeerNodeId = chip::kUndefinedNodeId;
-    uint16_t mVideoStreamID  = 0;
+    chip::Optional<uint16_t> mVideoStreamID;
 };

--- a/examples/camera-controller/device-manager/DeviceManager.cpp
+++ b/examples/camera-controller/device-manager/DeviceManager.cpp
@@ -82,6 +82,7 @@ void DeviceManager::Shutdown()
         StopVideoStreamProcess(pair.first);
     }
     mVideoStreamProcesses.clear();
+    mActiveLiveViewByNode.clear();
 
     // Disconnect WebRTC session
     WebRTCManager::Instance().Disconnect();
@@ -131,6 +132,15 @@ CHIP_ERROR DeviceManager::DeallocateVideoStream(NodeId nodeId, uint16_t videoStr
         // Stop the video stream process and disconnect WebRTC
         StopVideoStreamProcess(videoStreamId);
         WebRTCManager::Instance().Disconnect();
+
+        // Remove this node's active LiveView record only when the deallocated
+        // stream is the one we were tracking; this avoids dropping the record
+        // when the caller explicitly deallocates a different stream id.
+        auto it = mActiveLiveViewByNode.find(nodeId);
+        if (it != mActiveLiveViewByNode.end() && it->second == videoStreamId)
+        {
+            mActiveLiveViewByNode.erase(it);
+        }
     }
 
     return error;
@@ -238,9 +248,20 @@ void DeviceManager::OnWebRTCSessionEstablished(uint16_t streamId)
         if (streamId == mPendingVideoStreamId)
         {
             StartVideoStreamProcess(streamId);
-            mPendingVideoStreamId = 0;
+            mActiveLiveViewByNode[mNodeId] = streamId;
+            mPendingVideoStreamId          = 0;
         }
     }
+}
+
+std::optional<uint16_t> DeviceManager::GetActiveLiveViewStreamId(NodeId nodeId) const
+{
+    auto it = mActiveLiveViewByNode.find(nodeId);
+    if (it == mActiveLiveViewByNode.end())
+    {
+        return std::nullopt;
+    }
+    return it->second;
 }
 
 void DeviceManager::StartVideoStreamProcess(uint16_t streamId)

--- a/examples/camera-controller/device-manager/DeviceManager.h
+++ b/examples/camera-controller/device-manager/DeviceManager.h
@@ -22,6 +22,9 @@
 #include <device-manager/AVStreamManagement.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#include <map>
+#include <optional>
+
 namespace camera {
 
 enum class WebRTCOfferType : uint8_t
@@ -90,13 +93,25 @@ public:
      */
     void OnWebRTCSessionEstablished(uint16_t streamId);
 
+    /**
+     * @brief Look up the currently active LiveView video stream ID for a given node.
+     *
+     * Returns the stream ID recorded when a LiveView WebRTC session was last
+     * established for that node, or std::nullopt if no LiveView stream is
+     * currently tracked for it.
+     *
+     * @param nodeId The node ID of the remote camera device.
+     */
+    std::optional<uint16_t> GetActiveLiveViewStreamId(chip::NodeId nodeId) const;
+
 private:
     chip::Controller::DeviceCommissioner * mCommissioner = nullptr;
     chip::NodeId mNodeId                                 = chip::kUndefinedNodeId;
     uint8_t mStreamUsage                                 = 0;
     WebRTCOfferType mOfferType                           = WebRTCOfferType::kProvideOffer;
-    std::map<uint16_t, pid_t> mVideoStreamProcesses; // Stream ID -> Process ID mapping
-    uint16_t mPendingVideoStreamId = 0;              // Track the stream ID we're setting up
+    std::map<uint16_t, pid_t> mVideoStreamProcesses;            // Stream ID -> Process ID mapping
+    std::map<chip::NodeId, uint16_t> mActiveLiveViewByNode;     // Node ID -> active LiveView stream ID
+    uint16_t mPendingVideoStreamId = 0;                         // Track the stream ID we're setting up
 
     AVStreamManagement mAVStreamManagment;
 

--- a/examples/camera-controller/device-manager/DeviceManager.h
+++ b/examples/camera-controller/device-manager/DeviceManager.h
@@ -109,9 +109,9 @@ private:
     chip::NodeId mNodeId                                 = chip::kUndefinedNodeId;
     uint8_t mStreamUsage                                 = 0;
     WebRTCOfferType mOfferType                           = WebRTCOfferType::kProvideOffer;
-    std::map<uint16_t, pid_t> mVideoStreamProcesses;            // Stream ID -> Process ID mapping
-    std::map<chip::NodeId, uint16_t> mActiveLiveViewByNode;     // Node ID -> active LiveView stream ID
-    uint16_t mPendingVideoStreamId = 0;                         // Track the stream ID we're setting up
+    std::map<uint16_t, pid_t> mVideoStreamProcesses;        // Stream ID -> Process ID mapping
+    std::map<chip::NodeId, uint16_t> mActiveLiveViewByNode; // Node ID -> active LiveView stream ID
+    uint16_t mPendingVideoStreamId = 0;                     // Track the stream ID we're setting up
 
     AVStreamManagement mAVStreamManagment;
 


### PR DESCRIPTION
Track the active LiveView video stream id per node inside DeviceManager when a WebRTC session is established, and use it as the default target of `liveview stop <node>` so callers no longer need to copy the stream id from the log.

When no active stream is tracked (controller restart, multiple streams, etc.), the command returns CHIP_ERROR_NOT_FOUND and asks the caller to pass --video-stream-id explicitly. Behavior with an explicit id is unchanged.

README updated with the new short form and the fallback rules.

