### PR TITLE
widen shift to uint64_t in readBits bit accumulation

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -56,7 +56,7 @@ static CHIP_ERROR readBits(std::vector<uint8_t> buf, size_t & index, uint64_t & 
     {
         if (buf[currentIndex / 8] & (1 << (currentIndex % 8)))
         {
-            dest |= (1 << bitsRead);
+            dest |= (static_cast<uint64_t>(1) << bitsRead);
         }
         currentIndex++;
     }


### PR DESCRIPTION
### Summary

`readBits` accumulates parsed bits into a `uint64_t dest`, but builds the bit mask from a 32-bit `int`: `dest |= (1 << bitsRead)`. The guard at the top of the function already permits `numberOfBitsToRead` up to `sizeof(uint64_t) * 8`, so `bitsRead` can reach 63. For any bit position >= 31 the `int` shift is signed-shift undefined behavior, and values above bit 31 are lost since the shift result is a 32-bit `int` before being widened to `uint64_t`. Widen the shift operand to `uint64_t` so the accumulation matches the destination width the bounds check already allows.

### Related issues

None.

### Testing

UBSan over the extracted accumulation loop: a 40-bit read reports `shift exponent 32 is too large for 32-bit type 'int'` before the change and runs clean afterward, yielding the correct 40-bit value. All current setup-payload fields are <= 27 bits, so decoding of conformant QR payloads is unchanged.