### PR TITLE
[Realtek] Support non-concurrent connection handling

### DIFF
--- a/src/platform/realtek/freertos/BLEManagerImpl.cpp
+++ b/src/platform/realtek/freertos/BLEManagerImpl.cpp
@@ -759,7 +759,7 @@ void BLEManagerImpl::DriveBLEState()
 #if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled)
     {
-        //TODO: shut down realtek BT
+        // TODO: shut down realtek BT
         mFlags.ClearAll();
         ChipLogProgress(DeviceLayer, "Shut down BLE");
     }

--- a/src/platform/realtek/freertos/BLEManagerImpl.cpp
+++ b/src/platform/realtek/freertos/BLEManagerImpl.cpp
@@ -37,6 +37,10 @@
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
 #endif
 
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+#include <platform/DeviceControlServer.h>
+#endif
+
 #include "bt_types.h"
 #include "gap_msg.h"
 #include "matter_ble.h"
@@ -118,13 +122,13 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(!mFlags.Has(Flags::kAMEBABLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(!mFlags.Has(Flags::kBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
 
     matter_ble_cback_register((P_MATTER_BLE_CBACK) (ble_callback_dispatcher));
 
     // Set related flags
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
-    mFlags.Set(Flags::kAMEBABLEStackInitialized);
+    mFlags.Set(Flags::kBLEStackInitialized);
     mFlags.Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
     mFlags.Set(Flags::kFastAdvertisingEnabled);
 
@@ -521,6 +525,33 @@ void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
     TEMPORARY_RETURN_IGNORED CloseConnection(conId);
 }
 
+void BLEManagerImpl::CheckNonConcurrentBleClosing()
+{
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    if (mState == kState_Disconnecting)
+    {
+        CHIP_ERROR err = DeviceLayer::DeviceControlServer::DeviceControlSvr().PostCloseAllBLEConnectionsToOperationalNetworkEvent();
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "PostCloseAllBLEConnectionsToOperationalNetworkEvent failed: %" CHIP_ERROR_FORMAT,
+                         err.Format());
+        }
+    }
+#endif
+}
+
+void BLEManagerImpl::_Shutdown()
+{
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    BleLayer::Shutdown();
+
+    mFlags.ClearAll().Set(Flags::kBLEStackInitialized);
+    mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
+
+    PlatformMgr().ScheduleWork(DriveBLEState, 0);
+#endif
+}
+
 CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                           PacketBufferHandle data)
 {
@@ -703,7 +734,7 @@ void BLEManagerImpl::DriveBLEState()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(mFlags.Has(Flags::kAMEBABLEStackInitialized), /* */);
+    VerifyOrExit(mFlags.Has(Flags::kBLEStackInitialized), /* */);
 
     // Start advertising if needed...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kAdvertisingEnabled))
@@ -724,6 +755,15 @@ void BLEManagerImpl::DriveBLEState()
         SuccessOrExit(err);
         ChipLogProgress(DeviceLayer, "Stopped BLE Advertising");
     }
+
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled)
+    {
+        //TODO: shut down realtek BT
+        mFlags.ClearAll();
+        ChipLogProgress(DeviceLayer, "Shut down BLE");
+    }
+#endif
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/platform/realtek/freertos/BLEManagerImpl.cpp
+++ b/src/platform/realtek/freertos/BLEManagerImpl.cpp
@@ -127,9 +127,9 @@ CHIP_ERROR BLEManagerImpl::_Init()
     matter_ble_cback_register((P_MATTER_BLE_CBACK) (ble_callback_dispatcher));
 
     // Set related flags
-    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mFlags.ClearAll();
     mFlags.Set(Flags::kBLEStackInitialized);
-    mFlags.Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
+    mFlags.Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled);
 
     InitSubscribed();

--- a/src/platform/realtek/freertos/BLEManagerImpl.h
+++ b/src/platform/realtek/freertos/BLEManagerImpl.h
@@ -45,7 +45,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    void _Shutdown() {}
+    void _Shutdown();
     bool _IsAdvertisingEnabled(void);
     CHIP_ERROR _SetAdvertisingEnabled(bool val);
     bool _IsAdvertising(void);
@@ -72,6 +72,7 @@ private:
     // ===== Members that implement virtual methods on BleApplicationDelegate.
 
     void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) override;
+    void CheckNonConcurrentBleClosing() override;
 
     // ===== Members for internal use by the following friends.
 
@@ -88,10 +89,10 @@ private:
         kFastAdvertisingEnabled   = 0x0002,
         kAdvertising              = 0x0004,
         kRestartAdvertising       = 0x0008,
-        kAMEBABLEStackInitialized = 0x0010,
+        kBLEStackInitialized      = 0x0010,
         kDeviceNameSet            = 0x0020,
-        kAdvertisingRefreshNeeded = 0x030,
-        kAdvertisingConfigured    = 0x040,
+        kAdvertisingRefreshNeeded = 0x0040,
+        kAdvertisingConfigured    = 0x0080,
     };
     BitFlags<BLEManagerImpl::Flags> mFlags;
 


### PR DESCRIPTION
### Summary

  Support non-concurrent BLE connection handling on the Realtek platform.
  When `CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION` is not defined,
  the BLE stack will now properly shut down after the commissioning flow
  completes, rather than leaving the BLE stack running indefinitely.

### Related issues

NA

### Testing

  - Compiled and verified on Realtek platform with both
    `CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION` enabled and disabled.
  - Verified BLE advertising starts and stops correctly during commission flow.
