### PR TITLE
[clang-tidy] Enable bugprone-implicit-widening-of-multiplication-result

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-forward-declaration-namespace,
   -bugprone-forwarding-reference-overload,
-  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-inc-dec-in-conditions,
   -bugprone-macro-parentheses,
   -bugprone-misplaced-widening-cast,

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -57,7 +57,7 @@ enum class TagEndpoint : uint8_t
 static constexpr size_t kPersistentBufferNextIdBytes =
     EstimateStructOverhead(sizeof(uint16_t), // mNextId
                            EstimateStructOverhead(sizeof(EndpointId), sizeof(FabricIndex)) *
-                               (kMaxProvisionedEndpoints * CHIP_CONFIG_MAX_FABRICS)); // mEndpointMapping
+                               (static_cast<size_t>(kMaxProvisionedEndpoints) * CHIP_CONFIG_MAX_FABRICS)); // mEndpointMapping
 
 static constexpr size_t kTlsEndpointMaxBytes =
     EstimateStructOverhead(sizeof(chip::FabricIndex),                                    // Fabric ID
@@ -77,7 +77,7 @@ struct BufferedEndpoint
 
 class GlobalEndpointData : public PersistableData<kPersistentBufferNextIdBytes>
 {
-    IncrementingIdHelper<TlsEndpointId, kMaxProvisionedEndpoints * CHIP_CONFIG_MAX_FABRICS> mEndpoints;
+    IncrementingIdHelper<TlsEndpointId, static_cast<size_t>(kMaxProvisionedEndpoints) * CHIP_CONFIG_MAX_FABRICS> mEndpoints;
     EndpointId mEndpointId = kInvalidEndpointId;
 
 public:

--- a/examples/energy-management/energy-management-triggers/DEMTestEventTriggers.cpp
+++ b/examples/energy-management/energy-management-triggers/DEMTestEventTriggers.cpp
@@ -130,10 +130,10 @@ CHIP_ERROR ConfigureForecast(uint16_t numSlots)
 
 void SetTestEventTrigger_PowerAdjustment()
 {
-    sPowerAdjustments[0].minPower    = 5000 * 1000;  // 5kW
-    sPowerAdjustments[0].maxPower    = 30000 * 1000; // 30kW
-    sPowerAdjustments[0].minDuration = 10;           // 30s
-    sPowerAdjustments[0].maxDuration = 60;           // 60s
+    sPowerAdjustments[0].minPower    = static_cast<int64_t>(5000) * 1000;  // 5kW
+    sPowerAdjustments[0].maxPower    = static_cast<int64_t>(30000) * 1000; // 30kW
+    sPowerAdjustments[0].minDuration = 10;                                 // 30s
+    sPowerAdjustments[0].maxDuration = 60;                                 // 60s
 
     DataModel::List<const DeviceEnergyManagement::Structs::PowerAdjustStruct::Type> powerAdjustmentList(sPowerAdjustments, 1);
 

--- a/examples/energy-management/energy-management-triggers/FakeReadings.cpp
+++ b/examples/energy-management/energy-management-triggers/FakeReadings.cpp
@@ -122,10 +122,10 @@ void FakeReadings::FakeReadingsUpdate()
     // Update readings
     // Avoid using floats - so we will do a basic rand() call which will generate a integer value between 0 and RAND_MAX
     // first compute power as a mean + some random value in range +/- mPowerRandomness_mW
-    int64_t power = (static_cast<int64_t>(rand()) % (2 * mPowerRandomness_mW)) - mPowerRandomness_mW;
+    int64_t power = (static_cast<int64_t>(rand()) % (2 * static_cast<int64_t>(mPowerRandomness_mW))) - mPowerRandomness_mW;
     power += mPower_mW; // add in the base power
 
-    int64_t voltage = (static_cast<int64_t>(rand()) % (2 * mVoltageRandomness_mV)) - mVoltageRandomness_mV;
+    int64_t voltage = (static_cast<int64_t>(rand()) % (2 * static_cast<int64_t>(mVoltageRandomness_mV))) - mVoltageRandomness_mV;
     voltage += mVoltage_mV; // add in the base voltage
 
     /* Note: whilst we could compute a current from the power and voltage,
@@ -135,7 +135,7 @@ void FakeReadings::FakeReadingsUpdate()
      * This is meant more as an example to show how to use the APIs, not
      * to be a real representation of laws of physics.
      */
-    int64_t current = (static_cast<int64_t>(rand()) % (2 * mCurrentRandomness_mA)) - mCurrentRandomness_mA;
+    int64_t current = (static_cast<int64_t>(rand()) % (2 * static_cast<int64_t>(mCurrentRandomness_mA))) - mCurrentRandomness_mA;
     current += mCurrent_mA; // add in the base current
 
     ElectricalSensorManager * esManager = GetESManager();

--- a/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
+++ b/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
@@ -65,7 +65,7 @@ private:
         kContextTagMaxNum = UINT8_MAX
     };
 
-    constexpr static size_t kCastingDataMaxBytes               = 1024 * 100; // 100 KBs
+    constexpr static size_t kCastingDataMaxBytes               = static_cast<size_t>(1024) * 100; // 100 KBs
     constexpr static char * kCastingDataKey                    = (char *) "com.matter.casting";
     constexpr static uint32_t kCurrentCastingDataVersion       = 1;
     constexpr static uint32_t kSupportedCastingDataVersions[1] = { 1 };

--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -348,8 +348,9 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
         if (videoPlayersContainerTagNum == kVideoPlayerMACAddressTag)
         {
             MACAddressLength = reader.GetLength();
-            ReturnErrorOnFailure(reader.GetBytes(reinterpret_cast<uint8_t *>(MACAddressBuf),
-                                                 2 * chip::DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength));
+            ReturnErrorOnFailure(
+                reader.GetBytes(reinterpret_cast<uint8_t *>(MACAddressBuf),
+                                2 * static_cast<size_t>(chip::DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength)));
             continue;
         }
 

--- a/examples/tv-casting-app/tv-casting-common/src/WakeOnLan.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/WakeOnLan.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR SendWakeOnLanPacket(chip::CharSpan * MACAddress)
         return CHIP_ERROR_INCORRECT_STATE;
     }
     ChipLogProgress(AppServer, "Broadcasted WoL magic packet with MACAddress %s",
-                    chip::NullTerminated(MACAddress->data(), 2 * kMACLength).c_str());
+                    chip::NullTerminated(MACAddress->data(), 2 * static_cast<size_t>(kMACLength)).c_str());
     close(sockfd);
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -103,7 +103,7 @@ private:
         kContextTagMaxNum = UINT8_MAX
     };
 
-    constexpr static size_t kCastingStoreDataMaxBytes               = 1024 * 100; // 100 KBs
+    constexpr static size_t kCastingStoreDataMaxBytes               = static_cast<size_t>(1024) * 100; // 100 KBs
     constexpr static char * kCastingStoreDataKey                    = (char *) "com.matter.casting.CastingStore";
     constexpr static uint32_t kCurrentCastingStoreDataVersion       = 1;
     constexpr static uint32_t kSupportedCastingStoreDataVersions[1] = { 1 };

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -537,6 +537,8 @@ private:
     inline size_t GetPathPoolCapacityForReads() const
     {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+        // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
         return (mPathPoolCapacityForReadsOverride == -1) ? CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS
                                                          : static_cast<size_t>(mPathPoolCapacityForReadsOverride);
 #else
@@ -557,6 +559,8 @@ private:
     inline size_t GetPathPoolCapacityForSubscriptions() const
     {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+        // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
         return (mPathPoolCapacityForSubscriptionsOverride == -1) ? CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS
                                                                  : static_cast<size_t>(mPathPoolCapacityForSubscriptionsOverride);
 #else
@@ -568,6 +572,8 @@ private:
     {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
         return (mReadHandlerCapacityForSubscriptionsOverride == -1)
+            // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+            // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
             ? CHIP_IM_MAX_NUM_SUBSCRIPTIONS
             : static_cast<size_t>(mReadHandlerCapacityForSubscriptionsOverride);
 #else

--- a/src/app/SimpleSubscriptionResumptionStorage.h
+++ b/src/app/SimpleSubscriptionResumptionStorage.h
@@ -79,6 +79,8 @@ protected:
         return 2 *
             TLV::EstimateStructOverhead(
                    TLV::EstimateStructOverhead(sizeof(uint8_t), sizeof(EndpointId), sizeof(ClusterId), sizeof(AttributeId)) *
+                   // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+                   // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
                    CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS);
     }
 

--- a/src/app/clusters/bindings/binding-table.h
+++ b/src/app/clusters/bindings/binding-table.h
@@ -131,7 +131,8 @@ class Table
     friend class Iterator;
 
 public:
-    static constexpr size_t kMaxBindingEntries = CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
+    static constexpr size_t kMaxBindingEntries =
+        static_cast<size_t>(CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC) * CHIP_CONFIG_MAX_FABRICS;
     Table();
 
     class Iterator

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -588,8 +588,8 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
         }
 
         // Group2: 40 endpoints from intervals 1-2
-        EndpointId group2_endpoints[2 * kMaxEndpoints];
-        for (size_t i = 0; i < 2 * kMaxEndpoints; i++)
+        EndpointId group2_endpoints[2 * static_cast<size_t>(kMaxEndpoints)];
+        for (size_t i = 0; i < 2 * static_cast<size_t>(kMaxEndpoints); i++)
         {
             group2_endpoints[i] = static_cast<EndpointId>(i + 1);
         }
@@ -598,7 +598,7 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
         EndpointId group3_endpoints[8];
         for (size_t i = 0; i < 8; i++)
         {
-            group3_endpoints[i] = static_cast<EndpointId>(4 * kMaxEndpoints + i + 1);
+            group3_endpoints[i] = static_cast<EndpointId>(4 * static_cast<size_t>(kMaxEndpoints) + i + 1);
         }
 
         Clusters::Groupcast::Structs::MembershipStruct::Type expectedMembership[] = {

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -87,7 +87,7 @@ static constexpr size_t kMaxOneCurrentConnectionSerializedSize =
 
 // Max size for the TLV-encoded array of CurrentConnection structs
 static constexpr size_t kMaxCurrentConnectionsSerializedSize = 2 /* ArrayTlvOverhead */ +
-    (CHIP_CONFIG_MAX_FABRICS * CHIP_CONFIG_MAX_NUM_PUSH_TRANSPORTS * kMaxOneCurrentConnectionSerializedSize);
+    (static_cast<size_t>(CHIP_CONFIG_MAX_FABRICS) * CHIP_CONFIG_MAX_NUM_PUSH_TRANSPORTS * kMaxOneCurrentConnectionSerializedSize);
 
 /**
  * @brief Storage implementation for transport trigger options.

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -65,18 +65,18 @@ enum class CertificateType : uint8_t
     kRoot
 };
 
-static constexpr size_t kPersistentBufferNextIdBytes =
-    EstimateStructOverhead(sizeof(uint16_t), // mNextClientId
-                           sizeof(uint16_t), // mNextRootId,
-                           EstimateStructOverhead(sizeof(CertificateId), sizeof(FabricIndex)) *
-                               (kMaxRootCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS), // mRootCertMapping
-                           EstimateStructOverhead(sizeof(CertificateId), sizeof(FabricIndex)) *
-                               (kMaxClientCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS)); // mClientCertMapping
+static constexpr size_t kPersistentBufferNextIdBytes = EstimateStructOverhead(
+    sizeof(uint16_t), // mNextClientId
+    sizeof(uint16_t), // mNextRootId,
+    EstimateStructOverhead(sizeof(CertificateId), sizeof(FabricIndex)) *
+        (static_cast<size_t>(kMaxRootCertificatesPerFabric) * CHIP_CONFIG_MAX_FABRICS), // mRootCertMapping
+    EstimateStructOverhead(sizeof(CertificateId), sizeof(FabricIndex)) *
+        (static_cast<size_t>(kMaxClientCertificatesPerFabric) * CHIP_CONFIG_MAX_FABRICS)); // mClientCertMapping
 
 class GlobalCertificateData : public PersistableData<kPersistentBufferNextIdBytes>
 {
-    IncrementingIdHelper<CertificateId, kMaxRootCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS> mRoot;
-    IncrementingIdHelper<CertificateId, kMaxClientCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS> mClient;
+    IncrementingIdHelper<CertificateId, static_cast<size_t>(kMaxRootCertificatesPerFabric) * CHIP_CONFIG_MAX_FABRICS> mRoot;
+    IncrementingIdHelper<CertificateId, static_cast<size_t>(kMaxClientCertificatesPerFabric) * CHIP_CONFIG_MAX_FABRICS> mClient;
     EndpointId mEndpointId = kInvalidEndpointId;
 
 public:

--- a/src/lib/support/TimeUtils.cpp
+++ b/src/lib/support/TimeUtils.cpp
@@ -477,12 +477,13 @@ static void SecondsSinceUnixEpochToCalendarTime(uint64_t secondsSinceEpoch, uint
     static_assert((static_cast<uint64_t>(UINT32_MAX) + kChipEpochSecondsSinceUnixEpoch) / kSecondsPerDay <=
                       std::numeric_limits<decltype(daysSinceEpoch)>::max(),
                   "daysSinceEpoch would overflow");
-    uint32_t timeOfDay = static_cast<uint32_t>(secondsSinceEpoch - (daysSinceEpoch * kSecondsPerDay));
+    uint32_t timeOfDay = static_cast<uint32_t>(secondsSinceEpoch - (static_cast<uint64_t>(daysSinceEpoch) * kSecondsPerDay));
 
     // Note: This call to DaysSinceUnixEpochToCalendarDate can't fail, because we
     // can't overflow a uint16_t year with a muximum possible value of the
     // secondsSinceEpoch input.
-    static_assert((static_cast<uint64_t>(UINT32_MAX) + kChipEpochSecondsSinceUnixEpoch) / (kDaysPerStandardYear * kSecondsPerDay) +
+    static_assert((static_cast<uint64_t>(UINT32_MAX) + kChipEpochSecondsSinceUnixEpoch) /
+                              (static_cast<uint64_t>(kDaysPerStandardYear) * kSecondsPerDay) +
                           1 <=
                       std::numeric_limits<std::remove_reference<decltype(year)>::type>::max(),
                   "What happened to our year or day lengths?");

--- a/src/lib/support/tests/TestPrivateHeap.cpp
+++ b/src/lib/support/tests/TestPrivateHeap.cpp
@@ -99,7 +99,7 @@ TEST(TestPrivateHeap, TestSplitHeapAllocAndFree)
 
 TEST(TestPrivateHeap, TestFreeMergeNext)
 {
-    PrivateHeapAllocator<5 * 16> allocator;
+    PrivateHeapAllocator<static_cast<size_t>(5) * 16> allocator;
 
     void * p1 = allocator.HeapAlloc(16);
     void * p2 = allocator.HeapAlloc(16);
@@ -115,14 +115,14 @@ TEST(TestPrivateHeap, TestFreeMergeNext)
     allocator.HeapFree(p1);
     allocator.HeapFree(p2);
 
-    p1 = allocator.HeapAlloc(3 * 16);
+    p1 = allocator.HeapAlloc(static_cast<size_t>(3) * 16);
     ASSERT_NE(nullptr, p1);
     allocator.HeapFree(p1);
 }
 
 TEST(TestPrivateHeap, TestFreeMergePrevious)
 {
-    PrivateHeapAllocator<5 * 16> allocator;
+    PrivateHeapAllocator<static_cast<size_t>(5) * 16> allocator;
 
     void * p1 = allocator.HeapAlloc(16);
     void * p2 = allocator.HeapAlloc(16);
@@ -137,7 +137,7 @@ TEST(TestPrivateHeap, TestFreeMergePrevious)
     // freeing 2,1 should clear space
     allocator.HeapFree(p2);
     allocator.HeapFree(p1);
-    p1 = allocator.HeapAlloc(3 * 16);
+    p1 = allocator.HeapAlloc(static_cast<size_t>(3) * 16);
     ASSERT_NE(nullptr, p1);
     allocator.HeapFree(p1);
 }
@@ -145,7 +145,7 @@ TEST(TestPrivateHeap, TestFreeMergePrevious)
 TEST(TestPrivateHeap, TestFreeMergePreviousAndNext)
 {
 
-    PrivateHeapAllocator<7 * 16> allocator;
+    PrivateHeapAllocator<static_cast<size_t>(7) * 16> allocator;
 
     void * p1 = allocator.HeapAlloc(16);
     void * p2 = allocator.HeapAlloc(16);
@@ -167,7 +167,7 @@ TEST(TestPrivateHeap, TestFreeMergePreviousAndNext)
 
     // Freeing p2 makes enoug space
     allocator.HeapFree(p2);
-    p1 = allocator.HeapAlloc(5 * 16);
+    p1 = allocator.HeapAlloc(static_cast<size_t>(5) * 16);
     ASSERT_NE(nullptr, p1);
     allocator.HeapFree(p1);
 }
@@ -295,7 +295,7 @@ bool IsKnownPattern(void * buffer, size_t size, uint8_t start)
 
 TEST(TestPrivateHeap, TestRealloc)
 {
-    PrivateHeapAllocator<6 * 16> allocator;
+    PrivateHeapAllocator<static_cast<size_t>(6) * 16> allocator;
 
     void * p1 = allocator.HeapRealloc(nullptr, 16); // malloc basically
     ASSERT_NE(p1, nullptr);

--- a/src/lwip/standalone/sys_arch.c
+++ b/src/lwip/standalone/sys_arch.c
@@ -478,7 +478,7 @@ static u32_t cond_wait(pthread_cond_t * cond, pthread_mutex_t * mutex, u32_t tim
         gettimeofday(&rtime1, NULL);
         sec  = rtime1.tv_sec;
         usec = rtime1.tv_usec;
-        usec += timeout % 1000 * 1000;
+        usec += (time_t) (timeout % 1000) * 1000;
         sec += (int) (timeout / 1000) + (int) (usec / 1000000);
         usec       = usec % 1000000;
         ts.tv_nsec = usec * 1000;

--- a/src/messaging/tests/echo/common.h
+++ b/src/messaging/tests/echo/common.h
@@ -33,7 +33,7 @@
 
 inline constexpr size_t kMaxTcpActiveConnectionCount = 4;
 inline constexpr size_t kMaxTcpPendingPackets        = 4;
-inline constexpr size_t kNetworkSleepTimeMsecs       = (100 * 1000);
+inline constexpr size_t kNetworkSleepTimeMsecs       = (static_cast<size_t>(100) * 1000);
 
 extern chip::FabricTable gFabricTable;
 extern chip::SessionManager gSessionManager;

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -230,7 +230,7 @@ CHIP_ERROR ChipLinuxStorage::WriteValueStr(const char * key, const char * val)
 
 CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * data, size_t dataLen)
 {
-    static const size_t kMaxBlobSize = 10 * 1024;
+    static const size_t kMaxBlobSize = static_cast<size_t>(10) * 1024;
 
     CHIP_ERROR retval = CHIP_NO_ERROR;
     chip::Platform::ScopedMemoryBuffer<char> encodedData;

--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -90,6 +90,8 @@ CHIP_ERROR DefaultSessionResumptionStorage::Save(const ScopedNodeId & node, Cons
         }
     }
 
+    // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+    // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
     if (index.mSize == CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE)
     {
         // TODO: implement LRU for resumption

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.h
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.h
@@ -65,6 +65,8 @@ private:
     static constexpr size_t MaxIndexSize()
     {
         // The max size of the list is (1 byte control + bytes for actual value) times max number of list items
+        // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+        // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
         return TLV::EstimateStructOverhead((1 + MaxScopedNodeIdSize()) * CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE);
     }
 

--- a/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
@@ -54,6 +54,8 @@ TEST(TestDefaultSessionResumptionStorage, TestSave)
     }
 
     // Fill storage.
+    // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+    // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
     for (size_t i = 0; i < CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE; ++i)
     {
         EXPECT_EQ(sessionStorage.Save(vectors[i].node, vectors[i].resumptionId, vectors[i].sharedSecret, vectors[i].cats),
@@ -120,6 +122,8 @@ TEST(TestDefaultSessionResumptionStorage, TestInPlaceSave)
     // Construct only a few unique node identities to simulate talking to a
     // couple peers.
     chip::ScopedNodeId nodes[3];
+    // Constant product inside a CHIPConfig.h macro; cannot widen at the use site.
+    // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
     static_assert(MATTER_ARRAY_SIZE(nodes) < CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE,
                   "must have fewer nodes than slots in session resumption storage");
     for (size_t i = 0; i < MATTER_ARRAY_SIZE(nodes); ++i)

--- a/src/setup_payload/Base38Encode.cpp
+++ b/src/setup_payload/Base38Encode.cpp
@@ -51,7 +51,8 @@ CHIP_ERROR base38Encode(ByteSpan in_buf, MutableCharSpan & out_buf)
     while (in_buf_len > 0)
     {
         uint32_t value = 0;
-        static_assert((sizeof(value) * CHAR_BIT) >= (kMaxBytesSingleChunkLen * 8), "Type for value is too small for conversions");
+        static_assert((sizeof(value) * CHAR_BIT) >= (static_cast<size_t>(kMaxBytesSingleChunkLen) * 8),
+                      "Type for value is too small for conversions");
 
         size_t bytesInChunk = (in_buf_len >= kMaxBytesSingleChunkLen) ? kMaxBytesSingleChunkLen : in_buf_len;
 


### PR DESCRIPTION
#### Summary

Enables the `bugprone-implicit-widening-of-multiplication-result` clang-tidy check (removes it from the disabled list in `.clang-tidy`) and resolves all existing violations so it gates new code.

The check flags `int * int` (or narrower) multiplications whose result is implicitly widened to a larger type — the product is computed in the narrow type and can overflow *before* the widening. The motivating real bug was `SecondsToMilliseconds` (fixed separately in #72508).

#### Approach

- **Most sites — widen one operand** (`static_cast<size_t>` / `static_cast<int64_t>` / `static_cast<uint64_t>`) so the multiplication is performed in the target type. These are buffer/size estimates, durations, and config-derived constants.
- **7 sites — `NOLINT`** where the multiplication lives inside a `CHIPConfig.h` macro (`CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE` and the `CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_*` / `CHIP_IM_MAX_NUM_SUBSCRIPTIONS` family). The operands are small compile-time constants that cannot overflow, and widening the shared macro definition would change its type across the whole tree. Suppressing at the use site is the localized, side-effect-free choice.

#### Testing

- Built and ran the affected unit tests under the default ASan/`-Werror`/`-Wconversion` config — all pass (TestTimeUtils, TestPrivateHeap, TestGroupcastCluster, TestDefaultSessionResumptionStorage, TestBindingTable, TestCertificateTableImpl, TestSimpleSessionResumptionStorage, TestInteractionModelEngine, TestPushAVStreamTransportStorage, TestSetupPayload).
- Ran clang-tidy with only this check across the linux all-clusters / all-devices / tests compile databases: **0 remaining findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)