### PR TITLE
[Messaging] Fix flaky CheckNewContextTest on exchange-ID wraparound

### DIFF
--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -121,9 +121,10 @@ TEST_F(TestExchangeMgr, CheckNewContextTest)
 
     ExchangeContext * ec2 = NewExchangeToAlice(&mockAppDelegate);
     ASSERT_NE(ec2, nullptr);
-    // Exchange IDs are a 16-bit counter seeded randomly at init, so check that the
-    // second exchange got the next ID rather than a strictly larger one: the counter
-    // wraps (e.g. 0xFFFF -> 0x0000) and a `>` check is flaky across that boundary.
+    // Exchange IDs are a 16-bit counter that starts from a random value and increments
+    // per exchange. We do an exact (+1) check rather than a lenient greater-than check,
+    // because greater-than does not work when the exchange ID wraps (0xFFFF -> 0x0000) —
+    // and it will sometimes wrap, given the random starting ID.
     EXPECT_EQ(ec2->GetExchangeId(), static_cast<uint16_t>(ec1->GetExchangeId() + 1));
     EXPECT_EQ(ec2->GetSessionHandle(), GetSessionBobToAlice());
 

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -121,7 +121,10 @@ TEST_F(TestExchangeMgr, CheckNewContextTest)
 
     ExchangeContext * ec2 = NewExchangeToAlice(&mockAppDelegate);
     ASSERT_NE(ec2, nullptr);
-    EXPECT_GT(ec2->GetExchangeId(), ec1->GetExchangeId());
+    // Exchange IDs are a 16-bit counter seeded randomly at init, so check that the
+    // second exchange got the next ID rather than a strictly larger one: the counter
+    // wraps (e.g. 0xFFFF -> 0x0000) and a `>` check is flaky across that boundary.
+    EXPECT_EQ(ec2->GetExchangeId(), static_cast<uint16_t>(ec1->GetExchangeId() + 1));
     EXPECT_EQ(ec2->GetSessionHandle(), GetSessionBobToAlice());
 
     ec1->Close();


### PR DESCRIPTION
#### Summary

##### Problem

-   `TestExchangeMgr.CheckNewContextTest` asserts strict monotonicity of exchange IDs across two newly created exchanges:
    ```cpp
    EXPECT_GT(ec2->GetExchangeId(), ec1->GetExchangeId());
    ```
-   Exchange IDs are a 16-bit counter (`ExchangeManager::mNextExchangeId`) seeded with a **random** value at init (`Crypto::GetRandU16()`, `src/messaging/ExchangeMgr.cpp:67`) and post-incremented per `NewContext` (`src/messaging/ExchangeMgr.cpp:118`). The counter wraps `0xFFFF -> 0x0000` by design.

##### Impact

-   When the random seed lands on exactly `0xFFFF`, `ec1` gets `65535`, the counter wraps, and `ec2` gets `0`, so `0 > 65535` fails the assertion. This is a non-deterministic CI flake with probability ~1/65536 per test-binary run. Observed once in CI:
    ```
    src/messaging/tests/TestExchangeMgr.cpp:124: Failure
          Expected: ec2->GetExchangeId() > ec1->GetExchangeId()
          Actual:   0 > 65535
    ```
-   No production defect: 16-bit exchange-ID wraparound is expected, spec-conformant behavior. The bug is solely the test's assumption that the counter never wraps.

##### Solution

-   Assert **adjacency** with wrap-safe `uint16_t` arithmetic instead of magnitude:
    ```cpp
    EXPECT_EQ(ec2->GetExchangeId(), static_cast<uint16_t>(ec1->GetExchangeId() + 1));
    ```
-   When `ec1 == 0xFFFF`, the right-hand side is `static_cast<uint16_t>(0x10000) == 0`, matching `ec2 == 0`. This is wrap-safe and a *stronger* check than `>` (it verifies the increment is exactly 1, not merely larger).

#### Testing

-   Existing test `TestExchangeMgr.CheckNewContextTest`; no new test added (test-only fix to an existing assertion).
-   Verified the fix deterministically by temporarily forcing `mNextExchangeId = 0xFFFF` in `ExchangeManager::Init` and rebuilding `tests/TestExchangeMgr` (`out/linux-x64-tests-asan-clang`):
    -   Old `EXPECT_GT` assertion under the forced seed reproduces the exact CI failure (`Actual: 0 > 65535`) — **FAILED**.
    -   New `EXPECT_EQ` assertion under the same forced seed — **OK**.
    -   Both temporary changes reverted; final run with the random seed restored passes (`[  PASSED  ] 6 test(s).`).