### PR TITLE
[Cluster Testing] Increasing the event encode buffer from 128 to 256

### DIFF
--- a/src/app/server-cluster/testing/TestEventGenerator.h
+++ b/src/app/server-cluster/testing/TestEventGenerator.h
@@ -63,7 +63,7 @@ public:
         }
 
     private:
-        uint8_t mEventEncodeBuffer[128];
+        uint8_t mEventEncodeBuffer[256];
         uint32_t mEncodedLength;
 
         friend class LogOnlyEvents;


### PR DESCRIPTION

#### Summary

Increasing the event encode buffer from 128 to 256, to prevent overflow if there are attributes with maximum length of 128 bytes

Separated from [connectedhomeip-PR#72413](https://github.com/project-chip/connectedhomeip/pull/72413)


#### Testing

Trivial fix

