### PR TITLE
[Linux] Fix time since reset implementation for Ethernet diagnostics

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -567,7 +567,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetEthFullDuplex(bool & fullDuplex)
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetEthTimeSinceReset(uint64_t & timeSinceReset)
 {
-    return GetDiagnosticDataProvider().GetUpTime(timeSinceReset);
+    uint64_t currentUptime = 0;
+    ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(currentUptime));
+    VerifyOrReturnError(currentUptime >= mEthTimeSinceResetBaseline, CHIP_ERROR_INVALID_INTEGER_VALUE);
+
+    timeSinceReset = currentUptime - mEthTimeSinceResetBaseline;
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetEthPacketRxCount(uint64_t & packetRxCount)
@@ -678,6 +684,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 
         freeifaddrs(ifaddr);
     }
+
+    // Record the current uptime as the baseline for TimeSinceReset
+    ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(mEthTimeSinceResetBaseline));
 
     return err;
 }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -97,65 +97,44 @@ CHIP_ERROR GetThreadName(pid_t tid, char * nameBuf, size_t nameBufSize)
 
 CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
 {
-    CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
-    struct ifaddrs * ifaddr = nullptr;
+    const char * ifName = ConnectivityMgrImpl().GetEthernetIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
 
-    if (getifaddrs(&ifaddr) == -1)
-    {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
-    }
-    else
-    {
-        struct ifaddrs * ifa = nullptr;
+    struct ifaddrs * ifa = nullptr;
+    VerifyOrReturnError(getifaddrs(&ifa) != -1, CHIP_ERROR_READ_FAILED,
+                        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno)));
+    auto deferClose = MakeDefer([ifa]() { freeifaddrs(ifa); });
 
-        // Walk through linked list, maintaining head pointer so we can free list later.
-        for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+    for (; ifa != nullptr; ifa = ifa->ifa_next)
+    {
+        if (strcmp(ifa->ifa_name, ifName) == 0 && ifa->ifa_data != nullptr)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
+            auto stats = static_cast<struct rtnl_link_stats *>(ifa->ifa_data);
+            switch (type)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
+            case EthernetStatsCountType::kEthPacketRxCount:
+                count = stats->rx_packets;
+                return CHIP_NO_ERROR;
+            case EthernetStatsCountType::kEthPacketTxCount:
+                count = stats->tx_packets;
+                return CHIP_NO_ERROR;
+            case EthernetStatsCountType::kEthTxErrCount:
+                count = stats->tx_errors;
+                return CHIP_NO_ERROR;
+            case EthernetStatsCountType::kEthCollisionCount:
+                count = stats->collisions;
+                return CHIP_NO_ERROR;
+            case EthernetStatsCountType::kEthOverrunCount:
+                count = stats->rx_over_errors;
+                return CHIP_NO_ERROR;
+            default:
+                ChipLogError(DeviceLayer, "Unknown Ethernet statistic metric type");
                 break;
             }
         }
-
-        if (ifa != nullptr)
-        {
-            if (ifa->ifa_addr->sa_family == AF_PACKET && ifa->ifa_data != nullptr)
-            {
-                struct rtnl_link_stats * stats = (struct rtnl_link_stats *) ifa->ifa_data;
-                switch (type)
-                {
-                case EthernetStatsCountType::kEthPacketRxCount:
-                    count = stats->rx_packets;
-                    err   = CHIP_NO_ERROR;
-                    break;
-                case EthernetStatsCountType::kEthPacketTxCount:
-                    count = stats->tx_packets;
-                    err   = CHIP_NO_ERROR;
-                    break;
-                case EthernetStatsCountType::kEthTxErrCount:
-                    count = stats->tx_errors;
-                    err   = CHIP_NO_ERROR;
-                    break;
-                case EthernetStatsCountType::kEthCollisionCount:
-                    count = stats->collisions;
-                    err   = CHIP_NO_ERROR;
-                    break;
-                case EthernetStatsCountType::kEthOverrunCount:
-                    count = stats->rx_over_errors;
-                    err   = CHIP_NO_ERROR;
-                    break;
-                default:
-                    ChipLogError(DeviceLayer, "Unknown Ethernet statistic metric type");
-                    break;
-                }
-            }
-        }
-
-        freeifaddrs(ifaddr);
     }
 
-    return err;
+    return CHIP_ERROR_READ_FAILED;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
@@ -647,31 +626,22 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetEthCarrierDetect(bool & carrierDetect)
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 {
+    const char * ifName = ConnectivityMgrImpl().GetEthernetIfName();
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_READ_FAILED);
+
     uint64_t currentUptime = 0;
     ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(currentUptime));
 
-    struct ifaddrs * ifaddr = nullptr;
-    VerifyOrReturnError(getifaddrs(&ifaddr) != -1, CHIP_ERROR_READ_FAILED,
-                        ChipLogError(DeviceLayer, "Failed to get network interfaces"));
-    auto deferClose = MakeDefer([ifaddr]() { freeifaddrs(ifaddr); });
-
     struct ifaddrs * ifa = nullptr;
-    // Walk through linked list, maintaining head pointer so we can free list later.
-    for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
-    {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
-        {
-            ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
-            break;
-        }
-    }
+    VerifyOrReturnError(getifaddrs(&ifa) != -1, CHIP_ERROR_READ_FAILED,
+                        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno)));
+    auto deferClose = MakeDefer([ifa]() { freeifaddrs(ifa); });
 
-    if (ifa != nullptr)
+    for (; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ifa->ifa_addr->sa_family == AF_PACKET && ifa->ifa_data != nullptr)
+        if (strcmp(ifa->ifa_name, ifName) == 0 && ifa->ifa_data != nullptr)
         {
-            struct rtnl_link_stats * stats = (struct rtnl_link_stats *) ifa->ifa_data;
-
+            auto stats                 = static_cast<struct rtnl_link_stats *>(ifa->ifa_data);
             mEthPacketRxCount          = stats->rx_packets;
             mEthPacketTxCount          = stats->tx_packets;
             mEthTxErrCount             = stats->tx_errors;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -26,6 +26,7 @@
 #include <app/data-model/List.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>
+#include <lib/support/Defer.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/Linux/ConnectivityUtils.h>
@@ -646,49 +647,42 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetEthCarrierDetect(bool & carrierDetect)
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 {
-    CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
+    uint64_t currentUptime = 0;
+    ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(currentUptime));
+
     struct ifaddrs * ifaddr = nullptr;
+    VerifyOrReturnError(getifaddrs(&ifaddr) != -1, CHIP_ERROR_READ_FAILED,
+                        ChipLogError(DeviceLayer, "Failed to get network interfaces"));
+    auto deferClose = MakeDefer([ifaddr]() { freeifaddrs(ifaddr); });
 
-    if (getifaddrs(&ifaddr) == -1)
+    struct ifaddrs * ifa = nullptr;
+    // Walk through linked list, maintaining head pointer so we can free list later.
+    for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
-    }
-    else
-    {
-        struct ifaddrs * ifa = nullptr;
-
-        // Walk through linked list, maintaining head pointer so we can free list later.
-        for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
-            {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
-                break;
-            }
+            ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
+            break;
         }
-
-        if (ifa != nullptr)
-        {
-            if (ifa->ifa_addr->sa_family == AF_PACKET && ifa->ifa_data != nullptr)
-            {
-                struct rtnl_link_stats * stats = (struct rtnl_link_stats *) ifa->ifa_data;
-
-                mEthPacketRxCount  = stats->rx_packets;
-                mEthPacketTxCount  = stats->tx_packets;
-                mEthTxErrCount     = stats->tx_errors;
-                mEthCollisionCount = stats->collisions;
-                mEthOverrunCount   = stats->rx_over_errors;
-                err                = CHIP_NO_ERROR;
-            }
-        }
-
-        freeifaddrs(ifaddr);
     }
 
-    // Record the current uptime as the baseline for TimeSinceReset
-    ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(mEthTimeSinceResetBaseline));
+    if (ifa != nullptr)
+    {
+        if (ifa->ifa_addr->sa_family == AF_PACKET && ifa->ifa_data != nullptr)
+        {
+            struct rtnl_link_stats * stats = (struct rtnl_link_stats *) ifa->ifa_data;
 
-    return err;
+            mEthPacketRxCount          = stats->rx_packets;
+            mEthPacketTxCount          = stats->tx_packets;
+            mEthTxErrCount             = stats->tx_errors;
+            mEthCollisionCount         = stats->collisions;
+            mEthOverrunCount           = stats->rx_over_errors;
+            mEthTimeSinceResetBaseline = currentUptime;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_READ_FAILED;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -91,11 +91,12 @@ public:
 #endif
 
 private:
-    uint64_t mEthPacketRxCount  = 0;
-    uint64_t mEthPacketTxCount  = 0;
-    uint64_t mEthTxErrCount     = 0;
-    uint64_t mEthCollisionCount = 0;
-    uint64_t mEthOverrunCount   = 0;
+    uint64_t mEthPacketRxCount          = 0;
+    uint64_t mEthPacketTxCount          = 0;
+    uint64_t mEthTxErrCount             = 0;
+    uint64_t mEthCollisionCount         = 0;
+    uint64_t mEthOverrunCount           = 0;
+    uint64_t mEthTimeSinceResetBaseline = 0;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     uint32_t mBeaconLostCount        = 0;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -241,6 +241,11 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     // Initialize the configuration system.
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
 
+    // Initialize the reference time point as soon as possible, so we could
+    // use it during the CHIP stack initialization, e.g. time counters for
+    // diagnostics.
+    mStartTime = System::SystemClock().GetMonotonicTimestamp();
+
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
     ReturnErrorOnFailure(Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack());
@@ -248,8 +253,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     // Now set up our device instance info provider.  We couldn't do that
     // earlier, because the generic implementation sets a generic one.
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-
-    mStartTime = System::SystemClock().GetMonotonicTimestamp();
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
### Summary

The TimeSinceReset attribute on Ethernet Diagnostics cluster is not properly implemented on Linux. This PR fixes that by:

- implement `TimeSinceReset` reset in the `ResetCounts` command
- move `mStartTime` initialization before stack initialization so we could use `PlatformManagerImpl::GetStartTime()` during diagnostics provider initialization
- refactored `ResetEthNetworkDiagnosticsCounts` to use `MakeDefer`

### Testing

Verified locally that `ResetCounts` works as expected:

```console
$ chip-lighting-app &
$ chip-tool ethernetnetworkdiagnostics read time-since-reset 1 0
...
[1781853236.507] [2457157:2457159] [TOO] Endpoint: 0 Cluster: 0x0000_0037 Attribute 0x0000_0008 DataVersion: 856199395
[1781853236.507] [2457157:2457159] [TOO]   TimeSinceReset: 4
...
$ chip-tool ethernetnetworkdiagnostics read time-since-reset 1 0
...
[1781853259.207] [2457215:2457217] [TOO] Endpoint: 0 Cluster: 0x0000_0037 Attribute 0x0000_0008 DataVersion: 856199395
[1781853259.207] [2457215:2457217] [TOO]   TimeSinceReset: 27
...
$ chip-tool ethernetnetworkdiagnostics reset-counts 1 0
...
$ chip-tool ethernetnetworkdiagnostics read time-since-reset 1 0
...
[1781853315.366] [2457356:2457358] [TOO] Endpoint: 0 Cluster: 0x0000_0037 Attribute 0x0000_0008 DataVersion: 856199395
[1781853315.366] [2457356:2457358] [TOO]   TimeSinceReset: 2
...
```