### PR TITLE
tls-certificate-management: replace placement-new in DefaultSerializer::Clear()

### DIFF
--- a/src/app/clusters/tls-certificate-management-server/CertificateTable.h
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTable.h
@@ -48,6 +48,15 @@ public:
         // TODO(gmarcosb): We probably want to support using a handle here when the key is stored elsewhere,
         // see for example Symmetric128BitsKeyHandle
         Crypto::P256SerializedKeypair key;
+
+        // Reset to default state. key.Clear() invokes ClearSecretData on the
+        // underlying buffer; any new sensitive member added here must also be
+        // wiped explicitly.
+        void Clear()
+        {
+            detail = {};
+            key.Clear();
+        }
     };
 
     using IterateRootCertFnType   = std::function<CHIP_ERROR(CommonIterator<RootCertStruct> & iterator)>;

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -270,7 +270,7 @@ CHIP_ERROR RootSerializer::DeserializeData(TLV::TLVReader & reader, CertificateT
 template <>
 void RootSerializer::Clear(CertificateTable::RootCertStruct & data)
 {
-    new (&data) CertificateTable::RootCertStruct();
+    data = {};
 }
 
 template class chip::app::Storage::FabricTableImpl<CertificateId, CertificateTable::RootCertStruct>;
@@ -364,7 +364,8 @@ CHIP_ERROR ClientSerializer::DeserializeData(TLV::TLVReader & reader, Certificat
 template <>
 void ClientSerializer::Clear(CertificateTable::ClientCertWithKey & data)
 {
-    new (&data) CertificateTable::ClientCertWithKey();
+    data.detail = {};
+    data.key.Clear();
 }
 
 template class chip::app::Storage::FabricTableImpl<CertificateId, CertificateTable::ClientCertWithKey>;

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -364,8 +364,7 @@ CHIP_ERROR ClientSerializer::DeserializeData(TLV::TLVReader & reader, Certificat
 template <>
 void ClientSerializer::Clear(CertificateTable::ClientCertWithKey & data)
 {
-    data.detail = {};
-    data.key.Clear();
+    data.Clear();
 }
 
 template class chip::app::Storage::FabricTableImpl<CertificateId, CertificateTable::ClientCertWithKey>;


### PR DESCRIPTION
#### Summary

##### Problem

- `DefaultSerializer<…, RootCertStruct>::Clear()` and `DefaultSerializer<…, ClientCertWithKey>::Clear()` reset entries via `new (&data) T()`. Placement-new does not implicitly call the previous object's destructor.
- For `ClientCertWithKey::key` (a `SensitiveDataBuffer<97>`), that destructor is `~SensitiveDataBuffer()`, which calls `ClearSecretData(mBytes)` — a **compiler-barrier-protected** wipe whose purpose is to survive dead-store elimination.
- Without the destructor firing during `Clear()`, the only thing that zeroes `mBytes` is the value-initialization memset implied by `new (&data) T()`. That memset has no barrier and is exposed to dead-store elimination: the deserializer below writes only `key.size()` bytes back into `mBytes`; bytes beyond the new key's length are never read through `Span()` (which clamps to `mLength`), so their zero-init is a textbook dead store the optimizer is permitted to remove.
- Net effect: `Clear()` quietly relies on the optimizer to preserve an incidental memset, instead of invoking the explicit barrier-protected wipe `SensitiveDataBuffer` was designed around. The object's own destructor still wipes at scope exit (when the enclosing `BufferedClientCert` dies), so the exposure is the transient per-`Clear()` window between iterations, not a permanent leak.
- Also resolves a crash under `-fsanitize-address-field-padding=1`: the placement-new's wholesale memset crosses the inserted intra-object redzones and trips an `intra-object-overflow` report on the second `Clear()` invocation.

##### Solution

- Reset the members directly so the wipe is explicit at the call site:
    - `RootCertStruct` (no secret data): `data = {};`.
    - `ClientCertWithKey`: `data.detail = {};` followed by `data.key.Clear();`.
- `SensitiveDataBuffer::Clear()` already calls `ClearSecretData(mBytes)` ([CHIPCryptoPAL.h](https://github.com/project-chip/connectedhomeip/blob/master/src/crypto/CHIPCryptoPAL.h#L357)), so the wipe is now invoked unconditionally and independent of optimization level.
- No placement-new, no new include.

#### Testing

- `src/app/tests/TestCertificateTableImpl.cpp` exercises the `Load → Clear → Serializer::Clear` path. Builds and passes under `-fsanitize-address-field-padding=1` after the change; previously the placement-new tripped an `intra-object-overflow` report on the second `Clear()` invocation.
- No new automated test added. The change here just routes through the existing public `Clear()` method on `SensitiveDataBuffer`, whose wipe contract is the load-bearing invariant and is independently testable in `src/crypto/`.