### PR TITLE
[Silabs] SPAKE2+ verifier fixed for Si917.

### DIFF
--- a/src/platform/silabs/SiWx/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/silabs/SiWx/CHIPCryptoPALTinyCrypt.cpp
@@ -878,8 +878,13 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const uint8_t * in, size_t in_l
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
+    // Warning: SPAKE2+ Generate uses `kSpake2p_WS_Length = kP256_FE_Length + 8`
+    // (40-byte) > NUM_ECC_BYTES (32-byte)
     uECC_word_t tmp[2 * NUM_ECC_WORDS] = { 0 };
-    uECC_vli_bytesToNative(tmp, in, NUM_ECC_BYTES);
+
+    VerifyOrReturnError(in_len <= sizeof(tmp), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uECC_vli_bytesToNative(tmp, in, static_cast<int>(in_len));
 
     uECC_vli_mmod((uECC_word_t *) fe, tmp, curve_n);
 
@@ -1003,14 +1008,17 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result       = UECC_SUCCESS;
 
-    result = UECC_SUCCESS;
-    uECC_word_t tmp[2 * NUM_ECC_WORDS];
-    uECC_word_t w1_bn[NUM_ECC_WORDS];
-    uECC_word_t L_tmp[2 * NUM_ECC_WORDS];
+    // Warning: SPAKE2+ Generate uses `kSpake2p_WS_Length = kP256_FE_Length + 8`
+    // (40-byte) > NUM_ECC_BYTES (32-byte)
+    uECC_word_t tmp[2 * NUM_ECC_WORDS]   = { 0 };
+    uECC_word_t w1_bn[NUM_ECC_WORDS]     = { 0 };
+    uECC_word_t L_tmp[2 * NUM_ECC_WORDS] = { 0 };
 
-    uECC_vli_bytesToNative(tmp, w1sin, NUM_ECC_BYTES);
+    VerifyOrExit(w1sin_len <= sizeof(tmp), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    uECC_vli_bytesToNative(tmp, w1sin, static_cast<int>(w1sin_len));
 
     uECC_vli_mmod(w1_bn, tmp, curve_n);
 

--- a/src/platform/silabs/SiWx/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/silabs/SiWx/CHIPCryptoPALTinyCrypt.cpp
@@ -878,11 +878,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const uint8_t * in, size_t in_l
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
-    // Warning: SPAKE2+ Generate uses `kSpake2p_WS_Length = kP256_FE_Length + 8`
-    // (40-byte) > NUM_ECC_BYTES (32-byte)
     uECC_word_t tmp[2 * NUM_ECC_WORDS] = { 0 };
 
+    VerifyOrReturnError(in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(in_len <= sizeof(tmp), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError((in_len % sizeof(uECC_word_t)) == 0, CHIP_ERROR_INVALID_ARGUMENT);
 
     uECC_vli_bytesToNative(tmp, in, static_cast<int>(in_len));
 
@@ -1010,13 +1010,13 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = UECC_SUCCESS;
 
-    // Warning: SPAKE2+ Generate uses `kSpake2p_WS_Length = kP256_FE_Length + 8`
-    // (40-byte) > NUM_ECC_BYTES (32-byte)
     uECC_word_t tmp[2 * NUM_ECC_WORDS]   = { 0 };
     uECC_word_t w1_bn[NUM_ECC_WORDS]     = { 0 };
     uECC_word_t L_tmp[2 * NUM_ECC_WORDS] = { 0 };
 
+    VerifyOrExit(w1sin != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(w1sin_len <= sizeof(tmp), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit((w1sin_len % sizeof(uECC_word_t)) == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     uECC_vli_bytesToNative(tmp, w1sin, static_cast<int>(w1sin_len));
 


### PR DESCRIPTION
#### Summary

The SPAKE2+ algorithm uses `kSpake2p_WS_Length = kP256_FE_Length + 8` (40 bytes), but there are two methods in `CHIPCryptoPALTinyCrypt.cpp` that assumes 32 byte inputs:  `Spake2p_P256_SHA256_HKDF_HMAC::ComputeL`, and  `Spake2p_P256_SHA256_HKDF_HMAC::FELoad`, truncating the actual value. This causes an incorrect output `Crypto::Spake2pVerifier::Generate`.

#### Related issues

[MATTER-5716](https://jira.silabs.com/browse/MATTER-5716).

#### Testing

SPAKE2+ Verifier generated in BRD4338A (Si917) using the inputs from `TestOnlyCommissionableDataProvider`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
