### PR TITLE
Base CHIP_CONFIG_LAMBDA_EVENT_ALIGN on max_align_t, Not Pointer Size

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -39,6 +39,8 @@
 #include <core/CHIPBuildConfig.h>
 #endif
 
+#include <cstddef>
+
 #include <ble/BleConfig.h>
 #include <system/SystemConfig.h>
 
@@ -1049,9 +1051,19 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @def CHIP_CONFIG_LAMBDA_EVENT_ALIGN
  *
  * @brief The maximum alignment of the lambda which can be post into system event queue.
+ *
+ * @note For those platforms in which memory is not constrained,
+ * express the default as an alignment rather than a size, using
+ * alignof. The alignment that, by definition, covers every
+ * fundamental scalar a closure can capture, including `long
+ * double`. Otherwise, default to pointer alignment.
  */
 #ifndef CHIP_CONFIG_LAMBDA_EVENT_ALIGN
-#define CHIP_CONFIG_LAMBDA_EVENT_ALIGN (sizeof(void *))
+#if (defined(__linux__) && __linux__) || (defined(__MACH__) && __MACH__)
+#define CHIP_CONFIG_LAMBDA_EVENT_ALIGN (alignof(std::max_align_t))
+#else
+#define CHIP_CONFIG_LAMBDA_EVENT_ALIGN (alignof(void *))
+#endif
 #endif
 
 /**


### PR DESCRIPTION
### Summary

`CHIP_CONFIG_LAMBDA_EVENT_ALIGN` defaulted to `sizeof(void *)`, using a pointer size as the alignment of the `System::Layer` lambda event buffer. That coincides with the needed alignment only on LP64. On ILP32 targets it is 4, below `alignof(int64_t) == 8`, so any closure scheduled via `ScheduleLambda` that captures a 64-bit-aligned value fails the `static_assert` in `LambdaBridge::Initialize` ("lambda align too large").

#### Change

Express the default as an alignment rather than a size, using `alignof(std::max_align_t)`. The alignment that, by definition, covers every fundamental scalar a closure can capture. Adds `<cstddef>`.

#### Tradeoffs / Alternatives Considered

1. Raises the event object's alignment on some ABIs: 4 -> 8 on ILP32, and 8 -> 16 where `alignof(max_align_t) == 16` (for example x86-64 `long double`). The added padding per queued event is bounded by the event pool size.
2. A narrower fix, `alignof(std::uint64_t)` (always 8), avoids the 16-byte case for deployments that never capture wider than 64 bits. Happy to switch to that, or to gate the value, if reviewers prefer to keep the constrained-target footprint unchanged on 64-bit hosts.

### Related issues

Fixes #72655

### Testing

* Builds and runs on 32-bit ARM (arm-none-linux-gnueabihf, GCC 12.3.1) and on x86-64 host, where a lambda capturing an `int64_t` previously failed the assertion and now compiles and dispatches correctly.
* An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.5 Apple "Home" app with a wpa_supplicant implementation.