### PR TITLE
cast to unsigned char before isdigit in ASN1 time parsing

### DIFF
--- a/src/lib/asn1/ASN1Time.cpp
+++ b/src/lib/asn1/ASN1Time.cpp
@@ -77,7 +77,7 @@ CHIP_ERROR ASN1UniversalTime::ImportFrom_ASN1_TIME_string(const CharSpan & asn1_
     VerifyOrReturnError(p[size - 1] == 'Z', ASN1_ERROR_UNSUPPORTED_ENCODING);
     for (size_t i = 0; i < size - 1; i++)
     {
-        VerifyOrReturnError(isdigit(p[i]), ASN1_ERROR_INVALID_ENCODING);
+        VerifyOrReturnError(isdigit(static_cast<unsigned char>(p[i])), ASN1_ERROR_INVALID_ENCODING);
     }
 
     if (size == kASN1GeneralizedTimeStringLength)

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -355,6 +355,8 @@ TEST(TestASN1, ASN1UniversalTime)
         {    "2010115142343Z",   ASN1_ERROR_UNSUPPORTED_ENCODING },
         {    "201014415142343Z", ASN1_ERROR_UNSUPPORTED_ENCODING },
         {    "201O15142343Z",    ASN1_ERROR_INVALID_ENCODING     },
+        // High-bit byte (0xE9) in the time field: must be rejected, not fed to isdigit as a negative char.
+        {    "201" "\xe9" "15142343Z", ASN1_ERROR_INVALID_ENCODING },
         {    "200015142343Z",    ASN1_ERROR_INVALID_ENCODING     },
         {    "201315142343Z",    ASN1_ERROR_INVALID_ENCODING     },
         {    "201000142343Z",    ASN1_ERROR_INVALID_ENCODING     },

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -355,7 +355,6 @@ TEST(TestASN1, ASN1UniversalTime)
         {    "2010115142343Z",   ASN1_ERROR_UNSUPPORTED_ENCODING },
         {    "201014415142343Z", ASN1_ERROR_UNSUPPORTED_ENCODING },
         {    "201O15142343Z",    ASN1_ERROR_INVALID_ENCODING     },
-        // High-bit byte (0xE9) in the time field: must be rejected, not fed to isdigit as a negative char.
         {    "201" "\xe9" "15142343Z", ASN1_ERROR_INVALID_ENCODING },
         {    "200015142343Z",    ASN1_ERROR_INVALID_ENCODING     },
         {    "201315142343Z",    ASN1_ERROR_INVALID_ENCODING     },


### PR DESCRIPTION
### Summary

ImportFrom_ASN1_TIME_string validates the time field with isdigit(p[i]), where p is the CharSpan over the raw notBefore/notAfter bytes of a peer certificate (CHIPCryptoPALOpenSSL passes pNotBefore->data directly). On platforms where char is signed, a time byte with the high bit set arrives as a negative int that is neither a valid unsigned char value nor EOF, which is undefined behavior for the ctype functions (C11 7.4p1) and an out-of-bounds read of the classification table on libc builds that do not pad it for negative indices. The loop is the validation that rejects non-digits, so non-ASCII bytes from an untrusted cert reach it by design. Cast to unsigned char before the call, matching the SafeToLower convention already used in dnssd/TxtFields.cpp.

### Related issues

None.

### Testing

Added a high-bit-byte (0xE9) row to the ASN1UniversalTime error-case table in TestASN1.cpp; it is rejected with ASN1_ERROR_INVALID_ENCODING and exercises the call with a value that is well-defined only after the cast.