### PR TITLE
make dependabot scan nested actions + Fix CodeQL action pin drift

### DIFF
--- a/.github/actions/perform-codeql-analysis/action.yaml
+++ b/.github/actions/perform-codeql-analysis/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{ inputs.language }}"
         upload: False
@@ -27,7 +27,7 @@ runs:
         output: "sarif-results/${{ inputs.language }}.sarif"
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: "sarif-results/${{ inputs.language }}.sarif"
     - name: Upload loc as a Build Artifact

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/*"
+      - "/.github/actions/**"
     schedule:
       interval: "weekly"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
                 platform: linux
             - name: Initialize CodeQL
               if: ${{ inputs.run-codeql  }}
-              uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+              uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
               with:
                   languages: "cpp"
                   queries: security-extended, security-and-quality
@@ -196,7 +196,7 @@ jobs:
             # deactivate until a better workaround is found
             # - name: Initialize CodeQL
             #   if: ${{ inputs.run-codeql  }}
-            #   uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+            #   uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
             #   with:
             #       languages: "cpp"
             - name: Setup and Build Simulated Device
@@ -471,7 +471,7 @@ jobs:
             #  Build on Darwin + CodeQL often takes 6 hours (which is more than the maximum allowed by GitHub Runners), Deactivate it until we can investigate this
             # - name: Initialize CodeQL
             #   if: ${{ inputs.run-codeql  }}
-            #   uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+            #   uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
             #   with:
             #       languages: "cpp"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,36 +45,19 @@ jobs:
             - name: Mark workspace as safe for Git
               run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-            - name: Check CodeQL action version consistency
+            - name: Check CodeQL action pins are consistent
               if: always()
+              # All github/codeql-action pins (init, analyze, upload-sarif) must
+              # share one SHA; a mismatch breaks CodeQL with a CLI/config version skew.
               run: |
-                  python3 - <<'PY'
-                  import pathlib
-                  import re
-                  import sys
-
-                  codeql_action = re.compile(r"^\s*uses:\s+github/codeql-action/[^@\s]+@([^\s#]+)")
-                  refs = {}
-                  for base in (pathlib.Path(".github/workflows"), pathlib.Path(".github/actions")):
-                      for path in base.rglob("*"):
-                          if path.suffix not in (".yml", ".yaml"):
-                              continue
-                          for line_number, line in enumerate(path.read_text().splitlines(), 1):
-                              match = codeql_action.match(line)
-                              if match:
-                                  refs.setdefault(match.group(1), []).append(f"{path}:{line_number}")
-
-                  if len(refs) > 1:
-                      print("github/codeql-action refs must match across all workflows and local actions.")
-                      for ref, locations in sorted(refs.items()):
-                          print(f"{ref}:")
-                          for location in locations:
-                              print(f"  {location}")
-                      sys.exit(1)
-
-                  if refs:
-                      print(f"All github/codeql-action uses are pinned to {next(iter(refs))}.")
-                  PY
+                  shas=$(grep -rhoE '^[[:space:]]*uses:[[:space:]]+github/codeql-action/[^@[:space:]]+@[0-9a-f]{40}' \
+                      .github/workflows .github/actions | grep -oE '[0-9a-f]{40}' | sort -u)
+                  if [ "$(printf '%s\n' "$shas" | grep -c .)" -gt 1 ]; then
+                      echo "::error::github/codeql-action pins diverge across workflows/actions:"
+                      printf '%s\n' "$shas"
+                      exit 1
+                  fi
+                  echo "codeql-action pinned consistently: ${shas:-<none>}"
 
             - name: Check for orphaned gn files
               if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,37 @@ jobs:
             - name: Mark workspace as safe for Git
               run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+            - name: Check CodeQL action version consistency
+              if: always()
+              run: |
+                  python3 - <<'PY'
+                  import pathlib
+                  import re
+                  import sys
+
+                  codeql_action = re.compile(r"^\s*uses:\s+github/codeql-action/[^@\s]+@([^\s#]+)")
+                  refs = {}
+                  for base in (pathlib.Path(".github/workflows"), pathlib.Path(".github/actions")):
+                      for path in base.rglob("*"):
+                          if path.suffix not in (".yml", ".yaml"):
+                              continue
+                          for line_number, line in enumerate(path.read_text().splitlines(), 1):
+                              match = codeql_action.match(line)
+                              if match:
+                                  refs.setdefault(match.group(1), []).append(f"{path}:{line_number}")
+
+                  if len(refs) > 1:
+                      print("github/codeql-action refs must match across all workflows and local actions.")
+                      for ref, locations in sorted(refs.items()):
+                          print(f"{ref}:")
+                          for location in locations:
+                              print(f"  {location}")
+                      sys.exit(1)
+
+                  if refs:
+                      print(f"All github/codeql-action uses are pinned to {next(iter(refs))}.")
+                  PY
+
             - name: Check for orphaned gn files
               if: always()
               # We should enforce that ALL new files are referenced in our build scripts.


### PR DESCRIPTION
#### Summary

##### Problem

-   CodeQL `init` was updated by Dependabot, but the nested local composite action still used an older `github/codeql-action` SHA.
-   This caused CodeQL analysis to fail because the action state was written by one CodeQL action version and read by another.
-   Dependabot was only scanning the root GitHub Actions location, so nested local action metadata could drift.

##### Solution

-   Aligned all `github/codeql-action` uses to the same pinned SHA.
-   Expanded Dependabot's GitHub Actions scan to include nested local actions.
-   Added a lint check that rejects future CodeQL action version drift across workflows and local actions.

#### Testing

-   Ran the new CodeQL action consistency check locally.
-   Ran `git diff --check`.
-   Parsed the changed YAML files with PyYAML.