### PR TITLE
[Camera] Start/stop AV stream HAL pipelines lazily on transport acquire/release

### DIFF
--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -157,6 +157,21 @@ private:
      */
     void GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                 const Optional<DataModel::Nullable<uint16_t>> & audioStreamId, uint32_t & outBandwidthbps);
+
+    /**
+     * @brief Releases the audio/video streams referenced by the given connection so the AV Stream Management delegate can stop
+     *        the underlying HAL pipelines once no consumer remains. No-op if the connection has no stored transport options.
+     * @param connectionID The connection whose referenced streams should be released.
+     */
+    void ReleaseStreamsForConnection(uint16_t connectionID);
+
+    /**
+     * @brief Extracts the referenced audio/video streams from the given transport options into the given vectors.
+     *        An absent or null stream ID results in an empty vector for that stream type, which the AV Stream Management
+     *        controller treats as "no stream" and skips.
+     */
+    static void GetReferencedStreams(const TransportOptionsStruct & transportOptions, std::vector<uint16_t> & audioStreams,
+                                     std::vector<uint16_t> & videoStreams);
 };
 
 } // namespace PushAvStreamTransport

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -785,13 +785,12 @@ CameraAVStreamManager::AllocatedVideoStreamsLoaded()
 
         if (it != persistedStreams.end())
         {
-            // Found in persisted streams, mark as allocated in HAL
+            // Found in persisted streams, mark as allocated in HAL. The underlying HAL pipeline is started lazily when the
+            // first transport acquires the stream (see OnTransportAcquireAudioVideoStreams), so that a reboot with no active
+            // consumer does not leave encoder pipelines running idle.
             halStream.isAllocated = true;
             ChipLogProgress(Camera, "HAL Video Stream ID %u marked as allocated from persisted state.",
                             halStream.videoStreamParams.videoStreamID);
-
-            // Signal for starting the video stream
-            OnVideoStreamAllocated(*it, StreamAllocationAction::kNewAllocation);
         }
     }
 
@@ -812,18 +811,12 @@ CameraAVStreamManager::AllocatedAudioStreamsLoaded()
 
         if (it != persistedStreams.end())
         {
-            // Found in persisted streams, mark as allocated in HAL
+            // Found in persisted streams, mark as allocated in HAL. The underlying HAL pipeline is started lazily when the
+            // first transport acquires the stream (see OnTransportAcquireAudioVideoStreams), so that a reboot with no active
+            // consumer does not leave audio pipelines running idle.
             halStream.isAllocated = true;
             ChipLogProgress(Camera, "HAL Audio Stream ID %u marked as allocated from persisted state.",
                             halStream.audioStreamParams.audioStreamID);
-
-            // Start the audio stream from HAL for serving.
-            if (mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(halStream.audioStreamParams.audioStreamID) !=
-                CameraError::SUCCESS)
-            {
-                ChipLogError(Camera, "Failed to start HAL Audio Stream for persisted ID %u.",
-                             halStream.audioStreamParams.audioStreamID);
-            }
         }
     }
 
@@ -952,6 +945,15 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
             {
                 if (stream.audioStreamParams.referenceCount < UINT8_MAX)
                 {
+                    // Lazily start the HAL pipeline on the first consumer (0 -> 1 transition).
+                    if (stream.audioStreamParams.referenceCount == 0)
+                    {
+                        ChipLogProgress(Camera, "Starting audio stream with ID: %u on first acquire", audioStreamID);
+                        if (mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(audioStreamID) != CameraError::SUCCESS)
+                        {
+                            ChipLogError(Camera, "Failed to start HAL Audio Stream for ID %u on acquire.", audioStreamID);
+                        }
+                    }
                     stream.audioStreamParams.referenceCount++;
                 }
                 else
@@ -979,6 +981,22 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
             {
                 if (stream.videoStreamParams.referenceCount < UINT8_MAX)
                 {
+                    // Lazily start the HAL pipeline on the first consumer (0 -> 1 transition).
+                    if (stream.videoStreamParams.referenceCount == 0)
+                    {
+                        ChipLogProgress(Camera, "Starting video stream with ID: %u on first acquire", videoStreamID);
+                        if (mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(stream.videoStreamParams) !=
+                            CameraError::SUCCESS)
+                        {
+                            ChipLogError(Camera, "Failed to start HAL Video Stream for ID %u on acquire.", videoStreamID);
+                        }
+                        else
+                        {
+                            // Reflect the frame rate reported by the HAL once the stream has started.
+                            TEMPORARY_RETURN_IGNORED GetCameraAVStreamManagementCluster()->SetCurrentFrameRate(
+                                mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
+                        }
+                    }
                     stream.videoStreamParams.referenceCount++;
                 }
                 else
@@ -1014,6 +1032,15 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(const std::vector<uin
                 if (stream.audioStreamParams.referenceCount > 0)
                 {
                     stream.audioStreamParams.referenceCount--;
+                    // Stop the HAL pipeline once the last consumer releases (1 -> 0 transition).
+                    if (stream.audioStreamParams.referenceCount == 0)
+                    {
+                        ChipLogProgress(Camera, "Stopping audio stream with ID: %u on last release", audioStreamID);
+                        if (mCameraDeviceHAL->GetCameraHALInterface().StopAudioStream(audioStreamID) != CameraError::SUCCESS)
+                        {
+                            ChipLogError(Camera, "Failed to stop HAL Audio Stream for ID %u on release.", audioStreamID);
+                        }
+                    }
                 }
                 else
                 {
@@ -1041,6 +1068,15 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(const std::vector<uin
                 if (stream.videoStreamParams.referenceCount > 0)
                 {
                     stream.videoStreamParams.referenceCount--;
+                    // Stop the HAL pipeline once the last consumer releases (1 -> 0 transition).
+                    if (stream.videoStreamParams.referenceCount == 0)
+                    {
+                        ChipLogProgress(Camera, "Stopping video stream with ID: %u on last release", videoStreamID);
+                        if (mCameraDeviceHAL->GetCameraHALInterface().StopVideoStream(videoStreamID) != CameraError::SUCCESS)
+                        {
+                            ChipLogError(Camera, "Failed to stop HAL Video Stream for ID %u on release.", videoStreamID);
+                        }
+                    }
                 }
                 else
                 {

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -939,6 +939,7 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
     // Update the available audio streams in the HAL
     for (uint16_t audioStreamID : audioStreams)
     {
+        bool startFailed = false;
         for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
         {
             if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
@@ -951,7 +952,10 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
                         ChipLogProgress(Camera, "Starting audio stream with ID: %u on first acquire", audioStreamID);
                         if (mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(audioStreamID) != CameraError::SUCCESS)
                         {
+                            // Leave the reference count at 0 so a later acquire retries the start.
                             ChipLogError(Camera, "Failed to start HAL Audio Stream for ID %u on acquire.", audioStreamID);
+                            startFailed = true;
+                            break;
                         }
                     }
                     stream.audioStreamParams.referenceCount++;
@@ -962,6 +966,12 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
                 }
                 break;
             }
+        }
+
+        // Keep the SDK ref count consistent with the HAL: skip the increment when the HAL pipeline failed to start.
+        if (startFailed)
+        {
+            continue;
         }
 
         // Update the counts in the SDK allocated stream attributes
@@ -975,6 +985,7 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
     // Update the available video streams in the HAL
     for (uint16_t videoStreamID : videoStreams)
     {
+        bool startFailed = false;
         for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
         {
             if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
@@ -988,14 +999,14 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
                         if (mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(stream.videoStreamParams) !=
                             CameraError::SUCCESS)
                         {
+                            // Leave the reference count at 0 so a later acquire retries the start.
                             ChipLogError(Camera, "Failed to start HAL Video Stream for ID %u on acquire.", videoStreamID);
+                            startFailed = true;
+                            break;
                         }
-                        else
-                        {
-                            // Reflect the frame rate reported by the HAL once the stream has started.
-                            TEMPORARY_RETURN_IGNORED GetCameraAVStreamManagementCluster()->SetCurrentFrameRate(
-                                mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
-                        }
+                        // Reflect the frame rate reported by the HAL once the stream has started.
+                        TEMPORARY_RETURN_IGNORED GetCameraAVStreamManagementCluster()->SetCurrentFrameRate(
+                            mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
                     }
                     stream.videoStreamParams.referenceCount++;
                 }
@@ -1005,6 +1016,12 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(const std::vector<uin
                 }
                 break;
             }
+        }
+
+        // Keep the SDK ref count consistent with the HAL: skip the increment when the HAL pipeline failed to start.
+        if (startFailed)
+        {
+            continue;
         }
 
         // Update the counts in the SDK allocated stream attributes

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -41,6 +41,8 @@ PushAvStreamTransportManager::~PushAvStreamTransportManager()
         for (auto & kv : mTransportMap)
         {
             mMediaController->UnregisterTransport(kv.second.get());
+            // Release the referenced streams so the HAL pipelines are stopped when no consumer remains.
+            ReleaseStreamsForConnection(kv.first);
         }
     }
     mTransportMap.clear();
@@ -119,16 +121,7 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
 
     std::vector<uint16_t> videoStreams;
     std::vector<uint16_t> audioStreams;
-
-    if (transportOptions.videoStreamID.HasValue() && !transportOptions.videoStreamID.Value().IsNull())
-    {
-        videoStreams.push_back(transportOptions.videoStreamID.Value().Value());
-    }
-
-    if (transportOptions.audioStreamID.HasValue() && !transportOptions.audioStreamID.Value().IsNull())
-    {
-        audioStreams.push_back(transportOptions.audioStreamID.Value().Value());
-    }
+    GetReferencedStreams(transportOptions, audioStreams, videoStreams);
 
     ChipLogProgress(Camera,
                     "PushAvStreamTransportManager, RegisterTransport for connectionID: [%u], videoStreams count: [%u], "
@@ -136,6 +129,11 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
                     connectionID, static_cast<unsigned>(videoStreams.size()), static_cast<unsigned>(audioStreams.size()));
     mMediaController->RegisterTransport(mTransportMap[connectionID].get(), videoStreams, audioStreams);
     mMediaController->SetPreRollLength(mTransportMap[connectionID].get(), mTransportMap[connectionID].get()->GetPreRollLength());
+
+    // Acquire the referenced audio/video streams so the HAL pipelines are started for this consumer. Stream pipelines are
+    // started lazily on the first acquire and stopped on the last release.
+    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportAcquireAudioVideoStreams(audioStreams,
+                                                                                                                videoStreams);
 
     uint32_t newTransportBandwidthbps = 0;
     GetBandwidthForStreams(transportOptions.videoStreamID, transportOptions.audioStreamID, newTransportBandwidthbps);
@@ -184,6 +182,44 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     return Status::Success;
 }
 
+void PushAvStreamTransportManager::ReleaseStreamsForConnection(uint16_t connectionID)
+{
+    if (mCameraDevice == nullptr)
+    {
+        return;
+    }
+
+    auto optsIt = mTransportOptionsMap.find(connectionID);
+    if (optsIt == mTransportOptionsMap.end())
+    {
+        return;
+    }
+
+    std::vector<uint16_t> videoStreams;
+    std::vector<uint16_t> audioStreams;
+    GetReferencedStreams(optsIt->second, audioStreams, videoStreams);
+
+    TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportReleaseAudioVideoStreams(audioStreams,
+                                                                                                                videoStreams);
+}
+
+void PushAvStreamTransportManager::GetReferencedStreams(const TransportOptionsStruct & transportOptions,
+                                                        std::vector<uint16_t> & audioStreams, std::vector<uint16_t> & videoStreams)
+{
+    videoStreams.clear();
+    audioStreams.clear();
+
+    if (transportOptions.videoStreamID.HasValue() && !transportOptions.videoStreamID.Value().IsNull())
+    {
+        videoStreams.push_back(transportOptions.videoStreamID.Value().Value());
+    }
+
+    if (transportOptions.audioStreamID.HasValue() && !transportOptions.audioStreamID.Value().IsNull())
+    {
+        audioStreams.push_back(transportOptions.audioStreamID.Value().Value());
+    }
+}
+
 Protocols::InteractionModel::Status PushAvStreamTransportManager::DeallocatePushTransport(const uint16_t connectionID)
 {
     if (mTransportMap.find(connectionID) == mTransportMap.end())
@@ -193,6 +229,10 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::DeallocatePush
     }
     mTotalUsedBandwidthbps -= mTransportMap[connectionID].get()->GetCurrentlyUsedBandwidthbps();
     mMediaController->UnregisterTransport(mTransportMap[connectionID].get());
+
+    // Release the referenced audio/video streams so the HAL pipelines can be stopped once no consumer remains.
+    ReleaseStreamsForConnection(connectionID);
+
     mTransportMap.erase(connectionID);
     mTransportOptionsMap.erase(connectionID);
 
@@ -229,7 +269,47 @@ PushAvStreamTransportManager::ModifyPushTransport(const uint16_t connectionID, c
                   "New transport bandwidth: %u bps. Total used bandwidth: %u bps.",
                   connectionID, newTransportBandwidthbps, mTotalUsedBandwidthbps);
 
+    // Capture the streams referenced before the modification so the HAL pipeline acquire/release stays balanced if the
+    // modification changes which streams the connection references.
+    std::vector<uint16_t> oldAudioStreams;
+    std::vector<uint16_t> oldVideoStreams;
+    auto optsIt = mTransportOptionsMap.find(connectionID);
+    if (optsIt != mTransportOptionsMap.end())
+    {
+        GetReferencedStreams(optsIt->second, oldAudioStreams, oldVideoStreams);
+    }
+
     mTransportOptionsMap[connectionID] = transportOptions;
+
+    std::vector<uint16_t> newAudioStreams;
+    std::vector<uint16_t> newVideoStreams;
+    GetReferencedStreams(mTransportOptionsMap[connectionID], newAudioStreams, newVideoStreams);
+
+    // Release the streams that are no longer referenced and acquire the newly referenced ones. Unchanged streams are omitted
+    // from both lists so the controller skips them, avoiding an unnecessary HAL pipeline stop/start.
+    if (mCameraDevice != nullptr && (oldAudioStreams != newAudioStreams || oldVideoStreams != newVideoStreams))
+    {
+        std::vector<uint16_t> audioToRelease;
+        std::vector<uint16_t> videoToRelease;
+        std::vector<uint16_t> audioToAcquire;
+        std::vector<uint16_t> videoToAcquire;
+
+        if (oldAudioStreams != newAudioStreams)
+        {
+            audioToRelease = oldAudioStreams;
+            audioToAcquire = newAudioStreams;
+        }
+        if (oldVideoStreams != newVideoStreams)
+        {
+            videoToRelease = oldVideoStreams;
+            videoToAcquire = newVideoStreams;
+        }
+
+        TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportReleaseAudioVideoStreams(
+            audioToRelease, videoToRelease);
+        TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportAcquireAudioVideoStreams(
+            audioToAcquire, videoToAcquire);
+    }
 
     ChipLogProgress(Camera, "PushAvStreamTransportManager, success to modify Connection :[%u]", connectionID);
 
@@ -631,6 +711,10 @@ CHIP_ERROR PushAvStreamTransportManager::LoadCurrentConnections(std::vector<Tran
 {
     ChipLogProgress(Zcl, "Push AV Current Connections loaded");
 
+    // TODO: This is currently a no-op, so persisted Push AV connections are not restored after a reboot. When restoring
+    // connections here, each restored connection that should resume streaming must also re-acquire its referenced streams via
+    // GetCameraAVStreamMgmtController().OnTransportAcquireAudioVideoStreams(); otherwise the HAL pipelines will not restart (and
+    // the destructor's ReleaseStreamsForConnection would underflow the reference count on streams that were never acquired).
     return CHIP_NO_ERROR;
 }
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -133,7 +133,7 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     // Acquire the referenced audio/video streams so the HAL pipelines are started for this consumer. Stream pipelines are
     // started lazily on the first acquire and stopped on the last release.
     TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportAcquireAudioVideoStreams(audioStreams,
-                                                                                                                videoStreams);
+                                                                                                                  videoStreams);
 
     uint32_t newTransportBandwidthbps = 0;
     GetBandwidthForStreams(transportOptions.videoStreamID, transportOptions.audioStreamID, newTransportBandwidthbps);
@@ -200,7 +200,7 @@ void PushAvStreamTransportManager::ReleaseStreamsForConnection(uint16_t connecti
     GetReferencedStreams(optsIt->second, audioStreams, videoStreams);
 
     TEMPORARY_RETURN_IGNORED mCameraDevice->GetCameraAVStreamMgmtController().OnTransportReleaseAudioVideoStreams(audioStreams,
-                                                                                                                videoStreams);
+                                                                                                                  videoStreams);
 }
 
 void PushAvStreamTransportManager::GetReferencedStreams(const TransportOptionsStruct & transportOptions,


### PR DESCRIPTION
#### Summary

Start and stop the camera HAL audio/video pipelines lazily based on transport
reference counts, instead of eagerly starting every allocated/persisted stream.

##### Problem

- The Linux camera example started HAL stream pipelines eagerly:
    - Persisted streams were started at boot in `AllocatedAudioStreamsLoaded` /
      `AllocatedVideoStreamsLoaded`.
    - This left encoder/HAL pipelines **running with no consumer** when no
      WebRTC/Push-AV transport was actually using the stream, wasting CPU and
      device resources.
- Stream pipeline lifetime was not tied to transport acquire/release, so there
  was no point at which an unused pipeline would be stopped.

##### Solution

- Drive HAL pipeline start/stop from the per-stream reference count maintained
  on transport acquire/release:
    - Start the pipeline on the **first acquire** (ref count `0 -> 1`).
    - Stop the pipeline on the **last release** (ref count `1 -> 0`).
- Acquire referenced streams when a Push-AV transport is allocated and release
  them on deallocation and on manager teardown; keep acquire/release balanced
  across transport modification when the referenced streams change.
- Sync `CurrentFrameRate` from the HAL once a video stream starts, and skip
  absent/null stream IDs.

##### Caveats

- `LoadCurrentConnections` is currently a no-op, so persisted Push-AV
  connections are not restored after reboot. A TODO documents that, once it
  restores connections, each restored connection must re-acquire its referenced
  streams; otherwise teardown would underflow the stream reference count.

#### Testing

- Built `linux-x64-camera` successfully
  (`./scripts/build/build_examples.py --target linux-x64-camera build`).
- Exercised the transport acquire/release path end-to-end with the WebRTC
  Python tests against `chip-camera-app`:
  `./scripts/tests/local.py python-tests --test-filter "TC_WEBRTCP_,TC_WEBRTC_1_" --override-binary-path CAMERA_APP out/linux-x64-camera/chip-camera-app`.
  The full-session tests that start (acquire) and stop (release) streams —
  `TC_WEBRTC_1_1/1_2/1_3/1_4/1_7/1_8` — pass. The remaining failures in that run
  are unrelated to this change (camera app does not implement `PowerSource`, and
  the newer `VideoStreams`/`AudioStreams` list API expected by
  `TC_WEBRTCP_2_27..2_32`).
- No unit tests added: this is example-app HAL/pipeline glue code, which is not
  practical to unit test in isolation.