### PR TITLE
Clean up mTextEntries handling in Darwin DNS-SD code and the unit tests.

### DIFF
--- a/src/platform/Darwin/dnssd/DnssdContexts.cpp
+++ b/src/platform/Darwin/dnssd/DnssdContexts.cpp
@@ -47,9 +47,31 @@ std::string GetHostNameWithoutDomain(const char * hostnameWithDomain)
 
 void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t len)
 {
-    uint16_t recordCount   = TXTRecordGetCount(len, data);
+    service.mTextEntries   = nullptr;
+    service.mTextEntrySize = 0;
+
+    uint16_t recordCount = TXTRecordGetCount(len, data);
+    // A malicious advertiser could have something like 65k TXT records; we
+    // don't really want to go and allocate 1.5MB of memory here.  Cap at
+    // something reasonable which is still much larger than the number of TXT
+    // records we expect Matter nodes to have.
+    if (recordCount > kDnssdTxtRecordMaxEntries)
+    {
+        ChipLogError(Discovery, "Mdns: TXT record has %u entries; truncating to %u", recordCount, kDnssdTxtRecordMaxEntries);
+        recordCount = kDnssdTxtRecordMaxEntries;
+    }
+    if (recordCount == 0)
+    {
+        return;
+    }
+
+    service.mTextEntries = static_cast<TextEntry *>(chip::Platform::MemoryCalloc(recordCount, sizeof(TextEntry)));
+    if (service.mTextEntries == nullptr)
+    {
+        ChipLogError(Discovery, "Mdns: Failed to allocate %u TXT entries", recordCount);
+        return;
+    }
     service.mTextEntrySize = recordCount;
-    service.mTextEntries   = static_cast<TextEntry *>(chip::Platform::MemoryCalloc(kDnssdTxtRecordMaxEntries, sizeof(TextEntry)));
 
     for (uint16_t i = 0; i < recordCount; i++)
     {
@@ -71,14 +93,23 @@ void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t
             valueLen = chip::Dnssd::kDnssdTextMaxSize - 1;
         }
 
-        char value[chip::Dnssd::kDnssdTextMaxSize];
-        memcpy(value, valuePtr, valueLen);
-        value[valueLen] = 0;
-
         auto & textEntry    = service.mTextEntries[i];
-        textEntry.mKey      = strdup(key);
-        textEntry.mData     = reinterpret_cast<const uint8_t *>(strdup(value));
-        textEntry.mDataSize = valueLen;
+        textEntry.mKey      = chip::Platform::MemoryAllocString(key, strlen(key));
+        textEntry.mData     = nullptr;
+        textEntry.mDataSize = 0;
+
+        if (valueLen > 0)
+        {
+            auto * buf = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(valueLen, sizeof(uint8_t)));
+            if (buf == nullptr)
+            {
+                ChipLogError(Discovery, "Mdns: Failed to allocate %u-byte TXT value", valueLen);
+                continue;
+            }
+            memcpy(buf, valuePtr, valueLen);
+            textEntry.mData     = buf;
+            textEntry.mDataSize = valueLen;
+        }
     }
 }
 
@@ -812,8 +843,8 @@ InterfaceInfo::~InterfaceInfo()
     for (size_t i = 0; i < count; i++)
     {
         const auto & textEntry = service.mTextEntries[i];
-        free(const_cast<char *>(textEntry.mKey));
-        free(const_cast<uint8_t *>(textEntry.mData));
+        Platform::MemoryFree(const_cast<char *>(textEntry.mKey));
+        Platform::MemoryFree(const_cast<uint8_t *>(textEntry.mData));
     }
     Platform::MemoryFree(const_cast<TextEntry *>(service.mTextEntries));
 }

--- a/src/platform/Darwin/dnssd/DnssdContexts.cpp
+++ b/src/platform/Darwin/dnssd/DnssdContexts.cpp
@@ -97,6 +97,12 @@ void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t
         textEntry.mKey      = chip::Platform::MemoryAllocString(key, strlen(key));
         textEntry.mData     = nullptr;
         textEntry.mDataSize = 0;
+        if (textEntry.mKey == nullptr)
+        {
+            ChipLogError(Discovery, "Mdns: Failed to allocate TXT key");
+            service.mTextEntrySize = i;
+            break;
+        }
 
         if (valueLen > 0)
         {
@@ -104,7 +110,10 @@ void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t
             if (buf == nullptr)
             {
                 ChipLogError(Discovery, "Mdns: Failed to allocate %u-byte TXT value", valueLen);
-                continue;
+                chip::Platform::MemoryFree(const_cast<char *>(textEntry.mKey));
+                textEntry.mKey         = nullptr;
+                service.mTextEntrySize = i;
+                break;
             }
             memcpy(buf, valuePtr, valueLen);
             textEntry.mData     = buf;

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -131,8 +131,8 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     ASSERT_GE(result->mTextEntrySize, 1u);
     EXPECT_STREQ(result->mTextEntries[0].mKey, "key");
     constexpr uint8_t kExpectedVal[] = { 'v', 'a', 'l' };
-    EXPECT_TRUE(chip::ByteSpan(result->mTextEntries[0].mData, result->mTextEntries[0].mDataSize)
-                    .data_equal(chip::ByteSpan(kExpectedVal)));
+    EXPECT_TRUE(
+        chip::ByteSpan(result->mTextEntries[0].mData, result->mTextEntries[0].mDataSize).data_equal(chip::ByteSpan(kExpectedVal)));
 
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -130,7 +130,9 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     // must have at least 1 entry to check next key/val expectations.
     ASSERT_GE(result->mTextEntrySize, 1u);
     EXPECT_STREQ(result->mTextEntries[0].mKey, "key");
-    EXPECT_STREQ(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val");
+    constexpr uint8_t kExpectedVal[] = { 'v', 'a', 'l' };
+    EXPECT_TRUE(chip::ByteSpan(result->mTextEntries[0].mData, result->mTextEntries[0].mDataSize)
+                    .data_equal(chip::ByteSpan(kExpectedVal)));
 
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {


### PR DESCRIPTION
* Consistently use Platform::Memory* allocators.
* Avoid doing 0-size allocations.
* Handle allocation failures gracefully.
* Stop assuming in the unit test that the value byte buffer is "null terminated" when all it promises is to have a certain number of bytes in it.
* Stop adding that "null terminator" to the value in the Darwin code; other backends (e.g. avahi) don't do that.

### Testing

No real behavior changes here.