### PR TITLE
[all-devices-app]  Enable Pw attribute server on all devices app. Add Pigweed RPC Attributes Service Support for Boolean State Sensor

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
 source_set("boolean-state-sensor") {
   sources = [
@@ -29,4 +30,13 @@ source_set("boolean-state-sensor") {
     "${chip_root}/src/lib/core:error",
     "${chip_root}/src/lib/support",
   ]
+
+  if (chip_enable_pw_rpc) {
+    defines = [
+      "PW_RPC_ENABLED",
+      "PW_RPC_ATTRIBUTE_SERVICE=1",
+    ]
+    include_dirs = [ "${chip_root}/examples/common" ]
+    public_deps += [ "${chip_root}/config/linux/lib/pw_rpc:pw_rpc" ]
+  }
 }

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
 source_set("boolean-state-sensor") {

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BUILD.gn
@@ -37,6 +37,9 @@ source_set("boolean-state-sensor") {
       "PW_RPC_ATTRIBUTE_SERVICE=1",
     ]
     include_dirs = [ "${chip_root}/examples/common" ]
-    public_deps += [ "${chip_root}/config/linux/lib/pw_rpc:pw_rpc" ]
+    public_deps += [
+      "${chip_root}/config/linux/lib/pw_rpc:pw_rpc",
+      dir_pw_status,
+    ]
   }
 }

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
@@ -30,6 +30,10 @@ CHIP_ERROR BooleanStateSensorDevice::Register(chip::EndpointId endpoint, CodeDri
 
     mBooleanStateCluster.Create(endpoint);
     ReturnErrorOnFailure(provider.AddCluster(mBooleanStateCluster.Registration()));
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
+    mPwAccessor.SetDevice(this);
+    chip::rpc::PigweedDebugAccessInterceptorRegistry::Instance().Register(&mPwAccessor);
+#endif // defined(PW_RPC_ENABLED)
 
     return provider.AddEndpoint(mEndpointRegistration);
 }
@@ -47,6 +51,41 @@ void BooleanStateSensorDevice::Unregister(CodeDrivenDataModelProvider & provider
         LogErrorOnFailure(provider.RemoveCluster(&mIdentifyCluster.Cluster()));
         mIdentifyCluster.Destroy();
     }
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
+    mPwAccessor.SetDevice(nullptr);
+    chip::rpc::PigweedDebugAccessInterceptorRegistry::Instance().Unregister(&mPwAccessor);
+#endif // defined(PW_RPC_ENABLED)
 }
+
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
+std::optional<::pw::Status> BooleanStateSensor::AttributeAccessor::Write(const ConcreteDataAttributePath & path,
+                                                                         AttributeValueDecoder & decoder)
+{
+    chip::EndpointId endpoint = path.mEndpointId;
+    if (!mBooleanStateDevice || path.mEndpointId != mBooleanStateDevice->GetEndpointId())
+    {
+        return std::nullopt;
+    }
+    switch (path.mClusterId)
+    {
+    case BooleanState::Id:
+        switch (path.mAttributeId)
+        {
+        case BooleanState::Attributes::StateValue::Id: {
+            bool stateValue;
+            CHIP_ERROR err = decoder.Decode(stateValue);
+            if (err != CHIP_NO_ERROR)
+            {
+                return ::pw::Status::Internal();
+            }
+            mBooleanStateDevice->BooleanState().SetStateValue(stateValue);
+            return ::pw::OkStatus();
+        }
+        }
+        break;
+    }
+    return std::nullopt;
+}
+#endif // defined(PW_RPC_ENABLED)
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
@@ -61,7 +61,6 @@ void BooleanStateSensorDevice::Unregister(CodeDrivenDataModelProvider & provider
 std::optional<::pw::Status> BooleanStateSensor::AttributeAccessor::Write(const ConcreteDataAttributePath & path,
                                                                          AttributeValueDecoder & decoder)
 {
-    chip::EndpointId endpoint = path.mEndpointId;
     if (!mBooleanStateDevice || path.mEndpointId != mBooleanStateDevice->GetEndpointId())
     {
         return std::nullopt;

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
@@ -56,7 +56,6 @@ void BooleanStateSensorDevice::Unregister(CodeDrivenDataModelProvider & provider
     chip::rpc::PigweedDebugAccessInterceptorRegistry::Instance().Unregister(&mPwAccessor);
 #endif // defined(PW_RPC_ENABLED)
 }
-
 #if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
 std::optional<::pw::Status> BooleanStateSensor::AttributeAccessor::Write(const ConcreteDataAttributePath & path,
                                                                          AttributeValueDecoder & decoder)
@@ -65,6 +64,10 @@ std::optional<::pw::Status> BooleanStateSensor::AttributeAccessor::Write(const C
     {
         return std::nullopt;
     }
+    ChipLogProgress(Zcl,
+                    "[Pw] Received attribute write request for Cluster: " ChipLogFormatMEI " , Attribute: " ChipLogFormatMEI
+                    " on Endpoint: %d",
+                    ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId), path.mEndpointId);
     switch (path.mClusterId)
     {
     case BooleanState::Id:
@@ -75,9 +78,13 @@ std::optional<::pw::Status> BooleanStateSensor::AttributeAccessor::Write(const C
             CHIP_ERROR err = decoder.Decode(stateValue);
             if (err != CHIP_NO_ERROR)
             {
+                ChipLogError(Zcl, "[Pw] Failed to decode stateValue on Endpoint %d: %" CHIP_ERROR_FORMAT, path.mEndpointId,
+                             err.Format());
                 return ::pw::Status::Internal();
             }
             mBooleanStateDevice->BooleanState().SetStateValue(stateValue);
+            ChipLogProgress(Zcl, "[Pw] Successfully set BooleanState stateValue on Endpoint %d to %d", path.mEndpointId,
+                            stateValue);
             return ::pw::OkStatus();
         }
         }

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
@@ -21,9 +21,31 @@
 #include <devices/interface/SingleEndpointDevice.h>
 #include <lib/support/TimerDelegate.h>
 #include <memory>
+#include <pigweed/rpc_services/AccessInterceptor.h>
+#include <pigweed/rpc_services/AccessInterceptorRegistry.h>
 
 namespace chip {
 namespace app {
+
+class BooleanStateSensorDevice;
+
+namespace BooleanStateSensor {
+
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
+class AttributeAccessor : public chip::rpc::PigweedDebugAccessInterceptor
+{
+public:
+    AttributeAccessor() = default;
+    std::optional<::pw::Status> Write(const ConcreteDataAttributePath & path, AttributeValueDecoder & decoder) override;
+    ~AttributeAccessor() override = default;
+
+    void SetDevice(BooleanStateSensorDevice * device) { mBooleanStateDevice = device; }
+
+private:
+    BooleanStateSensorDevice * mBooleanStateDevice = nullptr;
+};
+#endif // defined(PW_RPC_ENABLED)
+} // namespace BooleanStateSensor
 
 class BooleanStateSensorDevice : public SingleEndpointDevice
 {
@@ -48,6 +70,9 @@ private:
     TimerDelegate * mTimerDelegate;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::BooleanStateCluster> mBooleanStateCluster;
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
+    BooleanStateSensor::AttributeAccessor mPwAccessor;
+#endif // defined(PW_RPC_ENABLED)
 };
 
 } // namespace app

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
@@ -21,8 +21,11 @@
 #include <devices/interface/SingleEndpointDevice.h>
 #include <lib/support/TimerDelegate.h>
 #include <memory>
+
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
 #include <pigweed/rpc_services/AccessInterceptor.h>
 #include <pigweed/rpc_services/AccessInterceptorRegistry.h>
+#endif // defined(PW_RPC_ENABLED)
 
 namespace chip {
 namespace app {

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
@@ -45,6 +45,11 @@ scripts/run_in_python_env.sh out/python_env \
 """
 
 import logging
+from attributes_service import attributes_service_pb2
+from mobly import asserts
+from pw_hdlc import rpc
+from pw_system.device_connection import create_device_serial_or_socket_connection
+
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest, TestStep
@@ -64,6 +69,19 @@ class BooleanStateSensorCommissioningTest(MatterBaseTest):
             attribute=Clusters.BooleanState.Attributes.StateValue
         )
 
+    def write_boolean_state_value_pwrpc(self, device, endpoint: int, value: bool):
+        """Helper method to write the StateValue attribute on a given endpoint via Pigweed RPC."""
+        result = device.rpcs.chip.rpc.Attributes.Write(
+            data=attributes_service_pb2.AttributeData(data_bool=value),
+            metadata=attributes_service_pb2.AttributeMetadata(
+                endpoint=endpoint,
+                cluster=Clusters.Objects.BooleanState.id,
+                attribute_id=Clusters.Objects.BooleanState.Attributes.StateValue.attribute_id,
+                type=attributes_service_pb2.AttributeType.ZCL_BOOLEAN_ATTRIBUTE_TYPE
+            )
+        )
+        asserts.assert_true(result.status.ok(), msg=f"PwRPC write failed for endpoint {endpoint}.")
+
     def desc_TC_BOOL_1_1(self) -> str:
         return "[TC_BOOL_1_1] Boolean State Sensor Commissioning and State Read Test"
 
@@ -71,6 +89,7 @@ class BooleanStateSensorCommissioningTest(MatterBaseTest):
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "Read Boolean State Value on Endpoint 1 and Endpoint 2"),
+            TestStep(3, "Toggle and assert state values on Endpoint 1 and Endpoint 2 independently via PwRPC"),
         ]
 
     @async_test_body
@@ -83,12 +102,58 @@ class BooleanStateSensorCommissioningTest(MatterBaseTest):
         self.step(2)
 
         # Read Endpoint 1
-        state_value_ep1 = await self.read_boolean_state_value(endpoint=1)
-        logger.info(f"Boolean State Value on Endpoint 1: {state_value_ep1}")
+        initial_val_ep1 = await self.read_boolean_state_value(endpoint=1)
+        logger.info(f"Initial Boolean State Value on Endpoint 1: {initial_val_ep1}")
 
         # Read Endpoint 2
-        state_value_ep2 = await self.read_boolean_state_value(endpoint=2)
-        logger.info(f"Boolean State Value on Endpoint 2: {state_value_ep2}")
+        initial_val_ep2 = await self.read_boolean_state_value(endpoint=2)
+        logger.info(f"Initial Boolean State Value on Endpoint 2: {initial_val_ep2}")
+
+        # Step 3: Toggle and assert state values on Endpoint 1 and Endpoint 2 independently via PwRPC
+        self.step(3)
+
+        # Establish PwRPC connection
+        logger.info("Establishing Pigweed RPC connection...")
+        device_connection = create_device_serial_or_socket_connection(
+            device="",
+            baudrate=115200,
+            token_databases=[],
+            socket_addr="0.0.0.0:33000",
+            compiled_protos=[attributes_service_pb2],
+            rpc_logging=True,
+            channel_id=rpc.DEFAULT_CHANNEL_ID,
+            hdlc_encoding=True,
+            device_tracing=False,
+        )
+
+        with device_connection as device:
+            # 1. Toggle Endpoint 1's state value and assert Endpoint 1's state changed while Endpoint 2's state remained intact.
+            new_val_ep1 = not initial_val_ep1
+            logger.info(f"Toggling Endpoint 1 from {initial_val_ep1} to {new_val_ep1} via PwRPC...")
+            self.write_boolean_state_value_pwrpc(device, endpoint=1, value=new_val_ep1)
+
+            # Assert Endpoint 1 changed
+            current_val_ep1 = await self.read_boolean_state_value(endpoint=1)
+            asserts.assert_equal(current_val_ep1, new_val_ep1, "Endpoint 1 state did not toggle successfully!")
+
+            # Assert Endpoint 2 remained intact
+            current_val_ep2 = await self.read_boolean_state_value(endpoint=2)
+            asserts.assert_equal(current_val_ep2, initial_val_ep2, "Endpoint 2 state was unexpectedly modified!")
+
+            # 2. Toggle Endpoint 2's state value and assert Endpoint 2's state changed while Endpoint 1's state remained intact.
+            new_val_ep2 = not initial_val_ep2
+            logger.info(f"Toggling Endpoint 2 from {initial_val_ep2} to {new_val_ep2} via PwRPC...")
+            self.write_boolean_state_value_pwrpc(device, endpoint=2, value=new_val_ep2)
+
+            # Assert Endpoint 2 changed
+            current_val_ep2 = await self.read_boolean_state_value(endpoint=2)
+            asserts.assert_equal(current_val_ep2, new_val_ep2, "Endpoint 2 state did not toggle successfully!")
+
+            # Assert Endpoint 1 remained intact
+            current_val_ep1 = await self.read_boolean_state_value(endpoint=1)
+            asserts.assert_equal(current_val_ep1, new_val_ep1, "Endpoint 1 state was unexpectedly modified!")
+
+            logger.info("Successfully toggled and verified independent state changes on endpoints 1 and 2!")
 
 
 if __name__ == "__main__":

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
@@ -1,0 +1,66 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest, TestStep
+from matter.testing.runner import default_matter_test_main
+
+logger = logging.getLogger(__name__)
+
+
+class BooleanStateSensorCommissioningTest(MatterBaseTest):
+    """Simple test that commissions and reads the Boolean State Sensor device."""
+
+    async def read_boolean_state_value(self, endpoint: int):
+        """Helper method to read the StateValue attribute from the BooleanState cluster on a given endpoint."""
+        return await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=Clusters.BooleanState,
+            attribute=Clusters.BooleanState.Attributes.StateValue
+        )
+
+    def desc_TC_BOOL_1_1(self) -> str:
+        return "[TC_BOOL_1_1] Boolean State Sensor Commissioning and State Read Test"
+
+    def steps_TC_BOOL_1_1(self) -> list[TestStep]:
+        return [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "Read Boolean State Value on Endpoint 1 and Endpoint 2"),
+        ]
+
+    @async_test_body
+    async def test_TC_BOOL_1_1(self):
+        # Step 1: Commissioning (handled automatically by the test runner)
+        self.step(1)
+        logger.info("Successfully completed commissioning step.")
+
+        # Step 2: Read Boolean State Value on Endpoint 1 and Endpoint 2
+        self.step(2)
+
+        # Read Endpoint 1
+        state_value_ep1 = await self.read_boolean_state_value(endpoint=1)
+        logger.info(f"Boolean State Value on Endpoint 1: {state_value_ep1}")
+
+        # Read Endpoint 2
+        state_value_ep2 = await self.read_boolean_state_value(endpoint=2)
+        logger.info(f"Boolean State Value on Endpoint 2: {state_value_ep2}")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
@@ -45,6 +45,7 @@ scripts/run_in_python_env.sh out/python_env \
 """
 
 import logging
+
 from attributes_service import attributes_service_pb2
 from mobly import asserts
 from pw_hdlc import rpc

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py
@@ -15,6 +15,35 @@
 #    limitations under the License.
 #
 
+"""
+# Setup env
+source ./scripts/bootstrap.sh -p linux
+scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/python_env -pw true'
+
+# Build app
+cd examples/all-devices-app/posix
+gn gen --add-export-compile-commands="*" out
+ninja -C out
+cd ../../..
+
+# Run test
+scripts/run_in_python_env.sh out/python_env \
+    './scripts/tests/run_python_test.py \
+    --app examples/all-devices-app/posix/out/all-devices-app \
+    --app-args "\
+        --device contact-sensor:1 \
+        --device contact-sensor:2" \
+    --factory-reset \
+    --script examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/test.py \
+    --script-args "\
+        --commissioning-method on-network \
+        --discriminator 3840 \
+        --passcode 20202021\
+        " \
+    --app-stdin-pipe /tmp/app_stdin.txt'
+
+"""
+
 import logging
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -72,11 +72,6 @@ executable("all-devices-app") {
     defines += [
       "PW_RPC_ENABLED",
       "PW_RPC_ATTRIBUTE_SERVICE=1",
-      "PW_RPC_BUTTON_SERVICE=1",
-      "PW_RPC_DESCRIPTOR_SERVICE=1",
-      "PW_RPC_DEVICE_SERVICE=1",
-      "PW_RPC_LIGHTING_SERVICE=1",
-      "PW_RPC_TRACING_SERVICE=1",
     ]
 
     sources += [

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -55,6 +55,7 @@ executable("all-devices-app") {
     "${chip_root}/third_party/miniaudio:miniaudio",
     "${chip_root}/zzz_generated/app-common/devices/",
   ]
+  defines = []
 
   if (chip_device_platform == "darwin") {
     deps += [ "${chip_root}/examples/all-devices-app/posix/darwin" ]

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/platform/device.gni")
 

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -16,6 +16,11 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/platform/device.gni")
 
+if (chip_enable_pw_rpc) {
+  import("//build_overrides/pigweed.gni")
+  import("$dir_pw_build/target_types.gni")
+}
+
 executable("all-devices-app") {
   sources = [
     "PosixBleRssiRangingAdapter.cpp",
@@ -60,6 +65,49 @@ executable("all-devices-app") {
     "include",
     "${chip_root}/examples/common",
   ]
+
+  if (chip_enable_pw_rpc) {
+    defines += [
+      "PW_RPC_ENABLED",
+      "PW_RPC_ATTRIBUTE_SERVICE=1",
+      "PW_RPC_BUTTON_SERVICE=1",
+      "PW_RPC_DESCRIPTOR_SERVICE=1",
+      "PW_RPC_DEVICE_SERVICE=1",
+      "PW_RPC_LIGHTING_SERVICE=1",
+      "PW_RPC_TRACING_SERVICE=1",
+    ]
+
+    sources += [
+      "${chip_root}/examples/platform/linux/Rpc.cpp",
+      "${chip_root}/examples/platform/linux/system_rpc_server.cc",
+    ]
+
+    deps += [
+      "$dir_pw_hdlc:default_addresses",
+      "$dir_pw_hdlc:rpc_channel_output",
+      "$dir_pw_log",
+      "$dir_pw_rpc:server",
+      "$dir_pw_rpc/system_server:facade",
+      "$dir_pw_rpc/system_server:socket",
+      "$dir_pw_stream:socket_stream",
+      "$dir_pw_stream:sys_io_stream",
+      "$dir_pw_sync:mutex",
+      "$dir_pw_trace",
+      "$dir_pw_trace_tokenized",
+      "$dir_pw_trace_tokenized:trace_rpc_service",
+      "${chip_root}/config/linux/lib/pw_rpc:pw_rpc",
+      "${chip_root}/examples/common/pigweed:attributes_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:button_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:descriptor_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:device_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:lighting_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:rpc_services",
+    ]
+
+    deps += pw_build_LINK_DEPS
+
+    include_dirs += [ "${chip_root}/examples/common" ]
+  }
 
   output_dir = root_out_dir
 }

--- a/examples/all-devices-app/posix/args.gni
+++ b/examples/all-devices-app/posix/args.gni
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("//with_pw_rpc.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -47,6 +47,9 @@
 
 #include <BleInit.h>
 #include <TermHandling.h>
+#if defined(PW_RPC_ENABLED)
+#include <Rpc.h>
+#endif // defined(PW_RPC_ENABLED)
 
 using namespace chip;
 using namespace chip::app;
@@ -281,6 +284,11 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 
     chip::CommandLineApp::TracingSetup tracing_setup;
     tracing_setup.EnableTracingFor("json:log");
+
+#if defined(PW_RPC_ENABLED)
+    chip::rpc::Init(33000);
+    ChipLogProgress(AppServer, "PW_RPC initialized.");
+#endif // defined(PW_RPC_ENABLED)
 
     // Init ZCL Data Model and CHIP App Server
     CHIP_ERROR err = Server::GetInstance().Init(initParams);

--- a/examples/all-devices-app/posix/with_pw_rpc.gni
+++ b/examples/all-devices-app/posix/with_pw_rpc.gni
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# add this gni as import in your build args to use pigweed in the example
+# 'import("//with_pw_rpc.gni")'
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/config/standalone/args.gni")
+
+import("//build_overrides/pigweed.gni")
+
+pw_log_BACKEND = "${chip_root}/src/pw_backends/log"
+pw_assert_BACKEND = "${chip_root}/src/pw_backends/assert"
+pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"
+pw_trace_BACKEND = "$dir_pw_trace_tokenized"
+pw_unit_test_MAIN = "$dir_pw_unit_test:logging_main"
+pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
+dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
+pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
+pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
+pw_sync_INTERRUPT_SPIN_LOCK_BACKEND = "$dir_pw_sync_stl:interrupt_spin_lock"
+pw_thread_YIELD_BACKEND = "$dir_pw_thread_stl:yield"
+pw_thread_SLEEP_BACKEND = "$dir_pw_thread_stl:sleep"
+
+pw_build_LINK_DEPS = [
+  "$dir_pw_assert:impl",
+  "$dir_pw_log:impl",
+]
+
+chip_enable_pw_rpc = true

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -31,7 +31,6 @@
 #include <app/data-model-provider/MetadataLookup.h>
 #include <app/data-model-provider/OperationTypes.h>
 #include <app/data-model-provider/Provider.h>
-#include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/core/TLV.h>

--- a/examples/common/pigweed/rpc_services/internal/StatusUtils.h
+++ b/examples/common/pigweed/rpc_services/internal/StatusUtils.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "app/util/attribute-storage.h"
 #include "protocols/interaction_model/StatusCode.h"
 #include "pw_status/status.h"
 


### PR DESCRIPTION
#### Summary

This PR introduces support for Pigweed RPC Attributes service in the POSIX all-devices-app, specifically enabling external attribute access for the Boolean State sensor devices.

#### Testing

In this PR added a Python CHIP controller test which toggles boolean state via Pigweed and reads state values.