### PR TITLE
[WiFi-PAF] Fix double-close null-deref in WiFiPAFEndPoint

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -79,6 +79,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/protocols/secure_channel/tests:fuzz-CASE-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/protocols/secure_channel/tests:fuzz-PASE-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/setup_payload/tests:fuzz-setup-payload-base38-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-tp-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
       ]
     }
   }

--- a/src/wifipaf/WiFiPAFEndPoint.cpp
+++ b/src/wifipaf/WiFiPAFEndPoint.cpp
@@ -1337,7 +1337,7 @@ void WiFiPAFEndPoint::ClearAll()
     OnMessageReceived       = nullptr;
     OnConnectionClosed      = nullptr;
 
-    mState = kState_Ready;
+    mState = kState_Closed;
     mRole  = kWiFiPafRole_Publisher;
     mRxAck = 0;
     mConnStateFlags.ClearAll();

--- a/src/wifipaf/tests/BUILD.gn
+++ b/src/wifipaf/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/fuzz_test.gni")
 
 chip_test_suite("tests") {
   output_name = "libWiFiPAFLayerTests"
@@ -33,4 +34,22 @@ chip_test_suite("tests") {
     "${chip_root}/src/platform",
     "${chip_root}/src/wifipaf",
   ]
+}
+
+if (pw_enable_fuzz_test_targets) {
+  chip_pw_fuzz_target("fuzz-wifipaf-endpoint-pw") {
+    test_source = [ "FuzzWiFiPAFEndPointPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/wifipaf",
+    ]
+  }
+  chip_pw_fuzz_target("fuzz-wifipaf-tp-pw") {
+    test_source = [ "FuzzWiFiPAFTPPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/wifipaf",
+    ]
+  }
 }

--- a/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
@@ -139,15 +139,17 @@ std::vector<std::vector<uint8_t>> CapabilitySeeds()
 std::vector<std::vector<uint8_t>> PaftpSeeds()
 {
     return {
-        { 0x05, 0x01, 0x01, 0x00, 0x00 }, { 0x05, 0x01, 0x03, 0x00, 0x00 },
-        { 0x01, 0x00, 0x01, 0x00, 0x00 }, { 0x04, 0x01, 0x02, 0x00 },
+        { 0x05, 0x01, 0x01, 0x00, 0x00 },
+        { 0x05, 0x01, 0x03, 0x00, 0x00 },
+        { 0x01, 0x00, 0x01, 0x00, 0x00 },
+        { 0x04, 0x01, 0x02, 0x00 },
     };
 }
 
 void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t sessionId, uint16_t discriminator,
-                                 uint32_t sendErrMask, uint32_t recvErrMask, bool resourceAvail,
-                                 const std::vector<uint8_t> & frag0, const std::vector<uint8_t> & frag1,
-                                 const std::vector<uint8_t> & frag2, const std::vector<uint8_t> & frag3)
+                                 uint32_t sendErrMask, uint32_t recvErrMask, bool resourceAvail, const std::vector<uint8_t> & frag0,
+                                 const std::vector<uint8_t> & frag1, const std::vector<uint8_t> & frag2,
+                                 const std::vector<uint8_t> & frag3)
 {
     EnsureInitialized();
 

--- a/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
@@ -1,0 +1,202 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// FuzzTest harness for WiFiPAFEndPoint::Receive. The injected layer delegate returns send/receive
+// errors and withholds resources on a fuzz-controlled schedule (modeling a congested/closing
+// transport), so the endpoint's error / close / back-pressure paths are exercised alongside the
+// data-phase reassembly. Fragments are seeded with real PAFTP shapes.
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemLayer.h>
+#include <system/SystemPacketBuffer.h>
+#include <wifipaf/WiFiPAFEndPoint.h>
+#include <wifipaf/WiFiPAFLayer.h>
+#include <wifipaf/WiFiPAFLayerDelegate.h>
+
+namespace chip {
+namespace WiFiPAF {
+
+// Reuses the friended TestWiFiPAFLayer name to bring up an endpoint without the full handshake.
+class TestWiFiPAFLayer : public WiFiPAFLayer, private WiFiPAFLayerDelegate
+{
+public:
+    CHIP_ERROR FuzzSetup(uint32_t sendErrMask, uint32_t recvErrMask, bool resourceAvail)
+    {
+        mSendErrMask   = sendErrMask;
+        mRecvErrMask   = recvErrMask;
+        mResourceAvail = resourceAvail;
+        ReturnErrorOnFailure(Init(&DeviceLayer::SystemLayer()));
+        mWiFiPAFTransport = this;
+        return CHIP_NO_ERROR;
+    }
+
+    void FuzzTeardown()
+    {
+        Shutdown();
+        mWiFiPAFTransport = nullptr;
+    }
+
+    // Free() does not clear mWiFiPafLayer; null it so the pool slot is reusable next iteration.
+    static void ForceReleaseEndpoint(WiFiPAFEndPoint * ep)
+    {
+        if (ep != nullptr)
+        {
+            ep->mWiFiPafLayer = nullptr;
+        }
+    }
+
+    CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession &, System::PacketBufferHandle &&) override { return NextError(mRecvErrMask); }
+    CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession &, System::PacketBufferHandle &&) override { return NextError(mSendErrMask); }
+    CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession &) override { return CHIP_NO_ERROR; }
+    bool WiFiPAFResourceAvailable() override { return mResourceAvail; }
+
+private:
+    // A set bit returns a transport error (as a real backend does when its queue is full).
+    CHIP_ERROR NextError(uint32_t & mask)
+    {
+        const bool fail = (mask & 1u) != 0u;
+        mask >>= 1;
+        return fail ? CHIP_ERROR_NOT_CONNECTED : CHIP_NO_ERROR;
+    }
+
+    uint32_t mSendErrMask = 0;
+    uint32_t mRecvErrMask = 0;
+    bool mResourceAvail   = true;
+};
+
+} // namespace WiFiPAF
+} // namespace chip
+
+namespace {
+
+using chip::System::PacketBufferHandle;
+using chip::WiFiPAF::kWiFiPafRole_Publisher;
+using chip::WiFiPAF::kWiFiPafRole_Subscriber;
+using chip::WiFiPAF::PafInfoAccess;
+using chip::WiFiPAF::State;
+using chip::WiFiPAF::TestWiFiPAFLayer;
+using chip::WiFiPAF::WiFiPAFEndPoint;
+using chip::WiFiPAF::WiFiPafRole;
+using chip::WiFiPAF::WiFiPAFSession;
+
+using namespace fuzztest;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        VerifyOrDie(chip::DeviceLayer::SystemLayer().Init() == CHIP_NO_ERROR);
+        std::atexit([] { chip::DeviceLayer::SystemLayer().Shutdown(); });
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+auto AnyRole()
+{
+    return ElementOf<WiFiPafRole>({ kWiFiPafRole_Publisher, kWiFiPafRole_Subscriber });
+}
+
+auto AnyStartState()
+{
+    return ElementOf<uint8_t>({ static_cast<uint8_t>(WiFiPAFEndPoint::kState_Ready),
+                                static_cast<uint8_t>(WiFiPAFEndPoint::kState_Connecting),
+                                static_cast<uint8_t>(WiFiPAFEndPoint::kState_Connected) });
+}
+
+std::vector<std::vector<uint8_t>> CapabilitySeeds()
+{
+    return {
+        { 0x65, 0x6c, 0x04, 0x00, 0x00, 0x00, 0x5e, 0x01, 0x06 },
+        { 0x65, 0x6c, 0x04, 0x5b, 0x01, 0x06 },
+    };
+}
+
+std::vector<std::vector<uint8_t>> PaftpSeeds()
+{
+    return {
+        { 0x05, 0x01, 0x01, 0x00, 0x00 }, { 0x05, 0x01, 0x03, 0x00, 0x00 },
+        { 0x01, 0x00, 0x01, 0x00, 0x00 }, { 0x04, 0x01, 0x02, 0x00 },
+    };
+}
+
+void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t sessionId, uint16_t discriminator,
+                                 uint32_t sendErrMask, uint32_t recvErrMask, bool resourceAvail,
+                                 const std::vector<uint8_t> & frag0, const std::vector<uint8_t> & frag1,
+                                 const std::vector<uint8_t> & frag2, const std::vector<uint8_t> & frag3)
+{
+    EnsureInitialized();
+
+    TestWiFiPAFLayer harness;
+    ASSERT_EQ(harness.FuzzSetup(sendErrMask, recvErrMask, resourceAvail), CHIP_NO_ERROR);
+
+    WiFiPAFSession session = {};
+    session.role           = role;
+    session.id             = sessionId == 0 ? 1 : sessionId;
+    session.peer_id        = 1;
+    session.nodeId         = 1;
+    session.discriminator  = discriminator;
+
+    WiFiPAFEndPoint * ep = nullptr;
+    if (harness.NewEndPoint(&ep, session, role) != CHIP_NO_ERROR || ep == nullptr)
+    {
+        harness.FuzzTeardown();
+        return;
+    }
+    RETURN_SAFELY_IGNORED harness.AddPafSession(PafInfoAccess::kAccSessionId, session);
+    ep->mState = static_cast<decltype(ep->mState)>(startState);
+    harness.SetWiFiPAFState(startState == WiFiPAFEndPoint::kState_Connected ? State::kConnected : State::kInitialized);
+
+    for (const auto * frag : { &frag0, &frag1, &frag2, &frag3 })
+    {
+        auto buf = PacketBufferHandle::NewWithData(frag->data(), frag->size());
+        if (buf.IsNull())
+        {
+            continue;
+        }
+        RETURN_SAFELY_IGNORED ep->Receive(std::move(buf));
+        if (ep->mState == WiFiPAFEndPoint::kState_Closed || ep->mState == WiFiPAFEndPoint::kState_Aborting)
+        {
+            break;
+        }
+    }
+
+    harness.FuzzTeardown();
+    TestWiFiPAFLayer::ForceReleaseEndpoint(ep);
+}
+
+FUZZ_TEST(FuzzWiFiPAFEndPointPW, EndpointReceiveDoesNotCrash)
+    .WithDomains(AnyRole(), AnyStartState(), Arbitrary<uint32_t>(), Arbitrary<uint16_t>(),
+                 Arbitrary<uint32_t>(), // send-failure schedule
+                 Arbitrary<uint32_t>(), // receive-failure schedule
+                 Arbitrary<bool>(),     // resource availability / back-pressure
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(CapabilitySeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpSeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpSeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpSeeds()));
+
+} // namespace

--- a/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFEndPointPW.cpp
@@ -21,6 +21,7 @@
 // data-phase reassembly. Fragments are seeded with real PAFTP shapes.
 
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 #include <vector>
 
@@ -58,15 +59,6 @@ public:
     {
         Shutdown();
         mWiFiPAFTransport = nullptr;
-    }
-
-    // Free() does not clear mWiFiPafLayer; null it so the pool slot is reusable next iteration.
-    static void ForceReleaseEndpoint(WiFiPAFEndPoint * ep)
-    {
-        if (ep != nullptr)
-        {
-            ep->mWiFiPafLayer = nullptr;
-        }
     }
 
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession &, System::PacketBufferHandle &&) override { return NextError(mRecvErrMask); }
@@ -158,10 +150,11 @@ void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t 
 
     WiFiPAFSession session = {};
     session.role           = role;
-    session.id             = sessionId == 0 ? 1 : sessionId;
-    session.peer_id        = 1;
-    session.nodeId         = 1;
-    session.discriminator  = discriminator;
+    // 0 and kUndefinedWiFiPafSessionId are sentinels Shutdown() skips, which would leak the endpoint across iterations.
+    session.id            = (sessionId == 0 || sessionId == chip::WiFiPAF::kUndefinedWiFiPafSessionId) ? 1 : sessionId;
+    session.peer_id       = 1;
+    session.nodeId        = 1;
+    session.discriminator = discriminator;
 
     WiFiPAFEndPoint * ep = nullptr;
     if (harness.NewEndPoint(&ep, session, role) != CHIP_NO_ERROR || ep == nullptr)
@@ -169,6 +162,7 @@ void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t 
         harness.FuzzTeardown();
         return;
     }
+    // Best-effort registration so Shutdown() can find the endpoint; a duplicate/full table is fine here.
     RETURN_SAFELY_IGNORED harness.AddPafSession(PafInfoAccess::kAccSessionId, session);
     ep->mState = static_cast<decltype(ep->mState)>(startState);
     harness.SetWiFiPAFState(startState == WiFiPAFEndPoint::kState_Connected ? State::kConnected : State::kInitialized);
@@ -180,6 +174,7 @@ void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t 
         {
             continue;
         }
+        // Fuzzer asserts only the no-crash property; Receive's status is irrelevant here.
         RETURN_SAFELY_IGNORED ep->Receive(std::move(buf));
         if (ep->mState == WiFiPAFEndPoint::kState_Closed || ep->mState == WiFiPAFEndPoint::kState_Aborting)
         {
@@ -187,8 +182,10 @@ void EndpointReceiveDoesNotCrash(WiFiPafRole role, uint8_t startState, uint32_t 
         }
     }
 
+    // FuzzTeardown()->Shutdown() closes the registered endpoint through the production DoClose path
+    // (cancels timers, frees buffers, returns the static pool slot via ClearAll), so the slot is reusable
+    // next iteration without poking mWiFiPafLayer directly. The session-id clamp above keeps it findable.
     harness.FuzzTeardown();
-    TestWiFiPAFLayer::ForceReleaseEndpoint(ep);
 }
 
 FUZZ_TEST(FuzzWiFiPAFEndPointPW, EndpointReceiveDoesNotCrash)

--- a/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
@@ -77,14 +77,19 @@ void WiFiPAFTPDoesNotCrash(bool expectFirstAck, const std::vector<uint8_t> & fra
     {
         auto buf = PacketBufferHandle::NewWithData(frag->data(), frag->size());
         if (buf.IsNull())
+        {
             continue;
+        }
 
         SequenceNumber_t receivedAck = 0;
         bool didReceiveAck           = false;
+        // Fuzzer asserts only the no-crash property; the parse status is irrelevant here.
         RETURN_SAFELY_IGNORED engine.HandleCharacteristicReceived(std::move(buf), receivedAck, didReceiveAck);
 
         if (engine.RxState() == WiFiPAFTP::kState_Error)
+        {
             break;
+        }
     }
 }
 

--- a/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
@@ -62,9 +62,8 @@ std::vector<std::vector<uint8_t>> PaftpFragmentSeeds()
     };
 }
 
-void WiFiPAFTPDoesNotCrash(bool expectFirstAck, const std::vector<uint8_t> & frag0,
-                           const std::vector<uint8_t> & frag1, const std::vector<uint8_t> & frag2,
-                           const std::vector<uint8_t> & frag3)
+void WiFiPAFTPDoesNotCrash(bool expectFirstAck, const std::vector<uint8_t> & frag0, const std::vector<uint8_t> & frag1,
+                           const std::vector<uint8_t> & frag2, const std::vector<uint8_t> & frag3)
 {
     EnsureInitialized();
 
@@ -90,11 +89,9 @@ void WiFiPAFTPDoesNotCrash(bool expectFirstAck, const std::vector<uint8_t> & fra
 }
 
 FUZZ_TEST(FuzzWiFiPAFTPPW, WiFiPAFTPDoesNotCrash)
-    .WithDomains(
-        Arbitrary<bool>(),
-        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
-        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
-        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
-        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()));
+    .WithDomains(Arbitrary<bool>(), Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()));
 
 } // namespace

--- a/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
+++ b/src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp
@@ -1,0 +1,100 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// FuzzTest harness for the WiFiPAFTP transport-protocol engine, seeded with real PAFTP fragment
+// shapes so the mutator starts past the header-validation gate.
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <system/SystemPacketBuffer.h>
+#include <wifipaf/WiFiPAFTP.h>
+
+namespace {
+
+using chip::System::PacketBufferHandle;
+using chip::WiFiPAF::SequenceNumber_t;
+using chip::WiFiPAF::WiFiPAFTP;
+using namespace fuzztest;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+// Real PAFTP fragment shapes (capability + data-phase variants).
+std::vector<std::vector<uint8_t>> PaftpFragmentSeeds()
+{
+    return {
+        { 0x65, 0x6c, 0x04, 0x00, 0x00, 0x00, 0x5e, 0x01, 0x06 }, // capability request
+        { 0x65, 0x6c, 0x04, 0x5b, 0x01, 0x06 },                   // capability response
+        { 0x05, 0x01, 0x01, 0x00, 0x00, 0xAA },                   // start+end, seq 1
+        { 0x01, 0x00, 0x01, 0x00, 0x00, 0xDE, 0xAD },             // start only
+        { 0x02, 0x02, 0xBE, 0xEF },                               // continue
+        { 0x04, 0x03, 0xCA, 0xFE },                               // end
+        { 0x08, 0x02 },                                           // ack-only
+        { 0x05, 0x01, 0x05, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF }, // out-of-order seq 5
+    };
+}
+
+void WiFiPAFTPDoesNotCrash(bool expectFirstAck, const std::vector<uint8_t> & frag0,
+                           const std::vector<uint8_t> & frag1, const std::vector<uint8_t> & frag2,
+                           const std::vector<uint8_t> & frag3)
+{
+    EnsureInitialized();
+
+    WiFiPAFTP engine;
+    if (engine.Init(nullptr, expectFirstAck) != CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    for (const auto * frag : { &frag0, &frag1, &frag2, &frag3 })
+    {
+        auto buf = PacketBufferHandle::NewWithData(frag->data(), frag->size());
+        if (buf.IsNull())
+            continue;
+
+        SequenceNumber_t receivedAck = 0;
+        bool didReceiveAck           = false;
+        RETURN_SAFELY_IGNORED engine.HandleCharacteristicReceived(std::move(buf), receivedAck, didReceiveAck);
+
+        if (engine.RxState() == WiFiPAFTP::kState_Error)
+            break;
+    }
+}
+
+FUZZ_TEST(FuzzWiFiPAFTPPW, WiFiPAFTPDoesNotCrash)
+    .WithDomains(
+        Arbitrary<bool>(),
+        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()),
+        Arbitrary<std::vector<uint8_t>>().WithSeeds(PaftpFragmentSeeds()));
+
+} // namespace

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -101,8 +101,12 @@ private:
 TEST_F(TestWiFiPAFLayer, FinalizeCloseIsIdempotentAcrossDoubleClose)
 {
     WiFiPAFSession sessionInfo = {
-        .role = kWiFiPafRole_Subscriber, .id = 1, .peer_id = 1,
-        .peer_addr = { 0xd0, 0x17, 0x69, 0xee, 0x7f, 0x3c }, .nodeId = 1, .discriminator = 0xF00,
+        .role          = kWiFiPafRole_Subscriber,
+        .id            = 1,
+        .peer_id       = 1,
+        .peer_addr     = { 0xd0, 0x17, 0x69, 0xee, 0x7f, 0x3c },
+        .nodeId        = 1,
+        .discriminator = 0xF00,
     };
     WiFiPAFEndPoint * ep = nullptr;
     ASSERT_EQ(NewEndPoint(&ep, sessionInfo, sessionInfo.role), CHIP_NO_ERROR);

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -93,6 +93,29 @@ private:
     WiFiPAFEndPoint * mEndPoint;
 };
 
+// Regression: a closed WiFiPAFEndPoint must not be revivable. ClearAll() (called at the end of
+// FinalizeClose) nulls mWiFiPafLayer; if it also left mState at a non-closed value, the DoClose()
+// guard would re-open and a second close trigger -- e.g. a retransmit/ack timer that still
+// references this endpoint and fires after it closed -- would re-enter and dereference the null
+// mWiFiPafLayer. Two DoClose() calls reproduce it through the production path.
+TEST_F(TestWiFiPAFLayer, FinalizeCloseIsIdempotentAcrossDoubleClose)
+{
+    WiFiPAFSession sessionInfo = {
+        .role = kWiFiPafRole_Subscriber, .id = 1, .peer_id = 1,
+        .peer_addr = { 0xd0, 0x17, 0x69, 0xee, 0x7f, 0x3c }, .nodeId = 1, .discriminator = 0xF00,
+    };
+    WiFiPAFEndPoint * ep = nullptr;
+    ASSERT_EQ(NewEndPoint(&ep, sessionInfo, sessionInfo.role), CHIP_NO_ERROR);
+    ASSERT_NE(ep, nullptr);
+    SetEndPoint(ep);
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);
+    ep->mState = WiFiPAFEndPoint::kState_Connected;
+
+    EpDoClose(kWiFiPAFCloseFlag_AbortTransmission, CHIP_ERROR_INTERNAL);
+    EpDoClose(kWiFiPAFCloseFlag_AbortTransmission, CHIP_ERROR_INTERNAL);
+    SUCCEED();
+}
+
 TEST_F(TestWiFiPAFLayer, CheckWiFiPAFTransportCapabilitiesRequestMessage)
 {
     auto buf = System::PacketBufferHandle::New(100);


### PR DESCRIPTION
#### Problem

`WiFiPAFEndPoint::ClearAll()` (run at the end of `FinalizeClose()`) nulls `mWiFiPafLayer` and reset `mState` to `kState_Ready`. Resetting to `kState_Ready` re-opened the `DoClose()` guard (`mState != kState_Closed && mState != kState_Closing`), so a **second close** on the same endpoint — e.g. a retransmit/ack timer that still references it and fires after it closed — re-entered the close path and dereferenced the now-null `mWiFiPafLayer`, crashing (SEGV). About a dozen `mWiFiPafLayer->mSystemLayer->...` sites are reachable in that revived state (`FinalizeClose`, `StartSendAckTimer`, `StopAckReceivedTimer`, …).

#### Fix

Leave a closed endpoint at `kState_Closed` in `ClearAll()`. `Init()` re-sets `mState` on pool reuse, so reuse is unaffected; a closed endpoint now stays closed, so `DoClose()` is a no-op and `Receive()` fails its state guards — nothing can drive the timer derefs.

#### Testing

- Adds a regression test `TestWiFiPAFLayer.FinalizeCloseIsIdempotentAcrossDoubleClose` (two production `DoClose()` calls): SEGVs at `WiFiPAFEndPoint.cpp` without the fix, passes with it.
- Adds pw_fuzztest harnesses for the endpoint and the transport engine (`fuzz-wifipaf-endpoint-pw`, `fuzz-wifipaf-tp-pw`). The endpoint harness drives the error / close / back-pressure paths through a configurable layer delegate — that is how this was found (out-of-order PAFTP fragment sequences).