### PR TITLE
[nxp][mcxw72] Removed Memory Manager Light

### DIFF
--- a/src/platform/nxp/common/CHIPNXPPlatformDefaultConfig.h
+++ b/src/platform/nxp/common/CHIPNXPPlatformDefaultConfig.h
@@ -270,8 +270,3 @@
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 #endif // CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
 #endif // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
-
-#ifndef NXP_USE_MML
-/* Do not use Memory Manager Light for dynamic memory allocation by default. */
-#define NXP_USE_MML 0
-#endif // NXP_USE_MML

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -22,6 +22,7 @@
  *          for nxp platform.
  */
 
+#include <FreeRTOS.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include "DiagnosticDataProviderImpl.h"
@@ -43,16 +44,15 @@ extern "C" {
 }
 #endif
 
-#if NXP_USE_MML
-#include "fsl_component_mem_manager.h"
-#define GetFreeHeapSize MEM_GetFreeHeapSize
-#define HEAP_SIZE MinimalHeapSize_c
-#define GetMinimumEverFreeHeapSize MEM_GetFreeHeapSizeLowWaterMark
-#else
-#define GetFreeHeapSize xPortGetFreeHeapSize
-#define HEAP_SIZE configTOTAL_HEAP_SIZE
-#define GetMinimumEverFreeHeapSize xPortGetMinimumEverFreeHeapSize
-#endif // NXP_USE_MML
+inline size_t GetFreeHeapSize()
+{
+    return xPortGetFreeHeapSize();
+}
+constexpr size_t HEAP_SIZE = configTOTAL_HEAP_SIZE;
+inline size_t GetMinimumEverFreeHeapSize()
+{
+    return xPortGetMinimumEverFreeHeapSize();
+}
 
 namespace chip {
 namespace DeviceLayer {
@@ -99,11 +99,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
     // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
     // value of the CurrentHeapUsed.
 
-#if NXP_USE_MML
-    MEM_ResetFreeHeapSizeLowWaterMark();
-#else
     xPortResetHeapMinimumEverFreeHeapSize();
-#endif
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nxp/mcxw72/BUILD.gn
+++ b/src/platform/nxp/mcxw72/BUILD.gn
@@ -73,10 +73,7 @@ static_library("nxp_platform") {
     "-Wno-sign-compare",
   ]
   deps = []
-  defines = [
-    "NXP_DEVICE_MCXW7X=1",
-    "NXP_USE_MML=1",
-  ]
+  defines = [ "NXP_DEVICE_MCXW7X=1" ]
 
   sources = [
     "../../FreeRTOS/SystemTimeSupport.cpp",


### PR DESCRIPTION
### Summary
Memory Manager Light is not supported or used anymore. It only affects one component, the SoftwareDiagnostics cluster, where it overrides diagnostic data such as GetCurrentHeapFree, GetCurrentHeapUsed and GetCurrentHeapHighWatermark.

### Testing

Tested manually using TC_RR.