### PR TITLE
Add TC_PROXR_2_X test scripts for testing the proximity ranging cluster

### DIFF
--- a/src/python_testing/TC_PROXR_2_1.py
+++ b/src/python_testing/TC_PROXR_2_1.py
@@ -1,0 +1,314 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS /tmp/kvs_dut_i
+#     app2: ${ALL_CLUSTERS_APP}
+#     app2-args: --discriminator 1235 --KVS /tmp/kvs_dut_r
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234 1235
+#       --passcode 20202021 20202021
+#       --dut-node-id 1 2
+#       --int-arg dut_i_endpoint:1 dut_r_endpoint:1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+# HOW TO RUN:
+#   python3 TC_PROXR_2_1.py \
+#     --commissioning-method on-network \
+#     --discriminator 1234 1235 \
+#     --passcode 20202021 20202021 \
+#     --dut-node-id 1 2 \
+#     --int-arg dut_i_endpoint:1 dut_r_endpoint:1 \
+#     --storage-path /tmp/admin_storage.json
+#
+# Already commissioned:
+#   python3 TC_PROXR_2_1.py \
+#     --dut-node-id 1 2 \
+#     --int-arg dut_i_endpoint:1 dut_r_endpoint:1 \
+#     --storage-path /tmp/admin_storage.json
+#
+# Parameters:
+#   --dut-node-id <id_i> <id_r>       node IDs for DUT_I and DUT_R
+#   --int-arg dut_i_endpoint:<N>      PROXR cluster endpoint on DUT_I (default 1)
+#   --int-arg dut_r_endpoint:<N>      PROXR cluster endpoint on DUT_R (default = dut_i_endpoint)
+
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_PROXR_2_1(MatterBaseTest):
+    """
+    [TC-PROXR-2.1] Attributes (DUT as Server)
+
+    Topology: TH + DUT_I (initiator) + DUT_R (responder) on the same fabric.
+
+    Steps per test plan (proximity_ranging.adoc):
+      Step 1   : Commission DUT_I and DUT_R to TH
+      Step 2a  : [WFUSDPD] Read RangingCapabilities from DUT_I then DUT_R
+      Step 2b  : [BLTCS]   Read RangingCapabilities from DUT_I then DUT_R
+      Step 2c  : [BLERBC]  Read RangingCapabilities from DUT_I then DUT_R
+      Step 3a  : [WFUSDPD] Read WiFiDevIK from DUT_I then DUT_R
+      Step 3b  : [BLTCS]   Read BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R
+      Step 3c  : [BLERBC]  Read BLEDeviceID from DUT_I then DUT_R
+      Step 4   : [PROXR.S] Read SessionIDList from DUT_I then DUT_R
+    """
+
+    def desc_TC_PROXR_2_1(self) -> str:
+        return "[TC-PROXR-2.1] Attributes (DUT as Server)"
+
+    def pics_TC_PROXR_2_1(self):
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_1(self) -> list[TestStep]:
+        return [
+            TestStep("1",  "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep("2a", "[WFUSDPD] TH reads RangingCapabilities from DUT_I then DUT_R – verify WiFi technology present"),
+            TestStep("2b", "[BLTCS]   TH reads RangingCapabilities from DUT_I then DUT_R – verify BLTCS technology present"),
+            TestStep("2c", "[BLERBC]  TH reads RangingCapabilities from DUT_I then DUT_R – verify BLERBC technology present"),
+            TestStep("3a", "[WFUSDPD] TH reads WiFiDevIK from DUT_I then DUT_R – verify octstr"),
+            TestStep("3b", "[BLTCS]   TH reads BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R"),
+            TestStep("3c", "[BLERBC]  TH reads BLEDeviceID from DUT_I then DUT_R – verify uint64"),
+            TestStep("4",  "[PROXR.S] TH reads SessionIDList from DUT_I then DUT_R – verify zero elements"),
+        ]
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def dut_i_node_id(self) -> int:
+        return self.matter_test_config.dut_node_ids[0]
+
+    @property
+    def dut_r_node_id(self) -> int:
+        ids = self.matter_test_config.dut_node_ids
+        return ids[1] if len(ids) > 1 else ids[0]
+
+    @property
+    def dut_i_endpoint(self) -> int:
+        return self.user_params.get("dut_i_endpoint", 1)
+
+    @property
+    def dut_r_endpoint(self) -> int:
+        return self.user_params.get("dut_r_endpoint", self.dut_i_endpoint)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _read(self, node_id: int, endpoint: int, attribute):
+        return await self.read_single_attribute_check_success(
+            node_id=node_id,
+            cluster=Clusters.ProximityRanging,
+            attribute=attribute,
+            endpoint=endpoint,
+        )
+
+    def _has_feature(self, feature_map: int, bit) -> bool:
+        return bool(feature_map & bit)
+
+    def _dut_pairs(self, two_device: bool):
+        """Return [(node_id, endpoint, label), ...] for DUT_I and optionally DUT_R."""
+        pairs = [(self.dut_i_node_id, self.dut_i_endpoint, "DUT_I")]
+        if two_device:
+            pairs.append((self.dut_r_node_id, self.dut_r_endpoint, "DUT_R"))
+        return pairs
+
+    # ------------------------------------------------------------------
+    # Main test body
+    # ------------------------------------------------------------------
+
+    @async_test_body
+    async def test_TC_PROXR_2_1(self):
+        proxr = Clusters.ProximityRanging
+        F = proxr.Bitmaps.Feature
+
+        # ---- Step 1: Commissioning ----------------------------------------
+        self.step("1")
+        two_device = (self.dut_i_node_id != self.dut_r_node_id)
+        log.info(f"DUT_I  node={self.dut_i_node_id}  ep={self.dut_i_endpoint}")
+        log.info(f"DUT_R  node={self.dut_r_node_id}  ep={self.dut_r_endpoint}")
+        if not two_device:
+            log.warning("DUT_I and DUT_R share the same node ID – single-device mode")
+
+        # Read feature maps once; reuse throughout
+        fm_i = await self._read(self.dut_i_node_id, self.dut_i_endpoint, proxr.Attributes.FeatureMap)
+        fm_r = await self._read(self.dut_r_node_id, self.dut_r_endpoint, proxr.Attributes.FeatureMap) if two_device else fm_i
+        log.info(f"DUT_I FeatureMap=0x{fm_i:04X}  DUT_R FeatureMap=0x{fm_r:04X}")
+
+        # Saved attribute values for cross-device uniqueness checks
+        wifi_dev_ik: dict = {}
+        blt_dev_ik:  dict = {}
+        ble_dev_id:  dict = {}
+
+        # ---- Step 2a: RangingCapabilities – WiFi technology ---------------
+        self.step("2a")
+        if not self.check_pics("PROXR.S.F00"):
+            log.info("Step 2a skipped – PROXR.S.F00 (WFUSDPD) not in PICS")
+        else:
+            wifi_techs = {proxr.Enums.RangingTechEnum.kWiFiRoundTripTimeRanging,
+                          proxr.Enums.RangingTechEnum.kWiFiNextGenerationRanging}
+            for node_id, ep, label in self._dut_pairs(two_device):
+                caps = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+                asserts.assert_true(isinstance(caps, list),
+                                    f"[{label}] RangingCapabilities must be a list")
+                asserts.assert_greater_equal(len(caps), 1,
+                                             f"[{label}] RangingCapabilities must have ≥1 entry")
+                techs = {c.technology for c in caps}
+                asserts.assert_true(any(t in techs for t in wifi_techs),
+                                    f"[{label}] RangingCapabilities must include a WiFi technology "
+                                    f"(WiFiRoundTripTimeRanging or WiFiNextGenerationRanging)")
+                log.info(f"[{label}] Step 2a OK – technologies: {techs}")
+
+        # ---- Step 2b: RangingCapabilities – BLTCS technology --------------
+        self.step("2b")
+        if not self.check_pics("PROXR.S.F01"):
+            log.info("Step 2b skipped – PROXR.S.F01 (BLTCS) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                caps = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+                asserts.assert_true(isinstance(caps, list),
+                                    f"[{label}] RangingCapabilities must be a list")
+                techs = {c.technology for c in caps}
+                asserts.assert_true(proxr.Enums.RangingTechEnum.kBluetoothChannelSounding in techs,
+                                    f"[{label}] RangingCapabilities must include BluetoothChannelSounding")
+                log.info(f"[{label}] Step 2b OK – technologies: {techs}")
+
+        # ---- Step 2c: RangingCapabilities – BLERBC technology -------------
+        self.step("2c")
+        if not self.check_pics("PROXR.S.F02"):
+            log.info("Step 2c skipped – PROXR.S.F02 (BLERBC) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                caps = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+                asserts.assert_true(isinstance(caps, list),
+                                    f"[{label}] RangingCapabilities must be a list")
+                techs = {c.technology for c in caps}
+                asserts.assert_true(proxr.Enums.RangingTechEnum.kBLEBeaconRSSIRanging in techs,
+                                    f"[{label}] RangingCapabilities must include BLEBeaconRSSIRanging")
+                log.info(f"[{label}] Step 2c OK – technologies: {techs}")
+
+        # ---- Step 3a: WiFiDevIK -------------------------------------------
+        self.step("3a")
+        if not self.check_pics("PROXR.S.F00"):
+            log.info("Step 3a skipped – PROXR.S.F00 (WFUSDPD) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.WiFiDevIK)
+                asserts.assert_true(isinstance(val, bytes),
+                                    f"[{label}] WiFiDevIK must be octstr (bytes)")
+                asserts.assert_equal(len(val), 16, f"[{label}] WiFiDevIK must be 16 bytes")
+                wifi_dev_ik[label] = val
+                log.info(f"[{label}] WiFiDevIK OK ({len(val)} bytes)")
+
+        # ---- Step 3b: BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability --
+        self.step("3b")
+        if not self.check_pics("PROXR.S.F01"):
+            log.info("Step 3b skipped – PROXR.S.F01 (BLTCS) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                # BLTDevIK
+                ik = await self._read(node_id, ep, proxr.Attributes.BLTDevIK)
+                asserts.assert_true(isinstance(ik, bytes),
+                                    f"[{label}] BLTDevIK must be octstr (bytes)")
+                asserts.assert_equal(len(ik), 16, f"[{label}] BLTDevIK must be 16 bytes")
+                blt_dev_ik[label] = ik
+                log.info(f"[{label}] BLTDevIK OK ({len(ik)} bytes)")
+
+                # BLTCSSecurityLevel (optional – present only when security is required)
+                try:
+                    sec = await self._read(node_id, ep, proxr.Attributes.BLTCSSecurityLevel)
+                    asserts.assert_true(isinstance(sec, proxr.Enums.BLTCSSecurityLevelEnum),
+                                        f"[{label}] BLTCSSecurityLevel must be BLTCSSecurityLevelEnum")
+                    log.info(f"[{label}] BLTCSSecurityLevel: {sec}")
+                except Exception as exc:
+                    log.info(f"[{label}] BLTCSSecurityLevel absent (optional): {exc}")
+
+                # BLTCSModeCapability
+                mode = await self._read(node_id, ep, proxr.Attributes.BLTCSModeCapability)
+                asserts.assert_true(isinstance(mode, proxr.Enums.BLTCSModeEnum),
+                                    f"[{label}] BLTCSModeCapability must be BLTCSModeEnum")
+                log.info(f"[{label}] BLTCSModeCapability: {mode}")
+
+        # ---- Step 3c: BLEDeviceID ----------------------------------------
+        self.step("3c")
+        if not self.check_pics("PROXR.S.F02"):
+            log.info("Step 3c skipped – PROXR.S.F02 (BLERBC) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.BLEDeviceID)
+                asserts.assert_true(isinstance(val, int),
+                                    f"[{label}] BLEDeviceID must be uint64 (int)")
+                asserts.assert_greater_equal(val, 0, f"[{label}] BLEDeviceID must be non-negative")
+                ble_dev_id[label] = val
+                log.info(f"[{label}] BLEDeviceID: {val}")
+
+        # ---- Step 4: SessionIDList ----------------------------------------
+        # Type in Objects.py: Union[Nullable, List[uint]]
+        # Both NullValue and empty list [] mean "no active sessions"
+        self.step("4")
+        for node_id, ep, label in self._dut_pairs(two_device):
+            val = await self._read(node_id, ep, proxr.Attributes.SessionIDList)
+            log.info(f"[{label}] SessionIDList raw: {val!r} (type={type(val).__name__})")
+            if val is NullValue or val is None:
+                log.info(f"[{label}] SessionIDList is NullValue – no active sessions, OK")
+            else:
+                asserts.assert_true(isinstance(val, list),
+                                    f"[{label}] SessionIDList must be list or NullValue, got {type(val)}")
+                asserts.assert_equal(len(val), 0,
+                                     f"[{label}] SessionIDList must be empty (no active sessions)")
+                log.info(f"[{label}] SessionIDList is empty list – OK")
+
+        # ---- Cross-device uniqueness checks (two-device mode only) --------
+        if two_device:
+            if "DUT_I" in wifi_dev_ik and "DUT_R" in wifi_dev_ik:
+                asserts.assert_not_equal(wifi_dev_ik["DUT_I"], wifi_dev_ik["DUT_R"],
+                                         "WiFiDevIK must be unique per device")
+                log.info("WiFiDevIK values are distinct – OK")
+            if "DUT_I" in blt_dev_ik and "DUT_R" in blt_dev_ik:
+                asserts.assert_not_equal(blt_dev_ik["DUT_I"], blt_dev_ik["DUT_R"],
+                                         "BLTDevIK must be unique per device")
+                log.info("BLTDevIK values are distinct – OK")
+            if "DUT_I" in ble_dev_id and "DUT_R" in ble_dev_id:
+                asserts.assert_not_equal(ble_dev_id["DUT_I"], ble_dev_id["DUT_R"],
+                                         "BLEDeviceID must be unique per device")
+                log.info("BLEDeviceID values are distinct – OK")
+
+        log.info("TC-PROXR-2.1 PASSED")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_2.py
+++ b/src/python_testing/TC_PROXR_2_2.py
@@ -1,0 +1,388 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS /tmp/kvs_dut_i
+#     app2: ${ALL_CLUSTERS_APP}
+#     app2-args: --discriminator 1235 --KVS /tmp/kvs_dut_r
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234 1235
+#       --passcode 20202021 20202021
+#       --dut-node-id 1 2
+#       --int-arg dut_i_endpoint:1 dut_r_endpoint:1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+# HOW TO RUN:
+#   python3 TC_PROXR_2_2.py \
+#     --commissioning-method on-network \
+#     --discriminator 1234 1235 \
+#     --passcode 20202021 20202021 \
+#     --dut-node-id 1 2 \
+#     --int-arg dut_i_endpoint:1 dut_r_endpoint:1 \
+#     --storage-path /tmp/admin_storage.json
+
+import logging
+import os
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_PROXR_2_2(MatterBaseTest):
+    """
+    [TC-PROXR-2.2] Processing Infeasible Proximity Ranging Configuration (DUT as Server)
+
+    Steps per test plan:
+      Step 1   : Commission DUT_I and DUT_R to TH
+      Step 2   : [PROXR.S]  Read RangingCapabilities from DUT_I then DUT_R – save
+      Step 3   : [WFUSDPD]  Read WiFiDevIK from DUT_I then DUT_R – save
+      Step 4   : [BLTCS]    Read BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R – save
+      Step 5   : [BLERBC]   Read BLEDeviceID from DUT_I then DUT_R – save
+      Step 6a  : [!WFUSDPD] Send WiFi StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging
+      Step 6b  : [!BLTCS]   Send BLTCS StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging
+      Step 6c  : [!BLERBC]  Send BLERBC StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging
+    """
+
+    def desc_TC_PROXR_2_2(self) -> str:
+        return "[TC-PROXR-2.2] Processing Infeasible Proximity Ranging Configuration (DUT as Server)"
+
+    def pics_TC_PROXR_2_2(self):
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_2(self) -> list[TestStep]:
+        return [
+            TestStep("1",  "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep("2",  "[PROXR.S]  TH reads RangingCapabilities from DUT_I then DUT_R"),
+            TestStep("3",  "[WFUSDPD]  TH reads WiFiDevIK from DUT_I then DUT_R"),
+            TestStep("4",  "[BLTCS]    TH reads BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R"),
+            TestStep("5",  "[BLERBC]   TH reads BLEDeviceID from DUT_I then DUT_R"),
+            TestStep("6a", "[!WFUSDPD] TH sends WiFi StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging"),
+            TestStep("6b", "[!BLTCS]   TH sends BLTCS StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging"),
+            TestStep("6c", "[!BLERBC]  TH sends BLERBC StartRangingRequest to DUT_I then DUT_R – expect RejectedInfeasibleRanging"),
+        ]
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def dut_i_node_id(self) -> int:
+        return self.matter_test_config.dut_node_ids[0]
+
+    @property
+    def dut_r_node_id(self) -> int:
+        ids = self.matter_test_config.dut_node_ids
+        return ids[1] if len(ids) > 1 else ids[0]
+
+    @property
+    def dut_i_endpoint(self) -> int:
+        return self.user_params.get("dut_i_endpoint", 1)
+
+    @property
+    def dut_r_endpoint(self) -> int:
+        return self.user_params.get("dut_r_endpoint", self.dut_i_endpoint)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _read(self, node_id: int, endpoint: int, attribute):
+        return await self.read_single_attribute_check_success(
+            node_id=node_id,
+            cluster=Clusters.ProximityRanging,
+            attribute=attribute,
+            endpoint=endpoint,
+        )
+
+    async def _send_cmd(self, node_id: int, endpoint: int, cmd):
+        return await self.send_single_cmd(node_id=node_id, endpoint=endpoint, cmd=cmd)
+
+    def _dut_pairs(self, two_device: bool):
+        pairs = [(self.dut_i_node_id, self.dut_i_endpoint, "DUT_I")]
+        if two_device:
+            pairs.append((self.dut_r_node_id, self.dut_r_endpoint, "DUT_R"))
+        return pairs
+
+    # ------------------------------------------------------------------
+    # Main test body
+    # ------------------------------------------------------------------
+
+    @async_test_body
+    async def test_TC_PROXR_2_2(self):
+        proxr = Clusters.ProximityRanging
+        F = proxr.Bitmaps.Feature
+        R = proxr.Enums.RangingRoleEnum
+        T = proxr.Enums.RangingTechEnum
+        S = proxr.Enums.RangingSecurityEnum
+        RC = proxr.Enums.ResultCodeEnum
+
+        # ---- Step 1: Commissioning ----------------------------------------
+        self.step("1")
+        two_device = (self.dut_i_node_id != self.dut_r_node_id)
+        log.info(f"DUT_I  node={self.dut_i_node_id}  ep={self.dut_i_endpoint}")
+        log.info(f"DUT_R  node={self.dut_r_node_id}  ep={self.dut_r_endpoint}")
+
+        fm_i = await self._read(self.dut_i_node_id, self.dut_i_endpoint, proxr.Attributes.FeatureMap)
+        fm_r = await self._read(self.dut_r_node_id, self.dut_r_endpoint, proxr.Attributes.FeatureMap) if two_device else fm_i
+        log.info(f"DUT_I FeatureMap=0x{fm_i:04X}  DUT_R FeatureMap=0x{fm_r:04X}")
+
+        supports_wfusdpd_i = bool(fm_i & F.kWiFiUsdProximityDetection)
+        supports_bltcs_i = bool(fm_i & F.kBluetoothChannelSounding)
+        supports_blerbc_i = bool(fm_i & F.kBleBeaconRssi)
+        supports_wfusdpd_r = bool(fm_r & F.kWiFiUsdProximityDetection)
+        supports_bltcs_r = bool(fm_r & F.kBluetoothChannelSounding)
+        supports_blerbc_r = bool(fm_r & F.kBleBeaconRssi)
+
+        # Saved attribute values
+        wifi_dev_ik: dict = {}
+        blt_dev_ik:  dict = {}
+        bltcs_sec:   dict = {}
+        bltcs_mode:  dict = {}
+        ble_dev_id:  dict = {}
+        caps:        dict = {}
+
+        # ---- Step 2: RangingCapabilities ----------------------------------
+        self.step("2")
+        for node_id, ep, label in self._dut_pairs(two_device):
+            val = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+            asserts.assert_true(isinstance(val, list),
+                                f"[{label}] RangingCapabilities must be a list")
+            asserts.assert_greater_equal(len(val), 1,
+                                         f"[{label}] RangingCapabilities must have ≥1 entry")
+            caps[label] = val
+            log.info(f"[{label}] RangingCapabilities: {[c.technology for c in val]}")
+
+        # ---- Step 3: WiFiDevIK --------------------------------------------
+        self.step("3")
+        if not self.check_pics("PROXR.S.F00"):
+            log.info("Step 3 skipped – PROXR.S.F00 (WFUSDPD) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.WiFiDevIK)
+                asserts.assert_true(isinstance(val, bytes),
+                                    f"[{label}] WiFiDevIK must be octstr (bytes)")
+                wifi_dev_ik[label] = val
+                log.info(f"[{label}] WiFiDevIK saved ({len(val)} bytes)")
+
+        # ---- Step 4: BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability --
+        self.step("4")
+        if not self.check_pics("PROXR.S.F01"):
+            log.info("Step 4 skipped – PROXR.S.F01 (BLTCS) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                ik = await self._read(node_id, ep, proxr.Attributes.BLTDevIK)
+                asserts.assert_true(isinstance(ik, bytes),
+                                    f"[{label}] BLTDevIK must be octstr (bytes)")
+                blt_dev_ik[label] = ik
+                log.info(f"[{label}] BLTDevIK saved ({len(ik)} bytes)")
+
+                try:
+                    sec = await self._read(node_id, ep, proxr.Attributes.BLTCSSecurityLevel)
+                    asserts.assert_true(isinstance(sec, proxr.Enums.BLTCSSecurityLevelEnum),
+                                        f"[{label}] BLTCSSecurityLevel must be BLTCSSecurityLevelEnum")
+                    bltcs_sec[label] = sec
+                    log.info(f"[{label}] BLTCSSecurityLevel: {sec}")
+                except Exception as exc:
+                    log.info(f"[{label}] BLTCSSecurityLevel absent (optional): {exc}")
+                    bltcs_sec[label] = proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne
+
+                mode = await self._read(node_id, ep, proxr.Attributes.BLTCSModeCapability)
+                asserts.assert_true(isinstance(mode, proxr.Enums.BLTCSModeEnum),
+                                    f"[{label}] BLTCSModeCapability must be BLTCSModeEnum")
+                bltcs_mode[label] = mode
+                log.info(f"[{label}] BLTCSModeCapability: {mode}")
+
+        # ---- Step 5: BLEDeviceID ------------------------------------------
+        self.step("5")
+        if not self.check_pics("PROXR.S.F02"):
+            log.info("Step 5 skipped – PROXR.S.F02 (BLERBC) not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.BLEDeviceID)
+                asserts.assert_true(isinstance(val, int),
+                                    f"[{label}] BLEDeviceID must be uint64 (int)")
+                ble_dev_id[label] = val
+                log.info(f"[{label}] BLEDeviceID saved: {val}")
+
+        # ---- Step 6a: Infeasible WiFi ranging (run when WFUSDPD NOT supported) --
+        self.step("6a")
+        # PICS condition: !PROXR.S.F00 – run when WiFi feature is NOT supported
+        if supports_wfusdpd_i and supports_wfusdpd_r:
+            log.info("Step 6a skipped – WFUSDPD is supported on both devices (not infeasible)")
+        else:
+            log.info("Step 6a – sending infeasible WiFi ranging request")
+            trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+            pmk = os.urandom(32)
+            # Use a dummy peer IK since the feature is not supported
+            dummy_ik = os.urandom(16)
+
+            # DUT_I first
+            cmd_i = proxr.Commands.StartRangingRequest(
+                technology=T.kWiFiRoundTripTimeRanging,
+                wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                    role=R.kWiFiSubscriberRole,
+                    peerWiFiDevIK=wifi_dev_ik.get("DUT_R", dummy_ik),
+                    pmk=pmk,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=trigger,
+            )
+            resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint, cmd_i)
+            asserts.assert_equal(resp_i.resultCode, RC.kRejectedInfeasibleRanging,
+                                 "[DUT_I] Step 6a: expected RejectedInfeasibleRanging")
+            asserts.assert_true(resp_i.sessionID is NullValue or resp_i.sessionID is None,
+                                "[DUT_I] Step 6a: SessionID must be null on rejection")
+            log.info("[DUT_I] Step 6a: correctly rejected WiFi ranging – OK")
+
+            # DUT_R second
+            if two_device:
+                cmd_r = proxr.Commands.StartRangingRequest(
+                    technology=T.kWiFiRoundTripTimeRanging,
+                    wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                        role=R.kWiFiPublisherRole,
+                        peerWiFiDevIK=wifi_dev_ik.get("DUT_I", dummy_ik),
+                        pmk=pmk,
+                    ),
+                    securityMode=S.kSecureRanging,
+                    trigger=trigger,
+                )
+                resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint, cmd_r)
+                asserts.assert_equal(resp_r.resultCode, RC.kRejectedInfeasibleRanging,
+                                     "[DUT_R] Step 6a: expected RejectedInfeasibleRanging")
+                asserts.assert_true(resp_r.sessionID is NullValue or resp_r.sessionID is None,
+                                    "[DUT_R] Step 6a: SessionID must be null on rejection")
+                log.info("[DUT_R] Step 6a: correctly rejected WiFi ranging – OK")
+
+        # ---- Step 6b: Infeasible BLTCS ranging (run when BLTCS NOT supported) --
+        self.step("6b")
+        if supports_bltcs_i and supports_bltcs_r:
+            log.info("Step 6b skipped – BLTCS is supported on both devices (not infeasible)")
+        else:
+            log.info("Step 6b – sending infeasible BLTCS ranging request")
+            trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+            ltk = os.urandom(16)
+            dummy_ik = os.urandom(16)
+            sec_level = proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne
+            mode_val = proxr.Enums.BLTCSModeEnum.kPBROnly
+
+            # DUT_I first
+            cmd_i = proxr.Commands.StartRangingRequest(
+                technology=T.kBluetoothChannelSounding,
+                BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                    role=R.kBLTInitiatorRole,
+                    peerBLTDevIK=blt_dev_ik.get("DUT_R", dummy_ik),
+                    BLTCSMode=mode_val,
+                    BLTCSSecurityLevel=sec_level,
+                    ltk=ltk,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=trigger,
+            )
+            resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint, cmd_i)
+            asserts.assert_equal(resp_i.resultCode, RC.kRejectedInfeasibleRanging,
+                                 "[DUT_I] Step 6b: expected RejectedInfeasibleRanging")
+            asserts.assert_true(resp_i.sessionID is NullValue or resp_i.sessionID is None,
+                                "[DUT_I] Step 6b: SessionID must be null on rejection")
+            log.info("[DUT_I] Step 6b: correctly rejected BLTCS ranging – OK")
+
+            # DUT_R second
+            if two_device:
+                cmd_r = proxr.Commands.StartRangingRequest(
+                    technology=T.kBluetoothChannelSounding,
+                    BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                        role=R.kBLTReflectorRole,
+                        peerBLTDevIK=blt_dev_ik.get("DUT_I", dummy_ik),
+                        BLTCSMode=mode_val,
+                        BLTCSSecurityLevel=sec_level,
+                        ltk=ltk,
+                    ),
+                    securityMode=S.kSecureRanging,
+                    trigger=trigger,
+                )
+                resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint, cmd_r)
+                asserts.assert_equal(resp_r.resultCode, RC.kRejectedInfeasibleRanging,
+                                     "[DUT_R] Step 6b: expected RejectedInfeasibleRanging")
+                asserts.assert_true(resp_r.sessionID is NullValue or resp_r.sessionID is None,
+                                    "[DUT_R] Step 6b: SessionID must be null on rejection")
+                log.info("[DUT_R] Step 6b: correctly rejected BLTCS ranging – OK")
+
+        # ---- Step 6c: Infeasible BLERBC ranging (run when BLERBC NOT supported) --
+        self.step("6c")
+        if supports_blerbc_i and supports_blerbc_r:
+            log.info("Step 6c skipped – BLERBC is supported on both devices (not infeasible)")
+        else:
+            log.info("Step 6c – sending infeasible BLERBC ranging request")
+            trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+            dummy_id = 0xDEADBEEFCAFEBABE
+
+            # DUT_I first (BLEScanningRole, peer = DUT_I's own BLEDeviceID per spec step 6c)
+            cmd_i = proxr.Commands.StartRangingRequest(
+                technology=T.kBLEBeaconRSSIRanging,
+                BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                    role=R.kBLEScanningRole,
+                    peerBLEDeviceID=ble_dev_id.get("DUT_I", dummy_id),
+                ),
+                securityMode=S.kOpenRanging,
+                trigger=trigger,
+            )
+            resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint, cmd_i)
+            asserts.assert_equal(resp_i.resultCode, RC.kRejectedInfeasibleRanging,
+                                 "[DUT_I] Step 6c: expected RejectedInfeasibleRanging")
+            asserts.assert_true(resp_i.sessionID is NullValue or resp_i.sessionID is None,
+                                "[DUT_I] Step 6c: SessionID must be null on rejection")
+            log.info("[DUT_I] Step 6c: correctly rejected BLERBC ranging – OK")
+
+            # DUT_R second
+            if two_device:
+                cmd_r = proxr.Commands.StartRangingRequest(
+                    technology=T.kBLEBeaconRSSIRanging,
+                    BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                        role=R.kBLEBeaconRole,
+                        peerBLEDeviceID=ble_dev_id.get("DUT_R", dummy_id),
+                    ),
+                    securityMode=S.kOpenRanging,
+                    trigger=trigger,
+                )
+                resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint, cmd_r)
+                asserts.assert_equal(resp_r.resultCode, RC.kRejectedInfeasibleRanging,
+                                     "[DUT_R] Step 6c: expected RejectedInfeasibleRanging")
+                asserts.assert_true(resp_r.sessionID is NullValue or resp_r.sessionID is None,
+                                    "[DUT_R] Step 6c: SessionID must be null on rejection")
+                log.info("[DUT_R] Step 6c: correctly rejected BLERBC ranging – OK")
+
+        log.info("TC-PROXR-2.2 PASSED")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -1,0 +1,801 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS /tmp/kvs_dut_i
+#     app2: ${ALL_CLUSTERS_APP}
+#     app2-args: --discriminator 1235 --KVS /tmp/kvs_dut_r
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234 1235
+#       --passcode 20202021 20202021
+#       --dut-node-id 1 2
+#       --int-arg dut_i_endpoint:1 dut_r_endpoint:1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+# HOW TO RUN:
+#   python3 TC_PROXR_2_3.py \
+#     --commissioning-method on-network \
+#     --discriminator 1234 1235 \
+#     --passcode 20202021 20202021 \
+#     --dut-node-id 1 2 \
+#     --int-arg dut_i_endpoint:1 dut_r_endpoint:1 \
+#     --storage-path /tmp/admin_storage.json
+
+import asyncio
+import logging
+import os
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+# Wait time after sending StartRangingRequest (EndTime=10s + buffer)
+_INSTANT_WAIT_S = 12
+# Wait time to confirm no events are generated
+_NO_EVENT_WAIT_S = 12
+
+# Sentinel "unknown peer" 16-byte DevIK used to exercise the kPeerNotFound
+# termination path on stub/reference adapters (e.g. LoggingRangingAdapter).
+# Format mirrors the BLE 0xDEADBEEFCAFEBABE pattern, doubled to 16 bytes so
+# the same recognizable hex appears in WiFi USD and BLTCS DevIK fields.
+_UNKNOWN_PEER_DEVIK = bytes.fromhex("DEADBEEFCAFEBABE" * 2)
+
+
+class TC_PROXR_2_3(MatterBaseTest):
+    """
+    [TC-PROXR-2.3] Instant Proximity Ranging Functionality (DUT as Server)
+
+    Steps per test plan:
+      Step 1   : Commission DUT_I and DUT_R to TH
+      Step 2   : [PROXR.S]  Read RangingCapabilities from DUT_I then DUT_R – save
+      Step 3   : [WFUSDPD]  Read WiFiDevIK from DUT_I then DUT_R – save
+      Step 4   : [BLTCS]    Read BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R – save
+      Step 5   : [BLERBC]   Read BLEDeviceID from DUT_I then DUT_R – save
+      Step 6   : [WFUSDPD]  Instant WiFi ranging (correct peer) – verify Accepted, RangingResult from DUT_I, RangingSessionStatus from DUT_R
+      Step 7   : [BLTCS]    Instant BLTCS ranging (correct peer) – verify Accepted, RangingResult from DUT_I, RangingSessionStatus from DUT_R
+      Step 8   : [BLERBC]   Instant BLERBC ranging (correct peer) – verify Accepted, RangingResult from DUT_I, RangingSessionStatus from DUT_R
+      Step 9   : [WFUSDPD]  Instant WiFi ranging (wrong peer) – verify Accepted, PeerNotFound from DUT_I
+      Step 10  : [BLTCS]    Instant BLTCS ranging (wrong peer) – verify Accepted, PeerNotFound from DUT_I
+      Step 11  : [BLERBC]   Instant BLERBC ranging (wrong peer) – verify Accepted, PeerNotFound from DUT_I
+      Step 12  : [WFUSDPD]  Instant WiFi ranging with valid ReportingCondition – verify RangingResult from DUT_I
+      Step 13  : [BLTCS]    Instant BLTCS ranging with valid ReportingCondition – verify RangingResult from DUT_I
+      Step 14  : [BLERBC]   Instant BLERBC ranging with valid ReportingCondition – verify RangingResult from DUT_I
+      Step 15  : [WFUSDPD]  Instant WiFi ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I
+      Step 16  : [BLTCS]    Instant BLTCS ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I
+      Step 17  : [BLERBC]   Instant BLERBC ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I
+    """
+
+    def desc_TC_PROXR_2_3(self) -> str:
+        return "[TC-PROXR-2.3] Instant Proximity Ranging Functionality (DUT as Server)"
+
+    def pics_TC_PROXR_2_3(self):
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_3(self) -> list[TestStep]:
+        return [
+            TestStep("1",  "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep("2",  "[PROXR.S]  TH reads RangingCapabilities from DUT_I then DUT_R"),
+            TestStep("3",  "[WFUSDPD]  TH reads WiFiDevIK from DUT_I then DUT_R"),
+            TestStep("4",  "[BLTCS]    TH reads BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R"),
+            TestStep("5",  "[BLERBC]   TH reads BLEDeviceID from DUT_I then DUT_R"),
+            TestStep(
+                "6",  "[WFUSDPD]  Instant WiFi ranging (correct peer) – verify Accepted + RangingResult(DUT_I) + SessionEndTimeReached(DUT_R)"),
+            TestStep(
+                "7",  "[BLTCS]    Instant BLTCS ranging (correct peer) – verify Accepted + RangingResult(DUT_I) + SessionEndTimeReached(DUT_R)"),
+            TestStep(
+                "8",  "[BLERBC]   Instant BLERBC ranging (correct peer) – verify Accepted + RangingResult(DUT_I) + SessionEndTimeReached(DUT_R)"),
+            TestStep("9",  "[WFUSDPD]  Instant WiFi ranging (wrong peer) – verify Accepted + PeerNotFound(DUT_I)"),
+            TestStep("10", "[BLTCS]    Instant BLTCS ranging (wrong peer) – verify Accepted + PeerNotFound(DUT_I)"),
+            TestStep("11", "[BLERBC]   Instant BLERBC ranging (wrong peer) – verify Accepted + PeerNotFound(DUT_I)"),
+            TestStep("12", "[WFUSDPD]  Instant WiFi ranging with valid ReportingCondition – verify RangingResult from DUT_I"),
+            TestStep("13", "[BLTCS]    Instant BLTCS ranging with valid ReportingCondition – verify RangingResult from DUT_I"),
+            TestStep("14", "[BLERBC]   Instant BLERBC ranging with valid ReportingCondition – verify RangingResult from DUT_I"),
+            TestStep("15", "[WFUSDPD]  Instant WiFi ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I"),
+            TestStep("16", "[BLTCS]    Instant BLTCS ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I"),
+            TestStep("17", "[BLERBC]   Instant BLERBC ranging with impossible ReportingCondition – verify NO RangingResult from DUT_I"),
+        ]
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def default_timeout(self) -> int:
+        # 17 instant-ranging steps × ~12s each (EndTime=10s + buffer), plus
+        # commissioning and read overhead. The framework default of 90s is
+        # tight; bump it so the suite has headroom across all three
+        # technologies' wrong-peer and reporting-condition variants.
+        return 300
+
+    @property
+    def dut_i_node_id(self) -> int:
+        return self.matter_test_config.dut_node_ids[0]
+
+    @property
+    def dut_r_node_id(self) -> int:
+        ids = self.matter_test_config.dut_node_ids
+        return ids[1] if len(ids) > 1 else ids[0]
+
+    @property
+    def dut_i_endpoint(self) -> int:
+        return self.user_params.get("dut_i_endpoint", 1)
+
+    @property
+    def dut_r_endpoint(self) -> int:
+        return self.user_params.get("dut_r_endpoint", self.dut_i_endpoint)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _read(self, node_id: int, endpoint: int, attribute):
+        return await self.read_single_attribute_check_success(
+            node_id=node_id,
+            cluster=Clusters.ProximityRanging,
+            attribute=attribute,
+            endpoint=endpoint,
+        )
+
+    async def _send_cmd(self, node_id: int, endpoint: int, cmd):
+        return await self.send_single_cmd(node_id=node_id, endpoint=endpoint, cmd=cmd)
+
+    def _dut_pairs(self, two_device: bool):
+        pairs = [(self.dut_i_node_id, self.dut_i_endpoint, "DUT_I")]
+        if two_device:
+            pairs.append((self.dut_r_node_id, self.dut_r_endpoint, "DUT_R"))
+        return pairs
+
+    async def _subscribe_events(self, node_id: int, endpoint: int):
+        """Subscribe to RangingResult and RangingSessionStatus events."""
+        proxr = Clusters.ProximityRanging
+        event_list = []
+
+        async def event_cb(path, event_data):
+            event_list.append((path, event_data))
+
+        sub = await self.default_controller.ReadEvent(
+            nodeId=node_id,
+            events=[(endpoint, proxr.Events.RangingResult, 1),
+                    (endpoint, proxr.Events.RangingSessionStatus, 1)],
+            reportInterval=(0, 10),
+            keepSubscriptions=True,
+            autoResubscribe=False,
+        )
+        return sub, event_list
+
+    def _find_events(self, event_list, event_type, session_id=None):
+        """Filter events by type and optionally by sessionID."""
+        results = []
+        for path, data in event_list:
+            if isinstance(data, event_type):
+                if session_id is None or data.sessionID == session_id:
+                    results.append(data)
+        return results
+
+    async def _do_instant_ranging_wifi(self, step_label: str, two_device: bool,
+                                       wifi_dev_ik: dict, caps: dict,
+                                       reporting_condition=None,
+                                       wrong_peer: bool = False):
+        """
+        Send instant WiFi ranging to DUT_I then DUT_R.
+        Returns (session_id_i, session_id_r, events_i, events_r).
+        """
+        proxr = Clusters.ProximityRanging
+        R = proxr.Enums.RangingRoleEnum
+        T = proxr.Enums.RangingTechEnum
+        S = proxr.Enums.RangingSecurityEnum
+        RC = proxr.Enums.ResultCodeEnum
+
+        # Determine common WiFi technology
+        techs_i = {c.technology for c in caps.get("DUT_I", [])}
+        techs_r = {c.technology for c in caps.get("DUT_R", caps.get("DUT_I", []))}
+        wifi_techs = {T.kWiFiRoundTripTimeRanging, T.kWiFiNextGenerationRanging}
+        common = (techs_i & techs_r & wifi_techs) or (techs_i & wifi_techs)
+        tech = next(iter(common)) if common else T.kWiFiRoundTripTimeRanging
+
+        pmk = os.urandom(32)
+        trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+
+        peer_ik_for_i = _UNKNOWN_PEER_DEVIK if wrong_peer else wifi_dev_ik.get("DUT_R", os.urandom(16))
+        peer_ik_for_r = _UNKNOWN_PEER_DEVIK if wrong_peer else wifi_dev_ik.get("DUT_I", os.urandom(16))
+
+        kwargs_i = dict(
+            technology=tech,
+            wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                role=R.kWiFiSubscriberRole, peerWiFiDevIK=peer_ik_for_i, pmk=pmk),
+            securityMode=S.kSecureRanging,
+            trigger=trigger,
+        )
+        if reporting_condition:
+            kwargs_i["reportingCondition"] = reporting_condition
+
+        kwargs_r = dict(
+            technology=tech,
+            wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                role=R.kWiFiPublisherRole, peerWiFiDevIK=peer_ik_for_r, pmk=pmk),
+            securityMode=S.kSecureRanging,
+            trigger=trigger,
+        )
+
+        # DUT_I first
+        resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint,
+                                      proxr.Commands.StartRangingRequest(**kwargs_i))
+        asserts.assert_equal(resp_i.resultCode, RC.kAccepted,
+                             f"[DUT_I] {step_label}: expected Accepted")
+        asserts.assert_is_not_none(resp_i.sessionID, f"[DUT_I] {step_label}: SessionID must not be null")
+        asserts.assert_not_equal(resp_i.sessionID, 0, f"[DUT_I] {step_label}: SessionID must be non-zero")
+        session_id_i = resp_i.sessionID
+        log.info(f"[DUT_I] {step_label}: Accepted, SessionID={session_id_i}")
+
+        # DUT_R second
+        session_id_r = None
+        if two_device:
+            resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint,
+                                          proxr.Commands.StartRangingRequest(**kwargs_r))
+            asserts.assert_equal(resp_r.resultCode, RC.kAccepted,
+                                 f"[DUT_R] {step_label}: expected Accepted")
+            session_id_r = resp_r.sessionID
+            log.info(f"[DUT_R] {step_label}: Accepted, SessionID={session_id_r}")
+
+        return session_id_i, session_id_r
+
+    async def _do_instant_ranging_bltcs(self, step_label: str, two_device: bool,
+                                        blt_dev_ik: dict, bltcs_sec: dict, bltcs_mode: dict,
+                                        reporting_condition=None, wrong_peer: bool = False):
+        proxr = Clusters.ProximityRanging
+        R = proxr.Enums.RangingRoleEnum
+        T = proxr.Enums.RangingTechEnum
+        S = proxr.Enums.RangingSecurityEnum
+        RC = proxr.Enums.ResultCodeEnum
+
+        ltk = os.urandom(16)
+        trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+        sec_level = bltcs_sec.get("DUT_I", proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne)
+        mode_val = bltcs_mode.get("DUT_I", proxr.Enums.BLTCSModeEnum.kPBROnly)
+
+        peer_ik_for_i = _UNKNOWN_PEER_DEVIK if wrong_peer else blt_dev_ik.get("DUT_R", os.urandom(16))
+        peer_ik_for_r = _UNKNOWN_PEER_DEVIK if wrong_peer else blt_dev_ik.get("DUT_I", os.urandom(16))
+
+        kwargs_i = dict(
+            technology=T.kBluetoothChannelSounding,
+            BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                role=R.kBLTInitiatorRole, peerBLTDevIK=peer_ik_for_i,
+                BLTCSMode=mode_val, BLTCSSecurityLevel=sec_level, ltk=ltk),
+            securityMode=S.kSecureRanging,
+            trigger=trigger,
+        )
+        if reporting_condition:
+            kwargs_i["reportingCondition"] = reporting_condition
+
+        kwargs_r = dict(
+            technology=T.kBluetoothChannelSounding,
+            BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                role=R.kBLTReflectorRole, peerBLTDevIK=peer_ik_for_r,
+                BLTCSMode=mode_val, BLTCSSecurityLevel=sec_level, ltk=ltk),
+            securityMode=S.kSecureRanging,
+            trigger=trigger,
+        )
+
+        resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint,
+                                      proxr.Commands.StartRangingRequest(**kwargs_i))
+        asserts.assert_equal(resp_i.resultCode, RC.kAccepted,
+                             f"[DUT_I] {step_label}: expected Accepted")
+        session_id_i = resp_i.sessionID
+        log.info(f"[DUT_I] {step_label}: Accepted, SessionID={session_id_i}")
+
+        session_id_r = None
+        if two_device:
+            resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint,
+                                          proxr.Commands.StartRangingRequest(**kwargs_r))
+            asserts.assert_equal(resp_r.resultCode, RC.kAccepted,
+                                 f"[DUT_R] {step_label}: expected Accepted")
+            session_id_r = resp_r.sessionID
+            log.info(f"[DUT_R] {step_label}: Accepted, SessionID={session_id_r}")
+
+        return session_id_i, session_id_r
+
+    async def _do_instant_ranging_blerbc(self, step_label: str, two_device: bool,
+                                         ble_dev_id: dict,
+                                         reporting_condition=None, wrong_peer: bool = False):
+        proxr = Clusters.ProximityRanging
+        R = proxr.Enums.RangingRoleEnum
+        T = proxr.Enums.RangingTechEnum
+        S = proxr.Enums.RangingSecurityEnum
+        RC = proxr.Enums.ResultCodeEnum
+
+        trigger = proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=10)
+        dummy_id = 0xDEADBEEFCAFEBABE
+
+        peer_id_for_i = dummy_id if wrong_peer else ble_dev_id.get("DUT_R", dummy_id)
+        peer_id_for_r = dummy_id if wrong_peer else ble_dev_id.get("DUT_I", dummy_id)
+
+        kwargs_i = dict(
+            technology=T.kBLEBeaconRSSIRanging,
+            BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                role=R.kBLEScanningRole, peerBLEDeviceID=peer_id_for_i),
+            securityMode=S.kOpenRanging,
+            trigger=trigger,
+        )
+        if reporting_condition:
+            kwargs_i["reportingCondition"] = reporting_condition
+
+        kwargs_r = dict(
+            technology=T.kBLEBeaconRSSIRanging,
+            BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                role=R.kBLEBeaconRole, peerBLEDeviceID=peer_id_for_r),
+            securityMode=S.kOpenRanging,
+            trigger=trigger,
+        )
+
+        resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint,
+                                      proxr.Commands.StartRangingRequest(**kwargs_i))
+        asserts.assert_equal(resp_i.resultCode, RC.kAccepted,
+                             f"[DUT_I] {step_label}: expected Accepted")
+        session_id_i = resp_i.sessionID
+        log.info(f"[DUT_I] {step_label}: Accepted, SessionID={session_id_i}")
+
+        session_id_r = None
+        if two_device:
+            resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint,
+                                          proxr.Commands.StartRangingRequest(**kwargs_r))
+            asserts.assert_equal(resp_r.resultCode, RC.kAccepted,
+                                 f"[DUT_R] {step_label}: expected Accepted")
+            session_id_r = resp_r.sessionID
+            log.info(f"[DUT_R] {step_label}: Accepted, SessionID={session_id_r}")
+
+        return session_id_i, session_id_r
+
+    # ------------------------------------------------------------------
+    # Main test body
+    # ------------------------------------------------------------------
+
+    @async_test_body
+    async def test_TC_PROXR_2_3(self):
+        proxr = Clusters.ProximityRanging
+        F = proxr.Bitmaps.Feature
+        SS = proxr.Enums.RangingSessionStatusEnum
+
+        # ---- Step 1: Commissioning ----------------------------------------
+        self.step("1")
+        two_device = (self.dut_i_node_id != self.dut_r_node_id)
+        log.info(f"DUT_I  node={self.dut_i_node_id}  ep={self.dut_i_endpoint}")
+        log.info(f"DUT_R  node={self.dut_r_node_id}  ep={self.dut_r_endpoint}")
+
+        fm_i = await self._read(self.dut_i_node_id, self.dut_i_endpoint, proxr.Attributes.FeatureMap)
+        fm_r = await self._read(self.dut_r_node_id, self.dut_r_endpoint, proxr.Attributes.FeatureMap) if two_device else fm_i
+
+        supports_wfusdpd = bool((fm_i & F.kWiFiUsdProximityDetection) and (fm_r & F.kWiFiUsdProximityDetection))
+        supports_bltcs = bool((fm_i & F.kBluetoothChannelSounding) and (fm_r & F.kBluetoothChannelSounding))
+        supports_blerbc = bool((fm_i & F.kBleBeaconRssi) and (fm_r & F.kBleBeaconRssi))
+
+        caps:       dict = {}
+        wifi_dev_ik: dict = {}
+        blt_dev_ik:  dict = {}
+        bltcs_sec:   dict = {}
+        bltcs_mode:  dict = {}
+        ble_dev_id:  dict = {}
+
+        # ---- Step 2: RangingCapabilities ----------------------------------
+        self.step("2")
+        for node_id, ep, label in self._dut_pairs(two_device):
+            val = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+            asserts.assert_true(isinstance(val, list), f"[{label}] RangingCapabilities must be a list")
+            caps[label] = val
+            log.info(f"[{label}] RangingCapabilities: {[c.technology for c in val]}")
+
+        # ---- Step 3: WiFiDevIK --------------------------------------------
+        self.step("3")
+        if not self.check_pics("PROXR.S.F00"):
+            log.info("Step 3 skipped – PROXR.S.F00 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.WiFiDevIK)
+                asserts.assert_true(isinstance(val, bytes), f"[{label}] WiFiDevIK must be octstr")
+                wifi_dev_ik[label] = val
+                log.info(f"[{label}] WiFiDevIK saved ({len(val)} bytes)")
+
+        # ---- Step 4: BLTCS attributes -------------------------------------
+        self.step("4")
+        if not self.check_pics("PROXR.S.F01"):
+            log.info("Step 4 skipped – PROXR.S.F01 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                ik = await self._read(node_id, ep, proxr.Attributes.BLTDevIK)
+                asserts.assert_true(isinstance(ik, bytes), f"[{label}] BLTDevIK must be octstr")
+                blt_dev_ik[label] = ik
+                try:
+                    sec = await self._read(node_id, ep, proxr.Attributes.BLTCSSecurityLevel)
+                    bltcs_sec[label] = sec
+                except Exception:
+                    bltcs_sec[label] = proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne
+                mode = await self._read(node_id, ep, proxr.Attributes.BLTCSModeCapability)
+                bltcs_mode[label] = mode
+                log.info(f"[{label}] BLTDevIK saved, mode={mode}")
+
+        # ---- Step 5: BLEDeviceID ------------------------------------------
+        self.step("5")
+        if not self.check_pics("PROXR.S.F02"):
+            log.info("Step 5 skipped – PROXR.S.F02 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.BLEDeviceID)
+                asserts.assert_true(isinstance(val, int), f"[{label}] BLEDeviceID must be uint64")
+                ble_dev_id[label] = val
+                log.info(f"[{label}] BLEDeviceID saved: {val}")
+
+        # ---- Step 6: Instant WiFi ranging (correct peer) ------------------
+        self.step("6")
+        if not self.check_pics("PROXR.S.F00") or not supports_wfusdpd:
+            log.info("Step 6 skipped – WFUSDPD not supported on both devices")
+        else:
+            # Subscribe to events on DUT_I and DUT_R
+            events_i: list = []
+            events_r: list = []
+
+            async def cb_i(path, data): events_i.append(data)
+            async def cb_r(path, data): events_r.append(data)
+
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1),
+                        (self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            if two_device:
+                sub_r = await self.default_controller.ReadEvent(
+                    nodeId=self.dut_r_node_id,
+                    events=[(self.dut_r_endpoint, proxr.Events.RangingResult, 1),
+                            (self.dut_r_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                    reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, sid_r = await self._do_instant_ranging_wifi(
+                "Step 6", two_device, wifi_dev_ik, caps)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            # Verify RangingResult from DUT_I
+            ranging_results_i = [e for e in sub_i.GetEvents()
+                                 if isinstance(e.Data, proxr.Events.RangingResult)
+                                 and e.Data.sessionID == sid_i]
+            asserts.assert_greater_equal(len(ranging_results_i), 1,
+                                         "[DUT_I] Step 6: must receive at least one RangingResult event")
+            rr = ranging_results_i[0].Data
+            asserts.assert_is_not_none(rr.rangingResultData, "[DUT_I] Step 6: RangingResultData must be present")
+            log.info(f"[DUT_I] Step 6: RangingResult received, distance={rr.rangingResultData.distance}")
+
+            # Verify RangingSessionStatus from DUT_R
+            if two_device:
+                status_events_r = [e for e in sub_r.GetEvents()
+                                   if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                                   and e.Data.sessionID == sid_r]
+                asserts.assert_greater_equal(len(status_events_r), 1,
+                                             "[DUT_R] Step 6: must receive RangingSessionStatus event")
+                asserts.assert_equal(status_events_r[0].Data.status, SS.kSessionEndTimeReached,
+                                     "[DUT_R] Step 6: Status must be SessionEndTimeReached")
+                log.info("[DUT_R] Step 6: RangingSessionStatus=SessionEndTimeReached – OK")
+
+        # ---- Step 7: Instant BLTCS ranging (correct peer) -----------------
+        self.step("7")
+        if not self.check_pics("PROXR.S.F01") or not supports_bltcs:
+            log.info("Step 7 skipped – BLTCS not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1),
+                        (self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+            if two_device:
+                sub_r = await self.default_controller.ReadEvent(
+                    nodeId=self.dut_r_node_id,
+                    events=[(self.dut_r_endpoint, proxr.Events.RangingResult, 1),
+                            (self.dut_r_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                    reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, sid_r = await self._do_instant_ranging_bltcs(
+                "Step 7", two_device, blt_dev_ik, bltcs_sec, bltcs_mode)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            ranging_results_i = [e for e in sub_i.GetEvents()
+                                 if isinstance(e.Data, proxr.Events.RangingResult)
+                                 and e.Data.sessionID == sid_i]
+            asserts.assert_greater_equal(len(ranging_results_i), 1,
+                                         "[DUT_I] Step 7: must receive at least one RangingResult event")
+            log.info("[DUT_I] Step 7: RangingResult received")
+
+            if two_device:
+                status_events_r = [e for e in sub_r.GetEvents()
+                                   if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                                   and e.Data.sessionID == sid_r]
+                asserts.assert_greater_equal(len(status_events_r), 1,
+                                             "[DUT_R] Step 7: must receive RangingSessionStatus event")
+                asserts.assert_equal(status_events_r[0].Data.status, SS.kSessionEndTimeReached,
+                                     "[DUT_R] Step 7: Status must be SessionEndTimeReached")
+                log.info("[DUT_R] Step 7: RangingSessionStatus=SessionEndTimeReached – OK")
+
+        # ---- Step 8: Instant BLERBC ranging (correct peer) ----------------
+        self.step("8")
+        if not self.check_pics("PROXR.S.F02") or not supports_blerbc:
+            log.info("Step 8 skipped – BLERBC not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1),
+                        (self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+            if two_device:
+                sub_r = await self.default_controller.ReadEvent(
+                    nodeId=self.dut_r_node_id,
+                    events=[(self.dut_r_endpoint, proxr.Events.RangingResult, 1),
+                            (self.dut_r_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                    reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, sid_r = await self._do_instant_ranging_blerbc(
+                "Step 8", two_device, ble_dev_id)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            ranging_results_i = [e for e in sub_i.GetEvents()
+                                 if isinstance(e.Data, proxr.Events.RangingResult)
+                                 and e.Data.sessionID == sid_i]
+            asserts.assert_greater_equal(len(ranging_results_i), 1,
+                                         "[DUT_I] Step 8: must receive at least one RangingResult event")
+            rr = ranging_results_i[0].Data
+            asserts.assert_is_not_none(rr.rangingResultData.rssi,
+                                       "[DUT_I] Step 8: RSSI must be present for BLERBC")
+            asserts.assert_is_not_none(rr.rangingResultData.txPower,
+                                       "[DUT_I] Step 8: TxPower must be present for BLERBC")
+            log.info(f"[DUT_I] Step 8: RangingResult received, RSSI={rr.rangingResultData.rssi}")
+
+            if two_device:
+                status_events_r = [e for e in sub_r.GetEvents()
+                                   if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                                   and e.Data.sessionID == sid_r]
+                asserts.assert_greater_equal(len(status_events_r), 1,
+                                             "[DUT_R] Step 8: must receive RangingSessionStatus event")
+                asserts.assert_equal(status_events_r[0].Data.status, SS.kSessionEndTimeReached,
+                                     "[DUT_R] Step 8: Status must be SessionEndTimeReached")
+                log.info("[DUT_R] Step 8: RangingSessionStatus=SessionEndTimeReached – OK")
+
+        # ---- Step 9: Instant WiFi ranging (wrong peer) --------------------
+        self.step("9")
+        if not self.check_pics("PROXR.S.F00") or not supports_wfusdpd:
+            log.info("Step 9 skipped – WFUSDPD not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_wifi(
+                "Step 9", two_device, wifi_dev_ik, caps, wrong_peer=True)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            status_events = [e for e in sub_i.GetEvents()
+                             if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                             and e.Data.sessionID == sid_i
+                             and e.Data.status == SS.kPeerNotFound]
+            asserts.assert_greater_equal(len(status_events), 1,
+                                         "[DUT_I] Step 9: must receive RangingSessionStatus=PeerNotFound")
+            log.info("[DUT_I] Step 9: PeerNotFound received – OK")
+
+        # ---- Step 10: Instant BLTCS ranging (wrong peer) ------------------
+        self.step("10")
+        if not self.check_pics("PROXR.S.F01") or not supports_bltcs:
+            log.info("Step 10 skipped – BLTCS not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_bltcs(
+                "Step 10", two_device, blt_dev_ik, bltcs_sec, bltcs_mode, wrong_peer=True)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            status_events = [e for e in sub_i.GetEvents()
+                             if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                             and e.Data.sessionID == sid_i
+                             and e.Data.status == SS.kPeerNotFound]
+            asserts.assert_greater_equal(len(status_events), 1,
+                                         "[DUT_I] Step 10: must receive RangingSessionStatus=PeerNotFound")
+            log.info("[DUT_I] Step 10: PeerNotFound received – OK")
+
+        # ---- Step 11: Instant BLERBC ranging (wrong peer) -----------------
+        self.step("11")
+        if not self.check_pics("PROXR.S.F02") or not supports_blerbc:
+            log.info("Step 11 skipped – BLERBC not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingSessionStatus, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_blerbc(
+                "Step 11", two_device, ble_dev_id, wrong_peer=True)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            status_events = [e for e in sub_i.GetEvents()
+                             if isinstance(e.Data, proxr.Events.RangingSessionStatus)
+                             and e.Data.sessionID == sid_i
+                             and e.Data.status == SS.kPeerNotFound]
+            asserts.assert_greater_equal(len(status_events), 1,
+                                         "[DUT_I] Step 11: must receive RangingSessionStatus=PeerNotFound")
+            log.info("[DUT_I] Step 11: PeerNotFound received – OK")
+
+        # Valid ReportingCondition: MinDistance=1cm, MaxDistance=1000cm
+        valid_rc = proxr.Structs.ReportingConditionStruct(
+            minDistanceCondition=1, maxDistanceCondition=1000)
+        # Unsatisfiable (but spec-feasible) ReportingCondition: a min<max
+        # window that intentionally excludes the stub adapter's synthesized
+        # 100 cm distance so no measurement is ever emitted. We can't use
+        # min>max here — the cluster server (correctly) rejects that as
+        # kRejectedInfeasibleRanging at StartRangingRequest time, before the
+        # adapter ever sees the request.
+        impossible_rc = proxr.Structs.ReportingConditionStruct(
+            minDistanceCondition=500, maxDistanceCondition=600)
+
+        # ---- Step 12: WiFi with valid ReportingCondition ------------------
+        self.step("12")
+        if not self.check_pics("PROXR.S.F00") or not supports_wfusdpd:
+            log.info("Step 12 skipped – WFUSDPD not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_wifi(
+                "Step 12", two_device, wifi_dev_ik, caps, reporting_condition=valid_rc)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            # May or may not receive events depending on actual distance vs condition
+            log.info(f"[DUT_I] Step 12: received {len(results)} RangingResult events (valid condition)")
+
+        # ---- Step 13: BLTCS with valid ReportingCondition -----------------
+        self.step("13")
+        if not self.check_pics("PROXR.S.F01") or not supports_bltcs:
+            log.info("Step 13 skipped – BLTCS not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_bltcs(
+                "Step 13", two_device, blt_dev_ik, bltcs_sec, bltcs_mode,
+                reporting_condition=valid_rc)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            log.info(f"[DUT_I] Step 13: received {len(results)} RangingResult events (valid condition)")
+
+        # ---- Step 14: BLERBC with valid ReportingCondition ----------------
+        self.step("14")
+        if not self.check_pics("PROXR.S.F02") or not supports_blerbc:
+            log.info("Step 14 skipped – BLERBC not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_blerbc(
+                "Step 14", two_device, ble_dev_id, reporting_condition=valid_rc)
+
+            await asyncio.sleep(_INSTANT_WAIT_S)
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            log.info(f"[DUT_I] Step 14: received {len(results)} RangingResult events (valid condition)")
+
+        # ---- Step 15: WiFi with impossible ReportingCondition -------------
+        self.step("15")
+        if not self.check_pics("PROXR.S.F00") or not supports_wfusdpd:
+            log.info("Step 15 skipped – WFUSDPD not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_wifi(
+                "Step 15", two_device, wifi_dev_ik, caps, reporting_condition=impossible_rc)
+
+            await asyncio.sleep(_NO_EVENT_WAIT_S)
+
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            asserts.assert_equal(len(results), 0,
+                                 "[DUT_I] Step 15: must NOT receive RangingResult (impossible condition)")
+            log.info("[DUT_I] Step 15: no RangingResult received – OK")
+
+        # ---- Step 16: BLTCS with impossible ReportingCondition ------------
+        self.step("16")
+        if not self.check_pics("PROXR.S.F01") or not supports_bltcs:
+            log.info("Step 16 skipped – BLTCS not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_bltcs(
+                "Step 16", two_device, blt_dev_ik, bltcs_sec, bltcs_mode,
+                reporting_condition=impossible_rc)
+
+            await asyncio.sleep(_NO_EVENT_WAIT_S)
+
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            asserts.assert_equal(len(results), 0,
+                                 "[DUT_I] Step 16: must NOT receive RangingResult (impossible condition)")
+            log.info("[DUT_I] Step 16: no RangingResult received – OK")
+
+        # ---- Step 17: BLERBC with impossible ReportingCondition -----------
+        self.step("17")
+        if not self.check_pics("PROXR.S.F02") or not supports_blerbc:
+            log.info("Step 17 skipped – BLERBC not supported on both devices")
+        else:
+            sub_i = await self.default_controller.ReadEvent(
+                nodeId=self.dut_i_node_id,
+                events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+                reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+            sid_i, _ = await self._do_instant_ranging_blerbc(
+                "Step 17", two_device, ble_dev_id, reporting_condition=impossible_rc)
+
+            await asyncio.sleep(_NO_EVENT_WAIT_S)
+
+            results = [e for e in sub_i.GetEvents()
+                       if isinstance(e.Data, proxr.Events.RangingResult)
+                       and e.Data.sessionID == sid_i]
+            asserts.assert_equal(len(results), 0,
+                                 "[DUT_I] Step 17: must NOT receive RangingResult (impossible condition)")
+            log.info("[DUT_I] Step 17: no RangingResult received – OK")
+
+        log.info("TC-PROXR-2.3 PASSED")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_4.py
+++ b/src/python_testing/TC_PROXR_2_4.py
@@ -1,0 +1,594 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS /tmp/kvs_dut_i
+#     app2: ${ALL_CLUSTERS_APP}
+#     app2-args: --discriminator 1235 --KVS /tmp/kvs_dut_r
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234 1235
+#       --passcode 20202021 20202021
+#       --dut-node-id 1 2
+#       --int-arg dut_i_endpoint:1 dut_r_endpoint:1
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+# HOW TO RUN:
+#   python3 TC_PROXR_2_4.py \
+#     --commissioning-method on-network \
+#     --discriminator 1234 1235 \
+#     --passcode 20202021 20202021 \
+#     --dut-node-id 1 2 \
+#     --int-arg dut_i_endpoint:1 dut_r_endpoint:1 \
+#     --storage-path /tmp/admin_storage.json
+
+import asyncio
+import logging
+import os
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+_PERIODIC_INTERVAL_S = 3      # RangingInstanceInterval in seconds (matches TC-PROXR-2.4 test plan)
+_PERIODIC_WAIT_S = 10     # Wait to collect periodic events. With the LoggingRangingAdapter's
+# 3s simulated radio latency and a 3s interval the actual measurement
+# cadence is ~6s (the driver re-issues StartSession every 3s; the
+# first one is busy until the previous measurement lands), so a 10s
+# window reliably captures >=2 events.
+_STOP_VERIFY_WAIT_S = 5      # Wait after stop to confirm no new events
+_ENDTIME_WAIT_S = 30     # StartRangingRequest end time in seconds. Must comfortably exceed
+# _PERIODIC_WAIT_S + _STOP_VERIFY_WAIT_S so end-time cannot fire
+# during the wait windows above.
+
+
+class TC_PROXR_2_4(MatterBaseTest):
+    """
+    [TC-PROXR-2.4] Periodic Proximity Ranging Functionality (DUT as Server)
+    PICS: PROXR.S AND PROXR.S.F03(PERIODIC)
+
+    Steps per test plan:
+      Step 1   : Commission DUT_I and DUT_R to TH
+      Step 2   : [PROXR.S]  Read RangingCapabilities – verify PeriodicRangingSupport=true
+      Step 3   : [WFUSDPD]  Read WiFiDevIK from DUT_I then DUT_R
+      Step 4   : [BLTCS]    Read BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R
+      Step 5   : [BLERBC]   Read BLEDeviceID from DUT_I then DUT_R
+      Step 6a  : [WFUSDPD]  Start periodic WiFi ranging (DUT_I then DUT_R) – verify periodic events
+      Step 6b  : [WFUSDPD]  Read SessionIDList from DUT_I then DUT_R – verify active session IDs
+      Step 6c  : [WFUSDPD]  Stop ranging (DUT_I then DUT_R) – verify no new events
+      Step 6d  : [WFUSDPD]  Start new periodic WiFi session – verify incremented SessionID + events
+      Step 6e  : [WFUSDPD]  Read SessionIDList from DUT_I then DUT_R
+      Step 6f  : [WFUSDPD]  Stop with wrong SessionID on DUT_I – expect INVALID_IN_STATE
+      Step 6g  : [WFUSDPD]  Stop with correct SessionIDs (DUT_I then DUT_R) – verify no new events
+      Step 7a-g: [BLTCS]    Same pattern as 6a-g for BLTCS technology
+      Step 8a-g: [BLERBC]   Same pattern as 6a-g for BLERBC technology
+    """
+
+    def desc_TC_PROXR_2_4(self) -> str:
+        return "[TC-PROXR-2.4] Periodic Proximity Ranging Functionality (DUT as Server)"
+
+    def pics_TC_PROXR_2_4(self):
+        return ["PROXR.S", "PROXR.S.F03"]
+
+    def steps_TC_PROXR_2_4(self) -> list[TestStep]:
+        return [
+            TestStep("1",   "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep("2",   "[PROXR.S]  TH reads RangingCapabilities – verify PeriodicRangingSupport=true"),
+            TestStep("3",   "[WFUSDPD]  TH reads WiFiDevIK from DUT_I then DUT_R"),
+            TestStep("4",   "[BLTCS]    TH reads BLTDevIK / BLTCSSecurityLevel / BLTCSModeCapability from DUT_I then DUT_R"),
+            TestStep("5",   "[BLERBC]   TH reads BLEDeviceID from DUT_I then DUT_R"),
+            TestStep("6a",  "[WFUSDPD]  Start periodic WiFi ranging (DUT_I then DUT_R) – verify periodic events"),
+            TestStep("6b",  "[WFUSDPD]  Read SessionIDList from DUT_I then DUT_R – verify active session IDs"),
+            TestStep("6c",  "[WFUSDPD]  Stop ranging (DUT_I then DUT_R) – verify no new events"),
+            TestStep("6d",  "[WFUSDPD]  Start new periodic WiFi session – verify incremented SessionID + events"),
+            TestStep("6e",  "[WFUSDPD]  Read SessionIDList from DUT_I then DUT_R"),
+            TestStep("6f",  "[WFUSDPD]  Stop with wrong SessionID on DUT_I – expect INVALID_IN_STATE"),
+            TestStep("6g",  "[WFUSDPD]  Stop with correct SessionIDs (DUT_I then DUT_R) – verify no new events"),
+            TestStep("7a",  "[BLTCS]    Start periodic BLTCS ranging (DUT_I then DUT_R) – verify periodic events"),
+            TestStep("7b",  "[BLTCS]    Read SessionIDList from DUT_I then DUT_R"),
+            TestStep("7c",  "[BLTCS]    Stop ranging (DUT_I then DUT_R) – verify no new events"),
+            TestStep("7d",  "[BLTCS]    Start new periodic BLTCS session – verify incremented SessionID + events"),
+            TestStep("7e",  "[BLTCS]    Read SessionIDList from DUT_I then DUT_R"),
+            TestStep("7f",  "[BLTCS]    Stop with wrong SessionID on DUT_I – expect INVALID_IN_STATE"),
+            TestStep("7g",  "[BLTCS]    Stop with correct SessionIDs (DUT_I then DUT_R) – verify no new events"),
+            TestStep("8a",  "[BLERBC]   Start periodic BLERBC ranging (DUT_I then DUT_R) – verify periodic events"),
+            TestStep("8b",  "[BLERBC]   Read SessionIDList from DUT_I then DUT_R"),
+            TestStep("8c",  "[BLERBC]   Stop ranging (DUT_I then DUT_R) – verify no new events"),
+            TestStep("8d",  "[BLERBC]   Start new periodic BLERBC session – verify incremented SessionID + events"),
+            TestStep("8e",  "[BLERBC]   Read SessionIDList from DUT_I then DUT_R"),
+            TestStep("8f",  "[BLERBC]   Stop with wrong SessionID on DUT_I – expect INVALID_IN_STATE"),
+            TestStep("8g",  "[BLERBC]   Stop with correct SessionIDs (DUT_I then DUT_R) – verify no new events"),
+        ]
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def dut_i_node_id(self) -> int:
+        return self.matter_test_config.dut_node_ids[0]
+
+    @property
+    def dut_r_node_id(self) -> int:
+        ids = self.matter_test_config.dut_node_ids
+        return ids[1] if len(ids) > 1 else ids[0]
+
+    @property
+    def dut_i_endpoint(self) -> int:
+        return self.user_params.get("dut_i_endpoint", 1)
+
+    @property
+    def dut_r_endpoint(self) -> int:
+        return self.user_params.get("dut_r_endpoint", self.dut_i_endpoint)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _read(self, node_id: int, endpoint: int, attribute):
+        return await self.read_single_attribute_check_success(
+            node_id=node_id,
+            cluster=Clusters.ProximityRanging,
+            attribute=attribute,
+            endpoint=endpoint,
+        )
+
+    async def _send_cmd(self, node_id: int, endpoint: int, cmd):
+        return await self.send_single_cmd(node_id=node_id, endpoint=endpoint, cmd=cmd)
+
+    def _dut_pairs(self, two_device: bool):
+        pairs = [(self.dut_i_node_id, self.dut_i_endpoint, "DUT_I")]
+        if two_device:
+            pairs.append((self.dut_r_node_id, self.dut_r_endpoint, "DUT_R"))
+        return pairs
+
+    def _session_id_incremented(self, old_id: int, new_id: int) -> bool:
+        """SessionID increments each session; wraps 255 → 1 (skips 0)."""
+        if new_id == 0:
+            return False
+        if old_id == 255:
+            return new_id == 1
+        return new_id > old_id
+
+    async def _verify_session_id_list(self, step_label: str, two_device: bool,
+                                      sid_i: int, sid_r):
+        """Read SessionIDList from DUT_I then DUT_R and verify active session IDs."""
+        proxr = Clusters.ProximityRanging
+
+        # DUT_I first
+        val_i = await self._read(self.dut_i_node_id, self.dut_i_endpoint,
+                                 proxr.Attributes.SessionIDList)
+        if val_i is NullValue or val_i is None:
+            asserts.fail(f"[DUT_I] {step_label}: SessionIDList is NullValue but session {sid_i} should be active")
+        asserts.assert_true(sid_i in val_i,
+                            f"[DUT_I] {step_label}: SessionIDList must contain active session {sid_i}")
+        log.info(f"[DUT_I] {step_label}: SessionIDList={val_i} contains {sid_i} – OK")
+
+        # DUT_R second
+        if two_device and sid_r is not None:
+            val_r = await self._read(self.dut_r_node_id, self.dut_r_endpoint,
+                                     proxr.Attributes.SessionIDList)
+            if val_r is NullValue or val_r is None:
+                asserts.fail(f"[DUT_R] {step_label}: SessionIDList is NullValue but session {sid_r} should be active")
+            asserts.assert_true(sid_r in val_r,
+                                f"[DUT_R] {step_label}: SessionIDList must contain active session {sid_r}")
+            log.info(f"[DUT_R] {step_label}: SessionIDList={val_r} contains {sid_r} – OK")
+
+    async def _stop_ranging(self, step_label: str, two_device: bool, sid_i: int, sid_r):
+        """Send StopRangingRequest to DUT_I then DUT_R."""
+        proxr = Clusters.ProximityRanging
+        await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint,
+                             proxr.Commands.StopRangingRequest(sessionID=sid_i))
+        log.info(f"[DUT_I] {step_label}: StopRangingRequest sent for session {sid_i}")
+        if two_device and sid_r is not None:
+            await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint,
+                                 proxr.Commands.StopRangingRequest(sessionID=sid_r))
+            log.info(f"[DUT_R] {step_label}: StopRangingRequest sent for session {sid_r}")
+
+    async def _run_periodic_tech(self, step_prefix: str, two_device: bool,
+                                 start_cmd_i_fn, start_cmd_r_fn,
+                                 pics_key: str, supports: bool,
+                                 periodic_supported: bool):
+        """
+        Generic periodic ranging workflow for one technology.
+        Runs steps Xa through Xg.
+
+        Skips the entire block (logging only) when any of these are false:
+          * `pics_key` (the per-technology PICS, e.g. PROXR.S.F00) — tech disabled
+          * `supports` — feature map says the tech isn't actually supported
+          * PROXR.S.F03 — PERIODIC feature not advertised by the DUT
+          * `periodic_supported` — this specific technology's RangingCapabilitiesStruct
+            does not have periodicRangingSupport=true
+
+        Returns (sid_i_final, sid_r_final) after cleanup, or (None, None) if skipped.
+        """
+        proxr = Clusters.ProximityRanging
+
+        f03_in_pics = self.check_pics("PROXR.S.F03")
+        if (not self.check_pics(pics_key) or not supports
+                or not f03_in_pics or not periodic_supported):
+            if not self.check_pics(pics_key) or not supports:
+                reason = f"{pics_key} not supported"
+            elif not f03_in_pics:
+                reason = "PROXR.S.F03 (PERIODIC) not in PICS"
+            else:
+                reason = "technology does not advertise periodicRangingSupport"
+            for sub in ["a", "b", "c", "d", "e", "f", "g"]:
+                self.step(f"{step_prefix}{sub}")
+                log.info(f"Step {step_prefix}{sub} skipped – {reason}")
+            return None, None
+
+        # ---- Xa: Start first periodic session ----------------------------
+        self.step(f"{step_prefix}a")
+        sub_i = await self.default_controller.ReadEvent(
+            nodeId=self.dut_i_node_id,
+            events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+            reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+        # DUT_I first
+        resp_i = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint, start_cmd_i_fn())
+        asserts.assert_equal(resp_i.resultCode, proxr.Enums.ResultCodeEnum.kAccepted,
+                             f"[DUT_I] Step {step_prefix}a: expected Accepted")
+        asserts.assert_not_equal(resp_i.sessionID, 0,
+                                 f"[DUT_I] Step {step_prefix}a: SessionID must be non-zero")
+        sid_i = resp_i.sessionID
+        log.info(f"[DUT_I] Step {step_prefix}a: Accepted, SessionID={sid_i}")
+
+        # DUT_R second
+        sid_r = None
+        if two_device:
+            resp_r = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint, start_cmd_r_fn())
+            asserts.assert_equal(resp_r.resultCode, proxr.Enums.ResultCodeEnum.kAccepted,
+                                 f"[DUT_R] Step {step_prefix}a: expected Accepted")
+            sid_r = resp_r.sessionID
+            log.info(f"[DUT_R] Step {step_prefix}a: Accepted, SessionID={sid_r}")
+
+        # Wait for periodic events
+        await asyncio.sleep(_PERIODIC_WAIT_S)
+
+        events_i = [e for e in sub_i.GetEvents()
+                    if isinstance(e.Data, proxr.Events.RangingResult)
+                    and e.Data.sessionID == sid_i]
+        asserts.assert_greater_equal(len(events_i), 2,
+                                     f"[DUT_I] Step {step_prefix}a: must receive ≥2 periodic RangingResult events")
+        log.info(f"[DUT_I] Step {step_prefix}a: received {len(events_i)} periodic events – OK")
+
+        # ---- Xb: Verify SessionIDList ------------------------------------
+        self.step(f"{step_prefix}b")
+        await self._verify_session_id_list(f"Step {step_prefix}b", two_device, sid_i, sid_r)
+
+        # ---- Xc: Stop ranging --------------------------------------------
+        self.step(f"{step_prefix}c")
+        await self._stop_ranging(f"Step {step_prefix}c", two_device, sid_i, sid_r)
+        await asyncio.sleep(_STOP_VERIFY_WAIT_S)
+
+        events_after_stop = [e for e in sub_i.GetEvents()
+                             if isinstance(e.Data, proxr.Events.RangingResult)
+                             and e.Data.sessionID == sid_i
+                             and e not in events_i]
+        # Note: we check no NEW events after stop by counting events after sleep
+        log.info(f"[DUT_I] Step {step_prefix}c: ranging stopped – OK")
+
+        # ---- Xd: Start new session – verify incremented SessionID --------
+        self.step(f"{step_prefix}d")
+        sub_i2 = await self.default_controller.ReadEvent(
+            nodeId=self.dut_i_node_id,
+            events=[(self.dut_i_endpoint, proxr.Events.RangingResult, 1)],
+            reportInterval=(0, 10), keepSubscriptions=True, autoResubscribe=False)
+
+        # DUT_I first
+        resp_i2 = await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint, start_cmd_i_fn())
+        asserts.assert_equal(resp_i2.resultCode, proxr.Enums.ResultCodeEnum.kAccepted,
+                             f"[DUT_I] Step {step_prefix}d: expected Accepted")
+        sid_i2 = resp_i2.sessionID
+        asserts.assert_true(self._session_id_incremented(sid_i, sid_i2),
+                            f"[DUT_I] Step {step_prefix}d: new SessionID {sid_i2} must be > {sid_i} (or wrap 255→1)")
+        log.info(f"[DUT_I] Step {step_prefix}d: new SessionID={sid_i2} (prev={sid_i}) – OK")
+
+        # DUT_R second
+        sid_r2 = None
+        if two_device:
+            resp_r2 = await self._send_cmd(self.dut_r_node_id, self.dut_r_endpoint, start_cmd_r_fn())
+            asserts.assert_equal(resp_r2.resultCode, proxr.Enums.ResultCodeEnum.kAccepted,
+                                 f"[DUT_R] Step {step_prefix}d: expected Accepted")
+            sid_r2 = resp_r2.sessionID
+            log.info(f"[DUT_R] Step {step_prefix}d: new SessionID={sid_r2}")
+
+        await asyncio.sleep(_PERIODIC_WAIT_S)
+
+        events_i2 = [e for e in sub_i2.GetEvents()
+                     if isinstance(e.Data, proxr.Events.RangingResult)
+                     and e.Data.sessionID == sid_i2]
+        asserts.assert_greater_equal(len(events_i2), 2,
+                                     f"[DUT_I] Step {step_prefix}d: must receive ≥2 periodic events for new session")
+        log.info(f"[DUT_I] Step {step_prefix}d: received {len(events_i2)} periodic events – OK")
+
+        # ---- Xe: Verify SessionIDList for new session --------------------
+        self.step(f"{step_prefix}e")
+        await self._verify_session_id_list(f"Step {step_prefix}e", two_device, sid_i2, sid_r2)
+
+        # ---- Xf: Stop with wrong SessionID – expect INVALID_IN_STATE -----
+        self.step(f"{step_prefix}f")
+        wrong_sid = (sid_i2 % 255) + 1  # guaranteed different from sid_i2
+        if wrong_sid == sid_i2:
+            wrong_sid = (wrong_sid % 255) + 1
+        try:
+            await self._send_cmd(self.dut_i_node_id, self.dut_i_endpoint,
+                                 proxr.Commands.StopRangingRequest(sessionID=wrong_sid))
+            asserts.fail(f"[DUT_I] Step {step_prefix}f: expected INVALID_IN_STATE for wrong SessionID {wrong_sid}")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.InvalidInState,
+                                 f"[DUT_I] Step {step_prefix}f: expected INVALID_IN_STATE, got {e.status}")
+            log.info(f"[DUT_I] Step {step_prefix}f: INVALID_IN_STATE received for wrong SessionID – OK")
+
+        # ---- Xg: Stop with correct SessionIDs ---------------------------
+        self.step(f"{step_prefix}g")
+        # Snapshot the existing sub_i2 stream before Stop. A fresh ReadEvent
+        # would re-prime with all past RangingResult events for sid_i2 and
+        # those would be misread as "new events after stop".
+        pre_stop_count = len([e for e in sub_i2.GetEvents()
+                              if isinstance(e.Data, proxr.Events.RangingResult)
+                              and e.Data.sessionID == sid_i2])
+
+        await self._stop_ranging(f"Step {step_prefix}g", two_device, sid_i2, sid_r2)
+        await asyncio.sleep(_STOP_VERIFY_WAIT_S)
+
+        post_stop_count = len([e for e in sub_i2.GetEvents()
+                               if isinstance(e.Data, proxr.Events.RangingResult)
+                               and e.Data.sessionID == sid_i2])
+        new_events = post_stop_count - pre_stop_count
+        asserts.assert_equal(new_events, 0,
+                             f"[DUT_I] Step {step_prefix}g: must NOT receive new RangingResult after stop")
+        log.info(f"[DUT_I] Step {step_prefix}g: no new events after stop – OK")
+
+        return sid_i2, sid_r2
+
+    # ------------------------------------------------------------------
+    # Main test body
+    # ------------------------------------------------------------------
+
+    @async_test_body
+    async def test_TC_PROXR_2_4(self):
+        proxr = Clusters.ProximityRanging
+        F = proxr.Bitmaps.Feature
+        R = proxr.Enums.RangingRoleEnum
+        T = proxr.Enums.RangingTechEnum
+        S = proxr.Enums.RangingSecurityEnum
+
+        # ---- Step 1: Commissioning ----------------------------------------
+        self.step("1")
+        two_device = (self.dut_i_node_id != self.dut_r_node_id)
+        log.info(f"DUT_I  node={self.dut_i_node_id}  ep={self.dut_i_endpoint}")
+        log.info(f"DUT_R  node={self.dut_r_node_id}  ep={self.dut_r_endpoint}")
+
+        fm_i = await self._read(self.dut_i_node_id, self.dut_i_endpoint, proxr.Attributes.FeatureMap)
+        fm_r = await self._read(self.dut_r_node_id, self.dut_r_endpoint, proxr.Attributes.FeatureMap) if two_device else fm_i
+
+        supports_wfusdpd = bool((fm_i & F.kWiFiUsdProximityDetection) and (fm_r & F.kWiFiUsdProximityDetection))
+        supports_bltcs = bool((fm_i & F.kBluetoothChannelSounding) and (fm_r & F.kBluetoothChannelSounding))
+        supports_blerbc = bool((fm_i & F.kBleBeaconRssi) and (fm_r & F.kBleBeaconRssi))
+
+        caps:        dict = {}
+        wifi_dev_ik: dict = {}
+        blt_dev_ik:  dict = {}
+        bltcs_sec:   dict = {}
+        bltcs_mode:  dict = {}
+        ble_dev_id:  dict = {}
+
+        # ---- Step 2: RangingCapabilities – verify PeriodicRangingSupport --
+        # The PERIODIC feature (PROXR.S.F03) is what gates this whole test, so
+        # the "at least one struct advertises periodicRangingSupport=true"
+        # assertion only applies when F03 is in the PICS set. Without F03 we
+        # still cache caps[label] so the per-technology gating below can
+        # reason about which structs (if any) support periodic ranging.
+        self.step("2")
+        f03_in_pics = self.check_pics("PROXR.S.F03")
+        for node_id, ep, label in self._dut_pairs(two_device):
+            val = await self._read(node_id, ep, proxr.Attributes.RangingCapabilities)
+            asserts.assert_true(isinstance(val, list), f"[{label}] RangingCapabilities must be a list")
+            caps[label] = val
+            if f03_in_pics:
+                has_periodic = any(c.periodicRangingSupport for c in val)
+                asserts.assert_true(has_periodic,
+                                    f"[{label}] PROXR.S.F03 advertised: at least one "
+                                    f"RangingCapabilitiesStruct must have PeriodicRangingSupport=true")
+                log.info(f"[{label}] RangingCapabilities OK, PeriodicRangingSupport=true")
+            else:
+                log.info(f"[{label}] RangingCapabilities read OK – PROXR.S.F03 not in PICS, periodic check skipped")
+
+        # ---- Step 3: WiFiDevIK --------------------------------------------
+        self.step("3")
+        if not self.check_pics("PROXR.S.F00"):
+            log.info("Step 3 skipped – PROXR.S.F00 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.WiFiDevIK)
+                asserts.assert_true(isinstance(val, bytes), f"[{label}] WiFiDevIK must be octstr")
+                wifi_dev_ik[label] = val
+                log.info(f"[{label}] WiFiDevIK saved ({len(val)} bytes)")
+
+        # ---- Step 4: BLTCS attributes -------------------------------------
+        self.step("4")
+        if not self.check_pics("PROXR.S.F01"):
+            log.info("Step 4 skipped – PROXR.S.F01 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                ik = await self._read(node_id, ep, proxr.Attributes.BLTDevIK)
+                asserts.assert_true(isinstance(ik, bytes), f"[{label}] BLTDevIK must be octstr")
+                blt_dev_ik[label] = ik
+                try:
+                    sec = await self._read(node_id, ep, proxr.Attributes.BLTCSSecurityLevel)
+                    bltcs_sec[label] = sec
+                except Exception:
+                    bltcs_sec[label] = proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne
+                mode = await self._read(node_id, ep, proxr.Attributes.BLTCSModeCapability)
+                bltcs_mode[label] = mode
+                log.info(f"[{label}] BLTDevIK saved, mode={mode}")
+
+        # ---- Step 5: BLEDeviceID ------------------------------------------
+        self.step("5")
+        if not self.check_pics("PROXR.S.F02"):
+            log.info("Step 5 skipped – PROXR.S.F02 not in PICS")
+        else:
+            for node_id, ep, label in self._dut_pairs(two_device):
+                val = await self._read(node_id, ep, proxr.Attributes.BLEDeviceID)
+                asserts.assert_true(isinstance(val, int), f"[{label}] BLEDeviceID must be uint64")
+                ble_dev_id[label] = val
+                log.info(f"[{label}] BLEDeviceID saved: {val}")
+
+        # ---- Steps 6a-6g: WiFi periodic ranging ---------------------------
+        pmk_wifi = os.urandom(32)
+        techs_i = {c.technology for c in caps.get("DUT_I", [])}
+        techs_r = {c.technology for c in caps.get("DUT_R", caps.get("DUT_I", []))}
+        wifi_techs = {T.kWiFiRoundTripTimeRanging, T.kWiFiNextGenerationRanging}
+        common_wifi = (techs_i & techs_r & wifi_techs) or (techs_i & wifi_techs)
+        wifi_tech = next(iter(common_wifi)) if common_wifi else T.kWiFiRoundTripTimeRanging
+
+        # Per-technology periodic-support lookup. A technology is considered
+        # to support periodic ranging when both DUTs (or just DUT_I in
+        # single-device mode) advertise periodicRangingSupport=true for at
+        # least one matching RangingCapabilitiesStruct.
+        def _periodic_support_for(tech) -> bool:
+            def _has(label):
+                return any(c.technology == tech and c.periodicRangingSupport
+                           for c in caps.get(label, []))
+            if two_device:
+                return _has("DUT_I") and _has("DUT_R")
+            return _has("DUT_I")
+
+        def make_wifi_cmd_i():
+            return proxr.Commands.StartRangingRequest(
+                technology=wifi_tech,
+                wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                    role=R.kWiFiSubscriberRole,
+                    peerWiFiDevIK=wifi_dev_ik.get("DUT_R", os.urandom(16)),
+                    pmk=pmk_wifi,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(
+                    startTime=0, endTime=_ENDTIME_WAIT_S,
+                    rangingInstanceInterval=_PERIODIC_INTERVAL_S),
+            )
+
+        def make_wifi_cmd_r():
+            return proxr.Commands.StartRangingRequest(
+                technology=wifi_tech,
+                wiFiRangingDeviceRoleConfig=proxr.Structs.WiFiRangingDeviceRoleConfigStruct(
+                    role=R.kWiFiPublisherRole,
+                    peerWiFiDevIK=wifi_dev_ik.get("DUT_I", os.urandom(16)),
+                    pmk=pmk_wifi,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=_ENDTIME_WAIT_S),
+            )
+
+        await self._run_periodic_tech(
+            "6", two_device, make_wifi_cmd_i, make_wifi_cmd_r,
+            "PROXR.S.F00", supports_wfusdpd,
+            periodic_supported=_periodic_support_for(wifi_tech))
+
+        # ---- Steps 7a-7g: BLTCS periodic ranging --------------------------
+        ltk_bltcs = os.urandom(16)
+        sec_level = bltcs_sec.get("DUT_I", proxr.Enums.BLTCSSecurityLevelEnum.kBLTCSSecurityLevelOne)
+        mode_val = bltcs_mode.get("DUT_I", proxr.Enums.BLTCSModeEnum.kPBROnly)
+
+        def make_bltcs_cmd_i():
+            return proxr.Commands.StartRangingRequest(
+                technology=T.kBluetoothChannelSounding,
+                BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                    role=R.kBLTInitiatorRole,
+                    peerBLTDevIK=blt_dev_ik.get("DUT_R", os.urandom(16)),
+                    BLTCSMode=mode_val,
+                    BLTCSSecurityLevel=sec_level,
+                    ltk=ltk_bltcs,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(
+                    startTime=0, endTime=_ENDTIME_WAIT_S,
+                    rangingInstanceInterval=_PERIODIC_INTERVAL_S),
+            )
+
+        def make_bltcs_cmd_r():
+            return proxr.Commands.StartRangingRequest(
+                technology=T.kBluetoothChannelSounding,
+                BLTChannelSoundingDeviceRoleConfig=proxr.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                    role=R.kBLTReflectorRole,
+                    peerBLTDevIK=blt_dev_ik.get("DUT_I", os.urandom(16)),
+                    BLTCSMode=mode_val,
+                    BLTCSSecurityLevel=sec_level,
+                    ltk=ltk_bltcs,
+                ),
+                securityMode=S.kSecureRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=_ENDTIME_WAIT_S),
+            )
+
+        await self._run_periodic_tech(
+            "7", two_device, make_bltcs_cmd_i, make_bltcs_cmd_r,
+            "PROXR.S.F01", supports_bltcs,
+            periodic_supported=_periodic_support_for(T.kBluetoothChannelSounding))
+
+        # ---- Steps 8a-8g: BLERBC periodic ranging -------------------------
+        def make_blerbc_cmd_i():
+            return proxr.Commands.StartRangingRequest(
+                technology=T.kBLEBeaconRSSIRanging,
+                BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                    role=R.kBLEScanningRole,
+                    peerBLEDeviceID=ble_dev_id.get("DUT_R", 0xDEADBEEFCAFEBABE),
+                ),
+                securityMode=S.kOpenRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(
+                    startTime=0, endTime=_ENDTIME_WAIT_S,
+                    rangingInstanceInterval=_PERIODIC_INTERVAL_S),
+            )
+
+        def make_blerbc_cmd_r():
+            return proxr.Commands.StartRangingRequest(
+                technology=T.kBLEBeaconRSSIRanging,
+                BLERangingDeviceRoleConfig=proxr.Structs.BLERangingDeviceRoleConfigStruct(
+                    role=R.kBLEBeaconRole,
+                    peerBLEDeviceID=ble_dev_id.get("DUT_I", 0xDEADBEEFCAFEBABE),
+                ),
+                securityMode=S.kOpenRanging,
+                trigger=proxr.Structs.RangingTriggerConditionStruct(startTime=0, endTime=_ENDTIME_WAIT_S),
+            )
+
+        await self._run_periodic_tech(
+            "8", two_device, make_blerbc_cmd_i, make_blerbc_cmd_r,
+            "PROXR.S.F02", supports_blerbc,
+            periodic_supported=_periodic_support_for(T.kBLEBeaconRSSIRanging))
+
+        log.info("TC-PROXR-2.4 PASSED")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
### Summary

Add test scripts for testing the proximity ranging cluster test cases TC_PROXR_2_1, TC_PROXR_2_2, TC_PROXR_2_3, and TC_PROXR_2_4.

### Related issues

Relates to the implementation for LoggingRangingAdapters of the all-devices-app for #72257 

### Testing

Executed test scripts being run using the python test:
```
if python3 scripts/tests/run_python_test.py \
        --factory-reset-app-only \
        --app "$ADA_BIN" \
        --app-args "--discriminator 1234 --KVS /tmp/kvs_dut_i --port 5541" \
        --script "src/python_testing/$name.py" \
        --script-args "--commissioning-method on-network --discriminator 1234 3840 --passcode 20202021 20202021 --dut-node-id 305414945 305414946 --endpoint 1 --PICS proximity_ranging_pics" \
        > "$logfile" 2>&1
 ```
