### PR TITLE
[UDC] Fix off-by-one string copy in ReadPayload

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -24,8 +24,8 @@
  */
 
 #include "UserDirectedCommissioning.h"
-#include <lib/support/CHIPMemString.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/CHIPMemString.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/raw/Base.h>
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "UserDirectedCommissioning.h"
+#include <lib/support/CHIPMemString.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/raw/Base.h>
@@ -244,13 +245,8 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
         return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
     }
 
-    size_t i = 0;
-    while (i < sizeof(mInstanceName) && udcPayload[i] != '\0')
-    {
-        mInstanceName[i] = static_cast<char>(udcPayload[i]);
-        i++;
-    }
-    mInstanceName[i] = '\0';
+    size_t instanceNameLen = strnlen(reinterpret_cast<const char *>(udcPayload), sizeof(mInstanceName) - 1);
+    Platform::CopyString(mInstanceName, ByteSpan(udcPayload, instanceNameLen));
 
     if (payloadBufferSize == sizeof(mInstanceName))
     {
@@ -258,7 +254,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
         return CHIP_NO_ERROR;
     }
     // advance i to the end of the fixed length block containing instance name
-    i = sizeof(mInstanceName);
+    size_t i = sizeof(mInstanceName);
 
     CHIP_ERROR err;
 

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -529,6 +529,26 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationPureHeader)
     EXPECT_STREQ(idOut.GetInstanceName(), instanceName);
 }
 
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOob)
+{
+    IdentificationDeclaration idOut;
+    uint8_t idBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(idBuffer, 'A', sizeof(idBuffer));
+
+    const char * deviceName = "test-device";
+    idOut.SetDeviceName(deviceName);
+    EXPECT_STREQ(idOut.GetDeviceName(), deviceName);
+
+    EXPECT_EQ(idOut.ReadPayload(idBuffer, sizeof(idBuffer)), CHIP_NO_ERROR);
+
+    EXPECT_STREQ(idOut.GetDeviceName(), deviceName);
+
+    char expectedInstanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(expectedInstanceName, 'A', Dnssd::Commission::kInstanceNameMaxLength);
+    expectedInstanceName[Dnssd::Commission::kInstanceNameMaxLength] = '\0';
+    EXPECT_STREQ(idOut.GetInstanceName(), expectedInstanceName);
+}
+
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;


### PR DESCRIPTION
#### Summary
Fix off-by-one out-of-bounds write in `IdentificationDeclaration::ReadPayload`.

Problem:
The copy loop bounded by `sizeof(mInstanceName)` allowed `i` to reach `17`.
Subsequent write of `\0` at index `17` was out-of-bounds of `mInstanceName` (size 17).
This could clobber the adjacent member variable `mDeviceName`.

Solution:
Used `strnlen` to find the length up to `sizeof(mInstanceName) - 1` and `Platform::CopyString` to perform bounds-checked copying.

#### Testing
Added `TestUDCIdentificationDeclarationOob` in `TestUdcMessages.cpp` and ran tests.
