### PR TITLE
Add GitHub PR description writer skill

### DIFF
--- a/.agents/skills.md
+++ b/.agents/skills.md
@@ -12,6 +12,13 @@ etc.) to assist with development and code review in the Matter repository.
 -   **Triggers**: Automatically activates when reviewing files ending in
     `_test.py` or located in `src/python_testing`.
 
+### GitHub PR Description Writer
+
+-   **Location**: `.agents/skills/github-pr-description-writer/`
+-   **Purpose**: Guidelines for generating clear, concise, and objective GitHub
+    Pull Request descriptions.
+-   **Triggers**: Use when preparing or writing descriptions for pull requests.
+
 ## Using Skills
 
 AI agents will automatically discover and load these skills when they are

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: github-pr-description-writer
+description:
+    Guidelines for generating clear, concise, and objective GitHub Pull Request
+    descriptions.
+---
+
+# Writing GitHub Pull Request Descriptions
+
+This skill provides guidelines for creating clear, concise, and objective pull
+request descriptions for the ConnectedHomeIP repository. The goal is to make PRs
+easy for human maintainers to understand and review.
+
+## Formatting Guidelines
+
+The PR description must follow a structured format based on the repository's
+template, focusing on: **Summary**, **Related Issues**, and **Testing**.
+
+### 1. Summary Section (`#### Summary`)
+
+The summary should explain the "what", "why", and "how" of the changes. It must
+address the following points:
+
+-   **The Problem**: Explain the underlying issue that this PR addresses. What
+    is broken, missing, or needs improvement?
+-   **The Impact**: Explain _why_ this is a problem if it is not immediately
+    obvious. What are the consequences of not fixing it?
+-   **The Solution**: Explain the proposed solution and _why_ it fixes the
+    problem.
+-   **Caveats**: Document any limitations, side effects,
+    performance/memory impacts, or specific concerns that reviewers should be
+    aware of.
+
+#### Style and Tone
+
+-   **Objective & Technical**: Write for a technical audience. Use precise
+    technical terms.
+-   **Concise**: Keep descriptions brief but informative. Avoid walls of text.
+    Use bullet points where appropriate.
+-   **No Prose or Hype**: Do not use marketing-style language, emojis, or
+    subjective/hyperbolic terms (e.g., "amazing", "triumph", "perfect",
+    "flawless").
+-   **No Filler**: Avoid conversational filler. Get straight to the point.
+
+### 2. Related Issues Section (`#### Related issues`)
+
+-   Reference any related GitHub issues.
+-   Use closing keywords (e.g., `Fixes #12345`) if the PR should close the issue
+    upon merging.
+
+### 3. Testing Section (`#### Testing`)
+
+Every PR must document how the changes were tested.
+
+-   **Automated Tests**:
+    -   If unit tests were added/updated, state so (e.g.,
+        `Added unit tests in src/app/tests/...`).
+    -   If integration tests (Python/YAML) were used, specify the test names
+        (e.g., `Verified with TC_S_2_3.py`).
+-   **Manual Testing**:
+    -   If manual testing was performed, provide the exact commands and steps to
+        reproduce.
+    -   Explain _why_ automated testing was not possible.
+-   **Trivial Changes**:
+    -   If the change is trivial (e.g., documentation typo), it still requires a
+        `#### Testing` section. You may use `N/A` with a brief justification.
+
+---
+
+## Example PR Description
+
+Here is an example of a good PR description:
+
+```markdown
+#### Summary
+
+Fixes a crash in the DNS-SD client when processing malformed SRV responses.
+
+-   **The Problem**: The DNS-SD client does not validate the target host name
+    length in incoming SRV records before copying it to a fixed-size buffer.
+-   **The Impact**: A malformed SRV record with a target host name longer than
+    63 characters causes a buffer overflow, leading to a crash.
+-   **The Solution**: Added validation to ensure the host name length does not
+    exceed `kMaxHostNameLength` before copying. Malformed records are now safely
+    discarded.
+-   **Caveats**: This change discards malformed records silently, logging a
+    warning.
+
+#### Related issues
+
+Fixes #72327
+
+#### Testing
+
+-   Added unit test `TestDnssdClient_MalformedSrvRecord` in
+    `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are
+    discarded and do not cause a crash.
+```

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -22,24 +22,38 @@ The summary should explain the "what", "why", and "how" of the changes. It must
 use the following sub-headings:
 
 ##### Problem
-*   Explain the underlying issue that this PR addresses. What is broken, missing, or needs improvement?
+
+-   Explain the underlying issue that this PR addresses. What is broken,
+    missing, or needs improvement?
 
 ##### Impact
-*   Explain _why_ this is a problem if it is not immediately obvious. What are the consequences of not fixing it?
+
+-   Explain _why_ this is a problem if it is not immediately obvious. What are
+    the consequences of not fixing it?
 
 ##### Solution
-*   Explain the proposed solution and _why_ it fixes the problem.
+
+-   Explain the proposed solution and _why_ it fixes the problem.
 
 ##### Caveats (Optional)
-*   Document any limitations, side effects, performance/memory impacts, or specific concerns that reviewers should be aware of. Omit this section entirely if there are no caveats.
+
+-   Document any limitations, side effects, performance/memory impacts, or
+    specific concerns that reviewers should be aware of. Omit this section
+    entirely if there are no caveats.
 
 #### Noise Reduction Rule
 
-*   **Say Nothing if Nothing to Say**: Do not include sections or bullet points with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`) has no content, omit the heading and content entirely to reduce noise.
+-   **Say Nothing if Nothing to Say**: Do not include sections or bullet points
+    with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`)
+    has no content, omit the heading and content entirely to reduce noise.
 
 #### Keeping in Sync Rule
 
-*   **Update on Change**: The PR description MUST be updated after every commit if the content of the PR materially changes. For example, if you remove a test or change the implementation details, immediately update the PR description on GitHub to reflect the current state of the code. Do not leave stale information in the description.
+-   **Update on Change**: The PR description MUST be updated after every commit
+    if the content of the PR materially changes. For example, if you remove a
+    test or change the implementation details, immediately update the PR
+    description on GitHub to reflect the current state of the code. Do not leave
+    stale information in the description.
 
 #### Style and Tone
 
@@ -87,17 +101,24 @@ Here is an example of a good PR description:
 Fixes a crash in the DNS-SD client when processing malformed SRV responses.
 
 ##### Problem
-*   The DNS-SD client does not validate the target host name length in incoming SRV records before copying it to a fixed-size buffer.
+
+-   The DNS-SD client does not validate the target host name length in incoming
+    SRV records before copying it to a fixed-size buffer.
 
 ##### Impact
-*   A malformed SRV record with a target host name longer than 63 characters causes a buffer overflow, leading to a crash.
+
+-   A malformed SRV record with a target host name longer than 63 characters
+    causes a buffer overflow, leading to a crash.
 
 ##### Solution
-*   Added validation to ensure the host name length does not exceed `kMaxHostNameLength` before copying.
-*   Malformed records are now safely discarded and a warning is logged.
+
+-   Added validation to ensure the host name length does not exceed
+    `kMaxHostNameLength` before copying.
+-   Malformed records are now safely discarded and a warning is logged.
 
 ##### Caveats
-*   This change discards malformed records silently, logging a warning.
+
+-   This change discards malformed records silently, logging a warning.
 
 #### Related issues
 
@@ -105,5 +126,7 @@ Fixes #72327
 
 #### Testing
 
--   Added unit test `TestDnssdClient_MalformedSrvRecord` in `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are discarded and do not cause a crash.
+-   Added unit test `TestDnssdClient_MalformedSrvRecord` in
+    `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are
+    discarded and do not cause a crash.
 ```

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -31,7 +31,7 @@ These rules apply globally to all sections of the PR description.
 -   **Say Nothing if Nothing to Say**: Do not include sections or bullet points
     with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`)
     has no content, omit the heading and content entirely to reduce noise.
-    *Exception*: The `#### Testing` section must always be present; you may use
+    _Exception_: The `#### Testing` section must always be present; you may use
     `N/A` there for trivial changes if accompanied by a brief justification.
 
 ### Keeping in Sync Rule
@@ -40,13 +40,15 @@ These rules apply globally to all sections of the PR description.
     if the content of the PR materially changes.
     -   **Requires Update**:
         -   Adding or deleting a test.
-        -   Changing the implementation approach (e.g., swapping a library function or logic).
+        -   Changing the implementation approach (e.g., swapping a library
+            function or logic).
         -   Adding or removing a feature flag.
     -   **Does NOT Require Update**:
         -   Rebasing or merging with master.
         -   Commit message wording changes only.
         -   Formatting-only changes that do not alter logic.
-        -   Minor test execution adjustments (e.g., changing log levels in test run) if they don't change what was tested.
+        -   Minor test execution adjustments (e.g., changing log levels in test
+            run) if they don't change what was tested.
 
 ## Formatting Guidelines
 
@@ -59,17 +61,21 @@ The summary should explain the "what", "why", and "how" of the changes. It must
 use the following sub-headings:
 
 ##### Problem
+
 -   Explain the underlying issue that this PR addresses. What is broken,
     missing, or needs improvement?
 
 ##### Impact
+
 -   Explain _why_ this is a problem if it is not immediately obvious. What are
     the consequences of not fixing it?
 
 ##### Solution
+
 -   Explain the proposed solution and _why_ it fixes the problem.
 
 ##### Caveats (Optional)
+
 -   Document any limitations, side effects, performance/memory impacts, or
     specific concerns that reviewers should be aware of. Omit this section
     entirely if there are no caveats.
@@ -109,16 +115,23 @@ Here is an example of a good PR description:
 Fixes a crash in the DNS-SD client when processing malformed SRV responses.
 
 ##### Problem
--   The DNS-SD client does not validate the target host name length in incoming SRV records before copying it to a fixed-size buffer.
+
+-   The DNS-SD client does not validate the target host name length in incoming
+    SRV records before copying it to a fixed-size buffer.
 
 ##### Impact
--   A malformed SRV record with a target host name longer than 63 characters causes a buffer overflow, leading to a crash.
+
+-   A malformed SRV record with a target host name longer than 63 characters
+    causes a buffer overflow, leading to a crash.
 
 ##### Solution
--   Added validation to ensure the host name length does not exceed `kMaxHostNameLength` before copying.
+
+-   Added validation to ensure the host name length does not exceed
+    `kMaxHostNameLength` before copying.
 -   Malformed records are now safely discarded and a warning is logged.
 
 ##### Caveats
+
 -   This change discards malformed records and logs a warning.
 
 #### Related issues
@@ -127,5 +140,7 @@ Fixes #72327
 
 #### Testing
 
--   Added unit test `TestDnssdClient_MalformedSrvRecord` in `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are discarded and do not cause a crash.
+-   Added unit test `TestDnssdClient_MalformedSrvRecord` in
+    `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are
+    discarded and do not cause a crash.
 ```

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -11,6 +11,43 @@ This skill provides guidelines for creating clear, concise, and objective pull
 request descriptions for the ConnectedHomeIP repository. The goal is to make PRs
 easy for human maintainers to understand and review.
 
+## General Rules
+
+These rules apply globally to all sections of the PR description.
+
+### Style and Tone
+
+-   **Objective & Technical**: Write for a technical audience. Use precise
+    technical terms.
+-   **Concise**: Keep descriptions brief but informative. Avoid walls of text.
+    Use bullet points where appropriate.
+-   **No Prose or Hype**: Do not use marketing-style language, emojis, or
+    subjective/hyperbolic terms (e.g., "amazing", "triumph", "perfect",
+    "flawless").
+-   **No Filler**: Avoid conversational filler. Get straight to the point.
+
+### Noise Reduction Rule
+
+-   **Say Nothing if Nothing to Say**: Do not include sections or bullet points
+    with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`)
+    has no content, omit the heading and content entirely to reduce noise.
+    *Exception*: The `#### Testing` section must always be present; you may use
+    `N/A` there for trivial changes if accompanied by a brief justification.
+
+### Keeping in Sync Rule
+
+-   **Update on Change**: The PR description MUST be updated after every commit
+    if the content of the PR materially changes.
+    -   **Requires Update**:
+        -   Adding or deleting a test.
+        -   Changing the implementation approach (e.g., swapping a library function or logic).
+        -   Adding or removing a feature flag.
+    -   **Does NOT Require Update**:
+        -   Rebasing or merging with master.
+        -   Commit message wording changes only.
+        -   Formatting-only changes that do not alter logic.
+        -   Minor test execution adjustments (e.g., changing log levels in test run) if they don't change what was tested.
+
 ## Formatting Guidelines
 
 The PR description must follow a structured format based on the repository's
@@ -22,51 +59,20 @@ The summary should explain the "what", "why", and "how" of the changes. It must
 use the following sub-headings:
 
 ##### Problem
-
 -   Explain the underlying issue that this PR addresses. What is broken,
     missing, or needs improvement?
 
 ##### Impact
-
 -   Explain _why_ this is a problem if it is not immediately obvious. What are
     the consequences of not fixing it?
 
 ##### Solution
-
 -   Explain the proposed solution and _why_ it fixes the problem.
 
 ##### Caveats (Optional)
-
 -   Document any limitations, side effects, performance/memory impacts, or
     specific concerns that reviewers should be aware of. Omit this section
     entirely if there are no caveats.
-
-#### Noise Reduction Rule
-
--   **Say Nothing if Nothing to Say**: Do not include sections or bullet points
-    with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`)
-    has no content, omit the heading and content entirely to reduce noise.
-    *Exception*: The `#### Testing` section must always be present; you may use
-    `N/A` there for trivial changes if accompanied by a brief justification.
-
-#### Keeping in Sync Rule
-
--   **Update on Change**: The PR description MUST be updated after every commit
-    if the content of the PR materially changes. For example, if you remove a
-    test or change the implementation details, immediately update the PR
-    description on GitHub to reflect the current state of the code. Do not leave
-    stale information in the description.
-
-#### Style and Tone
-
--   **Objective & Technical**: Write for a technical audience. Use precise
-    technical terms.
--   **Concise**: Keep descriptions brief but informative. Avoid walls of text.
-    Use bullet points where appropriate.
--   **No Prose or Hype**: Do not use marketing-style language, emojis, or
-    subjective/hyperbolic terms (e.g., "amazing", "triumph", "perfect",
-    "flawless").
--   **No Filler**: Avoid conversational filler. Get straight to the point.
 
 ### 2. Related Issues Section (`#### Related issues`)
 
@@ -103,23 +109,16 @@ Here is an example of a good PR description:
 Fixes a crash in the DNS-SD client when processing malformed SRV responses.
 
 ##### Problem
-
--   The DNS-SD client does not validate the target host name length in incoming
-    SRV records before copying it to a fixed-size buffer.
+-   The DNS-SD client does not validate the target host name length in incoming SRV records before copying it to a fixed-size buffer.
 
 ##### Impact
-
--   A malformed SRV record with a target host name longer than 63 characters
-    causes a buffer overflow, leading to a crash.
+-   A malformed SRV record with a target host name longer than 63 characters causes a buffer overflow, leading to a crash.
 
 ##### Solution
-
--   Added validation to ensure the host name length does not exceed
-    `kMaxHostNameLength` before copying.
+-   Added validation to ensure the host name length does not exceed `kMaxHostNameLength` before copying.
 -   Malformed records are now safely discarded and a warning is logged.
 
 ##### Caveats
-
 -   This change discards malformed records and logs a warning.
 
 #### Related issues
@@ -128,7 +127,5 @@ Fixes #72327
 
 #### Testing
 
--   Added unit test `TestDnssdClient_MalformedSrvRecord` in
-    `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are
-    discarded and do not cause a crash.
+-   Added unit test `TestDnssdClient_MalformedSrvRecord` in `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are discarded and do not cause a crash.
 ```

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -27,9 +27,8 @@ address the following points:
     obvious. What are the consequences of not fixing it?
 -   **The Solution**: Explain the proposed solution and _why_ it fixes the
     problem.
--   **Caveats**: Document any limitations, side effects,
-    performance/memory impacts, or specific concerns that reviewers should be
-    aware of.
+-   **Caveats**: Document any limitations, side effects, performance/memory
+    impacts, or specific concerns that reviewers should be aware of.
 
 #### Style and Tone
 

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -46,6 +46,8 @@ use the following sub-headings:
 -   **Say Nothing if Nothing to Say**: Do not include sections or bullet points
     with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`)
     has no content, omit the heading and content entirely to reduce noise.
+    *Exception*: The `#### Testing` section must always be present; you may use
+    `N/A` there for trivial changes if accompanied by a brief justification.
 
 #### Keeping in Sync Rule
 
@@ -118,7 +120,7 @@ Fixes a crash in the DNS-SD client when processing malformed SRV responses.
 
 ##### Caveats
 
--   This change discards malformed records silently, logging a warning.
+-   This change discards malformed records and logs a warning.
 
 #### Related issues
 

--- a/.agents/skills/github-pr-description-writer/SKILL.md
+++ b/.agents/skills/github-pr-description-writer/SKILL.md
@@ -19,16 +19,27 @@ template, focusing on: **Summary**, **Related Issues**, and **Testing**.
 ### 1. Summary Section (`#### Summary`)
 
 The summary should explain the "what", "why", and "how" of the changes. It must
-address the following points:
+use the following sub-headings:
 
--   **The Problem**: Explain the underlying issue that this PR addresses. What
-    is broken, missing, or needs improvement?
--   **The Impact**: Explain _why_ this is a problem if it is not immediately
-    obvious. What are the consequences of not fixing it?
--   **The Solution**: Explain the proposed solution and _why_ it fixes the
-    problem.
--   **Caveats**: Document any limitations, side effects, performance/memory
-    impacts, or specific concerns that reviewers should be aware of.
+##### Problem
+*   Explain the underlying issue that this PR addresses. What is broken, missing, or needs improvement?
+
+##### Impact
+*   Explain _why_ this is a problem if it is not immediately obvious. What are the consequences of not fixing it?
+
+##### Solution
+*   Explain the proposed solution and _why_ it fixes the problem.
+
+##### Caveats (Optional)
+*   Document any limitations, side effects, performance/memory impacts, or specific concerns that reviewers should be aware of. Omit this section entirely if there are no caveats.
+
+#### Noise Reduction Rule
+
+*   **Say Nothing if Nothing to Say**: Do not include sections or bullet points with "None" or "N/A". If a section (like `Caveats` or `#### Related issues`) has no content, omit the heading and content entirely to reduce noise.
+
+#### Keeping in Sync Rule
+
+*   **Update on Change**: The PR description MUST be updated after every commit if the content of the PR materially changes. For example, if you remove a test or change the implementation details, immediately update the PR description on GitHub to reflect the current state of the code. Do not leave stale information in the description.
 
 #### Style and Tone
 
@@ -75,15 +86,18 @@ Here is an example of a good PR description:
 
 Fixes a crash in the DNS-SD client when processing malformed SRV responses.
 
--   **The Problem**: The DNS-SD client does not validate the target host name
-    length in incoming SRV records before copying it to a fixed-size buffer.
--   **The Impact**: A malformed SRV record with a target host name longer than
-    63 characters causes a buffer overflow, leading to a crash.
--   **The Solution**: Added validation to ensure the host name length does not
-    exceed `kMaxHostNameLength` before copying. Malformed records are now safely
-    discarded.
--   **Caveats**: This change discards malformed records silently, logging a
-    warning.
+##### Problem
+*   The DNS-SD client does not validate the target host name length in incoming SRV records before copying it to a fixed-size buffer.
+
+##### Impact
+*   A malformed SRV record with a target host name longer than 63 characters causes a buffer overflow, leading to a crash.
+
+##### Solution
+*   Added validation to ensure the host name length does not exceed `kMaxHostNameLength` before copying.
+*   Malformed records are now safely discarded and a warning is logged.
+
+##### Caveats
+*   This change discards malformed records silently, logging a warning.
 
 #### Related issues
 
@@ -91,7 +105,5 @@ Fixes #72327
 
 #### Testing
 
--   Added unit test `TestDnssdClient_MalformedSrvRecord` in
-    `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are
-    discarded and do not cause a crash.
+-   Added unit test `TestDnssdClient_MalformedSrvRecord` in `src/lib/dnssd/tests/TestDnssdImpl.cpp` to verify that malformed records are discarded and do not cause a crash.
 ```


### PR DESCRIPTION
#### Summary

Adds a new agent skill to enforce clear, concise, and objective PR descriptions.

##### Problem
-   LLM-generated PR descriptions are often verbose "walls of text" and lack structure.
-   Descriptions often become stale after subsequent commits, misleading reviewers.
-   PRs often contain noisy "None" or "N/A" sections that add no value.

##### Impact
-   Reviewers spend more time parsing verbose descriptions or are misled by stale information, slowing down reviews.

##### Solution
-   Created a specialized `github-pr-description-writer` skill with guidelines for agents.
-   Enforces a structured summary using small headings (Problem, Impact, Solution, Caveats).
-   Added a **Noise Reduction Rule** to omit empty sections (except for `#### Testing`).
-   Added a **Keeping in Sync Rule** mandating updates to the PR description after material code changes.

#### Testing

-   Verified skill file creation and registration locally.
