### PR TITLE
Add automatic retry to tar artifact extraction in CI workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -267,9 +267,12 @@ jobs:
               with:
                 name: repl-build-data
 
-            - name: Unpack artifacts
-              run: |
-                tar xfJ repl-build-data.tar.xz
+            - uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
+              name: Unpack artifacts
+              with:
+                  command: tar xfJ repl-build-data.tar.xz
+                  attempt_limit: 3
+                  attempt_delay: 2000
 
             - name: Generate an argument environment file
               run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -267,6 +267,8 @@ jobs:
               with:
                 name: repl-build-data
 
+            # OverlayFS (Docker container storage) layer copy-up occasionally causes
+            # "Directory renamed before its status could be extracted" during rapid unpack.
             - uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
               name: Unpack artifacts
               with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1158,9 +1158,12 @@ jobs:
               with:
                 name: repl-build-data
 
-            - name: Unpack artifacts
-              run: |
-                tar xfJ repl-build-data.tar.xz
+            - uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
+              name: Unpack artifacts
+              with:
+                  command: tar xfJ repl-build-data.tar.xz
+                  attempt_limit: 3
+                  attempt_delay: 2000
 
             - name: Generate an argument environment file
               run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1158,6 +1158,8 @@ jobs:
               with:
                 name: repl-build-data
 
+            # OverlayFS (Docker container storage) layer copy-up occasionally causes
+            # "Directory renamed before its status could be extracted" during rapid unpack.
             - uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
               name: Unpack artifacts
               with:


### PR DESCRIPTION
#### Summary

- **Problem**: Occasional flaky CI job failures during `Unpack artifacts` ("Directory renamed before its status could be extracted"). This happens on union/overlay filesystems when rapid extraction triggers a copy-up between directory creation and delayed metadata restoration.
- **Impact**: Flaky REPL tests and Nightly workflow runs on Linux runners.
- **Solution**: Wrap the `tar xfJ repl-build-data.tar.xz` unpack step with `Wandalen/wretry.action` (3 attempts, 2000ms delay) to automatically retry upon transient OverlayFS/tar race conditions.

#### Testing

Verified strict YAML structure and indentation across both `tests.yaml` and `nightly.yaml`.
