### PR TITLE
Thread: continuous discovery

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1228,6 +1228,15 @@ static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE
 #define CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART 1
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS
+ *
+ * The interval in milliseconds between two seeker attempts in Thread Rendezvous.
+ */
+#ifndef CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS
+#define CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS 0
+#endif
+
 // -------------------- Network Telemetry Configuration --------------------
 
 /**

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -154,6 +154,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG=${chip_device_config_enable_dynamic_mrp_config}",
       "CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF=${chip_device_config_enable_wifipaf}",
       "CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP=${chip_device_config_enable_thread_meshcop}",
+      "CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS=${chip_device_config_thread_discovery_interval_ms}",
     ]
 
     _enable_joint_fabric = chip_device_config_enable_joint_fabric

--- a/src/platform/Linux/ThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl_OpenThread.cpp
@@ -67,8 +67,16 @@ CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()
 void ThreadStackManagerImpl::PrepareEvents(int & maxfd, fd_set & readfds, fd_set & writefds, fd_set & exceptfds,
                                            struct timeval & timeout)
 {
+    struct timeval timeoutOpenThread = timeout;
+
     otTaskletsProcess(OTInstance());
-    otSysUpdateEvents(OTInstance(), &maxfd, &readfds, &writefds, &exceptfds, &timeout);
+    otSysUpdateEvents(OTInstance(), &maxfd, &readfds, &writefds, &exceptfds, &timeoutOpenThread);
+
+    if (timeoutOpenThread.tv_sec < timeout.tv_sec ||
+        (timeoutOpenThread.tv_sec == timeout.tv_sec && timeoutOpenThread.tv_usec < timeout.tv_usec))
+    {
+        timeout = timeoutOpenThread;
+    }
 }
 
 void ThreadStackManagerImpl::ProcessEvents(const fd_set & readfds, const fd_set & writefds, const fd_set & exceptfds)

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -164,6 +164,9 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
     static otSeekerVerdict _HandleSeekerScanEvaluator(void * aContext, const otSeekerScanResult * aResult);
     static void _HandleRendezvousRetransmissionTimer(System::Layer * aLayer, void * aAppState);
+#if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
+    static void _HandleSeekerRestartTimer(System::Layer * aLayer, void * aAppState);
+#endif
     void SendRendezvousAnnouncement();
 #endif
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -882,6 +882,9 @@ template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_CancelRendezvousAnnouncement()
 {
     DeviceLayer::SystemLayer().CancelTimer(_HandleRendezvousRetransmissionTimer, this);
+#if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
+    DeviceLayer::SystemLayer().CancelTimer(_HandleSeekerRestartTimer, this);
+#endif
     mRendezvousRetransmissionCount = 0;
 }
 
@@ -961,6 +964,7 @@ template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::TryNextNetwork()
 {
     otSockAddr targetAddr;
+    bool isRunning = otSeekerIsRunning(mOTInst);
 
     if (otSeekerSetUpNextConnection(mOTInst, &targetAddr) == OT_ERROR_NONE)
     {
@@ -969,13 +973,25 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::TryNextNetwork()
 
         DeviceLayer::SystemLayer().ScheduleLambda([this]() { SendRendezvousAnnouncement(); });
     }
-    else if (otSeekerIsRunning(mOTInst))
+    else if (isRunning)
     {
         otSeekerStop(mOTInst);
 
+#if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
+        CHIP_ERROR err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS),
+                                                              _HandleSeekerRestartTimer, this);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Failed to start Thread discovery timer: %" CHIP_ERROR_FORMAT, err.Format());
+        } else {
+            ChipLogProgress(DeviceLayer, "Restart Thread discovery in %d ms", CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS);
+        }
+
+#else
         auto err = MapOpenThreadError(otSeekerStart(mOTInst, _HandleSeekerScanEvaluator, this));
 
-        ChipLogProgress(DeviceLayer, "Restart rendezvous: %s", chip::ErrorStr(err));
+        ChipLogProgress(DeviceLayer, "Thread Discovery restarted, no delay: %s", chip::ErrorStr(err));
+#endif
     }
 }
 
@@ -995,9 +1011,13 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%u", mRendezvousRetransmissionCount);
-            DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
-                                                  _HandleRendezvousRetransmissionTimer, this);
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%u in %d ms", mRendezvousRetransmissionCount, kRendezvousRetransmissionIntervalMs);
+            err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
+                                                       _HandleRendezvousRetransmissionTimer, this);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Failed to start rendezvous retransmission timer: %" CHIP_ERROR_FORMAT, err.Format());
+            }
         }
         else
         {
@@ -1020,6 +1040,19 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HandleRendezvousRetra
     auto * self = static_cast<GenericThreadStackManagerImpl_OpenThread *>(aAppState);
     self->SendRendezvousAnnouncement();
 }
+
+#if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HandleSeekerRestartTimer(System::Layer * aLayer,
+                                                                                    void * aAppState)
+{
+    auto * self = static_cast<GenericThreadStackManagerImpl_OpenThread *>(aAppState);
+    self->Impl()->LockThreadStack();
+    auto err = MapOpenThreadError(otSeekerStart(self->mOTInst, _HandleSeekerScanEvaluator, self));
+    self->Impl()->UnlockThreadStack();
+    ChipLogProgress(DeviceLayer, "Thread Discovery restarted: %s", chip::ErrorStr(err));
+}
+#endif
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -978,17 +978,19 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::TryNextNetwork()
         otSeekerStop(mOTInst);
 
 #if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
-        CHIP_ERROR err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS),
-                                                              _HandleSeekerRestartTimer, this);
+        CHIP_ERROR err = DeviceLayer::SystemLayer().StartTimer(
+            System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS), _HandleSeekerRestartTimer, this);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "Failed to start Thread discovery timer: %" CHIP_ERROR_FORMAT, err.Format());
-        } else {
+        }
+        else
+        {
             ChipLogProgress(DeviceLayer, "Restart Thread discovery in %d ms", CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS);
         }
 
 #else
-        auto err = MapOpenThreadError(otSeekerStart(mOTInst, _HandleSeekerScanEvaluator, this));
+        auto err      = MapOpenThreadError(otSeekerStart(mOTInst, _HandleSeekerScanEvaluator, this));
 
         ChipLogProgress(DeviceLayer, "Thread Discovery restarted, no delay: %s", chip::ErrorStr(err));
 #endif
@@ -1011,9 +1013,10 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%u in %d ms", mRendezvousRetransmissionCount, kRendezvousRetransmissionIntervalMs);
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%u in %d ms", mRendezvousRetransmissionCount,
+                            kRendezvousRetransmissionIntervalMs);
             err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
-                                                       _HandleRendezvousRetransmissionTimer, this);
+                                                        _HandleRendezvousRetransmissionTimer, this);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(DeviceLayer, "Failed to start rendezvous retransmission timer: %" CHIP_ERROR_FORMAT, err.Format());
@@ -1043,8 +1046,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HandleRendezvousRetra
 
 #if CHIP_DEVICE_CONFIG_THREAD_DISCOVERY_INTERVAL_MS > 0
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HandleSeekerRestartTimer(System::Layer * aLayer,
-                                                                                    void * aAppState)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HandleSeekerRestartTimer(System::Layer * aLayer, void * aAppState)
 {
     auto * self = static_cast<GenericThreadStackManagerImpl_OpenThread *>(aAppState);
     self->Impl()->LockThreadStack();

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -147,6 +147,9 @@ declare_args() {
   chip_device_config_enable_thread_meshcop =
       chip_device_platform == "linux" &&
       chip_system_config_use_openthread_inet_endpoints
+
+  # The interval in milliseconds between two Thread discovery attempts in Thread Rendezvous.
+  chip_device_config_thread_discovery_interval_ms = 0
 }
 
 declare_args() {


### PR DESCRIPTION
#### Summary

This commit adds supports to send Thread discovery requests with a configured interval.

With this change, the device maker may configure the `chip_device_config_thread_discovery_interval_ms` to specify the intervals between two Thread discovery request train attempts.

If `chip_device_config_thread_discovery_interval_ms` is 5000, then a node failed to finish commissioning will pause for 5 seconds before sending the next train of Thread discovery requests.

#### Related issues

This is to optimize the potential power consumption for devices supporting Matter commissioning over Thread.

#### Testing

I built the chip-all-clusters-app and observed the discovery requests message and verified that the rendezvous messages will continue to send with the interval configured.