### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-198 : [chip-build] Add openssl 3.5
+199 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=53d7a08eed45071e05117ecfb4d0967cefc9ceb1
+ARG ZEPHYR_REVISION=5f11e82665069674f6173cfddb6baaec0a24bc41
 ARG N22_BIN_REVISION=cb408c3fa44bfe97af6df70516b4882ea639939c
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 4.1.0; branch: develop
-ARG ZEPHYR_REVISION=e7d639c50c8c0a908968ac2b1dff11d9c44d3a2b
+ARG ZEPHYR_REVISION=2383bfa7d5ef20bdb1fc79a292690a9ac2cb10a3
 ARG N22_BIN_REVISION=cb408c3fa44bfe97af6df70516b4882ea639939c
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \


### PR DESCRIPTION
**Change overview:**

- hal: telink: fix PAD wakeup
- include: zephyr: net: net_if.h: Fix struct net_if_addr
- samples: boards: tlsr9x: gpio-kbd-matrix: Add new sample
- drivers: ieee802154: Optimize ACK sending mechanism
- sample: boards: ble: add BLE Central and Peripheral HT sample
- west.yml: Update Telink TLx libraries
- soc: telink: tlsr: Rework SHA HW cryptography
- soc: telink: tlsr: telink_x: Kconfig: Fix Kconfig dependencies
- soc: telink: add PLIC interrupt controller support

**Changes of N22 binary:**
(latest hash cb408c3fa44bfe97af6df70516b4882ea639939c)

- None

#### Testing
Tested manually.

**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully