### PR TITLE
[WiFi PAF] Fix buffer buffer size calculations

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1077,7 +1077,8 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandle &&
 
     // Select local and remote max receive window size based on local resources available for both incoming indications
     // AND GATT confirmations.
-    mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize = resp.mWindowSize;
+    mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
+        std::min(resp.mWindowSize, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE));
 
     ChipLogProgress(Ble, "local and remote recv window size = %u", resp.mWindowSize);
 

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1077,10 +1077,11 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandle &&
 
     // Select local and remote max receive window size based on local resources available for both incoming indications
     // AND GATT confirmations.
+    VerifyOrReturnError(resp.mWindowSize > 0, CHIP_ERROR_INVALID_ARGUMENT);
     mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
         std::min(resp.mWindowSize, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE));
 
-    ChipLogProgress(Ble, "local and remote recv window size = %u", resp.mWindowSize);
+    ChipLogProgress(Ble, "local and remote recv window size = %u", mReceiveWindowMaxSize);
 
     // Shrink local receive window counter by 1, since connect handshake indication requires acknowledgement.
     mLocalReceiveWindowSize = static_cast<SequenceNumber_t>(mLocalReceiveWindowSize - 1);

--- a/src/wifipaf/WiFiPAFEndPoint.cpp
+++ b/src/wifipaf/WiFiPAFEndPoint.cpp
@@ -784,7 +784,7 @@ CHIP_ERROR WiFiPAFEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandl
     }
     mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
         std::min(resp.mWindowSize, static_cast<uint8_t>(PAF_MAX_RECEIVE_WINDOW_SIZE));
-    ChipLogProgress(WiFiPAF, "local and remote recv window size = %u", resp.mWindowSize);
+    ChipLogProgress(WiFiPAF, "local and remote recv window size = %u", mReceiveWindowMaxSize);
 
     // Shrink local receive window counter by 1, since connect handshake indication requires acknowledgement.
     mLocalReceiveWindowSize = static_cast<SequenceNumber_t>(mLocalReceiveWindowSize - 1);

--- a/src/wifipaf/WiFiPAFEndPoint.cpp
+++ b/src/wifipaf/WiFiPAFEndPoint.cpp
@@ -24,6 +24,7 @@
 
 #include "WiFiPAFEndPoint.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <utility>
@@ -693,6 +694,7 @@ CHIP_ERROR WiFiPAFEndPoint::HandleCapabilitiesRequestReceived(PacketBufferHandle
     }
 
     // Select fragment size for connection based on MTU.
+    VerifyOrReturnError(mtu >= WiFiPAFTP::sMinFragmentSize, WIFIPAF_ERROR_INVALID_FRAGMENT_SIZE);
     resp.mFragmentSize = std::min(static_cast<uint16_t>(mtu), WiFiPAFTP::sMaxFragmentSize);
 
     // Select local and remote max receive window size based on local resources available for both incoming writes
@@ -752,7 +754,7 @@ CHIP_ERROR WiFiPAFEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandl
     // Decode PAFTP capabilities response.
     ReturnErrorOnFailure(PAFTransportCapabilitiesResponseMessage::Decode(data, resp));
 
-    VerifyOrReturnError(resp.mFragmentSize > 0, WIFIPAF_ERROR_INVALID_FRAGMENT_SIZE);
+    VerifyOrReturnError(resp.mFragmentSize >= WiFiPAFTP::sMinFragmentSize, WIFIPAF_ERROR_INVALID_FRAGMENT_SIZE);
 
     ChipLogProgress(WiFiPAF, "Publisher chose PAFTP version %d; subscriber expected between %d and %d",
                     resp.mSelectedProtocolVersion, CHIP_PAF_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION,
@@ -780,7 +782,8 @@ CHIP_ERROR WiFiPAFEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandl
         mState = kState_Aborting;
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize = resp.mWindowSize;
+    mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
+        std::min(resp.mWindowSize, static_cast<uint8_t>(PAF_MAX_RECEIVE_WINDOW_SIZE));
     ChipLogProgress(WiFiPAF, "local and remote recv window size = %u", resp.mWindowSize);
 
     // Shrink local receive window counter by 1, since connect handshake indication requires acknowledgement.

--- a/src/wifipaf/WiFiPAFTP.cpp
+++ b/src/wifipaf/WiFiPAFTP.cpp
@@ -70,6 +70,7 @@ static inline bool DidReceiveData(BitFlags<WiFiPAFTP::HeaderFlags> rx_flags)
 const uint16_t WiFiPAFTP::sDefaultFragmentSize = CHIP_PAF_DEFAULT_MTU; // minimum MTU - 3 bytes for operation header
 const uint16_t WiFiPAFTP::sMaxFragmentSize =
     CHIP_PAF_DEFAULT_MTU; // Maximum size of PAFTP segment. Ref: 4.21.3.1, "Supported Maximum Service Specific Info Length"
+const uint16_t WiFiPAFTP::sMinFragmentSize = kTransferProtocolMaxHeaderSize + 1;
 
 CHIP_ERROR WiFiPAFTP::Init(void * an_app_state, bool expect_first_ack)
 {

--- a/src/wifipaf/WiFiPAFTP.h
+++ b/src/wifipaf/WiFiPAFTP.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <lib/core/CHIPError.h>
@@ -92,12 +93,13 @@ public:
 
     static const uint16_t sDefaultFragmentSize;
     static const uint16_t sMaxFragmentSize;
+    static const uint16_t sMinFragmentSize;
 
     // Public functions:
     CHIP_ERROR Init(void * an_app_state, bool expect_first_ack);
 
-    inline void SetTxFragmentSize(uint16_t size) { mTxFragmentSize = size; }
-    inline void SetRxFragmentSize(uint16_t size) { mRxFragmentSize = size; }
+    inline void SetTxFragmentSize(uint16_t size) { mTxFragmentSize = std::clamp(size, sMinFragmentSize, sMaxFragmentSize); }
+    inline void SetRxFragmentSize(uint16_t size) { mRxFragmentSize = std::clamp(size, sMinFragmentSize, sMaxFragmentSize); }
 
     uint16_t GetRxFragmentSize() const { return mRxFragmentSize; }
     uint16_t GetTxFragmentSize() const { return mTxFragmentSize; }

--- a/src/wifipaf/tests/TestWiFiPAFTP.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFTP.cpp
@@ -181,5 +181,33 @@ TEST_F(TestWiFiPAFTP, CheckErrorRecv)
     auto packet_invalid_ack = System::PacketBufferHandle::NewWithData(packetData_invalid_ack, sizeof(packetData_invalid_ack));
     EXPECT_EQ(HandleCharacteristicReceived(std::move(packet_invalid_ack), receivedAck, didReceiveAck), CHIP_NO_ERROR);
 }
+
+TEST_F(TestWiFiPAFTP, EnforcesMinFragmentSize)
+{
+    const uint16_t belowMinFragmentSize = static_cast<uint16_t>(WiFiPAFTP::sMinFragmentSize - 1);
+    const uint16_t aboveMinFragmentSize = static_cast<uint16_t>(WiFiPAFTP::sMinFragmentSize + 4);
+    const uint16_t aboveMaxFragmentSize = static_cast<uint16_t>(WiFiPAFTP::sMaxFragmentSize + 3);
+
+    EXPECT_EQ(GetTxFragmentSize(), WiFiPAFTP::sDefaultFragmentSize);
+    EXPECT_EQ(GetRxFragmentSize(), WiFiPAFTP::sDefaultFragmentSize);
+
+    SetTxFragmentSize(belowMinFragmentSize);
+    SetRxFragmentSize(belowMinFragmentSize);
+
+    EXPECT_EQ(GetTxFragmentSize(), WiFiPAFTP::sMinFragmentSize);
+    EXPECT_EQ(GetRxFragmentSize(), WiFiPAFTP::sMinFragmentSize);
+
+    SetTxFragmentSize(aboveMinFragmentSize);
+    SetRxFragmentSize(aboveMinFragmentSize);
+
+    EXPECT_EQ(GetTxFragmentSize(), aboveMinFragmentSize);
+    EXPECT_EQ(GetRxFragmentSize(), aboveMinFragmentSize);
+
+    SetTxFragmentSize(aboveMaxFragmentSize);
+    SetRxFragmentSize(aboveMaxFragmentSize);
+
+    EXPECT_EQ(GetTxFragmentSize(), WiFiPAFTP::sMaxFragmentSize);
+    EXPECT_EQ(GetRxFragmentSize(), WiFiPAFTP::sMaxFragmentSize);
+}
 }; // namespace WiFiPAF
 }; // namespace chip


### PR DESCRIPTION
#### Summary
- **Problem**:
  1. **Handshake Frame**: Peer initiates a session with `PAFTransportCapabilitiesResponseMessage` specifying `mFragmentSize = 1`.
  2. **Un-Clamped Derivation**: `WiFiPAFEndPoint` sets `mTxFragmentSize = 1` without validating against protocol overhead.
  3. **Pointer Calculation Flaw**: During multi-fragment transmission (`WiFiPAFTP::HandleCharacteristicSend`), the header retreat (2–5 bytes) exceeds the forward payload advance (1 byte):
     $$\text{New Pointer} = \text{Start()} + \text{Advance (1)} - \text{Header Retreat (2)} = \text{Start()} - 1$$
  4. **Memory Overwrite**: The working pointer retreats past the payload boundary (`ReserveStart()`) into the `System::PacketBuffer` header (`alloc_size`).

- **Impact**: Packet buffer header corruption, assertion aborts, or infinite transmit loops.
- **Solution**: Enforces minimum safe fragment size clamping (`>= kTransferProtocolMaxHeaderSize + 1`) within `WiFiPAFTP` accessors and capabilities handshake handlers. Concurrently applies robust peer receive window upper-clamping across Wi-Fi PAF and BLE central endpoints (`std::min(resp.mWindowSize, MAX_RECEIVE_WINDOW_SIZE)`).

#### Testing
- Added the `EnforcesMinFragmentSize` unit test suite inside `TestWiFiPAFTP.cpp`.
- Compiled and successfully passed all 428 local transport unit tests (`src/wifipaf/tests:tests_run`, `src/ble/tests:tests_run`).
