### PR TITLE
ECB: add optional Electrical Alarm cluster include

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1673,7 +1673,16 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters>
-            <!-- TODO: Add Electrical Alarm (Provisional, Optional per spec, with OverCurrent feature mandatory) once https://github.com/project-chip/connectedhomeip/pull/72223 lands -->
+            <include cluster="Electrical Alarm" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="OVERCUR" name="OverCurrent">
+                        <otherwiseConform>
+                            <provisionalConform></provisionalConform>
+                            <mandatoryConform></mandatoryConform>
+                        </otherwiseConform>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Electrical Distribution" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Electrical Protection Alarm" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>


### PR DESCRIPTION
#### Summary

Adds the Electrical Alarm (ESALM, 0x00A1) cluster reference to the Electrical Circuit Breaker (ECB, 0x0516) device-type entry in `matter-devices.xml`.

This is the follow-on to the TODO comment landed in #72294 ("Add Electrical Circuit Breaker (ECB) device type 0x0516"), now unblocked since the ESALM cluster XML merged in #72223.

Per the spec, ESALM on ECB is conformance `P, O` (Provisional, Optional) — same shape as EPALM on EDE in #72277. The include uses `server="false" serverLocked="false"`, matching what Alchemy generates for `P, O` clusters and matching the convention #72277 established.

The OverCurrent (OVERCUR) feature is included with `otherwiseConform` { provisional, mandatory } — meaning the feature is mandatory when the cluster itself is implemented, per the spec's conformance table for ECB.

The TODO XML comment from #72294 is removed; the ESALM include is inserted in alphabetical order before Electrical Distribution and Electrical Protection Alarm.

#### Related issues

Follows #72294 (Electrical Circuit Breaker device-type registration — merged) and #72223 (Electrical Alarm cluster XML — merged). Mirror of #72277 (EDE+EPALM include — merged).

#### Testing

XML change is metadata only (one new `<include cluster=>` block in `matter-devices.xml`). The container regen (`chip-build:194` with `./scripts/run_in_build_env.sh "scripts/tools/zap_regen_all.py --no-parallel"`) produced no downstream file changes — same as #72277.

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short (10-line cluster-include block + 1 TODO removal)
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase