### PR TITLE
[NXP] Adding trigger CI for nxp build when changes are done in simw-top-mini folder

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -62,6 +62,7 @@ jobs:
                   filters: |
                       nxp:
                         - '**/nxp/**'
+                        - 'third_party/simw-top-mini/**'
 
             - name: Set up environment for size reports
               uses: ./.github/actions/setup-size-reports
@@ -164,6 +165,7 @@ jobs:
                         - '**/nxp/**'
                         - '**/Zephyr/**'
                         - '**/zephyr/**'
+                        - 'third_party/simw-top-mini/**'
                       pigweed:
                         - 'src/pw_backends/**'
                         - 'third_party/pigweed/**'


### PR DESCRIPTION
### Summary

Add third_party/simw-top-mini/** to the path filters of the NXP CI workflow to ensure that all NXP build jobs are triggered when any file under third_party/simw-top-mini/ is modified.

### Testing

No test required.
