### PR TITLE
[Thermostat] defensively delete `PresetStructWithOwnedMembers` copy constructor

### DIFF
--- a/src/app/clusters/thermostat-server/PresetStructWithOwnedMembers.h
+++ b/src/app/clusters/thermostat-server/PresetStructWithOwnedMembers.h
@@ -42,6 +42,8 @@ struct PresetStructWithOwnedMembers : protected Structs::PresetStruct::Type
 public:
     PresetStructWithOwnedMembers() = default;
     PresetStructWithOwnedMembers(const Structs::PresetStruct::Type & other);
+    // Non-copyable: a default copy constructor would alias the source's owned buffers (use-after-free).
+    PresetStructWithOwnedMembers(const PresetStructWithOwnedMembers & other) = delete;
     PresetStructWithOwnedMembers & operator=(const Structs::PresetStruct::Type & other);
     PresetStructWithOwnedMembers & operator=(const PresetStructWithOwnedMembers & other);
 

--- a/src/app/clusters/thermostat-server/PresetStructWithOwnedMembers.h
+++ b/src/app/clusters/thermostat-server/PresetStructWithOwnedMembers.h
@@ -42,7 +42,7 @@ struct PresetStructWithOwnedMembers : protected Structs::PresetStruct::Type
 public:
     PresetStructWithOwnedMembers() = default;
     PresetStructWithOwnedMembers(const Structs::PresetStruct::Type & other);
-    // Non-copyable: a default copy constructor would alias the source's owned buffers (use-after-free).
+    // Copy construction deleted: a defaulted copy ctor would shallow-copy the inherited spans into the source's buffers.
     PresetStructWithOwnedMembers(const PresetStructWithOwnedMembers & other) = delete;
     PresetStructWithOwnedMembers & operator=(const Structs::PresetStruct::Type & other);
     PresetStructWithOwnedMembers & operator=(const PresetStructWithOwnedMembers & other);


### PR DESCRIPTION
#### Summary

- `PresetStructWithOwnedMembers` inherits non-owning spans; It never declared a copy constructor, so the compiler-generated (member-wise) shallowly copies those inherited spans, exposing a use-after-free risk.

-  Delete that copy constructor since it isn't used anywhere.



#### Testing

CI will test
