### PR TITLE
[devcontainer] Remove invalid comment from devcontainer.json file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
     },
     "customizations": {
         "vscode": {
-            // Add the IDs of extensions you want installed when the container is created in the array below.
             "extensions": [
                 "mcu-debug.debug-tracker-vscode",
                 "aaron-bond.better-comments",


### PR DESCRIPTION
#### Summary

This is the only comment in this file. IMO it is not needed as it is clear what it describes even without it.
It just makes it harder to parse JSON files using utils like `jq`.

If we want to support JSONC format later, we can revert this.

```sh
vscode@martin-nb:/workspaces/connectedhomeip$ jq -r '.runArgs[] | capture("--device=(?<dev>.*)") | .dev' .devcontainer/devcontainer.json
jq: parse error: Invalid numeric literal at line 32, column 15
vscode@martin-nb:/workspaces/connectedhomeip$ sed -n 32p .devcontainer/devcontainer.json
            // Add the IDs of extensions you want installed when the container is created in the array below.
vscode@martin-nb:/workspaces/connectedhomeip$
```

#### Related issues

N/A (not preferable)

#### Testing

No functional change. The json file can be still loaded by VS Code - verified manually.

#### Readability checklist