### PR TITLE
    [OpenThread] Persist staged Thread dataset in CommitConfiguration

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -104,6 +104,26 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // the backup, so that it cannot be restored. If no backup could be found, it means that the
     // configuration has not been modified since the fail-safe was armed, so return with no error.
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    // When Thread is a secondary transport, commissioning may complete without ConnectNetwork
+    // (which is the usual persistence path via AttachToThreadNetwork). Persist the staged dataset
+    // to OT NVS here so that a later fallback can attach to it. Does not enable the Thread interface.
+    ChipLogProgress(NetworkProvisioning, "Thread CommitConfiguration: staged=%d attached=%d",
+                    mStagingNetwork.IsCommissioned(), ThreadStackMgrImpl().IsThreadAttached());
+    if (mStagingNetwork.IsCommissioned() && !ThreadStackMgrImpl().IsThreadAttached())
+    {
+        CHIP_ERROR persistErr = ThreadStackMgrImpl().SetThreadProvision(mStagingNetwork.AsByteSpan());
+        if (persistErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(NetworkProvisioning, "Failed to persist Thread dataset: %" CHIP_ERROR_FORMAT, persistErr.Format());
+        }
+        else
+        {
+            ChipLogProgress(NetworkProvisioning, "Thread dataset persisted to OT NVS");
+        }
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
     CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName());
 
     return error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND ? CHIP_NO_ERROR : error;

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -116,6 +116,7 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
         if (persistErr != CHIP_NO_ERROR)
         {
             ChipLogError(NetworkProvisioning, "Failed to persist Thread dataset: %" CHIP_ERROR_FORMAT, persistErr.Format());
+            return persistErr;
         }
         else
         {

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -110,7 +110,7 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // to OT NVS here so that a later fallback can attach to it. Does not enable the Thread interface.
     ChipLogProgress(NetworkProvisioning, "Thread CommitConfiguration: staged=%d attached=%d", mStagingNetwork.IsCommissioned(),
                     ThreadStackMgrImpl().IsThreadAttached());
-    if (mStagingNetwork.IsCommissioned() && !ThreadStackMgrImpl().IsThreadAttached())
+    if (BackupExists() && mStagingNetwork.IsCommissioned() && !ThreadStackMgrImpl().IsThreadAttached())
     {
         CHIP_ERROR persistErr = ThreadStackMgrImpl().SetThreadProvision(mStagingNetwork.AsByteSpan());
         if (persistErr != CHIP_NO_ERROR)

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -110,7 +110,7 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // to OT NVS here so that a later fallback can attach to it. Does not enable the Thread interface.
     ChipLogProgress(NetworkProvisioning, "Thread CommitConfiguration: staged=%d attached=%d", mStagingNetwork.IsCommissioned(),
                     ThreadStackMgrImpl().IsThreadAttached());
-    if (BackupExists() && mStagingNetwork.IsCommissioned() && !ThreadStackMgrImpl().IsThreadAttached())
+    if (BackupExists() && !ThreadStackMgrImpl().IsThreadAttached())
     {
         CHIP_ERROR persistErr = ThreadStackMgrImpl().SetThreadProvision(mStagingNetwork.AsByteSpan());
         if (persistErr != CHIP_NO_ERROR)

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -108,8 +108,8 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // When Thread is a secondary transport, commissioning may complete without ConnectNetwork
     // (which is the usual persistence path via AttachToThreadNetwork). Persist the staged dataset
     // to OT NVS here so that a later fallback can attach to it. Does not enable the Thread interface.
-    ChipLogProgress(NetworkProvisioning, "Thread CommitConfiguration: staged=%d attached=%d",
-                    mStagingNetwork.IsCommissioned(), ThreadStackMgrImpl().IsThreadAttached());
+    ChipLogProgress(NetworkProvisioning, "Thread CommitConfiguration: staged=%d attached=%d", mStagingNetwork.IsCommissioned(),
+                    ThreadStackMgrImpl().IsThreadAttached());
     if (mStagingNetwork.IsCommissioned() && !ThreadStackMgrImpl().IsThreadAttached())
     {
         CHIP_ERROR persistErr = ThreadStackMgrImpl().SetThreadProvision(mStagingNetwork.AsByteSpan());


### PR DESCRIPTION
#### Summary
On devices where Thread is a secondary transport, the controller may send
AddOrUpdateThreadNetwork + CommissioningComplete without ConnectNetwork,
because commissioning completes over the primary transport. The previous
CommitConfiguration() only deleted the fail-safe backup and relied on
ConnectNetwork's AttachToThreadNetwork path to persist the dataset, so
the staged dataset was silently dropped at CommissioningComplete.

Persist the staged dataset to OpenThread NVS inside CommitConfiguration
under CHIP_DEVICE_CONFIG_ENABLE_THREAD. This aligns with the
NetworkCommissioning driver contract that specifies CommitConfiguration
is where persistence occurs at CommissioningComplete.

Adds progress logs on entry and after SetThreadProvision success so the
code path can be observed in serial logs without reproducing a failure.

#### Related issues

Fixes: #72330 

#### Testing

Tested manually on an ESP32 c6 and see that the data set is being persisted.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
