### PR TITLE
[Silabs] Fixing the build of the SmokeCo App (#72603)

### DIFF
--- a/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <app/clusters/smoke-co-alarm-server/CodegenIntegration.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;


### PR DESCRIPTION
### Summary
The Build was failing for the smoke-co examples on the silabs platform since the header file was moved and the build was failing with the 
`  
../../../../examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp:44:44: error: 'ExpressedStateEnum' is not a member of 'chip::app::Clusters::SmokeCoAlarm'
     44 |         static_assert(sizeof(SmokeCoAlarm::ExpressedStateEnum) == 1, "Wrong size");
`
Adding the required header include to fix the build.

This is a quick fix, anyhow the code will be changed to DataModel::Provider::RegisterAttributeChangeListener once code driven is done so just fixing it by adding the required header.

### Related issues
NA


### Testing
Local build