### PR TITLE
Render provisionality for commands and other elements

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/idl/MatterIdl.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/idl/MatterIdl.jinja
@@ -7,6 +7,7 @@
  optional ExtensionFieldSet extensionFieldSets[] = 5;
 #}
 
+{{- field.api_maturity | idltxt -}}
 {%- if field.qualities %}{{field.qualities | idltxt}} {% endif -%}
 {{field.data_type.name}}
 {%- if field.data_type.max_length -%} <{{field.data_type.max_length}}> {%- endif -%}
@@ -18,6 +19,7 @@
 {% macro render_struct(s) -%}{#
  Macro for the output of a complete struct
 #}
+{{- s.api_maturity | idltxt -}}
 {%- if s.is_shared%}shared {% endif -%}
 {%- if s.tag %}{{s.tag | idltxt}} {% endif -%}
 {% if s.qualities %}{{s.qualities | idltxt}} {% endif -%}
@@ -42,18 +44,18 @@ struct {{s.name}} {##}
 // This IDL was auto-generated from a parsed data structure
 
 {% for enum in idl.global_enums %}
-enum {{enum.name}} : {{ enum.base_type}} {
+{{enum.api_maturity | idltxt}}enum {{enum.name}} : {{ enum.base_type}} {
   {% for entry in enum.entries %}
-  {{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
+  {{entry.api_maturity | idltxt}}{{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
   {% endfor %}
 }
 
 {% endfor %}
 
 {%- for bitmap in idl.global_bitmaps %}
-bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
+{{bitmap.api_maturity | idltxt}}bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
   {% for entry in bitmap.entries %}
-  {{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
+  {{entry.api_maturity | idltxt}}{{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
   {% endfor %}
 }
 
@@ -72,9 +74,9 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
 
   {% for enum in cluster.enums | selectattr("is_global")%}
   /* GLOBAL:
-  enum {{enum.name}} : {{ enum.base_type}} {
+  {{enum.api_maturity | idltxt}}enum {{enum.name}} : {{ enum.base_type}} {
     {% for entry in enum.entries %}
-    {{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
+    {{entry.api_maturity | idltxt}}{{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
     {% endfor %}
   }
   */
@@ -83,9 +85,9 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
 
   {%- for bitmap in cluster.bitmaps | selectattr("is_global")%}
   /* GLOBAL:
-  bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
+  {{bitmap.api_maturity | idltxt}}bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
     {% for entry in bitmap.entries %}
-    {{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
+    {{entry.api_maturity | idltxt}}{{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
     {% endfor %}
   }
   */
@@ -100,20 +102,20 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
   {% endfor %}
 
   {%- for enum in cluster.enums | rejectattr("is_global")%}
-  {%+ if enum.is_shared%}shared {% endif -%}
+  {##}  {{enum.api_maturity | idltxt}}{% if enum.is_shared%}shared {% endif -%}
   enum {{enum.name}} : {{ enum.base_type}} {
     {% for entry in enum.entries %}
-    {{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
+    {{entry.api_maturity | idltxt}}{{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
     {% endfor %}
   }
 
   {% endfor %}
 
   {%- for bitmap in cluster.bitmaps | rejectattr("is_global")%}
-  {%+ if bitmap.is_shared%}shared {% endif -%}
+  {##}  {{bitmap.api_maturity | idltxt}}{% if bitmap.is_shared%}shared {% endif -%}
   bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
     {% for entry in bitmap.entries %}
-    {{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
+    {{entry.api_maturity | idltxt}}{{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};
     {% endfor %}
   }
 
@@ -152,7 +154,7 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
   {% if c.description %}
   /** {{c.description}} */
   {% endif %}
-  {{c.qualities | idltxt}}command {{c | command_access}}{{c.name}}(
+  {{c.api_maturity | idltxt}}{{c.qualities | idltxt}}command {{c | command_access}}{{c.name}}(
      {%- if c.input_param %}{{c.input_param}}{% endif -%}
   ): {{c.output_param}} = {{c.code}};
   {% endfor %}

--- a/scripts/py_matter_idl/matter/idl/generators/idl/MatterIdl.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/idl/MatterIdl.jinja
@@ -102,7 +102,8 @@ struct {{s.name}} {##}
   {% endfor %}
 
   {%- for enum in cluster.enums | rejectattr("is_global")%}
-  {##}  {{enum.api_maturity | idltxt}}{% if enum.is_shared%}shared {% endif -%}
+  {%+ if enum.api_maturity %}{{enum.api_maturity | idltxt}}{% endif -%}
+  {%- if enum.is_shared%}shared {% endif -%}
   enum {{enum.name}} : {{ enum.base_type}} {
     {% for entry in enum.entries %}
     {{entry.api_maturity | idltxt}}{{entry.name}} = {{entry.code}} {{-specification_name_clarification(entry)}};
@@ -112,7 +113,8 @@ struct {{s.name}} {##}
   {% endfor %}
 
   {%- for bitmap in cluster.bitmaps | rejectattr("is_global")%}
-  {##}  {{bitmap.api_maturity | idltxt}}{% if bitmap.is_shared%}shared {% endif -%}
+  {%+ if bitmap.api_maturity %}{{bitmap.api_maturity | idltxt}}{% endif -%}
+  {%- if bitmap.is_shared%}shared {% endif -%}
   bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
     {% for entry in bitmap.entries %}
     {{entry.api_maturity | idltxt}}{{entry.name}} = 0x{{"%X" | format(entry.code)}} {{-specification_name_clarification(entry)}};

--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -50,7 +50,7 @@ class PrefixCppDocComment:
             return
 
         actual_pos = self.start_pos + self.value_len
-        while content[actual_pos] in ' \t\n\r':
+        while actual_pos < len(content) and content[actual_pos] in ' \t\n\r':
             actual_pos += 1
 
         # A doc comment will apply to any supported element assuming it immediately
@@ -506,10 +506,16 @@ class MatterIdlTransformer(Transformer):
         return AddServerClusterToEndpointTransform(
             ServerClusterInstantiation(parse_meta=meta, name=cluster_id, attributes=attributes, events_emitted=events, commands=commands))
 
-    @v_args(inline=True)
-    def cluster_content(self, api_maturity, element):
+    @v_args(meta=True)
+    def cluster_content(self, meta, args):
+        api_maturity, element = args[0], args[1]
         if api_maturity is not None:
             element.api_maturity = api_maturity
+        if not self.skip_meta:
+            if isinstance(element, Attribute):
+                element.definition.parse_meta = ParseMetaData(meta)
+            elif hasattr(element, 'parse_meta'):
+                element.parse_meta = ParseMetaData(meta)
         return element
 
     @v_args(inline=True, meta=True)

--- a/scripts/py_matter_idl/matter/idl/test_idl_generator.py
+++ b/scripts/py_matter_idl/matter/idl/test_idl_generator.py
@@ -149,11 +149,12 @@ class TestIdlRendering(unittest.TestCase):
                     provisional kProvisionalBit = 0x1;
                 }
 
+                /** Test command description */
                 provisional command ProvisionalCommand(): DefaultSuccess = 0;
             }
         """
-        # Parse and render
-        parser = CreateParser(skip_meta=True, merge_globals=False)
+        # Parse and render (skip_meta must be False for comment parsing to work)
+        parser = CreateParser(skip_meta=False, merge_globals=False)
         idl = parser.parse(idl_content)
         rendered = RenderAsIdlTxt(idl)
 
@@ -165,6 +166,9 @@ class TestIdlRendering(unittest.TestCase):
         self.assertIn("provisional bitmap ProvisionalBitmap", rendered)
         self.assertIn("provisional kProvisionalBit = 0x1;", rendered)
         self.assertIn("provisional command ProvisionalCommand(): DefaultSuccess = 0;", rendered)
+
+        # Verify that doc comment is matched and rendered correctly on the provisional command
+        self.assertIn("/** Test command description */", rendered)
 
         # Also ensure roundtrip parses back to the exact same IDL
         idl2 = parser.parse(rendered)

--- a/scripts/py_matter_idl/matter/idl/test_idl_generator.py
+++ b/scripts/py_matter_idl/matter/idl/test_idl_generator.py
@@ -134,6 +134,42 @@ class TestIdlRendering(unittest.TestCase):
             # checks that data types and content is the same
             self.assertEqual(idl, idl2)
 
+    def test_maturity_rendering(self):
+        idl_content = """
+            client cluster ProvisionalCluster = 1 {
+                provisional struct ProvisionalStruct {
+                    provisional int16u provisionalField = 1;
+                }
+
+                provisional enum ProvisionalEnum : ENUM16 {
+                    provisional kProvisionalValue = 0;
+                }
+
+                provisional bitmap ProvisionalBitmap : BITMAP32 {
+                    provisional kProvisionalBit = 0x1;
+                }
+
+                provisional command ProvisionalCommand(): DefaultSuccess = 0;
+            }
+        """
+        # Parse and render
+        parser = CreateParser(skip_meta=True, merge_globals=False)
+        idl = parser.parse(idl_content)
+        rendered = RenderAsIdlTxt(idl)
+
+        # Verify that maturity words are preserved in the rendered IDL
+        self.assertIn("provisional struct ProvisionalStruct", rendered)
+        self.assertIn("provisional int16u provisionalField = 1;", rendered)
+        self.assertIn("provisional enum ProvisionalEnum", rendered)
+        self.assertIn("provisional kProvisionalValue = 0;", rendered)
+        self.assertIn("provisional bitmap ProvisionalBitmap", rendered)
+        self.assertIn("provisional kProvisionalBit = 0x1;", rendered)
+        self.assertIn("provisional command ProvisionalCommand(): DefaultSuccess = 0;", rendered)
+
+        # Also ensure roundtrip parses back to the exact same IDL
+        idl2 = parser.parse(rendered)
+        self.assertEqual(idl, idl2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### Summary

This PR lands two improvements to the Matter IDL framework to fully support `api_maturity` modifiers (e.g., `provisional`, `internal`, `deprecated`) during parsing and code generation.

1. **Fixes IDL Serialization of Maturity Modifiers**: Adds `api_maturity` serialization to the IDL generator templates to prevent metadata from being dropped during code generation.
2. **Fixes Doc-Comment Mapping on Provisional Elements**: Resolves a parsing coordinate offset bug where C++ doc comments (`/** ... */`) immediately preceding elements with `api_maturity` modifiers were silently ignored.

---

##### 1. IDL Generator (`MatterIdl.jinja`)
* Prepend `api_maturity` to the following output templates to preserve maturity metadata during rendering:
  * Struct definitions (via `render_struct` macro)
  * Struct and event field definitions (via `render_field` macro)
  * Global Enums & Bitmaps, and their entries
  * Non-global Enums & Bitmaps (using clean, idiomatic Jinja `{%+` whitespace control on conditional blocks to cleanly handle leading indentation), and their entries
  * Cluster command definitions

#####  2. IDL Parser (`matter_idl_parser.py`)
* **Doc Comment Mapping Fix**: Updated the `cluster_content` rule transformer to use `meta` coordinates (which include the `api_maturity` prefix if present). This aligns `parse_meta` coordinates of parsed elements (commands, structs, attributes, enums, bitmaps, etc.) with the actual start of the statement, ensuring doc comments are successfully matched to their respective elements.
* **Indentation Handling for Attributes**: Configured `cluster_content` to map the updated `meta` coordinate into `element.definition.parse_meta` specifically for `Attribute` objects, as their metadata is held inside the nested `Field` class.
* **Defensive Check**: Added a boundary check (`actual_pos < len(content)`) to the whitespace stripping loop inside `PrefixCppDocComment.apply_to_idl` to prevent potential `IndexError` crashes on comments placed near the end of files.

##### 3. Unit Tests (`test_idl_generator.py`)
* Added `test_maturity_rendering` to verify that maturity tags on all supported cluster elements are parsed, correctly rendered, and perfectly round-tripped.
* Added doc-comment verification on a provisional command to assert that descriptions are successfully matched and preserved.


#### Related issues

#### Testing

- CI test
- Added unittest

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
