### PR TITLE
[all-devices-app] Name bridged nodes after child device types

### DIFF
--- a/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
@@ -54,7 +54,7 @@ namespace chip::app {
 class DeviceFactory
 {
 public:
-    using DeviceCreator = std::function<std::unique_ptr<DeviceInterface>()>;
+    using DeviceCreator = std::function<std::unique_ptr<DeviceInterface>(const std::string & nodeLabel)>;
 
     struct Context
     {
@@ -81,15 +81,25 @@ public:
         mRegistry[deviceTypeArg] = std::move(creator);
     }
 
+    /**
+     * Convenience overload to support making the label optional for creator registrations
+     * that do not care about the label (i.e. most cases).
+     */
+    void RegisterCreator(const std::string & deviceTypeArg, std::function<std::unique_ptr<DeviceInterface>()> && creator)
+    {
+        RegisterCreator(deviceTypeArg, [c = std::move(creator)](const std::string &) { return c(); });
+    }
+
     const std::string & GetDefaultDevice() const { return mDefaultDevice; }
 
     bool IsValidDevice(const std::string & deviceTypeArg) { return mRegistry.find(deviceTypeArg) != mRegistry.end(); }
 
-    std::unique_ptr<DeviceInterface> Create(const std::string & deviceTypeArg)
+    std::unique_ptr<DeviceInterface> Create(const std::string & deviceTypeArg, const std::string & nodeLabel = "")
     {
-        if (IsValidDevice(deviceTypeArg))
+        auto it = mRegistry.find(deviceTypeArg);
+        if (it != mRegistry.end())
         {
-            return mRegistry.find(deviceTypeArg)->second();
+            return it->second(nodeLabel);
         }
         ChipLogError(
             Support,
@@ -149,13 +159,14 @@ private:
         }
         if constexpr (ALL_DEVICES_ENABLE_BRIDGED_NODE)
         {
-            RegisterCreator("bridged-node", [this]() {
+            RegisterCreator("bridged-node", [this](const std::string & nodeLabel) {
                 VerifyOrDie(mContext.has_value());
                 static int sBridgedNodeCount = 0;
                 sBridgedNodeCount++;
+                std::string label = nodeLabel.empty() ? "Bridged Node " + std::to_string(sBridgedNodeCount) : nodeLabel;
                 return std::make_unique<BridgedNodeDevice>(mContext->timerDelegate,
                                                            "bridged-node-unique-id-" + std::to_string(sBridgedNodeCount),
-                                                           "Bridged Node " + std::to_string(sBridgedNodeCount));
+                                                           label);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_CONTACT_SENSOR)

--- a/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
@@ -165,8 +165,7 @@ private:
                 sBridgedNodeCount++;
                 std::string label = nodeLabel.empty() ? "Bridged Node " + std::to_string(sBridgedNodeCount) : nodeLabel;
                 return std::make_unique<BridgedNodeDevice>(mContext->timerDelegate,
-                                                           "bridged-node-unique-id-" + std::to_string(sBridgedNodeCount),
-                                                           label);
+                                                           "bridged-node-unique-id-" + std::to_string(sBridgedNodeCount), label);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_CONTACT_SENSOR)

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -28,18 +28,18 @@
 namespace {
 std::string KebabCaseToTitleCase(const std::string & input)
 {
-    std::string output = input;
+    std::string output  = input;
     bool capitalizeNext = true;
     for (char & c : output)
     {
         if (c == '-')
         {
-            c = ' ';
+            c              = ' ';
             capitalizeNext = true;
         }
         else if (capitalizeNext)
         {
-            c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+            c              = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
             capitalizeNext = false;
         }
     }

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.cpp
@@ -21,8 +21,31 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
+
+namespace {
+std::string KebabCaseToTitleCase(const std::string & input)
+{
+    std::string output = input;
+    bool capitalizeNext = true;
+    for (char & c : output)
+    {
+        if (c == '-')
+        {
+            c = ' ';
+            capitalizeNext = true;
+        }
+        else if (capitalizeNext)
+        {
+            c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+            capitalizeNext = false;
+        }
+    }
+    return output;
+}
+} // namespace
 
 bool DeviceTypeParser::ParseEndpointId(const char * str, chip::EndpointId & endpoint)
 {
@@ -176,6 +199,7 @@ void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcard
                         .endpoint = nextEp,
                         .parentId = entry.parentId,
                         .bridged  = true,
+                        .label    = KebabCaseToTitleCase(deviceType),
                     });
                     expandedEntries.push_back({
                         .type     = deviceType,
@@ -209,6 +233,7 @@ void DeviceTypeParser::ExpandWildcards(const std::vector<std::string> & wildcard
                 .endpoint = entry.endpoint,
                 .parentId = entry.parentId,
                 .bridged  = true,
+                .label    = KebabCaseToTitleCase(entry.type),
             });
             expandedEntries.push_back({
                 .type     = entry.type,

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/DeviceTypeParser.h
@@ -32,6 +32,7 @@ public:
         chip::EndpointId endpoint = chip::kInvalidEndpointId;
         chip::EndpointId parentId = chip::kInvalidEndpointId;
         bool bridged              = false;
+        std::string label;
     };
 
     DeviceTypeParser()  = default;

--- a/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/device-type-parser/tests/TestDeviceTypeParser.cpp
@@ -323,6 +323,7 @@ TEST_F(TestDeviceTypeParser, ExpandWildcards_ExplicitBridged)
 
     // Explicit chime:2,bridged is expanded into a parent bridged-node and the chime child.
     EXPECT_EQ(configs[0].type, "bridged-node");
+    EXPECT_EQ(configs[0].label, "Chime");
     EXPECT_EQ(configs[0].endpoint, 2);
     EXPECT_EQ(configs[0].parentId, 1);
     EXPECT_TRUE(configs[0].bridged);
@@ -351,6 +352,7 @@ TEST_F(TestDeviceTypeParser, ExpandWildcards_WildcardBridged)
     // Wildcard block starts at maxEp + 1 = 2.
     // For each device in wildcard, we get [bridged-node, device]
     EXPECT_EQ(configs[1].type, "bridged-node");
+    EXPECT_EQ(configs[1].label, "Chime");
     EXPECT_EQ(configs[1].endpoint, 2);
     EXPECT_EQ(configs[1].parentId, 1);
     EXPECT_TRUE(configs[1].bridged);
@@ -361,6 +363,7 @@ TEST_F(TestDeviceTypeParser, ExpandWildcards_WildcardBridged)
     EXPECT_TRUE(configs[2].bridged);
 
     EXPECT_EQ(configs[3].type, "bridged-node");
+    EXPECT_EQ(configs[3].label, "Speaker");
     EXPECT_EQ(configs[3].endpoint, 4);
     EXPECT_EQ(configs[3].parentId, 1);
     EXPECT_TRUE(configs[3].bridged);

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -154,7 +154,8 @@ public:
 
         for (const auto & entry : AppOptions::GetDeviceTypeEntries())
         {
-            auto device = DeviceFactory::GetInstance().Create(entry.type);
+            auto device = DeviceFactory::GetInstance().Create(entry.type, entry.label);
+
             VerifyOrReturnError(device, CHIP_ERROR_NO_MEMORY);
             ChipLogProgress(AppServer, "Registering device %s on endpoint %u with parent 0x%04X", entry.type.c_str(),
                             entry.endpoint, entry.parentId);


### PR DESCRIPTION
#### Summary

Implements nicer default labels for bridged devices in the all-devices-app based on the child device types they implement (e.g., "Temperature Sensor 1" instead of "Bridged Node 1").

##### Problem

- Bridged devices default to the generic label "Bridged Node X" (where X is a sequential number) in reference apps like `all-devices-app`.
- This leads to a generic, unhelpful display name in ecosystem apps (like the Google Home app) that makes it difficult to distinguish between multiple bridged devices.

##### Solution

- Updated the `DeviceFactory::Create` API to accept an optional `nodeLabel` argument.
- Overloaded `DeviceFactory::RegisterCreator` to support both zero-argument creators and creators accepting a `nodeLabel` argument, maintaining backwards compatibility with all other device types.
- Updated the `bridged-node` creator registration to use the passed `nodeLabel` (falling back to the generic sequential counter if empty).
- Updated the posix application startup loop to search for a child device for each `bridged-node` and format a human-readable title-case label (e.g. "Temperature Sensor 1") based on the child's type, keeping track of sequential counts per device type.

#### Testing

- Verified that the `TestDeviceTypeParser` unit tests compile and pass successfully under the `linux-x64-tests-clang` target.
- Verified that `all-devices-app` builds successfully with the target `linux-x64-all-devices-boringssl`.
- Tested the posix app locally using multiple bridged devices (`--device aggregator:1 --device "chime:2,parent=1,bridged" --device "temperature-sensor:4,parent=1,bridged"`) and confirmed that they register successfully on sequential endpoints.
