### PR TITLE
[Silabs] Pull latest matter_support commit. Update provisionlib name change

### DIFF
--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -35,9 +35,9 @@ source_set("storage") {
 
   if (wifi_soc) {
     if (sl_si91x_crypto_flavor == "psa") {
-      libs = [ "${sl_provision_root}/libs/libProvisionPSA_si917.a" ]
+      libs = [ "${sl_provision_root}/libs/libProvisionPSA-si917.a" ]
     } else {
-      libs = [ "${sl_provision_root}/libs/libProvision_si917.a" ]
+      libs = [ "${sl_provision_root}/libs/libProvision-si917.a" ]
     }
   } else {
     if (use_provision_flash_storage) {
@@ -45,7 +45,7 @@ source_set("storage") {
         libs = [ "${sl_provision_root}/libs/libProvisionFlash-${silabs_family}-clang.a" ]
       } else {
         libs =
-            [ "${sl_provision_root}/libs/libProvisionFlash_${silabs_family}.a" ]
+            [ "${sl_provision_root}/libs/libProvisionFlash-${silabs_family}.a" ]
       }
     } else {
       if (is_clang) {
@@ -53,7 +53,7 @@ source_set("storage") {
           "${sl_provision_root}/libs/libProvision-${silabs_family}-clang.a",
         ]
       } else {
-        libs = [ "${sl_provision_root}/libs/libProvision_${silabs_family}.a" ]
+        libs = [ "${sl_provision_root}/libs/libProvision-${silabs_family}.a" ]
       }
     }
   }

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -111,7 +111,7 @@ source_set("efr32_test_main") {
   deps += pw_build_LINK_DEPS
 
   libs = [
-    "${matter_support_root}/provision/libs/libProvision_${silabs_family}.a",
+    "${matter_support_root}/provision/libs/libProvision-${silabs_family}.a",
   ]
 
   include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]


### PR DESCRIPTION
#### Summary
Update the `matter_support` submodule to the latest commit on `main`:
https://github.com/SiliconLabsSoftware/matter_support/commit/ed3d8e92c580156a9e1f12f9124c22a77c53a6f8

##### Problem
-   The previous `matter_support` submodule SHA pointed to a commit on a PR
    branch rather than the resulting merge commit on `main`.
    
##### Solution
-   Bump the `matter_support` submodule to the merged commit on `main`
    (`ed3d8e9`).
- This also bring our latest provisionLibs which their name was slightly modified.
    
### Related issues
N/A

### Testing
Build EFR32 lighting-app and commission it.
