### PR TITLE
[esp32] serialize generation of builds for the same app.

### DIFF
--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import logging
 import os
 import shlex
@@ -218,83 +219,89 @@ class Esp32Builder(Builder):
         if os.path.exists(os.path.join(self.output_dir, 'build.ninja')):
             return
 
-        defaults = os.path.join(self.ExamplePath, DefaultsFileName(
-            self.board, self.app, self.enable_rpcs))
+        example_lock = self.output_dir_lock.lock_dir(
+            os.path.join(self.root, self.ExamplePath)) if self.output_dir_lock else contextlib.nullcontext()
+        with example_lock:
+            defaults = os.path.join(self.ExamplePath, DefaultsFileName(
+                self.board, self.app, self.enable_rpcs))
 
-        if not self._runner.dry_run and not os.path.exists(defaults):
-            raise Exception('SDK defaults file missing: %s' % defaults)
+            if not self._runner.dry_run and not os.path.exists(defaults):
+                raise Exception('SDK defaults file missing: %s' % defaults)
 
-        defaults_out = os.path.join(self.output_dir, 'sdkconfig.defaults')
+            defaults_out = os.path.join(self.output_dir, 'sdkconfig.defaults')
 
-        self._Execute(['mkdir', '-p', self.output_dir],
-                      title='Generating ' + self.identifier)
-        self._Execute(['cp', defaults, defaults_out])
-        self._Execute(
-            ['rm', '-f', os.path.join(self.ExamplePath, 'sdkconfig')])
-
-        if self.TargetFileName is not None:
-            target_defaults = os.path.join(self.ExamplePath, self.TargetFileName)
-            if os.path.exists(target_defaults):
-                self._Execute(['cp', target_defaults, os.path.join(self.output_dir, self.TargetFileName)])
-
-        if not self.enable_ipv4:
+            self._Execute(['mkdir', '-p', self.output_dir],
+                          title='Generating ' + self.identifier)
+            self._Execute(['cp', defaults, defaults_out])
             self._Execute(
-                ['bash', '-c', 'echo -e "\\nCONFIG_DISABLE_IPV4=y\\n" >>%s' % shlex.quote(defaults_out)])
+                ['rm', '-f', os.path.join(self.ExamplePath, 'sdkconfig')])
+
+            if self.TargetFileName is not None:
+                target_defaults = os.path.join(self.ExamplePath, self.TargetFileName)
+                if os.path.exists(target_defaults):
+                    self._Execute(['cp', target_defaults, os.path.join(self.output_dir, self.TargetFileName)])
+
+            if not self.enable_ipv4:
+                self._Execute(
+                    ['bash', '-c', 'echo -e "\\nCONFIG_DISABLE_IPV4=y\\n" >>%s' % shlex.quote(defaults_out)])
+                self._Execute(
+                    ['bash', '-c', 'echo -e "\\nCONFIG_LWIP_IPV4=n\\n" >>%s' % shlex.quote(defaults_out)])
+
+            if self.enable_insights_trace:
+                insights_flag = 'y'
+            else:
+                insights_flag = 'n'
+
+            # pre-requisite
             self._Execute(
-                ['bash', '-c', 'echo -e "\\nCONFIG_LWIP_IPV4=n\\n" >>%s' % shlex.quote(defaults_out)])
+                ['bash', '-c', 'echo -e "\\nCONFIG_ESP_INSIGHTS_ENABLED=%s\\nCONFIG_CHIP_ENABLE_ESP_DIAGNOSTICS=%s\\n" >>%s' % (insights_flag, insights_flag, shlex.quote(defaults_out))])
 
-        if self.enable_insights_trace:
-            insights_flag = 'y'
-        else:
-            insights_flag = 'n'
+            cmake_flags = []
 
-        # pre-requisite
-        self._Execute(
-            ['bash', '-c', 'echo -e "\\nCONFIG_ESP_INSIGHTS_ENABLED=%s\\nCONFIG_CHIP_ENABLE_ESP_DIAGNOSTICS=%s\\n" >>%s' % (insights_flag, insights_flag, shlex.quote(defaults_out))])
+            if self.options.pregen_dir:
+                cmake_flags.append(
+                    f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")
 
-        cmake_flags = []
+            if self.all_devices_enabled_devices:
+                cmake_flags.append(
+                    f"-DALL_DEVICES_ENABLED_DEVICES={shlex.quote(';'.join(self.all_devices_enabled_devices))}")
 
-        if self.options.pregen_dir:
-            cmake_flags.append(
-                f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")
+            cmake_args = ['-C', self.ExamplePath, '-B',
+                          shlex.quote(self.output_dir)] + cmake_flags
 
-        if self.all_devices_enabled_devices:
-            cmake_flags.append(
-                f"-DALL_DEVICES_ENABLED_DEVICES={shlex.quote(';'.join(self.all_devices_enabled_devices))}")
+            cmake_args = " ".join(cmake_args)
+            defaults = shlex.quote(defaults_out)
+            target = shlex.quote(self.TargetName)
 
-        cmake_args = ['-C', self.ExamplePath, '-B',
-                      shlex.quote(self.output_dir)] + cmake_flags
+            cmd = f"\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py {cmake_args} -DIDF_TARGET={target} reconfigure"
 
-        cmake_args = " ".join(cmake_args)
-        defaults = shlex.quote(defaults_out)
-        target = shlex.quote(self.TargetName)
-
-        cmd = f"\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py {cmake_args} -DIDF_TARGET={target} reconfigure"
-
-        # This will do a 'cmake reconfigure' which will create ninja files without rebuilding
-        self._IdfEnvExecute(cmd)
+            # This will do a 'cmake reconfigure' which will create ninja files without rebuilding
+            self._IdfEnvExecute(cmd)
 
     @lock_output_dir
     def _build(self):
         log.info('Compiling Esp32 at %s', self.output_dir)
 
-        # Unfortunately sdkconfig is sticky and needs reset on every build
-        self._Execute(
-            ['rm', '-f', os.path.join(self.ExamplePath, 'sdkconfig')])
+        example_lock = self.output_dir_lock.lock_dir(
+            os.path.join(self.root, self.ExamplePath)) if self.output_dir_lock else contextlib.nullcontext()
+        with example_lock:
+            # Unfortunately sdkconfig is sticky and needs reset on every build
+            self._Execute(
+                ['rm', '-f', os.path.join(self.ExamplePath, 'sdkconfig')])
 
-        defaults_out = os.path.join(self.output_dir, 'sdkconfig.defaults')
+            defaults_out = os.path.join(self.output_dir, 'sdkconfig.defaults')
 
-        # "ninja -C" is insufficient because sdkconfig changes on every 'config' and results
-        # in a full reconfiguration with default values
-        #
-        # This does a regen + reconfigure.
-        cmd = "\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py -C {example_path} -B {out} build".format(
-            defaults=shlex.quote(defaults_out),
-            example_path=self.ExamplePath,
-            out=shlex.quote(self.output_dir)
-        )
+            # "ninja -C" is insufficient because sdkconfig changes on every 'config' and results
+            # in a full reconfiguration with default values
+            #
+            # This does a regen + reconfigure.
+            cmd = "\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py -C {example_path} -B {out} build".format(
+                defaults=shlex.quote(defaults_out),
+                example_path=self.ExamplePath,
+                out=shlex.quote(self.output_dir)
+            )
 
-        self._IdfEnvExecute(cmd, title='Building ' + self.identifier)
+            self._IdfEnvExecute(cmd, title='Building ' + self.identifier)
 
     def _AllDevicesOutputName(self):
         """Return the binary base name produced by the all-devices-app build."""


### PR DESCRIPTION
#### Summary

Fix parallel build conflicts in ESP32 builder by serializing access to shared example directories (introduced by #72018). Cloudbuild builds the same app with different options and without serialization those builds are broken.

##### Problem

- When multiple ESP32 target configurations (e.g. `esp32-m5stack-light`, `esp32-m5stack-light-ipv6only`, and `esp32-devkitc-light-rpc`) are generated or built in parallel, they concurrently execute `idf.py` in the same shared source example directory.
- This results in two main race conditions:
  - **sdkconfig collision**: Concurrently deleting/re-generating the shared `sdkconfig` file in the example directory.
  - **Component Manager write conflict**: Concurrently running Espressif Component Manager to download/unpack dependencies into the shared `managed_components` folder, causing corruption and `OSError` (e.g., `Directory not empty: 'files'`).

##### Solution

- Introduced directory-level serialization by locking the example's source directory (`self.ExamplePath`) using `self.output_dir_lock` during both the `generate()` and `_build()` steps in the ESP32 builder.

#### Testing

- Executed build system unit tests via `python3 scripts/build/test.py` and verified all tests pass.
- Verified ESP32 build generation commands dry-run successfully using `build_examples.py --target esp32-m5stack-light --dry-run gen`.
