### PR TITLE
Fix error handling in network-manager ubus-related code

### DIFF
--- a/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
+++ b/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR OpenThreadUbusBorderRouterDelegate::Init(AttributeChangeCallback * at
 
 void OpenThreadUbusBorderRouterDelegate::GetBorderRouterName(MutableCharSpan & borderRouterName)
 {
-    CopyCharSpanToMutableCharSpan("OpenThread BorderRouter"_span, borderRouterName);
+    CopyCharSpanToMutableCharSpanWithTruncation("OpenThread BorderRouter"_span, borderRouterName);
 }
 
 CHIP_ERROR OpenThreadUbusBorderRouterDelegate::GetBorderAgentId(MutableByteSpan & borderAgentId)

--- a/examples/network-manager-app/linux/UbusManager.cpp
+++ b/examples/network-manager-app/linux/UbusManager.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR UbusManager::Init()
 {
     VerifyOrReturnError(!mInitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    UloopHandler::Register();
+    ReturnErrorOnFailure(UloopHandler::Register());
     if (!Connect())
     {
         UloopHandler::Unregister();

--- a/examples/network-manager-app/linux/UloopHandler.cpp
+++ b/examples/network-manager-app/linux/UloopHandler.cpp
@@ -103,9 +103,10 @@ void UloopHandler::UloopFdSet(uloop_fd * fd, unsigned int events)
     VerifyOrDieWithMsg(!(events & ~(ULOOP_READ | ULOOP_WRITE | ULOOP_BLOCKING)), DeviceLayer,
                        "Unsupported uloop fd_set events: 0x%x", events);
 
+    CHIP_ERROR err;
     auto & system = SystemLayer();
     System::SocketWatchToken watch;
-    CHIP_ERROR err = system.StartWatchingSocket(fd->fd, &watch); // or find existing watch
+    SuccessOrExit(err = system.StartWatchingSocket(fd->fd, &watch)); // or find existing watch
     if (events != 0)
     {
         int changed = fd->flags ^ events;
@@ -113,28 +114,27 @@ void UloopHandler::UloopFdSet(uloop_fd * fd, unsigned int events)
         {
             if (events & ULOOP_READ)
             {
-                system.RequestCallbackOnPendingRead(watch);
+                SuccessOrExit(err = system.RequestCallbackOnPendingRead(watch));
             }
             else
             {
-                system.ClearCallbackOnPendingRead(watch);
+                SuccessOrExit(err = system.ClearCallbackOnPendingRead(watch));
             }
         }
         if (changed & ULOOP_WRITE)
         {
             if (events & ULOOP_WRITE)
             {
-                system.RequestCallbackOnPendingWrite(watch);
+                SuccessOrExit(err = system.RequestCallbackOnPendingWrite(watch));
             }
             else
             {
-                system.ClearCallbackOnPendingWrite(watch);
+                SuccessOrExit(err = system.ClearCallbackOnPendingWrite(watch));
             }
         }
     }
     else
     {
-        VerifyOrReturn(err == CHIP_NO_ERROR); // shouldn't happen, but ignore
         SuccessOrExit(err = system.StopWatchingSocket(&watch));
     }
 

--- a/examples/network-manager-app/linux/UloopHandler.cpp
+++ b/examples/network-manager-app/linux/UloopHandler.cpp
@@ -103,12 +103,12 @@ void UloopHandler::UloopFdSet(uloop_fd * fd, unsigned int events)
     VerifyOrDieWithMsg(!(events & ~(ULOOP_READ | ULOOP_WRITE | ULOOP_BLOCKING)), DeviceLayer,
                        "Unsupported uloop fd_set events: 0x%x", events);
 
-    CHIP_ERROR err;
     auto & system = SystemLayer();
     System::SocketWatchToken watch;
-    SuccessOrExit(err = system.StartWatchingSocket(fd->fd, &watch)); // or find existing watch
+    CHIP_ERROR err = system.StartWatchingSocket(fd->fd, &watch); // or find existing watch
     if (events != 0)
     {
+        SuccessOrExit(err);
         int changed = fd->flags ^ events;
         if (changed & ULOOP_READ)
         {
@@ -135,6 +135,11 @@ void UloopHandler::UloopFdSet(uloop_fd * fd, unsigned int events)
     }
     else
     {
+        // We're being asked to stop watching a socket (events == 0), so an error
+        // from StartWatchingSocket() means there is no existing watch token and
+        // we failed to allocate a new one. The end result is that we're not
+        // watching the socket, so there is no need to log an error.
+        VerifyOrReturn(err == CHIP_NO_ERROR);
         SuccessOrExit(err = system.StopWatchingSocket(&watch));
     }
 


### PR DESCRIPTION
### Summary

Previously a number of CHIP_ERRORs were discarded which is now an error, and in UloopHandler::UloopFdSet the code might have called RequestCallback* with an invalid watch after an error from StartWatchingSocket.

### Testing

Compiles cleanly now, also tested manually on OpenWrt.