### PR TITLE
[clang-tidy] Re-enable NullDerefence and Malloc checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,6 @@ Checks: >
   -bugprone-unused-return-value,
   -clang-analyzer-core.CallAndMessage,
   -clang-analyzer-core.NonNullParamChecker,
-  -clang-analyzer-core.NullDereference,
   -clang-analyzer-cplusplus.Move,
   -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-nullability.NullablePassedToNonnull,
@@ -46,7 +45,6 @@ Checks: >
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.rand,
   -clang-analyzer-security.insecureAPI.strcpy,
-  -clang-analyzer-unix.Malloc,
   -clang-analyzer-webkit.NoUncountedMemberChecker,
   -clang-diagnostic-implicit-int-conversion,
   -clang-diagnostic-missing-template-arg-list-after-template-kw

--- a/src/app/clusters/descriptor/DescriptorCluster.cpp
+++ b/src/app/clusters/descriptor/DescriptorCluster.cpp
@@ -139,6 +139,8 @@ CHIP_ERROR ReadPartsAttribute(DataModel::Provider & provider, EndpointId endpoin
     case DataModel::EndpointCompositionPattern::kFullFamily:
         // encodes ALL endpoints that have the specified endpoint as a descendant.
         return aEncoder.EncodeList([&endpoints, endpoint](const auto & encoder) -> CHIP_ERROR {
+            // False-positive null-dereference: reaching this branch means endpoints[idx]
+            // existed, so the span is non-empty -- and a non-empty span has non-null data().
             // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             for (const auto & ep : endpoints)
             {

--- a/src/app/clusters/descriptor/DescriptorCluster.cpp
+++ b/src/app/clusters/descriptor/DescriptorCluster.cpp
@@ -139,6 +139,7 @@ CHIP_ERROR ReadPartsAttribute(DataModel::Provider & provider, EndpointId endpoin
     case DataModel::EndpointCompositionPattern::kFullFamily:
         // encodes ALL endpoints that have the specified endpoint as a descendant.
         return aEncoder.EncodeList([&endpoints, endpoint](const auto & encoder) -> CHIP_ERROR {
+            // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             for (const auto & ep : endpoints)
             {
                 if (IsDescendantOf(&ep, endpoint, endpoints))

--- a/src/credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.cpp
@@ -43,6 +43,9 @@ constexpr size_t kMaxResponseLength = 900;
 void PartialDACVerifier::VerifyAttestationInformation(const DeviceAttestationVerifier::AttestationInfo & info,
                                                       Callback::Callback<OnAttestationInformationVerification> * onCompletion)
 {
+    // The exit handler below dereferences onCompletion unconditionally; reject null here.
+    VerifyOrReturn(onCompletion != nullptr);
+
     AttestationVerificationResult attestationError = AttestationVerificationResult::kSuccess;
 
     AttestationCertVidPid dacVidPid;
@@ -56,7 +59,7 @@ void PartialDACVerifier::VerifyAttestationInformation(const DeviceAttestationVer
 
     VerifyOrExit(!info.attestationElementsBuffer.empty() && !info.attestationChallengeBuffer.empty() &&
                      !info.attestationSignatureBuffer.empty() && !info.paiDerBuffer.empty() && !info.dacDerBuffer.empty() &&
-                     !info.attestationNonceBuffer.empty() && onCompletion != nullptr,
+                     !info.attestationNonceBuffer.empty(),
                  attestationError = AttestationVerificationResult::kInvalidArgument);
 
     VerifyOrExit(info.attestationElementsBuffer.size() <= kMaxResponseLength,

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -432,6 +432,9 @@ const char * CertificationTypeAsString(CertificationType certificationType)
 void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVerifier::AttestationInfo & info,
                                                       Callback::Callback<OnAttestationInformationVerification> * onCompletion)
 {
+    // The exit handler below dereferences onCompletion unconditionally; reject null here.
+    VerifyOrReturn(onCompletion != nullptr);
+
     AttestationVerificationResult attestationError = AttestationVerificationResult::kSuccess;
 
     Platform::ScopedMemoryBuffer<uint8_t> paaCert;
@@ -441,8 +444,7 @@ void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVer
     AttestationCertVidPid paaVidPid;
 
     VerifyOrExit(!info.attestationElementsBuffer.empty() && !info.attestationChallengeBuffer.empty() &&
-                     !info.attestationSignatureBuffer.empty() && !info.dacDerBuffer.empty() &&
-                     !info.attestationNonceBuffer.empty() && onCompletion != nullptr,
+                     !info.attestationSignatureBuffer.empty() && !info.dacDerBuffer.empty() && !info.attestationNonceBuffer.empty(),
                  attestationError = AttestationVerificationResult::kInvalidArgument);
 
     VerifyOrExit(info.attestationElementsBuffer.size() <= kMaxResponseLength,

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -203,6 +203,19 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidParameters)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kInvalidArgument);
 }
 
+// VerifyAttestationInformation must not crash when given a null completion callback.
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithNullCompletionCallback)
+{
+    DeviceAttestationVerifier::AttestationInfo invalidInfo(ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(),
+                                                           kTestVendorId, kTestProductId);
+
+    // Must return without dereferencing the null callback (previously a null-pointer crash).
+    verifier.VerifyAttestationInformation(invalidInfo, nullptr);
+
+    // The callback was never invoked, so the captured result is left at its initial value.
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
+}
+
 // Test verifier behavior with oversized attestationElements buffer - verifies handling of large data
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithLargeAttestationElementsBuffer)
 {

--- a/src/credentials/tests/TestDeviceAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDeviceAttestationVerifier.cpp
@@ -229,3 +229,20 @@ TEST_F(TestDeviceAttestationVerifier, CheckForRevokedDACChainNoDelegate)
     verifier.CheckForRevokedDACChain(attestationInfo, &callback);
     EXPECT_EQ(result, AttestationVerificationResult::kSuccess);
 }
+
+// VerifyAttestationInformation must not crash when given a null completion callback.
+TEST_F(TestDeviceAttestationVerifier, VerifyAttestationInformationNullCompletionCallback)
+{
+    static uint8_t dummyCert[1]       = { 0x00 };
+    static const ByteSpan certSpans[] = { ByteSpan(dummyCert) };
+    ArrayAttestationTrustStore trustStore(certSpans, 1);
+    DefaultDACVerifier verifier(&trustStore);
+
+    // Empty buffers fail the first precondition and route to the exit handler; the danger being
+    // exercised is that handler dereferencing the (null) completion callback.
+    DeviceAttestationVerifier::AttestationInfo invalidInfo(ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(),
+                                                           VendorId(0x1234), 0x5678);
+
+    // Must return without dereferencing the null callback (previously a null-pointer crash).
+    verifier.VerifyAttestationInformation(invalidInfo, nullptr);
+}

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -781,7 +781,9 @@ CHIP_ERROR TCPEndPointImplSockets::GetSocket(IPAddressType addrType)
 // static
 void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events, intptr_t data)
 {
-    reinterpret_cast<TCPEndPointImplSockets *>(data)->HandlePendingIO(events);
+    auto * endPoint = reinterpret_cast<TCPEndPointImplSockets *>(data);
+    VerifyOrReturn(endPoint != nullptr);
+    endPoint->HandlePendingIO(events);
 }
 
 void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -562,7 +562,9 @@ CHIP_ERROR UDPEndPointImplSockets::GetSocket(IPAddressType addressType)
 // static
 void UDPEndPointImplSockets::HandlePendingIO(System::SocketEvents events, intptr_t data)
 {
-    reinterpret_cast<UDPEndPointImplSockets *>(data)->HandlePendingIO(events);
+    auto * endPoint = reinterpret_cast<UDPEndPointImplSockets *>(data);
+    VerifyOrReturn(endPoint != nullptr);
+    endPoint->HandlePendingIO(events);
 }
 
 void UDPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)


### PR DESCRIPTION
#### Summary
Removes the two disable lines from `.clang-tidy` and resolves the `NullDereference` sites that re-enabling surfaces.

- **`unix.Malloc`** — 0 findings across `src/`; clean flip, no code changes.
- **`NullDereference`** — 4 flagged sites:
  - **`Partial`/`DefaultDACVerifier::VerifyAttestationInformation`** — the `onCompletion != nullptr` precondition was checked via `VerifyOrExit`, but the `exit:` handler dereferences `onCompletion` unconditionally. Add an early `VerifyOrReturn`. 
     - **Not reachable** in production (sole caller passes the address of a member callback) — a latent defeated-guard defect, not a security fix. Regression tests added for both verifiers.
     
     
  - **TCP/UDP `HandlePendingIO`** trampolines — add `VerifyOrReturn(endPoint != nullptr)`. The `intptr_t` is always `&endpoint` (set internally), so this is a false positive; guard added for the analyzer + defense-in-depth.
  - **`DescriptorCluster::ReadPartsAttribute`** range-for over a `Span` — `NOLINT`; an empty span has `begin()==end()==nullptr` so the body never runs (analyzer can't prove `data()==nullptr` implies `size()==0`).

#### Testing
Verified: full `ninja` build clean; clang-tidy with both checks enabled reports 0 findings across `src/`.