### PR TITLE
Suppress pre-existing bugprone clang-tidy findings on trusted-input sites

### DIFF
--- a/examples/energy-management/energy-management-triggers/FakeReadings.cpp
+++ b/examples/energy-management/energy-management-triggers/FakeReadings.cpp
@@ -90,6 +90,7 @@ void FakeReadings::StartFakeReadings(EndpointId aEndpointId, int64_t aPower_mW, 
         // which are caused when the test is checking for 2 different numbers.
         // This is statistically more likely when the test runs for a long time
         // or if the seed is not set
+        // NOLINTNEXTLINE(bugprone-random-generator-seed)
         srand(1);
 
         mTotalEnergyImported = 0;

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
@@ -201,6 +201,8 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
+    // Fixed-width MAC from wpa_supplicant D-Bus reply
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
            &peer_addr[4], &peer_addr[5]);
 
@@ -294,6 +296,8 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
+    // Fixed-width MAC from wpa_supplicant D-Bus reply
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
            &peer_addr[4], &peer_addr[5]);
 
@@ -373,6 +377,8 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
+    // Fixed-width MAC from wpa_supplicant D-Bus reply
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &RxInfo.peer_addr[0], &RxInfo.peer_addr[1], &RxInfo.peer_addr[2],
            &RxInfo.peer_addr[3], &RxInfo.peer_addr[4], &RxInfo.peer_addr[5]);
 

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -323,6 +323,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             Platform::CopyString(thread->NameBuf, entry->d_name);
             thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            // /proc task entry name is always a numeric tid
+            // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
             thread->id = atoi(entry->d_name);
 
             // TODO: Get stack info of each thread: thread->stackFreeCurrent,

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -59,6 +59,8 @@ uint32_t AdapterIterator::GetIndex() const
     const char * path = g_dbus_proxy_get_object_path(G_DBUS_PROXY(mCurrentAdapter.get()));
     unsigned index    = 0;
 
+    // sscanf return value is checked
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     if (sscanf(path, BLUEZ_PATH "/hci%u", &index) != 1)
     {
         ChipLogError(DeviceLayer, "Failed to extract HCI index from '%s'", StringOrNullMarker(path));

--- a/src/platform/Linux/bluez/BluezObjectManager.cpp
+++ b/src/platform/Linux/bluez/BluezObjectManager.cpp
@@ -144,6 +144,8 @@ CHIP_ERROR BluezObjectManager::SetupAdapter(BluezAdapter1 * aAdapter)
 void BluezObjectManager::NotifyAdapterAdded(BluezAdapter1 * aAdapter)
 {
     unsigned int adapterId = 0;
+    // Trusted BlueZ D-Bus object path
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     sscanf(GetAdapterObjectPath(aAdapter), BLUEZ_PATH "/hci%u", &adapterId);
     // Notify the application that new adapter has been just added
     BLEManagerImpl::NotifyBLEAdapterAdded(adapterId, bluez_adapter1_get_address(aAdapter));
@@ -152,6 +154,8 @@ void BluezObjectManager::NotifyAdapterAdded(BluezAdapter1 * aAdapter)
 void BluezObjectManager::NotifyAdapterRemoved(BluezAdapter1 * aAdapter)
 {
     unsigned int adapterId = 0;
+    // Trusted BlueZ D-Bus object path
+    // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
     sscanf(GetAdapterObjectPath(aAdapter), BLUEZ_PATH "/hci%u", &adapterId);
     // Notify the application that the adapter is no longer available
     BLEManagerImpl::NotifyBLEAdapterRemoved(adapterId, bluez_adapter1_get_address(aAdapter));

--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -176,6 +176,8 @@ static uint32_t GetNextPinCode()
         {
             pinCodeStr = pinCodeStr.substr(0, 8);
         }
+        // Parsed value is validated by IsValidSetupPIN below
+        // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion)
         pinCode = static_cast<uint32_t>(atoi(pinCodeStr.c_str()));
         if (!chip::SetupPayload::IsValidSetupPIN(pinCode))
         {


### PR DESCRIPTION
#### Summary

##### Problem

-   A whole-tree clang-tidy pass surfaces pre-existing findings that the per-PR (changed-files) clang-tidy never flagged: **8** `bugprone-unchecked-string-to-number-conversion` and **1** `bugprone-random-generator-seed`.
-   None is a real defect. Every site parses **trusted or internally-shaped input**, and several already validate the result:
    -   `AdapterIterator` / `BluezObjectManager` — `sscanf` on BlueZ D-Bus object paths (`/org/bluez/hci0`); `AdapterIterator` already checks the `sscanf` return.
    -   `ConnectivityManagerImpl_WiFiPafWpaSupplicant` — `sscanf` of six `%02hhx` MAC bytes into a fixed six-byte array, from a `wpa_supplicant` D-Bus reply (cannot overflow).
    -   `DiagnosticDataProviderImpl` — `atoi` on `/proc` task-dir names (always-numeric tids).
    -   `spake2p Cmd_GenVerifier` — `atoi` result is validated by `IsValidSetupPIN`.
    -   `FakeReadings` (example) — `srand(1)` is intentionally deterministic to avoid flaky example output.
-   Because these checks are already enabled, any PR that merely **touches** one of these files would be blocked by a finding it did not introduce.

##### Solution

-   Add a `NOLINTNEXTLINE` with a one-line rationale at each of the 9 sites, using the separate-comment-line pattern (clang-format-safe).
-   No behavior change: the checks stay enabled to catch genuinely unchecked conversions in new code; only these specific trusted-input sites are annotated.

#### Testing

-   Ran clang-tidy (repo `.clang-tidy`, LLVM-23) over the affected translation units before and after: the 9 findings are present before and **0** remain after. No other findings introduced.
-   `git clang-format` reports no changes on the annotated lines (the `NOLINTNEXTLINE` pattern is preserved).