### PR TITLE
[PR templates] simplify PR template and align with CI checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,64 +1,34 @@
-#### Summary
+### Summary
 
 <!--
-    This section will help the reviewer better understand the context of this change.
-    Please provide a TLDR appropriate to the change's complexity on what was changed and why.
-    If fixing an error, explain the root cause and the chosen solution's rationale, especially if not obvious.
-    Include context like links to related documents/issues/test plans and highlight notable information or specific concerns.
+    Briefly describe what changed and why. For bug fixes, include the root cause
+    and your chosen solution. Link to relevant documents, test plans, or prior
+    issues.
 
-    See guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#pr-summary-description
-    See title formatting: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting
+    See [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html).
 
     Please replace this HTML comment with the actual PR summary.
 -->
 
-#### Related issues
+### Related issues
 
 <!--
-    This section will help the reviewer easily navigate to the GitHub issues related to this PR change.
-    Please mention all the related issues in this section.
+    Link to related GitHub issues. Use `Fixes #12345` to auto-close on merge,
+    or `#12345` to reference without closing.
 
-    Tip: use the syntax of Fixes #.... to mark issues completed on PR merge or use #... to reference issues that are addressed.
-
-    Examples:
-        Fixes: #12345
-        #12345
-        N/A (not preferable)
-
-    Please replace this HTML comment with the actual information about related issues.
+    Please replace this HTML comment with the actual related issues.
 -->
 
-#### Testing
+### Testing
 
 <!--
-    This section will help the reviewer understand how this PR change was tested.
-    As a general rule, a proposed PR change must not break the existing code and must be well-tested.
-    Please include information about testing.
-
-    See testing guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#testing
+    Describe how you tested this change.
 
     Examples:
-        added unit tests
-        verified by YAML test: TC_ABC.yaml
-        added Python test: TC_DEF.py
-        manually tested (mention steps to reproduce)
+        - Added unit tests
+        - Verified by YAML test: TC_ABC.yaml
+        - Added Python test: TC_DEF.py
+        - Manually tested (describe steps)
 
-    Please replace this HTML comment with the actual information about how the testing was done.
- -->
-
-#### Readability checklist
-
-The checklist below will help the reviewer finish PR review in time and keep the
-code readable:
-
--   [ ] PR title is
-        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
--   [ ] Apply the
-        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
-        rule (coding style)
--   [ ] PR size is short
--   [ ] Try to avoid "squashing" and "force-update" in commit history
--   [ ] CI time didn't increase
-
-See:
-[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
+    Please replace this HTML comment with the actual testing details.
+-->


### PR DESCRIPTION
#### Summary

   Simplify the PR template and align it with CI validation.
   
   - Remove the unused "Readability checklist" section that was never meaningfully filled out.
   - Change section headings from `####` to `###` to match the `### Testing` check in `pr-validation.yaml`.
   - Reduce each section to a single clear instruction instead of verbose meta-commentary.
   - Consolidate duplicate guidelines links into one per section.
   - Keep the `Please replace ...` guardrails that CI uses to detect unfilled templates.
   
#### Related issues

   N/A
   
#### Testing

   CI will also validate