### PR TITLE
[messaging] Restore unsolicited message handler when exchange setup fails validation

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -398,6 +398,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
                          CHIP_ERROR_INVALID_MESSAGE_TYPE.Format());
             if (delegate != nullptr)
             {
+                ec->SetDelegate(nullptr);
                 handler->OnExchangeCreationFailed(delegate);
             }
             ec->Close();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -398,6 +398,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
                          CHIP_ERROR_INVALID_MESSAGE_TYPE.Format());
             if (delegate != nullptr)
             {
+                // Prevent use-after-free in ec->Close() if the handler deallocates the delegate.
                 ec->SetDelegate(nullptr);
                 handler->OnExchangeCreationFailed(delegate);
             }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -361,7 +361,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     // If we found a handler, create an exchange to handle the message.
     if (matchingUMH != nullptr)
     {
-        ExchangeDelegate * delegate = nullptr;
+        ExchangeDelegate * delegate         = nullptr;
         UnsolicitedMessageHandler * handler = matchingUMH->Handler;
 
         // Fetch delegate from the handler

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -398,7 +398,8 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
                          CHIP_ERROR_INVALID_MESSAGE_TYPE.Format());
             if (delegate != nullptr)
             {
-                // Prevent use-after-free in ec->Close() if the handler deallocates the delegate.
+                // The OnExchangeCreationFailed contract allows the handler to deallocate the delegate.
+                // Clear it from the exchange context first to prevent use-after-free in ec->Close().
                 ec->SetDelegate(nullptr);
                 handler->OnExchangeCreationFailed(delegate);
             }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -362,9 +362,10 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     if (matchingUMH != nullptr)
     {
         ExchangeDelegate * delegate = nullptr;
+        UnsolicitedMessageHandler * handler = matchingUMH->Handler;
 
         // Fetch delegate from the handler
-        CHIP_ERROR err = matchingUMH->Handler->OnUnsolicitedMessageReceived(payloadHeader, session, delegate);
+        CHIP_ERROR err = handler->OnUnsolicitedMessageReceived(payloadHeader, session, delegate);
         if (err != CHIP_NO_ERROR)
         {
             // Using same error message for all errors to reduce code size.
@@ -379,7 +380,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         {
             if (delegate != nullptr)
             {
-                matchingUMH->Handler->OnExchangeCreationFailed(delegate);
+                handler->OnExchangeCreationFailed(delegate);
             }
 
             // Using same error message for all errors to reduce code size.
@@ -395,6 +396,10 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         {
             ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT,
                          CHIP_ERROR_INVALID_MESSAGE_TYPE.Format());
+            if (delegate != nullptr)
+            {
+                handler->OnExchangeCreationFailed(delegate);
+            }
             ec->Close();
             SendStandaloneAckIfNeeded(packetHeader, payloadHeader, session, msgFlags, std::move(msgBuf));
             return;

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -277,4 +277,81 @@ TEST_F(TestExchangeMgr, CheckExchangeMessages)
     EXPECT_EQ(removedHandler, &mockUnsolicitedAppDelegate);
 }
 
+class MockUHTempUnregister : public UnsolicitedMessageHandler, public ExchangeDelegate
+{
+public:
+    MockUHTempUnregister(ExchangeManager & em) : mEm(em) {}
+
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
+    {
+        ReturnErrorOnFailure(mEm.UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1));
+        mUnregistered = true;
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
+    void OnExchangeCreationFailed(ExchangeDelegate * delegate) override
+    {
+        (void) mEm.RegisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, this);
+        mRegisteredAgain = true;
+    }
+
+    CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                 System::PacketBufferHandle && buffer) override
+    {
+        mOnMessageReceivedCalled = true;
+        return CHIP_NO_ERROR;
+    }
+
+    void OnResponseTimeout(ExchangeContext * ec) override {}
+
+    Messaging::ExchangeMessageDispatch & GetMessageDispatch() override
+    {
+        return mDispatch;
+    }
+
+    class MockDispatch : public Messaging::ApplicationExchangeDispatch
+    {
+    public:
+        bool IsEncryptionRequired() const override { return false; }
+    };
+
+    ExchangeManager & mEm;
+    MockDispatch mDispatch;
+    bool mUnregistered = false;
+    bool mRegisteredAgain = false;
+    bool mOnMessageReceivedCalled = false;
+};
+
+// Verify UMH that unregisters on receive is re-registered on encryption mismatch.
+TEST_F(TestExchangeMgr, CheckUmhEncryptionMismatchCleanup)
+{
+    CHIP_ERROR err;
+
+    MockUHTempUnregister mockUH(GetExchangeManager());
+    err = GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, &mockUH);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    MockAppDelegate mockSolicitedAppDelegate;
+    ExchangeContext * ec1 = NewExchangeToBob(&mockSolicitedAppDelegate);
+    ASSERT_NE(ec1, nullptr);
+
+    EXPECT_SUCCESS(ec1->SendMessage(Protocols::BDX::Id, kMsgType_TEST1,
+                                    System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                                    SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck)));
+
+    DrainAndServiceIO();
+
+    EXPECT_TRUE(mockUH.mUnregistered);
+    EXPECT_TRUE(mockUH.mRegisteredAgain);
+
+    if (mockUH.mRegisteredAgain)
+    {
+        Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+        err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, &removedHandler);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(removedHandler, &mockUH);
+    }
+}
+
 } // namespace

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -286,7 +286,7 @@ public:
     {
         ReturnErrorOnFailure(mEm.UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1));
         mUnregistered = true;
-        newDelegate = this;
+        newDelegate   = this;
         return CHIP_NO_ERROR;
     }
 
@@ -305,10 +305,7 @@ public:
 
     void OnResponseTimeout(ExchangeContext * ec) override {}
 
-    Messaging::ExchangeMessageDispatch & GetMessageDispatch() override
-    {
-        return mDispatch;
-    }
+    Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return mDispatch; }
 
     class MockDispatch : public Messaging::ApplicationExchangeDispatch
     {
@@ -318,8 +315,8 @@ public:
 
     ExchangeManager & mEm;
     MockDispatch mDispatch;
-    bool mUnregistered = false;
-    bool mRegisteredAgain = false;
+    bool mUnregistered            = false;
+    bool mRegisteredAgain         = false;
     bool mOnMessageReceivedCalled = false;
 };
 

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -282,7 +282,8 @@ class MockUHTempUnregister : public UnsolicitedMessageHandler, public ExchangeDe
 public:
     MockUHTempUnregister(ExchangeManager & em) : mEm(em) {}
 
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, const SessionHandle & session,
+                                            ExchangeDelegate *& newDelegate) override
     {
         ReturnErrorOnFailure(mEm.UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1));
         mUnregistered = true;


### PR DESCRIPTION
#### Summary

**Problem:**
When unsolicited message received, handler (e.g. `CommissioningWindowManager`) can unregister. If exchange setup subsequently fails validation (e.g. encryption mismatch), exchange is closed without calling `OnExchangeCreationFailed`. Leaves handler permanently unregistered.

Also, potential null pointer dereference in existing error path because slot is reset during unregistration.

**Solution:**
1. Use local handler pointer in unsolicited message dispatch (prevents null-deref on unregistration).
2. Call `OnExchangeCreationFailed` when exchange validation fails due to encryption mismatch, restoring handler registration.
3. Add `CheckUmhEncryptionMismatchCleanup` test verifying correct recovery.

#### Testing

- Added `CheckUmhEncryptionMismatchCleanup` unit test to `TestExchangeMgr.cpp` that verifies re-registration of UMH on encryption mismatch. Verified it compiles, fails before the fix, and passes after the fix.
