### PR TITLE
Fix uint32 overflow in SecondsToMilliseconds

### DIFF
--- a/src/lib/support/TimeUtils.h
+++ b/src/lib/support/TimeUtils.h
@@ -210,7 +210,7 @@ bool UnixEpochToChipEpochMicros(uint64_t unixEpochTimeMicros, uint64_t & outChip
  */
 inline uint64_t SecondsToMilliseconds(uint32_t seconds)
 {
-    return (seconds * kMillisecondsPerSecond);
+    return (static_cast<uint64_t>(seconds) * kMillisecondsPerSecond);
 }
 
 // For backwards-compatibility of public API.

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -1053,7 +1053,7 @@ TEST(TestTimeUtils, TestSecondsToMilliseconds)
     // kMillisecondsPerSecond is an int, `seconds * kMillisecondsPerSecond` is computed
     // in 32-bit (unsigned) arithmetic and wraps once seconds * 1000 exceeds UINT32_MAX,
     // i.e. for seconds >= 4294968 (~49.7 days), before the widening to uint64_t.
-    EXPECT_EQ(SecondsToMilliseconds(4294968u), UINT64_C(4294968000));   // smallest overflowing input
-    EXPECT_EQ(SecondsToMilliseconds(5000000u), UINT64_C(5000000000));   // round value past the boundary
+    EXPECT_EQ(SecondsToMilliseconds(4294968u), UINT64_C(4294968000)); // smallest overflowing input
+    EXPECT_EQ(SecondsToMilliseconds(5000000u), UINT64_C(5000000000)); // round value past the boundary
     EXPECT_EQ(SecondsToMilliseconds(UINT32_MAX), UINT64_C(4294967295000));
 }

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -1041,3 +1041,19 @@ TEST(TestTimeUtils, TestChipEpochTimeEdgeConditions)
     EXPECT_EQ(UnixEpochToChipEpochTime(kUnix2000Jan1 - 1, chip_epoch_time_sec), false);
 #endif
 }
+
+TEST(TestTimeUtils, TestSecondsToMilliseconds)
+{
+    // Typical / regression values.
+    EXPECT_EQ(SecondsToMilliseconds(0u), UINT64_C(0));
+    EXPECT_EQ(SecondsToMilliseconds(1u), UINT64_C(1000));
+    EXPECT_EQ(SecondsToMilliseconds(1000u), UINT64_C(1000000));
+
+    // Overflow guard: the product must be evaluated in 64 bits. Because
+    // kMillisecondsPerSecond is an int, `seconds * kMillisecondsPerSecond` is computed
+    // in 32-bit (unsigned) arithmetic and wraps once seconds * 1000 exceeds UINT32_MAX,
+    // i.e. for seconds >= 4294968 (~49.7 days), before the widening to uint64_t.
+    EXPECT_EQ(SecondsToMilliseconds(4294968u), UINT64_C(4294968000));   // smallest overflowing input
+    EXPECT_EQ(SecondsToMilliseconds(5000000u), UINT64_C(5000000000));   // round value past the boundary
+    EXPECT_EQ(SecondsToMilliseconds(UINT32_MAX), UINT64_C(4294967295000));
+}


### PR DESCRIPTION
#### Summary

`SecondsToMilliseconds(uint32_t seconds)` in `src/lib/support/TimeUtils.h` returns `seconds * kMillisecondsPerSecond`. `kMillisecondsPerSecond` is an `int`, so the multiplication is performed in 32-bit (unsigned) arithmetic and wraps modulo 2^32 once `seconds * 1000` exceeds `UINT32_MAX` — i.e. for `seconds >= 4294968` (~49.7 days) — *before* the result is widened to the `uint64_t` return type.

For example, `SecondsToMilliseconds(4294968)` returns `704` instead of `4294968000`.

This is latent today (in-tree callers pass small/bounded values), but it is a public-API footgun for any caller converting large second counts to milliseconds.

#### Change

Widen the operand to `uint64_t` so the multiplication is evaluated in 64 bits:

```cpp
return (static_cast<uint64_t>(seconds) * kMillisecondsPerSecond);
```

The deprecated `secondsToMilliseconds` alias forwards to this function, so it is fixed as well.

#### Testing

Adds `TestTimeUtils.TestSecondsToMilliseconds`, covering small/regression values and the overflowing inputs (`4294968`, `5000000`, `UINT32_MAX`). The test fails before the fix (e.g. `704 != 4294968000`) and passes after.

Found by clang-tidy's `bugprone-implicit-widening-of-multiplication-result` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)