### PR TITLE
[NXP][SE05x] Add SE05x config for freeRTOS

### DIFF
--- a/config/nxp/chip-cmake-freertos/Kconfig
+++ b/config/nxp/chip-cmake-freertos/Kconfig
@@ -119,14 +119,6 @@ config CHIP_DEVICE_USE_ZEPHYR_BLE
 	help
 		Use Zephyr implementation for BLE manager.
 
-# Secure Element Configurations
-
-config CHIP_SE05X
-	bool "Enable Secure Element support"
-	select SE05X_LIB
-	help
-		Enable SE05x Secure element for offloading crypto operations.
-
 config CHIP_OTA_POSTED_OPERATIONS_IN_IDLE
 	bool "Use Posted Operations in Idle task for OTA Image Processing"
 	default y if CHIP_NXP_PLATFORM_RW61X || CHIP_NXP_PLATFORM_RT1060 || CHIP_NXP_PLATFORM_RT1170

--- a/config/nxp/chip-cmake-freertos/Kconfig
+++ b/config/nxp/chip-cmake-freertos/Kconfig
@@ -121,6 +121,12 @@ config CHIP_DEVICE_USE_ZEPHYR_BLE
 
 # Secure Element Configurations
 
+config CHIP_SE05X
+	bool "Enable Secure Element support"
+	select SE05X_LIB
+	help
+		Enable SE05x Secure element for offloading crypto operations.
+
 config CHIP_OTA_POSTED_OPERATIONS_IN_IDLE
 	bool "Use Posted Operations in Idle task for OTA Image Processing"
 	default y if CHIP_NXP_PLATFORM_RW61X || CHIP_NXP_PLATFORM_RT1060 || CHIP_NXP_PLATFORM_RT1170

--- a/config/nxp/cmake/Kconfig.matter.nxp
+++ b/config/nxp/cmake/Kconfig.matter.nxp
@@ -65,6 +65,12 @@ config CHIP_DEVICE_USE_TEST_PAIRING_CODE
 		Use a default pairing code if one hasn't been provisioned in flash.
 		(Macro value is in quotes.)
 
+config CHIP_SE05X
+	bool "Enable Secure Element support"
+	select SE05X_LIB
+	help
+		Enable SE05x Secure element for offloading crypto operations.
+
 config CHIP_NXP_CRYPTO_IMPL
 	string "NXP Crypto Implementation chosen"
 	default "se05x" if CHIP_SE05X


### PR DESCRIPTION
#### Summary

- Add SE05x config for freeRTOS

#### Testing
Tested by build for supported NXP MCUs using matter examples and offloading Node operational key to SE05x.