### PR TITLE
Operational State examples: Clean up logically redundant !IsNull() checks

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
@@ -146,7 +146,7 @@ static void onOperationalStateTimerTick(System::Layer * systemLayer, void * data
 
     auto countdown_time = delegate->GetCountdownTime();
 
-    if (countdown_time.IsNull() || (!countdown_time.IsNull() && countdown_time.Value() > 0))
+    if (countdown_time.IsNull() || countdown_time.Value() > 0)
     {
         if (state == OperationalState::OperationalStateEnum::kRunning)
         {
@@ -157,7 +157,7 @@ static void onOperationalStateTimerTick(System::Layer * systemLayer, void * data
             delegate->mPausedTime++;
         }
     }
-    else if (!countdown_time.IsNull() && countdown_time.Value() <= 0)
+    else
     {
         OperationalState::GenericOperationalError noError(to_underlying(OperationalState::ErrorStateEnum::kNoError));
         delegate->HandleStopStateCallback(noError);

--- a/examples/chef/common/chef-operational-state-delegate-impl.cpp
+++ b/examples/chef/common/chef-operational-state-delegate-impl.cpp
@@ -156,7 +156,7 @@ static void onOperationalStateTimerTick(System::Layer * systemLayer, void * data
 
     auto countdown_time = delegate->GetCountdownTime();
 
-    if (countdown_time.IsNull() || (!countdown_time.IsNull() && countdown_time.Value() > 0))
+    if (countdown_time.IsNull() || countdown_time.Value() > 0)
     {
         if (state == OperationalState::OperationalStateEnum::kRunning)
         {
@@ -167,7 +167,7 @@ static void onOperationalStateTimerTick(System::Layer * systemLayer, void * data
             delegate->mPausedTime++;
         }
     }
-    else if (!countdown_time.IsNull() && countdown_time.Value() <= 0)
+    else
     {
         OperationalState::GenericOperationalError noError(to_underlying(OperationalState::ErrorStateEnum::kNoError));
         delegate->HandleStopStateCallback(noError);


### PR DESCRIPTION
### Summary
As noted in [PR](https://github.com/project-chip/connectedhomeip/pull/71715) review, if `countdown_time.IsNull()` is false, then evaluating `(!countdown_time.IsNull() && ...)` on the right-hand side of an OR operator is logically redundant. Simplified the condition for better readability.

### Related issues
[PR](https://github.com/project-chip/connectedhomeip/pull/71715)

### Testing
N/A