### PR TITLE
[Silabs] Fixing the build with the Matter CLI enabled

### DIFF
--- a/examples/platform/silabs/MatterShell.cpp
+++ b/examples/platform/silabs/MatterShell.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR CmdSilabsDispatch(int argc, char ** argv)
 
     VerifyOrReturnError(builder.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    sl_cli_handle_input(sl_cli_default_handle, builder.c_str());
+    sl_cli_handle_input(sl_cli_default_handle, const_cast<char *>(builder.c_str()));
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary
With the PR: https://github.com/project-chip/connectedhomeip/pull/71788/changes#diff-35b726ef2b0dc2bdedca3cc987f19dea26aef0e1a16a3e1b061ee260ee6fe4af
The silabs build was failing when the CLI was enabled.

Fixing the build by correctly typecasting the argument

#### Related issues
NA

#### Testing
Local build