### PR TITLE
[Testing infra] Add missing nest-asyncio dependency to python testing requirements

### DIFF
--- a/src/python_testing/requirements.txt
+++ b/src/python_testing/requirements.txt
@@ -7,3 +7,4 @@ langcodes
 requests
 pycountry
 validators
+nest-asyncio


### PR DESCRIPTION
#### Summary

Add missing `nest-asyncio` dependency to `src/python_testing/requirements.txt` to resolve persistent CI failures in `TC_OPCREDS_3_8.py`.

##### Problem

-   `TC_OPCREDS_3_8.py` explicitly requires `nest_asyncio` but the dependency was never listed in `src/python_testing/requirements.txt`.
-   The test previously passed because `nest-asyncio` was being installed transitively by [ipython/ipykernel](https://github.com/ipython/ipykernel) (which is included in our Linux REPL test virtual environment).
-   `ipykernel` recently upgraded its dependency tree to rely on `nest-asyncio2` instead of `nest-asyncio`.
-   Because our Linux REPL CI builds do not cache pip packages between runs, new workflows immediately downloaded the updated `ipykernel` tree and broke with `ModuleNotFoundError: No module named 'nest_asyncio'`.
-   PR #72154 happened to be merged right when this PyPI update floated and was innocent, which is why reverting it in PR #72504 does not resolve the breakage.

##### Solution

-   Added `nest-asyncio` directly to `src/python_testing/requirements.txt` to make the test's dependency explicit, robust, and immune to upstream transitive floats.

#### Testing

-   Verified that `src/python_testing/requirements.txt` correctly includes `nest-asyncio`.
-   Relying on CI to execute `TC_OPCREDS_3_8.py` and confirm resolution.