### PR TITLE
Revert "[NXP] Fix OTBR cli init issue" to fix CI

### DIFF
--- a/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
@@ -90,10 +90,7 @@ void chip::NXP::App::AppCLIBase::RegisterDefaultCommands(void)
     cmd_misc_init();
     cmd_otcli_init();
 #if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
-    /* verify that otInstance is not null before initializing addons */
-    otInstance * instance = otInstanceGetSingle();
-    VerifyOrDie(instance != nullptr);
-    otAppCliAddonsInit(instance);
+    otAppCliAddonsInit(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
 #endif
 #if CHIP_SHELL_ENABLE_CMD_SERVER
     cmd_app_server_init();


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#71534 as it's failing tests such as
```
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12: /__w/connectedhomeip/connectedhomeip/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp: In member function 'void chip::NXP::App::AppCLIBase::RegisterDefaultCommands()':
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12: /__w/connectedhomeip/connectedhomeip/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp:94:29: error: 'otInstanceGetSingle' was not declared in this scope; did you mean 'otInstanceInitSingle'?
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12:    94 |     otInstance * instance = otInstanceGetSingle();
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12:       |                             ^~~~~~~~~~~~~~~~~~~
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12:       |                             otInstanceInitSingle
INFO    Building nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12: /__w/connectedhomeip/connectedhomeip/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp:94:29: note: maximum limit of 1000 namespaces searched for 'otInstanceGetSingle'
```

### Testing
Revert of a merged PR. No new testing required as it restores the previous state.

