### PR TITLE
Bump timeout for individual tests to 60 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1090,7 +1090,7 @@ jobs:
     repl_tests_linux_run:
         name: REPL Tests - Linux (RUN)
         needs: repl_tests_linux_build
-        timeout-minutes: 45
+        timeout-minutes: 60
 
         if: github.actor != 'restyled-io[bot]'
 


### PR DESCRIPTION
### Summary

We seem to have test timouets ... bump this up for now, however we may split this later better. We still want fast tests.

### Testing

Trivial change.