### PR TITLE
Address Leak of Scan Responses in '_OnWpaInterfaceScanDone' on ScheduleLambda Failure

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -1561,7 +1561,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * 
         return;
     }
 
-    std::vector<WiFiScanResponse> * networkScanned = new std::vector<WiFiScanResponse>();
+    auto networkScanned = std::make_unique<std::vector<WiFiScanResponse>>();
     for (const char * bssPath = (bsss != nullptr ? *bsss : nullptr); bssPath != nullptr; bssPath = *(++bsss))
     {
         WiFiScanResponse network;
@@ -1576,14 +1576,24 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * 
         }
     }
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, networkScanned]() {
+    CHIP_ERROR err = DeviceLayer::SystemLayer().ScheduleLambda([this, scanned = networkScanned.get()]() {
         // Note: We cannot post an event in ScheduleLambda since std::vector is not trivial copyable.
-        LinuxScanResponseIterator<WiFiScanResponse> iter(networkScanned);
+        LinuxScanResponseIterator<WiFiScanResponse> iter(scanned);
 
         OnScanFinished(Status::kSuccess, CharSpan(), &iter);
 
-        delete networkScanned;
+        delete scanned;
     });
+
+    if (err == CHIP_NO_ERROR)
+    {
+        networkScanned.release();
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to schedule scan completion: %" CHIP_ERROR_FORMAT,
+                     err.Format());
+    }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     mPafChannelAvailable = true;


### PR DESCRIPTION
### Summary

In `ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface`, the call to `DeviceLayer::SystemLayer().ScheduleLambda` returns a `CHIP_ERROR` and _can fail_: the event queue can be full, the `SystemLayer` can be shutting down, etc.

The original code discards that status via `TEMPORARY_RETURN_IGNORED`. When scheduling fails, the lambda never runs, so `delete networkScanned` never executes. The raw pointer then simply goes out of scope at the end of the method with no remaining owner, leaking the `std::vector` (and every `WiFiScanResponse` it holds).

The fix is a resource allocation is initialization (RAII)-until-commit pattern: a single owner holds the allocation until scheduling is confirmed to have succeeded, at which point ownership is handed off to the lambda.

`std::make_unique` makes `networkScanned` the unambiguous owner. From allocation onward, any early exit from the enclosing scope frees the vector automatically. The lambda captures `scanned = networkScanned.get()`, a non-owning weak, observer pointer. Capturing `.get()` **does not** move the `unique_ptr` into the lambda; the guard stays in the enclosing scope.

The lambda status is captured instead of ignored. On success, `networkScanned.release()` relinquishes ownership from the guard. Nothing in the method owns the vector anymore; the lambda's `delete scanned` becomes the one and only free. 
On failure, the guard is not released, so it deletes the vector on scope exit, and the error is logged. No leak.

This was identified in the course of work on #72153.

### Related issues

#42516
#72153

### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.4 Apple "Home" app with a wpa_supplicant implementation using this infrastructure.