### PR TITLE
[ESP32] refactor: rename VerifyHeaderData and deduplicate headerDataRead reset in delta OTA

### DIFF
--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -169,7 +169,9 @@ bool OTAImageProcessorImpl::VerifyPatchHeader(void * imgHeaderData)
     return true;
 }
 
-esp_err_t OTAImageProcessorImpl::VerifyHeaderData(const uint8_t * buf, size_t size, int * index)
+// Accumulates incoming delta OTA patch data until a complete patch header is buffered,
+// then validates it via VerifyPatchHeader.
+esp_err_t OTAImageProcessorImpl::DeltaOTAVerifyHeaderData(const uint8_t * buf, size_t size, int * index)
 {
     static char patchHeader[PATCH_HEADER_SIZE];
     static int headerDataRead = 0;
@@ -185,12 +187,11 @@ esp_err_t OTAImageProcessorImpl::VerifyHeaderData(const uint8_t * buf, size_t si
         {
             *index = PATCH_HEADER_SIZE - headerDataRead;
             memcpy(patchHeader + headerDataRead, buf, *index);
+            headerDataRead = 0;
             if (!VerifyPatchHeader(patchHeader))
             {
-                headerDataRead = 0;
                 return ESP_ERR_INVALID_VERSION;
             }
-            headerDataRead      = 0;
             patchHeaderVerified = true;
         }
     }
@@ -259,13 +260,12 @@ esp_err_t OTAImageProcessorImpl::DeltaOTAWriteCallback(const uint8_t * buf, size
             memcpy(headerData + headerDataRead, buf, index);
 
             esp_image_header_t * header = (esp_image_header_t *) headerData;
+            headerDataRead               = 0;
             if (!VerifyChipId(header->chip_id))
             {
-                headerDataRead = 0;
                 return ESP_ERR_INVALID_VERSION;
             }
             imageProcessor->chipIdVerified = true;
-            headerDataRead                 = 0;
 
             // Write data in headerData buffer.
             esp_err_t err = esp_ota_write(imageProcessor->mOTAUpdateHandle, headerData, IMG_HEADER_LEN);
@@ -499,7 +499,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 #ifdef CONFIG_ENABLE_DELTA_OTA
 
     int index = 0;
-    err       = imageProcessor->VerifyHeaderData(blockToWrite.data(), blockToWrite.size(), &index);
+    err       = imageProcessor->DeltaOTAVerifyHeaderData(blockToWrite.data(), blockToWrite.size(), &index);
 
     if (err != ESP_OK)
     {

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -260,7 +260,7 @@ esp_err_t OTAImageProcessorImpl::DeltaOTAWriteCallback(const uint8_t * buf, size
             memcpy(headerData + headerDataRead, buf, index);
 
             esp_image_header_t * header = (esp_image_header_t *) headerData;
-            headerDataRead               = 0;
+            headerDataRead              = 0;
             if (!VerifyChipId(header->chip_id))
             {
                 return ESP_ERR_INVALID_VERSION;

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -91,7 +91,7 @@ private:
     static void DeltaOTACleanUp(intptr_t context);
     static bool VerifyChipId(esp_chip_id_t chipId);
     static bool VerifyPatchHeader(void * imgHeaderData);
-    esp_err_t VerifyHeaderData(const uint8_t * buf, size_t size, int * index);
+    esp_err_t DeltaOTAVerifyHeaderData(const uint8_t * buf, size_t size, int * index);
     static esp_err_t DeltaOTAReadCallback(uint8_t * buf_p, size_t size, int src_offset);
     static esp_err_t DeltaOTAWriteCallback(const uint8_t * buf_p, size_t size, void * arg);
 #endif // CONFIG_ENABLE_DELTA_OTA


### PR DESCRIPTION
#### Change overview

  - Renamed `VerifyHeaderData` to `DeltaOTAVerifyHeaderData` in OTAImageProcessorImpl.h, OTAImageProcessorImpl.cpp (definition and call site in HandleProcessBlock).
  - Added a short doc comment above DeltaOTAVerifyHeaderData describing its accumulation and validation role.
  - Removing the duplicate reset of `headerDataRead` that was split across the error and success branches.

 #### Testing

  - Build examples/lighting-app/esp32 with CONFIG_ENABLE_DELTA_OTA=y (delta OTA code path compiled in)
