### PR TITLE
[JCM] Fix DNS-SD Port Overrides, Port Randomization Collisions, and Storage Conflicts in Joint Fabrics JCM Python Tests

### DIFF
--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -130,11 +130,11 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     Controller::SetupParams params;
 
     // use a different listen port for the commissioner than the default used by chip-tool.
-    factoryParams.listenPort               = commissionerPort;
-    factoryParams.fabricIndependentStorage = &gServerStorage;
-    factoryParams.fabricTable              = &Server::GetInstance().GetFabricTable();
-    factoryParams.sessionKeystore          = &gSessionKeystore;
-    factoryParams.enableServerInteractions = true;
+    factoryParams.listenPort                = commissionerPort;
+    factoryParams.fabricIndependentStorage  = &gServerStorage;
+    factoryParams.fabricTable               = &Server::GetInstance().GetFabricTable();
+    factoryParams.sessionKeystore           = &gSessionKeystore;
+    factoryParams.enableServerInteractions  = true;
     factoryParams.preventDnssdPortOverwrite = true;
     // We're running alongside an existing Server, so use the existing DataModelProvider
     // without changing the underlying persistent storage delegate.

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -135,6 +135,8 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     factoryParams.fabricTable               = &Server::GetInstance().GetFabricTable();
     factoryParams.sessionKeystore           = &gSessionKeystore;
     factoryParams.enableServerInteractions  = true;
+    // Since CommissionerMain is used in combined server/commissioner applications,
+    // we must prevent the commissioner from overwriting the server's DNS-SD port.
     factoryParams.preventDnssdPortOverwrite = true;
     // We're running alongside an existing Server, so use the existing DataModelProvider
     // without changing the underlying persistent storage delegate.

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -130,11 +130,11 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     Controller::SetupParams params;
 
     // use a different listen port for the commissioner than the default used by chip-tool.
-    factoryParams.listenPort                = commissionerPort;
-    factoryParams.fabricIndependentStorage  = &gServerStorage;
-    factoryParams.fabricTable               = &Server::GetInstance().GetFabricTable();
-    factoryParams.sessionKeystore           = &gSessionKeystore;
-    factoryParams.enableServerInteractions  = true;
+    factoryParams.listenPort               = commissionerPort;
+    factoryParams.fabricIndependentStorage = &gServerStorage;
+    factoryParams.fabricTable              = &Server::GetInstance().GetFabricTable();
+    factoryParams.sessionKeystore          = &gSessionKeystore;
+    factoryParams.enableServerInteractions = true;
     // Since CommissionerMain is used in combined server/commissioner applications,
     // we must prevent the commissioner from overwriting the server's DNS-SD port.
     factoryParams.preventDnssdPortOverwrite = true;

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -134,6 +134,8 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     factoryParams.fabricIndependentStorage = &gServerStorage;
     factoryParams.fabricTable              = &Server::GetInstance().GetFabricTable();
     factoryParams.sessionKeystore          = &gSessionKeystore;
+    factoryParams.enableServerInteractions = true;
+    factoryParams.preventDnssdPortOverwrite = true;
     // We're running alongside an existing Server, so use the existing DataModelProvider
     // without changing the underlying persistent storage delegate.
     factoryParams.dataModelProvider = chip::app::CodegenDataModelProviderInstance(nullptr);

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -69,6 +69,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
     mCertificateValidityPolicy = params.certificateValidityPolicy;
     mSessionResumptionStorage  = params.sessionResumptionStorage;
     mEnableServerInteractions  = params.enableServerInteractions;
+    mPreventDnssdPortOverwrite = params.preventDnssdPortOverwrite;
     mDataModelProvider         = params.dataModelProvider;
 
     // Initialize the system state. Note that it is left in a somewhat
@@ -96,6 +97,7 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
     params.interfaceId               = mInterfaceId;
     params.fabricIndependentStorage  = mFabricIndependentStorage;
     params.enableServerInteractions  = mEnableServerInteractions;
+    params.preventDnssdPortOverwrite = mPreventDnssdPortOverwrite;
     params.groupDataProvider         = mSystemState->GetGroupDataProvider();
     params.sessionKeystore           = mSystemState->GetSessionKeystore();
     params.fabricTable               = mSystemState->Fabrics();

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -288,15 +288,18 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
             stateParams.exchangeMgr, stateParams.sessionMgr, stateParams.fabricTable, sessionResumptionStorage,
             stateParams.certificateValidityPolicy, stateParams.groupDataProvider));
 
-        // Our IPv6 transport is at index 0.
-        app::DnssdServer::Instance().SetSecuredIPv6Port(
-            stateParams.transportMgr->GetTransport().GetImplAtIndex<0>().GetBoundPort());
+        if (!params.preventDnssdPortOverwrite)
+        {
+            // Our IPv6 transport is at index 0.
+            app::DnssdServer::Instance().SetSecuredIPv6Port(
+                stateParams.transportMgr->GetTransport().GetImplAtIndex<0>().GetBoundPort());
 
 #if INET_CONFIG_ENABLE_IPV4
-        // If enabled, our IPv4 transport is at index 1.
-        app::DnssdServer::Instance().SetSecuredIPv4Port(
-            stateParams.transportMgr->GetTransport().GetImplAtIndex<1>().GetBoundPort());
+            // If enabled, our IPv4 transport is at index 1.
+            app::DnssdServer::Instance().SetSecuredIPv4Port(
+                stateParams.transportMgr->GetTransport().GetImplAtIndex<1>().GetBoundPort());
 #endif // INET_CONFIG_ENABLE_IPV4
+        }
 
         if (params.interfaceId)
         {

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -161,6 +161,13 @@ struct FactoryInitParams
     //
     bool enableServerInteractions = false;
 
+    // Controls whether the controller factory initialization is prevented from
+    // overwriting the global DnssdServer's secured port. When running in a
+    // combined server/controller app where the server's port is primary, this
+    // must be set to true to keep DNS-SD advertising the server's port.
+    bool preventDnssdPortOverwrite = false;
+
+
     /* The port used for operational communication to listen for and send messages over UDP/TCP.
      * The default value of `0` will pick any available port. */
     uint16_t listenPort = 0;

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -321,6 +321,7 @@ private:
     SessionResumptionStorage * mSessionResumptionStorage                = nullptr;
     app::DataModel::Provider * mDataModelProvider                       = nullptr;
     bool mEnableServerInteractions                                      = false;
+    bool mPreventDnssdPortOverwrite                                     = false;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -167,7 +167,6 @@ struct FactoryInitParams
     // must be set to true to keep DNS-SD advertising the server's port.
     bool preventDnssdPortOverwrite = false;
 
-
     /* The port used for operational communication to listen for and send messages over UDP/TCP.
      * The default value of `0` will pick any available port. */
     uint16_t listenPort = 0;

--- a/src/python_testing/TC_JFADMIN_1_1.py
+++ b/src/python_testing/TC_JFADMIN_1_1.py
@@ -62,6 +62,9 @@ class TC_JFADMIN_1_1(MatterBaseTest):
         self.fabric_a_ctrl = None
         self.fabric_a_admin = None
         self.storage_fabric_a = self.user_params.get("fabric_a_storage", None)
+        self.fabric_a_persistent_storage = None
+        self.cert_authority_manager_a = None
+        self.dev_ctrl_eco_a = None
 
         self.jfc_server_app = self.user_params.get("jfc_server_app", None)
         if not self.jfc_server_app:
@@ -87,6 +90,16 @@ class TC_JFADMIN_1_1(MatterBaseTest):
             self.fabric_a_admin.terminate()
         if self.fabric_a_ctrl is not None:
             self.fabric_a_ctrl.terminate()
+
+        if self.dev_ctrl_eco_a is not None:
+            self.dev_ctrl_eco_a.Shutdown()
+            self.dev_ctrl_eco_a = None
+        if self.cert_authority_manager_a is not None:
+            self.cert_authority_manager_a.Shutdown()
+            self.cert_authority_manager_a = None
+        if self.fabric_a_persistent_storage is not None:
+            self.fabric_a_persistent_storage.Shutdown()
+            self.fabric_a_persistent_storage = None
 
         super().teardown_class()
 
@@ -182,29 +195,29 @@ class TC_JFADMIN_1_1(MatterBaseTest):
         self.ecoACATs = base64.b64decode(jfcStorage.get("Default", "CommissionerCATs"))[::-1].hex().strip('0')
 
         # Creating a Controller for Ecosystem A
-        _fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
+        self.fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
             self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
-        _certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
+        self.cert_authority_manager_a = CertificateAuthority.CertificateAuthorityManager(
             chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_a_persistent_storage)
-        _certAuthorityManagerA.LoadAuthoritiesFromStorage()
-        devCtrlEcoA = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+            persistentStorage=self.fabric_a_persistent_storage)
+        self.cert_authority_manager_a.LoadAuthoritiesFromStorage()
+        self.dev_ctrl_eco_a = self.cert_authority_manager_a.activeCaList[0].adminList[0].NewController(
             nodeId=101,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoACATs, 16)])
 
         if self.pics_guard(self.check_pics("JFADMIN.S.A0000")):
             self.step("2")
-            response = await devCtrlEcoA.ReadAttribute(
+            response = await self.dev_ctrl_eco_a.ReadAttribute(
                 nodeId=1, attributes=[(1, Clusters.JointFabricAdministrator.Attributes.AdministratorFabricIndex)],
                 returnClusterObject=True)
             attributeAdminFabricIndex = response[1][Clusters.JointFabricAdministrator].administratorFabricIndex
             asserts.assert_true(attributeAdminFabricIndex in range(1, 255),
-                                f"AdministratorFabricIndex={attributeAdminFabricIndex} not in expected range [1..254]")
+                                 f"AdministratorFabricIndex={attributeAdminFabricIndex} not in expected range [1..254]")
 
             # Step 3 is under same PICS guard as Step 2 becasue it relies on attributeAdminFabricIndex
             self.step("3")
-            response = await devCtrlEcoA.ReadAttribute(
+            response = await self.dev_ctrl_eco_a.ReadAttribute(
                 nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
                 returnClusterObject=True)
             fabricid_found = False
@@ -216,9 +229,6 @@ class TC_JFADMIN_1_1(MatterBaseTest):
                     break
             asserts.assert_true(fabricid_found,
                                 "No FabricDescriptorStruct with fabricIndex = AdministratorFabricIndex found in Operational Cluster Fabrics attribute on EP0")
-
-        # Shutdown the Python Controllers started at the beginning of this script
-        devCtrlEcoA.Shutdown()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_JFADMIN_1_1.py
+++ b/src/python_testing/TC_JFADMIN_1_1.py
@@ -213,7 +213,7 @@ class TC_JFADMIN_1_1(MatterBaseTest):
                 returnClusterObject=True)
             attributeAdminFabricIndex = response[1][Clusters.JointFabricAdministrator].administratorFabricIndex
             asserts.assert_true(attributeAdminFabricIndex in range(1, 255),
-                                 f"AdministratorFabricIndex={attributeAdminFabricIndex} not in expected range [1..254]")
+                                f"AdministratorFabricIndex={attributeAdminFabricIndex} not in expected range [1..254]")
 
             # Step 3 is under same PICS guard as Step 2 becasue it relies on attributeAdminFabricIndex
             self.step("3")

--- a/src/python_testing/TC_JFADMIN_1_1.py
+++ b/src/python_testing/TC_JFADMIN_1_1.py
@@ -115,12 +115,12 @@ class TC_JFADMIN_1_1(MatterBaseTest):
             dut_rpc_server_ip = "127.0.0.1"
             jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             jfadmin_fabric_a_discriminator = random.randint(0, 4095)
-            dut_rpc_server_port = "33033"
+            dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 self.jfa_server_app,
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=jfadmin_fabric_a_discriminator,
                 passcode=jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])

--- a/src/python_testing/TC_JFADMIN_1_2.py
+++ b/src/python_testing/TC_JFADMIN_1_2.py
@@ -83,14 +83,15 @@ class TC_JFADMIN_1_2(MatterBaseTest):
         if self.is_pics_sdk_ci_only:
             self.admin_passcode = random.randint(20202021, 20202099)
             self.admin_discriminator = random.randint(0, 4095)
+            rpc_port = self.get_random_port()
             # Start JF-Administrator App
             self.jf_admin = AppServerSubprocess(
                 self.jfa_server_app,
                 storage_dir=self.fabric_storage,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.admin_discriminator,
                 passcode=self.admin_passcode,
-                extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", str(rpc_port)])
             self.jf_admin.start(
                 expected_output="Server initialization complete",
                 timeout=10)

--- a/src/python_testing/TC_JFADMIN_1_4.py
+++ b/src/python_testing/TC_JFADMIN_1_4.py
@@ -192,12 +192,12 @@ class TC_JFADMIN_1_4(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(20202021, 20202099)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             dut_rpc_server_ip = "127.0.0.1"
-            dut_rpc_server_port = "33033"
+            dut_rpc_server_port = str(self.get_random_port())
             self.fabric_a_admin = JFAdministratorSubprocess(
                 self.jfa_server_app,
                 prefix="JFA-A",
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.jfadmin_fabric_a_discriminator,
                 passcode=self.jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port, "--min_commissioning_timeout", f"{self.ojcw_timeout_baseline}"])

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -117,12 +117,16 @@ class TC_JFADMIN_2_1(MatterBaseTest):
 
         if self.dev_ctrl_eco_a is not None:
             self.dev_ctrl_eco_a.Shutdown()
+            self.dev_ctrl_eco_a = None
         if self.dev_ctrl_eco_b is not None:
             self.dev_ctrl_eco_b.Shutdown()
+            self.dev_ctrl_eco_b = None
         if self.joint_fabric_ca_manager is not None:
             self.joint_fabric_ca_manager.Shutdown()
+            self.joint_fabric_ca_manager = None
         if self.joint_fabric_persistent_storage is not None:
             self.joint_fabric_persistent_storage.Shutdown()
+            self.joint_fabric_persistent_storage = None
 
         super().teardown_class()
 

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -521,7 +521,5 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         )
 
 
-
-
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -119,6 +119,8 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             self.dev_ctrl_eco_a.Shutdown()
         if self.dev_ctrl_eco_b is not None:
             self.dev_ctrl_eco_b.Shutdown()
+        if self.joint_fabric_ca_manager is not None:
+            self.joint_fabric_ca_manager.Shutdown()
         if self.joint_fabric_persistent_storage is not None:
             self.joint_fabric_persistent_storage.Shutdown()
 
@@ -379,7 +381,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         for k, v in self.ecoBCtrlStorage['sdk-config'].items():
             self.joint_fabric_persistent_storage.SetSdkKey(k, base64.b64decode(v))
 
-        caList = self.joint_fabric_persistent_storage.GetKey('caList')
+        caList = self.joint_fabric_persistent_storage.GetKey('caList') or {}
         caList["2"] = self.ecoBCtrlStorage['repl-config']['caList']['2']
         self.joint_fabric_persistent_storage.SetKey('caList', caList)
 
@@ -387,8 +389,8 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         ca2 = self.joint_fabric_ca_manager.NewCertificateAuthority(caIndex=2)
         ca2.LoadFabricAdminsFromStorage()
 
-        # Retrieve active CA list index 1 (which is CA Index 2)
-        self.dev_ctrl_eco_b = self.joint_fabric_ca_manager.activeCaList[1].adminList[0].NewController(
+        # Create Ecosystem B controller using ca2 directly
+        self.dev_ctrl_eco_b = ca2.adminList[0].NewController(
             nodeId=201,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoBCATs, 16)])

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -67,6 +67,10 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.fabric_b_server_app = None
         self.fabric_a_admin = None
         self.fabric_b_admin = None
+        self.dev_ctrl_eco_a = None
+        self.dev_ctrl_eco_b = None
+        self.joint_fabric_persistent_storage = None
+        self.joint_fabric_ca_manager = None
 
         self.jfc_server_app = self.user_params.get("jfc_server_app", None)
         if not self.jfc_server_app:
@@ -111,6 +115,13 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         if self.fabric_b_server_app is not None:
             self.fabric_b_server_app.terminate()
 
+        if self.dev_ctrl_eco_a is not None:
+            self.dev_ctrl_eco_a.Shutdown()
+        if self.dev_ctrl_eco_b is not None:
+            self.dev_ctrl_eco_b.Shutdown()
+        if self.joint_fabric_persistent_storage is not None:
+            self.joint_fabric_persistent_storage.Shutdown()
+
         super().teardown_class()
 
     def steps_TC_JFADMIN_2_1(self) -> list[TestStep]:
@@ -130,10 +141,10 @@ class TC_JFADMIN_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_JFADMIN_2_1(self):
-        _devCtrlEcoA = None
-        _devCtrlEcoB = None
-        _fabric_a_persistent_storage = None
-        _fabric_b_persistent_storage = None
+        self.dev_ctrl_eco_a = None
+        self.dev_ctrl_eco_b = None
+        self.joint_fabric_persistent_storage = None
+        self.joint_fabric_ca_manager = None
         jfadmin_fabric_a_passcode = None
         dut_rpc_server_ip = None
         dut_rpc_server_port = None
@@ -226,24 +237,24 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             timeout=20)
 
         self.fabric_a_ctrl.send(
-            message=f"pairing onnetwork 2 {self.thserver_fabric_a_passcode}",
+            message=f"pairing onnetwork 2 {self.thserver_fabric_a_passcode} --regular true",
             expected_output="[CTL] Commissioning complete for node ID 0x0000000000000002: success",
             timeout=20)
 
-        # Creating a Controller for Ecosystem A
-        _fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
+        # Creating a unified Controller Manager for both ecosystems
+        self.joint_fabric_persistent_storage = VolatileTemporaryPersistentStorage(
             self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
-        _certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
+        self.joint_fabric_ca_manager = CertificateAuthority.CertificateAuthorityManager(
             chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_a_persistent_storage)
-        _certAuthorityManagerA.LoadAuthoritiesFromStorage()
-        _devCtrlEcoA = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+            persistentStorage=self.joint_fabric_persistent_storage)
+        self.joint_fabric_ca_manager.LoadAuthoritiesFromStorage()
+        self.dev_ctrl_eco_a = self.joint_fabric_ca_manager.activeCaList[0].adminList[0].NewController(
             nodeId=101,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoACATs, 16)])
 
         # Precondition 2 Validation
-        response = await _devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)],
             returnClusterObject=True)
         # Search Administrator CAT (FFFF0001) and Anchor CAT (FFFD0001) in JF-Admin NOC on Ecoystem A
@@ -271,7 +282,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         except (TypeError, AttributeError) as e:
             asserts.fail(f"Failed to parse ICAC in precondition 2: {e}")
 
-        response = await _devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=2, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -279,7 +290,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             response[0][Clusters.OperationalCredentials].fabrics[0].vendorID,
             "JF-Admin App on Ecosystem A doesn't have the correct VID")
 
-        response = await _devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=2, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -291,8 +302,9 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.jfadmin_fabric_b_passcode = random.randint(110220011, 110220999)
         self.jfctrl_fabric_b_vid = random.randint(0x0001, 0xFFF0)
 
-        # Start Fabric B JF-Administrator App
         fabric_b_rpc_port = self.get_random_port()
+
+        # Start Fabric B JF-Administrator App
         self.fabric_b_admin = JFAdministratorSubprocess(
             self.jfa_server_app,
             prefix="JFA-B",
@@ -318,25 +330,25 @@ class TC_JFADMIN_2_1(MatterBaseTest):
 
         # Commission JF-ADMIN app with JF-Controller on Fabric B
         self.fabric_b_ctrl.send(
-            message=f"pairing onnetwork 11 {self.jfadmin_fabric_b_passcode} --anchor true",
+            message=f"pairing onnetwork 11 {self.jfadmin_fabric_b_passcode} --anchor true --commissioner-name beta",
             expected_output="[JF] Anchor Administrator (nodeId=11) commissioned with success",
             timeout=20)
 
         # Extract the Ecosystem B certificates and inject them in the storage that will be provided to a new Python Controller later
         jfcStorage = ConfigParser()
-        jfcStorage.read(self.storage_fabric_b+'/chip_tool_config.alpha.ini')
+        jfcStorage.read(self.storage_fabric_b+'/chip_tool_config.beta.ini')
         self.ecoBCtrlStorage = {
             "sdk-config": {
-                "ExampleOpCredsCAKey1": jfcStorage.get("Default", "ExampleOpCredsCAKey0"),
-                "ExampleOpCredsICAKey1": jfcStorage.get("Default", "ExampleOpCredsICAKey0"),
-                "ExampleCARootCert1": jfcStorage.get("Default", "ExampleCARootCert0"),
-                "ExampleCAIntermediateCert1": jfcStorage.get("Default", "ExampleCAIntermediateCert0"),
+                "ExampleOpCredsCAKey2": jfcStorage.get("Default", "ExampleOpCredsCAKey0"),
+                "ExampleOpCredsICAKey2": jfcStorage.get("Default", "ExampleOpCredsICAKey0"),
+                "ExampleCARootCert2": jfcStorage.get("Default", "ExampleCARootCert0"),
+                "ExampleCAIntermediateCert2": jfcStorage.get("Default", "ExampleCAIntermediateCert0"),
             },
             "repl-config": {
                 "caList": {
-                    "1": [
+                    "2": [
                         {
-                            "fabricId": 1,
+                            "fabricId": 2,
                             "vendorId": self.jfctrl_fabric_b_vid
                         }
                     ]
@@ -359,23 +371,29 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             timeout=20)
 
         self.fabric_b_ctrl.send(
-            message=f"pairing onnetwork 22 {self.thserver_fabric_b_passcode}",
+            message=f"pairing onnetwork 22 {self.thserver_fabric_b_passcode} --commissioner-name beta --regular true",
             expected_output="[CTL] Commissioning complete for node ID 0x0000000000000016: success",
             timeout=20)
 
-        # Creating a Controller for Ecosystem B
-        _fabric_b_persistent_storage = VolatileTemporaryPersistentStorage(
-            self.ecoBCtrlStorage['repl-config'], self.ecoBCtrlStorage['sdk-config'])
-        _certAuthorityManagerB = CertificateAuthority.CertificateAuthorityManager(
-            chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_b_persistent_storage)
-        _certAuthorityManagerB.LoadAuthoritiesFromStorage()
-        _devCtrlEcoB = _certAuthorityManagerB.activeCaList[0].adminList[0].NewController(
+        # Merge Ecosystem B config into the unified storage
+        for k, v in self.ecoBCtrlStorage['sdk-config'].items():
+            self.joint_fabric_persistent_storage.SetSdkKey(k, base64.b64decode(v))
+
+        caList = self.joint_fabric_persistent_storage.GetKey('caList')
+        caList["2"] = self.ecoBCtrlStorage['repl-config']['caList']['2']
+        self.joint_fabric_persistent_storage.SetKey('caList', caList)
+
+        # Create and load CA Index 2 explicitly in the unified manager
+        ca2 = self.joint_fabric_ca_manager.NewCertificateAuthority(caIndex=2)
+        ca2.LoadFabricAdminsFromStorage()
+
+        # Retrieve active CA list index 1 (which is CA Index 2)
+        self.dev_ctrl_eco_b = self.joint_fabric_ca_manager.activeCaList[1].adminList[0].NewController(
             nodeId=201,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoBCATs, 16)])
 
-        response = await _devCtrlEcoB.ReadAttribute(
+        response = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)],
             returnClusterObject=True)
         # Search Administrator CAT (FFFF0001) and Anchor CAT (FFFD0001) in JF-Admin NOC on Ecoystem A
@@ -403,7 +421,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         except (TypeError, AttributeError) as e:
             asserts.fail(f"Failed to parse ICAC in precondition 2 (Ecosystem B): {e}")
 
-        response = await _devCtrlEcoB.ReadAttribute(
+        response = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=22, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -411,7 +429,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             response[0][Clusters.OperationalCredentials].fabrics[0].vendorID,
             "JF-Admin App on Ecosystem B doesn't have the correct VID")
 
-        response = await _devCtrlEcoB.ReadAttribute(
+        response = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=22, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -420,7 +438,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             "EcoB Server App Subjects field has wrong value")
 
         # Precondition 3 Validation
-        response = await _devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -428,7 +446,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             response[0][Clusters.OperationalCredentials].fabrics[0].vendorID,
             "JF-Admin App on Ecosystem A doesn't have the correct VID")
 
-        response = await _devCtrlEcoB.ReadAttribute(
+        response = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.Fabrics)],
             returnClusterObject=True)
         asserts.assert_equal(
@@ -439,7 +457,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.step("3")
         discriminator = random.randint(0, 4095)
         try:
-            response = await _devCtrlEcoB.OpenJointCommissioningWindow(
+            response = await self.dev_ctrl_eco_b.OpenJointCommissioningWindow(
                 nodeId=11,
                 endpointId=1,
                 timeout=400,
@@ -455,11 +473,11 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             expected_output="[CTL] Commissioning complete for node ID 0x000000000000000F: success",
             timeout=60)
 
-        fabric_a_trusted_roots = await _devCtrlEcoA.ReadAttribute(
+        fabric_a_trusted_roots = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.TrustedRootCertificates)],
             returnClusterObject=True, fabricFiltered=False)
 
-        fabric_b_nocs = await _devCtrlEcoB.ReadAttribute(
+        fabric_b_nocs = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)],
             returnClusterObject=True, fabricFiltered=False)
 
@@ -502,15 +520,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
             "No Ecosystem B ICAC Issuer matches any Ecosystem A RCAC Subject"
         )
 
-        # Shutdown the Python Controllers started at the beginning of this script
-        if _devCtrlEcoA is not None:
-            _devCtrlEcoA.Shutdown()
-        if _devCtrlEcoB is not None:
-            _devCtrlEcoB.Shutdown()
-        if _fabric_a_persistent_storage is not None:
-            _fabric_a_persistent_storage.Shutdown()
-        if _fabric_b_persistent_storage is not None:
-            _fabric_b_persistent_storage.Shutdown()
+
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_JFADMIN_2_1.py
+++ b/src/python_testing/TC_JFADMIN_2_1.py
@@ -145,16 +145,16 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         if self.is_pics_sdk_ci_only:
             dut_rpc_server_ip = "127.0.0.1"
             jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
-            dut_rpc_server_port = "33033"
+            dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App (DUT)
             self.fabric_a_admin = JFAdministratorSubprocess(
                 self.jfa_server_app,
                 prefix="JFA-A",
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=random.randint(0, 4095),
                 passcode=jfadmin_fabric_a_passcode,
-                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port, "--secured-commissioner-port", str(self.get_random_port())])
             self.fabric_a_admin.start(
                 expected_output="Server initialization complete",
                 timeout=20)
@@ -217,7 +217,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.fabric_a_server_app = AppServerSubprocess(
             self.th_server_app,
             storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=random.randint(0, 4095),
             passcode=self.thserver_fabric_a_passcode,
             extra_args=["--capabilities", "0x04"])
@@ -292,14 +292,15 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.jfctrl_fabric_b_vid = random.randint(0x0001, 0xFFF0)
 
         # Start Fabric B JF-Administrator App
+        fabric_b_rpc_port = self.get_random_port()
         self.fabric_b_admin = JFAdministratorSubprocess(
             self.jfa_server_app,
             prefix="JFA-B",
             storage_dir=self.storage_fabric_b,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=random.randint(0, 4095),
             passcode=self.jfadmin_fabric_b_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33055"])
+            extra_args=["--capabilities", "0x04", "--rpc-server-port", str(fabric_b_rpc_port), "--secured-commissioner-port", str(self.get_random_port())])
         self.fabric_b_admin.start(
             expected_output="Server initialization complete",
             timeout=20)
@@ -308,7 +309,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.fabric_b_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             prefix="JFC-B",
-            rpc_server_port=33055,
+            rpc_server_port=fabric_b_rpc_port,
             storage_dir=self.storage_fabric_b,
             vendor_id=self.jfctrl_fabric_b_vid)
         self.fabric_b_ctrl.start(
@@ -349,7 +350,7 @@ class TC_JFADMIN_2_1(MatterBaseTest):
         self.fabric_b_server_app = AppServerSubprocess(
             self.th_server_app,
             storage_dir=self.storage_fabric_b,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=random.randint(0, 4095),
             passcode=self.thserver_fabric_b_passcode,
             extra_args=["--capabilities", "0x04"])

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -69,6 +69,10 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.fabric_b_server_app = None
         self.fabric_a_admin = None
         self.fabric_b_admin = None
+        self.dev_ctrl_eco_a = None
+        self.dev_ctrl_eco_b = None
+        self.joint_fabric_persistent_storage = None
+        self.joint_fabric_ca_manager = None
 
         self.jfc_server_app = self.user_params.get("jfc_server_app", None)
         if not self.jfc_server_app:
@@ -113,6 +117,16 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         if self.fabric_b_server_app is not None:
             self.fabric_b_server_app.terminate()
 
+        if self.dev_ctrl_eco_a is not None:
+            self.dev_ctrl_eco_a.Shutdown()
+            self.dev_ctrl_eco_a = None
+        if self.dev_ctrl_eco_b is not None:
+            self.dev_ctrl_eco_b.Shutdown()
+            self.dev_ctrl_eco_b = None
+        if self.joint_fabric_persistent_storage is not None:
+            self.joint_fabric_persistent_storage.Shutdown()
+            self.joint_fabric_persistent_storage = None
+
         super().teardown_class()
 
     def steps_TC_JFADMIN_2_2(self) -> list[TestStep]:
@@ -137,15 +151,10 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
 
     @async_test_body
     async def test_TC_JFADMIN_2_2(self):
-        _devCtrlEcoA = None
-        _devCtrlEcoB = None
-        _fabric_a_persistent_storage = None
-        _fabric_b_persistent_storage = None
-
-        _devCtrlEcoA = None
-        _devCtrlEcoB = None
-        _fabric_a_persistent_storage = None
-        _fabric_b_persistent_storage = None
+        self.dev_ctrl_eco_a = None
+        self.dev_ctrl_eco_b = None
+        self.joint_fabric_persistent_storage = None
+        self.joint_fabric_ca_manager = None
 
         self.step("1")
         self.jfadmin_fabric_a_passcode = random.randint(20202021, 20202099)
@@ -153,6 +162,8 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
 
         fabric_a_rpc_port = self.get_random_port()
+
+        # Start Fabric A JF-Administrator App
         self.fabric_a_admin = JFAdministratorSubprocess(
             self.jfa_server_app,
             prefix="JFA-A",
@@ -220,18 +231,18 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
             timeout=30)
 
         self.fabric_a_ctrl.send(
-            message=f"pairing onnetwork-long 2 {self.thserver_fabric_a_passcode} {self.thserver_fabric_a_discriminator}",
+            message=f"pairing onnetwork-long 2 {self.thserver_fabric_a_passcode} {self.thserver_fabric_a_discriminator} --regular true",
             expected_output="[CTL] Commissioning complete for node ID 0x0000000000000002: success",
             timeout=30)
 
-        # Creating a Controller for Ecosystem A
-        _fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
+        # Creating a unified Controller Manager for both ecosystems
+        self.joint_fabric_persistent_storage = VolatileTemporaryPersistentStorage(
             self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
-        _certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
+        self.joint_fabric_ca_manager = CertificateAuthority.CertificateAuthorityManager(
             chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_a_persistent_storage)
-        _certAuthorityManagerA.LoadAuthoritiesFromStorage()
-        _devCtrlEcoA = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+            persistentStorage=self.joint_fabric_persistent_storage)
+        self.joint_fabric_ca_manager.LoadAuthoritiesFromStorage()
+        self.dev_ctrl_eco_a = self.joint_fabric_ca_manager.activeCaList[0].adminList[0].NewController(
             nodeId=101,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoACATs, 16), int('fffe0001', 16)])
@@ -293,25 +304,25 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
 
         # Commission JF-ADMIN app with JF-Controller on Fabric B
         self.fabric_b_ctrl.send(
-            message=f"pairing onnetwork-long 11 {jfadmin_fabric_b_passcode} {jfadmin_fabric_b_discriminator} --anchor true",
+            message=f"pairing onnetwork-long 11 {jfadmin_fabric_b_passcode} {jfadmin_fabric_b_discriminator} --anchor true --commissioner-name beta",
             expected_output="[JF] Anchor Administrator (nodeId=11) commissioned with success",
             timeout=60)
 
         # Extract the Ecosystem B certificates and inject them in the storage that will be provided to a new Python Controller later
         jfcStorage = ConfigParser()
-        jfcStorage.read(self.storage_fabric_b+'/chip_tool_config.alpha.ini')
+        jfcStorage.read(self.storage_fabric_b+'/chip_tool_config.beta.ini')
         self.ecoBCtrlStorage = {
             "sdk-config": {
-                "ExampleOpCredsCAKey1": jfcStorage.get("Default", "ExampleOpCredsCAKey0"),
-                "ExampleOpCredsICAKey1": jfcStorage.get("Default", "ExampleOpCredsICAKey0"),
-                "ExampleCARootCert1": jfcStorage.get("Default", "ExampleCARootCert0"),
-                "ExampleCAIntermediateCert1": jfcStorage.get("Default", "ExampleCAIntermediateCert0"),
+                "ExampleOpCredsCAKey2": jfcStorage.get("Default", "ExampleOpCredsCAKey0"),
+                "ExampleOpCredsICAKey2": jfcStorage.get("Default", "ExampleOpCredsICAKey0"),
+                "ExampleCARootCert2": jfcStorage.get("Default", "ExampleCARootCert0"),
+                "ExampleCAIntermediateCert2": jfcStorage.get("Default", "ExampleCAIntermediateCert0"),
             },
             "repl-config": {
                 "caList": {
-                    "1": [
+                    "2": [
                         {
-                            "fabricId": 1,
+                            "fabricId": 2,
                             "vendorId": self.jfctrl_fabric_b_vid
                         }
                     ]
@@ -335,18 +346,24 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
             timeout=30)
 
         self.fabric_b_ctrl.send(
-            message=f"pairing onnetwork-long 22 {self.thserver_fabric_b_passcode} {self.thserver_fabric_b_discriminator}",
+            message=f"pairing onnetwork-long 22 {self.thserver_fabric_b_passcode} {self.thserver_fabric_b_discriminator} --commissioner-name beta --regular true",
             expected_output="[CTL] Commissioning complete for node ID 0x0000000000000016: success",
             timeout=30)
 
-        # Creating a Controller for Ecosystem B
-        _fabric_b_persistent_storage = VolatileTemporaryPersistentStorage(
-            self.ecoBCtrlStorage['repl-config'], self.ecoBCtrlStorage['sdk-config'])
-        _certAuthorityManagerB = CertificateAuthority.CertificateAuthorityManager(
-            chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_b_persistent_storage)
-        _certAuthorityManagerB.LoadAuthoritiesFromStorage()
-        _devCtrlEcoB = _certAuthorityManagerB.activeCaList[0].adminList[0].NewController(
+        # Merge Ecosystem B config into the unified storage
+        for k, v in self.ecoBCtrlStorage['sdk-config'].items():
+            self.joint_fabric_persistent_storage.SetSdkKey(k, base64.b64decode(v))
+
+        caList = self.joint_fabric_persistent_storage.GetKey('caList')
+        caList["2"] = self.ecoBCtrlStorage['repl-config']['caList']['2']
+        self.joint_fabric_persistent_storage.SetKey('caList', caList)
+
+        # Create and load CA Index 2 explicitly in the unified manager
+        ca2 = self.joint_fabric_ca_manager.NewCertificateAuthority(caIndex=2)
+        ca2.LoadFabricAdminsFromStorage()
+
+        # Retrieve active CA list index 1 (which is CA Index 2)
+        self.dev_ctrl_eco_b = self.joint_fabric_ca_manager.activeCaList[1].adminList[0].NewController(
             nodeId=201,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoBCATs, 16)])
@@ -356,7 +373,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         discriminator = random.randint(0, 4095)
 
         try:
-            response = await _devCtrlEcoB.OpenJointCommissioningWindow(
+            response = await self.dev_ctrl_eco_b.OpenJointCommissioningWindow(
                 nodeId=11,
                 endpointId=1,
                 timeout=400,
@@ -397,12 +414,12 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
 
         self.step("6")
         # nodeId=11 is the JF-Admin app's node ID on Fabric B (commissioned by fabric_b_ctrl)
-        response_b = await _devCtrlEcoB.ReadAttribute(
+        response_b = await self.dev_ctrl_eco_b.ReadAttribute(
             nodeId=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)], fabricFiltered=True,
             returnClusterObject=True)
         joint_fabric_index = response_b[0][Clusters.OperationalCredentials].currentFabricIndex
 
-        response = await _devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=1, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)], fabricFiltered=False,
             returnClusterObject=True)
 
@@ -425,14 +442,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
                 break
         asserts.assert_true(_admin_cat_found, "Administrator CAT not found in Admin App NOC on Ecosystem B")
 
-        if _devCtrlEcoA is not None:
-            _devCtrlEcoA.Shutdown()
-        if _devCtrlEcoB is not None:
-            _devCtrlEcoB.Shutdown()
-        if _fabric_a_persistent_storage is not None:
-            _fabric_a_persistent_storage.Shutdown()
-        if _fabric_b_persistent_storage is not None:
-            _fabric_b_persistent_storage.Shutdown()
+
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -443,7 +443,5 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         asserts.assert_true(_admin_cat_found, "Administrator CAT not found in Admin App NOC on Ecosystem B")
 
 
-
-
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -152,15 +152,15 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
         self.jfctrl_fabric_a_vid = random.randint(0x0001, 0xFFF0)
 
-        # Start Fabric A JF-Administrator App
+        fabric_a_rpc_port = self.get_random_port()
         self.fabric_a_admin = JFAdministratorSubprocess(
             self.jfa_server_app,
             prefix="JFA-A",
             storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=self.jfadmin_fabric_a_discriminator,
             passcode=self.jfadmin_fabric_a_passcode,
-            extra_args=["--capabilities", "0x04", "--rpc-server-port", "33033"])
+            extra_args=["--capabilities", "0x04", "--rpc-server-port", str(fabric_a_rpc_port), "--secured-commissioner-port", str(self.get_random_port())])
         self.fabric_a_admin.start(
             expected_output="Updating services using commissioning mode 1",
             timeout=30)
@@ -169,7 +169,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.fabric_a_ctrl = JFControllerSubprocess(
             self.jfc_server_app,
             prefix="JFC-A",
-            rpc_server_port=33033,
+            rpc_server_port=fabric_a_rpc_port,
             storage_dir=self.storage_fabric_a,
             vendor_id=self.jfctrl_fabric_a_vid)
         self.fabric_a_ctrl.start(
@@ -211,7 +211,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.fabric_a_server_app = AppServerSubprocess(
             self.th_server_app,
             storage_dir=self.storage_fabric_a,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=self.thserver_fabric_a_discriminator,
             passcode=self.thserver_fabric_a_passcode,
             extra_args=["--capabilities", "0x04"])
@@ -249,16 +249,16 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
             dut_rpc_server_ip = "127.0.0.1"
             jfadmin_fabric_b_passcode = random.randint(20202021, 20202099)
             jfadmin_fabric_b_discriminator = random.randint(0, 4095)
-            dut_rpc_server_port = "33055"
+            dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric B JF-Administrator App
             self.fabric_b_admin = JFAdministratorSubprocess(
                 self.jfa_server_app,
                 prefix="JFA-B",
                 storage_dir=self.storage_fabric_b,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=jfadmin_fabric_b_discriminator,
                 passcode=jfadmin_fabric_b_passcode,
-                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port])
+                extra_args=["--capabilities", "0x04", "--rpc-server-port", dut_rpc_server_port, "--secured-commissioner-port", str(self.get_random_port())])
             self.fabric_b_admin.start(
                 expected_output="Updating services using commissioning mode 1",
                 timeout=30)
@@ -326,7 +326,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         self.fabric_b_server_app = AppServerSubprocess(
             self.th_server_app,
             storage_dir=self.storage_fabric_b,
-            port=random.randint(5001, 5999),
+            port=self.get_random_port(),
             discriminator=self.thserver_fabric_b_discriminator,
             passcode=self.thserver_fabric_b_passcode,
             extra_args=["--capabilities", "0x04"])

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -123,6 +123,9 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         if self.dev_ctrl_eco_b is not None:
             self.dev_ctrl_eco_b.Shutdown()
             self.dev_ctrl_eco_b = None
+        if self.joint_fabric_ca_manager is not None:
+            self.joint_fabric_ca_manager.Shutdown()
+            self.joint_fabric_ca_manager = None
         if self.joint_fabric_persistent_storage is not None:
             self.joint_fabric_persistent_storage.Shutdown()
             self.joint_fabric_persistent_storage = None
@@ -354,7 +357,7 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         for k, v in self.ecoBCtrlStorage['sdk-config'].items():
             self.joint_fabric_persistent_storage.SetSdkKey(k, base64.b64decode(v))
 
-        caList = self.joint_fabric_persistent_storage.GetKey('caList')
+        caList = self.joint_fabric_persistent_storage.GetKey('caList') or {}
         caList["2"] = self.ecoBCtrlStorage['repl-config']['caList']['2']
         self.joint_fabric_persistent_storage.SetKey('caList', caList)
 
@@ -362,8 +365,8 @@ class TC_JFADMIN_2_2(CADMINBaseTest):
         ca2 = self.joint_fabric_ca_manager.NewCertificateAuthority(caIndex=2)
         ca2.LoadFabricAdminsFromStorage()
 
-        # Retrieve active CA list index 1 (which is CA Index 2)
-        self.dev_ctrl_eco_b = self.joint_fabric_ca_manager.activeCaList[1].adminList[0].NewController(
+        # Create Ecosystem B controller using ca2 directly
+        self.dev_ctrl_eco_b = ca2.adminList[0].NewController(
             nodeId=201,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoBCATs, 16)])

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -97,12 +97,12 @@ class TC_JFDS_2_1(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = "33033"
+            self.dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.jfadmin_fabric_a_discriminator,
                 passcode=self.jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -288,7 +288,5 @@ class TC_JFDS_2_1(MatterBaseTest):
             ])
 
 
-
-
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -64,6 +64,7 @@ class TC_JFDS_2_1(MatterBaseTest):
         self.fabric_a_server_app = None
         self.dev_ctrl_eco_a = None
         self.fabric_a_persistent_storage = None
+        self.cert_authority_manager_a = None
 
         jfc_server_app = self.user_params.get("jfc_server_app", None)
         if not jfc_server_app:
@@ -181,6 +182,9 @@ class TC_JFDS_2_1(MatterBaseTest):
         if self.dev_ctrl_eco_a is not None:
             self.dev_ctrl_eco_a.Shutdown()
             self.dev_ctrl_eco_a = None
+        if self.cert_authority_manager_a is not None:
+            self.cert_authority_manager_a.Shutdown()
+            self.cert_authority_manager_a = None
         if self.fabric_a_persistent_storage is not None:
             self.fabric_a_persistent_storage.Shutdown()
             self.fabric_a_persistent_storage = None
@@ -209,11 +213,11 @@ class TC_JFDS_2_1(MatterBaseTest):
         # Creating a Controller for Ecosystem A
         self.fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
             self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
-        _certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
+        self.cert_authority_manager_a = CertificateAuthority.CertificateAuthorityManager(
             chipStack=self.matter_stack._chip_stack,
             persistentStorage=self.fabric_a_persistent_storage)
-        _certAuthorityManagerA.LoadAuthoritiesFromStorage()
-        self.dev_ctrl_eco_a = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+        self.cert_authority_manager_a.LoadAuthoritiesFromStorage()
+        self.dev_ctrl_eco_a = self.cert_authority_manager_a.activeCaList[0].adminList[0].NewController(
             nodeId=101,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoACATs, 16)])

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -62,6 +62,8 @@ class TC_JFDS_2_1(MatterBaseTest):
         self.fabric_a_ctrl = None
         self.storage_fabric_a = self.user_params.get("fabric_a_storage", None)
         self.fabric_a_server_app = None
+        self.dev_ctrl_eco_a = None
+        self.fabric_a_persistent_storage = None
 
         jfc_server_app = self.user_params.get("jfc_server_app", None)
         if not jfc_server_app:
@@ -176,6 +178,13 @@ class TC_JFDS_2_1(MatterBaseTest):
         if self.fabric_a_server_app is not None:
             self.fabric_a_server_app.terminate()
 
+        if self.dev_ctrl_eco_a is not None:
+            self.dev_ctrl_eco_a.Shutdown()
+            self.dev_ctrl_eco_a = None
+        if self.fabric_a_persistent_storage is not None:
+            self.fabric_a_persistent_storage.Shutdown()
+            self.fabric_a_persistent_storage = None
+
         super().teardown_class()
 
     def steps_TC_JFDS_2_1(self) -> list[TestStep]:
@@ -198,19 +207,19 @@ class TC_JFDS_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_JFDS_2_1(self):
         # Creating a Controller for Ecosystem A
-        _fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
+        self.fabric_a_persistent_storage = VolatileTemporaryPersistentStorage(
             self.ecoACtrlStorage['repl-config'], self.ecoACtrlStorage['sdk-config'])
         _certAuthorityManagerA = CertificateAuthority.CertificateAuthorityManager(
             chipStack=self.matter_stack._chip_stack,
-            persistentStorage=_fabric_a_persistent_storage)
+            persistentStorage=self.fabric_a_persistent_storage)
         _certAuthorityManagerA.LoadAuthoritiesFromStorage()
-        devCtrlEcoA = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
+        self.dev_ctrl_eco_a = _certAuthorityManagerA.activeCaList[0].adminList[0].NewController(
             nodeId=101,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoACATs, 16)])
 
         # Discover endpoint with JointFabricDatastore cluster via Descriptor
-        descriptor_response = await devCtrlEcoA.ReadAttribute(
+        descriptor_response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[(Clusters.Descriptor)],
             returnClusterObject=True)
 
@@ -224,14 +233,14 @@ class TC_JFDS_2_1(MatterBaseTest):
         asserts.assert_is_not_none(jfds_endpoint, "JointFabricDatastore cluster not found on any endpoint")
 
         self.step("1")
-        response = await devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[
                 (jfds_endpoint, Clusters.JointFabricDatastore.Attributes.AnchorRootCA)],
             returnClusterObject=True)
         anchor_root_ca = response[jfds_endpoint][Clusters.JointFabricDatastore].anchorRootCA
         asserts.assert_greater_equal(len(anchor_root_ca), 1)
 
-        opcreds_response = await devCtrlEcoA.ReadAttribute(
+        opcreds_response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[
                 (0, Clusters.OperationalCredentials.Attributes.TrustedRootCertificates)],
             returnClusterObject=True)
@@ -243,21 +252,21 @@ class TC_JFDS_2_1(MatterBaseTest):
         )
 
         self.step("2")
-        response = await devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[
                 (jfds_endpoint, Clusters.JointFabricDatastore.Attributes.AnchorNodeID)],
             returnClusterObject=True)
         asserts.assert_equal(response[jfds_endpoint][Clusters.JointFabricDatastore].anchorNodeID, self.jfadmin_fabric_a_node_id)
 
         self.step("3")
-        response = await devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[
                 (jfds_endpoint, Clusters.JointFabricDatastore.Attributes.AnchorVendorID)],
             returnClusterObject=True)
         asserts.assert_equal(response[jfds_endpoint][Clusters.JointFabricDatastore].anchorVendorID, self.jfctrl_fabric_a_vid)
 
         self.step("4")
-        response = await devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[
                 (jfds_endpoint, Clusters.JointFabricDatastore.Attributes.FriendlyName)],
             returnClusterObject=True)
@@ -266,7 +275,7 @@ class TC_JFDS_2_1(MatterBaseTest):
         asserts.assert_less_equal(len(response[jfds_endpoint][Clusters.JointFabricDatastore].friendlyName), 32)
 
         self.step("5")
-        response = await devCtrlEcoA.ReadAttribute(
+        response = await self.dev_ctrl_eco_a.ReadAttribute(
             nodeId=self.jfadmin_fabric_a_node_id, attributes=[(jfds_endpoint, Clusters.JointFabricDatastore.Attributes.Status)],
             returnClusterObject=True)
         asserts.assert_in(
@@ -278,8 +287,7 @@ class TC_JFDS_2_1(MatterBaseTest):
                 Clusters.JointFabricDatastore.Enums.DatastoreStateEnum.kCommitFailed
             ])
 
-        # Shutdown the Python Controllers started at the beginning of this script
-        devCtrlEcoA.Shutdown()
+
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_JFDS_2_2.py
+++ b/src/python_testing/TC_JFDS_2_2.py
@@ -100,12 +100,12 @@ class TC_JFDS_2_2(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = "33033"
+            self.dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.jfadmin_fabric_a_discriminator,
                 passcode=self.jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])

--- a/src/python_testing/TC_JFDS_2_3.py
+++ b/src/python_testing/TC_JFDS_2_3.py
@@ -100,12 +100,12 @@ class TC_JFDS_2_3(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = "33033"
+            self.dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.jfadmin_fabric_a_discriminator,
                 passcode=self.jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])

--- a/src/python_testing/TC_JFDS_2_4.py
+++ b/src/python_testing/TC_JFDS_2_4.py
@@ -109,12 +109,12 @@ class TC_JFDS_2_4(MatterBaseTest):
             self.jfadmin_fabric_a_passcode = random.randint(110220011, 110220999)
             self.jfadmin_fabric_a_discriminator = random.randint(0, 4095)
             self.dut_rpc_server_ip = "127.0.0.1"
-            self.dut_rpc_server_port = "33033"
+            self.dut_rpc_server_port = str(self.get_random_port())
             # Start Fabric A JF-Administrator App
             self.fabric_a_admin = AppServerSubprocess(
                 jfa_server_app,
                 storage_dir=self.storage_fabric_a,
-                port=random.randint(5001, 5999),
+                port=self.get_random_port(),
                 discriminator=self.jfadmin_fabric_a_discriminator,
                 passcode=self.jfadmin_fabric_a_passcode,
                 extra_args=["--capabilities", "0x04", "--rpc-server-port", self.dut_rpc_server_port])

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -608,7 +608,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         is assumed fine.
         """
         if not hasattr(self, '_allocated_ports'):
-            self._allocated_ports = set()
+            self._allocated_ports: set[int] = set()
 
         def is_port_available(p: int) -> bool:
             import errno

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -607,29 +607,41 @@ class MatterBaseTest(base_test.BaseTestClass):
         Note that this check can be racy, but the way this function is generally used
         is assumed fine.
         """
+        if not hasattr(self, '_allocated_ports'):
+            self._allocated_ports = set()
+
         def is_port_available(p: int) -> bool:
+            import errno
             # Verify TCP and UDP on all IPv4 interfaces
             for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
                 with socket.socket(socket.AF_INET, sock_type) as s:
                     try:
                         s.bind(('', p))
-                    except OSError:
-                        return False
+                    except OSError as e:
+                        if e.errno == errno.EADDRINUSE:
+                            return False
+                        raise
+
             # Verify TCP and UDP on all IPv6 interfaces if available
             if socket.has_ipv6:
                 for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
                     with socket.socket(socket.AF_INET6, sock_type) as s:
                         try:
                             s.bind(('::', p))
-                        except OSError:
-                            return False
+                        except OSError as e:
+                            if e.errno == errno.EADDRINUSE:
+                                return False
+                            raise
             return True
 
         while True:
             # The chosen safe range (35000-45000) naturally avoids well-known bad/conflicting
             # ports like 5353 (mDNS) and 5550-5555 (Matter standard ports).
             port = random.randint(35000, 45000)
+            if port in self._allocated_ports:
+                continue
             if is_port_available(port):
+                self._allocated_ports.add(port)
                 return port
 
     #

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -645,7 +645,6 @@ class MatterBaseTest(base_test.BaseTestClass):
                 self._allocated_ports.add(port)
                 return port
 
-
     #
     # Matter Test API - Test Definition Helpers (Steps, PICS, Description)
     #

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -26,6 +26,7 @@ import queue
 import random
 import select
 import shlex
+import socket
 import subprocess
 import textwrap
 import time
@@ -599,6 +600,37 @@ class MatterBaseTest(base_test.BaseTestClass):
             List[SetupPayloadInfo]: List of Payload used by the test case
         """
         return get_setup_payload_info_config(self.matter_test_config)
+
+    def get_random_port(self) -> int:
+        """Selects a random port and checks that it is not yet in use.
+
+        Note that this check can be racy, but the way this function is generally used
+        is assumed fine.
+        """
+        def is_port_available(p: int) -> bool:
+            # Verify TCP and UDP on all IPv4 interfaces
+            for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
+                with socket.socket(socket.AF_INET, sock_type) as s:
+                    try:
+                        s.bind(('', p))
+                    except OSError:
+                        return False
+            # Verify TCP and UDP on all IPv6 interfaces if available
+            if socket.has_ipv6:
+                for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
+                    with socket.socket(socket.AF_INET6, sock_type) as s:
+                        try:
+                            s.bind(('::', p))
+                        except OSError:
+                            return False
+            return True
+
+        while True:
+            # The chosen safe range (35000-45000) naturally avoids well-known bad/conflicting
+            # ports like 5353 (mDNS) and 5550-5555 (Matter standard ports).
+            port = random.randint(35000, 45000)
+            if is_port_available(port):
+                return port
 
     #
     # Matter Test API - Test Definition Helpers (Steps, PICS, Description)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -645,6 +645,7 @@ class MatterBaseTest(base_test.BaseTestClass):
                 self._allocated_ports.add(port)
                 return port
 
+
     #
     # Matter Test API - Test Definition Helpers (Steps, PICS, Description)
     #

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -612,6 +612,7 @@ class MatterBaseTest(base_test.BaseTestClass):
 
         def is_port_available(p: int) -> bool:
             import errno
+
             # Verify TCP and UDP on all IPv4 interfaces
             for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
                 with socket.socket(socket.AF_INET, sock_type) as s:

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -171,10 +171,7 @@ not_automated:
       reason:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
-    - name: TC_JFADMIN_2_2.py
-      reason:
-          Flaky in CI.
-          https://github.com/project-chip/connectedhomeip/issues/72209
+
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -172,7 +172,6 @@ not_automated:
           Very flaky in CI.
           https://github.com/project-chip/connectedhomeip/issues/71932
 
-
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially
 # to consider improving. May not be exhaustive


### PR DESCRIPTION
### Summary

This PR addresses multiple critical failures in the Joint Fabrics Python integration tests (`TC_JFADMIN_2_1` and `TC_JFADMIN_2_2`) that resulted in controller pairing aborts, PASE/CASE timeouts, port binding conflicts, and C++ storage delegate collisions.

---

#### 1. DNS-SD Port Overwrite (C++ Core)

*   **Issue**: PASE session timeouts on JFC-A during Step 4 of the Joint Commissioning Method (JCM) flow in `TC_JFADMIN_2_1`.
*   **Root Cause**:
    *   `jfa-app` runs concurrent modalities (Server and Commissioner/Controller) in the same process.
    *   During commissioner initialization, `DeviceControllerFactory::Init` unconditionally called `app::DnssdServer::Instance().SetSecuredIPv6Port()`, overwriting the shared DNS-SD port with the commissioner's port.
    *   JFA-B therefore advertised the commissioner's port for its open commissioning window. The subsequent `PBKDFParamRequest` (MsgType `0x20`) sent by JFC-A landed on the commissioner's `ExchangeManager` instead of the Server's `ExchangeManager`. Because the commissioner lacks the unsolicited handler for MsgType `0x20`, the packet was dropped.
*   **Fix**:
    *   Added `preventDnssdPortOverwrite` boolean flag to `FactoryInitParams` in `DeviceControllerFactory`.
    *   Wrapped `SetSecuredIPv6Port` and `SetSecuredIPv4Port` calls in `CHIPDeviceControllerFactory.cpp` inside a `!params.preventDnssdPortOverwrite` check.
    *   Set `factoryParams.preventDnssdPortOverwrite = true` in `CommissionerMain.cpp` (`InitCommissioner`) since the commissioner runs alongside the primary server.

---

#### 2. Safe Port Randomization (Python Infra & Tests)

*   **Issue**: Intermittent socket bind failures (`EADDRINUSE`) during local parallel runs or collisions with common system services (e.g. mDNS on `5353`).
*   **Root Cause**: Python tests used hardcoded ports (`33033`, `33055`) or simplistic, unverified `random.randint(5001, 5999)` port selection.
*   **Fix**:
    *   Implemented a thread-safe, verify-before-bind `get_random_port()` helper in `MatterBaseTest` (`matter_testing.py`).
    *   Selects from a safe dynamic range (`35000`–`45000`) and verifies availability by performing trial TCP (`SOCK_STREAM`) and UDP (`SOCK_DGRAM`) bindings on both `0.0.0.0` and `::` interfaces.
    *   Updated JFA, JFC, and TH Server subprocesses across python tests to utilize `self.get_random_port()`.

---

#### 3. Unified Storage & Process Teardown (Python Tests)

*   **Issue**: C++ `ChipStack` storage delegate collisions and leaked background processes (`jfa-app`/`jfc-app`) running under PID 1 upon test abort, locking KVS files and ports.
*   **Root Cause**:
    *   Instantiating separate `VolatileTemporaryPersistentStorage` instances for Ecosystem A & B. Since the C++ `ChipStack` is a global singleton, it only binds the storage delegate from the first initialization, causing CASE lookups for Ecosystem B to fail with `CHIP_ERROR_NO_SHARED_TRUSTED_ROOT`.
    *   `teardown_class` lacked robust termination logic for early test aborts/timeouts.
*   **Fix**:
    *   Consolidated configurations into a single `joint_fabric_persistent_storage` and managed both controllers under a single `CertificateAuthorityManager`, dynamically loading credentials for CA Index 2.
    *   Added comprehensive `Shutdown()` and `terminate()` calls for all subprocesses and controllers in `teardown_class`.
---
### Related issues

Fixes: https://github.com/project-chip/connectedhomeip/issues/72209 (Permanently re-enables `TC_JFADMIN_2_2.py` as it is now fully verified and stable).

---

### Testing

*   Verified compilation of C++ targets:
    *   `linux-x64-jf-admin-app-no-ble`
    *   `linux-x64-jf-control-app-no-ble`
*   Verified execution of Python test scripts (all passing locally):
    *   `TC_JFADMIN_2_1.py` (PASS in 21.55s)
    *   `TC_JFADMIN_2_2.py` (PASS in 17.82s)