### PR TITLE
[CI REPL report] remove concurrency from PR runs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1317,7 +1317,7 @@ jobs:
 
       runs-on: ubuntu-latest
       concurrency:
-          group: gh-pages-deploy
+          group: ${{ github.event_name == 'pull_request' && format('gh-pages-report-{0}', github.run_id) || 'gh-pages-deploy' }}
           cancel-in-progress: false
       permissions:
           contents: write


### PR DESCRIPTION
#### Summary

- recreation of PR that got invalidated: https://github.com/project-chip/connectedhomeip/pull/72002 

- Github actions concurrency can only queue Two PRs at once, so when dependeabot opened 5 PRs at once, the Report job got cancelled for the other ones

- Fix: since we do not push to gh-pages in PRs (which is reason we have concurrency) we can stop doing it for PR runs (keep it for pushes to master/releases only)



#### Testing
- Testing will happen after the PR is merged
