### PR TITLE
[resource-monitoring] Delete the default copy ctor of ReplacementProductStruct

### DIFF
--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.h
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.h
@@ -100,7 +100,8 @@ public:
         TEMPORARY_RETURN_IGNORED SetProductIdentifierValue(aProductIdentifierValue);
     }
 
-    // Deleted: the default copy ctor would shallow-copy the inherited productIdentifierValue, a span into our own buffer (use-after-free).
+    // Deleted: the default copy ctor would shallow-copy the inherited productIdentifierValue, a span into our own buffer
+    // (use-after-free).
     ReplacementProductStruct(const ReplacementProductStruct &) = delete;
 
     ReplacementProductStruct & operator=(const ReplacementProductStruct & aReplacementProductStruct)

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.h
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.h
@@ -100,6 +100,9 @@ public:
         TEMPORARY_RETURN_IGNORED SetProductIdentifierValue(aProductIdentifierValue);
     }
 
+    // Deleted: the default copy ctor would shallow-copy the inherited productIdentifierValue, a span into our own buffer (use-after-free).
+    ReplacementProductStruct(const ReplacementProductStruct &) = delete;
+
     ReplacementProductStruct & operator=(const ReplacementProductStruct & aReplacementProductStruct)
     {
         SetProductIdentifierType(aReplacementProductStruct.GetProductIdentifierType());


### PR DESCRIPTION
#### Summary

Deletes the compiler-generated copy constructor of `ResourceMonitoring::ReplacementProductStruct`, which is unsafe.

##### Problem

- `productIdentifierValue` is inherited from the generated base `Type` and is a `CharSpan` that `SetProductIdentifierValue()` points into this struct's own `productIdentifierValueBuffer`.
- The struct defines a custom copy-assignment operator (which re-points the span correctly) but no copy constructor, so the compiler emits a defaulted one that shallow-copies the span.

##### Impact

- A copy-constructed instance's `productIdentifierValue` points into the source object's buffer. Once the source is destroyed, reading the copy is a use-after-free.
- Currently latent: all callers fill instances by reference. A by-value copy (`auto x = item;`, by-value parameter/return, or container storage) would make it live.

##### Solution

- Delete the copy constructor. All existing usage fills instances by reference, so no code path is affected.
- The custom copy-assignment operator (which copies into the destination's own buffer and re-points the span) is retained.
- Also resolves the `cpp/rule-of-two` code-scanning warning (copy assignment without a matching copy constructor).

##### Caveats

- The struct is now non-copy-constructible; move-construction (which fell back to the copy) is consequently also unavailable. Copy-assignment remains. This matches existing by-reference usage.

#### Testing

- No unit test added: the change removes the ability to copy-construct, so there is no runtime behavior to exercise.
- Verified that no code path copy-constructs the struct by compiling the two consumer translation units against the change — `ResourceMonitoringCluster.cpp` (attribute-read/encode path) and `resource-monitoring-delegates.cpp` (example delegate) — both compile cleanly.
