### PR TITLE
Disable CI for JFADMIN and JFDS flakes

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -175,6 +175,18 @@ not_automated:
       reason:
           Flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/72209
+    - name: TC_JFADMIN_2_1.py
+      reason:
+          Flaky in CI.
+          https://github.com/project-chip/connectedhomeip/issues/72209
+    - name: TC_JFDS_2_1.py
+      reason:
+          Flaky in CI.
+          https://github.com/project-chip/connectedhomeip/issues/72209
+    - name: TC_JFDS_2_3.py
+      reason:
+          Flaky in CI.
+          https://github.com/project-chip/connectedhomeip/issues/72209
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

Seeing lots of CI failures for JF tests right now. From today:
- https://github.com/project-chip/connectedhomeip/actions/runs/26821576831
- https://github.com/project-chip/connectedhomeip/actions/runs/26817197352
- https://github.com/project-chip/connectedhomeip/actions/runs/26817325273

Plus those outlined in https://github.com/project-chip/connectedhomeip/issues/72209

So this PR disables the affected tests in CI while we search for the fix. 

Note that we disabled JFADMIN 2.2 yesterday: https://github.com/project-chip/connectedhomeip/pull/72304

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/72209

#### Testing

N/A

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
