### PR TITLE
ci: use ubuntu-slim runner for lightweight workflows

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -9,7 +9,7 @@ concurrency:
   
 jobs:
   delete-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: kolpav/purge-artifacts-action@04c636a505f26ebc82f8d070b202fb87ff572b10 # v1
         with:

--- a/.github/workflows/buildjet-cache-delete.yaml
+++ b/.github/workflows/buildjet-cache-delete.yaml
@@ -8,7 +8,7 @@ on:
         type: string
 jobs:
   manually-delete-buildjet-cache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/cancel_workflows_for_pr.yaml
+++ b/.github/workflows/cancel_workflows_for_pr.yaml
@@ -22,7 +22,7 @@ jobs:
     cancel_workflow:
         name: Cancel CI on failing pull requests
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
 
         # Don't run on forked repos
         if: github.repository_owner == 'project-chip'

--- a/.github/workflows/cherry-picks.yaml
+++ b/.github/workflows/cherry-picks.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     cherry_pick_release_v1_0:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         name: Cherry-Pick into SVE
         if: |
             (github.event.pull_request.merged == true)

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
             GITHUB_CACHE_PATH: /tmp/cirque-cache
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]'
 
         # need to run with privilege, which isn't supported by job.XXX.contaner

--- a/.github/workflows/docbuild.yaml
+++ b/.github/workflows/docbuild.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -37,7 +37,7 @@ on:
 jobs:
     build_images_base:
         name: Build Docker CHIP Build images - base
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]'
         strategy:
             fail-fast: false
@@ -76,7 +76,7 @@ jobs:
     build_images_stage_1:
         needs: [build_images_base]
         name: Build Docker CHIP Build images - stage 1
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]' && false
         strategy:
             fail-fast: false
@@ -104,7 +104,7 @@ jobs:
     build_images_stage_2:
         needs: [build_images_base, build_images_stage_1]
         name: Build Docker CHIP Build images - stage 2
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]' && false
         strategy:
             fail-fast: false
@@ -151,7 +151,7 @@ jobs:
     build_images_stage_3:
         needs: [build_images_base, build_images_stage_1, build_images_stage_2]
         name: Build Docker CHIP Build images - stage 3
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]' && false
         strategy:
             fail-fast: false
@@ -181,7 +181,7 @@ jobs:
     build_images_vscode:
         needs: [build_images_base, build_images_stage_1, build_images_stage_2, build_images_stage_3]
         name: Build Docker CHIP Build images - vscode
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         if: github.actor != 'restyled-io[bot]' && false
         strategy:
             fail-fast: false

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -34,7 +34,7 @@ jobs:
   bouffalolab:
     name: Bouffalo Lab
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.actor != 'restyled-io[bot]'
 
     container:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -37,7 +37,7 @@ jobs:
       SILABS_BOARD: BRD4187C
       BUILD_TYPE: gn_efr32
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.actor != 'restyled-io[bot]'
 
     container:

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -43,7 +43,7 @@ jobs:
   nuttx:
     name: NuttX
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.actor != 'restyled-io[bot]'
 
     container:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validation:
     name: "Validation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0

--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: github/issue-labeler@v3.4 #May not be the latest version
       with:

--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -18,7 +18,7 @@ jobs:
   detekt:
     name: Static code analysis
     if: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: "checkout"
@@ -44,7 +44,7 @@ jobs:
           slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
   ktlint:
     name: "Format check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/labeler@v6
       with:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check_testing_header:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check for `### Testing` section in PR
         env:

--- a/.github/workflows/protocol_compatibility.yaml
+++ b/.github/workflows/protocol_compatibility.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   check_clusters_matter:
     name: Check controller-clusters.matter backwards compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event.pull_request && !(contains(github.event.pull_request.labels.*.name, 'skip-protocol-compatibility'))
 
     steps:

--- a/.github/workflows/recent_fail_summary.yaml
+++ b/.github/workflows/recent_fail_summary.yaml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   list_workflows:
     name: Summarize Recent Workflow Failures
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions: write-all
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   restyled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/roll_and_build_docker.yaml
+++ b/.github/workflows/roll_and_build_docker.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 jobs:
   roll_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -30,7 +30,7 @@ on:
 jobs:
     check-spellcheck:
         name: Check Spelling - pyspelling
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     stale:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         steps:
             - uses: actions/stale@v10
               with:

--- a/.github/workflows/third-party-check.yaml
+++ b/.github/workflows/third-party-check.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
     check-submodule-update-label:
         name: Check For Submodule Update Label
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         steps:
             - name: Fail
               if: (github.event.pull_request.user.login != 'dependabot[bot]') && !contains(github.event.pull_request.labels.*.name, 'changing-git-submodules-on-purpose')

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
     todos:
         name: Scan for To-Dos
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
 
         steps:
             - name: Checkout


### PR DESCRIPTION
 #### Summary

 Replaces runs-on: ubuntu-latest with runs-on: ubuntu-slim in 29 workflows that perform lightweight operations (linting, labeling, issue triage, caching, etc.). The intent is to have less stuff, so our containers get more storage (ASR and cirque had some out of storage errors recently)

 35 workflows remain on ubuntu-latest because they use features incompatible with ubuntu-slim:
 - 33 use container: (Docker-in-Docker is not supported in the unprivileged ubuntu-slim runner)
 - 1 uses sudo (tag-releases.yaml)
 - 1 uses docker/setup-buildx-action (build-cert-bins.yaml)

Expect more storage and faster start when using the slim image.

 #### Testing

 If CI passes all is good.