### PR TITLE
WriteClient: widen list-append loop counter to size_t

### DIFF
--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -267,7 +267,8 @@ public:
 
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
 
-        for (ListIndex i = firstItemToAppendIndex; i < listValue.size(); i++)
+        const size_t listSize = listValue.size();
+        for (size_t i = firstItemToAppendIndex; i < listSize; i++)
         {
             ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, listValue[i]));
         }


### PR DESCRIPTION
### Summary

`WriteClient::EncodeAttribute(const DataModel::List<T> &)` encodes the
remaining list items (in the `AppendItem` phase, after the first chunk)
with this loop:

```cpp
for (ListIndex i = firstItemToAppendIndex; i < listValue.size(); i++)
```

`ListIndex` is `uint16_t`, while `DataModel::List::size()` returns
`size_t`. CodeQL flags this as a comparison of a narrow type with a wide
type in a loop condition.

Beyond the warning, this is a latent bug: because the counter is
`uint16_t`, a list with more than 65535 items would wrap the counter
back to `0` before it ever reached `size()`, producing an infinite loop.

This change widens the loop counter to `size_t` and indexes directly:

```cpp
const size_t listSize = listValue.size();
for (size_t i = firstItemToAppendIndex; i < listSize; i++)
```

`DataModel::List<T>` derives from `Span<T>`, whose `operator[]` already
takes `size_t`, so no narrowing cast is needed — indexing uses `size_t`
throughout instead of implicitly widening a `ListIndex` on every
iteration. `firstItemToAppendIndex` (a `ListIndex`) widens to `size_t`
safely. Behavior is unchanged for any list with up to `size()` items.

### Related issues

None.

### Testing

No behavior change for realistic list sizes; existing write/chunking
tests (`TestWriteInteraction`, `TestWriteChunking`) continue to cover
this path. Verified the changed template overload
(`EncodeAttribute(DataModel::List<ByteSpan>)`, instantiated by
`TestWriteInteraction.cpp`) compiles cleanly under the project's
`-Wconversion -Werror` flags.