### PR TITLE
CI: Run Cirque only on master and not on PRs

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -19,8 +19,6 @@ on:
         branches:
             - master
             - 'v*-branch'
-    pull_request:
-    merge_group:
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
#### Summary

Restricts Cirque CI execution to `master` and release branches to conserve CI resources.

This was a discussion during the SWTT meeting on THU and has dual purpose:
  - free up some CI resources
  - we will prove out the theory of `cirque does not provide extra checks to what regular other CI does` over the long run: if we never have cirque failing in master, PR checks that we already do are probably sufficient.

##### Problem

-   Cirque currently runs on every PR and commit.
-   Given extensive test coverage and existing emulation runs (BLE/Wi-Fi), running Cirque on PRs provides marginal additional defect discovery.

##### Impact

-   Unnecessary CI resource utilization and extended PR verification times.

##### Solution

-   Removed `pull_request` and `merge_group` triggers from `.github/workflows/cirque.yaml`.

#### Testing

-   Verified valid YAML syntax for `.github/workflows/cirque.yaml`.
