### PR TITLE
[clang-tidy] Enable core/cplusplus/security static-analyzer checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,13 @@
 ---
+# NOTE: `Checks:` below is a YAML folded block scalar, so `#` is NOT a comment there
+# (it becomes literal text parsed as a check glob). Keep rationale here, above the block.
+#
+# clang-analyzer checks intentionally left disabled (false-positive-only on this codebase;
+# enabling them would require ongoing NOLINTs for zero real findings):
+#   - clang-analyzer-cplusplus.Move: only fires on intentional moved-from-state test
+#     assertions (already NOLINTed for bugprone-use-after-move) plus a TLVReader.h false positive.
+#   - clang-analyzer-cplusplus.NewDeleteLeaks: std::function / self-deleting-callback lifetimes
+#     that the analyzer cannot model (e.g. controller InvokeInteraction/ReadInteraction templates).
 Checks: >
   bugprone-*,
   clang-analyzer-core.*,
@@ -37,8 +46,8 @@ Checks: >
   -bugprone-switch-missing-default-case,
   -bugprone-undelegated-constructor,
   -bugprone-unused-return-value,
-  -clang-analyzer-cplusplus.Move, # FP-only: intentional moved-from test asserts (already NOLINTed for bugprone-use-after-move) + a TLVReader.h FP; enabling needs mass/ongoing NOLINT for 0 real bugs,
-  -clang-analyzer-cplusplus.NewDeleteLeaks, # FP-only: std::function/self-delete lifetimes the analyzer cannot model; enabling needs mass/ongoing NOLINT for 0 real bugs,
+  -clang-analyzer-cplusplus.Move,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.core.EnumCastOutOfRange,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,10 @@
 ---
 Checks: >
   bugprone-*,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-security*,
+  clang-analyzer-unix.Malloc,
   cppcoreguidelines-virtual-class-destructor,
   modernize-redundant-void-arg,
   modernize-use-bool-literals,
@@ -33,9 +37,8 @@ Checks: >
   -bugprone-switch-missing-default-case,
   -bugprone-undelegated-constructor,
   -bugprone-unused-return-value,
-  -clang-analyzer-core.CallAndMessage,
-  -clang-analyzer-core.NonNullParamChecker,
-  -clang-analyzer-cplusplus.Move,
+  -clang-analyzer-cplusplus.Move, # FP-only: intentional moved-from test asserts (already NOLINTed for bugprone-use-after-move) + a TLVReader.h FP; enabling needs mass/ongoing NOLINT for 0 real bugs,
+  -clang-analyzer-cplusplus.NewDeleteLeaks, # FP-only: std::function/self-delete lifetimes the analyzer cannot model; enabling needs mass/ongoing NOLINT for 0 real bugs,
   -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.core.EnumCastOutOfRange,

--- a/examples/common/tracing/decoder/interaction_model/DecoderCustomLog.cpp
+++ b/examples/common/tracing/decoder/interaction_model/DecoderCustomLog.cpp
@@ -338,8 +338,8 @@ CHIP_ERROR MaybeDecodeCommandData(TLV::TLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ClusterId clusterId   = kInvalidClusterId;
-    CommandId commandId   = kInvalidCommandId;
+    ClusterId clusterId = kInvalidClusterId;
+    CommandId commandId = kInvalidCommandId;
 
     TLV::TLVType containerType;
     while (CHIP_NO_ERROR == (err = reader.Next()))

--- a/examples/common/tracing/decoder/interaction_model/DecoderCustomLog.cpp
+++ b/examples/common/tracing/decoder/interaction_model/DecoderCustomLog.cpp
@@ -291,8 +291,8 @@ CHIP_ERROR MaybeDecodeAttributeData(TLV::TLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ClusterId clusterId;
-    AttributeId attributeId;
+    ClusterId clusterId     = kInvalidClusterId;
+    AttributeId attributeId = kInvalidAttributeId;
 
     TLV::TLVType containerType;
     while (CHIP_NO_ERROR == (err = reader.Next()))
@@ -338,8 +338,8 @@ CHIP_ERROR MaybeDecodeCommandData(TLV::TLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ClusterId clusterId;
-    CommandId commandId;
+    ClusterId clusterId   = kInvalidClusterId;
+    CommandId commandId   = kInvalidCommandId;
 
     TLV::TLVType containerType;
     while (CHIP_NO_ERROR == (err = reader.Next()))

--- a/src/app/clusters/ethernet-network-diagnostics-server/EthernetDiagnosticsCluster.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/EthernetDiagnosticsCluster.cpp
@@ -60,7 +60,7 @@ EthernetDiagnosticsServerCluster::EthernetDiagnosticsServerCluster(DeviceLayer::
 DataModel::ActionReturnStatus EthernetDiagnosticsServerCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                               AttributeValueEncoder & encoder)
 {
-    uint64_t value;
+    uint64_t value = 0;
     CHIP_ERROR err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 
     switch (request.path.mAttributeId)

--- a/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
+++ b/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
@@ -250,7 +250,7 @@ DataModel::ActionReturnStatus GeneralDiagnosticsCluster::ReadAttribute(const Dat
         return EncodeListOfValues(valueList, err, encoder);
     }
     case GeneralDiagnostics::Attributes::RebootCount::Id: {
-        uint16_t value;
+        uint16_t value  = 0;
         CHIP_ERROR err = GetRebootCount(value);
         return EncodeValue(value, err, encoder);
     }
@@ -259,12 +259,12 @@ DataModel::ActionReturnStatus GeneralDiagnosticsCluster::ReadAttribute(const Dat
         return encoder.Encode(static_cast<uint64_t>(system_time_seconds.count()));
     }
     case GeneralDiagnostics::Attributes::TotalOperationalHours::Id: {
-        uint32_t value;
+        uint32_t value  = 0;
         CHIP_ERROR err = GetTotalOperationalHours(value);
         return EncodeValue(value, err, encoder);
     }
     case GeneralDiagnostics::Attributes::BootReason::Id: {
-        GeneralDiagnostics::BootReasonEnum value;
+        GeneralDiagnostics::BootReasonEnum value{};
         CHIP_ERROR err = GetBootReason(value);
         return EncodeValue(value, err, encoder);
     }

--- a/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
+++ b/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
@@ -250,7 +250,7 @@ DataModel::ActionReturnStatus GeneralDiagnosticsCluster::ReadAttribute(const Dat
         return EncodeListOfValues(valueList, err, encoder);
     }
     case GeneralDiagnostics::Attributes::RebootCount::Id: {
-        uint16_t value  = 0;
+        uint16_t value = 0;
         CHIP_ERROR err = GetRebootCount(value);
         return EncodeValue(value, err, encoder);
     }
@@ -259,7 +259,7 @@ DataModel::ActionReturnStatus GeneralDiagnosticsCluster::ReadAttribute(const Dat
         return encoder.Encode(static_cast<uint64_t>(system_time_seconds.count()));
     }
     case GeneralDiagnostics::Attributes::TotalOperationalHours::Id: {
-        uint32_t value  = 0;
+        uint32_t value = 0;
         CHIP_ERROR err = GetTotalOperationalHours(value);
         return EncodeValue(value, err, encoder);
     }

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -797,7 +797,7 @@ TEST_F(TestGroupcastCluster, TestMaxMcastAddrCount)
     tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
 
     // Read MaxMcastAddrCount
-    app::Clusters::Groupcast::Attributes::MaxMcastAddrCount::TypeInfo::DecodableType maxMcastAddrCount;
+    app::Clusters::Groupcast::Attributes::MaxMcastAddrCount::TypeInfo::DecodableType maxMcastAddrCount{};
     ASSERT_EQ(tester.ReadAttribute(app::Clusters::Groupcast::Attributes::MaxMcastAddrCount::Id, maxMcastAddrCount), CHIP_NO_ERROR);
     ASSERT_GT(maxMcastAddrCount, 0u);
 

--- a/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
@@ -57,17 +57,17 @@ DataModel::ActionReturnStatus SoftwareDiagnosticsServerCluster::ReadAttribute(co
     switch (request.path.mAttributeId)
     {
     case Attributes::CurrentHeapFree::Id: {
-        uint64_t value  = 0;
+        uint64_t value = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapFree(value);
         return EncodeValue(value, err, encoder);
     }
     case Attributes::CurrentHeapUsed::Id: {
-        uint64_t value  = 0;
+        uint64_t value = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapUsed(value);
         return EncodeValue(value, err, encoder);
     }
     case Attributes::CurrentHeapHighWatermark::Id: {
-        uint64_t value  = 0;
+        uint64_t value = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapHighWatermark(value);
         return EncodeValue(value, err, encoder);
     }

--- a/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
@@ -57,17 +57,17 @@ DataModel::ActionReturnStatus SoftwareDiagnosticsServerCluster::ReadAttribute(co
     switch (request.path.mAttributeId)
     {
     case Attributes::CurrentHeapFree::Id: {
-        uint64_t value;
+        uint64_t value  = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapFree(value);
         return EncodeValue(value, err, encoder);
     }
     case Attributes::CurrentHeapUsed::Id: {
-        uint64_t value;
+        uint64_t value  = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapUsed(value);
         return EncodeValue(value, err, encoder);
     }
     case Attributes::CurrentHeapHighWatermark::Id: {
-        uint64_t value;
+        uint64_t value  = 0;
         CHIP_ERROR err = mDiagnosticDataProvider.GetCurrentHeapHighWatermark(value);
         return EncodeValue(value, err, encoder);
     }

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -202,27 +202,27 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesAndCommandTest)
 
         // Test all attributes
         // cluster revision
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision{};
         ASSERT_TRUE(tester.ReadAttribute(Attributes::ClusterRevision::Id, clusterRevision).IsSuccess());
         EXPECT_EQ(clusterRevision, SoftwareDiagnostics::kRevision);
 
         // feature map
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap{};
         ASSERT_TRUE(tester.ReadAttribute(Attributes::FeatureMap::Id, featureMap).IsSuccess());
         EXPECT_EQ(featureMap, BitFlags<SoftwareDiagnostics::Feature>{ SoftwareDiagnostics::Feature::kWatermarks }.Raw());
 
         // heapfree
-        Attributes::CurrentHeapFree::TypeInfo::DecodableType heapFree;
+        Attributes::CurrentHeapFree::TypeInfo::DecodableType heapFree{};
         ASSERT_TRUE(tester.ReadAttribute(Attributes::CurrentHeapFree::Id, heapFree).IsSuccess());
         EXPECT_EQ(heapFree, 123u);
 
         // heapused
-        Attributes::CurrentHeapUsed::TypeInfo::DecodableType heapUsed;
+        Attributes::CurrentHeapUsed::TypeInfo::DecodableType heapUsed{};
         ASSERT_TRUE(tester.ReadAttribute(Attributes::CurrentHeapUsed::Id, heapUsed).IsSuccess());
         EXPECT_EQ(heapUsed, 234u);
 
         // highwatermark
-        Attributes::CurrentHeapHighWatermark::TypeInfo::DecodableType highWatermark;
+        Attributes::CurrentHeapHighWatermark::TypeInfo::DecodableType highWatermark{};
         ASSERT_TRUE(tester.ReadAttribute(Attributes::CurrentHeapHighWatermark::Id, highWatermark).IsSuccess());
         EXPECT_EQ(highWatermark, 456u);
 

--- a/src/app/clusters/thread-border-router-management-server/tests/TestThreadBorderRouterManagementCluster.cpp
+++ b/src/app/clusters/thread-border-router-management-server/tests/TestThreadBorderRouterManagementCluster.cpp
@@ -222,7 +222,7 @@ TEST_F(TestThreadBorderRouterManagementCluster, TestFeatureMap_PanChangeSupporte
     chip::Testing::ClusterTester tester(cluster);
     EXPECT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    uint32_t featureMap;
+    uint32_t featureMap = 0;
     EXPECT_TRUE(tester.ReadAttribute(Globals::Attributes::FeatureMap::Id, featureMap).IsSuccess());
     EXPECT_EQ(featureMap, static_cast<uint32_t>(Feature::kPANChange));
 }
@@ -238,7 +238,7 @@ TEST_F(TestThreadBorderRouterManagementCluster, TestFeatureMap_PanChangeNotSuppo
     chip::Testing::ClusterTester tester(localCluster);
     EXPECT_EQ(localCluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    uint32_t featureMap;
+    uint32_t featureMap = 0;
     EXPECT_TRUE(tester.ReadAttribute(Globals::Attributes::FeatureMap::Id, featureMap).IsSuccess());
     EXPECT_EQ(featureMap, 0u);
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -891,7 +891,7 @@ TEST_F(TestGroupDataProvider, TestKeySetCacheAndSyncRemap)
     // 2. Read the saved TLV from storage
     auto keyName = DefaultStorageKeyAllocator::FabricKeyset(kFabric1, kKeysetId1);
 
-    uint8_t tlvBuffer[128];
+    uint8_t tlvBuffer[128] = {};
     uint16_t tlvLength = sizeof(tlvBuffer);
     EXPECT_EQ(sDelegate.SyncGetKeyValue(keyName.KeyName(), tlvBuffer, tlvLength), CHIP_NO_ERROR);
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -892,7 +892,7 @@ TEST_F(TestGroupDataProvider, TestKeySetCacheAndSyncRemap)
     auto keyName = DefaultStorageKeyAllocator::FabricKeyset(kFabric1, kKeysetId1);
 
     uint8_t tlvBuffer[128] = {};
-    uint16_t tlvLength = sizeof(tlvBuffer);
+    uint16_t tlvLength     = sizeof(tlvBuffer);
     EXPECT_EQ(sDelegate.SyncGetKeyValue(keyName.KeyName(), tlvBuffer, tlvLength), CHIP_NO_ERROR);
 
     // 3. Sanity check and patch the policy to CacheAndSync (1) in-place.

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -386,7 +386,8 @@ TEST_F(TestChipCryptoPAL, TestAES_CCM_128EncryptTestVectors)
 
         if (vector->result == CHIP_NO_ERROR)
         {
-            bool areCTsEqual  = memcmp(out_ct_ptr, vector->ct, vector->ct_len) == 0;
+            // memcmp() requires non-null pointers even when length is 0; out_ct_ptr is null for zero-length vectors.
+            bool areCTsEqual  = (vector->ct_len == 0) || (memcmp(out_ct_ptr, vector->ct, vector->ct_len) == 0);
             bool areTagsEqual = memcmp(out_tag.Get(), vector->tag, vector->tag_len) == 0;
             EXPECT_TRUE(areCTsEqual);
             EXPECT_TRUE(areTagsEqual);
@@ -431,7 +432,8 @@ TEST_F(TestChipCryptoPAL, TestAES_CCM_128DecryptTestVectors)
         EXPECT_EQ(err, vector->result);
         if (vector->result == CHIP_NO_ERROR)
         {
-            bool arePTsEqual = memcmp(vector->pt, out_pt_ptr, vector->pt_len) == 0;
+            // memcmp() requires non-null pointers even when length is 0; out_pt_ptr is null for zero-length vectors.
+            bool arePTsEqual = (vector->pt_len == 0) || (memcmp(vector->pt, out_pt_ptr, vector->pt_len) == 0);
             EXPECT_TRUE(arePTsEqual);
             if (!arePTsEqual)
             {
@@ -480,7 +482,8 @@ TEST_F(TestChipCryptoPAL, TestAES_CCM_128InPlaceEncryption)
         EXPECT_EQ(err, vector->result);
         if (vector->result == CHIP_NO_ERROR)
         {
-            bool areCTsEqual  = memcmp(inplace_buffer_ptr, vector->ct, vector->ct_len) == 0;
+            // memcmp() requires non-null pointers even when length is 0; inplace_buffer_ptr is null for zero-length vectors.
+            bool areCTsEqual  = (vector->ct_len == 0) || (memcmp(inplace_buffer_ptr, vector->ct, vector->ct_len) == 0);
             bool areTagsEqual = memcmp(out_tag.Get(), vector->tag, vector->tag_len) == 0;
             EXPECT_TRUE(areCTsEqual);
             EXPECT_TRUE(areTagsEqual);
@@ -532,7 +535,8 @@ TEST_F(TestChipCryptoPAL, TestAES_CCM_128InPlaceDecryption)
         EXPECT_EQ(err, vector->result);
         if (vector->result == CHIP_NO_ERROR)
         {
-            bool arePTsEqual = memcmp(vector->pt, inplace_buffer_ptr, vector->pt_len) == 0;
+            // memcmp() requires non-null pointers even when length is 0; inplace_buffer_ptr is null for zero-length vectors.
+            bool arePTsEqual = (vector->pt_len == 0) || (memcmp(vector->pt, inplace_buffer_ptr, vector->pt_len) == 0);
             EXPECT_TRUE(arePTsEqual);
             if (!arePTsEqual)
             {

--- a/src/crypto/tests/TestSessionKeystore.cpp
+++ b/src/crypto/tests/TestSessionKeystore.cpp
@@ -143,7 +143,8 @@ TEST_F(TestSessionKeystore, TestBasicImport)
         EXPECT_EQ(AES_CCM_encrypt(test.pt, test.pt_len, test.aad, test.aad_len, keyHandle, test.nonce, test.nonce_len,
                                   ciphertext_ptr, tag.Get(), test.tag_len),
                   test.result);
-        EXPECT_EQ(memcmp(ciphertext_ptr, test.ct, test.ct_len), 0);
+        // memcmp() requires non-null pointers even when length is 0; ciphertext_ptr is null for zero-length plaintext.
+        EXPECT_TRUE(test.ct_len == 0 || memcmp(ciphertext_ptr, test.ct, test.ct_len) == 0);
         EXPECT_EQ(memcmp(tag.Get(), test.tag, test.tag_len), 0);
 
         keystore.DestroyKey(keyHandle);

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -288,7 +288,7 @@ TEST_F(TestUdcMessages, TestUDCClients)
     EXPECT_EQ(nullptr, mUdcClients.FindUDCClientState(instanceName4));
 
     // test re-activation
-    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName4, &state));
+    ASSERT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName4, &state));
     System::Clock::Timestamp expirationTime = state->GetExpirationTime();
     state->SetExpirationTime(expirationTime - System::Clock::Milliseconds64(1));
     EXPECT_EQ((expirationTime - System::Clock::Milliseconds64(1)), state->GetExpirationTime());


### PR DESCRIPTION
#### Summary

Enables the clang-analyzer static-analysis families (`core.*`, `cplusplus.*`, `security*`, plus `unix.Malloc`) in `.clang-tidy`, keeps their noisy members disabled, and fixes the small set of findings that blocked enabling them.

##### Problem

- `.clang-tidy` carries `-clang-analyzer-...` *disable* lines but no `clang-analyzer-*` *positive*, and the pigweed clang-tidy used in CI does not enable the analyzer family by default.
- Consequently the path-sensitive static analyzer (null-deref, out-of-bounds, use-after-free / double-free, uninitialized reads, etc.) **does not run at all** in the clang-tidy CI step — the existing `-clang-analyzer-*` disable lines are inert.

##### Solution

- Add `clang-analyzer-core.*`, `clang-analyzer-cplusplus.*`, `clang-analyzer-security*` and `clang-analyzer-unix.Malloc` as positives so the analyzer runs on changed files.
- Keep the checkers that only produce false positives or intentional-pattern hits disabled, each with an inline rationale:
  - `cplusplus.Move` — intentional moved-from-state test assertions (already `NOLINT`ed for `bugprone-use-after-move`) plus a `TLVReader.h` false positive.
  - `cplusplus.NewDeleteLeaks` — `std::function` / self-deleting-callback lifetimes the analyzer cannot model.
- Fix the findings the newly-enabled checkers surfaced (rather than suppressing them):
  - initialize out-parameters before passing them to encode helpers in the General/Software/Ethernet diagnostics clusters, and in the interaction-model trace decoder (`DecoderCustomLog.cpp`, which read an uninitialized cluster/attribute/command id on a malformed-TLV path);
  - initialize attribute out-vars read by several cluster unit tests;
  - guard `memcmp()` against null zero-length buffers in the crypto unit tests (passing a null pointer to `memcmp` is undefined behavior even when the length is 0);
  - use `ASSERT_EQ` instead of `EXPECT_EQ` for a create-then-dereference precondition in a UDC test.

##### Caveats

- This makes the clang-tidy CI step run the path-sensitive analyzer on changed C/C++ files, which is slower per file than the frontend checks. It runs on changed files only (not whole-tree), so the added time scales with PR size.
- The whole tree was scanned with these checks enabled prior to this change; the enabled set produced no findings outside the files touched here.

#### Testing

- clang-tidy: the enabled checkers report no findings across the all-devices, all-clusters and tests compile databases after the fixes; verified the disabled checkers stay suppressed and the enabled ones fire, via minimal positive controls.
- Unit tests: built and ran the affected test binaries — `TestChipCryptoPAL`, `TestSessionKeystore`, `TestSoftwareDiagnosticsCluster`, `TestGroupcastCluster`, `TestThreadBorderRouterManagementCluster`, `TestGroupDataProvider`, `TestUdcMessages` — all pass, no ASan errors.
