### PR TITLE
[Linux] Get real thread names for software diagnostics

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -33,6 +33,7 @@
 
 #include <arpa/inet.h>
 #include <dirent.h>
+#include <fstream>
 #include <ifaddrs.h>
 #include <linux/ethtool.h>
 #include <linux/if_link.h>
@@ -78,6 +79,20 @@ enum class WiFiStatsCountType
 // Static variable to store the maximum heap size
 static uint64_t maxHeapHighWatermark = 0;
 #endif
+
+CHIP_ERROR GetThreadName(pid_t tid, char * nameBuf, size_t nameBufSize)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/self/task/%u/comm", tid);
+
+    std::ifstream commFile(path);
+    VerifyOrReturnError(commFile.is_open(), CHIP_ERROR_READ_FAILED);
+
+    commFile.getline(nameBuf, nameBufSize);
+    VerifyOrReturnError(commFile.gcount() > 0, CHIP_ERROR_READ_FAILED);
+
+    return CHIP_NO_ERROR;
+}
 
 CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
 {
@@ -320,10 +335,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
                 continue;
 
             ThreadMetrics * thread = new ThreadMetrics();
+            pid_t tid              = atoi(entry->d_name);
+            thread->id             = tid;
 
-            Platform::CopyString(thread->NameBuf, entry->d_name);
-            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
-            thread->id = atoi(entry->d_name);
+            if (GetThreadName(tid, thread->NameBuf, sizeof(thread->NameBuf)) == CHIP_NO_ERROR)
+            {
+                thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            }
 
             // TODO: Get stack info of each thread: thread->stackFreeCurrent,
             // thread->stackFreeMinimum, thread->stackSize.

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -204,7 +204,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     auto * context      = g_main_context_new();
     mGLibMainLoop       = g_main_loop_new(context, FALSE);
-    mGLibMainLoopThread = g_thread_new("gmain-matter", GLibMainLoopThread, mGLibMainLoop);
+    mGLibMainLoopThread = g_thread_new("gmatter", GLibMainLoopThread, mGLibMainLoop);
     g_main_context_unref(context);
 
     {


### PR DESCRIPTION
### Summary

Currently software diagnostics shows thread names as thread IDs which is redundant since thread ID is mandatory in the thread metrics structure. This PR fixes that by fetching real thread names.

Changes:
- fetch thread name from `/proc/self/task/<tid>/comm`
- rename matter glib thread to "gmatter" so it will fit in diagnostics buffer

### Testing

Manually tested with Linux example application:

```console
$ chip-tool softwarediagnostics read thread-metrics 1 0 
...
[1781598642.717] [1611609:1611611] [TOO]   ThreadMetrics: 5 entries
[1781598642.717] [1611609:1611611] [TOO]     [1]: {
[1781598642.718] [1611609:1611611] [TOO]       Id: 1611602
[1781598642.718] [1611609:1611611] [TOO]       Name: gdbus
[1781598642.718] [1611609:1611611] [TOO]      }
[1781598642.718] [1611609:1611611] [TOO]     [2]: {
[1781598642.718] [1611609:1611611] [TOO]       Id: 1611601
[1781598642.718] [1611609:1611611] [TOO]       Name: gmain
[1781598642.718] [1611609:1611611] [TOO]      }
[1781598642.718] [1611609:1611611] [TOO]     [3]: {
[1781598642.718] [1611609:1611611] [TOO]       Id: 1611600
[1781598642.718] [1611609:1611611] [TOO]       Name: pool-spa
[1781598642.718] [1611609:1611611] [TOO]      }
[1781598642.718] [1611609:1611611] [TOO]     [4]: {
[1781598642.718] [1611609:1611611] [TOO]       Id: 1611599
[1781598642.718] [1611609:1611611] [TOO]       Name: gmatter
[1781598642.718] [1611609:1611611] [TOO]      }
[1781598642.718] [1611609:1611611] [TOO]     [5]: {
[1781598642.718] [1611609:1611611] [TOO]       Id: 1611598
[1781598642.718] [1611609:1611611] [TOO]       Name: chip-lig
[1781598642.718] [1611609:1611611] [TOO]      }
```