### PR TITLE
[Silabs] ot-efr32 repo removal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,11 +66,6 @@
 	path = third_party/openthread/ot-qorvo
 	url = https://github.com/openthread/ot-qorvo.git
 	platforms = qpg
-[submodule "third_party/openthread/ot-efr32"]
-	path = third_party/openthread/ot-efr32
-	url = https://github.com/SiliconLabs/ot-efr32.git
-	branch  = matter_sve
-	platforms = silabs,silabs_docker
 [submodule "ot-stm32"]
 	path = third_party/openthread/ot-stm32
 	url = https://github.com/openthread/openthread

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -230,11 +230,6 @@ else
                 optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
                 shift
                 ;;
-            # Option not to be used until ot-efr32 github is updated
-            # --use_ot_github_sources)
-            #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
-            #    shift
-            #    ;;
             --release)
                 optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false sl_uart_log_output=false "
                 shift


### PR DESCRIPTION
#### Summary

The ot-efr32 submodule refers to a branch that had not seen commits in 4 years.

The gn_silabs_example.sh had commented out its usage a long time ago with no usage foreseen in the near future.

We are therefore removing the submodule.

#### Related issues

n/a

#### Testing

CI will test this.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
