### PR TITLE
Tizen fix crash for BLE

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -941,8 +941,16 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    ReturnErrorOnFailure(PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "BLEManager initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogProgress(DeviceLayer, "BLE will be disabled - Bluetooth may be off");
+        mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
+        return CHIP_NO_ERROR;
+    }
 
     mFlags.Set(Flags::kTizenBLELayerInitialized);
     return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });


### PR DESCRIPTION
### Summary

Fix a crash on Tizen on Raspberry Pi device when Bluetooth is off and application is compiled with BLE.

### Testing

Compile on docker image: `ghcr.io/project-chip/chip-build-tizen`
Run on Tizen 10 on Raspberry Pi 4 with disabled Bluetooth (default). 

```
./scripts/build/build_examples.py --target tizen-arm64-light-no-thread --enable-flashbundle build
sdb install out/tizen-arm64-light-no-thread/org.tizen.matter.example.lighting/out/org.tizen.matter.example.lighting-1.0.0.tpk
sdb shell app_launcher --start org.tizen.matter.example.lighting -- wifi true discriminator 1234 passcode 11223344
```

The application crashes after few seconds, with the following backtrace:

```
#3  0x0000aaaad9f74840 in chipAbort () at ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/support/Assertions.h:60
No locals.
#4  0x0000aaaada03aba4 in chip::Inet::EndPointManager<chip::Inet::TCPEndPoint>::~EndPointManager (this=0xaaaada165190 <chip::DeviceLayer::Internal::GenericConnectivityManagerImpl_TCP<chip::DeviceLayer::ConnectivityManagerImpl>::_TCPEndPointManager()::sTCPEndPointManagerImpl>, __in_chrg=<optimized out>) at ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/inet/InetLayer.h:75
No locals.
#5  0x0000aaaada03a90c in chip::Inet::EndPointManagerImplPool<chip::Inet::TCPEndPointImplSockets>::~EndPointManagerImplPool (this=0xaaaada165190 <chip::DeviceLayer::Internal::GenericConnectivityManagerImpl_TCP<chip::DeviceLayer::ConnectivityManagerImpl>::_TCPEndPointManager()::sTCPEndPointManagerImpl>, __in_chrg=<optimized out>) at ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/inet/InetLayer.h:144
No locals.
```

After applying this fix, the application works normally - but without BLE. 