### PR TITLE
[Groupcast] Reject LeaveGroup with an oversized Endpoints list

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -702,6 +702,13 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
 
     if (data.endpoints.HasValue())
     {
+        // Per the LeaveGroupResponse specification, when the requested Endpoints list size exceeds the
+        // maximum constraint, the response Endpoints list SHALL be empty. The endpoints are still
+        // removed, but they are not collected into the (fixed-size) response in that case.
+        size_t requestedCount = 0;
+        VerifyOrReturnError(data.endpoints.Value().ComputeSize(&requestedCount) == CHIP_NO_ERROR, Status::Failure);
+        EndpointList * responseEndpoints = (requestedCount > kMaxCommandEndpoints) ? nullptr : endpoints;
+
         // Remove endpoints
         auto iter = data.endpoints.Value().begin();
         while (iter.Next())
@@ -709,7 +716,7 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
             auto endpoint_id = iter.GetValue();
             if (groups.HasEndpoint(fabricIndex, group_id, endpoint_id))
             {
-                stat = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, endpoints);
+                stat = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, responseEndpoints);
                 VerifyOrReturnError(Status::Success == stat, stat);
             }
         }

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -706,19 +706,21 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
         // maximum constraint, the response Endpoints list SHALL be empty. The endpoints are still
         // removed, but they are not collected into the (fixed-size) response in that case.
         size_t requestedCount = 0;
-        VerifyOrReturnError(data.endpoints.Value().ComputeSize(&requestedCount) == CHIP_NO_ERROR, Status::Failure);
-        EndpointList * responseEndpoints = (requestedCount > kMaxCommandEndpoints) ? nullptr : endpoints;
-
-        // Remove endpoints
-        auto iter = data.endpoints.Value().begin();
+        auto iter             = data.endpoints.Value().begin();
         while (iter.Next())
         {
+            requestedCount++;
             auto endpoint_id = iter.GetValue();
             if (groups.HasEndpoint(fabricIndex, group_id, endpoint_id))
             {
-                stat = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, responseEndpoints);
+                EndpointList * responseEndpoints = (requestedCount <= kMaxCommandEndpoints) ? endpoints : nullptr;
+                stat                             = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, responseEndpoints);
                 VerifyOrReturnError(Status::Success == stat, stat);
             }
+        }
+        if (requestedCount > kMaxCommandEndpoints && endpoints != nullptr)
+        {
+            endpoints->count = 0;
         }
     }
     else

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -545,6 +545,15 @@ Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::Decod
     Status err                 = Status::Success;
 
     endpoints.count = 0;
+
+    // The Endpoints field is constrained to "1 to 20" per the spec; reject an oversized request.
+    if (data.endpoints.HasValue())
+    {
+        size_t endpoint_count = 0;
+        VerifyOrReturnError(data.endpoints.Value().ComputeSize(&endpoint_count) == CHIP_NO_ERROR, Status::Failure);
+        VerifyOrReturnError(endpoint_count <= kMaxCommandEndpoints, Status::ConstraintError);
+    }
+
     if (kUndefinedGroupId == data.groupID)
     {
         // Apply changes to all groups
@@ -702,25 +711,16 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
 
     if (data.endpoints.HasValue())
     {
-        // Per the LeaveGroupResponse specification, when the requested Endpoints list size exceeds the
-        // maximum constraint, the response Endpoints list SHALL be empty. The endpoints are still
-        // removed, but they are not collected into the (fixed-size) response in that case.
-        size_t requestedCount = 0;
-        auto iter             = data.endpoints.Value().begin();
+        // Remove endpoints
+        auto iter = data.endpoints.Value().begin();
         while (iter.Next())
         {
-            requestedCount++;
             auto endpoint_id = iter.GetValue();
             if (groups.HasEndpoint(fabricIndex, group_id, endpoint_id))
             {
-                EndpointList * responseEndpoints = (requestedCount <= kMaxCommandEndpoints) ? endpoints : nullptr;
-                stat                             = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, responseEndpoints);
+                stat = RemoveGroupEndpoint(fabricIndex, group_id, endpoint_id, endpoints);
                 VerifyOrReturnError(Status::Success == stat, stat);
             }
-        }
-        if (requestedCount > kMaxCommandEndpoints && endpoints != nullptr)
-        {
-            endpoints->count = 0;
         }
     }
     else
@@ -771,7 +771,7 @@ Status GroupcastCluster::RemoveGroupEndpoint(FabricIndex fabricIndex, GroupId gr
     {
         found = (endpoints->entries[i] == endpoint_id);
     }
-    if (!found)
+    if (!found && endpoints->count < kMaxMembershipEndpoints)
     {
         endpoints->entries[endpoints->count++] = endpoint_id;
     }

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -2129,4 +2129,77 @@ TEST_F(TestGroupcastCluster, TestTotalMaxMembership)
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
 }
 
+// When a LeaveGroup command's Endpoints list size exceeds the maximum constraint, the
+// LeaveGroupResponse Endpoints list must be empty (the endpoints are still removed). The response is
+// collected into a fixed-size buffer, so an oversized request must neither populate that response nor
+// write past the buffer.
+TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsEmptyResponse)
+{
+    static constexpr uint16_t kMaxCommandEndpoints = app::Clusters::GroupcastCluster::kMaxCommandEndpoints;
+    static constexpr uint16_t kEndpointsInGroup    = kMaxMembershipEndpoints + 5; // exceeds the per-command maximum
+    const GroupId kGroup                           = 0xab01;
+    const KeysetId kKeyset                         = 0xabcd;
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+    tester.SetSubjectDescriptor(kAdminSubjectDescriptor);
+
+    // Join the group with kEndpointsInGroup distinct endpoints, kMaxCommandEndpoints at a time.
+    {
+        Commands::JoinGroup::Type data;
+        data.groupID  = kGroup;
+        data.keySetID = kKeyset;
+        data.key      = MakeOptional(ByteSpan(key));
+
+        EndpointId nextEndpoint = 1;
+        for (uint16_t added = 0; added < kEndpointsInGroup;)
+        {
+            EndpointId chunk[kMaxCommandEndpoints];
+            uint16_t count = 0;
+            for (; count < kMaxCommandEndpoints && added < kEndpointsInGroup; count++, added++)
+            {
+                chunk[count] = nextEndpoint++;
+            }
+            data.endpoints = DataModel::List<const EndpointId>(chunk, count);
+            auto result    = tester.Invoke(Commands::JoinGroup::Id, data);
+            ASSERT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+            data.key.ClearValue();
+        }
+    }
+
+    // Leave the group naming every member endpoint (more than the maximum constraint). The command
+    // succeeds and the returned Endpoints list is empty.
+    {
+        EndpointId leaveEndpoints[kEndpointsInGroup];
+        for (uint16_t i = 0; i < kEndpointsInGroup; i++)
+        {
+            leaveEndpoints[i] = static_cast<EndpointId>(i + 1);
+        }
+
+        Commands::LeaveGroup::Type data;
+        data.groupID   = kGroup;
+        data.endpoints = MakeOptional(DataModel::List<const EndpointId>(leaveEndpoints, kEndpointsInGroup));
+
+        auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+        ASSERT_TRUE(result.response.has_value());
+        size_t responseEndpointCount = 0;
+        EXPECT_EQ(result.response->endpoints.ComputeSize(&responseEndpointCount), CHIP_NO_ERROR);
+        EXPECT_EQ(responseEndpointCount, 0u);
+    }
+
+    // The endpoints were removed: the group is no longer present in the Membership attribute.
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        auto it = memberships.begin();
+        while (it.Next())
+        {
+            EXPECT_NE(it.GetValue().groupID, kGroup);
+        }
+        EXPECT_EQ(it.GetStatus(), CHIP_NO_ERROR);
+    }
+}
+
 } // namespace

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -2129,11 +2129,9 @@ TEST_F(TestGroupcastCluster, TestTotalMaxMembership)
     EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
 }
 
-// When a LeaveGroup command's Endpoints list size exceeds the maximum constraint, the
-// LeaveGroupResponse Endpoints list must be empty (the endpoints are still removed). The response is
-// collected into a fixed-size buffer, so an oversized request must neither populate that response nor
-// write past the buffer.
-TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsEmptyResponse)
+// A LeaveGroup command whose Endpoints list exceeds the maximum constraint ("1 to 20") is rejected
+// with CONSTRAINT_ERROR, without writing past the fixed-size response buffer.
+TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsConstraintError)
 {
     static constexpr uint16_t kMaxCommandEndpoints = app::Clusters::GroupcastCluster::kMaxCommandEndpoints;
     // exceeds kMaxMembershipEndpoints (response buffer sizing) and kMaxCommandEndpoints
@@ -2169,8 +2167,8 @@ TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsEmptyResp
         }
     }
 
-    // Leave the group naming every member endpoint (more than the maximum constraint). The command
-    // succeeds and the returned Endpoints list is empty.
+    // Leaving the group while naming more than the maximum number of endpoints is rejected with
+    // CONSTRAINT_ERROR; no response payload is produced.
     {
         EndpointId leaveEndpoints[kEndpointsInGroup];
         for (uint16_t i = 0; i < kEndpointsInGroup; i++)
@@ -2183,23 +2181,8 @@ TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsEmptyResp
         data.endpoints = MakeOptional(DataModel::List<const EndpointId>(leaveEndpoints, kEndpointsInGroup));
 
         auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
-        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
-        ASSERT_TRUE(result.response.has_value());
-        size_t responseEndpointCount = 0;
-        EXPECT_EQ(result.response->endpoints.ComputeSize(&responseEndpointCount), CHIP_NO_ERROR);
-        EXPECT_EQ(responseEndpointCount, 0u);
-    }
-
-    // The endpoints were removed: the group is no longer present in the Membership attribute.
-    {
-        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
-        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
-        auto it = memberships.begin();
-        while (it.Next())
-        {
-            EXPECT_NE(it.GetValue().groupID, kGroup);
-        }
-        EXPECT_EQ(it.GetStatus(), CHIP_NO_ERROR);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
+        EXPECT_FALSE(result.response.has_value());
     }
 }
 

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -2136,9 +2136,10 @@ TEST_F(TestGroupcastCluster, TestTotalMaxMembership)
 TEST_F(TestGroupcastCluster, TestLeaveGroupEndpointsExceedingMaxReturnsEmptyResponse)
 {
     static constexpr uint16_t kMaxCommandEndpoints = app::Clusters::GroupcastCluster::kMaxCommandEndpoints;
-    static constexpr uint16_t kEndpointsInGroup    = kMaxMembershipEndpoints + 5; // exceeds the per-command maximum
-    const GroupId kGroup                           = 0xab01;
-    const KeysetId kKeyset                         = 0xabcd;
+    // exceeds kMaxMembershipEndpoints (response buffer sizing) and kMaxCommandEndpoints
+    static constexpr uint16_t kEndpointsInGroup = kMaxMembershipEndpoints + 5;
+    const GroupId kGroup                        = 0xab01;
+    const KeysetId kKeyset                      = 0xabcd;
     const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
 
     chip::Testing::ClusterTester tester(mListener);


### PR DESCRIPTION
#### Summary

##### Problem

- The `LeaveGroup` `Endpoints` field is constrained to `1 to 20` by the spec, but the server does not enforce that bound.
- In the explicit-`Endpoints` path, `RemoveGroupEndpoint()` appends each removed endpoint to a fixed-size, stack-allocated response buffer `EndpointList::entries[kMaxMembershipEndpoints]` (255 slots) with **no bounds check** (`entries[count++]`).
- A group can hold more than 255 members (grown via repeated `JoinGroup`), so a single `LeaveGroup` naming more than 255 of them drives `count` past the buffer — an out-of-bounds stack write.

##### Impact

- Out-of-bounds stack write on a `LeaveGroup` that removes more than 255 endpoints in one command. Reaching it requires a device exposing 256+ endpoints (e.g. a bridge/aggregator), since `JoinGroup` validates each endpoint against the device's endpoint list.

##### Solution

- Reject a `LeaveGroup` whose `Endpoints` list exceeds the maximum (`kMaxCommandEndpoints`, 20) with `CONSTRAINT_ERROR` in the command handler, matching the check `JoinGroup` already performs. The request is rejected before any endpoint is processed, so the response buffer is never reached with an oversized list.
- As defense-in-depth, bound the append in `RemoveGroupEndpoint()` so the fixed-size buffer cannot be overrun regardless of caller, consistent with the other response-collection sites.

#### Testing

- Added `TestGroupcastCluster.TestLeaveGroupEndpointsExceedingMaxReturnsConstraintError`: joins a group with more than 255 members and leaves naming all of them, verifying the command is rejected with `CONSTRAINT_ERROR`. Without the fix the oversized leave writes out of bounds (fails under ASan); with the fix it passes.
