### PR TITLE
Add cluster revision override to Datamodel Errata engine

### DIFF
--- a/docs/guides/data_model_errata.md
+++ b/docs/guides/data_model_errata.md
@@ -83,16 +83,16 @@ GroupKeyManagement:
 The conformance check (`device_conformance_tests.py`) compares the device's
 reported `ClusterRevision` attribute (`0xFFFD`) against the _reference_ revision
 from the `<cluster revision="...">` XML property, parsed into
-`XmlCluster.revision`. That reference is a cluster property, not an attribute,
-so it can't be targeted by an attribute name (it isn't in `attribute_map`).
+`XmlCluster.revision`. This revision is parsed as cluster property, not an
+attribute, so it can't be targeted by an attribute name (it isn't in
+`attribute_map`).
 
-The `revision` key bridges this gap: the engine parses the value as an integer
+The `revision` keys allows the errata engine to parses the value as an integer
 and writes it directly to `XmlCluster.revision`, so the test compares against
 the overridden reference instead of the stale baseline.
 
 Use this when a cluster revision is bumped in a "next" spec release (or SDK PR)
-ahead of the checked-in baseline XML, so the device legitimately reports a newer
-revision than the baseline records.
+ahead of the checked-in baseline XML.
 
 ## Extending Engine Capabilities (Supporting New Errata Overrides)
 

--- a/docs/guides/data_model_errata.md
+++ b/docs/guides/data_model_errata.md
@@ -59,12 +59,40 @@ applies the specified overrides in memory.
 
 ### Supported Overrides
 
--   **Attributes**: `read_access`, `write_access` (Supports standard access
-    privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
-    `manage`, `administer`).
--   **Commands**: `invoke_access` / `privilege` (Supports standard access
-    privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
-    `manage`, `administer`).
+- **Cluster**: `revision` (integer). A reserved cluster-level key that overrides
+  the cluster's reference revision (see "The `revision` key" below).
+- **Attributes**: `read_access`, `write_access` (Supports standard access
+  privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
+  `manage`, `administer`).
+- **Commands**: `invoke_access` / `privilege` (Supports standard access
+  privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
+  `manage`, `administer`).
+
+### The `revision` key
+
+`revision` is a reserved key matched at the **cluster** level (a sibling of
+attribute/command element names, not an element name itself):
+
+```yaml
+GroupKeyManagement:
+    revision: 4
+```
+
+#### How it works
+
+The conformance check (`device_conformance_tests.py`) compares the device's
+reported `ClusterRevision` attribute (`0xFFFD`) against the _reference_ revision
+from the `<cluster revision="...">` XML property, parsed into
+`XmlCluster.revision`. That reference is a cluster property, not an attribute,
+so it can't be targeted by an attribute name (it isn't in `attribute_map`).
+
+The `revision` key bridges this gap: the engine parses the value as an integer
+and writes it directly to `XmlCluster.revision`, so the test compares against
+the overridden reference instead of the stale baseline.
+
+Use this when a cluster revision is bumped in a "next" spec release (or SDK PR)
+ahead of the checked-in baseline XML, so the device legitimately reports a newer
+revision than the baseline records.
 
 ## Extending Engine Capabilities (Supporting New Errata Overrides)
 

--- a/docs/guides/data_model_errata.md
+++ b/docs/guides/data_model_errata.md
@@ -59,14 +59,14 @@ applies the specified overrides in memory.
 
 ### Supported Overrides
 
-- **Cluster**: `revision` (integer). A reserved cluster-level key that overrides
-  the cluster's reference revision (see "The `revision` key" below).
-- **Attributes**: `read_access`, `write_access` (Supports standard access
-  privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
-  `manage`, `administer`).
-- **Commands**: `invoke_access` / `privilege` (Supports standard access
-  privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
-  `manage`, `administer`).
+-   **Cluster**: `revision` (integer). A reserved cluster-level key that
+    overrides the cluster's reference revision (see "The `revision` key" below).
+-   **Attributes**: `read_access`, `write_access` (Supports standard access
+    privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
+    `manage`, `administer`).
+-   **Commands**: `invoke_access` / `privilege` (Supports standard access
+    privilege codes: `RV`, `RO`, `RM`, `RA`, `none`, or `view`, `operate`,
+    `manage`, `administer`).
 
 ### The `revision` key
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
@@ -33,6 +33,13 @@ LOGGER = logging.getLogger(__name__)
 
 AccessControlEntryPrivilegeEnum = Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum
 
+# Reserved key under a cluster that targets the cluster's own reference revision
+# (the `revision` property on the <cluster> XML element, stored as XmlCluster.revision)
+# rather than a named attribute or command. This is distinct from the device's runtime
+# ClusterRevision global attribute (0xFFFD), which is the value the conformance test
+# compares against this reference.
+CLUSTER_REVISION_KEY = 'revision'
+
 
 def parse_errata_access(val: str) -> int:
     """Parses a human-readable access string into an AccessControlEntryPrivilegeEnum value."""
@@ -139,6 +146,21 @@ def _apply_command_errata(target_cmd: Any, overrides: dict[str, Any], cluster_id
                                           severity=ProblemSeverity.ERROR, problem=f"Invalid privilege/invoke_access on '{context}': {e}"))
 
 
+def _apply_cluster_revision_errata(target_cluster: Any, cluster_id: int, value: Any, cluster_name: str,
+                                   problems: list[ProblemNotice]) -> None:
+    """Overrides the cluster's reference revision in the AST (XmlCluster.revision).
+
+    The conformance test compares the device-reported ClusterRevision attribute (0xFFFD)
+    against this reference value. Bumping it here lets a device legitimately report a
+    revision newer than the checked-in baseline XML records (e.g. a 'next' spec bump).
+    """
+    try:
+        target_cluster.revision = int(value)
+    except (TypeError, ValueError):
+        problems.append(ProblemNotice(test_name='Data Model Errata', location=ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id),
+                                      severity=ProblemSeverity.ERROR, problem=f"Invalid revision override on '{cluster_name}': {value!r} is not an integer."))
+
+
 def _apply_element_errata(target_cluster: Any, cluster_id: int, element_name: str, overrides: Any, cluster_name: str,
                           sanitized_attr_map: Mapping[str, int], sanitized_cmd_map: Mapping[str, int],
                           problems: list[ProblemNotice]) -> None:
@@ -219,6 +241,9 @@ def apply_errata(clusters: Mapping[uint, Any], errata_data: dict[str, Any],
         sanitized_cmd_map = {_sanitize_name(k): v for k, v in target_cluster.command_map.items()}
 
         for element_name, overrides in elements.items():
+            if element_name.lower() == CLUSTER_REVISION_KEY:
+                _apply_cluster_revision_errata(target_cluster, target_cluster_id, overrides, cluster_name, problems)
+                continue
             _apply_element_errata(target_cluster, target_cluster_id, element_name, overrides, cluster_name,
                                   sanitized_attr_map, sanitized_cmd_map, problems)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
@@ -155,6 +155,8 @@ def _apply_cluster_revision_errata(target_cluster: Any, cluster_id: int, value: 
     revision newer than the checked-in baseline XML records (e.g. a 'next/in-progress' spec bump).
     """
     try:
+        if isinstance(value, (bool, float)):
+            raise ValueError
         target_cluster.revision = int(value)
     except (TypeError, ValueError):
         problems.append(ProblemNotice(test_name='Data Model Errata', location=ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id),

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/data_model_errata.py
@@ -151,8 +151,8 @@ def _apply_cluster_revision_errata(target_cluster: Any, cluster_id: int, value: 
     """Overrides the cluster's reference revision in the AST (XmlCluster.revision).
 
     The conformance test compares the device-reported ClusterRevision attribute (0xFFFD)
-    against this reference value. Bumping it here lets a device legitimately report a
-    revision newer than the checked-in baseline XML records (e.g. a 'next' spec bump).
+    against this reference value. Bumping it here lets a device report a
+    revision newer than the checked-in baseline XML records (e.g. a 'next/in-progress' spec bump).
     """
     try:
         target_cluster.revision = int(value)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/test_data_model_errata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/test_data_model_errata.py
@@ -113,6 +113,37 @@ class TestDataModelErrata(unittest.TestCase):
         self.assertEqual(len(problems), 0, f"Unexpected problems: {problems}")
         self.assertEqual(cmd.privilege, AccessControlEntryPrivilegeEnum.kManage)
 
+    def test_cluster_revision_override(self):
+        cluster = self._create_dummy_cluster("GroupKeyManagement")
+        clusters = {uint(63): cluster}
+
+        errata = {
+            "GroupKeyManagement": {
+                "revision": 4,
+            }
+        }
+
+        problems = apply_errata(clusters, errata)
+
+        self.assertEqual(len(problems), 0, f"Unexpected problems: {problems}")
+        self.assertEqual(cluster.revision, 4)
+
+    def test_cluster_revision_override_invalid(self):
+        cluster = self._create_dummy_cluster("GroupKeyManagement")
+        clusters = {uint(63): cluster}
+
+        errata = {
+            "GroupKeyManagement": {
+                "revision": "not-a-number",
+            }
+        }
+
+        problems = apply_errata(clusters, errata)
+
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Invalid revision override", problems[0].problem)
+        self.assertEqual(cluster.revision, 1)
+
     def test_error_unknown_cluster(self):
         clusters: dict[uint, XmlCluster] = {}
         errata = {


### PR DESCRIPTION
#### Summary
Add support for overriding a cluster's reference revision in the Data Model Errata engine, so a device reporting a "next"-revision cluster can pass IDM conformance tests against an older datamodel baseline XML.

##### Problem
- The Data Model Errata engine (`data_model/errata_future.yaml`) only supported **attribute** (`read_access`/`write_access`) and **command** (`invoke_access`/`privilege`) overrides.
- When a cluster's revision is bumped in a "next" spec release (or SDK PR) ahead of the checked-in baseline XML, IDM conformance tests (e.g. `TC_DeviceConformance` / IDM-10.3) fail:
    - The test compares the device-reported `ClusterRevision` (`0xFFFD`) against the spec reference from data_model/x.y/ xmls.
    - The reference revision in the xmls is parsed as a **cluster property, not an attribute**, so it is absent from `attribute_map` and could not be targeted by any existing errata override.

##### Solution
- Added a reserved cluster-level `revision` key to the errata overlay schema. It is matched at the cluster level and writes directly to the `XmlCluster.revision`, so conformance checks compare against the overridden reference instead of the previous baseline. Invalid (non-integer) values raise an errata `ProblemNotice` and leave the revision unchanged.
- Documented the new override and the device-vs-reference distinction in `docs/guides/data_model_errata.md`.
Pure (no-errata) certification parsing is unaffected; the override only applies when the harness explicitly enables errata loading.
- Added unit tests in `src/python_testing/matter_testing_infrastructure/matter/testing/test_data_model_errata.py`:
    - `test_cluster_revision_override` verifies `XmlCluster.revision` is updated.
    - `test_cluster_revision_override_invalid` verifies a non-integer value reports a `ProblemNotice` and leaves the revision unchanged.

#### Testing
Run test_data_model_errata.py
```
test_attribute_access_override (test_data_model_errata.TestDataModelErrata.test_attribute_access_override) ... ok
test_cluster_revision_override (test_data_model_errata.TestDataModelErrata.test_cluster_revision_override) ... ok
test_cluster_revision_override_invalid (test_data_model_errata.TestDataModelErrata.test_cluster_revision_override_invalid) ... ok
test_command_privilege_override (test_data_model_errata.TestDataModelErrata.test_command_privilege_override) ... ok
test_error_unknown_cluster (test_data_model_errata.TestDataModelErrata.test_error_unknown_cluster) ... ok
test_error_unknown_element (test_data_model_errata.TestDataModelErrata.test_error_unknown_element) ... ok
test_load_authoritative_errata_missing_file (test_data_model_errata.TestDataModelErrata.test_load_authoritative_errata_missing_file) ... Errata file path 'non_existent_errata_file_99.yaml' not found.
ok
test_reject_raw_xml_cluster_name (test_data_model_errata.TestDataModelErrata.test_reject_raw_xml_cluster_name) ... ok
test_reject_raw_xml_element_name (test_data_model_errata.TestDataModelErrata.test_reject_raw_xml_element_name) ... ok
test_revision_compatibility_fail (test_data_model_errata.TestDataModelErrata.test_revision_compatibility_fail) ... ok
test_revision_compatibility_missing_active_rev (test_data_model_errata.TestDataModelErrata.test_revision_compatibility_missing_active_rev) ... ok
test_revision_compatibility_pass (test_data_model_errata.TestDataModelErrata.test_revision_compatibility_pass) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.001s
```