### PR TITLE
Harden WiFi-PAF PASE setup error paths

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -922,14 +922,15 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             auto setupDiscriminator                             = params.GetSetupDiscriminator();
             VerifyOrExit(setupDiscriminator.has_value(), err = CHIP_ERROR_INVALID_ARGUMENT);
             const SetupDiscriminator connDiscriminator(setupDiscriminator.value());
-            VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
-                                ChipLogError(Controller, "Error, Long discriminator is required"));
+            VerifyOrExit(!connDiscriminator.IsShortDiscriminator(),
+                         ChipLogError(Controller, "Error, Long discriminator is required");
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
             uint16_t discriminator              = connDiscriminator.GetLongValue();
             WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
                                                     .nodeId        = nodeId,
                                                     .discriminator = discriminator };
-            ReturnErrorOnFailure(
-                DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+            SuccessOrExit(
+                err = DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
             ExitNow(err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, reinterpret_cast<void *>(this),
                                                                           OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError));
         }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -919,7 +919,9 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                             params.GetPeerAddress().GetRemoteId());
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
             auto nodeId                                         = params.GetPeerAddress().GetRemoteId();
-            const SetupDiscriminator connDiscriminator(params.GetSetupDiscriminator().value());
+            auto setupDiscriminator                             = params.GetSetupDiscriminator();
+            VerifyOrExit(setupDiscriminator.has_value(), err = CHIP_ERROR_INVALID_ARGUMENT);
+            const SetupDiscriminator connDiscriminator(setupDiscriminator.value());
             VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
                                 ChipLogError(Controller, "Error, Long discriminator is required"));
             uint16_t discriminator              = connDiscriminator.GetLongValue();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -920,7 +920,9 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
             auto nodeId                                         = params.GetPeerAddress().GetRemoteId();
             auto setupDiscriminator                             = params.GetSetupDiscriminator();
-            VerifyOrExit(setupDiscriminator.has_value(), err = CHIP_ERROR_INVALID_ARGUMENT);
+            VerifyOrExit(setupDiscriminator.has_value(),
+                         ChipLogError(Controller, "WiFi-PAF: Missing setup discriminator");
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
             const SetupDiscriminator connDiscriminator(setupDiscriminator.value());
             VerifyOrExit(!connDiscriminator.IsShortDiscriminator(),
                          ChipLogError(Controller, "Error, Long discriminator is required");

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -929,8 +929,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
                                                     .nodeId        = nodeId,
                                                     .discriminator = discriminator };
-            SuccessOrExit(
-                err = DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+            SuccessOrExit(err = DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo,
+                                                                                           sessionInfo));
             ExitNow(err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, reinterpret_cast<void *>(this),
                                                                           OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError));
         }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -920,8 +920,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
             auto nodeId                                         = params.GetPeerAddress().GetRemoteId();
             auto setupDiscriminator                             = params.GetSetupDiscriminator();
-            VerifyOrExit(setupDiscriminator.has_value(),
-                         ChipLogError(Controller, "WiFi-PAF: Missing setup discriminator");
+            VerifyOrExit(setupDiscriminator.has_value(), ChipLogError(Controller, "WiFi-PAF: Missing setup discriminator");
                          err = CHIP_ERROR_INVALID_ARGUMENT);
             const SetupDiscriminator connDiscriminator(setupDiscriminator.value());
             VerifyOrExit(!connDiscriminator.IsShortDiscriminator(),


### PR DESCRIPTION
#### Summary

Two error paths in the WiFi-PAF branch of `DeviceCommissioner::EstablishPASEConnection`: one dereferences an optional without checking its existence, and two others return directly and skip the function's `exit:` cleanup.



#### Changes

- **WiFi-PAF discriminator guard** (`bugprone-unchecked-optional-access`): `EstablishPASEConnection` dereferenced `params.GetSetupDiscriminator().value()` unconditionally on the WiFi-PAF path while the sibling BLE path guards `has_value()` first; an empty optional aborts the process (`std::bad_optional_access` under `-fno-exceptions`). Adds the matching `VerifyOrExit` guard.
- **Route WiFi-PAF PASE error paths through `exit:`**: the short-discriminator check (`VerifyOrReturnValue`) and the `AddPafSession` check (`ReturnErrorOnFailure`) returned directly, skipping the `exit:` cleanup. That leaks the commissionee device and the metric and leaves `mDeviceInPASEEstablishment` set, which wedges all later PASE attempts with `CHIP_ERROR_INCORRECT_STATE` (and `AddPafSession` can fail in normal operation when the PAF session table is full). Converts both to `VerifyOrExit`/`SuccessOrExit`.

#### Testing

- Touched translation unit compile-verified with WiFi-PAF enabled.
