### PR TITLE
gn: Contain nlassert only as dependency of nlfaultinjection

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -178,7 +178,6 @@ executable("darwin-framework-tool") {
     "${chip_root}/src/include/",
     "${chip_root}/src/protocols/",
     "${chip_root}/src/protocols/interaction_model",
-    "${chip_root}/third_party/nlassert/repo/include/",
     "${chip_root}/third_party/nlio/repo/include/",
     "${chip_root}/zzz_generated/app-common/",
     "${root_gen_dir}/include",

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 import("//build_overrides/pigweed.gni")
 
@@ -394,10 +393,7 @@ static_library("support") {
       "CHIPFaultInjection.cpp",
       "CHIPFaultInjection.h",
     ]
-    public_deps += [
-      "${nlassert_root}:nlassert",
-      "${nlfaultinjection_root}:nlfaultinjection",
-    ]
+    public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
 
   if (chip_pw_tokenizer_logging) {

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlassert.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 

--- a/src/platform/Infineon/crypto/trustm/BUILD.gn
+++ b/src/platform/Infineon/crypto/trustm/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlassert.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/Infineon/crypto/trustm/args.gni")
@@ -30,7 +29,6 @@ source_set("public_headers") {
     "${chip_root}/src/lib/asn1",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
-    "${nlassert_root}:nlassert",
   ]
 }
 

--- a/src/platform/nxp/crypto/se05x/BUILD.gn
+++ b/src/platform/nxp/crypto/se05x/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlassert.gni")
 import("//build_overrides/nxp_sdk.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 
 import("${build_root}/config/compiler/compiler.gni")
@@ -304,9 +303,6 @@ static_library("system") {
       "SystemFaultInjection.cpp",
       "SystemFaultInjection.h",
     ]
-    public_deps += [
-      "${nlassert_root}:nlassert",
-      "${nlfaultinjection_root}:nlfaultinjection",
-    ]
+    public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
 }


### PR DESCRIPTION
### Summary

Adjust gn files to further restrict nlassert presence - now it is strictly a dependency of the `nlfaultinjection` target.

### Testing

Local application build.
