### PR TITLE
fix off-by-one write in IdentificationDeclaration::ReadPayload

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -245,7 +245,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
     }
 
     size_t i = 0;
-    while (i < sizeof(mInstanceName) && udcPayload[i] != '\0')
+    while (i < sizeof(mInstanceName) - 1 && udcPayload[i] != '\0')
     {
         mInstanceName[i] = static_cast<char>(udcPayload[i]);
         i++;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -529,6 +529,23 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationPureHeader)
     EXPECT_STREQ(idOut.GetInstanceName(), instanceName);
 }
 
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationUnterminatedInstanceName)
+{
+    IdentificationDeclaration idOut;
+
+    // Fill the entire fixed-size instance name block with non-null bytes so there is no
+    // terminator within it. ReadPayload must keep the copy and terminator within mInstanceName.
+    uint8_t idBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(idBuffer, 'A', sizeof(idBuffer));
+
+    EXPECT_EQ(idOut.ReadPayload(idBuffer, sizeof(idBuffer)), CHIP_NO_ERROR);
+
+    char expected[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(expected, 'A', Dnssd::Commission::kInstanceNameMaxLength);
+    expected[Dnssd::Commission::kInstanceNameMaxLength] = '\0';
+    EXPECT_STREQ(idOut.GetInstanceName(), expected);
+}
+
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;


### PR DESCRIPTION
### Summary

the instance name block at the start of an identification declaration is copied into mInstanceName with the loop bounded by `i < sizeof(mInstanceName)`, and the terminating null is then written at mInstanceName[i]. when that fixed-width field carries no null byte, the loop advances i all the way to sizeof(mInstanceName), so `mInstanceName[i] = '\0'` lands one byte past the array. the udc server hands unauthenticated, network-supplied declarations straight to ReadPayload, so a peer reaches this out-of-bounds write before any commissioning happens. bounding the copy at `sizeof(mInstanceName) - 1` keeps the terminator inside the buffer and truncates an over-long name to the maximum instance length.

### Related issues

None.

### Testing

added `TestUDCIdentificationDeclarationUnterminatedInstanceName`, which feeds an instance-name block with no terminator and checks the parsed name truncates to kInstanceNameMaxLength. with the original bound the terminating write is one byte past mInstanceName (ASan reports a heap-buffer-overflow write of size 1 at the ReadPayload terminator); with the fix the same input parses clean and the name is truncated.
