### PR TITLE
[NXP] ci: ensure clean build after each build step in NXP workflow

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -169,7 +169,7 @@ jobs:
                       pigweed:
                         - 'src/pw_backends/**'
                         - 'third_party/pigweed/**'
-            - name: Build NXP Zephyr examples
+            - name: Build NXP Zephyr all-clusters example
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp
                   == 'true' || steps.changed_paths.outputs.pigweed == 'true'
@@ -177,13 +177,54 @@ jobs:
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-rw61x-zephyr-all-clusters \
+                      build \
+                  "
+
+            - name: clean build
+              run: rm -rf ./out
+
+            - name: Build NXP Zephyr thermostat Wi-Fi example
+              if:
+                  github.event_name == 'push' || steps.changed_paths.outputs.nxp
+                  == 'true' || steps.changed_paths.outputs.pigweed == 'true'
+              run: |
+                  scripts/run_in_build_env.sh "\
+                      ./scripts/build/build_examples.py \
                       --target nxp-rw61x-zephyr-thermostat \
+                      build \
+                  "
+
+            - name: clean build
+              run: rm -rf ./out
+
+            - name: Build NXP Zephyr thermostat Thread example
+              if:
+                  github.event_name == 'push' || steps.changed_paths.outputs.nxp
+                  == 'true' || steps.changed_paths.outputs.pigweed == 'true'
+              run: |
+                  scripts/run_in_build_env.sh "\
+                      ./scripts/build/build_examples.py \
                       --target nxp-rw61x-zephyr-thermostat-thread \
+                      build \
+                  "
+
+            - name: clean build
+              run: rm -rf ./out
+
+            - name: Build NXP Zephyr laundry-washer-factory example
+              if:
+                  github.event_name == 'push' || steps.changed_paths.outputs.nxp
+                  == 'true' || steps.changed_paths.outputs.pigweed == 'true'
+              run: |
+                  scripts/run_in_build_env.sh "\
+                      ./scripts/build/build_examples.py \
                       --target nxp-rw61x-zephyr-laundry-washer-factory \
                       build \
                   "
+
             - name: clean build
               run: rm -rf ./out
+
             - name: Build NXP Zephyr Unit Tests
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp


### PR DESCRIPTION
### Summary

The issue is that all 4 Zephyr targets were built in a single step with no intermediate cleanup, causing the disk to fill up before the last targets could complete.

This fix splits the 4-target build into individual steps with rm -rf ./out between each, following the same pattern already established in the FreeRTOS job.

### Testing

No particular test done. Github CI would be monitored
