### PR TITLE
Clear actionable clang-tidy readability/modernize findings

### DIFF
--- a/src/lib/support/utf8.cpp
+++ b/src/lib/support/utf8.cpp
@@ -62,105 +62,81 @@ ParserState NextState(ParserState state, uint8_t value)
         {
             return ParserState::kFirstByte;
         }
-        else if ((value >= 0xC2) && (value <= 0xDF))
+        if ((value >= 0xC2) && (value <= 0xDF))
         {
             return ParserState::kExtraOneByte;
         }
-        else if (value == 0xE0)
+        if (value == 0xE0)
         {
             return ParserState::kSecondByte_A;
         }
-        else if ((value >= 0xE1) && (value <= 0xEC))
+        if ((value >= 0xE1) && (value <= 0xEC))
         {
             return ParserState::kExtraTwoBytes;
         }
-        else if (value == 0xED)
+        if (value == 0xED)
         {
             return ParserState::kSecondByte_B;
         }
-        else if ((value >= 0xEE) && (value <= 0xEF))
+        if ((value >= 0xEE) && (value <= 0xEF))
         {
             return ParserState::kExtraTwoBytes;
         }
-        else if (value == 0xF0)
+        if (value == 0xF0)
         {
             return ParserState::kSecondByte_C;
         }
-        else if ((value >= 0xF1) && (value <= 0xF3))
+        if ((value >= 0xF1) && (value <= 0xF3))
         {
             return ParserState::kExtraThreeBytes;
         }
-        else if (value == 0xF4)
+        if (value == 0xF4)
         {
             return ParserState::kSecondByte_D;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kSecondByte_A:
         if (value >= 0xA0 && value <= 0xBF)
         {
             return ParserState::kExtraOneByte;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kSecondByte_B:
         if (value >= 0x80 && value <= 0x9F)
         {
             return ParserState::kExtraOneByte;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kSecondByte_C:
         if (value >= 0x90 && value <= 0xBF)
         {
             return ParserState::kExtraTwoBytes;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kSecondByte_D:
         if (value >= 0x80 && value <= 0x8F)
         {
             return ParserState::kExtraTwoBytes;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kExtraOneByte:
         if (value >= 0x80 && value <= 0xBF)
         {
             return ParserState::kFirstByte;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kExtraTwoBytes:
         if (value >= 0x80 && value <= 0xBF)
         {
             return ParserState::kExtraOneByte;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     case ParserState::kExtraThreeBytes:
         if (value >= 0x80 && value <= 0xBF)
         {
             return ParserState::kExtraTwoBytes;
         }
-        else
-        {
-            return ParserState::kInvalid;
-        }
+        return ParserState::kInvalid;
     default:
         return ParserState::kInvalid;
     }

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -210,7 +210,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 }
 
-ConnectivityManagerImpl & ConnectivityMgrImpl(void)
+ConnectivityManagerImpl & ConnectivityMgrImpl()
 {
     return ConnectivityManagerImpl::GetDefaultInstance();
 }

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -116,7 +116,7 @@ CHIP_ERROR WiFiPAFBase::WiFiPAFCloseSession(WiFiPAFSession & SessionInfo)
     return CHIP_NO_ERROR;
 }
 
-bool WiFiPAFBase::WiFiPAFResourceAvailable(void)
+bool WiFiPAFBase::WiFiPAFResourceAvailable()
 {
     return DeviceLayer::ConnectivityMgr().WiFiPAFResourceAvailable();
 }

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -66,7 +66,7 @@ public:
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAF::WiFiPAFSession & RxInfo, System::PacketBufferHandle && buffer) override;
     CHIP_ERROR WiFiPAFMessageSend(WiFiPAF::WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg) override;
     CHIP_ERROR WiFiPAFCloseSession(WiFiPAF::WiFiPAFSession & SessionInfo) override;
-    bool WiFiPAFResourceAvailable(void) override;
+    bool WiFiPAFResourceAvailable() override;
 
 private:
     /**

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -403,7 +403,6 @@ void WiFiPAFLayer::CleanPafInfo(WiFiPAFSession & SessionInfo)
     SessionInfo.peer_id       = kUndefinedWiFiPafSessionId;
     SessionInfo.nodeId        = kUndefinedNodeId;
     SessionInfo.discriminator = UINT16_MAX;
-    return;
 }
 
 CHIP_ERROR WiFiPAFLayer::AddPafSession(PafInfoAccess accType, WiFiPAFSession & SessionInfo)
@@ -506,8 +505,7 @@ WiFiPAFSession * WiFiPAFLayer::GetPAFInfo(PafInfoAccess accType, WiFiPAFSession 
         {
             if (pPafSession->id != kUndefinedWiFiPafSessionId)
                 return pPafSession;
-            else
-                continue;
+            continue;
         }
         switch (accType)
         {


### PR DESCRIPTION
#### Summary

- Following clang-tidy issues are related to checks already activated in our PR runs; cleaning them before they make un-releated PRs fail.

#### Changes (no behavior change)

- `readability-else-after-return` in the `utf8.cpp` UTF-8 parser state machine and `WiFiPAFLayer.cpp`.
- A redundant trailing `return;` in a void function (`WiFiPAFLayer.cpp::CleanPafInfo`).
- Redundant `(void)` parameter lists dropped in `transport/raw/WiFiPAF.{h,cpp}` and Linux `ConnectivityManagerImpl.cpp` (`modernize-redundant-void-arg`); the canonical declarations already use `()`.

#### Testing

- Touched translation units compile-verified.
