### PR TITLE
fix(inet): preserve IPv6 LLA interface ID in discovery and resolve header circular dependency

### DIFF
--- a/examples/camera-controller/commands/common/Command.h
+++ b/examples/camera-controller/commands/common/Command.h
@@ -21,6 +21,7 @@
 #include <app/data-model/Nullable.h>
 #include <commands/clusters/ComplexArgument.h>
 #include <commands/clusters/CustomArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/Optional.h>
 #include <lib/support/Span.h>

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -21,6 +21,7 @@
 #include <app/data-model/Nullable.h>
 #include <commands/clusters/ComplexArgument.h>
 #include <commands/clusters/CustomArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/Optional.h>
 #include <lib/support/Span.h>

--- a/examples/fabric-admin/commands/common/Command.h
+++ b/examples/fabric-admin/commands/common/Command.h
@@ -21,6 +21,7 @@
 #include <app/data-model/Nullable.h>
 #include <commands/clusters/ComplexArgument.h>
 #include <commands/clusters/CustomArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/Optional.h>
 #include <lib/support/Span.h>

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <TracingCommandLineArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/dnssd/MinimalMdnsServer.h>

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -21,6 +21,7 @@
 #include <arpa/inet.h>
 
 #include <TracingCommandLineArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/dnssd/MinimalMdnsServer.h>

--- a/examples/minimal-mdns/tester.cpp
+++ b/examples/minimal-mdns/tester.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include <TracingCommandLineArgument.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/dnssd/MinimalMdnsServer.h>

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -47,6 +47,7 @@
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPCore.h>

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -154,8 +154,8 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
             Json::Value addresses;
             for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)
             {
-                char buf[Inet::IPAddress::kMaxStringLength];
-                dnsSdInfo->ipAddress[j].ToString(buf);
+                char buf[Inet::IPAddress::kMaxAddressWithInterfaceLength];
+                dnsSdInfo->ipAddress[j].ToString(buf, dnsSdInfo->interfaceId);
                 addresses[j] = buf;
             }
             jsonVal["addresses"] = addresses;

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -46,7 +46,7 @@ namespace Inet {
 // non-canonical.
 static void NormalizeIp6ToLower(char * str)
 {
-    for (char *p = str; *p != '\0'; ++p)
+    for (char * p = str; *p != '\0'; ++p)
     {
         if (*p >= 'A' && *p <= 'F')
         {

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -86,23 +86,29 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
     return buf;
 }
 
-char * IPAddress::ToString(char * buf, uint32_t bufSize, const class InterfaceId & interfaceId) const
+char * IPAddress::ToString(char * buf, uint32_t bufSize, const Inet::InterfaceId & interfaceId) const
 {
-    char ipStr[IPAddress::kMaxStringLength];
-    ToString(ipStr, sizeof(ipStr));
-
-    StringBuilderBase builder(buf, bufSize);
-    builder.Add(ipStr);
-
     if (IsIPv6LinkLocal() && interfaceId.IsPresent())
     {
-        char ifName[InterfaceId::kMaxIfNameLength];
+        char ipStr[IPAddress::kMaxStringLength];
+        if (ToString(ipStr, sizeof(ipStr)) == nullptr)
+        {
+            return nullptr;
+        }
+
+        StringBuilderBase builder(buf, bufSize);
+        builder.Add(ipStr);
+
+        char ifName[Inet::InterfaceId::kMaxIfNameLength];
         if (interfaceId.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR)
         {
             builder.Add("%").Add(ifName);
         }
+
+        return builder.Fit() ? buf : nullptr;
     }
-    return buf;
+
+    return ToString(buf, bufSize);
 }
 
 bool IPAddress::FromString(const char * str, IPAddress & output)

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -30,7 +30,9 @@
 #include <string.h>
 
 #include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/StringBuilder.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_SOCKETS
 #include <arpa/inet.h>
@@ -81,6 +83,25 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
     otIp6AddressToString(&addr, buf, static_cast<uint16_t>(bufSize));
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 
+    return buf;
+}
+
+char * IPAddress::ToString(char * buf, uint32_t bufSize, const class InterfaceId & interfaceId) const
+{
+    char ipStr[IPAddress::kMaxStringLength];
+    ToString(ipStr, sizeof(ipStr));
+
+    StringBuilderBase builder(buf, bufSize);
+    builder.Add(ipStr);
+
+    if (IsIPv6LinkLocal() && interfaceId.IsPresent())
+    {
+        char ifName[InterfaceId::kMaxIfNameLength];
+        if (interfaceId.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR)
+        {
+            builder.Add("%").Add(ifName);
+        }
+    }
     return buf;
 }
 

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -41,6 +41,20 @@
 namespace chip {
 namespace Inet {
 
+// Normalize a string to lowercase per RFC 5952 (canonical IPv6 text form).
+// ip6addr_ntoa_r and otIp6AddressToString output uppercase, which is
+// non-canonical.
+static void NormalizeIp6ToLower(char * str)
+{
+    for (char *p = str; *p != '\0'; ++p)
+    {
+        if (*p >= 'A' && *p <= 'F')
+        {
+            *p = static_cast<char>(*p + ('a' - 'A'));
+        }
+    }
+}
+
 char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
@@ -55,6 +69,8 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
     {
         ip6_addr_t ip6_addr = ToIPv6();
         ip6addr_ntoa_r(&ip6_addr, buf, (int) bufSize);
+        // Normalize to lowercase per RFC 5952 (canonical IPv6 text form).
+        NormalizeIp6ToLower(buf);
     }
 #elif CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     // socklen_t is sometimes signed, sometimes not, so the only safe way to do
@@ -81,6 +97,8 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 #elif CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     otIp6Address addr = ToIPv6();
     otIp6AddressToString(&addr, buf, static_cast<uint16_t>(bufSize));
+    // Normalize to lowercase per RFC 5952 (canonical IPv6 text form).
+    NormalizeIp6ToLower(buf);
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 
     return buf;
@@ -95,6 +113,9 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize, const Inet::InterfaceId
         {
             return nullptr;
         }
+
+        // Normalize to lowercase per RFC 5952 (canonical IPv6 text form).
+        NormalizeIp6ToLower(ipStr);
 
         StringBuilderBase builder(buf, bufSize);
         builder.Add(ipStr);

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -170,6 +170,7 @@ public:
 #endif
     static constexpr uint16_t kMaxStringLength = OT_IP6_ADDRESS_STRING_SIZE;
 #endif
+    static constexpr uint16_t kMaxAddressWithInterfaceLength = kMaxStringLength + 1 + InterfaceId::kMaxIfNameLength;
 
     IPAddress() = default;
 
@@ -371,6 +372,7 @@ public:
      * @return  The argument \c buf if no formatting error, or zero otherwise.
      */
     char * ToString(char * buf, uint32_t bufSize) const;
+    char * ToString(char * buf, uint32_t bufSize, const class InterfaceId & interfaceId) const;
 
     /**
      * A version of ToString that writes to a literal and deduces how much space
@@ -380,6 +382,12 @@ public:
     inline char * ToString(char (&buf)[N]) const
     {
         return ToString(buf, N);
+    }
+
+    template <uint32_t N>
+    inline char * ToString(char (&buf)[N], const class InterfaceId & interfaceId) const
+    {
+        return ToString(buf, N, interfaceId);
     }
 
     /**

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -372,7 +372,7 @@ public:
      * @return  The argument \c buf if no formatting error, or zero otherwise.
      */
     char * ToString(char * buf, uint32_t bufSize) const;
-    char * ToString(char * buf, uint32_t bufSize, const class InterfaceId & interfaceId) const;
+    char * ToString(char * buf, uint32_t bufSize, const Inet::InterfaceId & interfaceId) const;
 
     /**
      * A version of ToString that writes to a literal and deduces how much space
@@ -385,7 +385,7 @@ public:
     }
 
     template <uint32_t N>
-    inline char * ToString(char (&buf)[N], const class InterfaceId & interfaceId) const
+    inline char * ToString(char (&buf)[N], const Inet::InterfaceId & interfaceId) const
     {
         return ToString(buf, N, interfaceId);
     }
@@ -436,7 +436,7 @@ public:
      * @retval true  The presentation format is valid
      * @retval false Otherwise
      */
-    static bool FromString(const char * str, IPAddress & addrOutput, class InterfaceId & ifaceOutput);
+    static bool FromString(const char * str, IPAddress & addrOutput, Inet::InterfaceId & ifaceOutput);
 
     /**
      * @brief   Emit the IP address in standard network representation.

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -170,7 +170,7 @@ public:
 #endif
     static constexpr uint16_t kMaxStringLength = OT_IP6_ADDRESS_STRING_SIZE;
 #endif
-    static constexpr uint16_t kMaxAddressWithInterfaceLength = kMaxStringLength + 1 + InterfaceId::kMaxIfNameLength;
+    static constexpr uint16_t kMaxAddressWithInterfaceLength = kMaxStringLength + 1 + Inet::InterfaceId::kMaxIfNameLength;
 
     IPAddress() = default;
 

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -25,6 +25,7 @@
 
 #include <inet/InetInterface.h>
 
+#include <inet/IPAddress.h>
 #include <inet/IPPrefix.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -49,6 +49,10 @@ struct net_if_ipv4;
 struct net_if_ipv6;
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
+#if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
+#include <openthread/ip6.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -28,7 +28,6 @@
 
 #include <inet/InetConfig.h>
 
-#include <inet/IPAddress.h>
 #include <inet/InetError.h>
 #include <lib/support/DLLUtil.h>
 
@@ -37,6 +36,7 @@
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
+#include <net/if.h>
 struct if_nameindex;
 struct ifaddrs;
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
@@ -95,6 +95,7 @@ public:
     using PlatformType                       = unsigned int;
     static constexpr size_t kMaxIfNameLength = 6;
 #endif
+
 
     ~InterfaceId() = default;
 

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -96,7 +96,6 @@ public:
     static constexpr size_t kMaxIfNameLength = 6;
 #endif
 
-
     ~InterfaceId() = default;
 
     constexpr InterfaceId() : mPlatformInterface(kPlatformNull) {}

--- a/src/inet/tests/TestBasicPacketFilters.cpp
+++ b/src/inet/tests/TestBasicPacketFilters.cpp
@@ -21,6 +21,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <inet/BasicPacketFilters.h>
+#include <inet/IPAddress.h>
 #include <inet/IPPacketInfo.h>
 #include <inet/InetInterface.h>
 #include <lib/core/StringBuilderAdapters.h>

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -842,10 +842,10 @@ TEST_F(TestInetAddress, TestCheckToStringWithInterface)
         // 1. Test IPv6 Link-Local Address (LLA) with Interface ID
         IPAddress llaAddress;
         EXPECT_TRUE(IPAddress::FromString("fe80::8edc:d4ff:fe3a:ebfb", llaAddress));
-        
+
         char buf[IPAddress::kMaxAddressWithInterfaceLength];
         EXPECT_NE(llaAddress.ToString(buf, sizeof(buf), ifaceId), nullptr);
-        
+
         char expected[IPAddress::kMaxAddressWithInterfaceLength];
         snprintf(expected, sizeof(expected), "fe80::8edc:d4ff:fe3a:ebfb%%%s", ifName);
         EXPECT_STREQ(buf, expected);
@@ -872,7 +872,6 @@ TEST_F(TestInetAddress, TestCheckToStringWithInterface)
         EXPECT_EQ(llaAddress.ToString(smallBufAlloc.get(), static_cast<uint32_t>(requiredSize - 1), ifaceId), nullptr);
     }
 }
-
 
 /**
  *  Test correct identification of IPv6 ULA addresses.

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -861,10 +861,12 @@ TEST_F(TestInetAddress, TestCheckToStringWithInterface)
         EXPECT_STREQ(buf, "fd00::1");
 
         // 4. Test IPv4 Address with Interface ID (should NOT append suffix)
+#if INET_CONFIG_ENABLE_IPV4
         IPAddress ipv4Address;
         EXPECT_TRUE(IPAddress::FromString("1.2.3.4", ipv4Address));
         EXPECT_NE(ipv4Address.ToString(buf, sizeof(buf), ifaceId), nullptr);
         EXPECT_STREQ(buf, "1.2.3.4");
+#endif // INET_CONFIG_ENABLE_IPV4
 
         // 5. Test Buffer Too Small
         size_t requiredSize = strlen("fe80::8edc:d4ff:fe3a:ebfb") + 1 + strlen(ifName) + 1;

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -869,7 +869,7 @@ TEST_F(TestInetAddress, TestCheckToStringWithInterface)
         // 5. Test Buffer Too Small
         size_t requiredSize = strlen("fe80::8edc:d4ff:fe3a:ebfb") + 1 + strlen(ifName) + 1;
         std::unique_ptr<char[]> smallBufAlloc(new char[requiredSize - 1]);
-        EXPECT_EQ(llaAddress.ToString(smallBufAlloc.get(), requiredSize - 1, ifaceId), nullptr);
+        EXPECT_EQ(llaAddress.ToString(smallBufAlloc.get(), static_cast<uint32_t>(requiredSize - 1), ifaceId), nullptr);
     }
 }
 

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -29,6 +29,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/StringBuilderAdapters.h>
 
@@ -825,6 +826,53 @@ TEST_F(TestInetAddress, TestCheckToString)
         ++lCurrent;
     }
 }
+
+/**
+ *  Test IP address conversion to a string with interface ID.
+ */
+TEST_F(TestInetAddress, TestCheckToStringWithInterface)
+{
+    InterfaceIterator iter;
+    if (iter.HasCurrent())
+    {
+        InterfaceId ifaceId = iter.GetInterfaceId();
+        char ifName[InterfaceId::kMaxIfNameLength];
+        EXPECT_EQ(ifaceId.GetInterfaceName(ifName, sizeof(ifName)), CHIP_NO_ERROR);
+
+        // 1. Test IPv6 Link-Local Address (LLA) with Interface ID
+        IPAddress llaAddress;
+        EXPECT_TRUE(IPAddress::FromString("fe80::8edc:d4ff:fe3a:ebfb", llaAddress));
+        
+        char buf[IPAddress::kMaxAddressWithInterfaceLength];
+        EXPECT_NE(llaAddress.ToString(buf, sizeof(buf), ifaceId), nullptr);
+        
+        char expected[IPAddress::kMaxAddressWithInterfaceLength];
+        snprintf(expected, sizeof(expected), "fe80::8edc:d4ff:fe3a:ebfb%%%s", ifName);
+        EXPECT_STREQ(buf, expected);
+
+        // 2. Test IPv6 LLA with Null Interface ID (should NOT append suffix)
+        EXPECT_NE(llaAddress.ToString(buf, sizeof(buf), InterfaceId::Null()), nullptr);
+        EXPECT_STREQ(buf, "fe80::8edc:d4ff:fe3a:ebfb");
+
+        // 3. Test Standard IPv6 Address (non-LLA) with Interface ID (should NOT append suffix)
+        IPAddress ulaAddress;
+        EXPECT_TRUE(IPAddress::FromString("fd00::1", ulaAddress));
+        EXPECT_NE(ulaAddress.ToString(buf, sizeof(buf), ifaceId), nullptr);
+        EXPECT_STREQ(buf, "fd00::1");
+
+        // 4. Test IPv4 Address with Interface ID (should NOT append suffix)
+        IPAddress ipv4Address;
+        EXPECT_TRUE(IPAddress::FromString("1.2.3.4", ipv4Address));
+        EXPECT_NE(ipv4Address.ToString(buf, sizeof(buf), ifaceId), nullptr);
+        EXPECT_STREQ(buf, "1.2.3.4");
+
+        // 5. Test Buffer Too Small
+        size_t requiredSize = strlen("fe80::8edc:d4ff:fe3a:ebfb") + 1 + strlen(ifName) + 1;
+        std::unique_ptr<char[]> smallBufAlloc(new char[requiredSize - 1]);
+        EXPECT_EQ(llaAddress.ToString(smallBufAlloc.get(), requiredSize - 1, ifaceId), nullptr);
+    }
+}
+
 
 /**
  *  Test correct identification of IPv6 ULA addresses.

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <optional>
 
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/PeerId.h>

--- a/src/platform/Zephyr/InetUtils.h
+++ b/src/platform/Zephyr/InetUtils.h
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 
 #if defined(CONFIG_ZEPHYR_VERSION_3_3)

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -29,6 +29,7 @@
 #include <lib/support/CHIPMemString.h>
 #include <platform/DiagnosticDataProvider.h>
 
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -31,6 +31,7 @@
 #endif
 #include "sl_memory_manager.h"
 #include <cmsis_os2.h>
+#include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <lib/support/CHIPMemString.h>
 #include <sl_cmsis_os2_common.h>


### PR DESCRIPTION
#### Summary

Fixes #72243

During DNS-SD discovery, IPv6 Link-Local Addresses (LLAs) had their InterfaceId discarded when serialized to Python in the device controller discovery wrapper. When Python subsequently passed the address string back to C++ for session establishment (e.g., EstablishPASESession), it lacked the "%interface" scope suffix. This caused the address to resolve to InterfaceId::Null(), leading to session establishment failures on multi-interface devices (such as in TC_OPCREDS_3_1).

##### Changes:

- Added a new IPAddress::ToString overload that accepts InterfaceId and safely appends the "%interface" suffix for IPv6 LLAs using StringBuilderBase.
- Updated the Python discovery bindings wrapper (ChipDeviceController-Discovery.cpp) to use this new ToString overload and safely size buffers using a new kMaxAddressWithInterfaceLength constant.
- Resolved the tight circular include dependency between IPAddress.h and InetInterface.h (make ipaddress include inetinterface)
   - fixed some missing includes across the board as a sideffect.
   
#### Testing

Unit tests pass and added a unit test.
Validated independently by QA for solving the original bug report.
