### PR TITLE
Surface instructionDependency and discovery bitmaps (per Alchemy update) into the data model parser

### DIFF
--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -38,6 +38,7 @@
 import re
 
 from mobly import asserts
+from support_modules.icd_support import kUatColorInstructionBitMask, kUatNumberInstructionBitMask, uat_instruction_bitmasks
 
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body
@@ -52,18 +53,6 @@ cluster = Clusters.Objects.IcdManagement
 uat = cluster.Bitmaps.UserActiveModeTriggerBitmap
 modes = cluster.Enums.OperatingModeEnum
 features = cluster.Bitmaps.Feature
-
-# BitMask for all user active mode trigger hints that are depedent on the UserActiveModeTriggerInstruction
-kUatInstructionDependentBitMask = uat.kCustomInstruction | uat.kActuateSensorSeconds | uat.kActuateSensorTimes | uat.kActuateSensorLightsBlink | uat.kResetButtonLightsBlink | uat.kResetButtonSeconds | uat.kResetButtonTimes | uat.kSetupButtonSeconds | uat.kSetupButtonLightsBlink | uat.kSetupButtonTimes | uat.kAppDefinedButton
-
-# BitMask for UserActiveModeTriggerHint that REQUIRE the prescense of the UserActiveModeTriggerInstruction
-kUatInstructionMandatoryBitMask = uat.kCustomInstruction | uat.kActuateSensorSeconds | uat.kActuateSensorTimes | uat.kResetButtonSeconds | uat.kResetButtonTimes | uat.kSetupButtonSeconds | uat.kSetupButtonTimes | uat.kAppDefinedButton
-
-# BitMask for all user active mode trigger hints that have the UserActiveModeTriggerInstruction as an uint
-kUatNumberInstructionBitMask = uat.kActuateSensorSeconds | uat.kActuateSensorTimes | uat.kResetButtonSeconds | uat.kResetButtonTimes | uat.kSetupButtonSeconds | uat.kSetupButtonTimes
-
-# BitMask for all user active mode trigger hints that provide a color in the UserActiveModeTriggerInstruction
-kUatColorInstructionBitMask = uat.kActuateSensorLightsBlink | uat.kResetButtonLightsBlink | uat.kSetupButtonLightsBlink
 
 
 class TC_ICDM_2_1(MatterBaseTest):
@@ -136,6 +125,9 @@ class TC_ICDM_2_1(MatterBaseTest):
 
         cluster = Clusters.Objects.IcdManagement
         attributes = cluster.Attributes
+
+        # Instruction-dependency masks
+        kUatInstructionDependentBitMask, kUatInstructionMandatoryBitMask = uat_instruction_bitmasks()
 
         # Commissioning
         self.step("1a")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -40,7 +40,7 @@ from matter.testing.matter_test_config import MatterTestConfig
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.problem_notices import ProblemNotice
 from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlCluster, XmlDeviceType, build_xml_clusters,
-                                         build_xml_device_types, dm_from_spec_version)
+                                         build_xml_device_types, build_xml_discovery_bitmaps, dm_from_spec_version)
 from matter.tlv import uint
 
 LOGGER = logging.getLogger(__name__)
@@ -274,4 +274,6 @@ class BasicCompositionTests(MatterBaseTest):
         LOGGER.info("----------------------------------------------------------------------------------")
         self.xml_clusters, self.problems = build_xml_clusters(dm, errata_path=errata_path)
         self.xml_device_types, problems = build_xml_device_types(dm)
+        self.problems.extend(problems)
+        self.xml_discovery_bitmaps, problems = build_xml_discovery_bitmaps(dm)
         self.problems.extend(problems)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -150,6 +150,7 @@ class XmlDataTypeComponent:
     is_optional: bool = False  # Whether field is optional
     is_nullable: bool = False  # Whether field can be null
     constraints: Optional[Constraints] = None  # For min/max values, lists, etc.
+    instruction_dependency: Optional[str] = None  # M/O/no — bitmap bits only
 
 
 @dataclass
@@ -779,6 +780,8 @@ class ClusterParser:
             # Extract additional field attributes
             summary = xml_field.attrib.get('summary', None)
             type_info = xml_field.attrib.get('type', None) if component_type == DataTypeEnum.kStruct else None
+            instruction_dependency = xml_field.attrib.get(
+                'instructionDependency', None) if component_type == DataTypeEnum.kBitmap else None
 
             # Check for duplicate IDs to detect invalid XML data
             if aid in components:
@@ -802,7 +805,8 @@ class ClusterParser:
                 type_info=type_info,
                 is_optional=is_optional,
                 is_nullable=is_nullable,
-                constraints=constraints
+                constraints=constraints,
+                instruction_dependency=instruction_dependency
             )
         return components
 
@@ -1199,6 +1203,7 @@ class DataModelLevel(Enum):
     kDeviceType = auto()
     kGlobal = auto()
     kNamespace = auto()
+    kDiscovery = auto()
 
     @property
     def dirname(self):
@@ -1210,6 +1215,8 @@ class DataModelLevel(Enum):
             return "globals"
         if self == DataModelLevel.kNamespace:
             return "namespaces"
+        if self == DataModelLevel.kDiscovery:
+            return "discovery"
         raise KeyError("Invalid enum: %r" % self)
 
 
@@ -1906,6 +1913,73 @@ def build_xml_global_data_types(data_model_directory: Union[PrebuiltDataModelDir
         raise SpecParsingException(f'Did not find all 3 global data model files in specified directory {top:!r}')
 
     return global_data_types, problems
+
+
+def build_xml_discovery_bitmaps(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable]) -> tuple[dict[str, XmlDataType], list[ProblemNotice]]:
+    """
+    Build XML bitmaps from the discovery data model directory.
+
+    Args:
+        data_model_directory: The data model directory to parse.
+
+    Returns:
+        Tuple of (bitmaps, problems) where bitmaps is a dict mapping bitmap name to XmlDataType.
+    """
+    bitmaps: dict[str, XmlDataType] = {}
+    problems: list[ProblemNotice] = []
+
+    top = get_data_model_directory(data_model_directory, DataModelLevel.kDiscovery)
+    # Defensive: older/unpackaged data models have no discovery/ directory, so there is nothing to parse.
+    if not top.is_dir():
+        return bitmaps, problems
+    LOGGER.info("Reading XML discovery bitmaps from %r", top)
+
+    for f in top.iterdir():
+        if not f.name.endswith('.xml'):
+            continue
+        with f.open("r", encoding="utf8") as file:
+            root = ElementTree.parse(file).getroot()
+            for element in root.iter('bitmap'):
+                try:
+                    name = element.attrib['name']
+                except KeyError:
+                    location = ClusterPathLocation(0, 0)
+                    problems.append(ProblemNotice("Discovery XML Parsing", location=location,
+                                                  severity=ProblemSeverity.WARNING,
+                                                  problem=f"Discovery bitmap with no name in {f.name}"))
+                    continue
+                temp_parser = ClusterParser(ElementTree.Element('cluster'), None, 'DiscoveryDataTypes')
+                components = temp_parser._parse_components(element, DataTypeEnum.kBitmap)
+                bitmaps[name] = XmlDataType(
+                    data_type=DataTypeEnum.kBitmap,
+                    name=name,
+                    components=components,
+                    cluster_ids=None
+                )
+
+    return bitmaps, problems
+
+
+def instruction_dependency_masks(bitmap: XmlDataType) -> tuple[int, int]:
+    """Derive (dependent, mandatory) bitmasks from a bitmap's instructionDependency column.
+
+    A bit is in the dependent mask if its instructionDependency is "M" or "O", and in the
+    mandatory mask only if it is "M". Raises if the bitmap carries no instructionDependency
+    data at all, which means the source XML predates the scraped Instruction Dependency column
+    (e.g. a stale prebuilt data model) rather than a spec where the column is genuinely empty.
+    """
+    dependent = 0
+    mandatory = 0
+    for bit, component in bitmap.components.items():
+        if component.instruction_dependency in ("M", "O"):
+            dependent |= (1 << int(bit))
+        if component.instruction_dependency == "M":
+            mandatory |= (1 << int(bit))
+    if all(component.instruction_dependency is None for component in bitmap.components.values()):
+        raise SpecParsingException(
+            f"Bitmap {bitmap.name!r} has no instructionDependency data; the data model XML is "
+            "missing the scraped Instruction Dependency column")
+    return dependent, mandatory
 
 
 def dm_from_spec_version(specification_version: uint) -> PrebuiltDataModelDirectory:

--- a/src/python_testing/support_modules/icd_support.py
+++ b/src/python_testing/support_modules/icd_support.py
@@ -25,6 +25,7 @@ import random
 import re
 import time
 from enum import IntEnum
+from functools import cache
 
 from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
 from mdns_discovery.utils.asserts import assert_valid_icd_key
@@ -33,6 +34,8 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError
 from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, instruction_dependency_masks
+from matter.tlv import uint
 
 log = logging.getLogger(__name__)
 
@@ -68,18 +71,20 @@ class ICDTestEventTriggerOperations(IntEnum):
 _cluster = Clusters.Objects.IcdManagement
 uat = _cluster.Bitmaps.UserActiveModeTriggerBitmap
 
-# BitMask for hints that are dependent on UserActiveModeTriggerInstruction
-kUatInstructionDependentBitMask = (
-    uat.kCustomInstruction | uat.kActuateSensorSeconds | uat.kActuateSensorTimes |
-    uat.kActuateSensorLightsBlink | uat.kResetButtonLightsBlink | uat.kResetButtonSeconds |
-    uat.kResetButtonTimes | uat.kSetupButtonSeconds | uat.kSetupButtonLightsBlink |
-    uat.kSetupButtonTimes | uat.kAppDefinedButton)
+_ICDM_CLUSTER_ID = uint(0x0046)
 
-# BitMask for hints that REQUIRE the presence of UserActiveModeTriggerInstruction
-kUatInstructionMandatoryBitMask = (
-    uat.kCustomInstruction | uat.kActuateSensorSeconds | uat.kActuateSensorTimes |
-    uat.kResetButtonSeconds | uat.kResetButtonTimes | uat.kSetupButtonSeconds |
-    uat.kSetupButtonTimes | uat.kAppDefinedButton)
+
+@cache
+def uat_instruction_bitmasks(data_model: PrebuiltDataModelDirectory = PrebuiltDataModelDirectory.k1_6) -> tuple[int, int]:
+    """Return (dependent, mandatory) UAT bitmasks scraped from the spec data model.
+
+    A bit is "dependent" if its Instruction Dependency is M or O, and "mandatory" only if it is M.
+    Raises SpecParsingException if the data model lacks the Instruction Dependency column.
+    """
+    clusters, _ = build_xml_clusters(data_model)
+    icd_cluster = clusters[_ICDM_CLUSTER_ID]
+    return instruction_dependency_masks(icd_cluster.bitmaps["UserActiveModeTriggerBitmap"])
+
 
 # BitMask for hints where UserActiveModeTriggerInstruction is a uint (number)
 kUatNumberInstructionBitMask = (


### PR DESCRIPTION
### Summary

Addresses
[Alchemy for hint tables #71750](https://github.com/project-chip/connectedhomeip/issues/71750)

Follows the Alchemy + spec changes that scrape the Instruction Dependency column into the data model. 

This PR surfaces the scraped instructionDependency data, now present in the generated data model XML, into the Python testing framework, and swaps TC-ICDM-2.1 over to derive its UAT instruction-dependency bitmasks from the shared **icd_support helper**, where `build_xml_clusters` feeds `instruction_dependency_masks`, instead of maintaining its own hardcoded copy.

### Parse discovery bitmaps and add a shared mask helper

`PairingHintBitmap` lives outside any cluster (generated to `discovery/PairingHint.xml`), so it needs its own reader; the mask computation is shared so both UAT and PH derive masks the same way.

#### matter/testing/spec_parsing.py

- added `DataModelLevel.kDiscovery` and `build_xml_discovery_bitmaps()` to read **discovery/*.xml**
- added `instruction_dependency_masks(bitmap)`, returns (dependent, mandatory) from the instructionDependency column, raising `SpecParsingException` if the column is absent (no silent fallback)

#### Load discovery bitmaps in the test framework

#### matter/testing/basic_composition.py

- `build_spec_xmls()` now also populates `self.xml_discovery_bitmaps` (version-correct, from the DUT's reported spec version)

### Derive UAT masks from the spec instead of hardcoding

#### support_modules/icd_support.py

- added `uat_instruction_bitmasks()`, which scrapes the dependent/mandatory masks from the data model; replaces the hand-maintained constants

### Consume the shared masks in TC-ICDM-2.1

#### TC_ICDM_2_1.py

- removed the hardcoded mask computation; imports the helpers from icd_support and computes the masks once per run

### Impact

- TC-ICDM-2.1's instruction-dependency checks now track the spec automatically; no hand-edited bitmasks to drift.
- `uat_instruction_bitmasks()` raises rather than silently falling back, surfacing a stale data model loudly instead of passing on wrong values.

### Testing
TC_ICDM_2_1.py excerpt, example use
```
  from support_modules.icd_support import (kUatColorInstructionBitMask, kUatNumberInstructionBitMask, uat_instruction_bitmasks)
  ...
  # in the test body:
  kUatInstructionDependentBitMask, kUatInstructionMandatoryBitMask = uat_instruction_bitmasks()
```
