### PR TITLE
testing

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1016,31 +1016,35 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
     VerifyOrReturnError(report.ExitContainer() == CHIP_NO_ERROR, Status::InvalidAction);
 
     ReadClient * foundSubscription = nullptr;
-    for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
+    for (ReadClient * readClient = mpActiveReadClientList; readClient != nullptr;)
     {
+        // OnUnsolicitedMessageFromPublisher() below can synchronously close and destroy readClient
+        // (a scheduled resubscribe whose session re-establishment fails -> Close -> OnDone unlinks it
+        // from mpActiveReadClientList). Cache the next pointer before the callback and do not
+        // dereference readClient afterwards. Mirrors OnActiveModeNotification / OnPeerTypeChange.
+        ReadClient * nextClient = readClient->GetNextClient();
+
         auto peer = apExchangeContext->GetSessionHandle()->GetPeer();
         if (readClient->GetFabricIndex() != peer.GetFabricIndex() || readClient->GetPeerNodeId() != peer.GetNodeId())
         {
+            readClient = nextClient;
             continue;
         }
 
-        // Notify Subscriptions about incoming communication from node
-        readClient->OnUnsolicitedMessageFromPublisher();
-
-        if (!readClient->IsSubscriptionActive())
-        {
-            continue;
-        }
-
-        if (!readClient->IsMatchingSubscriptionId(subscriptionId))
-        {
-            continue;
-        }
-
-        if (!foundSubscription)
+        // Determine whether this is the subscription the report is for before notifying, because the
+        // notification may destroy readClient. An active subscription never has a resubscribe
+        // scheduled (ScheduleResubscription requires the Idle state), so the captured client is never
+        // freed by its own notification and stays valid for the dispatch below.
+        if (foundSubscription == nullptr && readClient->IsSubscriptionActive() &&
+            readClient->IsMatchingSubscriptionId(subscriptionId))
         {
             foundSubscription = readClient;
         }
+
+        // Notify Subscriptions about incoming communication from node.
+        readClient->OnUnsolicitedMessageFromPublisher();
+
+        readClient = nextClient;
     }
 
     if (foundSubscription)

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -368,10 +368,15 @@ public:
 
     void OnUnsolicitedMessageFromPublisher()
     {
-        TriggerResubscribeIfScheduled("unsolicited message");
-
-        // Then notify callbacks
+        // Notify callbacks first. Per this method's contract the notification fires even for
+        // disconnected subscriptions, and OnUnsolicitedMessageFromPublisher() callees must not destroy
+        // the ReadClient before returning, so `this` is guaranteed valid for the call below.
         mpCallback.OnUnsolicitedMessageFromPublisher(this);
+
+        // Trigger the resubscribe last: it can synchronously close and destroy this ReadClient (a
+        // scheduled resubscribe whose session re-establishment fails -> Close -> OnDone). As the final
+        // statement, nothing dereferences `this` afterwards.
+        TriggerResubscribeIfScheduled("unsolicited message");
     }
 
     auto GetSubscriptionId() const
@@ -516,6 +521,9 @@ public:
 private:
     friend class TestReadInteraction;
     friend class InteractionModelEngine;
+    // Test-only: TestInteractionModelEngine sets mPeer / mIsResubscriptionScheduled to drive the
+    // OnUnsolicitedReportData read-client-destroyed-during-walk regression test.
+    friend class TestInteractionModelEngine;
 
     enum class ClientState : uint8_t
     {

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -18,6 +18,9 @@
 
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
+#include <app/MessageDef/ReportDataMessage.h>
+#include <app/ReadClient.h>
+#include <app/StatusResponse.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
@@ -71,6 +74,7 @@ public:
     void TestHasSubscriptionsToResumeHandlesNullIterator();
     void TestFabricHasAtLeastOneActiveSubscription();
     void TestFabricHasAtLeastOneActiveSubscriptionWithMixedStates();
+    void TestUnsolicitedReportDataReadClientDestroyedDuringWalk();
     static int GetAttributePathListLength(SingleLinkedListNode<AttributePathParams> * apattributePathParamsList);
 };
 
@@ -877,6 +881,73 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResumeHand
 }
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+
+namespace {
+// A ReadClient::Callback whose OnDone deletes the ReadClient. This mirrors an application that destroys
+// its ReadClient from within OnDone, which the ReadClient API contract permits.
+class FreeingReadClientCallback : public ReadClient::Callback
+{
+public:
+    bool mOnDoneCalled = false;
+    void OnDone(ReadClient * apReadClient) override
+    {
+        mOnDoneCalled = true;
+        delete apReadClient;
+    }
+};
+} // namespace
+
+// InteractionModelEngine::OnUnsolicitedReportData walks mpActiveReadClientList and notifies each entry via
+// readClient->OnUnsolicitedMessageFromPublisher(). For a subscription with a scheduled resubscribe and no
+// live session, that notification synchronously runs the resubscribe, fails to re-establish the session, and
+// closes the client (Close -> OnDone), which an application may use to destroy it. The walk must snapshot the
+// next pointer before the notification and not dereference the client afterwards, mirroring the sibling
+// walkers OnActiveModeNotification / OnPeerTypeChange. This drives that exact path and verifies the walk
+// completes cleanly while the client is destroyed mid-walk (confirmed via mOnDoneCalled).
+TEST_F_FROM_FIXTURE_NO_BODY(TestInteractionModelEngine, TestUnsolicitedReportDataReadClientDestroyedDuringWalk)
+void TestInteractionModelEngine::TestUnsolicitedReportDataReadClientDestroyedDuringWalk()
+{
+    InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+    engine->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
+
+    // Exchange whose session peer the ReadClient is matched against.
+    Messaging::ExchangeContext * exchange = NewExchangeToAlice(nullptr, false);
+    ASSERT_TRUE(exchange);
+    const ScopedNodeId peer = exchange->GetSessionHandle()->GetPeer();
+
+    // Heap-allocate the subscribe ReadClient; its constructor registers it on mpActiveReadClientList. The
+    // callback frees it on OnDone.
+    FreeingReadClientCallback callback;
+    auto * readClient = new ReadClient(engine, &GetExchangeManager(), callback, ReadClient::InteractionType::Subscribe);
+
+    // Drive the client into the "resubscription scheduled, no active session" state so that
+    // OnUnsolicitedMessageFromPublisher() -> TriggerResubscribeIfScheduled() fires OnResubscribeTimerCallback()
+    // synchronously, fails EstablishSessionToPeer() (no CASESessionManager registered), and Close()s -> OnDone()
+    // -> the callback deletes the client mid-walk.
+    readClient->mPeer                      = peer; // match the loop's peer filter so the callback is reached
+    readClient->mIsResubscriptionScheduled = true;
+
+    // A minimal ReportDataMessage carrying a SubscriptionId so OnUnsolicitedReportData parses past its header
+    // checks and reaches the active-read-client walk.
+    System::PacketBufferHandle payload = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);
+    ASSERT_FALSE(payload.IsNull());
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(payload));
+    ReportDataMessage::Builder reportBuilder;
+    EXPECT_SUCCESS(reportBuilder.Init(&writer));
+    reportBuilder.SubscriptionId(0x1234);
+    EXPECT_SUCCESS(reportBuilder.EndOfReportDataMessage());
+    EXPECT_EQ(writer.Finalize(&payload), CHIP_NO_ERROR);
+
+    PayloadHeader payloadHeader;
+    // The walk notifies readClient, which is destroyed during the notification; it must continue past the
+    // destroyed entry (via the snapshotted next pointer) and return without dereferencing it.
+    engine->OnUnsolicitedReportData(exchange, payloadHeader, std::move(payload));
+
+    EXPECT_TRUE(callback.mOnDoneCalled); // confirms the client was destroyed during the walk
+    engine->Shutdown();
+}
 
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
#### Summary

`InteractionModelEngine::OnUnsolicitedReportData` walks `mpActiveReadClientList` and could continue to use a `ReadClient` that was destroyed mid-walk by its own notification.

##### Problem

- `OnUnsolicitedReportData` iterates `mpActiveReadClientList` and calls `OnUnsolicitedMessageFromPublisher()` on each entry. For a disconnected subscription that notification synchronously runs a scheduled resubscribe; if re-establishing the session fails, the client is closed (`Close` -> `OnDone`), and an application is permitted to destroy its `ReadClient` from `OnDone`.
- After that notification the loop kept using the same entry: `IsSubscriptionActive()`, `IsMatchingSubscriptionId()`, the `readClient = readClient->GetNextClient()` increment, and capturing it into `foundSubscription` for the post-loop dispatch.

##### Impact

- The iterated `ReadClient` can be freed by the notification, so the subsequent reads and the loop increment operate on a destroyed object. The sibling walkers `OnActiveModeNotification` and `OnPeerTypeChange` already pre-cache the next pointer specifically to avoid this; `OnUnsolicitedReportData` did not.

##### Solution

- In the `OnUnsolicitedReportData` walk, snapshot `GetNextClient()` before the notification and evaluate the subscription match before notifying, so a destroyed entry is never dereferenced or captured. Matching before notifying is safe because an active subscription never has a resubscribe scheduled (`ScheduleResubscription` requires the `Idle` state), so the matched client is not the one torn down by its own notification.
- In `ReadClient::OnUnsolicitedMessageFromPublisher()`, notify the callback before triggering the scheduled resubscribe. `TriggerResubscribeIfScheduled()` can destroy the `ReadClient`, so it must run last.

##### Caveats

- The callback notification now runs before the resubscribe trigger rather than after it. The notification still fires in every case it did before (including for disconnected subscriptions, per the `OnUnsolicitedMessageFromPublisher` contract); only its ordering relative to the resubscribe trigger changed, which is not observable on the wire.

#### Testing

- Added unit test `TestUnsolicitedReportDataReadClientDestroyedDuringWalk` in `src/app/tests/TestInteractionModelEngine.cpp`, which drives a ReportData walk over a subscription destroyed during its own notification and verifies the walk completes cleanly. Confirmed it fails under ASan without the fix and passes with it.
- Ran the surrounding suites under ASan with no regressions: `TestInteractionModelEngine` (15), `TestReadInteraction` (112), `TestReportingEngine` (3), `TestBufferedReadCallback` (2).
