### PR TITLE
[Linux] Implement carrier detection for Ethernet Diagnostics

### DIFF
--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -43,6 +43,7 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/Defer.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 using namespace ::chip::app::Clusters::GeneralDiagnostics;
@@ -710,71 +711,46 @@ CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiag
 
 CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex)
 {
-    CHIP_ERROR err = CHIP_ERROR_READ_FAILED;
-
-    int skfd;
-    struct ethtool_cmd ecmd = {};
-    ecmd.cmd                = ETHTOOL_GSET;
     struct ifreq ifr        = {};
+    struct ethtool_cmd ecmd = {};
+
+    ecmd.cmd = ETHTOOL_GSET;
 
     ifr.ifr_data = reinterpret_cast<char *>(&ecmd);
     Platform::CopyString(ifr.ifr_name, ifname);
 
-    if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
-    {
-        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
-        return CHIP_ERROR_OPEN_FAILED;
-    }
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    VerifyOrReturnError(fd != -1, CHIP_ERROR_OPEN_FAILED,
+                        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
+    auto deferClose = MakeDefer([fd]() { close(fd); });
 
-    if (ioctl(skfd, SIOCETHTOOL, &ifr) == -1)
-    {
-        ChipLogError(DeviceLayer, "Cannot get interface settings: %s", strerror(errno));
-        err = CHIP_ERROR_READ_FAILED;
-    }
-    else
-    {
-        fullDuplex = ecmd.duplex == DUPLEX_FULL;
-        err        = CHIP_NO_ERROR;
-    }
+    VerifyOrReturnError(ioctl(fd, SIOCETHTOOL, &ifr) != -1, CHIP_ERROR_READ_FAILED,
+                        ChipLogError(DeviceLayer, "Cannot get interface settings: %s", strerror(errno)));
 
-    close(skfd);
-
-    return err;
+    fullDuplex = ecmd.duplex == DUPLEX_FULL;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GetEthCarrierDetect(const char * ifname, bool & carrierDetect)
 {
-    CHIP_ERROR err = CHIP_ERROR_READ_FAILED;
-
-    int skfd;
     struct ifreq ifr           = {};
-    struct ethtool_value edata = {};
+    struct ethtool_value evalue = {};
 
-    edata.cmd = ETHTOOL_GLINK;
+    evalue.cmd = ETHTOOL_GLINK;
 
-    ifr.ifr_data = reinterpret_cast<char *>(&edata);
+    ifr.ifr_data = reinterpret_cast<char *>(&evalue);
     Platform::CopyString(ifr.ifr_name, ifname);
 
-    if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
-    {
-        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
-        return CHIP_ERROR_OPEN_FAILED;
-    }
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    VerifyOrReturnError(fd != -1, CHIP_ERROR_OPEN_FAILED,
+                        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
+    auto deferClose = MakeDefer([fd]() { close(fd); });
 
-    if (ioctl(skfd, SIOCETHTOOL, &ifr) == -1)
-    {
-        ChipLogError(DeviceLayer, "Cannot get link status: %s", strerror(errno));
-        err = CHIP_ERROR_READ_FAILED;
-    }
-    else
-    {
-        carrierDetect = edata.data != 0;
-        err           = CHIP_NO_ERROR;
-    }
+    VerifyOrReturnError(ioctl(fd, SIOCETHTOOL, &ifr) != -1, CHIP_ERROR_READ_FAILED,
+                        ChipLogError(DeviceLayer, "Cannot get link status: %s", strerror(errno)));
 
-    close(skfd);
-
-    return err;
+    carrierDetect = evalue.data != 0;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace ConnectivityUtils

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -285,7 +285,7 @@ InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname)
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to open socket");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return InterfaceTypeEnum::kUnspecified;
     }
 
@@ -329,7 +329,7 @@ CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t 
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
@@ -482,7 +482,7 @@ CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber)
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
@@ -508,7 +508,7 @@ CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi)
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
@@ -569,7 +569,7 @@ CHIP_ERROR GetWiFiBeaconLostCount(const char * ifname, uint32_t & beaconLostCoun
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
@@ -592,7 +592,7 @@ CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate)
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
@@ -653,13 +653,13 @@ CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiag
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
     if (ioctl(skfd, SIOCETHTOOL, &ifr) == -1)
     {
-        ChipLogError(DeviceLayer, "Cannot get device settings");
+        ChipLogError(DeviceLayer, "Cannot get interface settings: %s", strerror(errno));
         close(skfd);
         return CHIP_ERROR_READ_FAILED;
     }
@@ -722,19 +722,54 @@ CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex)
 
     if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        ChipLogError(DeviceLayer, "Failed to create a channel to the NET kernel.");
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
         return CHIP_ERROR_OPEN_FAILED;
     }
 
     if (ioctl(skfd, SIOCETHTOOL, &ifr) == -1)
     {
-        ChipLogError(DeviceLayer, "Cannot get device settings");
+        ChipLogError(DeviceLayer, "Cannot get interface settings: %s", strerror(errno));
         err = CHIP_ERROR_READ_FAILED;
     }
     else
     {
         fullDuplex = ecmd.duplex == DUPLEX_FULL;
         err        = CHIP_NO_ERROR;
+    }
+
+    close(skfd);
+
+    return err;
+}
+
+CHIP_ERROR GetEthCarrierDetect(const char * ifname, bool & carrierDetect)
+{
+    CHIP_ERROR err = CHIP_ERROR_READ_FAILED;
+
+    int skfd;
+    struct ifreq ifr           = {};
+    struct ethtool_value edata = {};
+
+    edata.cmd = ETHTOOL_GLINK;
+
+    ifr.ifr_data = reinterpret_cast<char *>(&edata);
+    Platform::CopyString(ifr.ifr_name, ifname);
+
+    if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+    {
+        ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno));
+        return CHIP_ERROR_OPEN_FAILED;
+    }
+
+    if (ioctl(skfd, SIOCETHTOOL, &ifr) == -1)
+    {
+        ChipLogError(DeviceLayer, "Cannot get link status: %s", strerror(errno));
+        err = CHIP_ERROR_READ_FAILED;
+    }
+    else
+    {
+        carrierDetect = edata.data != 0;
+        err           = CHIP_NO_ERROR;
     }
 
     close(skfd);

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -733,7 +733,7 @@ CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex)
 
 CHIP_ERROR GetEthCarrierDetect(const char * ifname, bool & carrierDetect)
 {
-    struct ifreq ifr           = {};
+    struct ifreq ifr            = {};
     struct ethtool_value evalue = {};
 
     evalue.cmd = ETHTOOL_GLINK;

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -49,6 +49,7 @@ CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate)
 CHIP_ERROR GetEthInterfaceName(char * ifname, size_t bufSize);
 CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum & pHYRate);
 CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex);
+CHIP_ERROR GetEthCarrierDetect(const char * ifname, bool & carrierDetect);
 
 } // namespace ConnectivityUtils
 

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -551,22 +551,18 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetEthPHYRate(app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum & pHYRate)
 {
-    if (ConnectivityMgrImpl().GetEthernetIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
+    const char * ifName = ConnectivityMgrImpl().GetEthernetIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    return ConnectivityUtils::GetEthPHYRate(ConnectivityMgrImpl().GetEthernetIfName(), pHYRate);
+    return ConnectivityUtils::GetEthPHYRate(ifName, pHYRate);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetEthFullDuplex(bool & fullDuplex)
 {
-    if (ConnectivityMgrImpl().GetEthernetIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
+    const char * ifName = ConnectivityMgrImpl().GetEthernetIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    return ConnectivityUtils::GetEthFullDuplex(ConnectivityMgrImpl().GetEthernetIfName(), fullDuplex);
+    return ConnectivityUtils::GetEthFullDuplex(ifName, fullDuplex);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetEthTimeSinceReset(uint64_t & timeSinceReset)
@@ -634,6 +630,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetEthOverrunCount(uint64_t & overrunCoun
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetEthCarrierDetect(bool & carrierDetect)
+{
+    const char * ifName = ConnectivityMgrImpl().GetEthernetIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
+
+    return ConnectivityUtils::GetEthCarrierDetect(ifName, carrierDetect);
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 {
     CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
@@ -681,34 +685,27 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNumber)
 {
-    if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
+    const char * ifName = ConnectivityMgrImpl().GetWiFiIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    return ConnectivityUtils::GetWiFiChannelNumber(ConnectivityMgrImpl().GetWiFiIfName(), channelNumber);
+    return ConnectivityUtils::GetWiFiChannelNumber(ifName, channelNumber);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiRssi(int8_t & rssi)
 {
-    if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
+    const char * ifName = ConnectivityMgrImpl().GetWiFiIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    return ConnectivityUtils::GetWiFiRssi(ConnectivityMgrImpl().GetWiFiIfName(), rssi);
+    return ConnectivityUtils::GetWiFiRssi(ifName, rssi);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
 {
+    const char * ifName = ConnectivityMgrImpl().GetWiFiIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
+
     uint32_t count;
-
-    if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
-
-    ReturnErrorOnFailure(ConnectivityUtils::GetWiFiBeaconLostCount(ConnectivityMgrImpl().GetWiFiIfName(), count));
+    ReturnErrorOnFailure(ConnectivityUtils::GetWiFiBeaconLostCount(ifName, count));
     VerifyOrReturnError(count >= mBeaconLostCount, CHIP_ERROR_INVALID_INTEGER_VALUE);
     beaconLostCount = count - mBeaconLostCount;
 
@@ -717,12 +714,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconLostCount(uint32_t & beaconL
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
 {
-    if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
-    {
-        return CHIP_ERROR_READ_FAILED;
-    }
+    const char * ifName = ConnectivityMgrImpl().GetWiFiIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    return ConnectivityUtils::GetWiFiCurrentMaxRate(ConnectivityMgrImpl().GetWiFiIfName(), currentMaxRate);
+    return ConnectivityUtils::GetWiFiCurrentMaxRate(ifName, currentMaxRate);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -67,6 +67,7 @@ public:
     CHIP_ERROR GetEthTxErrCount(uint64_t & txErrCount) override;
     CHIP_ERROR GetEthCollisionCount(uint64_t & collisionCount) override;
     CHIP_ERROR GetEthOverrunCount(uint64_t & overrunCount) override;
+    CHIP_ERROR GetEthCarrierDetect(bool & carrierDetect) override;
     CHIP_ERROR ResetEthNetworkDiagnosticsCounts() override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI


### PR DESCRIPTION
### Summary

It seems that Ethernet carrier detection is not implmented on any platform. Since Linux is a reference platform it should implement that attribute if possible.

### Testing

Verified locally that carrier detection works:

```console
$ chip-lighting-app
$ chip-tool ethernetnetworkdiagnostics read carrier-detect 1 0
...
[1781789372.277] [2357138:2357140] [TOO] Endpoint: 0 Cluster: 0x0000_0037 Attribute 0x0000_0007 DataVersion: 282037477
[1781789372.278] [2357138:2357140] [TOO]   CarrierDetect: TRUE
```

When Ethernet cable is detached, the attribute is reported as FALSE.