### PR TITLE
[bouffalolab] stop dependabot ci updates for bouffalo iot sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       - dependency-name: "third_party/android_deps/repo"
       - dependency-name: "third_party/asr/repo"
       - dependency-name: "third_party/boringssl/repo"
-      - dependency-name: "third_party/bouffalolab/repo"
       - dependency-name: "third_party/cirque/repo"
       - dependency-name: "third_party/editline/repo"
       - dependency-name: "third_party/freertos/repo"


### PR DESCRIPTION
### Summary
remove bouffalo iot sdk auto update from dependabot list

### Related issues
(#72437)

### Testing

N/A