### PR TITLE
[ci] Bump zephyr-silabs version in silabs-zephyr Docker to add OpenThread module

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-201 : [Silabs] Update Silabs Zephyr Docker image (7a26730)
+202 : [Silabs] Update Silabs Zephyr Docker image (86c6d6a)

--- a/integrations/docker/images/stage-2/chip-build-silabs-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-silabs-zephyr/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /opt/silabs/
 RUN set -x \
     && ZEPHYR_SDK_VERSION=1.0.1 \
     # Zephyr Silabs commit hash silabs/dev branch June 3 2026:
-    # v4.4.0 + 917 fixes and ieee802.15.4 drivers
-    && ZEPHYR_SILABS_HASH=7a2673077f4d2fbec085d6bc43259e084a32d2b2 \
+    # v4.4.0 + 917 fixes, ieee802.15.4 drivers and OT module
+    && ZEPHYR_SILABS_HASH=86c6d6a8e2622b9dc533790582417006f135706d \
     && python3 -m venv venv \
     && . venv/bin/activate \
     && pip3 install west \


### PR DESCRIPTION
### Summary

Bump hash of zephyr-silabs version which allows OpenThread module, which will allow CI for Matter Zephyr on xG24.

### Related issues

https://github.com/SiliconLabsSoftware/zephyr-silabs/pull/170

### Testing

Built and ran image locally.
