### PR TITLE
[clang-tidy] Enable VirtualCall and virtual-class-destructor checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   bugprone-*,
+  cppcoreguidelines-virtual-class-destructor,
   modernize-redundant-void-arg,
   modernize-use-bool-literals,
   modernize-use-nullptr,
@@ -40,7 +41,6 @@ Checks: >
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.core.EnumCastOutOfRange,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
-  -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker,
   -clang-analyzer-optin.performance,
   -clang-analyzer-optin.performance.Padding,

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -57,7 +57,7 @@ GroupcastCluster::~GroupcastCluster()
     // Shutdown() to ensure proper cleanup if the cluster was started.
     if (mContext != nullptr)
     {
-        Shutdown(ClusterShutdownType::kPermanentRemove);
+        GroupcastCluster::Shutdown(ClusterShutdownType::kPermanentRemove);
     }
 }
 

--- a/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
@@ -72,7 +72,7 @@ LocalizationConfigurationCluster::LocalizationConfigurationCluster(DeviceLayer::
     {
         char tempBuf[kActiveLocaleMaxLength];
         MutableCharSpan validLocale(tempBuf);
-        if (GetDefaultLocale(validLocale))
+        if (LocalizationConfigurationCluster::GetDefaultLocale(validLocale))
         {
             status = SetActiveLocale(validLocale);
             if (status != Protocols::InteractionModel::Status::Success)

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -43,7 +43,7 @@ public:
     using Super = app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData>;
 
     DefaultSceneTableImpl() : Super(kMaxScenesPerFabric, kMaxScenesPerEndpoint) {}
-    ~DefaultSceneTableImpl() { Finish(); };
+    ~DefaultSceneTableImpl() { DefaultSceneTableImpl::Finish(); };
 
     CHIP_ERROR Init(PersistentStorageDelegate & storage, app::DataModel::Provider & dataModel) override;
     void Finish() override;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -35,7 +35,7 @@ using chip::app::DataModel::NullNullable;
 
 AutoCommissioner::AutoCommissioner()
 {
-    TEMPORARY_RETURN_IGNORED SetCommissioningParameters(CommissioningParameters());
+    TEMPORARY_RETURN_IGNORED AutoCommissioner::SetCommissioningParameters(CommissioningParameters());
 }
 
 AutoCommissioner::~AutoCommissioner() {}

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR CommissioneeDeviceProxy::SetConnected(const SessionHandle & session)
 
 CommissioneeDeviceProxy::~CommissioneeDeviceProxy()
 {
-    auto session = GetSecureSession();
+    auto session = CommissioneeDeviceProxy::GetSecureSession();
     if (session.HasValue())
     {
         session.Value()->AsSecureSession()->MarkForEviction();

--- a/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
@@ -222,7 +222,6 @@ public:
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
-protected:
     ::TestProviderChangeListener mChangeListener;
     chip::Testing::LogOnlyEvents mEventGenerator;
     TestActionContext mActionContext;


### PR DESCRIPTION

#### Summary

- Renables `clang-analyzer-optin.cplusplus.VirtualCall` — flags virtual calls made from constructors/destructors.
- Enables `cppcoreguidelines-virtual-class-destructor` — flags base classes whose destructor isn't safe for polymorphic use.
- VirtualCall fixes: 5 ctor/dtor calls now explicitly qualified (`ClassName::method()`) —  no behavior change.
- virtual-class-destructor fix: one test fixture's destructor moved out of `protected:`.
- Preventive only: both checks pass tree-wide, no functional change to production code.


#### Testing

locally ran clang-tidy with the enabled check on the whole repo