### PR TITLE
closure-app: bind endpoint to a reference, not a copy

### DIFF
--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -386,7 +386,7 @@ chip::Protocols::InteractionModel::Status ClosureManager::OnSetTargetCommand(con
         overallTargetState.SetNonNull(GenericOverallTargetState{});
     }
 
-    ClosureDimensionEndpoint mClosurePanelEndpoint =
+    ClosureDimensionEndpoint & mClosurePanelEndpoint =
         endpointId == kClosurePanelEndpoint2 ? mClosurePanelEndpoint2 : mClosurePanelEndpoint3;
     ClosureDimension::ClusterConformance mClosurePanelConformance = mClosurePanelEndpoint.GetClusterInstance().GetConformance();
 


### PR DESCRIPTION
#### Summary

##### Problem

- `OnSetTargetCommand` in `examples/closure-app/linux/ClosureManager.cpp` creates a local copy of a `ClosureDimensionEndpoint` (~1.5 KB) only to read conformance from it via a const method.
- The implicit copy constructor of the `Interface` member is lowered to a wholesale `memcpy(sizeof(Interface))`, which crosses the intra-object redzones inserted by `-fsanitize-address-field-padding=1`. ASAN reports this as `intra-object-overflow`. **Both source and destination include those bytes in their sizeof**, so the access is in-bounds — there is no UB; the flag has no way to distinguish a legitimate per-class memcpy from a real overflow.
- **Consequences**:
    - Wasted ~1.5 KB stack copy on every `SetTarget` command invocation.
    - Spurious ASAN report that masks genuine overflows when the closure-app is run under field padding.

##### Solution

- Bind the local to `ClosureDimensionEndpoint &` instead of copying. Both operands of the conditional are lvalues of the same type, so reference binding is well-formed.
- No observable behaviour change: the local is only used to call the const method `GetClusterInstance().GetConformance()`.

#### Testing

- N/A for new automated tests: the change is a one-line, behaviour-preserving edit in a sample app's command handler that has no targeted unit-test coverage in the existing suite.
- The exact codepath that produced the original ASAN report (closure-app under `-fsanitize-address-field-padding=1`, server-side `SetTarget` invocation) is the codepath being modified; the wholesale memcpy is removed, so the report no longer fires.