### PR TITLE
[Silabs]Reduce Silabs CI time by removing the # of builds

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -64,30 +64,15 @@ jobs:
       #   run: |
       #     scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
       #     rm -rf ./out/
-      - name: Build some BRD4187C variants (1)
+      - name: Build some BRD4187C variants
         # TODO #39216 : Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
-                --enable-flashbundle \
                 --target efr32-brd4187c-all-devices \
-                --target efr32-brd4187c-light \
-                --target efr32-brd4187c-thermostat-use-ot-lib \
-                --target efr32-brd4187c-switch-shell-use-ot-coap-lib \
-                build \
-                --copy-artifacts-to out/artifacts \
-             "
-      - name: Clean out build output
-        run: rm -rf ./out
-      - name: Build some BRD4187C variants (2)
-        run: |
-          ./scripts/run_in_build_env.sh \
-             "./scripts/build/build_examples.py \
-                --enable-flashbundle \
+                --target efr32-brd4187c-light-shell-use-ot-lib \
+                --target efr32-brd4187c-switch-use-ot-coap-lib-additional-data-advertising \
                 --target efr32-brd4187c-lock-rpc \
-                --target efr32-brd4187c-air-quality-sensor-app-shell-heap-monitoring \
-                --target efr32-brd4187c-window-covering-additional-data-advertising \
-                --target efr32-brd4187c-closure \
                 build \
                 --copy-artifacts-to out/artifacts \
              "
@@ -98,8 +83,8 @@ jobs:
              out/efr32-brd4187c-lock-rpc/matter-silabs-lock-example.out \
              /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py  \
-             efr32 BRD4187C window-app \
-             out/efr32-brd4187c-window-covering-additional-data-advertising/matter-silabs-window-example.out \
+             efr32 BRD4187C lighting-app \
+             out/efr32-brd4187c-light/matter-silabs-lighting-example.out \
              /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
@@ -107,10 +92,8 @@ jobs:
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
-                --enable-flashbundle \
-                --target efr32-brd2605a-light-skip-rps-generation \
                 --target efr32-brd4338a-lock-skip-rps-generation \
-                --target efr32-brd4338a-closure-skip-rps-generation \
+                --target efr32-brd2605a-closure-skip-rps-generation \
                 build \
                 --copy-artifacts-to out/artifacts \
              "
@@ -126,20 +109,18 @@ jobs:
       #   run: |
       #     scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app-clang BRD4187C --uart_log is_clang=true
       #     rm -rf ./out/
-          
+
       - name: Clean out build output
         run: rm -rf ./out
       - name: Build EFR32 with WiFi NCP
         run: |
           ./scripts/run_in_build_env.sh \
             "./scripts/build/build_examples.py \
-                --enable-flashbundle \
                 --target efr32-brd4187c-lock-wifi-siwx917 \
                 build \
                 --copy-artifacts-to out/artifacts \
             "
-      - name: Clean out build output
-        run: rm -rf ./out
+
       - name: Uploading Size Reports
         uses: ./.github/actions/upload-size-reports
         if: ${{ !env.ACT }}

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -84,7 +84,7 @@ jobs:
              /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py  \
              efr32 BRD4187C lighting-app \
-             out/efr32-brd4187c-light/matter-silabs-lighting-example.out \
+             out/efr32-brd4187c-light-shell-use-ot-lib/matter-silabs-lighting-example.out \
              /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out


### PR DESCRIPTION
### Summary
Silabs CI time is currently above 60 minutes.

- Reduce the number of different apps built across Thread and Wifi platforms.
- Keep apps or option combination that are relevant to us.
- Replace Window-app by Lighting-app for the code bloat check.
- Remove flash-bundle action. It is not relevant for the ci.
- In total, 5 target have been removed.

### Related issues
N/A

### Testing
N/A The remaining build should complete normally.
