### PR TITLE
[PushAVStreamTransport] Handle null MotionZones in TransportTriggerOptions storage

### DIFF
--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -148,7 +148,8 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
                   connectionID, newTransportBandwidthbps, mTotalUsedBandwidthbps);
 
     if (transportOptions.triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion &&
-        transportOptions.triggerOptions.motionZones.HasValue())
+        transportOptions.triggerOptions.motionZones.HasValue() &&
+        !transportOptions.triggerOptions.motionZones.Value().IsNull())
     {
         std::vector<std::pair<chip::app::DataModel::Nullable<uint16_t>, uint8_t>> zoneSensitivityList;
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -148,8 +148,7 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
                   connectionID, newTransportBandwidthbps, mTotalUsedBandwidthbps);
 
     if (transportOptions.triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion &&
-        transportOptions.triggerOptions.motionZones.HasValue() &&
-        !transportOptions.triggerOptions.motionZones.Value().IsNull())
+        transportOptions.triggerOptions.motionZones.HasValue() && !transportOptions.triggerOptions.motionZones.Value().IsNull())
     {
         std::vector<std::pair<chip::app::DataModel::Nullable<uint16_t>, uint8_t>> zoneSensitivityList;
 

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -157,7 +157,9 @@ struct TransportTriggerOptionsStorage : public TransportTriggerOptionsStruct
             }
             else
             {
-                motionZones.Value().SetNull();
+                // The incoming motionZones field is present and explicitly null; SetValue()
+                // makes the stored Optional present with a null Nullable.
+                motionZones.SetValue(DataModel::NullNullable);
             }
         }
         else

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -136,6 +136,9 @@ struct TransportTriggerOptionsStorage : public TransportTriggerOptionsStruct
 
         triggerType = aTransportTriggerOptions.triggerType;
 
+        // Reset before repopulating, as done for video/audio streams.
+        mTransportZoneOptions.clear();
+
         auto & motionZonesList = aTransportTriggerOptions.motionZones;
 
         if (triggerType == TransportTriggerTypeEnum::kMotion && motionZonesList.HasValue())

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
@@ -181,6 +181,32 @@ TEST_F(TestPushAVStreamTransportStorage, TestTransportTriggerOptionsStorage)
     EXPECT_EQ(motionZone2Base.sensitivity.Value(), 10);
 }
 
+// Test corner case where kMotion with motionZones present-but-null (spec: null motionZones ==
+// "motion anywhere triggers"). Verify the decodable->storage copy preserves
+// that state as a present Optional containing a null Nullable.
+TEST_F(TestPushAVStreamTransportStorage, TestTransportTriggerOptionsStorageMotionZonesNull)
+{
+    TransportMotionTriggerTimeControlDecodableStruct motionTimeControl;
+    motionTimeControl.initialDuration      = 5000;
+    motionTimeControl.augmentationDuration = 2000;
+    motionTimeControl.maxDuration          = 30000;
+    motionTimeControl.blindDuration        = 1000;
+
+    TransportTriggerOptionsDecodableStruct triggerOptions;
+    triggerOptions.triggerType = TransportTriggerTypeEnum::kMotion;
+    // present (HasValue) but explicitly null (IsNull)
+    triggerOptions.motionZones.SetValue(DataModel::NullNullable);
+    triggerOptions.motionSensitivity.SetValue(DataModel::MakeNullable((uint8_t) 5));
+    triggerOptions.motionTimeControl.SetValue(motionTimeControl);
+    triggerOptions.maxPreRollLen.SetValue(1000);
+
+    TransportTriggerOptionsStorage transportTriggerOptionsStorage(triggerOptions);
+
+    EXPECT_EQ(transportTriggerOptionsStorage.triggerType, TransportTriggerTypeEnum::kMotion);
+    ASSERT_TRUE(transportTriggerOptionsStorage.motionZones.HasValue());
+    EXPECT_TRUE(transportTriggerOptionsStorage.motionZones.Value().IsNull());
+}
+
 TEST_F(TestPushAVStreamTransportStorage, TestCMAFContainerOptionsStorage)
 {
     CMAFContainerOptionsStruct cmafContainerOptions;

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
@@ -196,7 +196,7 @@ TEST_F(TestPushAVStreamTransportStorage, TestTransportTriggerOptionsStorageMotio
     triggerOptions.triggerType = TransportTriggerTypeEnum::kMotion;
     // present (HasValue) but explicitly null (IsNull)
     triggerOptions.motionZones.SetValue(DataModel::NullNullable);
-    triggerOptions.motionSensitivity.SetValue(DataModel::MakeNullable((uint8_t) 5));
+    triggerOptions.motionSensitivity.SetValue(DataModel::MakeNullable<uint8_t>(5));
     triggerOptions.motionTimeControl.SetValue(motionTimeControl);
     triggerOptions.maxPreRollLen.SetValue(1000);
 


### PR DESCRIPTION
#### Summary

##### Problem

- For a Motion trigger, a present-but-null `MotionZones` is valid per the spec  (null or empty `MotionZones` means "motion anywhere triggers"). The decodable→storage `operator=` in `TransportTriggerOptionsStorage` did not
  handle the present-but-null case, so the stored `TriggerOptions` did not  reflect the commanded `MotionZones`.

##### Solution

- When the incoming `MotionZones` is present and null, store a present-but-null value (`SetValue(DataModel::NullNullable)`), preserving the present-vs-absent  distinction per spec.

#### Testing

- Added unit test `TestPushAVStreamTransportStorage.TestTransportTriggerOptionsStorageMotionZonesNull`,
  verifying a Motion trigger with present-but-null `MotionZones` is stored as a present Optional containing a null Nullable.