### PR TITLE
chip-tool: avoid sending mDNS traffic inside Thread network

### DIFF
--- a/src/lib/dnssd/minimal_mdns/AddressPolicy_DefaultImpl.cpp
+++ b/src/lib/dnssd/minimal_mdns/AddressPolicy_DefaultImpl.cpp
@@ -51,6 +51,13 @@ bool IsCurrentInterfaceUsable(T & iterator)
         /// local loopback interface is not usable by MDNS
         return false;
     }
+
+    // skip IEEE 802.15.4 / Thread interfaces — not suitable for mDNS
+    if (strncmp(name, "wpan", 4) == 0)
+    {
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Summary

6762: "A Multicast DNS querier SHOULD NOT send queries on an interface where it knows that there are no Multicast DNS responders."

### Related issues

https://github.com/openthread/ot-br-posix/issues/3401

### Testing
Once the fix is applied, there is no mDNS traffic with destination ff02::fb seen in the Thread network (checked this using Wireshark and an IEEE 802.15.4 air traffic sniffer).