### PR TITLE
Set Privacy Flag on Outgoing Group Messages

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -268,7 +268,8 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // Begin privacy encrypt for appropriate header fields
 
         // Since we are not using chained buffers, the message data length should be equal to the total length
-        if(message->TotalLength() != message->DataLength()) {
+        if (message->TotalLength() != message->DataLength())
+        {
             ChipLogError(ExchangeManager, "PrepareMessage: Total length of message does not match the data length.");
             return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
         }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -264,7 +264,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // Begin privacy encrypt for appropriate header fields
 
         // Since we are not using chained buffers, the message data length should be equal to the total length
-        VerifyOrReturnError(message->TotalLength() == message->DataLength(),  CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+        VerifyOrReturnError(message->TotalLength() == message->DataLength(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
         uint8_t * data     = message->Start();
         size_t len         = message->TotalLength();
         uint16_t footerLen = packetHeader.MICTagLength();

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -280,7 +280,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         uint8_t * privacyHeader = packetHeader.PrivacyHeader(message->Start());
         size_t privacyLength    = packetHeader.PrivacyHeaderLength();
 
-        // We must ensure that:
+        // We must ensure that
         // 1. The privacy header starts within the message buffer.
         // 2. The privacy header lies entirely within the encoded packet header bounds (to prevent encrypting payload).
         // 3. The packet header lies entirely within the valid message buffer bounds.

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1123,7 +1123,7 @@ static bool GroupKeyDecryptAttempt(const PacketHeader & partialPacketHeader, Pac
 
         // Bounds check: we decrypt in place a privacy header located inside the packet.
         // Validate that we are still within the packet as the length is based on header flags.
-        VerifyOrReturnValue(privacyHeader + privacyLength <= msgCopy->Start() + msgCopy->TotalLength(), false);
+        VerifyOrReturnValue((privacyHeader + privacyLength) <= (msgCopy->Start() + msgCopy->TotalLength()), false);
 
         if (CHIP_NO_ERROR != context.PrivacyDecrypt(privacyHeader, privacyLength, privacyHeader, partialPacketHeader, mac))
         {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -301,7 +301,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         uint8_t * messageEnd       = (message->Start() + message->TotalLength());
 
         // Other fields such as message flags and session ID should exist in the header BEFORE the privacy fields,
-        // so they start of the privacy header must be strictly after the message start
+        // so the start of the privacy header must be strictly after the message start
         VerifyOrReturnError(privacyHeader > message->Start(), CHIP_ERROR_INTERNAL);
 
         // When the message extensions (MX) security flag is set, this indicates that there will be a message extensions

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -179,11 +179,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 {
     MATTER_TRACE_SCOPE("PrepareMessage", "SessionManager");
 
-    if (message->HasChainedBuffer())
-    {
-        ChipLogError(ExchangeManager, "PrepareMessage: Chained buffers are not supported");
-        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
-    }
+    VerifyOrReturnError(!message->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     bool headerEncoded = false;
     PacketHeader packetHeader;
@@ -268,12 +264,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // Begin privacy encrypt for appropriate header fields
 
         // Since we are not using chained buffers, the message data length should be equal to the total length
-        if (message->TotalLength() != message->DataLength())
-        {
-            ChipLogError(ExchangeManager, "PrepareMessage: Total length of message does not match the data length.");
-            return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
-        }
-
+        VerifyOrReturnError(message->TotalLength() == message->DataLength(),  CHIP_ERROR_INVALID_MESSAGE_LENGTH);
         uint8_t * data     = message->Start();
         size_t len         = message->TotalLength();
         uint16_t footerLen = packetHeader.MICTagLength();
@@ -309,22 +300,16 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // portion of the header (with a non-zero length). This portion of the header exists after the privacy header end.
         // If the flag is not set, the end of the privacy header should be the end of the header itself.
         bool mxEnabled = packetHeader.GetSecurityFlags() & to_underlying(Header::SecFlagValues::kMsgExtensionFlag);
-        if (mxEnabled && (privacyHeaderEnd >= headerEnd))
+        if (mxEnabled)
         {
-            ChipLogError(ExchangeManager, "PrepareMessage: Privacy header exceeds header bounds (MX set)");
-            return CHIP_ERROR_INTERNAL;
+            VerifyOrReturnError(privacyHeaderEnd < headerEnd, CHIP_ERROR_INTERNAL);
         }
-        else if (!mxEnabled && (privacyHeaderEnd != headerEnd))
+        else
         {
-            ChipLogError(ExchangeManager, "PrepareMessage: Privacy header length mismatch with header bounds");
-            return CHIP_ERROR_INTERNAL;
+            VerifyOrReturnError(privacyHeaderEnd == headerEnd, CHIP_ERROR_INTERNAL);
         }
 
-        if (headerEnd >= messageEnd)
-        {
-            ChipLogError(ExchangeManager, "PrepareMessage: Message header exceeds its expected size");
-            return CHIP_ERROR_INTERNAL;
-        }
+        VerifyOrReturnError(headerEnd < messageEnd, CHIP_ERROR_INTERNAL);
         ReturnErrorOnFailure(cryptoContext.PrivacyEncrypt(privacyHeader, privacyLength, privacyHeader, packetHeader, mac));
 
 #if CHIP_PROGRESS_LOGGING
@@ -1138,11 +1123,7 @@ static bool GroupKeyDecryptAttempt(const PacketHeader & partialPacketHeader, Pac
 
         // Bounds check: we decrypt in place a privacy header located inside the packet.
         // Validate that we are still within the packet as the length is based on header flags.
-        if ((privacyHeader + privacyLength) > (msgCopy->Start() + msgCopy->TotalLength()))
-        {
-            ChipLogError(ExchangeManager, "GroupKeyDecryptAttempt: Privacy header exceeds message bounds");
-            return false;
-        }
+        VerifyOrReturnValue(privacyHeader + privacyLength <= msgCopy->Start() + msgCopy->TotalLength(), false);
 
         if (CHIP_NO_ERROR != context.PrivacyDecrypt(privacyHeader, privacyLength, privacyHeader, partialPacketHeader, mac))
         {
@@ -1178,11 +1159,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & partialPack
 {
     MATTER_TRACE_SCOPE("Group Message Dispatch", "SessionManager");
 
-    if (msg->HasChainedBuffer())
-    {
-        ChipLogError(ExchangeManager, "SecureGroupMessageDispatch: Chained buffers are not supported");
-        return;
-    }
+    VerifyOrReturn(!msg->HasChainedBuffer());
 
     // Capture length before consuming headers.
     [[maybe_unused]] size_t messageTotalSize = msg->TotalLength();

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -280,7 +280,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         uint8_t * privacyHeader = packetHeader.PrivacyHeader(message->Start());
         size_t privacyLength    = packetHeader.PrivacyHeaderLength();
 
-        // We must ensure that
+        // We must ensure that:
         // 1. The privacy header starts within the message buffer.
         // 2. The privacy header lies entirely within the encoded packet header bounds (to prevent encrypting payload).
         // 3. The packet header lies entirely within the valid message buffer bounds.

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -179,6 +179,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 {
     MATTER_TRACE_SCOPE("PrepareMessage", "SessionManager");
 
+    bool headerEncoded = false;
     PacketHeader packetHeader;
     bool isControlMsg = IsControlMessage(payloadHeader);
     if (isControlMsg)
@@ -217,6 +218,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         packetHeader.SetMessageCounter(mGroupClientCounter.GetCounter(isControlMsg));
         TEMPORARY_RETURN_IGNORED mGroupClientCounter.IncrementCounter(isControlMsg);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
+        packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         sourceNodeId = fabric->GetNodeId();
         packetHeader.SetSourceNodeId(sourceNodeId);
 
@@ -234,6 +236,8 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         Crypto::SymmetricKeyContext * keyContext =
             groups->GetKeyContext(groupSession->GetFabricIndex(), groupSession->GetGroupId());
         VerifyOrReturnError(nullptr != keyContext, CHIP_ERROR_INTERNAL);
+        AutoRelease<Crypto::SymmetricKeyContext> keyContextOwner(keyContext);
+
         packetHeader.SetSessionId(keyContext->GetKeyHash());
         CryptoContext cryptoContext(keyContext);
 
@@ -249,8 +253,44 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         ReturnErrorOnFailure(
             CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), sourceNodeId));
         CHIP_ERROR err = SecureMessageCodec::Encrypt(cryptoContext, nonce, payloadHeader, packetHeader, message);
-        keyContext->Release();
         ReturnErrorOnFailure(err);
+
+        // Encode header now so we can privacy encrypt it
+        ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));
+        headerEncoded = true;
+
+        // Privacy Encrypt
+        uint8_t * data     = message->Start();
+        size_t len         = message->DataLength();
+        uint16_t footerLen = packetHeader.MICTagLength();
+        VerifyOrReturnError(footerLen <= len, CHIP_ERROR_INTERNAL);
+
+        uint16_t taglen = 0;
+        MessageAuthenticationCode mac;
+        ReturnErrorOnFailure(mac.Decode(packetHeader, &data[len - footerLen], footerLen, &taglen));
+        VerifyOrReturnError(taglen == footerLen, CHIP_ERROR_INTERNAL);
+
+        // Pointer to the start of the privacy header within the message buffer.
+        // The privacy header contains fields that need to be privacy-encrypted (e.g. Session ID, Message Counter).
+        uint8_t * privacyHeader = packetHeader.PrivacyHeader(message->Start());
+        size_t privacyLength    = packetHeader.PrivacyHeaderLength();
+
+        // We must ensure that:
+        // 1. The privacy header starts within the message buffer.
+        // 2. The privacy header lies entirely within the encoded packet header bounds (to prevent encrypting payload).
+        // 3. The packet header lies entirely within the valid message buffer bounds.
+        //
+        // (privacyHeader + privacyLength): Pointer to the end of the privacy header.
+        // (message->Start() + packetHeader.EncodeSizeBytes()): Pointer to the end of the packet header.
+        // (message->Start() + message->DataLength()): Pointer to the end of the valid message data in the buffer.
+        uint8_t * privacyHeaderEnd = (privacyHeader + privacyLength);
+        uint8_t * headerEnd        = (message->Start() + packetHeader.EncodeSizeBytes());
+        uint8_t * messageEnd       = (message->Start() + message->DataLength());
+
+        VerifyOrReturnError(privacyHeader >= message->Start(), CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(privacyHeaderEnd <= headerEnd, CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(headerEnd <= messageEnd, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(cryptoContext.PrivacyEncrypt(privacyHeader, privacyLength, privacyHeader, packetHeader, mac));
 
 #if CHIP_PROGRESS_LOGGING
         destination = NodeIdFromGroupId(groupSession->GetGroupId());
@@ -342,7 +382,10 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         return CHIP_ERROR_INTERNAL;
     }
 
-    ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));
+    if (!headerEncoded)
+    {
+        ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));
+    }
 
 #if CHIP_PROGRESS_LOGGING
     CompressedFabricId compressedFabricId = kUndefinedCompressedFabricId;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -179,6 +179,12 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 {
     MATTER_TRACE_SCOPE("PrepareMessage", "SessionManager");
 
+    if (message->HasChainedBuffer())
+    {
+        ChipLogError(ExchangeManager, "PrepareMessage: Chained buffers are not supported");
+        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
+    }
+
     bool headerEncoded = false;
     PacketHeader packetHeader;
     bool isControlMsg = IsControlMessage(payloadHeader);
@@ -259,9 +265,16 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));
         headerEncoded = true;
 
-        // Privacy Encrypt
+        // Begin privacy encrypt for appropriate header fields
+
+        // Since we are not using chained buffers, the message data length should be equal to the total length
+        if(message->TotalLength() != message->DataLength()) {
+            ChipLogError(ExchangeManager, "PrepareMessage: Total length of message does not match the data length.");
+            return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
+        }
+
         uint8_t * data     = message->Start();
-        size_t len         = message->DataLength();
+        size_t len         = message->TotalLength();
         uint16_t footerLen = packetHeader.MICTagLength();
         VerifyOrReturnError(footerLen <= len, CHIP_ERROR_INTERNAL);
 
@@ -282,14 +295,35 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         //
         // (privacyHeader + privacyLength): Pointer to the end of the privacy header.
         // (message->Start() + packetHeader.EncodeSizeBytes()): Pointer to the end of the packet header.
-        // (message->Start() + message->DataLength()): Pointer to the end of the valid message data in the buffer.
+        // (message->Start() + message->TotalLength()): Pointer to the end of the valid message data in the buffer.
         uint8_t * privacyHeaderEnd = (privacyHeader + privacyLength);
         uint8_t * headerEnd        = (message->Start() + packetHeader.EncodeSizeBytes());
-        uint8_t * messageEnd       = (message->Start() + message->DataLength());
+        uint8_t * messageEnd       = (message->Start() + message->TotalLength());
 
-        VerifyOrReturnError(privacyHeader >= message->Start(), CHIP_ERROR_INTERNAL);
-        VerifyOrReturnError(privacyHeaderEnd <= headerEnd, CHIP_ERROR_INTERNAL);
-        VerifyOrReturnError(headerEnd <= messageEnd, CHIP_ERROR_INTERNAL);
+        // Other fields such as message flags and session ID should exist in the header BEFORE the privacy fields,
+        // so they start of the privacy header must be strictly after the message start
+        VerifyOrReturnError(privacyHeader > message->Start(), CHIP_ERROR_INTERNAL);
+
+        // When the message extensions (MX) security flag is set, this indicates that there will be a message extensions
+        // portion of the header (with a non-zero length). This portion of the header exists after the privacy header end.
+        // If the flag is not set, the end of the privacy header should be the end of the header itself.
+        bool mxEnabled = packetHeader.GetSecurityFlags() & to_underlying(Header::SecFlagValues::kMsgExtensionFlag);
+        if (mxEnabled && (privacyHeaderEnd >= headerEnd))
+        {
+            ChipLogError(ExchangeManager, "PrepareMessage: Privacy header exceeds header bounds (MX set)");
+            return CHIP_ERROR_INTERNAL;
+        }
+        else if (!mxEnabled && (privacyHeaderEnd != headerEnd))
+        {
+            ChipLogError(ExchangeManager, "PrepareMessage: Privacy header length mismatch with header bounds");
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        if (headerEnd >= messageEnd)
+        {
+            ChipLogError(ExchangeManager, "PrepareMessage: Message header exceeds its expected size");
+            return CHIP_ERROR_INTERNAL;
+        }
         ReturnErrorOnFailure(cryptoContext.PrivacyEncrypt(privacyHeader, privacyLength, privacyHeader, packetHeader, mac));
 
 #if CHIP_PROGRESS_LOGGING
@@ -1103,7 +1137,11 @@ static bool GroupKeyDecryptAttempt(const PacketHeader & partialPacketHeader, Pac
 
         // Bounds check: we decrypt in place a privacy header located inside the packet.
         // Validate that we are still within the packet as the length is based on header flags.
-        VerifyOrReturnValue(privacyHeader + privacyLength <= msgCopy->Start() + msgCopy->DataLength(), false);
+        if ((privacyHeader + privacyLength) > (msgCopy->Start() + msgCopy->TotalLength()))
+        {
+            ChipLogError(ExchangeManager, "GroupKeyDecryptAttempt: Privacy header exceeds message bounds");
+            return false;
+        }
 
         if (CHIP_NO_ERROR != context.PrivacyDecrypt(privacyHeader, privacyLength, privacyHeader, partialPacketHeader, mac))
         {
@@ -1138,6 +1176,12 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & partialPack
                                                 const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msg)
 {
     MATTER_TRACE_SCOPE("Group Message Dispatch", "SessionManager");
+
+    if (msg->HasChainedBuffer())
+    {
+        ChipLogError(ExchangeManager, "SecureGroupMessageDispatch: Chained buffers are not supported");
+        return;
+    }
 
     // Capture length before consuming headers.
     [[maybe_unused]] size_t messageTotalSize = msg->TotalLength();
@@ -1175,7 +1219,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & partialPack
 
     // Extract MIC from the end of the message.
     uint8_t * data     = msg->Start();
-    size_t len         = msg->DataLength();
+    size_t len         = msg->TotalLength();
     uint16_t footerLen = partialPacketHeader.MICTagLength();
     VerifyOrReturn(footerLen <= len);
 

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -692,7 +692,8 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
 
     // Prepare the group message
     EncryptedPacketBufferHandle preparedMessage;
-    CHIP_ERROR err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
+    CHIP_ERROR err =
+        sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
     EXPECT_EQ(CHIP_NO_ERROR, err);
 
     // Unwraps the buffer and verifies PrepareMessage set the privacy flag bit high and set the group session type.
@@ -754,7 +755,8 @@ TEST_F(TestSessionManagerDispatch, TestGroupIncomingPrivacyBoundsCheck)
 
     // Prepare the group message
     EncryptedPacketBufferHandle preparedMessage;
-    CHIP_ERROR err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
+    CHIP_ERROR err =
+        sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
     EXPECT_EQ(CHIP_NO_ERROR, err);
 
     System::PacketBufferHandle writableMsg = preparedMessage.CastToWritable();

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -37,7 +37,7 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-#include <protocols/echo/Echo.h>
+#include <protocols/interaction_model/Constants.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
@@ -677,7 +677,7 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
 
     // Create the test payload header, data, and buffer
     PayloadHeader payloadHeader;
-    payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
     const char testPayload[] = "PrivacyTest";
     System::PacketBufferHandle payloadBuf =
         MessagePacketBuffer::NewWithData(reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -640,9 +640,9 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
     // Injects a test fabric to obtain FabricIndex 1
     FabricTable * fabricTable = sessionManager.GetFabricTable();
     ASSERT_NE(nullptr, fabricTable);
-    FabricIndex fabricIndex   = kUndefinedFabricIndex;
-    CHIP_ERROR err = fabricTable->AddNewFabricForTestIgnoringCollisions(GetRootACertAsset().mCert, GetIAA1CertAsset().mCert,
-                                                             GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey, &fabricIndex);
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    CHIP_ERROR err          = fabricTable->AddNewFabricForTestIgnoringCollisions(
+        GetRootACertAsset().mCert, GetIAA1CertAsset().mCert, GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey, &fabricIndex);
     EXPECT_EQ(CHIP_NO_ERROR, err);
 
     // Extracts assigned 64-bit compressed fabric ID span.
@@ -669,7 +669,7 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
     EXPECT_EQ(CHIP_NO_ERROR, provider->SetKeySet(fabricIndex, compressedFabricSpan, keySet));
     EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupKeyAt(fabricIndex, 0, groupKey));
     EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupInfoAt(fabricIndex, 0, groupInfo));
-    
+
     // Instantiates outgoing (for PrepareMessage) session.
     Transport::OutgoingGroupSession outgoingSession(testEntry.groupId, fabricIndex);
     SessionHandle outgoingHandle(outgoingSession);
@@ -678,9 +678,9 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
     // Create the test payload header, data, and buffer
     PayloadHeader payloadHeader;
     payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
-    const char testPayload[]              = "PrivacyTest";
-    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(
-        reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));
+    const char testPayload[] = "PrivacyTest";
+    System::PacketBufferHandle payloadBuf =
+        MessagePacketBuffer::NewWithData(reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));
     ASSERT_FALSE(payloadBuf.IsNull());
 
     // Prepare the group message
@@ -690,7 +690,7 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
 
     // Unwraps the buffer and verifies PrepareMessage set the privacy flag bit high and set the group session type.
     PacketHeader decodedHeader;
-    uint16_t headerSize = 0;
+    uint16_t headerSize                    = 0;
     System::PacketBufferHandle writableMsg = preparedMessage.CastToWritable();
     ASSERT_FALSE(writableMsg.IsNull());
     EXPECT_EQ(CHIP_NO_ERROR, decodedHeader.Decode(writableMsg->Start(), writableMsg->DataLength(), &headerSize));

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -628,6 +628,40 @@ public:
     PacketHeader mHeader;
 };
 
+static void SetupGroupKeys(SessionManager & sessionManager, FabricIndex & fabricIndex, GroupId groupId, const char * epochKey)
+{
+    using namespace chip::TestCerts;
+
+    // Injects a test fabric
+    FabricTable * fabricTable = sessionManager.GetFabricTable();
+    ASSERT_NE(nullptr, fabricTable);
+    CHIP_ERROR err = fabricTable->AddNewFabricForTestIgnoringCollisions(
+        GetRootACertAsset().mCert, GetIAA1CertAsset().mCert, GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey, &fabricIndex);
+    EXPECT_EQ(CHIP_NO_ERROR, err);
+
+    // Extracts assigned 64-bit compressed fabric ID span.
+    uint8_t compressedFabricBuf[sizeof(uint64_t)];
+    MutableByteSpan compressedFabricSpan(compressedFabricBuf);
+    EXPECT_EQ(CHIP_NO_ERROR, fabricTable->FindFabricWithIndex(fabricIndex)->GetCompressedFabricIdBytes(compressedFabricSpan));
+
+    // Get pointer to active group data provider
+    GroupDataProvider * provider = GetGroupDataProvider();
+    ASSERT_NE(nullptr, provider);
+
+    // registers symmetric keys under non-zero KeySetID 0x0123.
+    constexpr uint16_t kTestKeysetId = 0x0123;
+    KeySet keySet(kTestKeysetId, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
+    memcpy(keySet.epoch_keys[0].key, epochKey, 16);
+    keySet.epoch_keys[0].start_time = 0;
+    GroupKey groupKey(groupId, kTestKeysetId);
+    GroupInfo groupInfo(groupId, "Privacy Group");
+
+    // Setup Group key sets, group key maps, and group info
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetKeySet(fabricIndex, compressedFabricSpan, keySet));
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupKeyAt(fabricIndex, 0, groupKey));
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupInfoAt(fabricIndex, 0, groupInfo));
+}
+
 TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
 {
     using namespace chip::TestCerts;
@@ -637,38 +671,11 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
     TestSessionManagerInit(mContext, sessionManager);
     sessionManager.SetMessageDelegate(&delegate);
 
-    // Injects a test fabric to obtain FabricIndex 1
-    FabricTable * fabricTable = sessionManager.GetFabricTable();
-    ASSERT_NE(nullptr, fabricTable);
-    FabricIndex fabricIndex = kUndefinedFabricIndex;
-    CHIP_ERROR err          = fabricTable->AddNewFabricForTestIgnoringCollisions(
-        GetRootACertAsset().mCert, GetIAA1CertAsset().mCert, GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey, &fabricIndex);
-    EXPECT_EQ(CHIP_NO_ERROR, err);
-
-    // Extracts assigned 64-bit compressed fabric ID span.
-    uint8_t compressedFabricBuf[sizeof(uint64_t)];
-    MutableByteSpan compressedFabricSpan(compressedFabricBuf);
-    EXPECT_EQ(CHIP_NO_ERROR, fabricTable->FindFabricWithIndex(fabricIndex)->GetCompressedFabricIdBytes(compressedFabricSpan));
-
     // Loads test parameters for GroupId 2
     const MessageTestEntry & testEntry = theMessageTestVector[7];
 
-    // Get pointer to active group data provider
-    GroupDataProvider * provider = GetGroupDataProvider();
-    ASSERT_NE(nullptr, provider);
-
-    // registers symmetric keys under non-zero KeySetID 0x0123.
-    constexpr uint16_t kTestKeysetId = 0x0123;
-    KeySet keySet(kTestKeysetId, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
-    memcpy(keySet.epoch_keys[0].key, testEntry.epochKey, 16);
-    keySet.epoch_keys[0].start_time = 0;
-    GroupKey groupKey(testEntry.groupId, kTestKeysetId);
-    GroupInfo groupInfo(testEntry.groupId, "Privacy Group");
-
-    // Setup Group key sets, group key maps, and group info
-    EXPECT_EQ(CHIP_NO_ERROR, provider->SetKeySet(fabricIndex, compressedFabricSpan, keySet));
-    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupKeyAt(fabricIndex, 0, groupKey));
-    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupInfoAt(fabricIndex, 0, groupInfo));
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    SetupGroupKeys(sessionManager, fabricIndex, testEntry.groupId, testEntry.epochKey);
 
     // Instantiates outgoing (for PrepareMessage) session.
     Transport::OutgoingGroupSession outgoingSession(testEntry.groupId, fabricIndex);
@@ -685,7 +692,7 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
 
     // Prepare the group message
     EncryptedPacketBufferHandle preparedMessage;
-    err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
+    CHIP_ERROR err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
     EXPECT_EQ(CHIP_NO_ERROR, err);
 
     // Unwraps the buffer and verifies PrepareMessage set the privacy flag bit high and set the group session type.
@@ -708,9 +715,98 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
     EXPECT_EQ(delegate.mHeader.GetSessionId(), decodedHeader.GetSessionId());
     EXPECT_EQ(delegate.mHeader.GetDestinationGroupId().Value(), testEntry.groupId);
 
+    FabricTable * fabricTable = sessionManager.GetFabricTable();
+    ASSERT_NE(nullptr, fabricTable);
     NodeId expectedSourceNodeId = fabricTable->FindFabricWithIndex(fabricIndex)->GetNodeId();
     EXPECT_TRUE(delegate.mHeader.GetSourceNodeId().HasValue());
     EXPECT_EQ(delegate.mHeader.GetSourceNodeId().Value(), expectedSourceNodeId);
+
+    sessionManager.Shutdown();
+}
+
+TEST_F(TestSessionManagerDispatch, TestGroupIncomingPrivacyBoundsCheck)
+{
+    using namespace chip::TestCerts;
+
+    SessionManager sessionManager;
+    TestGroupPrivacyMessageDelegate delegate;
+    TestSessionManagerInit(mContext, sessionManager);
+    sessionManager.SetMessageDelegate(&delegate);
+
+    // Loads test parameters for GroupId 2
+    const MessageTestEntry & testEntry = theMessageTestVector[7];
+
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    SetupGroupKeys(sessionManager, fabricIndex, testEntry.groupId, testEntry.epochKey);
+
+    // Instantiates outgoing (for PrepareMessage) session.
+    Transport::OutgoingGroupSession outgoingSession(testEntry.groupId, fabricIndex);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    // Create the test payload header, data, and buffer
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+    const char testPayload[] = "PrivacyTest";
+    System::PacketBufferHandle payloadBuf =
+        MessagePacketBuffer::NewWithData(reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));
+    ASSERT_FALSE(payloadBuf.IsNull());
+
+    // Prepare the group message
+    EncryptedPacketBufferHandle preparedMessage;
+    CHIP_ERROR err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
+    EXPECT_EQ(CHIP_NO_ERROR, err);
+
+    System::PacketBufferHandle writableMsg = preparedMessage.CastToWritable();
+    ASSERT_FALSE(writableMsg.IsNull());
+
+    // Shrink the buffer to trigger the bounds check failure in GroupKeyDecryptAttempt.
+    writableMsg->SetDataLength(1);
+
+    IPAddress loopbackAddress;
+    IPAddress::FromString("::1", loopbackAddress);
+    const PeerAddress peerAddress = PeerAddress::UDP(loopbackAddress, CHIP_PORT);
+    sessionManager.OnMessageReceived(peerAddress, std::move(writableMsg));
+
+    // The message should be discarded and NOT received by the delegate.
+    EXPECT_FALSE(delegate.mMessageReceived);
+
+    sessionManager.Shutdown();
+}
+
+TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessageChainedBufferFailure)
+{
+    using namespace chip::TestCerts;
+
+    SessionManager sessionManager;
+    TestSessionManagerInit(mContext, sessionManager);
+
+    // Loads test parameters for GroupId 2
+    const MessageTestEntry & testEntry = theMessageTestVector[7];
+
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    SetupGroupKeys(sessionManager, fabricIndex, testEntry.groupId, testEntry.epochKey);
+
+    // Instantiates outgoing (for PrepareMessage) session.
+    Transport::OutgoingGroupSession outgoingSession(testEntry.groupId, fabricIndex);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+
+    // Create a chained buffer
+    System::PacketBufferHandle buf1 = MessagePacketBuffer::New(0);
+    System::PacketBufferHandle buf2 = MessagePacketBuffer::New(0);
+    ASSERT_FALSE(buf1.IsNull());
+    ASSERT_FALSE(buf2.IsNull());
+    buf1.AddToEnd(std::move(buf2));
+
+    EXPECT_TRUE(buf1->HasChainedBuffer());
+
+    EncryptedPacketBufferHandle preparedMessage;
+    CHIP_ERROR err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(buf1), preparedMessage);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     sessionManager.Shutdown();
 }

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -30,12 +30,14 @@
 
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
+#include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
+#include <protocols/echo/Echo.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
@@ -501,8 +503,14 @@ void TestSessionManagerInit(TestContext & ctx, SessionManager & sessionManager)
     static secure_channel::MessageCounterManager gMessageCounterManager;
     static chip::TestPersistentStorageDelegate deviceStorage;
     static chip::Crypto::DefaultSessionKeystore sessionKeystore;
+    static bool sInitialized = false;
 
-    EXPECT_EQ(CHIP_NO_ERROR, fabricTableHolder.Init());
+    if (!sInitialized)
+    {
+        EXPECT_EQ(CHIP_NO_ERROR, fabricTableHolder.Init());
+        sInitialized = true;
+    }
+
     EXPECT_EQ(CHIP_NO_ERROR,
               sessionManager.Init(&ctx.GetSystemLayer(), &ctx.GetTransportMgr(), &gMessageCounterManager, &deviceStorage,
                                   &fabricTableHolder.GetFabricTable(), sessionKeystore));
@@ -604,5 +612,108 @@ TEST_F(TestSessionManagerDispatch, TestSessionManagerDispatch)
 
     sessionManager.Shutdown();
 }
+
+#if !CHIP_CONFIG_SECURITY_TEST_MODE
+class TestGroupPrivacyMessageDelegate : public SessionMessageDelegate
+{
+public:
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, const SessionHandle & session,
+                           DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf) override
+    {
+        mMessageReceived = true;
+        mHeader          = header;
+    }
+
+    bool mMessageReceived = false;
+    PacketHeader mHeader;
+};
+
+TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessagePrivacy)
+{
+    using namespace chip::TestCerts;
+
+    SessionManager sessionManager;
+    TestGroupPrivacyMessageDelegate delegate;
+    TestSessionManagerInit(mContext, sessionManager);
+    sessionManager.SetMessageDelegate(&delegate);
+
+    // Injects a test fabric to obtain FabricIndex 1
+    FabricTable * fabricTable = sessionManager.GetFabricTable();
+    ASSERT_NE(nullptr, fabricTable);
+    FabricIndex fabricIndex   = kUndefinedFabricIndex;
+    CHIP_ERROR err = fabricTable->AddNewFabricForTestIgnoringCollisions(GetRootACertAsset().mCert, GetIAA1CertAsset().mCert,
+                                                             GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey, &fabricIndex);
+    EXPECT_EQ(CHIP_NO_ERROR, err);
+
+    // Extracts assigned 64-bit compressed fabric ID span.
+    uint8_t compressedFabricBuf[sizeof(uint64_t)];
+    MutableByteSpan compressedFabricSpan(compressedFabricBuf);
+    EXPECT_EQ(CHIP_NO_ERROR, fabricTable->FindFabricWithIndex(fabricIndex)->GetCompressedFabricIdBytes(compressedFabricSpan));
+
+    // Loads test parameters for GroupId 2
+    const MessageTestEntry & testEntry = theMessageTestVector[7];
+
+    // Get pointer to active group data provider
+    GroupDataProvider * provider = GetGroupDataProvider();
+    ASSERT_NE(nullptr, provider);
+
+    // registers symmetric keys under non-zero KeySetID 0x0123.
+    constexpr uint16_t kTestKeysetId = 0x0123;
+    KeySet keySet(kTestKeysetId, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
+    memcpy(keySet.epoch_keys[0].key, testEntry.epochKey, 16);
+    keySet.epoch_keys[0].start_time = 0;
+    GroupKey groupKey(testEntry.groupId, kTestKeysetId);
+    GroupInfo groupInfo(testEntry.groupId, "Privacy Group");
+
+    // Setup Group key sets, group key maps, and group info
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetKeySet(fabricIndex, compressedFabricSpan, keySet));
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupKeyAt(fabricIndex, 0, groupKey));
+    EXPECT_EQ(CHIP_NO_ERROR, provider->SetGroupInfoAt(fabricIndex, 0, groupInfo));
+    
+    // Instantiates outgoing (for PrepareMessage) session.
+    Transport::OutgoingGroupSession outgoingSession(testEntry.groupId, fabricIndex);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    // Create the test payload header, data, and buffer
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
+    const char testPayload[]              = "PrivacyTest";
+    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(
+        reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));
+    ASSERT_FALSE(payloadBuf.IsNull());
+
+    // Prepare the group message
+    EncryptedPacketBufferHandle preparedMessage;
+    err = sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), preparedMessage);
+    EXPECT_EQ(CHIP_NO_ERROR, err);
+
+    // Unwraps the buffer and verifies PrepareMessage set the privacy flag bit high and set the group session type.
+    PacketHeader decodedHeader;
+    uint16_t headerSize = 0;
+    System::PacketBufferHandle writableMsg = preparedMessage.CastToWritable();
+    ASSERT_FALSE(writableMsg.IsNull());
+    EXPECT_EQ(CHIP_NO_ERROR, decodedHeader.Decode(writableMsg->Start(), writableMsg->DataLength(), &headerSize));
+    EXPECT_TRUE(decodedHeader.IsGroupSession());
+    EXPECT_TRUE(decodedHeader.HasPrivacyFlag());
+
+    // Feeds ciphertext back into transport dispatch to verify PrivacyDecrypt and MIC authentication.
+    IPAddress loopbackAddress;
+    IPAddress::FromString("::1", loopbackAddress);
+    const PeerAddress peerAddress = PeerAddress::UDP(loopbackAddress, CHIP_PORT);
+    sessionManager.OnMessageReceived(peerAddress, std::move(writableMsg));
+    EXPECT_TRUE(delegate.mMessageReceived);
+
+    // Verify decrypted fields match expectations
+    EXPECT_EQ(delegate.mHeader.GetSessionId(), decodedHeader.GetSessionId());
+    EXPECT_EQ(delegate.mHeader.GetDestinationGroupId().Value(), testEntry.groupId);
+
+    NodeId expectedSourceNodeId = fabricTable->FindFabricWithIndex(fabricIndex)->GetNodeId();
+    EXPECT_TRUE(delegate.mHeader.GetSourceNodeId().HasValue());
+    EXPECT_EQ(delegate.mHeader.GetSourceNodeId().Value(), expectedSourceNodeId);
+
+    sessionManager.Shutdown();
+}
+#endif // !CHIP_CONFIG_SECURITY_TEST_MODE
 
 } // namespace


### PR DESCRIPTION
### Summary

This PR sets the privacy flag on the packet header for an outgoing group message. It also calls PrivacyEncrypt() on the the privacy header to ensure the appropriate fields are actually encrypted along with the flag being set here that states they are. 

### Testing

- CI Should still pass
- Added unit test
- Ran the ACE_1.6 test (that sends group messages) with these changes against an older matter device. Group messages still work as expected (since the PrivacyDecrypt() code is always being called already). 
