### PR TITLE
Fix PushAV transport status not restored after app restart

### DIFF
--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -658,9 +658,9 @@ PushAvStreamTransportManager::PersistentAttributesLoadedCallback()
                 else
                 {
                     // Restore transport status from persisted configuration
-                    if (transportConfig.transportStatus == TransportStatusEnum::kActive)
+                    if (transportConfig.transportStatus != TransportStatusEnum::kInactive)
                     {
-                        this->SetTransportStatus({ connectionID }, TransportStatusEnum::kActive);
+                        this->SetTransportStatus({ connectionID }, transportConfig.transportStatus);
                     }
                 }
             }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -655,6 +655,14 @@ PushAvStreamTransportManager::PersistentAttributesLoadedCallback()
                     ChipLogError(Zcl, "Failed to re-allocate transport for connection ID: %u, status: %u", connectionID,
                                  to_underlying(status));
                 }
+                else
+                {
+                    // Restore transport status from persisted configuration
+                    if (transportConfig.transportStatus == TransportStatusEnum::kActive)
+                    {
+                        this->SetTransportStatus({ connectionID }, TransportStatusEnum::kActive);
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
### Summary

After the persistence changes, when the camera-app restarts, PersistentAttributesLoadedCallback() re-allocates PushAVTransport objects but does not restore their transport status from the persisted configuration. The PushAVTransport constructor always sets mTransportStatus to kInactive, while the cluster server's mCurrentConnections has kActive from persistent storage.

This causes ManuallyTriggerTransport to fail.

Fix by calling SetTransportStatus(kActive) on the re-allocated transport when the persisted configuration has transportStatus=kActive.

### Related issues

### Testing
* Run below scenario
```
AllocatePushTransport -> SetTransportStatus -> Restart camera-app -> ModifyPushTransport -> ManuallyTriggerTransport 
```
* Clip record should trigger successfully