### PR TITLE
Add nightly whole-tree clang-tidy job publishing SARIF to Code Scanning

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,12 +17,12 @@ on:
     schedule:
       - cron: '0 0 * * *'
 # --- TEST SECTION: Uncomment below to test on PRs ---
-    # push:
-    #     branches:
-    #         - master
-    #         - 'v*-branch'
-    # pull_request:
-    # merge_group:
+    push:
+        branches:
+            - master
+            - 'v*-branch'
+    pull_request:
+    merge_group:
 # --- END TEST SECTION ---
     workflow_dispatch:
         inputs:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -439,3 +439,95 @@ jobs:
               uses: ./.github/actions/notify-slack-failure
               with:
                 slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}
+
+    # Whole-tree clang-tidy using the stock bootstrap clang-tidy and the repo
+    # .clang-tidy check set (no custom/patched binary, no --checks override),
+    # published to GitHub Code Scanning as SARIF. ADVISORY: never blocks.
+    nightly_clang_tidy_sarif:
+        name: Nightly clang-tidy whole-tree (.clang-tidy) -> Code Scanning
+        if: github.actor != 'restyled-io[bot]'
+        permissions:
+            contents: read
+            security-events: write
+        env:
+            DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}
+            CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
+
+        # CPU-bound whole-tree scan; same class of runner as the other build jobs.
+        runs-on: namespace-profile-4x16
+
+        container:
+            image: ghcr.io/project-chip/chip-build:200
+            volumes:
+                - /var/run/nsc/:/var/run/nsc/
+            env:
+                NSC_TOKEN_FILE: ${{ env.NSC_TOKEN_FILE }}
+                NAMESPACE_ACTIONS_RESULTS_URL: ${{ env.NAMESPACE_ACTIONS_RESULTS_URL }}
+                NAMESPACE_ACTIONS_RESULTS_SERVICE: ${{ env.NAMESPACE_ACTIONS_RESULTS_SERVICE }}
+                NAMESPACE_ACTIONS_DIRECT_ZIP_UPLOAD: ${{ env.NAMESPACE_ACTIONS_DIRECT_ZIP_UPLOAD }}
+            options: --privileged
+
+        steps:
+            - name: Set up additional environment
+              run: echo "CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache" >> $GITHUB_ENV
+            - name: Checkout
+              uses: actions/checkout@v6.0.3
+            - name: Checkout submodules & Bootstrap
+              uses: ./.github/actions/checkout-submodules-and-bootstrap
+              with:
+                  platform: linux
+                  bootstrap-log-name: bootstrap-logs-clang-tidy-sarif
+            - name: Setup and Restore ccache
+              uses: ./.github/actions/setup-ccache
+              with:
+                  disable: ${{ env.DISABLE_CCACHE }}
+                  cache-suffix: ${{ env.CCACHE_KEY_SUFFIX }}
+
+            # Plain host config (NO sanitizers — clang-tidy ignores -fsanitize).
+            # gn_gen writes the compile DB; `ninja -k 0 ... || true` then builds so the
+            # zap-generated headers exist on disk (a TU only parses when its generated
+            # headers are present). chip_build_tests=true pulls the whole src/ tree into
+            # the graph so those headers get generated; without it ~all cluster TUs fail
+            # to parse (missing headers) and produce no findings. We build but never run
+            # the suite (no `ninja check`); -k 0 || true tolerates pw_pystamp test stamps
+            # that execute during the build.
+            - name: Generate compile DB (host build for generated headers)
+              run: >-
+                  ./scripts/run_in_build_env.sh "
+                  BUILD_TYPE=host scripts/build/gn_gen.sh --args='is_clang=true chip_build_tests=true' --add-export-compile-commands=* &&
+                  (ninja -k 0 -C out/host || true)"
+
+            # Stock bootstrap clang-tidy (resolved on PATH inside the build env) + the
+            # repo .clang-tidy check set: no custom/patched binary, no --checks override.
+            # Advisory: `|| true` so findings never fail the job.
+            #
+            # ci-apply-runner-overrides.py injects CI-only mechanics the runner exposes
+            # no flag for: -Wno-error (compile commands
+            # carry -Werror; glib system-header warnings would otherwise abort ~200 TUs
+            # before the check runs), --header-filter=src/ (frontend checks hide
+            # header-located findings) and --warnings-as-errors=-* (a TU that merely HAS
+            # a finding is not miscounted as a failed TU). These do not change the check
+            # set — only the repo .clang-tidy decides that.
+            #
+            # CodegenIntegration excluded: those TUs hard-include a specific app's
+            # generated static-cluster-config header a single host build cannot produce
+            # for every cluster (benign "file not found", not a real finding).
+            - name: Run clang-tidy (whole tree, advisory)
+              run: |
+                  python3 scripts/tools/clang-tidy/ci-apply-runner-overrides.py
+                  ./scripts/run_in_build_env.sh './scripts/run-clang-tidy-on-compile-commands.py --compile-database out/host/compile_commands.json --file-include-regex "(src|examples)/" --file-exclude-regex "/(repo|zzz_generated|lwip)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting|/tests/|CodegenIntegration" check' 2>&1 | tee clang-tidy.log || true
+
+            - name: Convert clang-tidy log to SARIF
+              run: python3 scripts/tools/clang-tidy/clang_tidy_to_sarif.py clang-tidy.log --repo-root . > clang-tidy.sarif
+
+            - name: Upload SARIF to Code Scanning
+              uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+              with:
+                  sarif_file: clang-tidy.sarif
+                  category: clang-tidy
+
+            - name: Notify Slack on Failure
+              if: failure()
+              uses: ./.github/actions/notify-slack-failure
+              with:
+                slack-webhook: ${{ secrets.SWTT_SLACK_WEBHOOK }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -517,8 +517,10 @@ jobs:
                   python3 scripts/tools/clang-tidy/ci-apply-runner-overrides.py
                   ./scripts/run_in_build_env.sh './scripts/run-clang-tidy-on-compile-commands.py --compile-database out/host/compile_commands.json --file-include-regex "(src|examples)/" --file-exclude-regex "/(repo|zzz_generated|lwip)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting|/tests/|CodegenIntegration" check' 2>&1 | tee clang-tidy.log || true
 
+            # --build-dir matches the compile DB above: the runner emits diagnostic
+            # paths relative to out/host, so the converter must resolve them there.
             - name: Convert clang-tidy log to SARIF
-              run: python3 scripts/tools/clang-tidy/clang_tidy_to_sarif.py clang-tidy.log --repo-root . > clang-tidy.sarif
+              run: python3 scripts/tools/clang-tidy/clang_tidy_to_sarif.py clang-tidy.log --repo-root . --build-dir out/host > clang-tidy.sarif
 
             - name: Upload SARIF to Code Scanning
               uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e

--- a/scripts/tools/clang-tidy/ci-apply-runner-overrides.py
+++ b/scripts/tools/clang-tidy/ci-apply-runner-overrides.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Inject CI-only clang-tidy overrides into run-clang-tidy-on-compile-commands.py.
+
+The shared runner exposes no flag for these, so the nightly whole-tree scan patches
+the (ephemeral CI checkout of the) runner in place. This never lands in a commit of
+the runner itself, so the PR clang-tidy job is unaffected. Rationale:
+
+  -Wno-error               The compile commands carry -Werror. Warnings clang-tidy
+                           emits but the original build does not
+                           (clang-diagnostic-missing-format-attribute,
+                           -thread-safety-attributes) become fatal, so ~200 TUs abort
+                           with "Found compiler error(s)" before the check ever runs.
+  --header-filter=src/     Frontend checks (bugprone-*) do NOT display a finding whose
+                           location is a header unless this is set; much C++ code is
+                           inline in headers/templates.
+  --warnings-as-errors=-*  Override the repo .clang-tidy WarningsAsErrors:'*' so a TU
+                           that merely HAS a finding exits 0 and is not miscounted as a
+                           failed/aborted TU (keeps "Failed to process" honest).
+
+Idempotent. Asserts the anchor still exists so a future runner rewrite fails loudly
+(re-roll the overrides) instead of silently scanning ~all TUs broken again.
+"""
+import sys
+
+RUNNER = "scripts/run-clang-tidy-on-compile-commands.py"
+ANCHOR = "            self.clang_arguments = command_items[1:]\n"
+INJECT = (
+    '            self.clang_arguments.append("-Wno-error")\n'
+    '            self.tidy_arguments.append("--header-filter=src/")\n'
+    '            self.tidy_arguments.append("--warnings-as-errors=-*")\n'
+)
+
+
+def main() -> int:
+    with open(RUNNER, encoding="utf-8") as fh:
+        src = fh.read()
+    if '"-Wno-error"' in src and "--header-filter=src/" in src:
+        print("runner already patched; nothing to do")
+        return 0
+    if ANCHOR not in src:
+        print(f"ERROR: anchor not found in {RUNNER}; re-roll the CI overrides", file=sys.stderr)
+        return 1
+    with open(RUNNER, "w", encoding="utf-8") as fh:
+        fh.write(src.replace(ANCHOR, ANCHOR + INJECT, 1))
+    print(f"patched {RUNNER} with CI clang-tidy overrides")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/clang-tidy/ci-apply-runner-overrides.py
+++ b/scripts/tools/clang-tidy/ci-apply-runner-overrides.py
@@ -20,9 +20,13 @@ the runner itself, so the PR clang-tidy job is unaffected. Rationale:
 Idempotent. Asserts the anchor still exists so a future runner rewrite fails loudly
 (re-roll the overrides) instead of silently scanning ~all TUs broken again.
 """
+import os
 import sys
 
-RUNNER = "scripts/run-clang-tidy-on-compile-commands.py"
+# Resolve the runner relative to this script so it works regardless of CWD.
+RUNNER = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "run-clang-tidy-on-compile-commands.py")
+)
 ANCHOR = "            self.clang_arguments = command_items[1:]\n"
 INJECT = (
     '            self.clang_arguments.append("-Wno-error")\n'

--- a/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
+++ b/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
@@ -61,7 +61,11 @@ def to_repo_relative(path, repo_root):
     """Resolve a diagnostic path to a repo-root-relative POSIX path, or None if
     it lands outside the repo (system / third-party headers)."""
     abs_path = path if os.path.isabs(path) else os.path.join(repo_root, path)
-    rel = os.path.relpath(os.path.realpath(abs_path), repo_root)
+    try:
+        rel = os.path.relpath(os.path.realpath(abs_path), repo_root)
+    except ValueError:
+        # Different drives on Windows -> not under the repo root.
+        return None
     if rel.startswith(".."):
         return None
     return rel.replace(os.sep, "/")
@@ -76,13 +80,17 @@ def main():
     args = ap.parse_args()
 
     repo_root = os.path.realpath(args.repo_root)
-    stream = open(args.log, encoding="utf-8", errors="replace") if args.log else sys.stdin
+    if args.log:
+        with open(args.log, encoding="utf-8", errors="replace") as fh:
+            raw_lines = fh.readlines()
+    else:
+        raw_lines = sys.stdin.readlines()
 
     rules = {}      # check-name -> rule object
     results = []
     seen = set()    # dedup (rel, line, col, check, msg)
 
-    for raw in stream:
+    for raw in raw_lines:
         m = DIAG_RE.search(raw.rstrip("\n"))
         if not m:
             continue

--- a/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
+++ b/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
@@ -57,10 +57,17 @@ def check_help_uri(check):
     return CLANG_TIDY_CHECKS_URL
 
 
-def to_repo_relative(path, repo_root):
+def to_repo_relative(path, repo_root, base_dir):
     """Resolve a diagnostic path to a repo-root-relative POSIX path, or None if
-    it lands outside the repo (system / third-party headers)."""
-    abs_path = path if os.path.isabs(path) else os.path.join(repo_root, path)
+    it lands outside the repo (system / third-party headers).
+
+    Relative paths are resolved against base_dir, the directory the compile
+    commands ran from. run-clang-tidy-on-compile-commands.py replays each command
+    with cwd=<build dir>, so clang-tidy emits paths relative to that dir (e.g.
+    '../../src/foo.h' from out/host) -- NOT relative to the repo root. Anchoring
+    them at repo_root instead would push every '../..'-prefixed path above the
+    root and silently drop it."""
+    abs_path = path if os.path.isabs(path) else os.path.join(base_dir, path)
     try:
         rel = os.path.relpath(os.path.realpath(abs_path), repo_root)
     except ValueError:
@@ -76,10 +83,15 @@ def main():
     ap.add_argument("log", nargs="?", help="clang-tidy log file (default: stdin)")
     ap.add_argument("--repo-root", default=os.getcwd(),
                     help="repo root for relativizing paths (default: cwd)")
+    ap.add_argument("--build-dir",
+                    help="directory the compile commands ran from (e.g. out/host); "
+                         "relative diagnostic paths are resolved against it "
+                         "(default: repo root)")
     ap.add_argument("--tool-name", default="clang-tidy")
     args = ap.parse_args()
 
     repo_root = os.path.realpath(args.repo_root)
+    base_dir = os.path.realpath(args.build_dir) if args.build_dir else repo_root
     if args.log:
         with open(args.log, encoding="utf-8", errors="replace") as fh:
             raw_lines = fh.readlines()
@@ -94,7 +106,7 @@ def main():
         m = DIAG_RE.search(raw.rstrip("\n"))
         if not m:
             continue
-        rel = to_repo_relative(m["path"], repo_root)
+        rel = to_repo_relative(m["path"], repo_root, base_dir)
         if rel is None:
             continue
         line, col = int(m["line"]), int(m["col"])

--- a/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
+++ b/scripts/tools/clang-tidy/clang_tidy_to_sarif.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert clang-tidy text diagnostics to SARIF 2.1.0 for GitHub Code Scanning.
+
+Reads the combined log produced by run-clang-tidy-on-compile-commands.py (or raw
+clang-tidy output) and extracts the standard diagnostic lines:
+
+    <path>:<line>:<col>: warning|error: <message> [<check-name>]
+
+Paths are normalized to repo-root-relative so Code Scanning can map them to
+source. Stdlib only.
+
+Usage:
+    clang_tidy_to_sarif.py [LOG] --repo-root . > clang-tidy.sarif
+    (LOG defaults to stdin)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# A clang-tidy diagnostic line. The path token excludes whitespace and quotes so
+# it survives the runner's `TIDY <file>: '<output>'` log wrapping; on Linux paths
+# contain no ':' before the line/col, so ':' also terminates the path.
+# Greedy msg so the LAST bracket is taken as the check name; tolerate a trailing
+# quote because run-clang-tidy-on-compile-commands.py wraps output as `'<output>'`,
+# so the final diagnostic line ends with `]'`.
+DIAG_RE = re.compile(
+    r"(?P<path>[^\s'\":]+):(?P<line>\d+):(?P<col>\d+):\s+"
+    r"(?P<level>warning|error):\s+(?P<msg>.*)\s+\[(?P<checks>[A-Za-z][\w.,-]*)\]'?\s*$"
+)
+
+CLANG_TIDY_CHECKS_URL = "https://clang.llvm.org/extra/clang-tidy/checks/list.html"
+
+
+def check_help_uri(check):
+    """Best-effort doc URL for a clang-tidy check (module-name/check-name.html)."""
+    if "-" in check:
+        module, name = check.split("-", 1)
+        return f"https://clang.llvm.org/extra/clang-tidy/checks/{module}/{name}.html"
+    return CLANG_TIDY_CHECKS_URL
+
+
+def to_repo_relative(path, repo_root):
+    """Resolve a diagnostic path to a repo-root-relative POSIX path, or None if
+    it lands outside the repo (system / third-party headers)."""
+    abs_path = path if os.path.isabs(path) else os.path.join(repo_root, path)
+    rel = os.path.relpath(os.path.realpath(abs_path), repo_root)
+    if rel.startswith(".."):
+        return None
+    return rel.replace(os.sep, "/")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("log", nargs="?", help="clang-tidy log file (default: stdin)")
+    ap.add_argument("--repo-root", default=os.getcwd(),
+                    help="repo root for relativizing paths (default: cwd)")
+    ap.add_argument("--tool-name", default="clang-tidy")
+    args = ap.parse_args()
+
+    repo_root = os.path.realpath(args.repo_root)
+    stream = open(args.log, encoding="utf-8", errors="replace") if args.log else sys.stdin
+
+    rules = {}      # check-name -> rule object
+    results = []
+    seen = set()    # dedup (rel, line, col, check, msg)
+
+    for raw in stream:
+        m = DIAG_RE.search(raw.rstrip("\n"))
+        if not m:
+            continue
+        rel = to_repo_relative(m["path"], repo_root)
+        if rel is None:
+            continue
+        line, col = int(m["line"]), int(m["col"])
+        # The bracket can carry the WarningsAsErrors suffix (e.g.
+        # "[bugprone-foo,-warnings-as-errors]"); the primary check is first.
+        check = m["checks"].split(",")[0].strip()
+        # Skip compiler diagnostics (clang-diagnostic-*): these are build errors
+        # (e.g. a TU that failed to parse due to a missing generated header), not
+        # clang-tidy lint findings — they would be noise in Code Scanning.
+        if check.startswith("clang-diagnostic"):
+            continue
+        msg = m["msg"].strip()
+        level = "error" if m["level"] == "error" else "warning"
+
+        key = (rel, line, col, check, msg)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        if check not in rules:
+            rules[check] = {
+                "id": check,
+                "name": check,
+                "shortDescription": {"text": check},
+                "helpUri": check_help_uri(check),
+            }
+        results.append({
+            "ruleId": check,
+            "level": level,
+            "message": {"text": msg},
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": rel},
+                    "region": {"startLine": line, "startColumn": col},
+                }
+            }],
+        })
+
+    sarif = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {
+                "name": args.tool_name,
+                "informationUri": "https://clang.llvm.org/extra/clang-tidy/",
+                "rules": list(rules.values()),
+            }},
+            "results": results,
+        }],
+    }
+    json.dump(sarif, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    print(f"clang_tidy_to_sarif: {len(results)} results, {len(rules)} rules",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Summary

Adds an advisory nightly clang-tidy job that scans the whole tree with the existing `.clang-tidy` check set and publishes results to GitHub Code Scanning as SARIF.

##### Problem

-   clang-tidy currently runs only on **changed files** at PR time (`build.yaml`). There is no whole-tree signal, so pre-existing violations in untouched files are never surfaced or tracked.

##### Solution

-   New non-blocking `nightly_clang_tidy_sarif` job in the daily workflow:
    -   Runs the **stock bootstrap clang-tidy** over `src/` and `examples/` using the repo `.clang-tidy` as-is — no patched binary, no `--checks` override.
    -   Converts diagnostics to SARIF 2.1.0 and uploads to Code Scanning (category `clang-tidy`). Findings appear as alerts; `|| true` keeps them from failing the run.
-   Builds a plain host config solely to materialize the zap-generated headers the TUs need (`chip_build_tests=true`, `ninja -k 0 || true`; the unit-test suite is not run), then scans that compile DB.
-   Two helpers under `scripts/tools/clang-tidy/`:
    -   `clang_tidy_to_sarif.py` — text diagnostics to SARIF, repo-root-relative paths, dropping `clang-diagnostic-*` build noise and out-of-tree headers.
    -   `ci-apply-runner-overrides.py` — injects CI-only mechanics the shared runner exposes no flag for: `-Wno-error` (glib `-Werror` system-header warnings would otherwise abort TUs before the check runs), `--header-filter=src/` (frontend checks otherwise hide header-located findings), `--warnings-as-errors=-*` (a TU that merely has a finding is not miscounted as failed). The check set is unchanged.

##### Caveats

-   Advisory only; does not gate merges and does not modify `.clang-tidy`. The PR-time changed-files clang-tidy job is unaffected.
-   `clang-analyzer-*` checks in `.clang-tidy` are slow over a whole-tree run; the nightly cadence absorbs this.
-   The final `TEMP (do not merge)` commit uncomments the workflow's test-section triggers (`push`/`pull_request`/`merge_group`) so this job runs on the PR for validation. It must be reverted before this PR leaves draft.

#### Testing

-   Validated `nightly.yaml` parses and the new job is registered under `jobs`.
-   Dry-ran `ci-apply-runner-overrides.py` against the current runner: the injection anchor matches and the three overrides apply idempotently.
-   Smoke-tested `clang_tidy_to_sarif.py`: emits SARIF results for both `.cpp` and header findings, and drops `clang-diagnostic-*` and out-of-tree (system-header) lines.
-   End-to-end whole-tree run is exercised by this draft PR's nightly run (via the `TEMP` commit's PR triggers).