### PR TITLE
ci(build-cert-bins): native arm64 build, parameterize commit and publish to docker.io

### DIFF
--- a/.github/workflows/build-cert-bins.yaml
+++ b/.github/workflows/build-cert-bins.yaml
@@ -1,10 +1,22 @@
 name: Build Certification Image
 on:
     workflow_call:
+        inputs:
+            commit_hash:
+                description: 'Upstream project-chip/connectedhomeip commit to build (defaults to the workflow trigger SHA)'
+                required: false
+                type: string
+                default: ''
     workflow_dispatch:
+        inputs:
+            commit_hash:
+                description: 'Upstream project-chip/connectedhomeip commit to build (defaults to the workflow trigger SHA)'
+                required: false
+                type: string
+                default: ''
 jobs:
     build-cert-bin:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04-arm
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - name: Set up Docker Buildx
@@ -12,13 +24,14 @@ jobs:
             - name: Publish to Registry
               uses: elgohr/Publish-Docker-Github-Action@1c2f28ccd9476e8a936ac9a1f287405504c93304 # v5
               with:
-                  name: ghcr.io/project-chip/chip-cert-bins
-                  tags: latest
+                  name: connectedhomeip/chip-cert-bins
+                  tags: ${{ inputs.commit_hash || github.sha }}
                   dockerfile: ./integrations/docker/images/chip-cert-bins/Dockerfile
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-                  registry: ghcr.io
-                  platforms: linux/amd64,linux/arm64,linux/arm
+                  username: ${{ secrets.CHIP_CERT_BINS_REGISTRY_USER }}
+                  password: ${{ secrets.CHIP_CERT_BINS_REGISTRY_TOKEN }}
+                  registry: docker.io
+                  platforms: linux/arm64
+                  buildargs: COMMITHASH=${{ inputs.commit_hash || github.sha }}
             - name: Notify Slack on Failure
               if: failure()
               uses: ./.github/actions/notify-slack-failure


### PR DESCRIPTION
### Summary

Fixes the `build-cert-bins.yaml` workflow so it can be run via `workflow_dispatch` and publishes a working image:

- **Drop `linux/arm`** from the `platforms` list. Docker normalises it to `linux/arm/v7`, which is rejected by the `chip-cert-bins` Dockerfile (only `linux/amd64` / `linux/arm64` are accepted) and not present in the `ubuntu:24.04` manifest, causing manual runs to fail with `Unsupported platform linux/arm/v7.`
- **Run on `ubuntu-24.04-arm`** (Graviton) so `linux/arm64` builds natively, instead of multi-hour QEMU emulation on `ubuntu-latest`.
- **Publish to `docker.io/connectedhomeip/chip-cert-bins:<sha>`** using `CHIP_CERT_BINS_REGISTRY_USER` / `CHIP_CERT_BINS_REGISTRY_TOKEN` secrets.
- **Pass `--build-arg COMMITHASH`** so the Dockerfile clones the same commit that triggered the workflow rather than the in-tree default.
- **Add a `commit_hash` `workflow_dispatch` / `workflow_call` input** that overrides `github.sha` for both the image tag and the `COMMITHASH` build-arg, so the workflow can be triggered against an arbitrary upstream SHA (useful when invoked from a fork branch where `github.sha` is fork-only).

<img width="682" height="716" alt="image" src="https://github.com/user-attachments/assets/d7b24854-2b7b-48f7-ab09-42e1f4bb941c" />

The Dockerfile itself is untouched; this is a workflow-only change.

### Testing

- [x] Manual `workflow_dispatch` run on a fork branch with `commit_hash` set to current upstream master — build completes successfully on `ubuntu-24.04-arm` and publishes `docker.io/connectedhomeip/chip-cert-bins:<sha>`.
- [ ] Verify maintainers have set the `CHIP_CERT_BINS_REGISTRY_USER` / `CHIP_CERT_BINS_REGISTRY_TOKEN` secrets in `project-chip/connectedhomeip` (these are not inherited from forks).
- [ ] One `workflow_call` invocation from another upstream workflow without the `commit_hash` input, confirming the fallback to `github.sha` still publishes correctly on master pushes.

### Notes for reviewers

- The image previously pushed to `ghcr.io/project-chip/chip-cert-bins:latest` using the auto-provided `GITHUB_TOKEN`. The new path uses the Matter-team-provided Docker Hub credentials and a SHA-based tag instead of `:latest` so each build is uniquely addressable.
- If you prefer to keep `:latest` as a moving alias, the `tags:` list can be set to `${{ inputs.commit_hash || github.sha }},latest` — happy to make that change.