### PR TITLE
Fix Ruff G004 rule violation after merging #72206

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -350,7 +350,7 @@ class MatterBaseTest(base_test.BaseTestClass):
                     [(0, Clusters.BasicInformation.Attributes.VendorID)]
                 )
             except Exception as e:  # DUT may be unreachable or mid-reboot; skip all DUT cleanup rather than failing the test
-                LOGGER.warning(f"[CLN] DUT is unreachable, skipping all DUT cleanup: {e}")
+                LOGGER.warning("[CLN] DUT is unreachable, skipping all DUT cleanup: %s", e)
                 dut_reachable = False
 
         if dut_reachable:
@@ -412,11 +412,11 @@ class MatterBaseTest(base_test.BaseTestClass):
         """
         for ctrl in self._extra_controllers:
             try:
-                LOGGER.info(f"[CLN] shutting down controller nodeId={ctrl.nodeId:#x}")
+                LOGGER.info("[CLN] shutting down controller nodeId=%#x", ctrl.nodeId)
                 ctrl.Shutdown()
-                LOGGER.info(f"[CLN] controller nodeId={ctrl.nodeId:#x} shut down successfully")
+                LOGGER.info("[CLN] controller nodeId=%#x shut down successfully", ctrl.nodeId)
             except Exception as e:  # Shutdown can fail if the controller is already stopped or the stack is in a bad state
-                LOGGER.warning(f"[CLN] controller shutdown failed: {e}")
+                LOGGER.warning("[CLN] controller shutdown failed: %s", e)
         self._extra_controllers.clear()
 
         # Shut down each CA and remove it from the manager's active list and from
@@ -424,7 +424,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         mgr = self.certificate_authority_manager
         for ca in self._extra_cas:
             try:
-                LOGGER.info(f"[CLN] shutting down CA index {ca.caIndex}")
+                LOGGER.info("[CLN] shutting down CA index %d", ca.caIndex)
                 ca.Shutdown()
                 if ca in mgr._activeCaList:
                     mgr._activeCaList.remove(ca)
@@ -432,9 +432,9 @@ class MatterBaseTest(base_test.BaseTestClass):
                 if str(ca.caIndex) in ca_list:
                     del ca_list[str(ca.caIndex)]
                     mgr._persistentStorage.SetKey('caList', ca_list)
-                LOGGER.info(f"[CLN] CA index {ca.caIndex} removed successfully")
+                LOGGER.info("[CLN] CA index %d removed successfully", ca.caIndex)
             except Exception as e:  # Storage may be inconsistent if the controller was shut down in a bad state
-                LOGGER.warning(f"[CLN] CA removal failed: {e}")
+                LOGGER.warning("[CLN] CA removal failed: %s", e)
         self._extra_cas.clear()
 
     async def _disarm_failsafes(self) -> None:
@@ -449,11 +449,11 @@ class MatterBaseTest(base_test.BaseTestClass):
                 )
             )
             if resp.errorCode != Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk:
-                LOGGER.warning(f"[CLN] disarm failsafe returned errorCode {resp.errorCode}")
+                LOGGER.warning("[CLN] disarm failsafe returned errorCode %s", resp.errorCode)
             else:
                 LOGGER.info("[CLN] failsafe disarmed successfully")
         except Exception as e:  # DUT may be unreachable or session may have expired; log and continue cleanup
-            LOGGER.warning(f"[CLN] disarm failsafe failed: {e}")
+            LOGGER.warning("[CLN] disarm failsafe failed: %s", e)
 
     async def _reset_acls_to_default(self) -> None:
         """Restores the ACL on endpoint 0 to the state captured before the test ran.
@@ -470,11 +470,11 @@ class MatterBaseTest(base_test.BaseTestClass):
                 [(0, Clusters.AccessControl.Attributes.Acl(self._original_acl))]
             )
             if result[0].Status != Status.Success:
-                LOGGER.warning(f"[CLN] ACL reset returned status {result[0].Status}")
+                LOGGER.warning("[CLN] ACL reset returned status %s", result[0].Status)
             else:
                 LOGGER.info("[CLN] ACL restored successfully")
         except Exception as e:  # Session may have expired or DUT ACL may be in a state that rejects the write
-            LOGGER.warning(f"[CLN] ACL reset failed: {e}")
+            LOGGER.warning("[CLN] ACL reset failed: %s", e)
 
     async def _remove_extra_fabrics(self) -> None:
         """Removes any fabric on the DUT that is not the default controller's fabric."""
@@ -498,7 +498,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             )
         except Exception as e:  # DUT may be unreachable or session may have expired after a multi-fabric test
             LOGGER.warning(
-                f"[CLN] could not read fabric list (DUT unreachable, session expired, or attribute read error), skipping fabric removal: {e}")
+                "[CLN] could not read fabric list (DUT unreachable, session expired, or attribute read error), skipping fabric removal: %s", e)
             return
 
         extra_fabric_indices = [f.fabricIndex for f in fabrics if f.fabricIndex != th1_fabric_index]
@@ -507,17 +507,17 @@ class MatterBaseTest(base_test.BaseTestClass):
             LOGGER.info("[CLN] no extra fabrics to remove")
             return
 
-        LOGGER.info(f"[CLN] removing {len(extra_fabric_indices)} extra fabric(s) from DUT")
+        LOGGER.info("[CLN] removing %d extra fabric(s) from DUT", len(extra_fabric_indices))
         for fabric_index in extra_fabric_indices:
-            LOGGER.info(f"[CLN] sending RemoveFabric(fabricIndex={fabric_index})")
+            LOGGER.info("[CLN] sending RemoveFabric(fabricIndex=%d)", fabric_index)
             try:
                 await self.send_single_cmd(
                     cmd=Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric_index),
                     endpoint=0
                 )
-                LOGGER.info(f"[CLN] fabric index {fabric_index} removed successfully")
+                LOGGER.info("[CLN] fabric index %d removed successfully", fabric_index)
             except Exception as e:  # RemoveFabric may fail if the fabric was already removed by the test or a prior cleanup
-                LOGGER.warning(f"[CLN] RemoveFabric({fabric_index}) failed: {e}")
+                LOGGER.warning("[CLN] RemoveFabric(%d) failed: %s", fabric_index, e)
 
     async def _purge_groups(self) -> None:
         """Removes all non-IPK group key sets and clears the group key map on the DUT.
@@ -537,13 +537,13 @@ class MatterBaseTest(base_test.BaseTestClass):
             # Remove all non-IPK key sets, key set 0 (IPK) cannot be removed
             for key_set_id in resp.groupKeySetIDs:
                 if key_set_id != 0:
-                    LOGGER.info(f"[CLN] removing group key set {key_set_id}")
+                    LOGGER.info("[CLN] removing group key set %d", key_set_id)
                     await self.send_single_cmd(
                         cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(groupKeySetID=key_set_id),
                         endpoint=0
                     )
         except Exception as e:  # DUT may be unreachable, or key sets may already be absent; skip rather than aborting cleanup
-            LOGGER.warning(f"[CLN] key set removal failed: {e}")
+            LOGGER.warning("[CLN] key set removal failed: %s", e)
 
         # Clear all group key mappings
         try:
@@ -552,11 +552,11 @@ class MatterBaseTest(base_test.BaseTestClass):
                 [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap([]))]
             )
             if result[0].Status != Status.Success:
-                LOGGER.warning(f"[CLN] GroupKeyMap clear returned status {result[0].Status}")
+                LOGGER.warning("[CLN] GroupKeyMap clear returned status %s", result[0].Status)
             else:
                 LOGGER.info("[CLN] group key map cleared successfully")
         except Exception as e:  # Write may fail if session expired or the DUT rejected the empty map
-            LOGGER.warning(f"[CLN] GroupKeyMap clear failed: {e}")
+            LOGGER.warning("[CLN] GroupKeyMap clear failed: %s", e)
 
     async def _purge_scenes(self) -> None:
         """Removes all scenes from all groups on every endpoint that has ScenesManagement.
@@ -586,15 +586,15 @@ class MatterBaseTest(base_test.BaseTestClass):
                 group_ids = resp.groupList
                 if not group_ids:
                     continue
-                LOGGER.info(f"[CLN] removing scenes for groups {group_ids} on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] removing scenes for groups %s on endpoint %d", group_ids, endpoint_id)
                 for gid in group_ids:
                     await self.send_single_cmd(
                         cmd=Clusters.ScenesManagement.Commands.RemoveAllScenes(groupID=gid),
                         endpoint=endpoint_id
                     )
-                LOGGER.info(f"[CLN] scenes cleared on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] scenes cleared on endpoint %d", endpoint_id)
             except Exception as e:  # DUT may be unreachable or the group may have been removed by the test
-                LOGGER.warning(f"[CLN] scene removal failed on endpoint {endpoint_id}: {e}")
+                LOGGER.warning("[CLN] scene removal failed on endpoint %d: %s", endpoint_id, e)
 
     async def _purge_group_memberships(self) -> None:
         """Removes all group memberships from the DUT's group table.
@@ -611,15 +611,15 @@ class MatterBaseTest(base_test.BaseTestClass):
                                 cluster=Clusters.Groups):  # type: ignore[arg-type]
                 continue
             found_any = True
-            LOGGER.info(f"[CLN] sending RemoveAllGroups on endpoint {endpoint_id}")
+            LOGGER.info("[CLN] sending RemoveAllGroups on endpoint %d", endpoint_id)
             try:
                 await self.send_single_cmd(
                     cmd=Clusters.Groups.Commands.RemoveAllGroups(),
                     endpoint=endpoint_id
                 )
-                LOGGER.info(f"[CLN] group memberships cleared on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] group memberships cleared on endpoint %d", endpoint_id)
             except Exception as e:  # DUT may be unreachable or session may have expired after a multi-fabric test
-                LOGGER.warning(f"[CLN] RemoveAllGroups failed on endpoint {endpoint_id}: {e}")
+                LOGGER.warning("[CLN] RemoveAllGroups failed on endpoint %d: %s", endpoint_id, e)
         if not found_any:
             LOGGER.info("[CLN] Groups cluster not present on any endpoint, skipping group membership cleanup")
 
@@ -635,7 +635,7 @@ class MatterBaseTest(base_test.BaseTestClass):
                                 cluster=Clusters.DoorLock):  # type: ignore[arg-type]
                 continue
             found_any = True
-            LOGGER.info(f"[CLN] clearing DoorLock users and credentials on endpoint {endpoint_id}")
+            LOGGER.info("[CLN] clearing DoorLock users and credentials on endpoint %d", endpoint_id)
             try:
                 await self.send_single_cmd(
                     cmd=Clusters.DoorLock.Commands.ClearCredential(credential=NullValue),
@@ -647,9 +647,9 @@ class MatterBaseTest(base_test.BaseTestClass):
                     endpoint=endpoint_id,
                     timedRequestTimeoutMs=1000
                 )
-                LOGGER.info(f"[CLN] DoorLock users and credentials cleared on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] DoorLock users and credentials cleared on endpoint %d", endpoint_id)
             except Exception as e:  # DUT may be unreachable or DoorLock may be in a state that rejects the clear
-                LOGGER.warning(f"[CLN] DoorLock cleanup failed on endpoint {endpoint_id}: {e}")
+                LOGGER.warning("[CLN] DoorLock cleanup failed on endpoint %d: %s", endpoint_id, e)
         if not found_any:
             LOGGER.info("[CLN] DoorLock cluster not present on any endpoint, skipping DoorLock cleanup")
 
@@ -676,18 +676,18 @@ class MatterBaseTest(base_test.BaseTestClass):
                     )
                 )
                 if not provisioned:
-                    LOGGER.info(f"[CLN] no TLS endpoints provisioned on endpoint {endpoint_id}")
+                    LOGGER.info("[CLN] no TLS endpoints provisioned on endpoint %d", endpoint_id)
                     continue
-                LOGGER.info(f"[CLN] removing {len(provisioned)} TLS endpoint(s) on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] removing %d TLS endpoint(s) on endpoint %d", len(provisioned), endpoint_id)
                 for tls_ep in provisioned:
                     await self.send_single_cmd(
                         cmd=Clusters.TlsClientManagement.Commands.RemoveEndpoint(endpointID=tls_ep.endpointID),
                         endpoint=endpoint_id,
                         payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD
                     )
-                LOGGER.info(f"[CLN] TLS endpoints removed on endpoint {endpoint_id}")
+                LOGGER.info("[CLN] TLS endpoints removed on endpoint %d", endpoint_id)
             except Exception as e:  # DUT may be unreachable or TLS endpoint may have already been removed
-                LOGGER.warning(f"[CLN] TLS endpoint cleanup failed on endpoint {endpoint_id}: {e}")
+                LOGGER.warning("[CLN] TLS endpoint cleanup failed on endpoint %d: %s", endpoint_id, e)
         if not found_any:
             LOGGER.info("[CLN] TlsClientManagement cluster not present on any endpoint, skipping TLS endpoint cleanup")
 
@@ -705,7 +705,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             )
             LOGGER.info("[CLN] commissioning window revoked successfully")
         except Exception as e:  # Expected when no commissioning window is open; the DUT returns an error in that case
-            LOGGER.info(f"[CLN] RevokeCommissioning skipped (likely no window open): {e}")
+            LOGGER.info("[CLN] RevokeCommissioning skipped (likely no window open): %s", e)
 
     async def _unregister_icd_clients(self) -> None:
         """Unregisters all ICD clients registered on the DUT via the default controller"""
@@ -726,7 +726,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             LOGGER.info("[CLN] no ICD clients registered, skipping")
             return
 
-        LOGGER.info(f"[CLN] unregistering {len(registered_clients)} ICD client(s)")
+        LOGGER.info("[CLN] unregistering %d ICD client(s)", len(registered_clients))
         for entry in registered_clients:
             try:
                 await self.send_single_cmd(
@@ -735,9 +735,9 @@ class MatterBaseTest(base_test.BaseTestClass):
                     ),
                     endpoint=0
                 )
-                LOGGER.info(f"[CLN] unregistered ICD client {entry.checkInNodeID:#x}")
+                LOGGER.info("[CLN] unregistered ICD client %#x", entry.checkInNodeID)
             except Exception as e:  # DUT may be unreachable or the client may have already been unregistered
-                LOGGER.warning(f"[CLN] UnregisterClient({entry.checkInNodeID:#x}) failed: {e}")
+                LOGGER.warning("[CLN] UnregisterClient(%#x) failed: %s", entry.checkInNodeID, e)
 
     def _format_summary_value(self, key: str, value: Any) -> str:
         """Format values for end-of-test summary logs."""

--- a/src/python_testing/test_testing/TestCleanupFramework.py
+++ b/src/python_testing/test_testing/TestCleanupFramework.py
@@ -160,8 +160,7 @@ class TestCleanupFramework(MatterBaseTest):
         logger.info("--- Scenario: open commissioning window ---")
         logger.info("Opening an Enhanced Commissioning Window and leaving it open")
         ecw = await self.open_commissioning_window(dev_ctrl=self.default_controller, node_id=self.dut_node_id)
-        logger.info(f"Window open: discriminator={ecw.randomDiscriminator}, "
-                    f"pin={ecw.commissioningParameters.setupPinCode}")
+        logger.info("Window open: discriminator=%s, pin=%s", ecw.randomDiscriminator, ecw.commissioningParameters.setupPinCode)
         logger.info("Expected: cleanup framework closes this window via _close_commissioning_windows")
 
     @async_test_body
@@ -176,7 +175,7 @@ class TestCleanupFramework(MatterBaseTest):
         ecw = await self.open_commissioning_window(dev_ctrl=self.default_controller, node_id=self.dut_node_id)
         th2_node_id = self.dut_node_id + 1
 
-        logger.info(f"TH2 commissioning DUT (th2_node_id={th2_node_id:#x})")
+        logger.info("TH2 commissioning DUT (th2_node_id=%#x)", th2_node_id)
         await th2.CommissionOnNetwork(
             nodeId=th2_node_id,
             setupPinCode=ecw.commissioningParameters.setupPinCode,
@@ -192,12 +191,12 @@ class TestCleanupFramework(MatterBaseTest):
     async def test_failsafe_cleanup(self):
         logger.info("--- Scenario: armed failsafe ---")
         expiry = 30
-        logger.info(f"Arming failsafe with expiryLengthSeconds={expiry}")
+        logger.info("Arming failsafe with expiryLengthSeconds=%d", expiry)
         resp = await self.send_single_cmd(
             cmd=Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=expiry),
             endpoint=0
         )
-        logger.info(f"ArmFailSafe response: errorCode={resp.errorCode}")
+        logger.info("ArmFailSafe response: errorCode=%s", resp.errorCode)
         logger.info("Expected: cleanup framework disarms this failsafe via _disarm_failsafes")
 
     @async_test_body
@@ -206,7 +205,7 @@ class TestCleanupFramework(MatterBaseTest):
         key_set_id = 1
         epoch_key = b'\x00' * 16
 
-        logger.info(f"Writing group key set groupKeySetID={key_set_id}")
+        logger.info("Writing group key set groupKeySetID=%d", key_set_id)
         await self.send_single_cmd(
             cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
                 groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
@@ -230,7 +229,7 @@ class TestCleanupFramework(MatterBaseTest):
                 Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=1, groupKeySetID=key_set_id)
             ]))]
         )
-        logger.info(f"Group key set {key_set_id} and mapping added")
+        logger.info("Group key set %d and mapping added", key_set_id)
         logger.info("Expected: cleanup framework removes key sets and mappings via _purge_groups")
 
     @async_test_body
@@ -242,12 +241,12 @@ class TestCleanupFramework(MatterBaseTest):
             return
 
         group_id = 0x0001
-        logger.info(f"Adding group {group_id:#x} on endpoint {ep}")
+        logger.info("Adding group %#x on endpoint %d", group_id, ep)
         await self.send_single_cmd(
             cmd=Clusters.Groups.Commands.AddGroup(groupID=group_id, groupName="cleanup-test"),
             endpoint=ep
         )
-        logger.info(f"Group {group_id:#x} added on endpoint {ep}")
+        logger.info("Group %#x added on endpoint %d", group_id, ep)
         logger.info("Expected: cleanup framework removes all group memberships via _purge_group_memberships")
 
     @async_test_body
@@ -258,24 +257,24 @@ class TestCleanupFramework(MatterBaseTest):
             logger.info("ScenesManagement cluster not present on DUT — skipping")
             return
         if not _has_cluster(self.stored_global_wildcard, ep, Clusters.Groups):
-            logger.info(f"Groups cluster not present on endpoint {ep} — skipping scenes scenario")
+            logger.info("Groups cluster not present on endpoint %d — skipping scenes scenario", ep)
             return
 
         group_id = 0x0002
         scene_id = 0x01
 
-        logger.info(f"Adding group {group_id:#x} on endpoint {ep}")
+        logger.info("Adding group %#x on endpoint %d", group_id, ep)
         await self.send_single_cmd(
             cmd=Clusters.Groups.Commands.AddGroup(groupID=group_id, groupName="scenes-test"),
             endpoint=ep
         )
 
-        logger.info(f"Storing scene {scene_id:#x} for group {group_id:#x} on endpoint {ep}")
+        logger.info("Storing scene %#x for group %#x on endpoint %d", scene_id, group_id, ep)
         await self.send_single_cmd(
             cmd=Clusters.ScenesManagement.Commands.StoreScene(groupID=group_id, sceneID=scene_id),
             endpoint=ep
         )
-        logger.info(f"Scene {scene_id:#x} stored for group {group_id:#x}")
+        logger.info("Scene %#x stored for group %#x", scene_id, group_id)
         logger.info("Expected: cleanup framework removes scenes via _purge_scenes, "
                     "then group membership via _purge_group_memberships")
 
@@ -287,7 +286,7 @@ class TestCleanupFramework(MatterBaseTest):
             logger.info("DoorLock cluster not present on DUT — skipping")
             return
 
-        logger.info(f"Setting PIN credential on DoorLock endpoint {ep}")
+        logger.info("Setting PIN credential on DoorLock endpoint %d", ep)
         await self.send_single_cmd(
             cmd=Clusters.DoorLock.Commands.SetCredential(
                 operationType=Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
@@ -316,7 +315,7 @@ class TestCleanupFramework(MatterBaseTest):
             return
 
         check_in_node_id = self.default_controller.nodeId
-        logger.info(f"Registering ICD client checkInNodeID={check_in_node_id:#x}")
+        logger.info("Registering ICD client checkInNodeID=%#x", check_in_node_id)
         await self.send_single_cmd(
             cmd=Clusters.IcdManagement.Commands.RegisterClient(
                 checkInNodeID=check_in_node_id,
@@ -326,7 +325,7 @@ class TestCleanupFramework(MatterBaseTest):
             ),
             endpoint=0
         )
-        logger.info(f"ICD client {check_in_node_id:#x} registered")
+        logger.info("ICD client %#x registered", check_in_node_id)
         logger.info("Expected: cleanup framework unregisters this client via _unregister_icd_clients")
 
     @async_test_body
@@ -337,7 +336,7 @@ class TestCleanupFramework(MatterBaseTest):
             logger.info("TlsClientManagement cluster not present on DUT — skipping")
             return
         if not _has_cluster(self.stored_global_wildcard, ep, Clusters.TlsCertificateManagement):
-            logger.info(f"TlsCertificateManagement cluster not present on endpoint {ep} — skipping")
+            logger.info("TlsCertificateManagement cluster not present on endpoint %d — skipping", ep)
             return
 
         # Generate a minimal self-signed root certificate for provisioning
@@ -356,7 +355,7 @@ class TestCleanupFramework(MatterBaseTest):
             .public_bytes(serialization.Encoding.DER)
         )
 
-        logger.info(f"Provisioning root certificate on endpoint {ep}")
+        logger.info("Provisioning root certificate on endpoint %d", ep)
         resp = await self.send_single_cmd(
             cmd=Clusters.TlsCertificateManagement.Commands.ProvisionRootCertificate(
                 certificate=cert_bytes,
@@ -366,9 +365,9 @@ class TestCleanupFramework(MatterBaseTest):
             payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
         )
         caid = resp.caid
-        logger.info(f"Root certificate provisioned with CAID={caid:#x}")
+        logger.info("Root certificate provisioned with CAID=%#x", caid)
 
-        logger.info(f"Provisioning TLS endpoint with CAID={caid:#x} on endpoint {ep}")
+        logger.info("Provisioning TLS endpoint with CAID=%#x on endpoint %d", caid, ep)
         await self.send_single_cmd(
             cmd=Clusters.TlsClientManagement.Commands.ProvisionEndpoint(
                 hostname=b"cleanup-test.example.com",


### PR DESCRIPTION
### Summary

After merging #72206 there is a ruff linter failure on master because #72206 was not up to date.

### Testing

Tested manually with `ruff check`. CI will verify as well.