### PR TITLE
Fixed Misspelling of Key Management Handle Local Variable in '_GetBssInfo'

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -1451,12 +1451,12 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
             return 0;
         }
         GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
-        const gchar ** keyMgmtsHendle = keyMgmts.get();
+        const gchar ** keyMgmtsHandle = keyMgmts.get();
         uint8_t res                   = 0;
 
-        VerifyOrReturnError(keyMgmtsHendle != nullptr, res);
+        VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
 
-        for (auto keyMgmtVal = *keyMgmtsHendle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHendle))
+        for (auto keyMgmtVal = *keyMgmtsHandle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHandle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-none") == 0)
             {
@@ -1481,12 +1481,12 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
             return 0;
         }
         GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
-        const gchar ** keyMgmtsHendle = keyMgmts.get();
+        const gchar ** keyMgmtsHandle = keyMgmts.get();
         uint8_t res                   = 0;
 
-        VerifyOrReturnError(keyMgmtsHendle != nullptr, res);
+        VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
 
-        for (auto keyMgmtVal = *keyMgmtsHendle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHendle))
+        for (auto keyMgmtVal = *keyMgmtsHandle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHandle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-psk-sha256") == 0 ||
                 g_strcasecmp(keyMgmtVal, "wpa-ft-psk") == 0)


### PR DESCRIPTION
#### Summary

Per #42516 and [this overview](https://github.com/user-attachments/files/25854289/Matter.ConnectivityManager.Linux.Platform.Refactoring.html), this continues the work from #72153 and fixes a misspelling of the key management handle local variable in `_GetBssInfo`, caught by @enkiusz.

#### Related issues

#42516
#72153

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.4 Apple "Home" app with a wpa_supplicant implementation using this infrastructure.