### PR TITLE
[Valve Cluster] Fix 32-bit overflow in AutoCloseTime calculation

### DIFF
--- a/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
@@ -398,7 +398,8 @@ CHIP_ERROR ValveConfigurationAndControlCluster::SetAutoCloseTime(DataModel::Null
         ReturnErrorOnFailure(System::SystemClock().GetClock_RealTime(utcTime));
         VerifyOrReturnError(UnixEpochToChipEpochMicros(utcTime.count(), chipEpochTime), CHIP_ERROR_INVALID_TIME);
 
-        uint64_t time = openDuration.Value() * kMicrosecondsPerSecond;
+        // Cast to 64-bit before multiplying: the uint32_t * int product otherwise overflows for durations > ~4294 s.
+        uint64_t time = static_cast<uint64_t>(openDuration.Value()) * kMicrosecondsPerSecond;
         SetAttributeValue(mAutoCloseTime, DataModel::MakeNullable(time + chipEpochTime), Attributes::AutoCloseTime::Id);
     }
     else
@@ -414,7 +415,8 @@ void ValveConfigurationAndControlCluster::UpdateAutoCloseTime(uint64_t epochTime
 {
     if (!mRemainingDuration.value().IsNull() && mRemainingDuration.value().Value() != 0)
     {
-        uint64_t closingTime = mRemainingDuration.value().Value() * kMicrosecondsPerSecond + epochTime;
+        // Cast to 64-bit before multiplying: the uint32_t * int product otherwise overflows for durations > ~4294 s.
+        uint64_t closingTime = static_cast<uint64_t>(mRemainingDuration.value().Value()) * kMicrosecondsPerSecond + epochTime;
         SetAttributeValue(mAutoCloseTime, DataModel::MakeNullable(closingTime), Attributes::AutoCloseTime::Id);
     }
 }

--- a/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
@@ -29,6 +29,8 @@
 #include <clusters/ValveConfigurationAndControl/Commands.h>
 #include <clusters/ValveConfigurationAndControl/Events.h>
 #include <clusters/ValveConfigurationAndControl/Metadata.h>
+#include <lib/support/TimeUtils.h>
+#include <system/RAIIMockClock.h>
 
 namespace {
 
@@ -75,6 +77,11 @@ class DummyTimeSyncTracker : public TimeSyncTracker
 {
 public:
     bool IsValidUTCTime() override { return false; }
+};
+class ValidTimeSyncTracker : public TimeSyncTracker
+{
+public:
+    bool IsValidUTCTime() override { return true; }
 };
 
 struct TestValveConfigurationAndControlCluster : public ::testing::Test
@@ -403,6 +410,97 @@ TEST_F(TestValveConfigurationAndControlCluster, ReadAttributeTestTimeSync)
     AutoCloseTime::TypeInfo::DecodableType autoCloseTime;
     ASSERT_EQ(tester.ReadAttribute(AutoCloseTime::Id, autoCloseTime), CHIP_NO_ERROR);
     EXPECT_EQ(autoCloseTime, DataModel::NullNullable);
+
+    valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// Regression test: RemainingDuration * kMicrosecondsPerSecond (1000000) must be computed in 64-bit.
+// RemainingDuration is uint32_t and kMicrosecondsPerSecond is int, so the product is evaluated in
+// 32-bit arithmetic and wraps for RemainingDuration > ~4294 s, corrupting AutoCloseTime.
+TEST_F(TestValveConfigurationAndControlCluster, UpdateAutoCloseTimeNoIntegerOverflow)
+{
+    const BitFlags<Feature> features{ Feature::kTimeSync };
+    ValveConfigurationAndControlCluster::StartupConfiguration config{ DataModel::NullNullable,
+                                                                      ValveConfigurationAndControlCluster::kDefaultOpenLevel,
+                                                                      ValveConfigurationAndControlCluster::kDefaultLevelStep };
+    ValveConfigurationAndControlCluster::ValveContext context = {
+        .features             = features,
+        .optionalAttributeSet = ValveConfigurationAndControlCluster::OptionalAttributeSet(),
+        .config               = config,
+        .tsTracker            = &timeSyncTracker,
+        .delegate             = &delegate,
+    };
+    ValveConfigurationAndControlCluster valveCluster(kRootEndpointId, context);
+    ASSERT_EQ(valveCluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(valveCluster);
+
+    // Open with a duration whose microsecond conversion exceeds UINT32_MAX (> ~4294 s).
+    Commands::Open::Type request;
+    request.openDuration = MakeOptional(DataModel::Nullable<uint32_t>(5000));
+    ASSERT_TRUE(tester.Invoke(request).IsSuccess());
+
+    RemainingDuration::TypeInfo::DecodableType remaining;
+    ASSERT_EQ(tester.ReadAttribute(RemainingDuration::Id, remaining), CHIP_NO_ERROR);
+    ASSERT_FALSE(remaining.IsNull());
+    const uint32_t rd = remaining.Value();
+    ASSERT_GT(rd, 4294u); // ensure a 32-bit product would overflow
+
+    constexpr uint64_t kEpochMicros = 1000000;
+    valveCluster.UpdateAutoCloseTime(kEpochMicros);
+
+    AutoCloseTime::TypeInfo::DecodableType autoCloseTime;
+    ASSERT_EQ(tester.ReadAttribute(AutoCloseTime::Id, autoCloseTime), CHIP_NO_ERROR);
+    ASSERT_FALSE(autoCloseTime.IsNull());
+
+    const uint64_t expected = static_cast<uint64_t>(rd) * 1000000u + kEpochMicros;
+    EXPECT_EQ(autoCloseTime.Value(), expected);
+
+    valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// Regression test for the same 32-bit overflow on the Open path: SetAutoCloseTime() computes
+// OpenDuration * kMicrosecondsPerSecond, which must be done in 64-bit. This path requires a
+// synchronized UTC time, so the real-time clock is mocked to a fixed value.
+TEST_F(TestValveConfigurationAndControlCluster, SetAutoCloseTimeNoIntegerOverflow)
+{
+    System::Clock::Internal::RAIIMockClock mockClock;
+    // Fixed UTC time well after the CHIP epoch (~2023-11-14) so UnixEpochToChipEpochMicros succeeds.
+    constexpr uint64_t kMockUnixMicros = 1700000000000000ULL;
+    ASSERT_EQ(mockClock.SetClock_RealTime(System::Clock::Microseconds64(kMockUnixMicros)), CHIP_NO_ERROR);
+
+    uint64_t chipEpochMicros = 0;
+    ASSERT_TRUE(UnixEpochToChipEpochMicros(kMockUnixMicros, chipEpochMicros));
+
+    ValidTimeSyncTracker validTracker;
+    const BitFlags<Feature> features{ Feature::kTimeSync };
+    ValveConfigurationAndControlCluster::StartupConfiguration config{ DataModel::NullNullable,
+                                                                      ValveConfigurationAndControlCluster::kDefaultOpenLevel,
+                                                                      ValveConfigurationAndControlCluster::kDefaultLevelStep };
+    ValveConfigurationAndControlCluster::ValveContext context = {
+        .features             = features,
+        .optionalAttributeSet = ValveConfigurationAndControlCluster::OptionalAttributeSet(),
+        .config               = config,
+        .tsTracker            = &validTracker,
+        .delegate             = &delegate,
+    };
+    ValveConfigurationAndControlCluster valveCluster(kRootEndpointId, context);
+    ASSERT_EQ(valveCluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(valveCluster);
+
+    // OpenDuration whose microsecond conversion exceeds UINT32_MAX (> ~4294 s).
+    constexpr uint32_t kOpenDurationSeconds = 5000;
+    Commands::Open::Type request;
+    request.openDuration = MakeOptional(DataModel::Nullable<uint32_t>(kOpenDurationSeconds));
+    ASSERT_TRUE(tester.Invoke(request).IsSuccess());
+
+    AutoCloseTime::TypeInfo::DecodableType autoCloseTime;
+    ASSERT_EQ(tester.ReadAttribute(AutoCloseTime::Id, autoCloseTime), CHIP_NO_ERROR);
+    ASSERT_FALSE(autoCloseTime.IsNull());
+
+    const uint64_t expected = static_cast<uint64_t>(kOpenDurationSeconds) * 1000000u + chipEpochMicros;
+    EXPECT_EQ(autoCloseTime.Value(), expected);
 
     valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
@@ -446,14 +446,15 @@ TEST_F(TestValveConfigurationAndControlCluster, UpdateAutoCloseTimeNoIntegerOver
     const uint32_t rd = remaining.Value();
     ASSERT_GT(rd, 4294u); // ensure a 32-bit product would overflow
 
-    constexpr uint64_t kEpochMicros = 1000000;
+    // Arbitrary chip-epoch timestamp (microseconds) standing in for "now"; not a unit conversion.
+    constexpr uint64_t kEpochMicros = 1700000000000000ULL;
     valveCluster.UpdateAutoCloseTime(kEpochMicros);
 
     AutoCloseTime::TypeInfo::DecodableType autoCloseTime;
     ASSERT_EQ(tester.ReadAttribute(AutoCloseTime::Id, autoCloseTime), CHIP_NO_ERROR);
     ASSERT_FALSE(autoCloseTime.IsNull());
 
-    const uint64_t expected = static_cast<uint64_t>(rd) * 1000000u + kEpochMicros;
+    const uint64_t expected = static_cast<uint64_t>(rd) * kMicrosecondsPerSecond + kEpochMicros;
     EXPECT_EQ(autoCloseTime.Value(), expected);
 
     valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -499,7 +500,7 @@ TEST_F(TestValveConfigurationAndControlCluster, SetAutoCloseTimeNoIntegerOverflo
     ASSERT_EQ(tester.ReadAttribute(AutoCloseTime::Id, autoCloseTime), CHIP_NO_ERROR);
     ASSERT_FALSE(autoCloseTime.IsNull());
 
-    const uint64_t expected = static_cast<uint64_t>(kOpenDurationSeconds) * 1000000u + chipEpochMicros;
+    const uint64_t expected = static_cast<uint64_t>(kOpenDurationSeconds) * kMicrosecondsPerSecond + chipEpochMicros;
     EXPECT_EQ(autoCloseTime.Value(), expected);
 
     valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);


### PR DESCRIPTION
#### Summary


- `OpenDuration` and `RemainingDuration` (uint32_t) were multiplied by kMicrosecondsPerSecond (int), so the product was computed in 32-bit and wrapped for durations > ~4294 s (~71 min), producing a too-early AutoCloseTime. Cast to uint64_t before the multiply at both sites.


#### Testing

Adds two unit test cases for both paths
