### PR TITLE
Refactor ACE 1.6 Steps for Clearer Separation of Steps

### DIFF
--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -97,8 +97,12 @@ class TC_ACE_1_6(MatterBaseTest):
     def steps_TC_ACE_1_6(self) -> list[TestStep]:
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep("1a", "TH sends KeySetWrite command for GroupKeySetID 0x01a3"),
-            TestStep("1b", "TH sends KeySetWrite command for GroupKeySetID 0x01a1"),
+            TestStep("1a", "Verify endpoint composition"),
+            TestStep("1b", "TH sends KeySetWrite command for GroupKeySetID 0x01a3"),
+            TestStep("1c", "TH sends KeySetWrite command for GroupKeySetID 0x01a1"),
+            TestStep("1d", "TH configures GroupKeySetID 0x01a1 and 0x01a3 on the TH"),
+            TestStep("1e", "TH maps GroupIds to KeySetIDs on the TH"),
+            TestStep("1f", "TH configures group information on the TH"),
             TestStep(2, "TH writes GroupKeyMap attribute with three entries"),
             TestStep("3a", "TH sends a AddGroup Command to the Groups cluster on Endpoint PIXIT.G.ENDPOINT over CASE with GroupID 0x0103"),
             TestStep("3b", "TH sends Groupcast JoinGroup command with GroupID 0x0103, Endpoints ep1 and KeySetID 0x01a3"),
@@ -125,7 +129,9 @@ class TC_ACE_1_6(MatterBaseTest):
             TestStep(17, "TH sends ConfigureAuxiliaryACL command for GroupID 0x0103 with UseAuxiliaryACL: true"),
             TestStep(18, "TH sends a group command requiring the Operate privilege to GroupID 0x0103"),
             TestStep("19a", "TH waits for and verifies the GroupcastTesting event from DUT (AccessAllowed: true)"),
-            TestStep("19b", "TH sends RemoveAllGroups Command to Groups cluster on ep1 - expect AuxiliaryAccessUpdated event"),
+            TestStep("19b", "TH subscribes to listen to AuxiliaryAccessUpdated events on the access control cluster"),
+            TestStep("19c", "TH reads and stores the value of the CurrentFabricIndex attribute"),
+            TestStep("19d", "TH sends RemoveAllGroups Command to Groups cluster on ep1 and verifies AuxiliaryAccessUpdated event"),
             TestStep(20, "TH sends GroupcastTesting command with DisableTesting"),
             TestStep(21, "TH sends a ViewGroup Command for Group 0x0101 - expect SUCCESS"),
             TestStep(22, "TH sends a ViewGroup Command for Group 0x0102 - expect NOT_FOUND"),
@@ -155,9 +161,12 @@ class TC_ACE_1_6(MatterBaseTest):
         key1 = bytes.fromhex("a0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
         key3 = bytes.fromhex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
 
-        # Commissioning
+        # Commissioning (Already done)
         self.step(1)
         th1_nodeid = self.matter_test_config.controller_node_id
+
+        # Step 1a: Verify endpoint composition
+        self.step("1a")
 
         # Check if Groupcast cluster is on RootNode (endpoint 0)
         gc_on_root = await is_groupcast_on_root_node(self)
@@ -168,7 +177,7 @@ class TC_ACE_1_6(MatterBaseTest):
         # Indicate endpoints to be used for test. These default values will be
         # verified or changed depending on use of groupcast or groups clusters
         operate_only_command = None
-        ep1 = self.get_endpoint()
+        ep1 = None
         pixit_g_endpoint = self.get_endpoint()
 
         if not gc_on_root:
@@ -183,7 +192,6 @@ class TC_ACE_1_6(MatterBaseTest):
             asserts.assert_greater(len(operate_only_commands_dict), 0,
                                    "DUT must have at least 1 non-root endpoint with a cluster with commands requiring operate privilege.")
 
-            ep1 = None
             operate_only_command = None
             for ep, cmds in operate_only_commands_dict.items():
                 try:
@@ -209,8 +217,8 @@ class TC_ACE_1_6(MatterBaseTest):
             log.info(
                 f"Targeted command with operate priviliege on the targeted cluster used for groupcast case is: {operate_only_command.command_object.__name__}")
 
-        # Step 1a: KeySetWrite 0x01a3
-        self.step("1a")
+        # Step 1b: KeySetWrite 0x01a3
+        self.step("1b")
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
             groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
                 groupKeySetID=keySetID3,
@@ -224,8 +232,8 @@ class TC_ACE_1_6(MatterBaseTest):
             )
         ))
 
-        # Step 1b: KeySetWrite 0x01a1
-        self.step("1b")
+        # Step 1c: KeySetWrite 0x01a1
+        self.step("1c")
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
             groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
                 groupKeySetID=keySetID1,
@@ -239,7 +247,8 @@ class TC_ACE_1_6(MatterBaseTest):
             )
         ))
 
-        # Must manually set the group key sets for the controller.
+        # Step 1d: Must manually set the group key sets for the controller.
+        self.step("1d")
         self.default_controller.SetGroupKeySet(
             keyset_id=keySetID1,
             policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
@@ -264,12 +273,14 @@ class TC_ACE_1_6(MatterBaseTest):
             epoch_start_time2=2220002
         )
 
-        # Set group keys for the groups
+        # Step 1e: Set group key maps for the groups on the controller
+        self.step("1e")
         self.default_controller.SetGroupKey(groupID1, keySetID1)
         self.default_controller.SetGroupKey(groupID2, keySetID1)
         self.default_controller.SetGroupKey(groupID3, keySetID3)
 
-        # Set group info on controller
+        # Step 1f: Set group info on controller
+        self.step("1f")
         INTERNAL_USE_IANA_ADDR_AND_NO_AUX_ACL = 0
         INTERNAL_USE_PER_GROUP_ADDR_AND_NO_AUX_ACL = 2
 
@@ -285,7 +296,7 @@ class TC_ACE_1_6(MatterBaseTest):
             self.default_controller.SetGroupInfo(groupID2, "Group 2", INTERNAL_USE_PER_GROUP_ADDR_AND_NO_AUX_ACL)
             self.default_controller.SetGroupInfo(groupID3, "Group 3", INTERNAL_USE_PER_GROUP_ADDR_AND_NO_AUX_ACL)
 
-        # Step 2: GroupKeyMap
+        # Step 2: GroupKeyMap on DUT
         if gc_on_root:
             self.skip_step(2)
         else:
@@ -537,18 +548,23 @@ class TC_ACE_1_6(MatterBaseTest):
             asserts.assert_equal(event_data.destinationIpAddress, get_iana_multicast_address(),
                                  "Incorrect destination IP address in event")
 
-            # Step 19b: RemoveAllGroups and verify AuxiliaryAccessUpdated event
+            # Step 19b: Subscribe to listen to AuxiliaryAccessUpdated events
             self.step("19b")
             ac_event_sub = EventSubscriptionHandler(expected_cluster=Clusters.AccessControl,
                                                     expected_event_id=Clusters.AccessControl.Events.AuxiliaryAccessUpdated.event_id)
             await ac_event_sub.start(self.default_controller, self.dut_node_id, endpoint=0, min_interval_sec=0, max_interval_sec=30)
 
+            # Step 19c: Read and store CurrentFabricIndex
+            self.step("19c")
+            fabric_index = await self.read_single_attribute_check_success(Clusters.OperationalCredentials, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex, endpoint=0)
+
+            # Step 19d: RemoveAllGroups and verify AuxiliaryAccessUpdated event
+            self.step("19d")
             # Call RemoveAllGroups on ep1 (which has Groups cluster and was joined to groupID3 with AuxACL enabled)
             await self.send_single_cmd(Clusters.Groups.Commands.RemoveAllGroups(), endpoint=ep1)
 
             # Verify AuxiliaryAccessUpdated event
             event_data = ac_event_sub.wait_for_event_report(Clusters.AccessControl.Events.AuxiliaryAccessUpdated, timeout_sec=30)
-            fabric_index = await self.read_single_attribute_check_success(Clusters.OperationalCredentials, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex, endpoint=0)
             asserts.assert_equal(event_data.fabricIndex, fabric_index, "Incorrect fabric index in event")
             asserts.assert_equal(event_data.adminNodeID, th1_nodeid, "Incorrect adminNodeID in event")
 


### PR DESCRIPTION
#### Summary

This PR cleans up `TC_ACE_1_6.py` to have a more logical separation of steps in accordance to test plan updates, and to just be more readable. Functionality of this test remains the same, this is just a refactor of the code for better organization 

#### Testing

- CI should still pass