### PR TITLE
[Linux] Do not return WiFi version if WiFi is not enabled

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -1207,6 +1207,9 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
 
 CHIP_ERROR ConnectivityManagerImpl::GetWiFiVersion(WiFiVersionEnum & wiFiVersion)
 {
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
+
     // We don't have direct API to get the WiFi version yet, return 802.11n on Linux simulation.
     wiFiVersion = WiFiVersionEnum::kN;
 


### PR DESCRIPTION
### Summary

If WiFi interface is not available on the host or WiFi is not enabled, the WiFi Diagnostics cluster still returns WiFi version which is misleading.

```console
$ chip-lighting-app &
$ chip-tool wifinetworkdiagnostics read wi-fi-version 1 0
...
[1781770273.140] [2034083:2034085] [TOO] Endpoint: 0 Cluster: 0x0000_0036 Attribute 0x0000_0002 DataVersion: 276423531
[1781770273.140] [2034083:2034085] [TOO]   WiFiVersion: 3
```

### Testing

Verified locally that WiFi version (just like other attributes) is returned only if WiFi is enabled and is available on the host.

```console
$ chip-lighting-app &
$ chip-tool wifinetworkdiagnostics read wi-fi-version 1 0
...
[1781770291.482] [2034419:2034421] [TOO] Endpoint: 0 Cluster: 0x0000_0036 Attribute 0x0000_0002 DataVersion: 2293863517
[1781770291.482] [2034419:2034421] [TOO]   WiFiVersion: null
```

```console
$ chip-lighting-app --wifi &
$ chip-tool wifinetworkdiagnostics read wi-fi-version 1 0
...
[1781770273.140] [2034083:2034085] [TOO] Endpoint: 0 Cluster: 0x0000_0036 Attribute 0x0000_0002 DataVersion: 276423531
[1781770273.140] [2034083:2034085] [TOO]   WiFiVersion: 3
```