### PR TITLE
fix size_t underflow in GetProduct on empty txt value

### DIFF
--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -136,7 +136,7 @@ size_t GetPlusSignIdx(const ByteSpan & value)
 uint16_t GetProduct(const ByteSpan & value)
 {
     size_t plussign = GetPlusSignIdx(value);
-    if (plussign < value.size() - 1)
+    if (plussign + 1 < value.size())
     {
         const uint8_t * productStrStart = value.data() + plussign + 1;
         size_t productStrLen            = value.size() - plussign - 1;

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -140,6 +140,10 @@ TEST(TestTxtFields, TestGetProduct)
     // overflow a uint16
     sprintf(vp, "123+%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     EXPECT_EQ(GetProduct(GetSpan(vp)), 0);
+
+    // Empty value (e.g. an on-wire "VP=" TXT entry, which ParseTxtRecord delivers as an
+    // empty ByteSpan). The length check must not underflow on a zero-length span.
+    EXPECT_EQ(GetProduct(ByteSpan()), 0);
 }
 TEST(TestTxtFields, TestGetVendor)
 {


### PR DESCRIPTION
### Summary

`GetProduct` parses the product id out of the commissionable-node VP TXT record value. Its guard is `if (plussign < value.size() - 1)`. When the value is empty, which is what an on-wire `VP=` entry produces (ParseTxtRecord hands such an entry over as an empty ByteSpan), `value.size()` is 0 and `value.size() - 1` wraps to SIZE_MAX, so the branch runs anyway. It then forms `value.data() + plussign + 1`, i.e. `nullptr + 1`, and sets `productStrLen = value.size() - plussign - 1`, also SIZE_MAX. The value comes straight off the wire from an unauthenticated mDNS responder during discovery, so a peer reaches this with a crafted TXT record. Rewriting the check as `plussign + 1 < value.size()` is underflow-safe and yields the same result for every valid input.

### Related issues

None.

### Testing

Added an empty-value case to `TestGetProduct`. A standalone build of the guard arithmetic under `-fsanitize=undefined,address` reports `applying non-zero offset 1 to null pointer` at the `value.data() + plussign + 1` line for an empty value; with the fix the branch is skipped and `GetProduct` returns 0.