### PR TITLE
[Code Driven Cluster] Add cluster destroy to Chime CodegenIntegration

### DIFF
--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -50,6 +50,7 @@ ChimeServer::~ChimeServer()
     if (mCluster.IsConstructed())
     {
         RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+        mCluster.Destroy();
     }
 }
 

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -84,15 +84,17 @@ public:
      */
     EndpointId GetEndpointId() { return mEndpointId; }
 
-    // Cluster constants from the spec
-    static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;
-
-    // The Code Driven ChimeCluster instance (lazy-initialized)
-    chip::app::LazyRegisteredServerCluster<CodegenChimeCluster> mCluster;
+    /**
+     * @return The Code Driven ChimeCluster instance.
+     */
+    CodegenChimeCluster & Cluster() { return mCluster.Cluster(); }
 
 private:
     EndpointId mEndpointId;
     ChimeDelegate * mDelegate;
+
+    // The Code Driven ChimeCluster instance (lazy-initialized)
+    chip::app::LazyRegisteredServerCluster<CodegenChimeCluster> mCluster;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -89,6 +89,9 @@ public:
      */
     CodegenChimeCluster & Cluster() { return mCluster.Cluster(); }
 
+    // Cluster constants from the spec
+    static constexpr uint8_t kMaxChimeSoundNameSize = CodegenChimeCluster::kMaxChimeSoundNameSize;
+
 private:
     EndpointId mEndpointId;
     ChimeDelegate * mDelegate;

--- a/src/app/clusters/chime-server/tests/TestChimeClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeClusterBackwardsCompatibility.cpp
@@ -72,7 +72,7 @@ struct TestChimeClusterBackwardsCompatibility : public ::testing::Test
     void SetUp() override
     {
         EXPECT_EQ(mChimeServer.Init(), CHIP_NO_ERROR);
-        EXPECT_EQ(mChimeServer.mCluster.Cluster().Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
+        EXPECT_EQ(mChimeServer.Cluster().Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
 
     void TearDown() override {}
@@ -81,7 +81,7 @@ struct TestChimeClusterBackwardsCompatibility : public ::testing::Test
 
     ChimeServer mChimeServer{ kTestEndpointId, mMockDelegate };
 
-    chip::Testing::ClusterTester mClusterTester{ mChimeServer.mCluster.Cluster() };
+    chip::Testing::ClusterTester mClusterTester{ mChimeServer.Cluster() };
 };
 
 TEST_F(TestChimeClusterBackwardsCompatibility, TestLegacyInstantiation)


### PR DESCRIPTION
#### Summary

Add cluster destroy to CodegenIntegration for Chime cluster.

#### Testing

Verifying that CI passes successfully.