### PR TITLE
[Silabs] Fixing the build of the SmokeCo App

### DIFF
--- a/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
@@ -25,7 +25,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
-#include <clusters/SmokeCoAlarm/Enums.h>
+#include <app/clusters/smoke-co-alarm-server/CodegenIntegration.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
@@ -34,17 +34,17 @@ using namespace chip::app::Clusters;
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
+    ClusterId clusterId     = attributePath.mClusterId;
+    AttributeId attributeId = attributePath.mAttributeId;
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+
     // TODO: this will NOT be called after code driven conversion
     //       You may intercept data model provider attribute changes by DataModel::Provider::RegisterAttributeChangeListener
-
-    // ClusterId clusterId     = attributePath.mClusterId;
-    // AttributeId attributeId = attributePath.mAttributeId;
-    // ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-    // if (clusterId == SmokeCoAlarm::Id && attributeId == SmokeCoAlarm::Attributes::ExpressedState::Id)
-    // {
-    //     static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
-    //     SmokeCoAlarm::ExpressedStateEnum expressedState = *(reinterpret_cast<SmokeCoAlarm::ExpressedStateEnum *>(value));
-    //     ChipLogProgress(Zcl, "Smoke CO Alarm cluster: " ChipLogFormatMEI " state %d", ChipLogValueMEI(clusterId),
-    //                     to_underlying(expressedState));
-    // }
+    if (clusterId == SmokeCoAlarm::Id && attributeId == SmokeCoAlarm::Attributes::ExpressedState::Id)
+    {
+        static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
+        SmokeCoAlarm::ExpressedStateEnum expressedState = *(reinterpret_cast<SmokeCoAlarm::ExpressedStateEnum *>(value));
+        ChipLogProgress(Zcl, "Smoke CO Alarm cluster: " ChipLogFormatMEI " state %d", ChipLogValueMEI(clusterId),
+                        to_underlying(expressedState));
+    }
 }

--- a/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <clusters/SmokeCoAlarm/Enums.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
@@ -33,17 +34,17 @@ using namespace chip::app::Clusters;
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    ClusterId clusterId     = attributePath.mClusterId;
-    AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-
     // TODO: this will NOT be called after code driven conversion
     //       You may intercept data model provider attribute changes by DataModel::Provider::RegisterAttributeChangeListener
-    if (clusterId == SmokeCoAlarm::Id && attributeId == SmokeCoAlarm::Attributes::ExpressedState::Id)
-    {
-        static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
-        SmokeCoAlarm::ExpressedStateEnum expressedState = *(reinterpret_cast<SmokeCoAlarm::ExpressedStateEnum *>(value));
-        ChipLogProgress(Zcl, "Smoke CO Alarm cluster: " ChipLogFormatMEI " state %d", ChipLogValueMEI(clusterId),
-                        to_underlying(expressedState));
-    }
+
+    // ClusterId clusterId     = attributePath.mClusterId;
+    // AttributeId attributeId = attributePath.mAttributeId;
+    // ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    // if (clusterId == SmokeCoAlarm::Id && attributeId == SmokeCoAlarm::Attributes::ExpressedState::Id)
+    // {
+    //     static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
+    //     SmokeCoAlarm::ExpressedStateEnum expressedState = *(reinterpret_cast<SmokeCoAlarm::ExpressedStateEnum *>(value));
+    //     ChipLogProgress(Zcl, "Smoke CO Alarm cluster: " ChipLogFormatMEI " state %d", ChipLogValueMEI(clusterId),
+    //                     to_underlying(expressedState));
+    // }
 }


### PR DESCRIPTION
### Summary
The Build was failing for the smoke-co examples on the silabs platform since the header file was moved and the build was failing with the 
`  
../../../../examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp:44:44: error: 'ExpressedStateEnum' is not a member of 'chip::app::Clusters::SmokeCoAlarm'
     44 |         static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
`
Adding the required header include to fix the build.

This is a quick fix, anyhow the code will be changed to DataModel::Provider::RegisterAttributeChangeListener once code driven is done so just fixing it by adding the required header.

### Related issues
NA


### Testing
Local build