### PR TITLE
[Cleanup] Reduce chip-cert-bins docker image size and speed up builds.

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -131,7 +131,7 @@ RUN set -x \
 ARG COMMITHASH=c1ec2d777456924dcaa59b53351b00d73caf378f
 # This does a shallower checkout of the repo
 RUN echo "Cloning at commit: ${COMMITHASH}" \
-    mkdir /root/connectedhomeip \
+    && mkdir /root/connectedhomeip \
     && git init /root/connectedhomeip \
     && cd /root/connectedhomeip \
     && git init . \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -155,17 +155,17 @@ SHELL ["/bin/bash", "-c"]
 RUN git rev-parse HEAD > /root/.sdk-sha-version
 
 #setup ccache
-ARG CCACHE_NOHASHDIR=1 
-ARG CCACHE_BASEDIR=/root/connectedhomeip/ 
-ARG CCACHE_NODIRECT=1 
-ARG CCACHE_PREFIX_CPP=/root/connectedhomeip/scripts/helpers/ccache-prefix-cpp.sh 
-ARG CCACHE_SLOPPINESS=time_macros 
-ARG CCACHE_DIR=/root/connectedhomeip/.ccache 
-ARG CCACHE_COMPILERCHECK=content 
-ARG CCACHE_MAXSIZE=5G 
-ARG CCACHE_COMPRESS=1 
-ARG CCACHE_COMPRESSLEVEL=6 
-ARG CHIP_PW_COMMAND_LAUNCHER=ccache 
+ARG CCACHE_NOHASHDIR=1
+ARG CCACHE_BASEDIR=/root/connectedhomeip/
+ARG CCACHE_NODIRECT=1
+ARG CCACHE_PREFIX_CPP=/root/connectedhomeip/scripts/helpers/ccache-prefix-cpp.sh
+ARG CCACHE_SLOPPINESS=time_macros
+ARG CCACHE_DIR=/root/connectedhomeip/.ccache
+ARG CCACHE_COMPILERCHECK=content
+ARG CCACHE_MAXSIZE=5G
+ARG CCACHE_COMPRESS=1
+ARG CCACHE_COMPRESSLEVEL=6
+ARG CHIP_PW_COMMAND_LAUNCHER=ccache
 
 # Target suffixes shared across all supported architectures.
 # The arch prefix (linux-x64 / linux-arm64) is prepended at build time.
@@ -177,7 +177,7 @@ RUN case ${TARGETPLATFORM} in \
             && exit 1 \
         ;; \
     esac \
-    && echo "ARCH=${ARCH}" > /tmp/arch.env 
+    && echo "ARCH=${ARCH}" > /tmp/arch.env
 
 ARG BUILD_EXAMPLES_ARGS="--pw-command-launcher=ccache --build-profile=release-size --pregen-dir ./zzz_pregenerated"
 
@@ -187,7 +187,7 @@ RUN printf '%s\n' \
     shell-ipv6only-platform-mdns \
     fabric-admin-rpc-ipv6only \
     fabric-bridge-rpc-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
@@ -200,13 +200,13 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     all-clusters-ipv6only \
     all-clusters-ipv6only-nlfaultinject \
     all-clusters-minimal-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
@@ -219,7 +219,7 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     light-ipv6only \
@@ -227,12 +227,12 @@ RUN printf '%s\n' \
     lock-ipv6only \
     air-purifier-ipv6only \
     bridge-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
     "${TARGET_ARGS[@]}" \
@@ -240,19 +240,19 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     tv-app-ipv6only \
     tv-casting-app-ipv6only \
     camera-clang-ipv6only \
     camera-controller-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
     "${TARGET_ARGS[@]}" \
@@ -260,7 +260,7 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     microwave-oven-ipv6only \
@@ -268,12 +268,12 @@ RUN printf '%s\n' \
     water-heater-ipv6only \
     water-leak-detector-ipv6only \
     rvc-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
     "${TARGET_ARGS[@]}" \
@@ -281,19 +281,19 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     simulated-app1-ipv6only \
     lit-icd-ipv6only \
     energy-gateway-ipv6only \
     closure-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
     "${TARGET_ARGS[@]}" \
@@ -301,17 +301,17 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     jf-control-app-ipv6only \
     jf-admin-app-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
     "${TARGET_ARGS[@]}" \
@@ -319,17 +319,17 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN printf '%s\n' \
     ota-provider-ipv6only \
     ota-requestor-ipv6only \
-    > /tmp/targets.txt    
+    > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
     && source /tmp/arch.env \
     && set -x \
-    && source scripts/activate.sh \    
+    && source scripts/activate.sh \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
     && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
     "${TARGET_ARGS[@]}" \
@@ -337,7 +337,7 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     && while IFS= read -r suffix; do \
         find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
         && rm -rf out/${ARCH}-${suffix}-release-size; \
-    done < /tmp/targets.txt 
+    done < /tmp/targets.txt
 
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     source scripts/activate.sh \
@@ -345,8 +345,8 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
         -m platform \
         -d true \
         --enable_nfc true \
-        --enable-ccache        
-       
+        --enable-ccache
+
 # Generate OTA image from the built OTA requestor app
 # This creates ota-requestor-app.ota for OTA testing
 RUN case ${TARGETPLATFORM} in \
@@ -440,7 +440,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-
 COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-attestation-certificates/revocation-sets credentials/test/revoked-attestation-certificates/revocation-sets
 
 RUN apt-get remove -y \
-    meson 
+    meson
 
-RUN apt-get autoremove -y 
+RUN apt-get autoremove -y
 RUN apt-get clean

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -2,8 +2,6 @@
 FROM ubuntu:24.04 AS chip-build-cert
 LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
 ARG TARGETPLATFORM
-# COMMITHASH defines the target commit to build from. May be passed in using --build-arg.
-ARG COMMITHASH=c1ec2d777456924dcaa59b53351b00d73caf378f
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \
@@ -34,6 +32,7 @@ RUN set -x \
     bison \
     bluez \
     bridge-utils \
+    ccache \
     clang \
     clang-format \
     clang-tidy \
@@ -111,18 +110,6 @@ RUN set -x \
     attrs coloredlogs PyGithub pygit future portpicker mobly click cxxfilt ghapi pandas tabulate \
     && : # last line
 
-# Install bloat comparison tools
-RUN set -x \
-    && git clone https://github.com/google/bloaty.git \
-    && mkdir -p bloaty/build \
-    && cd bloaty/build \
-    && cmake -G Ninja ../ \
-    && ninja \
-    && ninja install \
-    && cd ../.. \
-    && rm -rf bloaty \
-    && : # last line
-
 # Build and install OpenSSL 3.5 LTS (post-quantum ML-DSA / ML-KEM support)
 ARG OPENSSL_VERSION=3.5.0
 ARG OPENSSL_SHA256=344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0
@@ -140,14 +127,24 @@ RUN set -x \
     && : # last line
 
 # Stage 1.5: Bootstrap Matter.
+# COMMITHASH defines the target commit to build from. May be passed in using --build-arg.
+ARG COMMITHASH=c1ec2d777456924dcaa59b53351b00d73caf378f
+# This does a shallower checkout of the repo
 RUN echo "Cloning at commit: ${COMMITHASH}" \
-    && git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip \
+    mkdir /root/connectedhomeip \
+    && git init /root/connectedhomeip \
     && cd /root/connectedhomeip \
-    && git checkout ${COMMITHASH}
+    && git init . \
+    && git remote add origin https://github.com/project-chip/connectedhomeip.git \
+    && git fetch --depth 1 origin ${COMMITHASH} \
+    && git checkout FETCH_HEAD
 
 WORKDIR /root/connectedhomeip/
-RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
+# If building locally, uncomment this line if you encounter failed builds due to warnings
+# RUN sed -i 's/treat_warnings_as_errors = true/treat_warnings_as_errors = false/' build/config/compiler/BUILD.gn
+RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux --jobs $(nproc)
 RUN bash scripts/bootstrap.sh
+RUN ./scripts/run_in_build_env.sh "./scripts/codepregen.py ./zzz_pregenerated"
 
 # Stage 2: Build.
 FROM chip-build-cert AS chip-build-cert-bins
@@ -157,69 +154,199 @@ SHELL ["/bin/bash", "-c"]
 # Records Matter SDK commit hash to include in the image.
 RUN git rev-parse HEAD > /root/.sdk-sha-version
 
+#setup ccache
+ARG CCACHE_NOHASHDIR=1 
+ARG CCACHE_BASEDIR=/root/connectedhomeip/ 
+ARG CCACHE_NODIRECT=1 
+ARG CCACHE_PREFIX_CPP=/root/connectedhomeip/scripts/helpers/ccache-prefix-cpp.sh 
+ARG CCACHE_SLOPPINESS=time_macros 
+ARG CCACHE_DIR=/root/connectedhomeip/.ccache 
+ARG CCACHE_COMPILERCHECK=content 
+ARG CCACHE_MAXSIZE=5G 
+ARG CCACHE_COMPRESS=1 
+ARG CCACHE_COMPRESSLEVEL=6 
+ARG CHIP_PW_COMMAND_LAUNCHER=ccache 
+
 # Target suffixes shared across all supported architectures.
 # The arch prefix (linux-x64 / linux-arm64) is prepended at build time.
-RUN printf '%s\n' \
-    chip-tool-ipv6only-platform-mdns-nfc-commission \
-    shell-ipv6only-platform-mdns \
-    chip-cert-ipv6only-platform-mdns \
-    air-purifier-ipv6only \
-    all-clusters-ipv6only \
-    all-clusters-ipv6only-nlfaultinject \
-    all-clusters-minimal-ipv6only \
-    bridge-ipv6only \
-    tv-app-ipv6only \
-    tv-casting-app-ipv6only \
-    light-ipv6only \
-    thermostat-ipv6only \
-    ota-provider-ipv6only \
-    ota-requestor-ipv6only \
-    lock-ipv6only \
-    simulated-app1-ipv6only \
-    lit-icd-ipv6only \
-    energy-gateway-ipv6only \
-    evse-ipv6only \
-    microwave-oven-ipv6only \
-    rvc-ipv6only \
-    fabric-bridge-rpc-ipv6only \
-    fabric-admin-rpc-ipv6only \
-    light-data-model-no-unique-id-ipv6only \
-    network-manager-ipv6only \
-    terms-and-conditions-ipv6only \
-    water-leak-detector-ipv6only \
-    camera-clang-ipv6only \
-    camera-controller-ipv6only \
-    closure-ipv6only \
-    jf-control-app-ipv6only \
-    jf-admin-app-ipv6only \
-    water-heater-ipv6only \
-    > /tmp/targets.txt
-
 RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") ARCH=linux-x64 ;; \
-    "linux/arm64") ARCH=linux-arm64 ;; \
-    *) ;; \
+        "linux/amd64") ARCH=linux-x64 ;; \
+        "linux/arm64") ARCH=linux-arm64 ;; \
+        *) \
+            echo "ERROR: Unsupported platform ${TARGETPLATFORM}" \
+            && exit 1 \
+        ;; \
     esac \
+    && echo "ARCH=${ARCH}" > /tmp/arch.env 
+
+ARG BUILD_EXAMPLES_ARGS="--pw-command-launcher=ccache --build-profile=release-size --pregen-dir ./zzz_pregenerated"
+
+RUN printf '%s\n' \
+    chip-tool-ipv6only \
+    chip-cert-ipv6only-platform-mdns-nfc-commission \
+    shell-ipv6only-platform-mdns \
+    fabric-admin-rpc-ipv6only \
+    fabric-bridge-rpc-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
     && set -x \
     && source scripts/activate.sh \
-    && TARGET_ARGS=() \
     && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
-    && scripts/build/build_examples.py \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
     "${TARGET_ARGS[@]}" \
     build \
     && while IFS= read -r suffix; do \
-        find out/${ARCH}-${suffix} -maxdepth 1 -type f -executable -exec mv {} out/ \; \
-        && rm -rf out/${ARCH}-${suffix}; \
-    done < /tmp/targets.txt \
-    && find out -maxdepth 1 -type f -executable -exec strip --strip-unneeded {} \; \
-    && : # last line
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
 
-RUN source scripts/activate.sh \
+RUN printf '%s\n' \
+    all-clusters-ipv6only \
+    all-clusters-ipv6only-nlfaultinject \
+    all-clusters-minimal-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    light-ipv6only \
+    thermostat-ipv6only \
+    lock-ipv6only \
+    air-purifier-ipv6only \
+    bridge-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    tv-app-ipv6only \
+    tv-casting-app-ipv6only \
+    camera-clang-ipv6only \
+    camera-controller-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    microwave-oven-ipv6only \
+    evse-ipv6only \
+    water-heater-ipv6only \
+    water-leak-detector-ipv6only \
+    rvc-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    simulated-app1-ipv6only \
+    lit-icd-ipv6only \
+    energy-gateway-ipv6only \
+    closure-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    jf-control-app-ipv6only \
+    jf-admin-app-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS}\
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN printf '%s\n' \
+    ota-provider-ipv6only \
+    ota-requestor-ipv6only \
+    > /tmp/targets.txt    
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    TARGET_ARGS=() \
+    && source /tmp/arch.env \
+    && set -x \
+    && source scripts/activate.sh \    
+    && while IFS= read -r suffix; do TARGET_ARGS+=("--target" "${ARCH}-${suffix}"); done < /tmp/targets.txt \
+    && scripts/build/build_examples.py ${BUILD_EXAMPLES_ARGS} \
+    "${TARGET_ARGS[@]}" \
+    build \
+    && while IFS= read -r suffix; do \
+        find out/${ARCH}-${suffix}-release-size -maxdepth 1 -type f -executable -exec mv {} out/ \; \
+        && rm -rf out/${ARCH}-${suffix}-release-size; \
+    done < /tmp/targets.txt 
+
+RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
+    source scripts/activate.sh \
     && scripts/build_python.sh \
         -m platform \
         -d true \
-        --enable_nfc true
-
+        --enable_nfc true \
+        --enable-ccache        
+       
 # Generate OTA image from the built OTA requestor app
 # This creates ota-requestor-app.ota for OTA testing
 RUN case ${TARGETPLATFORM} in \
@@ -238,13 +365,15 @@ RUN case ${TARGETPLATFORM} in \
     *) ;; \
     esac
 
+RUN find out -maxdepth 1 -type f -executable -exec strip --strip-all {} \;
+
 # Stage 3: Copy relevant cert bins to a minimal image to reduce size.
 FROM ubuntu:24.04
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get satisfy -y --no-install-recommends \
     avahi-utils \
     ffmpeg \
     gstreamer1.0-plugins-good \
@@ -266,7 +395,6 @@ RUN apt-get update -y \
     pcscd \
     python3-dev \
     python3-pip \
-    && rm -rf /var/lib/apt/lists/* \
     && : # last line
 
 WORKDIR /root/
@@ -301,11 +429,18 @@ RUN pip install --break-system-packages --no-cache-dir \
     python_lib/python/obj/scripts/py_matter_yamltests/matter-yamltests._build_wheel/matter_yamltests-*.whl \
     python_lib/obj/src/python_testing/matter_testing_infrastructure/matter-testing._build_wheel/matter_testing-*.whl \
     python_lib/obj/src/controller/python/matter-controller-wheels/*.whl \
-    && rm ../python_lib \
-    && rm -rf python_lib
+    && rm -rf ../python_lib \
+    && rm -rf python_lib \
+    && rm -rf /root/.cache
 
 # Copy device attestation revocation set and device attestation test vectors
 WORKDIR /root
 RUN mkdir -p credentials/test/revoked-attestation-certificates
 COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-attestation-certificates/dac-provider-test-vectors credentials/test/revoked-attestation-certificates/dac-provider-test-vectors
 COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-attestation-certificates/revocation-sets credentials/test/revoked-attestation-certificates/revocation-sets
+
+RUN apt-get remove -y \
+    meson 
+
+RUN apt-get autoremove -y 
+RUN apt-get clean

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -431,8 +431,11 @@ RUN pip install --break-system-packages --no-cache-dir \
     python_lib/python/obj/scripts/py_matter_idl/matter-idl._build_wheel/matter_idl-*.whl \
     python_lib/python/obj/scripts/py_matter_yamltests/matter-yamltests._build_wheel/matter_yamltests-*.whl \
     python_lib/obj/src/python_testing/matter_testing_infrastructure/matter-testing._build_wheel/matter_testing-*.whl \
-    python_lib/obj/src/controller/python/matter-controller-wheels/*.whl
+    python_lib/obj/src/controller/python/matter-controller-wheels/*.whl \
+    && rm ../python_lib \
+    && rm -rf python_lib
 
+# Stage 4: Create final minimal image
 FROM ubuntu:24.04
 
 ENV TZ=Etc/UTC

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -134,7 +134,6 @@ RUN echo "Cloning at commit: ${COMMITHASH}" \
     && mkdir /root/connectedhomeip \
     && git init /root/connectedhomeip \
     && cd /root/connectedhomeip \
-    && git init . \
     && git remote add origin https://github.com/project-chip/connectedhomeip.git \
     && git fetch --depth 1 origin ${COMMITHASH} \
     && git checkout FETCH_HEAD
@@ -187,6 +186,7 @@ RUN printf '%s\n' \
     shell-ipv6only-platform-mdns \
     fabric-admin-rpc-ipv6only \
     fabric-bridge-rpc-ipv6only \
+    network-manager-ipv6only \
     > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
@@ -223,6 +223,7 @@ RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
 
 RUN printf '%s\n' \
     light-ipv6only \
+    light-data-model-no-unique-id-ipv6only \
     thermostat-ipv6only \
     lock-ipv6only \
     air-purifier-ipv6only \
@@ -288,6 +289,7 @@ RUN printf '%s\n' \
     lit-icd-ipv6only \
     energy-gateway-ipv6only \
     closure-ipv6only \
+    terms-and-conditions-ipv6only \
     > /tmp/targets.txt
 RUN --mount=type=cache,target=/root/connectedhomeip/.ccache \
     TARGET_ARGS=() \
@@ -373,7 +375,7 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get satisfy -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         avahi-utils \
         ffmpeg \
         gstreamer1.0-plugins-good \
@@ -437,7 +439,7 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get satsify -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         avahi-utils \
         ffmpeg \
         gstreamer1.0-plugins-good \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -3,6 +3,11 @@ FROM ubuntu:24.04 AS chip-build-cert
 LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
 ARG TARGETPLATFORM
 
+# COMMITHASH defines the target commit to build from. Must be passed in using --build-arg.
+ARG COMMITHASH
+# Fail if COMMITHASH is not provided
+RUN set -eu; [ -n "$COMMITHASH" ]
+
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \
     "linux/amd64") \
@@ -127,8 +132,6 @@ RUN set -x \
     && : # last line
 
 # Stage 1.5: Bootstrap Matter.
-# COMMITHASH defines the target commit to build from. May be passed in using --build-arg.
-ARG COMMITHASH=c1ec2d777456924dcaa59b53351b00d73caf378f
 # This does a shallower checkout of the repo
 RUN echo "Cloning at commit: ${COMMITHASH}" \
     && mkdir /root/connectedhomeip \
@@ -181,8 +184,8 @@ RUN case ${TARGETPLATFORM} in \
 ARG BUILD_EXAMPLES_ARGS="--pw-command-launcher=ccache --build-profile=release-size --pregen-dir ./zzz_pregenerated"
 
 RUN printf '%s\n' \
-    chip-tool-ipv6only \
-    chip-cert-ipv6only-platform-mdns-nfc-commission \
+    chip-tool-ipv6only-platform-mdns-nfc-commission \
+    chip-cert-ipv6only-platform-mdns \
     shell-ipv6only-platform-mdns \
     fabric-admin-rpc-ipv6only \
     fabric-bridge-rpc-ipv6only \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -368,34 +368,35 @@ RUN case ${TARGETPLATFORM} in \
 RUN find out -maxdepth 1 -type f -executable -exec strip --strip-all {} \;
 
 # Stage 3: Copy relevant cert bins to a minimal image to reduce size.
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS builder
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get satisfy -y --no-install-recommends \
-    avahi-utils \
-    ffmpeg \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-ugly \
-    iproute2 \
-    libavahi-client-dev \
-    libcairo2-dev \
-    libcurl4 \
-    libdbus-1-dev \
-    libevent-dev \
-    libgirepository1.0-dev \
-    libglib2.0-dev \
-    libgstreamer1.0-0 \
-    libgstreamer-plugins-base1.0-0 \
-    libpcsclite1 \
-    libpcsclite-dev \
-    libssl-dev \
-    meson \
-    pcscd \
-    python3-dev \
-    python3-pip \
-    && : # last line
+        avahi-utils \
+        ffmpeg \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-ugly \
+        iproute2 \
+        libavahi-client-dev \
+        libcairo2-dev \
+        libcurl4 \
+        libdbus-1-dev \
+        libevent-dev \
+        libgirepository1.0-dev \
+        libglib2.0-dev \
+        libgstreamer1.0-0 \
+        libgstreamer-plugins-base1.0-0 \
+        libpcsclite1 \
+        libpcsclite-dev \
+        libssl-dev \
+        meson \
+        pcscd \
+        python3-dev \
+        python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/
 COPY --from=chip-build-cert-bins /root/.sdk-sha-version .sdk-sha-version
@@ -428,19 +429,50 @@ RUN pip install --break-system-packages --no-cache-dir \
     python_lib/python/obj/scripts/py_matter_idl/matter-idl._build_wheel/matter_idl-*.whl \
     python_lib/python/obj/scripts/py_matter_yamltests/matter-yamltests._build_wheel/matter_yamltests-*.whl \
     python_lib/obj/src/python_testing/matter_testing_infrastructure/matter-testing._build_wheel/matter_testing-*.whl \
-    python_lib/obj/src/controller/python/matter-controller-wheels/*.whl \
-    && rm -rf ../python_lib \
-    && rm -rf python_lib \
-    && rm -rf /root/.cache
+    python_lib/obj/src/controller/python/matter-controller-wheels/*.whl
 
-# Copy device attestation revocation set and device attestation test vectors
-WORKDIR /root
-RUN mkdir -p credentials/test/revoked-attestation-certificates
+FROM ubuntu:24.04
+
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get satsify -y --no-install-recommends \
+        avahi-utils \
+        ffmpeg \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-ugly \
+        iproute2 \
+        libavahi-client3 \
+        libcairo2 \
+        libcurl4 \
+        libdbus-1-3 \
+        # commands still fail without the dev packages from libevent
+        libevent-dev \
+        libglib2.0-0t64 \
+        libgstreamer1.0-0 \
+        libgstreamer-plugins-base1.0-0 \
+        libpcsclite1 \
+        libssl3t64 \
+        pcscd \
+        python3 \
+        python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/
+
+COPY --from=chip-build-cert-bins /root/.sdk-sha-version .sdk-sha-version
 COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-attestation-certificates/dac-provider-test-vectors credentials/test/revoked-attestation-certificates/dac-provider-test-vectors
 COPY --from=chip-build-cert-bins /root/connectedhomeip/credentials/test/revoked-attestation-certificates/revocation-sets credentials/test/revoked-attestation-certificates/revocation-sets
+COPY --from=builder /root/apps ./apps
+COPY --from=builder /root/python_testing ./python_testing
+COPY --from=builder /root/mock_server ./mock_server
 
-RUN apt-get remove -y \
-    meson
+# Copy the installed Python packages from builder's site-packages
+COPY --from=builder /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
+# Copy any symlinks or scripts from /usr/local/bin
+COPY --from=builder /usr/local/bin /usr/local/bin
 
-RUN apt-get autoremove -y
-RUN apt-get clean
+# Recreate symlinks in runtime stage
+RUN cd /root && ln -s apps/* .


### PR DESCRIPTION
#### Summary

The test harness pulls in this image as part of its setup and operation. Currently it is about 8GB in size, and includes several unneeded or un-optimized binaries. 

With these changes I believe I've shrunk the size of the docker image to about 4GB, with no loss in functionality, and with much faster builds.

For illustration, in the current version of this image, this is the size of the binaries in the `/app` directory:
```
root@cdd3254fa2a1:~/apps# ls -lhr
total 4.1G
-rwxr-xr-x 1 root root 109M May 15 01:01 water-leak-detector-app
-rwxr-xr-x 1 root root 122M May 15 00:46 thermostat-app
drwxr-xr-x 4 root root 4.0K May 14 23:24 push_av_server
-rw-r--r-- 1 root root 112M May 15 01:12 ota-requestor-app.ota
-rwxr-xr-x 1 root root 122M May 15 00:06 matter-water-heater-app
-rwxr-xr-x 1 root root 101M May 15 00:24 matter-network-manager-app
-rwxr-xr-x 1 root root 113M May 15 00:03 lit-icd-app
-rwxr-xr-x 1 root root 166M May 15 00:28 jfc-app
-rwxr-xr-x 1 root root 164M May 15 00:39 jfa-app
-rwxr-xr-x 1 root root  12K May 14 23:24 fabric-sync-app
-rwxr-xr-x 1 root root 116M May 14 23:39 fabric-bridge-app
-rwxr-xr-x 1 root root 171M May 15 00:43 fabric-admin
-rwxr-xr-x 1 root root 117M May 15 00:55 closure-app
-rwxr-xr-x 1 root root 180M May 15 00:58 chip-tv-casting-app
-rwxr-xr-x 1 root root 159M May 14 23:56 chip-tv-app
-rwxr-xr-x 1 root root 173M May 15 00:32 chip-tool
-rwxr-xr-x 1 root root  54M May 15 01:02 chip-terms-and-conditions-app
-rwxr-xr-x 1 root root  77M May 15 00:19 chip-shell
-rwxr-xr-x 1 root root 112M May 15 00:49 chip-rvc-app
-rwxr-xr-x 1 root root 112M May 15 00:10 chip-ota-requestor-app
-rwxr-xr-x 1 root root 103M May 14 23:50 chip-ota-provider-app
-rwxr-xr-x 1 root root 111M May 15 01:05 chip-microwave-oven-app
-rwxr-xr-x 1 root root 118M May 14 23:44 chip-lock-app
-rwxr-xr-x 1 root root 127M May 15 00:52 chip-lighting-data-model-no-unique-id-app
-rwxr-xr-x 1 root root 124M May 14 23:41 chip-lighting-app
-rwxr-xr-x 1 root root 120M May 15 00:22 chip-evse-app
-rwxr-xr-x 1 root root 118M May 15 00:13 chip-energy-gateway-app
-rwxr-xr-x 1 root root 2.9M May 15 00:01 chip-cert
-rwxr-xr-x 1 root root 170M May 15 00:36 chip-camera-controller
-rwxr-xr-x 1 root root 142M May 14 23:36 chip-camera-app
-rwxr-xr-x 1 root root 123M May 14 23:53 chip-bridge-app
-rwxr-xr-x 1 root root 132M May 14 23:47 chip-app1
-rwxr-xr-x 1 root root 146M May 15 01:08 chip-all-clusters-minimal-app
-rwxr-xr-x 1 root root 165M May 15 00:00 chip-all-clusters-app-nlfaultinject
-rwxr-xr-x 1 root root 165M May 15 00:17 chip-all-clusters-app
-rwxr-xr-x 1 root root  60M May 15 00:08 chip-air-purifier-app
```

And after:
```
root@5ae68e3a3562:~/apps# ls -lhr
total 194M
-rwxr-xr-x 1 root root 1.8M Jun  5 23:37 water-leak-detector-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 thermostat-app
drwxr-xr-x 4 root root 4.0K Jun  4 17:33 push_av_server
-rw-r--r-- 1 root root 106M Jun  5 23:37 ota-requestor-app.ota
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 matter-water-heater-app
-rwxr-xr-x 1 root root 1.8M Jun  5 23:37 lit-icd-app
-rwxr-xr-x 1 root root 7.3M Jun  5 23:37 jfc-app
-rwxr-xr-x 1 root root 2.8M Jun  5 23:37 jfa-app
-rwxr-xr-x 1 root root  12K Jun  4 17:33 fabric-sync-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 fabric-bridge-app
-rwxr-xr-x 1 root root 7.0M Jun  5 23:37 fabric-admin
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 closure-app
-rwxr-xr-x 1 root root 7.1M Jun  5 23:37 chip-tv-casting-app
-rwxr-xr-x 1 root root 3.3M Jun  5 23:37 chip-tv-app
-rwxr-xr-x 1 root root 7.7M Jun  5 23:37 chip-tool
-rwxr-xr-x 1 root root 1.4M Jun  5 23:37 chip-shell
-rwxr-xr-x 1 root root 1.8M Jun  5 23:37 chip-rvc-app
-rwxr-xr-x 1 root root 1.7M Jun  5 23:37 chip-ota-requestor-app
-rwxr-xr-x 1 root root 1.7M Jun  5 23:37 chip-ota-provider-app
-rwxr-xr-x 1 root root 1.8M Jun  5 23:37 chip-microwave-oven-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 chip-lock-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 chip-lighting-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 chip-evse-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 chip-energy-gateway-app
-rwxr-xr-x 1 root root 206K Jun  5 23:37 chip-cert
-rwxr-xr-x 1 root root 8.9M Jun  5 23:37 chip-camera-controller
-rwxr-xr-x 1 root root 4.3M Jun  5 23:37 chip-camera-app
-rwxr-xr-x 1 root root 1.9M Jun  5 23:37 chip-bridge-app
-rwxr-xr-x 1 root root 2.0M Jun  5 23:37 chip-app1
-rwxr-xr-x 1 root root 2.1M Jun  5 23:37 chip-all-clusters-minimal-app
-rwxr-xr-x 1 root root 3.0M Jun  5 23:37 chip-all-clusters-app-nlfaultinject
-rwxr-xr-x 1 root root 3.0M Jun  5 23:37 chip-all-clusters-app
-rwxr-xr-x 1 root root 1.3M Jun  5 23:37 chip-air-purifier-app
```

This is primarily thanks, I think, to the `--build-profiles` option for the example apps added by @arkq here: https://github.com/project-chip/connectedhomeip/pull/40247 .

Some savings were also realized via the removal of gcc and related tooling in the final image, and the removal of bloaty, which was unused in this image.

The build process was sped up primarily though the use of ccache, but I've also rearranged the order of the example app builds so that failing to build one example app does not require a full rebuild of the docker image. It also has the benefit of preventing build logs from being truncated, as the step to build every example app would produce far too many. I tested the idea of parallelizing the builds using either multiple docker stages or the `--concurrent-builders` option, but found that that either resulted in out-of-memory errors or no change in build time at all.

I also added a small tweak to the checkout logic to have a shallower pull for the build, which saves a few minutes.

I also added in pregeneration via the `codepregen.py` script (by @andreilitvin), but am unsure about the exact benefit it has. But the penalty seems minimal even if there's no speedup.

#### Testing

My test setup is currently limited, but I did run successfully against local example apps using both YAML and Python tests in the test harness using this image. I would appreciate input from those who can perhaps offer something more robust.

#### Questions for reviewers
1. I added this line (commented out):` 
RUN sed -i 's/treat_warnings_as_errors = true/treat_warnings_as_errors = false/' build/config/compiler/BUILD.gn`
because builds were failing locally without it, just to make it simpler for future users.
2. It seems that this image is currently (or was, I don't have insight) being built here: https://console.cloud.google.com/cloud-build/builds?project=matter-build-automation, but there was some [work](https://github.com/project-chip/connectedhomeip/pull/28180) done by @woody-apple to bring it into Github Actions, but this never seemed to have been used. Any thoughts on the current process and any changes to it?