### PR TITLE
Make NFCTag::Identifier an aggregate again under C++20

### DIFF
--- a/src/nfc/NFCTag.h
+++ b/src/nfc/NFCTag.h
@@ -70,12 +70,6 @@ public:
     {
         uint16_t discriminator = 0;
 
-        constexpr Identifier()                     = default;
-        constexpr Identifier(const Identifier &)   = default;
-        constexpr Identifier(Identifier &&)        = default;
-        Identifier & operator=(const Identifier &) = default;
-        Identifier & operator=(Identifier &&)      = default;
-
         bool IsValid() const
         {
             static constexpr Identifier _invalidID;


### PR DESCRIPTION
### Summary

Linux host builds default to `gnu++20` ([build/config/compiler/compiler.gni:46-49](https://github.com/project-chip/connectedhomeip/blob/master/build/config/compiler/compiler.gni#L46-L49)), and under C++20 `chip::Nfc::NFCTag::Identifier` is no longer an aggregate (it has user-declared `= default` constructors at [src/nfc/NFCTag.h:73-77](https://github.com/project-chip/connectedhomeip/blob/master/src/nfc/NFCTag.h#L73-L77)). The designated-initializer brace-init at `src/controller/SetUpCodePairer.cpp:354` therefore fails to compile with GCC 13:

```
src/controller/SetUpCodePairer.cpp:354:105: error: designated initializers
  cannot be used with a non-aggregate type 'chip::Nfc::NFCTag::Identifier'
    chip::Nfc::NFCTag::Identifier identifier  = { .discriminator = payload.discriminator.GetLongValue() };
```

This reproduces in the `chip-cert-bins` Docker build (Stage 2, target `chip-tool-ipv6only-platform-mdns-nfc-commission`) on Ubuntu 24.04. It does not surface on `v1.6-sve-branch`, which still builds with `gnu++17` where defaulted constructors don't disqualify aggregates.

### Root cause

Two changes combined:

- `49cf915ec` — *NFC support for SetUpCodePairer and AutoCommissioner (#40783)* introduced both the `Identifier` struct (with `= default` ctors) and the designated-initializer call site. Compiled fine under C++17.
- `fd06d0433` — *[C++20] compile linux with C++20 by default (#72010)* switched Linux/Tizen host builds to `gnu++20`. C++20 tightened the aggregate rule from "no user-*provided* constructors" to "no user-*declared* constructors", which now disqualifies `Identifier`.

### Fix

Remove the five `= default` declarations from `NFCTag::Identifier`. The compiler implicitly generates the same trivial default/copy/move constructors and copy/move assignments — and they are implicitly `constexpr` because the only data member (`uint16_t discriminator = 0;`) is trivially constructible. The struct is an aggregate again under C++20, and the original designated-initializer at the call site compiles unchanged.

Header-only diff. No call sites change.

### Testing

- [ ] `chip-cert-bins` Docker build (Stage 2 target `chip-tool-ipv6only-platform-mdns-nfc-commission`) succeeds on Ubuntu 24.04 / GCC 13
- [ ] Cross-check the `linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission` build from `scripts/build/build_examples.py`
- [ ] Confirm `v1.6-sve-branch` (C++17) still builds — implicit ctors should be equivalent to the explicit `= default` ones