### PR TITLE
[Chef] Enable Pw write access for concentration measurement clusters

### DIFF
--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -401,11 +401,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode MeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetMeasuredValue(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set MeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
@@ -415,11 +417,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode PeakMeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetPeakMeasuredValue(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set PeakMeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
@@ -429,11 +433,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode PeakMeasuredValueWindow: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetPeakMeasuredValueWindow(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set PeakMeasuredValueWindow: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
@@ -443,11 +449,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode AverageMeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetAverageMeasuredValue(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set AverageMeasuredValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
@@ -457,11 +465,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode AverageMeasuredValueWindow: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetAverageMeasuredValueWindow(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set AverageMeasuredValueWindow: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();
@@ -471,11 +481,13 @@ public:
                 CHIP_ERROR err = decoder.Decode(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to decode LevelValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 err = cluster->SetLevelValue(value);
                 if (err != CHIP_NO_ERROR)
                 {
+                    ChipLogError(Zcl, "[Pw] Failed to set LevelValue: %" CHIP_ERROR_FORMAT, err.Format());
                     return ::pw::Status::Internal();
                 }
                 return ::pw::OkStatus();

--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -366,7 +366,7 @@ public:
             }
             break;
 #endif // MATTER_DM_BOOLEAN_STATE_CONFIGURATION_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-#if MATTER_DM_CONCENTRATION_MEASUREMENT_WANTED
+#if defined(MATTER_DM_CONCENTRATION_MEASUREMENT_WANTED)
         case CarbonDioxideConcentrationMeasurement::Id:
         case CarbonMonoxideConcentrationMeasurement::Id:
         case NitrogenDioxideConcentrationMeasurement::Id:

--- a/examples/chef/common/FakeAttributeAccess.cpp
+++ b/examples/chef/common/FakeAttributeAccess.cpp
@@ -55,6 +55,22 @@
 #include <app/clusters/boolean-state-configuration-server/CodegenIntegration.h>
 #endif
 
+#if (MATTER_DM_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                     \
+    (MATTER_DM_CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                      \
+    (MATTER_DM_NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                    \
+    (MATTER_DM_PM1_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                                 \
+    (MATTER_DM_PM10_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                                \
+    (MATTER_DM_PM2_5_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                               \
+    (MATTER_DM_RADON_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                               \
+    (MATTER_DM_TVOC_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                                \
+    (MATTER_DM_OZONE_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0) ||                                               \
+    (MATTER_DM_FORMALDEHYDE_CONCENTRATION_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0)
+#define MATTER_DM_CONCENTRATION_MEASUREMENT_WANTED 1
+#include <app/clusters/concentration-measurement-server/ConcentrationMeasurementCluster.h>
+#include <app/clusters/concentration-measurement-server/concentration-measurement-cluster-objects.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#endif
+
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -350,6 +366,124 @@ public:
             }
             break;
 #endif // MATTER_DM_BOOLEAN_STATE_CONFIGURATION_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#if MATTER_DM_CONCENTRATION_MEASUREMENT_WANTED
+        case CarbonDioxideConcentrationMeasurement::Id:
+        case CarbonMonoxideConcentrationMeasurement::Id:
+        case NitrogenDioxideConcentrationMeasurement::Id:
+        case Pm1ConcentrationMeasurement::Id:
+        case Pm10ConcentrationMeasurement::Id:
+        case Pm25ConcentrationMeasurement::Id:
+        case RadonConcentrationMeasurement::Id:
+        case TotalVolatileOrganicCompoundsConcentrationMeasurement::Id:
+        case OzoneConcentrationMeasurement::Id:
+        case FormaldehydeConcentrationMeasurement::Id: {
+            auto & registry                           = CodegenDataModelProvider::Instance().Registry();
+            ServerClusterInterface * clusterInterface = registry.Get(ConcreteClusterPath(path.mEndpointId, path.mClusterId));
+            if (clusterInterface == nullptr)
+            {
+                ChipLogError(Zcl, "[Pw] Failed to find concentration measurement cluster " ChipLogFormatMEI " on endpoint %d",
+                             ChipLogValueMEI(path.mClusterId), path.mEndpointId);
+                return ::pw::Status::Internal();
+            }
+            auto * cluster = static_cast<ConcentrationMeasurement::ConcentrationMeasurementCluster *>(clusterInterface);
+
+            // Note: The following attributes are read-only/static and cannot be written at runtime
+            // because they lack setters in ConcentrationMeasurementCluster:
+            // - MinMeasuredValue
+            // - MaxMeasuredValue
+            // - Uncertainty
+            // - MeasurementUnit
+            // - MeasurementMedium
+            switch (path.mAttributeId)
+            {
+            case ConcentrationMeasurement::Attributes::MeasuredValue::Id: {
+                DataModel::Nullable<float> value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetMeasuredValue(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            case ConcentrationMeasurement::Attributes::PeakMeasuredValue::Id: {
+                DataModel::Nullable<float> value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetPeakMeasuredValue(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            case ConcentrationMeasurement::Attributes::PeakMeasuredValueWindow::Id: {
+                uint32_t value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetPeakMeasuredValueWindow(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            case ConcentrationMeasurement::Attributes::AverageMeasuredValue::Id: {
+                DataModel::Nullable<float> value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetAverageMeasuredValue(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            case ConcentrationMeasurement::Attributes::AverageMeasuredValueWindow::Id: {
+                uint32_t value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetAverageMeasuredValueWindow(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            case ConcentrationMeasurement::Attributes::LevelValue::Id: {
+                ConcentrationMeasurement::LevelValueEnum value;
+                CHIP_ERROR err = decoder.Decode(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                err = cluster->SetLevelValue(value);
+                if (err != CHIP_NO_ERROR)
+                {
+                    return ::pw::Status::Internal();
+                }
+                return ::pw::OkStatus();
+            }
+            }
+            break;
+        }
+#endif // MATTER_DM_CONCENTRATION_MEASUREMENT_WANTED
         }
         return std::nullopt;
     }


### PR DESCRIPTION
#### Summary

This PR enables Pw write access to concentration measurement clusters in chef.

#### Testing

Tested with RPC console. Commands:

```
# 1. MeasuredValue (ID: 0x0000, Type: Single Precision Float)
# Read:
rpcs.chip.rpc.Attributes.Read(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=0, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE)
# Write (Example: 12.3):
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=0, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE), data=protos.chip.rpc.AttributeData(data_single=12.3))

# 2. PeakMeasuredValue (ID: 0x0003, Type: Single Precision Float)
# Read:
rpcs.chip.rpc.Attributes.Read(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=3, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE)
# Write (Example: 15.4):
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=3, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE), data=protos.chip.rpc.AttributeData(data_single=15.4))

# 3. PeakMeasuredValueWindow (ID: 0x0004, Type: Unsigned 32-bit Integer)
# Read:
rpcs.chip.rpc.Attributes.Read(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=4, type=protos.chip.rpc.AttributeType.ZCL_INT32U_ATTRIBUTE_TYPE)
# Write (Example: 3600):
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=4, type=protos.chip.rpc.AttributeType.ZCL_INT32U_ATTRIBUTE_TYPE), data=protos.chip.rpc.AttributeData(data_uint32=3600))

# 4. AverageMeasuredValue (ID: 0x0005, Type: Single Precision Float)
# Read:
rpcs.chip.rpc.Attributes.Read(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=5, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE)
# Write (Example: 5.5):
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=5, type=protos.chip.rpc.AttributeType.ZCL_SINGLE_ATTRIBUTE_TYPE), data=protos.chip.rpc.AttributeData(data_single=5.5))

# 5. AverageMeasuredValueWindow (ID: 0x0006, Type: Unsigned 32-bit Integer)
# Read:
rpcs.chip.rpc.Attributes.Read(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=6, type=protos.chip.rpc.AttributeType.ZCL_INT32U_ATTRIBUTE_TYPE)
# Write (Example: 86400):
rpcs.chip.rpc.Attributes.Write(metadata=protos.chip.rpc.AttributeMetadata(endpoint=1, cluster=protos.chip.rpc.ClusterType.ZCL_CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER_ID, attribute_id=6, type=protos.chip.rpc.AttributeType.ZCL_INT32U_ATTRIBUTE_TYPE), data=protos.chip.rpc.AttributeData(data_uint32=86400))
```