### PR TITLE
[Camera] Start AV stream HAL pipelines lazily on transport acquire/release

### DIFF
--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -179,6 +179,13 @@ private:
     void GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                 const Optional<DataModel::Nullable<uint16_t>> & audioStreamId, uint32_t & outBandwidthbps);
 
+    /**
+     * @brief Releases the audio/video streams referenced by the given connection so the AV Stream Management delegate can stop
+     *        the underlying HAL pipelines once no consumer remains. No-op if the connection has no stored transport options.
+     * @param connectionID The connection whose referenced streams should be released.
+     */
+    void ReleaseStreamsForConnection(uint16_t connectionID);
+
     void StartSessionMonitor();
     void StopSessionMonitor();
     void SessionMonitor();

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -186,6 +186,14 @@ private:
      */
     void ReleaseStreamsForConnection(uint16_t connectionID);
 
+    /**
+     * @brief Extracts the referenced audio/video stream IDs from the given transport options.
+     *        An absent or null stream ID is reported as UINT16_MAX, which the AV Stream Management delegate treats as
+     *        "no stream" and skips.
+     */
+    static void GetReferencedStreamIds(const TransportOptionsStruct & transportOptions, uint16_t & audioStreamID,
+                                       uint16_t & videoStreamID);
+
     void StartSessionMonitor();
     void StopSessionMonitor();
     void SessionMonitor();

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -735,13 +735,12 @@ CameraAVStreamManager::AllocatedVideoStreamsLoaded()
 
         if (it != persistedStreams.end())
         {
-            // Found in persisted streams, mark as allocated in HAL
+            // Found in persisted streams, mark as allocated in HAL. The underlying HAL pipeline is started lazily when the
+            // first transport acquires the stream (see OnTransportAcquireAudioVideoStreams), so that a reboot with no active
+            // consumer does not leave encoder pipelines running idle.
             halStream.isAllocated = true;
             ChipLogProgress(Camera, "HAL Video Stream ID %u marked as allocated from persisted state.",
                             halStream.videoStreamParams.videoStreamID);
-
-            // Signal for starting the video stream
-            OnVideoStreamAllocated(*it, StreamAllocationAction::kNewAllocation);
         }
     }
 
@@ -762,18 +761,12 @@ CameraAVStreamManager::AllocatedAudioStreamsLoaded()
 
         if (it != persistedStreams.end())
         {
-            // Found in persisted streams, mark as allocated in HAL
+            // Found in persisted streams, mark as allocated in HAL. The underlying HAL pipeline is started lazily when the
+            // first transport acquires the stream (see OnTransportAcquireAudioVideoStreams), so that a reboot with no active
+            // consumer does not leave audio pipelines running idle.
             halStream.isAllocated = true;
             ChipLogProgress(Camera, "HAL Audio Stream ID %u marked as allocated from persisted state.",
                             halStream.audioStreamParams.audioStreamID);
-
-            // Start the audio stream from HAL for serving.
-            if (mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(halStream.audioStreamParams.audioStreamID) !=
-                CameraError::SUCCESS)
-            {
-                ChipLogError(Camera, "Failed to start HAL Audio Stream for persisted ID %u.",
-                             halStream.audioStreamParams.audioStreamID);
-            }
         }
     }
 
@@ -899,6 +892,15 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
         {
             if (stream.audioStreamParams.referenceCount < UINT8_MAX)
             {
+                // Lazily start the HAL pipeline on the first consumer (0 -> 1 transition).
+                if (stream.audioStreamParams.referenceCount == 0)
+                {
+                    ChipLogProgress(Camera, "Starting audio stream with ID: %u on first acquire", audioStreamID);
+                    if (mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(audioStreamID) != CameraError::SUCCESS)
+                    {
+                        ChipLogError(Camera, "Failed to start HAL Audio Stream for ID %u on acquire.", audioStreamID);
+                    }
+                }
                 stream.audioStreamParams.referenceCount++;
             }
             else
@@ -915,6 +917,16 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
         {
             if (stream.videoStreamParams.referenceCount < UINT8_MAX)
             {
+                // Lazily start the HAL pipeline on the first consumer (0 -> 1 transition).
+                if (stream.videoStreamParams.referenceCount == 0)
+                {
+                    ChipLogProgress(Camera, "Starting video stream with ID: %u on first acquire", videoStreamID);
+                    if (mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(stream.videoStreamParams) !=
+                        CameraError::SUCCESS)
+                    {
+                        ChipLogError(Camera, "Failed to start HAL Video Stream for ID %u on acquire.", videoStreamID);
+                    }
+                }
                 stream.videoStreamParams.referenceCount++;
             }
             else
@@ -951,6 +963,15 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
             if (stream.audioStreamParams.referenceCount > 0)
             {
                 stream.audioStreamParams.referenceCount--;
+                // Stop the HAL pipeline once the last consumer releases (1 -> 0 transition).
+                if (stream.audioStreamParams.referenceCount == 0)
+                {
+                    ChipLogProgress(Camera, "Stopping audio stream with ID: %u on last release", audioStreamID);
+                    if (mCameraDeviceHAL->GetCameraHALInterface().StopAudioStream(audioStreamID) != CameraError::SUCCESS)
+                    {
+                        ChipLogError(Camera, "Failed to stop HAL Audio Stream for ID %u on release.", audioStreamID);
+                    }
+                }
             }
             else
             {
@@ -967,6 +988,15 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
             if (stream.videoStreamParams.referenceCount > 0)
             {
                 stream.videoStreamParams.referenceCount--;
+                // Stop the HAL pipeline once the last consumer releases (1 -> 0 transition).
+                if (stream.videoStreamParams.referenceCount == 0)
+                {
+                    ChipLogProgress(Camera, "Stopping video stream with ID: %u on last release", videoStreamID);
+                    if (mCameraDeviceHAL->GetCameraHALInterface().StopVideoStream(videoStreamID) != CameraError::SUCCESS)
+                    {
+                        ChipLogError(Camera, "Failed to stop HAL Video Stream for ID %u on release.", videoStreamID);
+                    }
+                }
             }
             else
             {

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -926,6 +926,12 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
                     {
                         ChipLogError(Camera, "Failed to start HAL Video Stream for ID %u on acquire.", videoStreamID);
                     }
+                    else
+                    {
+                        // Reflect the frame rate reported by the HAL once the stream has started.
+                        TEMPORARY_RETURN_IGNORED GetCameraAVStreamManagementCluster()->SetCurrentFrameRate(
+                            mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
+                    }
                 }
                 stream.videoStreamParams.referenceCount++;
             }
@@ -936,15 +942,18 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
         }
     }
 
-    // Update the counts in the SDK allocated stream attributes
-    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true) !=
-        CHIP_NO_ERROR)
+    // Update the counts in the SDK allocated stream attributes. A transport may reference only one of the two stream types, in
+    // which case the absent stream ID is UINT16_MAX and must be skipped.
+    if (audioStreamID != UINT16_MAX &&
+        GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true) !=
+            CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "Failed to increment audio stream %u ref count in SDK", audioStreamID);
     }
 
-    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true) !=
-        CHIP_NO_ERROR)
+    if (videoStreamID != UINT16_MAX &&
+        GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true) !=
+            CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "Failed to increment video stream %u ref count in SDK", videoStreamID);
     }
@@ -1005,15 +1014,18 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
         }
     }
 
-    // Update the counts in the SDK allocated stream attributes
-    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false) !=
-        CHIP_NO_ERROR)
+    // Update the counts in the SDK allocated stream attributes. A transport may reference only one of the two stream types, in
+    // which case the absent stream ID is UINT16_MAX and must be skipped.
+    if (audioStreamID != UINT16_MAX &&
+        GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false) !=
+            CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "Failed to decrement audio stream %u ref count in SDK", audioStreamID);
     }
 
-    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false) !=
-        CHIP_NO_ERROR)
+    if (videoStreamID != UINT16_MAX &&
+        GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false) !=
+            CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "Failed to decrement video stream %u ref count in SDK", videoStreamID);
     }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -43,6 +43,8 @@ PushAvStreamTransportManager::~PushAvStreamTransportManager()
         for (auto & kv : mTransportMap)
         {
             mMediaController->UnregisterTransport(kv.second.get());
+            // Release the referenced streams so the HAL pipelines are stopped when no consumer remains.
+            ReleaseStreamsForConnection(kv.first);
         }
     }
     mTransportMap.clear();
@@ -135,6 +137,11 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     mMediaController->RegisterTransport(mTransportMap[connectionID].get(), videoStreamID, audioStreamID);
     mMediaController->SetPreRollLength(mTransportMap[connectionID].get(), mTransportMap[connectionID].get()->GetPreRollLength());
 
+    // Acquire the referenced audio/video streams so the HAL pipelines are started for this consumer. Stream pipelines are
+    // started lazily on the first acquire and stopped on the last release.
+    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(audioStreamID,
+                                                                                                               videoStreamID);
+
     uint32_t newTransportBandwidthbps = 0;
     GetBandwidthForStreams(transportOptions.videoStreamID, transportOptions.audioStreamID, newTransportBandwidthbps);
 
@@ -182,6 +189,38 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     return Status::Success;
 }
 
+void PushAvStreamTransportManager::ReleaseStreamsForConnection(uint16_t connectionID)
+{
+    if (mCameraDevice == nullptr)
+    {
+        return;
+    }
+
+    auto optsIt = mTransportOptionsMap.find(connectionID);
+    if (optsIt == mTransportOptionsMap.end())
+    {
+        return;
+    }
+
+    const TransportOptionsStruct & transportOptions = optsIt->second;
+
+    uint16_t videoStreamID = -1;
+    uint16_t audioStreamID = -1;
+
+    if (transportOptions.videoStreamID.HasValue() && !transportOptions.videoStreamID.Value().IsNull())
+    {
+        videoStreamID = transportOptions.videoStreamID.Value().Value();
+    }
+
+    if (transportOptions.audioStreamID.HasValue() && !transportOptions.audioStreamID.Value().IsNull())
+    {
+        audioStreamID = transportOptions.audioStreamID.Value().Value();
+    }
+
+    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(audioStreamID,
+                                                                                                               videoStreamID);
+}
+
 Protocols::InteractionModel::Status PushAvStreamTransportManager::DeallocatePushTransport(const uint16_t connectionID)
 {
     if (mTransportMap.find(connectionID) == mTransportMap.end())
@@ -191,6 +230,10 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::DeallocatePush
     }
     mTotalUsedBandwidthbps -= mTransportMap[connectionID].get()->GetCurrentlyUsedBandwidthbps();
     mMediaController->UnregisterTransport(mTransportMap[connectionID].get());
+
+    // Release the referenced audio/video streams so the HAL pipelines can be stopped once no consumer remains.
+    ReleaseStreamsForConnection(connectionID);
+
     mTransportMap.erase(connectionID);
     mTransportOptionsMap.erase(connectionID);
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -117,20 +117,12 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     /*
     Initialize video, audio stream ids with default invalid value (UINT16_MAX = 65535)
     This is necessary because the MediaController API expects these values to be set.
-    If any of video/audio stream id is absent in the transport options,UINT16_MAX max is used as default value.
+    If any of video/audio stream id is absent in the transport options, UINT16_MAX is used as default value.
     */
-    uint16_t videoStreamID = -1;
-    uint16_t audioStreamID = -1;
+    uint16_t videoStreamID = UINT16_MAX;
+    uint16_t audioStreamID = UINT16_MAX;
+    GetReferencedStreamIds(transportOptions, audioStreamID, videoStreamID);
 
-    if (transportOptions.videoStreamID.HasValue() && !transportOptions.videoStreamID.Value().IsNull())
-    {
-        videoStreamID = transportOptions.videoStreamID.Value().Value();
-    }
-
-    if (transportOptions.audioStreamID.HasValue() && !transportOptions.audioStreamID.Value().IsNull())
-    {
-        audioStreamID = transportOptions.audioStreamID.Value().Value();
-    }
     ChipLogProgress(
         Camera, "PushAvStreamTransportManager, RegisterTransport for connectionID: [%u], videoStreamID: [%u], audioStreamID: [%u]",
         connectionID, videoStreamID, audioStreamID);
@@ -202,10 +194,19 @@ void PushAvStreamTransportManager::ReleaseStreamsForConnection(uint16_t connecti
         return;
     }
 
-    const TransportOptionsStruct & transportOptions = optsIt->second;
+    uint16_t videoStreamID = UINT16_MAX;
+    uint16_t audioStreamID = UINT16_MAX;
+    GetReferencedStreamIds(optsIt->second, audioStreamID, videoStreamID);
 
-    uint16_t videoStreamID = -1;
-    uint16_t audioStreamID = -1;
+    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(audioStreamID,
+                                                                                                               videoStreamID);
+}
+
+void PushAvStreamTransportManager::GetReferencedStreamIds(const TransportOptionsStruct & transportOptions,
+                                                          uint16_t & audioStreamID, uint16_t & videoStreamID)
+{
+    videoStreamID = UINT16_MAX;
+    audioStreamID = UINT16_MAX;
 
     if (transportOptions.videoStreamID.HasValue() && !transportOptions.videoStreamID.Value().IsNull())
     {
@@ -216,9 +217,6 @@ void PushAvStreamTransportManager::ReleaseStreamsForConnection(uint16_t connecti
     {
         audioStreamID = transportOptions.audioStreamID.Value().Value();
     }
-
-    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(audioStreamID,
-                                                                                                               videoStreamID);
 }
 
 Protocols::InteractionModel::Status PushAvStreamTransportManager::DeallocatePushTransport(const uint16_t connectionID)
@@ -262,8 +260,38 @@ PushAvStreamTransportManager::ModifyPushTransport(const uint16_t connectionID, c
                   "New transport bandwidth: %u bps. Total used bandwidth: %u bps.",
                   connectionID, newTransportBandwidthbps, mTotalUsedBandwidthbps);
 
+    // Capture the streams referenced before the modification so the HAL pipeline acquire/release stays balanced if the
+    // modification changes which streams the connection references.
+    uint16_t oldAudioStreamID = UINT16_MAX;
+    uint16_t oldVideoStreamID = UINT16_MAX;
+    auto optsIt               = mTransportOptionsMap.find(connectionID);
+    if (optsIt != mTransportOptionsMap.end())
+    {
+        GetReferencedStreamIds(optsIt->second, oldAudioStreamID, oldVideoStreamID);
+    }
+
     mTransportOptionsMap[connectionID] = transportOptions;
     mTransportMap[connectionID].get()->ModifyPushTransport(transportOptions);
+
+    uint16_t newAudioStreamID = UINT16_MAX;
+    uint16_t newVideoStreamID = UINT16_MAX;
+    GetReferencedStreamIds(mTransportOptionsMap[connectionID], newAudioStreamID, newVideoStreamID);
+
+    // Release the streams that are no longer referenced and acquire the newly referenced ones. Streams that are unchanged
+    // are passed as UINT16_MAX so the delegate skips them, avoiding an unnecessary HAL pipeline stop/start.
+    if (mCameraDevice != nullptr && (oldAudioStreamID != newAudioStreamID || oldVideoStreamID != newVideoStreamID))
+    {
+        uint16_t audioToRelease = (oldAudioStreamID != newAudioStreamID) ? oldAudioStreamID : UINT16_MAX;
+        uint16_t videoToRelease = (oldVideoStreamID != newVideoStreamID) ? oldVideoStreamID : UINT16_MAX;
+        TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(
+            audioToRelease, videoToRelease);
+
+        uint16_t audioToAcquire = (newAudioStreamID != oldAudioStreamID) ? newAudioStreamID : UINT16_MAX;
+        uint16_t videoToAcquire = (newVideoStreamID != oldVideoStreamID) ? newVideoStreamID : UINT16_MAX;
+        TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(
+            audioToAcquire, videoToAcquire);
+    }
+
     ChipLogProgress(Camera, "PushAvStreamTransportManager, success to modify Connection :[%u]", connectionID);
 
     return Status::Success;
@@ -625,6 +653,10 @@ CHIP_ERROR PushAvStreamTransportManager::LoadCurrentConnections(std::vector<Tran
 {
     ChipLogProgress(Zcl, "Push AV Current Connections loaded");
 
+    // TODO: This is currently a no-op, so persisted Push AV connections are not restored after a reboot. When restoring
+    // connections here, each restored connection that should resume streaming must also re-acquire its referenced streams via
+    // GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(); otherwise the HAL pipelines will not restart (and
+    // the destructor's ReleaseStreamsForConnection would underflow the reference count on streams that were never acquired).
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Summary

In the camera-app Linux example, every persisted video/audio stream pipeline
was started immediately when the allocated streams were restored on reboot
(in `PersistentAttributesLoadedCallback`), regardless of whether any transport
was actually consuming them. This left encoder/capture pipelines running idle
and wasting CPU after a reboot with no active session.

This PR makes the HAL pipeline lifecycle **consumer-driven** instead, so a
stream's underlying pipeline only runs while something is actually consuming it:

- `AllocatedVideoStreamsLoaded` / `AllocatedAudioStreamsLoaded` now only restore
  the allocated configuration (mark `isAllocated`) and no longer start pipelines.
- `OnTransportAcquireAudioVideoStreams` starts the HAL stream on the first
  consumer (`referenceCount` 0 → 1) and `OnTransportReleaseAudioVideoStreams`
  stops it on the last release (1 → 0). When a video stream is lazily started,
  the `CurrentFrameRate` attribute is restored from the HAL (parity with the
  previous `OnVideoStreamAllocated` path).
- Push AV transports are routed through the same acquire/release path, so
  streams are started when a Push transport registers (`AllocatePushTransport`)
  and stopped when it is deallocated/destroyed (`DeallocatePushTransport`,
  destructor). `ModifyPushTransport` rebalances the reference counts when the
  referenced streams change: it releases the streams no longer referenced and
  acquires the newly referenced ones, skipping unchanged streams to avoid an
  unnecessary HAL pipeline stop/start.

Additional robustness fixes that fall out of routing more callers through the
acquire/release path:

- The referenced-stream-id extraction is factored into a shared helper
  (`GetReferencedStreamIds`), replacing the implicit `uint16_t = -1` wrap with
  an explicit `UINT16_MAX` sentinel.
- The SDK ref-count updates are guarded with a `UINT16_MAX` check, so Push AV
  transports that reference only audio or only video no longer emit spurious
  "Failed to increment/decrement ref count" errors and cannot corrupt ref counts
  via the invalid sentinel stream ID.

WebRTC already calls acquire/release, so live view continues to work. Snapshot
stream handling is intentionally left unchanged.

Note: `LoadCurrentConnections` is currently a no-op, so persisted Push AV
connections are not restored after a reboot. A `TODO` documents that, once those
connections are restored, each restored connection must re-acquire its
referenced streams; otherwise the HAL pipelines will not restart and the
destructor's release would underflow the reference count.

#### Related issues

N/A

#### Testing

Manually tested with the camera-app Linux example (`--camera-test-videosrc --camera-test-audiosrc`):

- Reboot with allocated-but-unconsumed streams: HAL audio/video pipelines are no
  longer started on boot (only `... marked as allocated from persisted state` is
  logged; no pipeline start), confirming pipelines no longer run idle after reboot.
- WebRTC `ProvideOffer` (first consumer): the referenced video stream is started
  lazily on acquire (`Starting video stream with ID: 3 on first acquire`, pipeline
  reaches PLAYING) and live view works end to end.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase