### PR TITLE
[Code Driven Cluster] Add cluster destroy to CodegenIntegration Deinit()

### DIFF
--- a/src/app/clusters/commissioner-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/commissioner-control-server/CodegenIntegration.cpp
@@ -46,7 +46,10 @@ CHIP_ERROR CommissionerControlServer::Init()
 CHIP_ERROR CommissionerControlServer::Deinit()
 {
     VerifyOrReturnError(mCluster.IsConstructed(), CHIP_ERROR_INCORRECT_STATE);
-    return CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    LogErrorOnFailure(err);
+    mCluster.Destroy();
+    return err;
 }
 
 Status CommissionerControlServer::GetSupportedDeviceCategoriesValue(

--- a/src/app/clusters/microwave-oven-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/microwave-oven-control-server/CodegenIntegration.cpp
@@ -32,7 +32,8 @@ using namespace Commands;
 
 CodegenIntegrationDelegate::CodegenIntegrationDelegate(Clusters::OperationalState::Instance & aOpStateInstance,
                                                        Clusters::ModeBase::Instance & aMicrowaveOvenModeInstance) :
-    mOpStateInstance(aOpStateInstance), mMicrowaveOvenModeInstance(aMicrowaveOvenModeInstance)
+    mOpStateInstance(aOpStateInstance),
+    mMicrowaveOvenModeInstance(aMicrowaveOvenModeInstance)
 {}
 
 uint8_t CodegenIntegrationDelegate::GetCurrentOperationalState() const
@@ -68,8 +69,8 @@ bool CodegenIntegrationDelegate::IsSupportedOperationalStateCommand(EndpointId e
 
 Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId, ClusterId aClusterId, BitMask<Feature> aFeature,
                    OperationalState::Instance & aOpStateInstance, ModeBase::Instance & aMicrowaveOvenModeInstance) :
-    mDelegate(aDelegate), mClusterPath(aEndpointId, aClusterId), mFeature(aFeature),
-    mIntegrationDelegate(aOpStateInstance, aMicrowaveOvenModeInstance)
+    mDelegate(aDelegate),
+    mClusterPath(aEndpointId, aClusterId), mFeature(aFeature), mIntegrationDelegate(aOpStateInstance, aMicrowaveOvenModeInstance)
 {
     VerifyOrDie(aClusterId == MicrowaveOvenControl::Id);
 }

--- a/src/app/clusters/microwave-oven-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/microwave-oven-control-server/CodegenIntegration.cpp
@@ -32,8 +32,7 @@ using namespace Commands;
 
 CodegenIntegrationDelegate::CodegenIntegrationDelegate(Clusters::OperationalState::Instance & aOpStateInstance,
                                                        Clusters::ModeBase::Instance & aMicrowaveOvenModeInstance) :
-    mOpStateInstance(aOpStateInstance),
-    mMicrowaveOvenModeInstance(aMicrowaveOvenModeInstance)
+    mOpStateInstance(aOpStateInstance), mMicrowaveOvenModeInstance(aMicrowaveOvenModeInstance)
 {}
 
 uint8_t CodegenIntegrationDelegate::GetCurrentOperationalState() const
@@ -69,8 +68,8 @@ bool CodegenIntegrationDelegate::IsSupportedOperationalStateCommand(EndpointId e
 
 Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId, ClusterId aClusterId, BitMask<Feature> aFeature,
                    OperationalState::Instance & aOpStateInstance, ModeBase::Instance & aMicrowaveOvenModeInstance) :
-    mDelegate(aDelegate),
-    mClusterPath(aEndpointId, aClusterId), mFeature(aFeature), mIntegrationDelegate(aOpStateInstance, aMicrowaveOvenModeInstance)
+    mDelegate(aDelegate), mClusterPath(aEndpointId, aClusterId), mFeature(aFeature),
+    mIntegrationDelegate(aOpStateInstance, aMicrowaveOvenModeInstance)
 {
     VerifyOrDie(aClusterId == MicrowaveOvenControl::Id);
 }
@@ -146,7 +145,10 @@ CHIP_ERROR Instance::Deinit()
         mDelegate->SetInstance(nullptr);
     }
     VerifyOrReturnError(mCluster.IsConstructed(), CHIP_ERROR_INCORRECT_STATE);
-    return CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    LogErrorOnFailure(err);
+    mCluster.Destroy();
+    return err;
 }
 
 uint8_t Instance::GetCountOfSupportedWattLevels() const


### PR DESCRIPTION
#### Summary

Add cluster destroy to CodegenIntegration Deinit() for Commissioner Control and Microwave Oven Control clusters.

#### Testing

Verifying that CI passes successfully.
