### PR TITLE
Pass through NotifySubscriptionStillActive in ClusterStateCache

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -228,6 +228,12 @@ CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::UpdateEventCache(const Even
 }
 
 template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::NotifySubscriptionStillActive(const ReadClient & aReadClient)
+{
+    mCallback.NotifySubscriptionStillActive(aReadClient);
+}
+
+template <bool CanEnableDataCaching>
 void ClusterStateCacheT<CanEnableDataCaching>::OnReportBegin()
 {
     mLastReportDataPath = ConcreteClusterPath(kInvalidEndpointId, kInvalidClusterId);

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -665,6 +665,7 @@ private:
     //
     // ReadClient::Callback
     //
+    void NotifySubscriptionStillActive(const ReadClient & aReadClient) override;
     void OnReportBegin() override;
     void OnReportEnd() override;
     void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2529,9 +2529,9 @@ void TestReadInteraction::TestSubscribeWithCache()
         // Advance clock by MaxInterval without making anything dirty -> should trigger keep-alive
         System::Clock::Timeout delta2 = System::Clock::Seconds16(readPrepareParams.mMaxIntervalCeilingSeconds);
         gMockClock.AdvanceMonotonic(delta2);
+        cacheCallback.Reset();
         GetIOContext().DriveIO(); // Trigger timer and schedule run
 
-        cacheCallback.Reset();
         DrainAndServiceIO();
 
         EXPECT_EQ(cacheCallback.mNotifySubscriptionStillActiveCalledCount, 1);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2492,6 +2492,15 @@ void TestReadInteraction::TestSubscribeWithCache()
 
         DrainAndServiceIO();
 
+        auto * engine = chip::app::InteractionModelEngine::GetInstance();
+        EXPECT_EQ(engine->GetNumActiveReadHandlers(), 1u);
+        ASSERT_NE(engine->ActiveHandlerAt(0), nullptr);
+        auto & readHandler = *engine->ActiveHandlerAt(0);
+
+        uint16_t minInterval;
+        uint16_t maxInterval;
+        readHandler.GetReportingIntervals(minInterval, maxInterval);
+
         // Priming report should have been received.
         EXPECT_EQ(cacheCallback.mOnReportBeginCalledCount, 1);
         EXPECT_EQ(cacheCallback.mOnReportEndCalledCount, 1);
@@ -2507,7 +2516,7 @@ void TestReadInteraction::TestSubscribeWithCache()
 
         // Case 1: NON-EMPTY report (data update)
         // Trigger report after subscription established -> should call NotifySubscriptionStillActive
-        System::Clock::Timeout delta1 = System::Clock::Seconds16(readPrepareParams.mMinIntervalFloorSeconds);
+        System::Clock::Timeout delta1 = System::Clock::Seconds16(minInterval);
         gMockClock.AdvanceMonotonic(delta1);
 
         chip::app::AttributePathParams dirtyPath;
@@ -2527,7 +2536,7 @@ void TestReadInteraction::TestSubscribeWithCache()
 
         // Case 2: EMPTY report (keep-alive)
         // Advance clock by MaxInterval without making anything dirty -> should trigger keep-alive
-        System::Clock::Timeout delta2 = System::Clock::Seconds16(readPrepareParams.mMaxIntervalCeilingSeconds);
+        System::Clock::Timeout delta2 = System::Clock::Seconds16(maxInterval);
         gMockClock.AdvanceMonotonic(delta2);
         cacheCallback.Reset();
         GetIOContext().DriveIO(); // Trigger timer and schedule run
@@ -2541,7 +2550,7 @@ void TestReadInteraction::TestSubscribeWithCache()
         EXPECT_EQ(cacheCallback.GetSubscriptionUptime(), delta1 + delta2);
 
         // Case 3: Another NON-EMPTY report
-        System::Clock::Timeout delta3 = System::Clock::Seconds16(readPrepareParams.mMinIntervalFloorSeconds);
+        System::Clock::Timeout delta3 = System::Clock::Seconds16(minInterval);
         gMockClock.AdvanceMonotonic(delta3);
         EXPECT_EQ(chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath), CHIP_NO_ERROR);
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -19,9 +19,9 @@
 
 #include <access/examples/PermissiveAccessControlDelegate.h>
 #include <app/AttributeValueEncoder.h>
+#include <app/ClusterStateCache.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
-#include <app/ClusterStateCache.h>
 #include <app/InteractionModelHelper.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/EventDataIB.h>

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -21,6 +21,7 @@
 #include <app/AttributeValueEncoder.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
+#include <app/ClusterStateCache.h>
 #include <app/InteractionModelHelper.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/EventDataIB.h>
@@ -584,6 +585,7 @@ public:
     void TestSubscribeUrgentWildcardEvent();
     void TestSubscribeWildcard();
     void TestSubscriptionReportWithDefunctSession();
+    void TestSubscribeWithCache();
 
     enum class ReportType : uint8_t
     {
@@ -2406,6 +2408,158 @@ void TestReadInteraction::TestSubscribeRoundtrip()
     EXPECT_EQ(engine->GetNumActiveReadClients(), 0u);
     engine->Shutdown();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
+class IntegrationCacheCallback : public ClusterStateCache::Callback
+{
+public:
+    void Reset()
+    {
+        mOnDoneCalledCount                        = 0;
+        mOnReportBeginCalledCount                 = 0;
+        mOnReportEndCalledCount                   = 0;
+        mOnAttributeChangedCalledCount            = 0;
+        mNotifySubscriptionStillActiveCalledCount = 0;
+        mOnSubscriptionEstablishedCalledCount     = 0;
+    }
+
+    void OnDone(ReadClient * apReadClient) override { mOnDoneCalledCount++; }
+    void OnReportBegin() override { mOnReportBeginCalledCount++; }
+    void OnReportEnd() override { mOnReportEndCalledCount++; }
+    void OnAttributeChanged(ClusterStateCache * cache, const ConcreteAttributePath & path) override
+    {
+        mOnAttributeChangedCalledCount++;
+    }
+    void NotifySubscriptionStillActive(const ReadClient & aReadClient) override
+    {
+        mNotifySubscriptionStillActiveCalledCount++;
+        System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
+        if (mLastLivenessTime != System::Clock::kZero)
+        {
+            mSubscriptionUptime += std::chrono::duration_cast<System::Clock::Timeout>(now - mLastLivenessTime);
+        }
+        mLastLivenessTime = now;
+    }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    {
+        mOnSubscriptionEstablishedCalledCount++;
+        mSubscriptionEstablishmentTime = System::SystemClock().GetMonotonicTimestamp();
+        mLastLivenessTime              = mSubscriptionEstablishmentTime;
+        mSubscriptionUptime            = System::Clock::kZero;
+    }
+
+    System::Clock::Timeout GetSubscriptionUptime() const { return mSubscriptionUptime; }
+
+    int mOnDoneCalledCount                        = 0;
+    int mOnReportBeginCalledCount                 = 0;
+    int mOnReportEndCalledCount                   = 0;
+    int mOnAttributeChangedCalledCount            = 0;
+    int mNotifySubscriptionStillActiveCalledCount = 0;
+    int mOnSubscriptionEstablishedCalledCount     = 0;
+
+private:
+    System::Clock::Timestamp mSubscriptionEstablishmentTime = System::Clock::kZero;
+    System::Clock::Timestamp mLastLivenessTime              = System::Clock::kZero;
+    System::Clock::Timeout mSubscriptionUptime              = System::Clock::kZero;
+};
+
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteraction, TestSubscribeWithCache)
+TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteractionSync, TestSubscribeWithCache)
+void TestReadInteraction::TestSubscribeWithCache()
+{
+    // Test that ClusterStateCache correctly forwards all subscription reporting lifecycle callbacks
+    // (such as OnReportBegin, OnReportEnd, OnAttributeChanged, and NotifySubscriptionStillActive)
+    // to the registered application callback. This also verifies that we can track subscription
+    // liveness and uptime from the application callback.
+    IntegrationCacheCallback cacheCallback;
+    ClusterStateCache cache(cacheCallback);
+
+    ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+    chip::app::AttributePathParams attributePathParams[1];
+    readPrepareParams.mpAttributePathParamsList                 = attributePathParams;
+    readPrepareParams.mpAttributePathParamsList[0].mEndpointId  = kTestEndpointId;
+    readPrepareParams.mpAttributePathParamsList[0].mClusterId   = kTestClusterId;
+    readPrepareParams.mpAttributePathParamsList[0].mAttributeId = 1;
+    readPrepareParams.mAttributePathParamsListSize              = 1;
+    readPrepareParams.mMinIntervalFloorSeconds                  = 1;
+    readPrepareParams.mMaxIntervalCeilingSeconds                = 2;
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
+                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Subscribe);
+
+        EXPECT_EQ(readClient.SendRequest(readPrepareParams), CHIP_NO_ERROR);
+
+        DrainAndServiceIO();
+
+        // Priming report should have been received.
+        EXPECT_EQ(cacheCallback.mOnReportBeginCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportEndCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnAttributeChangedCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mNotifySubscriptionStillActiveCalledCount, 0); // Not called for priming report
+        EXPECT_EQ(cacheCallback.mOnSubscriptionEstablishedCalledCount, 1);
+
+        // Initial uptime should be 0
+        EXPECT_EQ(cacheCallback.GetSubscriptionUptime(), System::Clock::kZero);
+
+        TLV::TLVReader reader;
+        EXPECT_EQ(cache.Get(ConcreteAttributePath(kTestEndpointId, kTestClusterId, 1), reader), CHIP_NO_ERROR);
+
+        // Case 1: NON-EMPTY report (data update)
+        // Trigger report after subscription established -> should call NotifySubscriptionStillActive
+        System::Clock::Timeout delta1 = System::Clock::Seconds16(readPrepareParams.mMinIntervalFloorSeconds);
+        gMockClock.AdvanceMonotonic(delta1);
+
+        chip::app::AttributePathParams dirtyPath;
+        dirtyPath.mEndpointId  = kTestEndpointId;
+        dirtyPath.mClusterId   = kTestClusterId;
+        dirtyPath.mAttributeId = 1;
+        EXPECT_EQ(chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath), CHIP_NO_ERROR);
+
+        cacheCallback.Reset();
+        DrainAndServiceIO();
+
+        EXPECT_EQ(cacheCallback.mNotifySubscriptionStillActiveCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportBeginCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportEndCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnAttributeChangedCalledCount, 1);
+        EXPECT_EQ(cacheCallback.GetSubscriptionUptime(), delta1);
+
+        // Case 2: EMPTY report (keep-alive)
+        // Advance clock by MaxInterval without making anything dirty -> should trigger keep-alive
+        System::Clock::Timeout delta2 = System::Clock::Seconds16(readPrepareParams.mMaxIntervalCeilingSeconds);
+        gMockClock.AdvanceMonotonic(delta2);
+        GetIOContext().DriveIO(); // Trigger timer and schedule run
+
+        cacheCallback.Reset();
+        DrainAndServiceIO();
+
+        EXPECT_EQ(cacheCallback.mNotifySubscriptionStillActiveCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportBeginCalledCount, 0); // No data, so no ReportBegin
+        EXPECT_EQ(cacheCallback.mOnReportEndCalledCount, 0);   // No data, so no ReportEnd
+        EXPECT_EQ(cacheCallback.mOnAttributeChangedCalledCount, 0);
+        EXPECT_EQ(cacheCallback.GetSubscriptionUptime(), delta1 + delta2);
+
+        // Case 3: Another NON-EMPTY report
+        System::Clock::Timeout delta3 = System::Clock::Seconds16(readPrepareParams.mMinIntervalFloorSeconds);
+        gMockClock.AdvanceMonotonic(delta3);
+        EXPECT_EQ(chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath), CHIP_NO_ERROR);
+
+        cacheCallback.Reset();
+        DrainAndServiceIO();
+
+        EXPECT_EQ(cacheCallback.mNotifySubscriptionStillActiveCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportBeginCalledCount, 1);
+        EXPECT_EQ(cacheCallback.mOnReportEndCalledCount, 1);
+        EXPECT_EQ(cacheCallback.GetSubscriptionUptime(), delta1 + delta2 + delta3);
+
+        chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
+    }
+
+    DrainAndServiceIO();
+    EXPECT_EQ(cacheCallback.mOnDoneCalledCount, 1);
+
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
 }
 
 TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteraction, TestSubscribeEarlyReport)


### PR DESCRIPTION
This callback is important for maintaining liveness statistics (eg, uptime of the subscription in the absence of reported data).

#### Summary

ClusterStateCache drops the NotifySubscriptionStillActive callback rather than forwarding it to the client. Update
it to pass through the notification, consistent with other reporting lifecycle notifications (OnReportBegin/End).


#### Testing

Updated TestReadInteraction to validate passthrough, and accumulate subscription uptime as an example use case.