### PR TITLE
[all-devices-app] Support wildcard (*) expansion to instantiate all devices

### DIFF
--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -116,6 +116,7 @@ You can use the wildcard `*` to automatically instantiate all supported leaf
 device types. When an endpoint is specified, it represents the starting number.
 
 -   **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
+
     ```bash
     ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
     ```

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -109,19 +109,23 @@ rm -rf /tmp/chip_*
 # Run a chime on endpoint 1, a speaker on endpoint 2 (child of endpoint 1), and a dimmable light on endpoint 3
 ./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2,parent=1 --device dimmable-light:3
 ```
+
 ## Advanced Topology: Wildcard Expansion (`*`)
 
-You can use the wildcard `*` to automatically instantiate all supported leaf device types. When an endpoint is specified, it represents the starting number.
+You can use the wildcard `*` to automatically instantiate all supported leaf
+device types. When an endpoint is specified, it represents the starting number.
 
-- **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
-  ```bash
-  ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
-  ```
+-   **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
 
-- **Parented Wildcard:** Start all devices from endpoint 2 sequentially and make them all children of parent endpoint 1.
-  ```bash
-  ./out/linux-x64-all-devices-boringssl/all-devices-app --device speaker:1 --device *:2,parent=1
-  ```
+    ```bash
+    ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
+    ```
+
+-   **Parented Wildcard:** Start all devices from endpoint 2 sequentially and
+    make them all children of parent endpoint 1.
+    ```bash
+    ./out/linux-x64-all-devices-boringssl/all-devices-app --device speaker:1 --device *:2,parent=1
+    ```
 
 ## Testing with chip-tool
 

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -118,13 +118,13 @@ device types. When an endpoint is specified, it represents the starting number.
 -   **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
 
     ```bash
-    ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
+    ./out/linux-x64-all-devices-boringssl/all-devices-app --device "*:1"
     ```
 
 -   **Parented Wildcard:** Start all devices from endpoint 2 sequentially and
     make them all children of parent endpoint 1 (e.g., an aggregator).
     ```bash
-    ./out/linux-x64-all-devices-boringssl/all-devices-app --device aggregator:1 --device *:2,parent=1
+    ./out/linux-x64-all-devices-boringssl/all-devices-app --device aggregator:1 --device "*:2,parent=1"
     ```
 
 ## Testing with chip-tool

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -109,6 +109,19 @@ rm -rf /tmp/chip_*
 # Run a chime on endpoint 1, a speaker on endpoint 2 (child of endpoint 1), and a dimmable light on endpoint 3
 ./out/linux-x64-all-devices-boringssl-no-ble/all-devices-app --device chime:1 --device speaker:2,parent=1 --device dimmable-light:3
 ```
+## Advanced Topology: Wildcard Expansion (`*`)
+
+You can use the wildcard `*` to automatically instantiate all supported leaf device types. When an endpoint is specified, it represents the starting number.
+
+- **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
+  ```bash
+  ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
+  ```
+
+- **Parented Wildcard:** Start all devices from endpoint 2 sequentially and make them all children of parent endpoint 1.
+  ```bash
+  ./out/linux-x64-all-devices-boringssl/all-devices-app --device speaker:1 --device *:2,parent=1
+  ```
 
 ## Testing with chip-tool
 

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -116,15 +116,14 @@ You can use the wildcard `*` to automatically instantiate all supported leaf
 device types. When an endpoint is specified, it represents the starting number.
 
 -   **Standard Wildcard:** Start all devices from endpoint 1 sequentially.
-
     ```bash
     ./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1
     ```
 
 -   **Parented Wildcard:** Start all devices from endpoint 2 sequentially and
-    make them all children of parent endpoint 1.
+    make them all children of parent endpoint 1 (e.g., an aggregator).
     ```bash
-    ./out/linux-x64-all-devices-boringssl/all-devices-app --device speaker:1 --device *:2,parent=1
+    ./out/linux-x64-all-devices-boringssl/all-devices-app --device aggregator:1 --device *:2,parent=1
     ```
 
 ## Testing with chip-tool

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -20,6 +20,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 
@@ -63,6 +64,10 @@ bool DeviceTypeParser::ParseDeviceTypeEntry(const char * value, Entry & entry)
     if (colon == nullptr)
     {
         entry.type = mainConfig;
+        if (entry.type == "*")
+        {
+            entry.endpoint = chip::kInvalidEndpointId;
+        }
     }
     else
     {
@@ -120,4 +125,46 @@ CHIP_ERROR DeviceTypeParser::ParseSingleDeviceString(const char * value)
 const std::vector<DeviceTypeParser::Entry> & DeviceTypeParser::GetDeviceTypeEntries()
 {
     return mDeviceTypeEntries;
+}
+
+void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcardExpandedTypes)
+{
+    if (std::none_of(mDeviceTypeEntries.begin(), mDeviceTypeEntries.end(),
+                     [](const auto & entry) { return entry.type == "*"; }))
+    {
+        return;
+    }
+
+    std::vector<Entry> expandedEntries;
+    chip::EndpointId nextAvailableEp = 1;
+
+    for (const auto & entry : mDeviceTypeEntries)
+    {
+        if (entry.type == "*")
+        {
+            chip::EndpointId nextEp = (entry.endpoint == chip::kInvalidEndpointId) ? nextAvailableEp : entry.endpoint;
+            for (const auto & deviceType : wildcardExpandedTypes)
+            {
+                expandedEntries.push_back({
+                    .type     = deviceType,
+                    .endpoint = nextEp++,
+                    .parentId = entry.parentId,
+                });
+            }
+            if (nextEp > nextAvailableEp)
+            {
+                nextAvailableEp = nextEp;
+            }
+        }
+        else
+        {
+            expandedEntries.push_back(entry);
+            if (entry.endpoint != chip::kInvalidEndpointId && entry.endpoint >= nextAvailableEp)
+            {
+                nextAvailableEp = entry.endpoint + 1;
+            }
+        }
+    }
+
+    mDeviceTypeEntries = std::move(expandedEntries);
 }

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -138,14 +138,14 @@ void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcard
     chip::EndpointId maxEp = 0;
     for (const auto & entry : mDeviceTypeEntries)
     {
-        if (entry.type != "*" && entry.endpoint != chip::kInvalidEndpointId && entry.endpoint > maxEp)
+        if (entry.endpoint != chip::kInvalidEndpointId && entry.endpoint > maxEp)
         {
             maxEp = entry.endpoint;
         }
     }
 
     std::vector<Entry> expandedEntries;
-    chip::EndpointId nextAvailableEp = (maxEp == 0) ? 1 : static_cast<chip::EndpointId>(maxEp + 1);
+    chip::EndpointId nextAvailableEp = static_cast<chip::EndpointId>(maxEp + 1);
 
     for (const auto & entry : mDeviceTypeEntries)
     {

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -134,8 +134,18 @@ void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcard
         return;
     }
 
+    // Find the highest explicit endpoint ID in the list
+    chip::EndpointId maxEp = 0;
+    for (const auto & entry : mDeviceTypeEntries)
+    {
+        if (entry.type != "*" && entry.endpoint != chip::kInvalidEndpointId && entry.endpoint > maxEp)
+        {
+            maxEp = entry.endpoint;
+        }
+    }
+
     std::vector<Entry> expandedEntries;
-    chip::EndpointId nextAvailableEp = 1;
+    chip::EndpointId nextAvailableEp = (maxEp == 0) ? 1 : static_cast<chip::EndpointId>(maxEp + 1);
 
     for (const auto & entry : mDeviceTypeEntries)
     {
@@ -158,10 +168,6 @@ void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcard
         else
         {
             expandedEntries.push_back(entry);
-            if (entry.endpoint != chip::kInvalidEndpointId && entry.endpoint >= nextAvailableEp)
-            {
-                nextAvailableEp = entry.endpoint + 1;
-            }
         }
     }
 

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -129,8 +129,7 @@ const std::vector<DeviceTypeParser::Entry> & DeviceTypeParser::GetDeviceTypeEntr
 
 void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcardExpandedTypes)
 {
-    if (std::none_of(mDeviceTypeEntries.begin(), mDeviceTypeEntries.end(),
-                     [](const auto & entry) { return entry.type == "*"; }))
+    if (std::none_of(mDeviceTypeEntries.begin(), mDeviceTypeEntries.end(), [](const auto & entry) { return entry.type == "*"; }))
     {
         return;
     }

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
@@ -50,6 +50,14 @@ public:
     CHIP_ERROR ParseSingleDeviceString(const char * value);
 
     /**
+     * Expands any wildcard "*" entries in the parsed list into the given list of device types,
+     * maintaining parentage and allocating sequential endpoints.
+     *
+     * @param wildcardExpandedTypes The list of leaf device types that wildcard should expand to.
+     */
+    void ExpandWildcards(const std::vector<std::string> & wildcardExpandedTypes);
+
+    /**
      * Gets the list of parsed device configurations.
      */
     const std::vector<Entry> & GetDeviceTypeEntries();

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -96,3 +96,108 @@ TEST_F(TestDeviceTypeParser, AccumulateDevices)
     EXPECT_EQ(configs[1].endpoint, 2);
     EXPECT_EQ(configs[1].parentId, 1);
 }
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_NoWildcard)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("chime:1"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("speaker:2"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker", "light" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 2U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 2);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_DefaultEndpoint)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker", "light" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 3U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 2);
+    EXPECT_EQ(configs[2].type, "light");
+    EXPECT_EQ(configs[2].endpoint, 3);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_ExplicitEndpoint)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*:10"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 2U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 10);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 11);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_ParentPropagation)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*:5,parent=2"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 2U);
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 5);
+    EXPECT_EQ(configs[0].parentId, 2);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 6);
+    EXPECT_EQ(configs[1].parentId, 2);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_MixedOrdering)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("light:5"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 3U);
+    EXPECT_EQ(configs[0].type, "light");
+    EXPECT_EQ(configs[0].endpoint, 5);
+    EXPECT_EQ(configs[1].type, "chime");
+    EXPECT_EQ(configs[1].endpoint, 6);
+    EXPECT_EQ(configs[2].type, "speaker");
+    EXPECT_EQ(configs[2].endpoint, 7);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_MultipleWildcards)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 4U);
+    // First wildcard
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 1);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 2);
+    // Second wildcard
+    EXPECT_EQ(configs[2].type, "chime");
+    EXPECT_EQ(configs[2].endpoint, 3);
+    EXPECT_EQ(configs[3].type, "speaker");
+    EXPECT_EQ(configs[3].endpoint, 4);
+}

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -201,3 +201,61 @@ TEST_F(TestDeviceTypeParser, ExpandWildcards_MultipleWildcards)
     EXPECT_EQ(configs[3].type, "speaker");
     EXPECT_EQ(configs[3].endpoint, 4);
 }
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_MixedOrderingAfter)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("light:10"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 3U);
+    // Wildcard expanded starting at maxEp + 1 = 11
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 11);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 12);
+    // light explicit endpoint at 10
+    EXPECT_EQ(configs[2].type, "light");
+    EXPECT_EQ(configs[2].endpoint, 10);
+}
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_Subtrees)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("aggregator:1"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*,parent=1"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("aggregator:20"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*,parent=20"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 6U);
+
+    // aggregator:1
+    EXPECT_EQ(configs[0].type, "aggregator");
+    EXPECT_EQ(configs[0].endpoint, 1);
+
+    // first wildcard block starts at maxEp + 1 = 21
+    EXPECT_EQ(configs[1].type, "chime");
+    EXPECT_EQ(configs[1].endpoint, 21);
+    EXPECT_EQ(configs[1].parentId, 1);
+    EXPECT_EQ(configs[2].type, "speaker");
+    EXPECT_EQ(configs[2].endpoint, 22);
+    EXPECT_EQ(configs[2].parentId, 1);
+
+    // aggregator:20
+    EXPECT_EQ(configs[3].type, "aggregator");
+    EXPECT_EQ(configs[3].endpoint, 20);
+
+    // second wildcard block starts at nextAvailableEp = 23
+    EXPECT_EQ(configs[4].type, "chime");
+    EXPECT_EQ(configs[4].endpoint, 23);
+    EXPECT_EQ(configs[4].parentId, 20);
+    EXPECT_EQ(configs[5].type, "speaker");
+    EXPECT_EQ(configs[5].endpoint, 24);
+    EXPECT_EQ(configs[5].parentId, 20);
+}

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -259,3 +259,32 @@ TEST_F(TestDeviceTypeParser, ExpandWildcards_Subtrees)
     EXPECT_EQ(configs[5].endpoint, 24);
     EXPECT_EQ(configs[5].parentId, 20);
 }
+
+TEST_F(TestDeviceTypeParser, ExpandWildcards_WildcardExplicitMaxEp)
+{
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*,parent=1"), CHIP_NO_ERROR);
+    EXPECT_EQ(mParser.ParseSingleDeviceString("*:10,parent=20"), CHIP_NO_ERROR);
+
+    std::vector<std::string> deviceTypes = { "chime", "speaker" };
+    mParser.ExpandWildcards(deviceTypes);
+
+    const auto & configs = mParser.GetDeviceTypeEntries();
+    EXPECT_EQ(configs.size(), 4U);
+
+    // Because *:10 is parsed, maxEp is 10.
+    // Therefore, the first wildcard starts at maxEp + 1 = 11.
+    EXPECT_EQ(configs[0].type, "chime");
+    EXPECT_EQ(configs[0].endpoint, 11);
+    EXPECT_EQ(configs[0].parentId, 1);
+    EXPECT_EQ(configs[1].type, "speaker");
+    EXPECT_EQ(configs[1].endpoint, 12);
+    EXPECT_EQ(configs[1].parentId, 1);
+
+    // The second wildcard starts at its explicit endpoint 10.
+    EXPECT_EQ(configs[2].type, "chime");
+    EXPECT_EQ(configs[2].endpoint, 10);
+    EXPECT_EQ(configs[2].parentId, 20);
+    EXPECT_EQ(configs[3].type, "speaker");
+    EXPECT_EQ(configs[3].endpoint, 11);
+    EXPECT_EQ(configs[3].parentId, 20);
+}

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -71,17 +71,8 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
     }
 
     // Check if wildcard expansion is needed
-    bool hasWildcard = false;
-    for (const auto & entry : mConfig.deviceTypeEntries)
-    {
-        if (entry.type == "*")
-        {
-            hasWildcard = true;
-            break;
-        }
-    }
-
-    if (!hasWildcard)
+    if (std::none_of(mConfig.deviceTypeEntries.begin(), mConfig.deviceTypeEntries.end(),
+                     [](const auto & entry) { return entry.type == "*"; }))
     {
         return mConfig;
     }

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -59,20 +59,41 @@ AppOptions::AppConfig AppOptions::mConfig;
 
 const AppOptions::AppConfig & AppOptions::GetConfig()
 {
-    static bool expanded = false;
-    if (expanded)
+    // Default device fallback if no devices are configured
+    if (mConfig.deviceTypeEntries.empty())
+    {
+        mConfig.deviceTypeEntries.push_back({
+            .type     = chip::app::DeviceFactory::GetInstance().GetDefaultDevice(),
+            .endpoint = 1,
+            .parentId = chip::kInvalidEndpointId,
+        });
+        return mConfig;
+    }
+
+    // Check if wildcard expansion is needed
+    bool hasWildcard = false;
+    for (const auto & entry : mConfig.deviceTypeEntries)
+    {
+        if (entry.type == "*")
+        {
+            hasWildcard = true;
+            break;
+        }
+    }
+
+    if (!hasWildcard)
     {
         return mConfig;
     }
 
     std::vector<DeviceTypeParser::Entry> finalEntries;
 
-    // Process all standard devices, expanding wildcard (*)
+    // Process and expand wildcard (*) entries
     for (const auto & entry : mConfig.deviceTypeEntries)
     {
         if (entry.type == "*")
         {
-            chip::EndpointId nextEp = entry.endpoint;
+            chip::EndpointId nextEp = (entry.endpoint == chip::kInvalidEndpointId) ? 1 : entry.endpoint;
             for (const auto & deviceType : chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes())
             {
                 if (IsExcludedFromWildcard(deviceType))
@@ -92,18 +113,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
         }
     }
 
-    // Default device fallback
-    if (finalEntries.empty())
-    {
-        finalEntries.push_back({
-            .type     = chip::app::DeviceFactory::GetInstance().GetDefaultDevice(),
-            .endpoint = 1,
-            .parentId = chip::kInvalidEndpointId,
-        });
-    }
-
     mConfig.deviceTypeEntries = finalEntries;
-    expanded                  = true;
     return mConfig;
 }
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -46,6 +46,18 @@ bool IsExcludedFromWildcard(const std::string & type)
     return false;
 }
 
+bool HasWildcard(const std::vector<DeviceTypeParser::Entry> & entries)
+{
+    for (const auto & entry : entries)
+    {
+        if (entry.type == "*")
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace
 
 // App custom argument handling
@@ -77,17 +89,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
     }
 
     // Check if wildcard expansion is needed
-    bool hasWildcard = false;
-    for (const auto & entry : mConfig.deviceTypeEntries)
-    {
-        if (entry.type == "*")
-        {
-            hasWildcard = true;
-            break;
-        }
-    }
-
-    if (!hasWildcard)
+    if (!HasWildcard(mConfig.deviceTypeEntries))
     {
         return mConfig;
     }

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -21,11 +21,26 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 
 using namespace chip;
 using namespace chip::ArgParser;
+
+namespace {
+
+bool IsExcludedFromWildcard(const std::string & type)
+{
+    static const std::vector<std::string> kExcludedDevices = {
+        "aggregator",
+        "bridged-node",
+        "fan-no-onoff",
+    };
+    return std::find(kExcludedDevices.begin(), kExcludedDevices.end(), type) != kExcludedDevices.end();
+}
+
+} // namespace
 
 // App custom argument handling
 constexpr uint16_t kOptionDeviceType    = 0xffd0;
@@ -60,7 +75,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
             chip::EndpointId nextEp = entry.endpoint;
             for (const auto & deviceType : chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes())
             {
-                if (deviceType == "aggregator" || deviceType == "bridged-node" || deviceType == "fan-no-onoff")
+                if (IsExcludedFromWildcard(deviceType))
                 {
                     continue;
                 }

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -77,7 +77,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
         return mConfig;
     }
 
-    std::vector<DeviceTypeParser::Entry> finalEntries;
+    std::vector<DeviceTypeParser::Entry> expandedEntries;
 
     // Process and expand wildcard (*) entries
     for (const auto & entry : mConfig.deviceTypeEntries)
@@ -91,7 +91,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
                 {
                     continue;
                 }
-                finalEntries.push_back({
+                expandedEntries.push_back({
                     .type     = deviceType,
                     .endpoint = nextEp++,
                     .parentId = entry.parentId,
@@ -100,11 +100,11 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
         }
         else
         {
-            finalEntries.push_back(entry);
+            expandedEntries.push_back(entry);
         }
     }
 
-    mConfig.deviceTypeEntries = finalEntries;
+    mConfig.deviceTypeEntries = expandedEntries;
     return mConfig;
 }
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -191,7 +191,7 @@ OptionSet * AppOptions::GetOptions()
         result.append(">");
         result += "\n";
         result += "       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'.\n";
-        result += "       Use '*' to select all supported leaf devices (e.g. --device *:1).\n";
+        result += "       Use '*' to select all supported leaf devices (e.g. --device \"*:1\").\n";
         result += "       Can be specified multiple times for multi-endpoint devices.\n";
         result += "       Example: --device chime:1 --device speaker:2,parent=1\n\n";
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 
@@ -31,31 +32,14 @@ namespace {
 
 bool IsExcludedFromWildcard(const std::string & type)
 {
+    // These device types are excluded from the wildcard (*) expansion to prevent redundant,
+    // invalid, or non-leaf endpoint structures.
     static const std::vector<std::string> kExcludedDevices = {
-        "aggregator",
-        "bridged-node",
-        "fan-no-onoff",
+        "aggregator",   // Top-level container representing a bridge; not a standalone leaf device.
+        "bridged-node", // Base class representing a bridged endpoint wrapper; not a standalone leaf device.
     };
-    for (const auto & excluded : kExcludedDevices)
-    {
-        if (excluded == type)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool HasWildcard(const std::vector<DeviceTypeParser::Entry> & entries)
-{
-    for (const auto & entry : entries)
-    {
-        if (entry.type == "*")
-        {
-            return true;
-        }
-    }
-    return false;
+    return std::any_of(kExcludedDevices.begin(), kExcludedDevices.end(),
+                       [&type](const auto & excluded) { return excluded == type; });
 }
 
 } // namespace
@@ -88,40 +72,19 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
         return mConfig;
     }
 
-    // Check if wildcard expansion is needed
-    if (!HasWildcard(mConfig.deviceTypeEntries))
+    // Expand wildcards using the supported device types from DeviceFactory
+    std::vector<std::string> supportedTypes;
+    for (const auto & deviceType : chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes())
     {
-        return mConfig;
-    }
-
-    std::vector<DeviceTypeParser::Entry> expandedEntries;
-
-    // Process and expand wildcard (*) entries
-    for (const auto & entry : mConfig.deviceTypeEntries)
-    {
-        if (entry.type == "*")
+        if (!IsExcludedFromWildcard(deviceType))
         {
-            chip::EndpointId nextEp = (entry.endpoint == chip::kInvalidEndpointId) ? 1 : entry.endpoint;
-            for (const auto & deviceType : chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes())
-            {
-                if (IsExcludedFromWildcard(deviceType))
-                {
-                    continue;
-                }
-                expandedEntries.push_back({
-                    .type     = deviceType,
-                    .endpoint = nextEp++,
-                    .parentId = entry.parentId,
-                });
-            }
-        }
-        else
-        {
-            expandedEntries.push_back(entry);
+            supportedTypes.push_back(deviceType);
         }
     }
 
-    mConfig.deviceTypeEntries = expandedEntries;
+    sParser.ExpandWildcards(supportedTypes);
+    mConfig.deviceTypeEntries = sParser.GetDeviceTypeEntries();
+
     return mConfig;
 }
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -44,14 +44,51 @@ AppOptions::AppConfig AppOptions::mConfig;
 
 const AppOptions::AppConfig & AppOptions::GetConfig()
 {
-    if (mConfig.deviceTypeEntries.empty())
+    static bool expanded = false;
+    if (expanded)
     {
-        mConfig.deviceTypeEntries.push_back({
+        return mConfig;
+    }
+
+    std::vector<DeviceTypeParser::Entry> finalEntries;
+
+    // Process all standard devices, expanding wildcard (*)
+    for (const auto & entry : mConfig.deviceTypeEntries)
+    {
+        if (entry.type == "*")
+        {
+            chip::EndpointId nextEp = entry.endpoint;
+            for (const auto & deviceType : chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes())
+            {
+                if (deviceType == "aggregator" || deviceType == "bridged-node" || deviceType == "fan-no-onoff")
+                {
+                    continue;
+                }
+                finalEntries.push_back({
+                    .type     = deviceType,
+                    .endpoint = nextEp++,
+                    .parentId = entry.parentId,
+                });
+            }
+        }
+        else
+        {
+            finalEntries.push_back(entry);
+        }
+    }
+
+    // Default device fallback
+    if (finalEntries.empty())
+    {
+        finalEntries.push_back({
             .type     = chip::app::DeviceFactory::GetInstance().GetDefaultDevice(),
             .endpoint = 1,
             .parentId = chip::kInvalidEndpointId,
         });
     }
+
+    mConfig.deviceTypeEntries = finalEntries;
+    expanded = true;
     return mConfig;
 }
 
@@ -154,9 +191,11 @@ OptionSet * AppOptions::GetOptions()
             result.append(name);
             result.append("|");
         }
-        result.replace(result.length() - 1, 1, ">");
+        result.append("*");
+        result.append(">");
         result += "\n";
-        result += "       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'\n";
+        result += "       Select the device to start up. Format: 'type' or 'type:endpoint' or 'type:endpoint,parent=parentId'.\n";
+        result += "       Use '*' to select all supported leaf devices (e.g. --device *:1).\n";
         result += "       Can be specified multiple times for multi-endpoint devices.\n";
         result += "       Example: --device chime:1 --device speaker:2,parent=1\n\n";
 

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -21,7 +21,6 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 
@@ -37,7 +36,14 @@ bool IsExcludedFromWildcard(const std::string & type)
         "bridged-node",
         "fan-no-onoff",
     };
-    return std::find(kExcludedDevices.begin(), kExcludedDevices.end(), type) != kExcludedDevices.end();
+    for (const auto & excluded : kExcludedDevices)
+    {
+        if (excluded == type)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace
@@ -71,8 +77,17 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
     }
 
     // Check if wildcard expansion is needed
-    if (std::none_of(mConfig.deviceTypeEntries.begin(), mConfig.deviceTypeEntries.end(),
-                     [](const auto & entry) { return entry.type == "*"; }))
+    bool hasWildcard = false;
+    for (const auto & entry : mConfig.deviceTypeEntries)
+    {
+        if (entry.type == "*")
+        {
+            hasWildcard = true;
+            break;
+        }
+    }
+
+    if (!hasWildcard)
     {
         return mConfig;
     }

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -103,7 +103,7 @@ const AppOptions::AppConfig & AppOptions::GetConfig()
     }
 
     mConfig.deviceTypeEntries = finalEntries;
-    expanded = true;
+    expanded                  = true;
     return mConfig;
 }
 


### PR DESCRIPTION
### Summary
This PR adds support for wildcard '*' expansion to the `--device` option in `all-devices-app`. It expands the wildcard to all supported leaf device types (excluding `aggregator` and `bridged-node`), beginning at the specified endpoint number.

### Testing
1. Built the POSIX `linux-x64-all-devices-boringssl` target.
2. Verified using `all-devices-app` argument expansion:
   `./out/linux-x64-all-devices-boringssl/all-devices-app --device *:1`
   and verified correct endpoints layout using `chip-tool descriptor read parts-list`.