### PR TITLE
Make clusters with external dependencies configurable

### DIFF
--- a/config/ameba/args.gni
+++ b/config/ameba/args.gni
@@ -33,6 +33,24 @@ chip_inet_config_enable_udp_endpoint = true
 
 chip_config_network_layer_ble = true
 
+# Ameba/Realtek overrides various things in c-headers that are C++ standard items. Generally
+# these get pulled via LWIP and end up overriding things like true/false/isalpha by macros.
+#
+# This results in errors in libraries used by these clusters, like:
+#
+# INFO    In file included from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/platform/platform_stdlib_rtl8721d.h:25,
+# INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/platform/platform_stdlib.h:39,
+# INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/network/include/lwipopts.h:17,
+# INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/network/lwip/lwip_v2.1.2/src/include/lwip/opt.h:51,
+# INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/network/lwip/lwip_v2.1.2/src/include/lwip/errno.h:40,
+# INFO                     from ../../../config/ameba/third_party/connectedhomeip/third_party/uriparser/repo/src/UriMemory.c:56:
+# INFO    /__w/connectedhomeip/connectedhomeip/.environment/cipd/packages/arm/arm-none-eabi/include/ctype.h:14:5: error: expected identifier or '(' before 'int'
+# INFO       14 | int isalpha (int __c);
+# INFO          |     ^~~~~~~
+# INFO    /opt/ameba/ambd_sdk_with_chip_non_NDA/component/soc/realtek/amebad/swlib/string/strproc.h:26:30: error: expected ')' before '>=' token
+# INFO       26 | #define isupper(c)      (((c)>='A')&&((c)<='Z'))
+chip_enable_push_av_stream_transport = false
+
 custom_toolchain = "//third_party/connectedhomeip/config/ameba/toolchain:ameba"
 
 pw_build_PIP_CONSTRAINTS =

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -19,6 +19,7 @@ import("${build_root}/config/compiler/compiler.gni")
 import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/ble/ble.gni")
+import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/src/tracing/tracing_args.gni")
 
@@ -49,6 +50,9 @@ if (chip_build_tests) {
 
   chip_test_group("tests") {
     deps = []
+
+    # Note: Tests for cluster with external dependencies must be included
+    # conditionally on a per-cluster chip_enable_* argument declared in lib.gni.
     tests = [
       # keep-sorted: start
       "${chip_root}/src/access/tests",
@@ -99,7 +103,6 @@ if (chip_build_tests) {
       "${chip_root}/src/app/clusters/ota-requestor/tests",
       "${chip_root}/src/app/clusters/power-topology-server/tests",
       "${chip_root}/src/app/clusters/proximity-ranging-server/tests",
-      "${chip_root}/src/app/clusters/push-av-stream-transport-server/tests",
       "${chip_root}/src/app/clusters/resource-monitoring-server/tests",
       "${chip_root}/src/app/clusters/scenes-server/tests",
       "${chip_root}/src/app/clusters/flow-measurement-server/tests",
@@ -162,6 +165,12 @@ if (chip_build_tests) {
       # "${chip_root}/src/app/clusters/commodity-tariff-server/tests",
     ]
 
+    if (chip_enable_push_av_stream_transport) {
+      tests += [
+        "${chip_root}/src/app/clusters/push-av-stream-transport-server/tests",
+      ]
+    }
+
     # Backwards compatibility uses ember mocks, so they cannot run in a "unified"
     # test build. Restrict them to specific platforms only
     if (chip_device_platform == "darwin" || chip_device_platform == "linux") {
@@ -184,14 +193,6 @@ if (chip_build_tests) {
 
     if (current_os != "zephyr") {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
-    }
-
-    if (chip_device_platform == "darwin") {
-      # Darwin does not include the uriparser submodule, which is required by
-      # push-av-stream-transport-server tests.
-      tests -= [
-        "${chip_root}/src/app/clusters/push-av-stream-transport-server/tests",
-      ]
     }
 
     if (current_os != "zephyr") {

--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -75,24 +75,4 @@ source_set("clusters") {
   if (chip_enable_push_av_stream_transport) {
     public_deps += [ "push-av-stream-transport-server" ]
   }
-
-  if (chip_device_platform == "ameba") {
-    # Ameba/Realtek overrides various things in c-headers that are C++ standard items. Generally
-    # these get pulled via LWIP and end up overriding things like true/false/isalpha by macros.
-    #
-    # This results in errors in libraries used by these clusters, like:
-    #
-    # INFO    In file included from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/platform/platform_stdlib_rtl8721d.h:25,
-    # INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/platform/platform_stdlib.h:39,
-    # INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/api/network/include/lwipopts.h:17,
-    # INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/network/lwip/lwip_v2.1.2/src/include/lwip/opt.h:51,
-    # INFO                     from /opt/ameba/ambd_sdk_with_chip_non_NDA/component/common/network/lwip/lwip_v2.1.2/src/include/lwip/errno.h:40,
-    # INFO                     from ../../../config/ameba/third_party/connectedhomeip/third_party/uriparser/repo/src/UriMemory.c:56:
-    # INFO    /__w/connectedhomeip/connectedhomeip/.environment/cipd/packages/arm/arm-none-eabi/include/ctype.h:14:5: error: expected identifier or '(' before 'int'
-    # INFO       14 | int isalpha (int __c);
-    # INFO          |     ^~~~~~~
-    # INFO    /opt/ameba/ambd_sdk_with_chip_non_NDA/component/soc/realtek/amebad/swlib/string/strproc.h:26:30: error: expected ')' before '>=' token
-    # INFO       26 | #define isupper(c)      (((c)>='A')&&((c)<='Z'))
-    public_deps -= [ "push-av-stream-transport-server" ]
-  }
 }

--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
+import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 
 source_set("clusters") {
+  # Note: Cluster with external dependencies must be included conditionally
+  # on a per-cluster chip_enable_* argument declared in lib.gni.
   public_deps = [
     # keep-sorted: start
     "access-control-server",
@@ -50,7 +53,6 @@ source_set("clusters") {
     "operational-credentials-server",
     "pressure-measurement-server",
     "proximity-ranging-server",
-    "push-av-stream-transport-server",
     "relative-humidity-measurement-server",
     "resource-monitoring-server",
     "scenes-server",
@@ -70,6 +72,10 @@ source_set("clusters") {
     # keep-sorted: end
   ]
 
+  if (chip_enable_push_av_stream_transport) {
+    public_deps += [ "push-av-stream-transport-server" ]
+  }
+
   if (chip_device_platform == "ameba") {
     # Ameba/Realtek overrides various things in c-headers that are C++ standard items. Generally
     # these get pulled via LWIP and end up overriding things like true/false/isalpha by macros.
@@ -87,12 +93,6 @@ source_set("clusters") {
     # INFO          |     ^~~~~~~
     # INFO    /opt/ameba/ambd_sdk_with_chip_non_NDA/component/soc/realtek/amebad/swlib/string/strproc.h:26:30: error: expected ')' before '>=' token
     # INFO       26 | #define isupper(c)      (((c)>='A')&&((c)<='Z'))
-    public_deps -= [ "push-av-stream-transport-server" ]
-  }
-
-  if (chip_device_platform == "darwin") {
-    # Darwin does not include the uriparser submodule, which is required by
-    # push-av-stream-transport-server.
     public_deps -= [ "push-av-stream-transport-server" ]
   }
 }

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -109,6 +109,7 @@ declare -a args=(
     'chip_build_controller_dynamic_server=false'
     'chip_build_tools=false'
     'chip_build_tests=false'
+    'chip_enable_all_clusters=false'
     'chip_enable_wifi=false'
     'chip_enable_nfc_based_commissioning=true'
     'chip_enable_python_modules=false'
@@ -237,6 +238,6 @@ find_in_ancestors() {
     # generate and build
     set -x
     gn --root="$CHIP_ROOT" gen --check out --args="${args[*]}"
-    ninja -C out -v
+    ninja -C out -v src/lib:lib # build libCHIP
     ninja -C out -t missingdeps
 }

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/config/recommended.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
 declare_args() {
@@ -35,4 +36,13 @@ declare_args() {
   # This is to allow cmake-based systems to have a CodegenProcessingConfig available
   # since the build config headers are processed as part of gn processing.
   chip_build_enable_codegen_configuration = true
+
+  # Default value for libchip_enable_*_cluster arguments.
+  # Setting this to false allows individual required clusters to be enabled via opt-in.
+  chip_enable_all_clusters = matter_enable_recommended
+}
+
+declare_args() {
+  # Enable the push-av-stream-transport cluster server
+  chip_enable_push_av_stream_transport = chip_enable_all_clusters
 }

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -37,12 +37,13 @@ declare_args() {
   # since the build config headers are processed as part of gn processing.
   chip_build_enable_codegen_configuration = true
 
-  # Default value for libchip_enable_*_cluster arguments.
-  # Setting this to false allows individual required clusters to be enabled via opt-in.
+  # Default value for libchip_enable_*_cluster arguments that control whether clusters
+  # with external dependencies get built. The default (via matter_enable_recommended)
+  # is true. Setting this to false allows individual required clusters to be enabled via opt-in.
   chip_enable_all_clusters = matter_enable_recommended
 }
 
 declare_args() {
-  # Enable the push-av-stream-transport cluster server
+  # Enable the push-av-stream-transport cluster server (depends on uriparser)
   chip_enable_push_av_stream_transport = chip_enable_all_clusters
 }


### PR DESCRIPTION
#### Summary

This adds the chip_enable_push_av_stream_transport build setting, because the
push av cluster depends on uriparser, which is not present on all platforms.
The chip_enable_all_clusters meta-setting is introduced so builds can be
configured based on which clusters to include rather than which to exclude.
Note that clusters without external dependencies are currently always built.

#### Testing

CI.