### PR TITLE
[wifipaf] Release owned PacketBuffers in WiFiPAFEndPoint::ClearAll()

### DIFF
--- a/src/wifipaf/WiFiPAFEndPoint.cpp
+++ b/src/wifipaf/WiFiPAFEndPoint.cpp
@@ -1316,8 +1316,37 @@ void WiFiPAFEndPoint::HandleWaitResourceTimeout(chip::System::Layer * systemLaye
 
 void WiFiPAFEndPoint::ClearAll()
 {
-    memset(reinterpret_cast<uint8_t *>(this), 0, sizeof(WiFiPAFEndPoint));
-    return;
+    // Return the end point to the free state the pool relies on (GetFree()/Find() key off
+    // mWiFiPafLayer == nullptr). The endpoint owns ref-counted PacketBufferHandles (mSendQueue,
+    // mAckToSend, ReorderQueue and buffers inside mPafTP); release those explicitly, then reset
+    // the trivially-copyable state. Any owning member added here later must be released too.
+    mSendQueue = nullptr;
+    mAckToSend = nullptr;
+    for (auto & queued : ReorderQueue)
+    {
+        queued = nullptr;
+    }
+    ItemsInReorderQueue = 0;
+    mPafTP.ClearRxPacket();
+    mPafTP.ClearTxPacket();
+
+    mWiFiPafLayer           = nullptr;
+    mOnPafSubscribeComplete = nullptr;
+    mOnPafSubscribeError    = nullptr;
+    mAppState               = nullptr;
+    OnMessageReceived       = nullptr;
+    OnConnectionClosed      = nullptr;
+
+    mState = kState_Ready;
+    mRole  = kWiFiPafRole_Publisher;
+    mRxAck = 0;
+    mConnStateFlags.ClearAll();
+    mTimerStateFlags.ClearAll();
+    mLocalReceiveWindowSize  = 0;
+    mRemoteReceiveWindowSize = 0;
+    mReceiveWindowMaxSize    = 0;
+    mResourceWaitCount       = 0;
+    mSessionInfo             = WiFiPAFSession{};
 }
 
 } /* namespace WiFiPAF */

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -488,5 +488,5 @@ TEST_F(TestWiFiPAFLayer, SubscriberNonFatalCloseReleasesPendingAck)
     EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
 }
 #endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
-}; // namespace WiFiPAF
-}; // namespace chip
+};     // namespace WiFiPAF
+};     // namespace chip

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -415,7 +415,10 @@ TEST_F(TestWiFiPAFLayer, CheckRunAsCommissionee)
     EpDoClose(kWiFiPAFCloseFlag_AbortTransmission, WIFIPAF_ERROR_APP_CLOSED_CONNECTION);
 }
 
-#if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
+// kSystemLayer_NumPacketBufs only exists as a single counter when packet buffers are not the
+// custom-pool LWIP configuration (which splits the counter per pool via lwippools.h), so guard
+// these counter-based checks the same way SystemStats.h declares the entry.
+#if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS && !(CHIP_SYSTEM_CONFIG_USE_LWIP && CHIP_SYSTEM_CONFIG_LWIP_PBUF_FROM_CUSTOM_POOL)
 // ClearAll() must release any PacketBufferHandle the endpoint still owns. Park one in a handle
 // member, then check ClearAll() returns it to the pool.
 TEST_F(TestWiFiPAFLayer, ClearAllReleasesOwnedBuffer)
@@ -487,6 +490,6 @@ TEST_F(TestWiFiPAFLayer, SubscriberNonFatalCloseReleasesPendingAck)
 
     EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
 }
-#endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
+#endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS && !(custom-pool LWIP)
 };     // namespace WiFiPAF
 };     // namespace chip

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -33,6 +33,7 @@
 #include <system/RAIIMockClock.h>
 #include <system/SystemLayer.h>
 #include <system/SystemPacketBuffer.h>
+#include <system/SystemStats.h>
 
 #include <wifipaf/WiFiPAFError.h>
 #include <wifipaf/WiFiPAFLayer.h>
@@ -85,6 +86,8 @@ public:
     bool mResourceAvailable = true;
     bool isSendQueueNull() { return mEndPoint->mSendQueue.IsNull(); }
     uint8_t GetResourceWaitCount() { return mEndPoint->mResourceWaitCount; }
+    void EpParkAckToSend(System::PacketBufferHandle && b) { mEndPoint->mAckToSend = std::move(b); }
+    void EpClearAll() { mEndPoint->ClearAll(); }
 
 private:
     WiFiPAFEndPoint * mEndPoint;
@@ -411,5 +414,79 @@ TEST_F(TestWiFiPAFLayer, CheckRunAsCommissionee)
     EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
     EpDoClose(kWiFiPAFCloseFlag_AbortTransmission, WIFIPAF_ERROR_APP_CLOSED_CONNECTION);
 }
+
+#if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
+// ClearAll() must release any PacketBufferHandle the endpoint still owns. Park one in a handle
+// member, then check ClearAll() returns it to the pool.
+TEST_F(TestWiFiPAFLayer, ClearAllReleasesOwnedBuffer)
+{
+    WiFiPAFSession sessionInfo = {
+        .role          = kWiFiPafRole_Subscriber,
+        .id            = 1,
+        .peer_id       = 1,
+        .peer_addr     = { 0xd0, 0x17, 0x69, 0xee, 0x7f, 0x3c },
+        .nodeId        = 1,
+        .discriminator = 0xF00,
+    };
+
+    WiFiPAFEndPoint * newEndPoint = nullptr;
+    ASSERT_EQ(NewEndPoint(&newEndPoint, sessionInfo, sessionInfo.role), CHIP_NO_ERROR);
+    ASSERT_NE(newEndPoint, nullptr);
+    SetEndPoint(newEndPoint);
+
+    auto * inUse                 = chip::System::Stats::GetResourcesInUse();
+    const int baselinePacketBufs = inUse[chip::System::Stats::kSystemLayer_NumPacketBufs];
+
+    // Park a live packet buffer in a handle member.
+    auto buf = System::PacketBufferHandle::New(kTestPacketLength);
+    ASSERT_FALSE(buf.IsNull());
+    EXPECT_GT(static_cast<int>(inUse[chip::System::Stats::kSystemLayer_NumPacketBufs]), baselinePacketBufs);
+    EpParkAckToSend(std::move(buf));
+
+    EpClearAll();
+
+    // The buffer must be back in the pool.
+    EXPECT_EQ(static_cast<int>(inUse[chip::System::Stats::kSystemLayer_NumPacketBufs]), baselinePacketBufs);
+}
+
+// A Subscriber closed with a non-fatal error reaches ClearAll() via FinalizeClose without going
+// through Free() (the endpoint is kept to signal close). A pending ack owned at that point must
+// still be released.
+TEST_F(TestWiFiPAFLayer, SubscriberNonFatalCloseReleasesPendingAck)
+{
+    WiFiPAFSession sessionInfo = {
+        .role          = kWiFiPafRole_Subscriber,
+        .id            = 1,
+        .peer_id       = 1,
+        .peer_addr     = { 0xd0, 0x17, 0x69, 0xee, 0x7f, 0x3c },
+        .nodeId        = 1,
+        .discriminator = 0xF00,
+    };
+
+    WiFiPAFEndPoint * newEndPoint = nullptr;
+    ASSERT_EQ(NewEndPoint(&newEndPoint, sessionInfo, sessionInfo.role), CHIP_NO_ERROR);
+    ASSERT_NE(newEndPoint, nullptr);
+    SetEndPoint(newEndPoint);
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
+    newEndPoint->mState = WiFiPAFEndPoint::kState_Connected;
+
+    auto * inUse                 = chip::System::Stats::GetResourcesInUse();
+    const int baselinePacketBufs = inUse[chip::System::Stats::kSystemLayer_NumPacketBufs];
+
+    // A pending stand-alone ack, as if queued when the close arrives.
+    auto buf = System::PacketBufferHandle::New(kTestPacketLength);
+    ASSERT_FALSE(buf.IsNull());
+    EXPECT_GT(static_cast<int>(inUse[chip::System::Stats::kSystemLayer_NumPacketBufs]), baselinePacketBufs);
+    EpParkAckToSend(std::move(buf));
+
+    // Subscriber + non-fatal error: FinalizeClose skips Free(), then calls ClearAll().
+    EpDoClose(kWiFiPAFCloseFlag_AbortTransmission, CHIP_ERROR_INTERNAL);
+
+    // The pending ack must be back in the pool.
+    EXPECT_EQ(static_cast<int>(inUse[chip::System::Stats::kSystemLayer_NumPacketBufs]), baselinePacketBufs);
+
+    EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
+}
+#endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
 }; // namespace WiFiPAF
 }; // namespace chip


### PR DESCRIPTION
#### Summary

`WiFiPAFEndPoint::ClearAll()` reset the end point with `memset()` over the whole object, including members that own reference-counted `System::PacketBufferHandle`s. This replaces it with an explicit reset that releases those handles.

##### Problem

-   `ClearAll()` zeroed the end point with `memset(this, 0, sizeof(WiFiPAFEndPoint))`.
-   `WiFiPAFEndPoint` is **not** trivially copyable: it owns `PacketBufferHandle`s directly (`mSendQueue`, `mAckToSend`, `ReorderQueue`) and indirectly through `mPafTP`.
-   `memset()` overwrites those handles **without running their destructors**, so the underlying `PacketBuffer`s are not released. On close paths that reach `ClearAll()` without going through `Free()` (a subscriber kept alive to signal close), a buffer still owned at that point is never returned to the pool.

##### Impact

-   A `PacketBuffer` is lost from the pool on each such close — a gradual resource leak. The buffer pool is bounded on constrained platforms, so repeated occurrences degrade the node's ability to allocate buffers.
-   `memset()` over a non-trivially-copyable type is also undefined behavior.

##### Solution

-   Replaced the `memset()` with an explicit per-member reset: release the owned `PacketBufferHandle`s (and `mPafTP`'s Tx/Rx buffers), then reset the remaining trivially-copyable state.
-   The reset also clears the members `Init()` does not (`mConnStateFlags`, `mResourceWaitCount`, the callbacks, `mRxAck`, `ItemsInReorderQueue`), and preserves the pool free-slot invariant that `GetFree()`/`Find()` rely on (`mWiFiPafLayer == nullptr`).

#### Testing

-   Added `ClearAllReleasesOwnedBuffer` in `src/wifipaf/tests/TestWiFiPAFLayer.cpp`: parks a buffer in an owned handle, calls `ClearAll()`, and verifies it is returned to the pool (tracked via `kSystemLayer_NumPacketBufs`).
-   Added `SubscriberNonFatalCloseReleasesPendingAck`: drives the subscriber non-fatal close path (`DoClose` → `FinalizeClose` without `Free()`) and verifies a pending ack is released.
-   Both tests fail on the previous `memset()` implementation (confirmed by the stat counter and AddressSanitizer/LeakSanitizer) and pass with the fix. The full `tests/TestWiFiPAFLayer` suite (8 cases) passes under ASan with no leaks.
