### PR TITLE
[gn] Clean up matter_build_venv by removing chef and pw_rpc

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -97,12 +97,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     # NOTE: Don't add "$dir_pw_env_setup:core_pigweed_python_packages"  here since it
     # pulls in a large number of dependencies that we are not using;  instead add dependencies
     # on the relevant pigweed modules via python_deps where they are needed.
-    source_packages = [
-      "//examples/chef",
-      "//examples/common/pigweed/rpc_console/py:chip_rpc",
-      "//integrations/mobly:chip_mobly",
-      "//src/python_testing/matter_testing_infrastructure:matter-testing",
-    ]
+    source_packages = [ "//integrations/mobly:chip_mobly" ]
   }
 
   pw_python_pip_install("pip_install_matter_packages") {


### PR DESCRIPTION
#### Summary

Problem: `matter_build_venv` in `BUILD.gn` contains packages (`chef` and `pw_rpc`) that are unrelated to building Matter. This slows down GN build generation and causes conceptual confusion.

Impact: Slower virtual environment creation during GN build generation and potential for unstable build baselines if testing or example tools evolve.

Solution: Removed `chef` and `chip_rpc` from `matter_build_venv`'s `source_packages`. Confirmed that core SDK and standard example builds execute successfully without them.

#### Testing

• Compiled standard example applications (`linux-x64-all-clusters-clang`) to ensure no GN build steps (`python_action`) depend on the removed packages.
