### PR TITLE
fix off-by-one length check in BluedroidGetChipDeviceInfo

### DIFF
--- a/src/platform/ESP32/bluedroid/ChipDeviceScanner.cpp
+++ b/src/platform/ESP32/bluedroid/ChipDeviceScanner.cpp
@@ -33,7 +33,7 @@ bool BluedroidGetChipDeviceInfo(esp_ble_gap_cb_param_t & scan_result, chip::Ble:
     // Check for CHIP Service UUID
     if (scan_result.scan_rst.ble_adv != NULL)
     {
-        if (scan_result.scan_rst.adv_data_len > 13 && scan_result.scan_rst.ble_adv[5] == 0xf6 &&
+        if (scan_result.scan_rst.adv_data_len > 14 && scan_result.scan_rst.ble_adv[5] == 0xf6 &&
             scan_result.scan_rst.ble_adv[6] == 0xff)
         {
             deviceInfo.OpCode                              = scan_result.scan_rst.ble_adv[7];


### PR DESCRIPTION
### Summary

`BluedroidGetChipDeviceInfo` reads `scan_rst.ble_adv[5]` through `scan_rst.ble_adv[14]` after gating on `adv_data_len > 13`. The highest index it touches is `ble_adv[14]` (the `AdditionalDataFlag` byte of the 8-byte `ChipBLEDeviceIdentificationInfo` payload at offsets 7..14), which requires `adv_data_len >= 15`. With `> 13` an advertisement carrying the Matter service UUID (`0xf6 0xff` at offset 5/6) and exactly 14 bytes passes the guard, so the parser reads one byte past the advertised data into `AdditionalDataFlag`. The advertising payload comes straight off the air, so the length is attacker controlled. This tightens the guard to `> 14` so every indexed byte is within the advertised range.

### Related issues

None.

### Testing

Traced the indexed reads against the guard: the last byte accessed is `ble_adv[14]`, so the minimum safe `adv_data_len` is 15. A conformant Matter advertisement (flags AD + 11-byte service-data AD = 15 bytes) is unaffected; only truncated/crafted 14-byte advertisements that previously slipped through are now rejected, matching the strict length checks used by the Linux and Darwin scanners.