### PR TITLE
[ci] split ASR workflow into PR-only and master-only builds

### DIFF
--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -47,31 +47,40 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: asr
-            - name: Build all ASR582X examples (part1)
+            - name: Build all-clusters-app (PR)
+              if: github.event_name == 'pull_request'
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target asr-asr582x-all-clusters \
-                        --target asr-asr582x-all-clusters-minimal \
-                        --target asr-asr582x-lighting-ota \
-                        --target asr-asr582x-light-switch-shell \
-                        --target asr-asr582x-lock-no_logging \
-                        --target asr-asr582x-ota-requestor \
                         build \
                      "
-            - name: Clean out directory (make some room for more compiles)
-              run: rm -rf out/
-            - name: Build all ASR582X examples (part2)
+                  rm -rf out/
+            - name: Build all ASR582X examples (master)
+              if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
               run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target asr-asr582x-bridge-factory \
-                        --target asr-asr582x-temperature-measurement-rotating_id \
-                        --target asr-asr582x-thermostat-rio \
-                        --target asr-asr582x-dishwasher \
-                        --target asr-asr582x-refrigerator \
-                        build \
-                     "
+                  targets=(
+                      asr-asr582x-all-clusters
+                      asr-asr582x-all-clusters-minimal
+                      asr-asr582x-lighting-ota
+                      asr-asr582x-light-switch-shell
+                      asr-asr582x-lock-no_logging
+                      asr-asr582x-ota-requestor
+                      asr-asr582x-bridge-factory
+                      asr-asr582x-temperature-measurement-rotating_id
+                      asr-asr582x-thermostat-rio
+                      asr-asr582x-dishwasher
+                      asr-asr582x-refrigerator
+                  )
+                  for target in "${targets[@]}"; do
+                      echo "=== Building $target ==="
+                      ./scripts/run_in_build_env.sh \
+                         "./scripts/build/build_examples.py \
+                            --target $target \
+                            build \
+                         "
+                      rm -rf out/
+                  done
             - name: Notify Slack on Failure
               if: failure()
               uses: ./.github/actions/notify-slack-failure


### PR DESCRIPTION
 #### Summary

 Splits the .github/workflows/examples-asr.yaml workflow into two stages gated by github.event_name:

 - PR builds — runs a minimal set of targets (all-clusters-app only) to keep PR CI fast and lightweight.
 - Master builds — runs the full target set (all-clusters-app, bridge-factory, temperature-measurement-rotating_id, thermostat-rio, dishwasher, refrigerator) to
   ensure complete coverage on mainline.

 The change introduces a loop over an array of targets for the master build and cleans out/ between each to avoid disk space issues.

 #### Testing

CI will validate.