### PR TITLE
TC-ELDIST-2.2: Add Python automation test script for Electrical Distribution Cluster (Fixed-by-Manufacturer Quality)

### DIFF
--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -40,7 +40,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.interaction_model import InteractionModelError, Status
+from matter.interaction_model import Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -117,39 +117,30 @@ class TC_ELDIST_2_2(MatterBaseTest):
 
         # Step 4: Write to MaxVoltage
         self.step(4)
-        try:
-            await self.default_controller.WriteAttribute(
-                self.dut_node_id,
-                [(endpoint, attributes.MaxVoltage(230000))]
-            )
-            asserts.fail("Write to MaxVoltage should have failed")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.UnsupportedWrite,
-                                 "Write to MaxVoltage should return UNSUPPORTED_WRITE")
+        status = await self.write_single_attribute(
+            attribute_value=attributes.MaxVoltage(230000),
+            endpoint_id=endpoint,
+            expect_success=False)
+        asserts.assert_equal(status, Status.UnsupportedWrite,
+                             "Write to MaxVoltage should return UNSUPPORTED_WRITE")
 
         # Step 5: Write to NumberOfPoles
         self.step(5)
-        try:
-            await self.default_controller.WriteAttribute(
-                self.dut_node_id,
-                [(endpoint, attributes.NumberOfPoles(2))]
-            )
-            asserts.fail("Write to NumberOfPoles should have failed")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.UnsupportedWrite,
-                                 "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
+        status = await self.write_single_attribute(
+            attribute_value=attributes.NumberOfPoles(2),
+            endpoint_id=endpoint,
+            expect_success=False)
+        asserts.assert_equal(status, Status.UnsupportedWrite,
+                             "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
 
         # Step 6: Write to ServiceEntranceRated
         self.step(6)
-        try:
-            await self.default_controller.WriteAttribute(
-                self.dut_node_id,
-                [(endpoint, attributes.ServiceEntranceRated(False))]
-            )
-            asserts.fail("Write to ServiceEntranceRated should have failed")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.UnsupportedWrite,
-                                 "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
+        status = await self.write_single_attribute(
+            attribute_value=attributes.ServiceEntranceRated(False),
+            endpoint_id=endpoint,
+            expect_success=False)
+        asserts.assert_equal(status, Status.UnsupportedWrite,
+                             "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
 
         # Step 7: Reboot DUT
         self.step(7)

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -40,7 +40,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.interaction_model import Status
+from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -117,30 +117,39 @@ class TC_ELDIST_2_2(MatterBaseTest):
 
         # Step 4: Write to MaxVoltage
         self.step(4)
-        result = await self.default_controller.WriteAttribute(
-            self.dut_node_id,
-            [(endpoint, attributes.MaxVoltage(230000))]
-        )
-        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
-                             "Write to MaxVoltage should return UNSUPPORTED_WRITE")
+        try:
+            await self.default_controller.WriteAttribute(
+                self.dut_node_id,
+                [(endpoint, attributes.MaxVoltage(230000))]
+            )
+            asserts.fail("Write to MaxVoltage should have failed")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.UnsupportedWrite,
+                                 "Write to MaxVoltage should return UNSUPPORTED_WRITE")
 
         # Step 5: Write to NumberOfPoles
         self.step(5)
-        result = await self.default_controller.WriteAttribute(
-            self.dut_node_id,
-            [(endpoint, attributes.NumberOfPoles(2))]
-        )
-        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
-                             "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
+        try:
+            await self.default_controller.WriteAttribute(
+                self.dut_node_id,
+                [(endpoint, attributes.NumberOfPoles(2))]
+            )
+            asserts.fail("Write to NumberOfPoles should have failed")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.UnsupportedWrite,
+                                 "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
 
         # Step 6: Write to ServiceEntranceRated
         self.step(6)
-        result = await self.default_controller.WriteAttribute(
-            self.dut_node_id,
-            [(endpoint, attributes.ServiceEntranceRated(False))]
-        )
-        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
-                             "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
+        try:
+            await self.default_controller.WriteAttribute(
+                self.dut_node_id,
+                [(endpoint, attributes.ServiceEntranceRated(False))]
+            )
+            asserts.fail("Write to ServiceEntranceRated should have failed")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.UnsupportedWrite,
+                                 "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
 
         # Step 7: Reboot DUT
         self.step(7)

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -41,52 +41,36 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.decorators import has_cluster, pics, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.runner import default_matter_test_main
 
 log = logging.getLogger(__name__)
 
 
 class TC_ELDIST_2_2(MatterBaseTest):
-    """TC-ELDIST-2.2: Fixed-by-Manufacturer Quality Verification with Server as DUT
-
-    Verify that all five mandatory attributes of the Electrical Distribution
-    Cluster maintain their values across reboot (Fixed-by-manufacturer quality X).
-    """
-
-    def desc_TC_ELDIST_2_2(self) -> str:
-        return "[TC-ELDIST-2.2] Fixed-by-Manufacturer Quality Verification with Server as DUT"
-
-    def pics_TC_ELDIST_2_2(self) -> list[str]:
-        return ["ELDIST.S"]
-
-    def steps_TC_ELDIST_2_2(self) -> list[TestStep]:
-        return [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep(2, "TH reads all five mandatory attributes and records values"),
-            TestStep(3, "TH re-reads MaxContinuousCurrent to confirm stability within single boot"),
-            TestStep(4, "TH attempts write to MaxVoltage - expect UNSUPPORTED_WRITE"),
-            TestStep(5, "TH attempts write to NumberOfPoles - expect UNSUPPORTED_WRITE"),
-            TestStep(6, "TH attempts write to ServiceEntranceRated - expect UNSUPPORTED_WRITE"),
-            TestStep(7, "Operator reboots DUT"),
-            TestStep(8, "TH re-reads all five attributes and verifies values unchanged"),
-        ]
 
     @property
     def default_endpoint(self) -> int:
         return 1
 
+    @pics('ELDIST.S')
     @run_if_endpoint_matches(has_cluster(Clusters.ElectricalDistribution))
     async def test_TC_ELDIST_2_2(self):
+        """[TC-ELDIST-2.2] Fixed-by-Manufacturer Quality Verification with Server as DUT
+
+        Verify that all five mandatory attributes of the Electrical Distribution
+        Cluster maintain their values across reboot (Fixed-by-manufacturer
+        quality X). The reboot + persistence verification steps are operator-
+        driven and dispatch via is_pics_sdk_ci_only (skipped in CI).
+        """
         endpoint = self.get_endpoint()
         cluster = Clusters.ElectricalDistribution
         attributes = cluster.Attributes
 
-        self.step(1)
+        self.step(1, "Commissioning, already done", is_commissioning=True)
 
-        # Step 2: Read all attributes and record
-        self.step(2)
+        self.step(2, "TH reads all five mandatory attributes and records values as MCC1/MV1/NOP1/EOL1/SER1")
         mcc_1 = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster,
             attribute=attributes.MaxContinuousCurrent)
@@ -102,12 +86,10 @@ class TC_ELDIST_2_2(MatterBaseTest):
         ser_1 = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster,
             attribute=attributes.ServiceEntranceRated)
-
         log.info(f"Pre-reboot values: MCC={mcc_1}, MV={mv_1}, "
                  f"NOP={nop_1}, EOL={eol_1}, SER={ser_1}")
 
-        # Step 3: Re-read MaxContinuousCurrent within same boot
-        self.step(3)
+        self.step(3, "TH re-reads MaxContinuousCurrent to confirm stability within single boot")
         mcc_2 = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster,
             attribute=attributes.MaxContinuousCurrent)
@@ -115,8 +97,7 @@ class TC_ELDIST_2_2(MatterBaseTest):
                              "MaxContinuousCurrent changed within single boot - "
                              "violates Fixed-by-manufacturer quality")
 
-        # Step 4: Write to MaxVoltage
-        self.step(4)
+        self.step(4, "TH attempts write to MaxVoltage - expect UNSUPPORTED_WRITE")
         status = await self.write_single_attribute(
             attribute_value=attributes.MaxVoltage(230000),
             endpoint_id=endpoint,
@@ -124,8 +105,7 @@ class TC_ELDIST_2_2(MatterBaseTest):
         asserts.assert_equal(status, Status.UnsupportedWrite,
                              "Write to MaxVoltage should return UNSUPPORTED_WRITE")
 
-        # Step 5: Write to NumberOfPoles
-        self.step(5)
+        self.step(5, "TH attempts write to NumberOfPoles - expect UNSUPPORTED_WRITE")
         status = await self.write_single_attribute(
             attribute_value=attributes.NumberOfPoles(2),
             endpoint_id=endpoint,
@@ -133,8 +113,7 @@ class TC_ELDIST_2_2(MatterBaseTest):
         asserts.assert_equal(status, Status.UnsupportedWrite,
                              "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
 
-        # Step 6: Write to ServiceEntranceRated
-        self.step(6)
+        self.step(6, "TH attempts write to ServiceEntranceRated - expect UNSUPPORTED_WRITE")
         status = await self.write_single_attribute(
             attribute_value=attributes.ServiceEntranceRated(False),
             endpoint_id=endpoint,
@@ -142,41 +121,44 @@ class TC_ELDIST_2_2(MatterBaseTest):
         asserts.assert_equal(status, Status.UnsupportedWrite,
                              "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
 
-        # Step 7: Reboot DUT
-        self.step(7)
-        self.wait_for_user_input(
-            prompt_msg="Reboot the DUT and wait for it to rejoin the fabric. Press Enter.")
+        self.step(7, "Operator reboots DUT (skipped in CI)")
+        if self.is_pics_sdk_ci_only:
+            self.mark_current_step_skipped()
+        else:
+            self.wait_for_user_input(
+                prompt_msg="Reboot the DUT and wait for it to rejoin the fabric. Press Enter.")
 
-        # Step 8: Re-read and verify persistence
-        self.step(8)
-        mcc_post = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster,
-            attribute=attributes.MaxContinuousCurrent)
-        mv_post = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster,
-            attribute=attributes.MaxVoltage)
-        nop_post = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster,
-            attribute=attributes.NumberOfPoles)
-        eol_post = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster,
-            attribute=attributes.EndOfLife)
-        ser_post = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster,
-            attribute=attributes.ServiceEntranceRated)
+        self.step(8, "TH re-reads all five attributes and verifies values unchanged across reboot (skipped in CI)")
+        if self.is_pics_sdk_ci_only:
+            self.mark_current_step_skipped()
+        else:
+            mcc_post = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster,
+                attribute=attributes.MaxContinuousCurrent)
+            mv_post = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster,
+                attribute=attributes.MaxVoltage)
+            nop_post = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster,
+                attribute=attributes.NumberOfPoles)
+            eol_post = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster,
+                attribute=attributes.EndOfLife)
+            ser_post = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster,
+                attribute=attributes.ServiceEntranceRated)
 
-        asserts.assert_equal(mcc_post, mcc_1,
-                             "MaxContinuousCurrent changed after reboot")
-        asserts.assert_equal(mv_post, mv_1,
-                             "MaxVoltage changed after reboot")
-        asserts.assert_equal(nop_post, nop_1,
-                             "NumberOfPoles changed after reboot")
-        asserts.assert_equal(eol_post, eol_1,
-                             "EndOfLife changed after reboot")
-        asserts.assert_equal(ser_post, ser_1,
-                             "ServiceEntranceRated changed after reboot")
-
-        log.info("All Fixed-by-manufacturer attributes verified stable across reboot")
+            asserts.assert_equal(mcc_post, mcc_1,
+                                 "MaxContinuousCurrent changed after reboot")
+            asserts.assert_equal(mv_post, mv_1,
+                                 "MaxVoltage changed after reboot")
+            asserts.assert_equal(nop_post, nop_1,
+                                 "NumberOfPoles changed after reboot")
+            asserts.assert_equal(eol_post, eol_1,
+                                 "EndOfLife changed after reboot")
+            asserts.assert_equal(ser_post, ser_1,
+                                 "ServiceEntranceRated changed after reboot")
+            log.info("All Fixed-by-manufacturer attributes verified stable across reboot")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -89,8 +89,8 @@ class TC_ELDIST_2_2(MatterBaseTest):
         ser_1 = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster,
             attribute=attributes.ServiceEntranceRated)
-        log.info(f"Pre-reboot values: MCC={mcc_1}, MV={mv_1}, "
-                 f"NOP={nop_1}, EOL={eol_1}, SER={ser_1}")
+        log.info("Pre-reboot values: MCC=%s, MV=%s, NOP=%s, EOL=%s, SER=%s",
+                 mcc_1, mv_1, nop_1, eol_1, ser_1)
 
         self.step(3, "TH re-reads MaxContinuousCurrent to confirm stability within single boot")
         mcc_2 = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -1,0 +1,183 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.interaction_model import Status
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_ELDIST_2_2(MatterBaseTest):
+    """TC-ELDIST-2.2: Fixed-by-Manufacturer Quality Verification with Server as DUT
+
+    Verify that all five mandatory attributes of the Electrical Distribution
+    Cluster maintain their values across reboot (Fixed-by-manufacturer quality X).
+    """
+
+    def desc_TC_ELDIST_2_2(self) -> str:
+        return "[TC-ELDIST-2.2] Fixed-by-Manufacturer Quality Verification with Server as DUT"
+
+    def pics_TC_ELDIST_2_2(self) -> list[str]:
+        return ["ELDIST.S"]
+
+    def steps_TC_ELDIST_2_2(self) -> list[TestStep]:
+        return [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "TH reads all five mandatory attributes and records values"),
+            TestStep(3, "TH re-reads MaxContinuousCurrent to confirm stability within single boot"),
+            TestStep(4, "TH attempts write to MaxVoltage - expect UNSUPPORTED_WRITE"),
+            TestStep(5, "TH attempts write to NumberOfPoles - expect UNSUPPORTED_WRITE"),
+            TestStep(6, "TH attempts write to ServiceEntranceRated - expect UNSUPPORTED_WRITE"),
+            TestStep(7, "Operator reboots DUT"),
+            TestStep(8, "TH re-reads all five attributes and verifies values unchanged"),
+        ]
+
+    @property
+    def default_endpoint(self) -> int:
+        return 1
+
+    @run_if_endpoint_matches(has_cluster(Clusters.ElectricalDistribution))
+    async def test_TC_ELDIST_2_2(self):
+        endpoint = self.get_endpoint()
+        cluster = Clusters.ElectricalDistribution
+        attributes = cluster.Attributes
+
+        self.step(1)
+
+        # Step 2: Read all attributes and record
+        self.step(2)
+        mcc_1 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxContinuousCurrent)
+        mv_1 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxVoltage)
+        nop_1 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.NumberOfPoles)
+        eol_1 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.EndOfLife)
+        ser_1 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.ServiceEntranceRated)
+
+        log.info(f"Pre-reboot values: MCC={mcc_1}, MV={mv_1}, "
+                 f"NOP={nop_1}, EOL={eol_1}, SER={ser_1}")
+
+        # Step 3: Re-read MaxContinuousCurrent within same boot
+        self.step(3)
+        mcc_2 = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxContinuousCurrent)
+        asserts.assert_equal(mcc_2, mcc_1,
+                             "MaxContinuousCurrent changed within single boot - "
+                             "violates Fixed-by-manufacturer quality")
+
+        # Step 4: Write to MaxVoltage
+        self.step(4)
+        result = await self.default_controller.WriteAttribute(
+            self.dut_node_id,
+            [(endpoint, attributes.MaxVoltage(230000))]
+        )
+        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
+                             "Write to MaxVoltage should return UNSUPPORTED_WRITE")
+
+        # Step 5: Write to NumberOfPoles
+        self.step(5)
+        result = await self.default_controller.WriteAttribute(
+            self.dut_node_id,
+            [(endpoint, attributes.NumberOfPoles(2))]
+        )
+        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
+                             "Write to NumberOfPoles should return UNSUPPORTED_WRITE")
+
+        # Step 6: Write to ServiceEntranceRated
+        self.step(6)
+        result = await self.default_controller.WriteAttribute(
+            self.dut_node_id,
+            [(endpoint, attributes.ServiceEntranceRated(False))]
+        )
+        asserts.assert_equal(result[0].Status, Status.UnsupportedWrite,
+                             "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
+
+        # Step 7: Reboot DUT
+        self.step(7)
+        self.wait_for_user_input(
+            prompt_msg="Reboot the DUT and wait for it to rejoin the fabric. Press Enter.")
+
+        # Step 8: Re-read and verify persistence
+        self.step(8)
+        mcc_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxContinuousCurrent)
+        mv_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxVoltage)
+        nop_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.NumberOfPoles)
+        eol_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.EndOfLife)
+        ser_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.ServiceEntranceRated)
+
+        asserts.assert_equal(mcc_post, mcc_1,
+                             "MaxContinuousCurrent changed after reboot")
+        asserts.assert_equal(mv_post, mv_1,
+                             "MaxVoltage changed after reboot")
+        asserts.assert_equal(nop_post, nop_1,
+                             "NumberOfPoles changed after reboot")
+        asserts.assert_equal(eol_post, eol_1,
+                             "EndOfLife changed after reboot")
+        asserts.assert_equal(ser_post, ser_1,
+                             "ServiceEntranceRated changed after reboot")
+
+        log.info("All Fixed-by-manufacturer attributes verified stable across reboot")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -41,7 +41,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.decorators import has_cluster, pics, run_if_endpoint_matches
+from matter.testing.decorators import async_test_body, pics
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main
 
@@ -55,7 +55,7 @@ class TC_ELDIST_2_2(MatterBaseTest):
         return 1
 
     @pics('ELDIST.S')
-    @run_if_endpoint_matches(has_cluster(Clusters.ElectricalDistribution))
+    @async_test_body
     async def test_TC_ELDIST_2_2(self):
         """[TC-ELDIST-2.2] Fixed-by-Manufacturer Quality Verification with Server as DUT
 

--- a/src/python_testing/TC_ELDIST_2_2.py
+++ b/src/python_testing/TC_ELDIST_2_2.py
@@ -23,6 +23,7 @@
 #   run1:
 #     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
@@ -61,8 +62,10 @@ class TC_ELDIST_2_2(MatterBaseTest):
 
         Verify that all five mandatory attributes of the Electrical Distribution
         Cluster maintain their values across reboot (Fixed-by-manufacturer
-        quality X). The reboot + persistence verification steps are operator-
-        driven and dispatch via is_pics_sdk_ci_only (skipped in CI).
+        quality X). The reboot is driven by the framework helper
+        self.request_device_reboot() in conjunction with the app-ready-pattern
+        directive in the CI block above; canonical reference pattern is
+        TC_AVSUM_2_9.py.
         """
         endpoint = self.get_endpoint()
         cluster = Clusters.ElectricalDistribution
@@ -121,44 +124,37 @@ class TC_ELDIST_2_2(MatterBaseTest):
         asserts.assert_equal(status, Status.UnsupportedWrite,
                              "Write to ServiceEntranceRated should return UNSUPPORTED_WRITE")
 
-        self.step(7, "Operator reboots DUT (skipped in CI)")
-        if self.is_pics_sdk_ci_only:
-            self.mark_current_step_skipped()
-        else:
-            self.wait_for_user_input(
-                prompt_msg="Reboot the DUT and wait for it to rejoin the fabric. Press Enter.")
+        self.step(7, "Reboot DUT via the framework helper (returns when the app comes back up)")
+        await self.request_device_reboot()
 
-        self.step(8, "TH re-reads all five attributes and verifies values unchanged across reboot (skipped in CI)")
-        if self.is_pics_sdk_ci_only:
-            self.mark_current_step_skipped()
-        else:
-            mcc_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster,
-                attribute=attributes.MaxContinuousCurrent)
-            mv_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster,
-                attribute=attributes.MaxVoltage)
-            nop_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster,
-                attribute=attributes.NumberOfPoles)
-            eol_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster,
-                attribute=attributes.EndOfLife)
-            ser_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster,
-                attribute=attributes.ServiceEntranceRated)
+        self.step(8, "TH re-reads all five attributes and verifies values unchanged across reboot")
+        mcc_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxContinuousCurrent)
+        mv_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.MaxVoltage)
+        nop_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.NumberOfPoles)
+        eol_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.EndOfLife)
+        ser_post = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster,
+            attribute=attributes.ServiceEntranceRated)
 
-            asserts.assert_equal(mcc_post, mcc_1,
-                                 "MaxContinuousCurrent changed after reboot")
-            asserts.assert_equal(mv_post, mv_1,
-                                 "MaxVoltage changed after reboot")
-            asserts.assert_equal(nop_post, nop_1,
-                                 "NumberOfPoles changed after reboot")
-            asserts.assert_equal(eol_post, eol_1,
-                                 "EndOfLife changed after reboot")
-            asserts.assert_equal(ser_post, ser_1,
-                                 "ServiceEntranceRated changed after reboot")
-            log.info("All Fixed-by-manufacturer attributes verified stable across reboot")
+        asserts.assert_equal(mcc_post, mcc_1,
+                             "MaxContinuousCurrent changed after reboot")
+        asserts.assert_equal(mv_post, mv_1,
+                             "MaxVoltage changed after reboot")
+        asserts.assert_equal(nop_post, nop_1,
+                             "NumberOfPoles changed after reboot")
+        asserts.assert_equal(eol_post, eol_1,
+                             "EndOfLife changed after reboot")
+        asserts.assert_equal(ser_post, ser_1,
+                             "ServiceEntranceRated changed after reboot")
+        log.info("All Fixed-by-manufacturer attributes verified stable across reboot")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -50,9 +50,9 @@ not_automated:
     - name: TC_ELDIST_2_2.py
       reason:
           Electrical Distribution Cluster (ELDIST, 0x00A2) server is not yet
-          integrated into any example app; this script will be enabled when
-          the upcoming electrical-protection-app provides an ELDIST server
-          on a non-root endpoint
+          integrated into any example app; this script will be enabled when the
+          upcoming electrical-protection-app provides an ELDIST server on a
+          non-root endpoint
     - name: TC_OpstateCommon.py
       reason: Shared code for TC_OPSTATE, not a standalone test
     - name: TC_pics_checker.py

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -47,6 +47,12 @@ not_automated:
       reason: Shared code for TC_EEM and TC_EPM, not a standalone test
     - name: TC_EGCTestBase.py
       reason: Shared code for TC_EGC, not a standalone test
+    - name: TC_ELDIST_2_2.py
+      reason:
+          Electrical Distribution Cluster (ELDIST, 0x00A2) server is not yet
+          integrated into any example app; this script will be enabled when
+          the upcoming electrical-protection-app provides an ELDIST server
+          on a non-root endpoint
     - name: TC_OpstateCommon.py
       reason: Shared code for TC_OPSTATE, not a standalone test
     - name: TC_pics_checker.py


### PR DESCRIPTION
#### Summary

Adds `TC_ELDIST_2_2.py` implementing TC-ELDIST-2.2 ("Fixed-by-Manufacturer Quality Verification with Server as DUT") from the Electrical Distribution Cluster test plan.

This is the Python automation companion to TC-ELDIST-2.2 in [chip-test-plans #6156](https://github.com/CHIP-Specifications/chip-test-plans/pull/6156). Filed as a sibling to the in-flight TC-ELDIST-2.1 PR #72278.

#### What the script tests

- **Within-boot stability**: re-read of MaxContinuousCurrent must equal the initial read (per the Fixed-by-Manufacturer (X) quality).
- **Write rejection**: writes to MaxVoltage, NumberOfPoles, and ServiceEntranceRated must each return `UNSUPPORTED_WRITE` (complements PR #72278's write probe on MaxContinuousCurrent).
- **Persistence across reboot**: after operator-driven power cycle, all five mandatory attributes must read back to the same values they had pre-reboot (including `null` staying `null`).

Uses the modern `@run_if_endpoint_matches(has_cluster(Clusters.ElectricalDistribution))` decorator for proper self-skip behavior when no endpoint hosts the cluster.

#### Related issues / PRs

- Implements TC-ELDIST-2.2 from chip-test-plans #6156.
- Sibling to in-flight #72278 (TC-ELDIST-2.1 Python script).
- Depends on the Electrical Distribution cluster XML, which is already in master via #72229.

#### Testing

Filed as Draft because no example app currently integrates the Electrical Distribution cluster server on a non-root endpoint; the script will run cleanly under CI once an example app (anticipated `electrical-protection-app`) provides ELDIST. A `not_automated` entry in `test_metadata.yaml` keeps CI green in the interim.

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short (1 new test file + 1 metadata entry)
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase (test is `not_automated` until app integration)