### PR TITLE
Use App sink for starting Snapshot stream and not have a continuous stream writing an image to flash.

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -387,7 +387,7 @@ private:
     GstElement * CreateAudioPlaybackPipeline(CameraError & error);
 
     GstElement * CreateSnapshotPipeline(const std::string & device, int width, int height, int quality, int frameRate,
-                                        const std::string & filename, CameraError & error);
+                                        CameraError & error);
     CameraError SetV4l2Control(uint32_t controlId, int value);
 
     bool MatchClosestSnapshotParams(const VideoResolutionStruct & requested, VideoResolutionStruct & outResolution,

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -301,7 +301,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     GstElement * videorate      = gst_element_factory_make("videorate", "videorate");
     GstElement * videorate_caps = gst_element_factory_make("capsfilter", "timelapse_framerate");
     GstElement * queue          = gst_element_factory_make("queue", "queue");
-    GstElement * filesink       = gst_element_factory_make("multifilesink", "sink");
+    GstElement * appsink        = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -311,7 +311,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
         { videorate, "videorate" },           //
         { videorate_caps, "videorate_caps" }, //
         { queue, "queue" },                   //
-        { filesink, "filesink" }              //
+        { appsink, "appsink" }              //
     };
     bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -319,7 +319,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     if (isElementFactoryMakeFailed)
     {
         // Unreference the elements that were created
-        GstreamerPipepline::unrefGstElements(pipeline, source, jpeg_caps, videorate, videorate_caps, queue, filesink);
+        GstreamerPipepline::unrefGstElements(pipeline, source, jpeg_caps, videorate, videorate_caps, queue, appsink);
 
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
@@ -339,14 +339,14 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     g_object_set(jpeg_caps, "caps", caps, nullptr);
     gst_caps_unref(caps);
 
-    // Set the output file location
-    g_object_set(filesink, "location", config.filename.c_str(), nullptr);
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
 
     // Add elements to the pipeline
-    gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, filesink, nullptr);
+    gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr);
 
     // Link the elements
-    if (gst_element_link_many(source, jpeg_caps, videorate, videorate_caps, queue, filesink, nullptr) != TRUE)
+    if (gst_element_link_many(source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr) != TRUE)
     {
         ChipLogError(Camera, "Elements could not be linked.");
 
@@ -367,7 +367,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * filesink   = gst_element_factory_make("multifilesink", "sink");
+    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -376,7 +376,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
         { capsfilter, "capsfilter" }, //
         { jpegenc, "jpegenc" },       //
         { queue, "queue" },           //
-        { filesink, "filesink" }      //
+        { appsink, "appsink" }        //
     };
     const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -384,7 +384,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     if (isElementFactoryMakeFailed)
     {
         // Unreference the elements that were created
-        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, filesink);
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, queue, appsink);
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
     }
@@ -403,12 +403,12 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     // Set JPEG quality
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
-    // Set multifilesink to write only one file
-    g_object_set(filesink, "location", config.filename.c_str(), nullptr);
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
 
     // Add and link elements
-    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, filesink, nullptr);
-    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, filesink, nullptr))
+    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
+    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, appsink, nullptr))
     {
         ChipLogError(Camera, "Elements could not be linked.");
         gst_object_unref(pipeline);
@@ -832,6 +832,8 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 {
     VideoResolutionStruct matchedRes;
     ImageCodecEnum matchedCodec;
+    uint16_t streamId = 0;
+    SnapshotStream * snapshotStream = nullptr;
 
     if (streamID.IsNull())
     {
@@ -841,10 +843,22 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
                          resolution.height);
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
+        // Find the stream that matched
+        for (auto & s : mSnapshotStreams)
+        {
+            if (s.snapshotStreamParams.minResolution.width == matchedRes.width &&
+                s.snapshotStreamParams.minResolution.height == matchedRes.height &&
+                s.snapshotStreamParams.imageCodec == matchedCodec)
+            {
+                snapshotStream = &s;
+                streamId = s.snapshotStreamParams.snapshotStreamID;
+                break;
+            }
+        }
     }
     else
     {
-        uint16_t streamId = streamID.Value();
+        streamId = streamID.Value();
         auto it           = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
             return s.snapshotStreamParams.snapshotStreamID == streamId;
         });
@@ -853,32 +867,93 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             ChipLogError(Camera, "Snapshot stream not found for stream ID %u", streamId);
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
+        snapshotStream = &(*it);
         matchedRes   = it->snapshotStreamParams.minResolution;
         matchedCodec = it->snapshotStreamParams.imageCodec;
     }
 
-    // Read from image file stored from snapshot stream.
-    std::ifstream file(SNAPSHOT_FILE_PATH, std::ios::binary | std::ios::ate);
-    if (!file.is_open())
+    if (snapshotStream == nullptr)
     {
-        ChipLogError(Camera, "Error opening snapshot image file: ");
+        ChipLogError(Camera, "Failed to determine snapshot stream");
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
-    std::streamsize size = file.tellg();
-    file.seekg(0, std::ios::beg);
+    GstElement * snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
+    bool startedOnDemand = false;
 
-    // Ensure space for image snapshot data in outImageSnapshot
-    outImageSnapshot.data.resize(static_cast<size_t>(size));
-
-    if (!file.read(reinterpret_cast<char *>(outImageSnapshot.data.data()), size))
+    if (snapshotPipeline == nullptr)
     {
-        ChipLogError(Camera, "Error reading image file: ");
-        file.close();
+        // Stream is not running, start it temporarily
+        ChipLogProgress(Camera, "Snapshot stream not running, starting on demand");
+        if (StartSnapshotStream(streamId) != CameraError::SUCCESS)
+        {
+            ChipLogError(Camera, "Failed to start snapshot stream on demand");
+            return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+        }
+        snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
+        startedOnDemand = true;
+    }
+
+    if (snapshotPipeline == nullptr)
+    {
+        ChipLogError(Camera, "Snapshot pipeline is still null after trying to start");
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
-    file.close();
+    // Get the appsink
+    GstElement * appsink = gst_bin_get_by_name(GST_BIN(snapshotPipeline), "sink");
+    if (!appsink)
+    {
+        ChipLogError(Camera, "Failed to get appsink from snapshot pipeline");
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    // Pull sample from appsink
+    ChipLogProgress(Camera, "Pulling sample from appsink...");
+    GstSample * sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    gst_object_unref(appsink);
+
+    if (!sample)
+    {
+        ChipLogError(Camera, "Failed to pull sample from appsink");
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    GstBuffer * buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+
+    if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+    {
+        outImageSnapshot.data.resize(map.size);
+        memcpy(outImageSnapshot.data.data(), map.data, map.size);
+        gst_buffer_unmap(buffer, &map);
+    }
+    else
+    {
+        ChipLogError(Camera, "Failed to map buffer");
+        gst_sample_unref(sample);
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    gst_sample_unref(sample);
+
+    if (startedOnDemand)
+    {
+        ChipLogProgress(Camera, "Stopping snapshot stream that was started on demand");
+        StopSnapshotStream(streamId);
+    }
 
     outImageSnapshot.imageRes   = matchedRes;
     outImageSnapshot.imageCodec = matchedCodec;
@@ -1292,13 +1367,7 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
         it->snapshotContext = nullptr;
     }
 
-    // Remove the snapshot file
-    std::string fileName = SNAPSHOT_FILE_PATH;
-    if (unlink(fileName.c_str()) == -1)
-    {
-        ChipLogError(Camera, "Failed to remove snapshot file after stopping stream (err = %s).", strerror(errno));
-        return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
-    }
+
 
     return CameraError::SUCCESS;
 }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -340,7 +340,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     gst_caps_unref(caps);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add elements to the pipeline
     gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr);
@@ -404,7 +404,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add and link elements
     gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
@@ -463,7 +463,7 @@ GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & c
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add and link elements
     gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
@@ -1428,9 +1428,9 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
                     {
                         ChipLogError(Camera, "Debug info: %s", debug_info);
                     }
+                    g_error_free(err);
+                    g_free(debug_info);
                 }
-                g_error_free(err);
-                g_free(debug_info);
                 gst_message_unref(msg);
             }
             gst_object_unref(bus);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -418,6 +418,65 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
 
     return pipeline;
 }
+
+GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & config, CameraError & error)
+{
+    GstElement * pipeline   = gst_pipeline_new("snapshot-pipeline-test");
+    GstElement * source     = gst_element_factory_make("videotestsrc", "source");
+    GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
+    GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
+    GstElement * queue      = gst_element_factory_make("queue", "queue");
+    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+
+    const std::vector<std::pair<GstElement *, const char *>> elements = {
+        { pipeline, "pipeline" },     //
+        { source, "source" },         //
+        { capsfilter, "capsfilter" }, //
+        { jpegenc, "jpegenc" },       //
+        { queue, "queue" },           //
+        { appsink, "appsink" }        //
+    };
+    const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
+
+    if (isElementFactoryMakeFailed)
+    {
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, queue, appsink);
+        error = CameraError::ERROR_INIT_FAILED;
+        return nullptr;
+    }
+
+    // Configure videotestsrc: pattern=18 (ball animation), live=true
+    g_object_set(source, "pattern", 18, "is-live", TRUE, nullptr);
+
+    // Set resolution and framerate caps
+    GstCaps * caps = gst_caps_new_simple(                    //
+        "video/x-raw",                                       //
+        "width", G_TYPE_INT, config.width,                   //
+        "height", G_TYPE_INT, config.height,                 //
+        "framerate", GST_TYPE_FRACTION, config.framerate, 1, //
+        nullptr                                              //
+    );
+    g_object_set(capsfilter, "caps", caps, nullptr);
+    gst_caps_unref(caps);
+
+    // Set JPEG quality
+    g_object_set(jpegenc, "quality", config.quality, nullptr);
+
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+
+    // Add and link elements
+    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
+    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, appsink, nullptr))
+    {
+        ChipLogError(Camera, "Elements could not be linked.");
+        gst_object_unref(pipeline);
+        error = CameraError::ERROR_INIT_FAILED;
+        return nullptr;
+    }
+
+    return pipeline;
+}
 } // namespace Snapshot
 
 } // namespace GstreamerPipepline
@@ -510,8 +569,6 @@ CameraError CameraDevice::InitializeStreams()
 GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, int width, int height, int quality, int framerate,
                                                   const std::string & filename, CameraError & error)
 {
-    const auto cameraType = GstreamerPipepline::detectCameraType(device);
-
     const GstreamerPipepline::Snapshot::SnapshotPipelineConfig config = {
         .device    = device,
         .width     = width,
@@ -520,6 +577,14 @@ GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, in
         .framerate = framerate,
         .filename  = filename,
     };
+
+    if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
+    {
+        ChipLogProgress(Camera, "Using test video source for snapshot pipeline");
+        return GstreamerPipepline::Snapshot::CreateSnapshotPipelineTestVideosrc(config, error);
+    }
+
+    const auto cameraType = GstreamerPipepline::detectCameraType(device);
 
     switch (cameraType)
     {
@@ -914,12 +979,12 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 
     // Pull sample from appsink
     ChipLogProgress(Camera, "Pulling sample from appsink...");
-    GstSample * sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    GstSample * sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink), 2 * GST_SECOND);
     gst_object_unref(appsink);
 
     if (!sample)
     {
-        ChipLogError(Camera, "Failed to pull sample from appsink");
+        ChipLogError(Camera, "Failed to pull sample from appsink (timeout or error)");
         if (startedOnDemand)
         {
             StopSnapshotStream(streamId);
@@ -928,6 +993,17 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     }
 
     GstBuffer * buffer = gst_sample_get_buffer(sample);
+    if (!buffer)
+    {
+        ChipLogError(Camera, "Failed to get buffer from sample");
+        gst_sample_unref(sample);
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
     GstMapInfo map;
 
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
@@ -1150,7 +1226,7 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
 
     // Wait for the pipeline to reach the PLAYING state
     GstState state;
-    gst_element_get_state(audioPipeline, &state, nullptr, GST_CLOCK_TIME_NONE);
+    gst_element_get_state(audioPipeline, &state, nullptr, 5 * GST_SECOND);
     if (state != GST_STATE_PLAYING)
     {
         ChipLogError(Camera, "Audio pipeline did not reach PLAYING state.");
@@ -1192,12 +1268,15 @@ CameraError CameraDevice::StopAudioStream(uint16_t streamID)
     if (audioPipeline != nullptr)
     {
         GstStateChangeReturn result = gst_element_set_state(audioPipeline, GST_STATE_NULL);
-        if (result == GST_STATE_CHANGE_FAILURE)
-        {
-            return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
-        }
+
+        // Always clean up, regardless of state change result
         gst_object_unref(audioPipeline);
         it->audioContext = nullptr;
+
+        if (result == GST_STATE_CHANGE_FAILURE)
+        {
+            return CameraError::ERROR_AUDIO_STREAM_STOP_FAILED;
+        }
     }
 
     // Stop the audio playback pipeline
@@ -1326,10 +1405,37 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
 
     // Wait for the pipeline to reach the PLAYING state
     GstState state;
-    gst_element_get_state(snapshotPipeline, &state, nullptr, GST_CLOCK_TIME_NONE);
-    if (state != GST_STATE_PLAYING)
+    GstStateChangeReturn state_result = gst_element_get_state(snapshotPipeline, &state, nullptr, 5 * GST_SECOND);
+    if (state_result == GST_STATE_CHANGE_FAILURE || state != GST_STATE_PLAYING)
     {
-        ChipLogError(Camera, "Snapshot pipeline did not reach PLAYING state.");
+        ChipLogError(Camera, "Snapshot pipeline did not reach PLAYING state. Result: %d, State: %d", state_result, state);
+
+        // Try to get error message from GStreamer bus
+        GstBus * bus = gst_element_get_bus(snapshotPipeline);
+        if (bus)
+        {
+            GstMessage * msg = gst_bus_pop_filtered(bus, (GstMessageType) (GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+            if (msg)
+            {
+                GError * err       = nullptr;
+                gchar * debug_info = nullptr;
+
+                if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR)
+                {
+                    gst_message_parse_error(msg, &err, &debug_info);
+                    ChipLogError(Camera, "GStreamer Error: %s", err ? err->message : "unknown");
+                    if (debug_info)
+                    {
+                        ChipLogError(Camera, "Debug info: %s", debug_info);
+                    }
+                }
+                g_error_free(err);
+                g_free(debug_info);
+                gst_message_unref(msg);
+            }
+            gst_object_unref(bus);
+        }
+
         gst_element_set_state(snapshotPipeline, GST_STATE_NULL);
         gst_object_unref(snapshotPipeline);
         it->snapshotContext = nullptr;
@@ -1357,14 +1463,15 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
     {
         // Stop the pipeline
         GstStateChangeReturn result = gst_element_set_state(snapshotPipeline, GST_STATE_NULL);
+
+        // Always clean up, regardless of state change result
+        gst_object_unref(snapshotPipeline);
+        it->snapshotContext = nullptr;
+
         if (result == GST_STATE_CHANGE_FAILURE)
         {
             return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
         }
-
-        // Unreference the pipeline
-        gst_object_unref(snapshotPipeline);
-        it->snapshotContext = nullptr;
     }
 
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -544,6 +544,12 @@ CameraError CameraDevice::InitializeCameraDevice()
         gstreamerInitialized = true;
     }
 
+    if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
+    {
+        ChipLogProgress(Camera, "Using test video source, skipping physical camera initialization");
+        return CameraError::SUCCESS;
+    }
+
     ChipLogDetail(Camera, "InitializeCameraDevice: %s", mVideoDevicePath.c_str());
 
     videoDeviceFd = open(mVideoDevicePath.c_str(), O_RDWR);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -311,7 +311,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
         { videorate, "videorate" },           //
         { videorate_caps, "videorate_caps" }, //
         { queue, "queue" },                   //
-        { appsink, "appsink" }              //
+        { appsink, "appsink" }                //
     };
     bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -367,7 +367,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+    GstElement * appsink    = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -426,7 +426,7 @@ GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+    GstElement * appsink    = gst_element_factory_make("appsink", "sink");
 
     const std::vector<std::pair<GstElement *, const char *>> elements = {
         { pipeline, "pipeline" },     //
@@ -897,7 +897,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 {
     VideoResolutionStruct matchedRes;
     ImageCodecEnum matchedCodec;
-    uint16_t streamId = 0;
+    uint16_t streamId               = 0;
     SnapshotStream * snapshotStream = nullptr;
 
     if (streamID.IsNull())
@@ -916,7 +916,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
                 s.snapshotStreamParams.imageCodec == matchedCodec)
             {
                 snapshotStream = &s;
-                streamId = s.snapshotStreamParams.snapshotStreamID;
+                streamId       = s.snapshotStreamParams.snapshotStreamID;
                 break;
             }
         }
@@ -924,7 +924,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     else
     {
         streamId = streamID.Value();
-        auto it           = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
+        auto it  = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
             return s.snapshotStreamParams.snapshotStreamID == streamId;
         });
         if (it == mSnapshotStreams.end())
@@ -933,8 +933,8 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
         snapshotStream = &(*it);
-        matchedRes   = it->snapshotStreamParams.minResolution;
-        matchedCodec = it->snapshotStreamParams.imageCodec;
+        matchedRes     = it->snapshotStreamParams.minResolution;
+        matchedCodec   = it->snapshotStreamParams.imageCodec;
     }
 
     if (snapshotStream == nullptr)
@@ -944,7 +944,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     }
 
     GstElement * snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
-    bool startedOnDemand = false;
+    bool startedOnDemand          = false;
 
     if (snapshotPipeline == nullptr)
     {
@@ -956,7 +956,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
         snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
-        startedOnDemand = true;
+        startedOnDemand  = true;
     }
 
     if (snapshotPipeline == nullptr)
@@ -1473,8 +1473,6 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
             return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
         }
     }
-
-
 
     return CameraError::SUCCESS;
 }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -545,6 +545,12 @@ CameraError CameraDevice::InitializeCameraDevice()
         gstreamerInitialized = true;
     }
 
+    if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
+    {
+        ChipLogProgress(Camera, "Using test video source, skipping physical camera initialization");
+        return CameraError::SUCCESS;
+    }
+
     ChipLogDetail(Camera, "InitializeCameraDevice: %s", mVideoDevicePath.c_str());
 
     videoDeviceFd = open(mVideoDevicePath.c_str(), O_RDWR);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -312,7 +312,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
         { videorate, "videorate" },           //
         { videorate_caps, "videorate_caps" }, //
         { queue, "queue" },                   //
-        { appsink, "appsink" }              //
+        { appsink, "appsink" }                //
     };
     bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -368,7 +368,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+    GstElement * appsink    = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -427,7 +427,7 @@ GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+    GstElement * appsink    = gst_element_factory_make("appsink", "sink");
 
     const std::vector<std::pair<GstElement *, const char *>> elements = {
         { pipeline, "pipeline" },     //
@@ -898,7 +898,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 {
     VideoResolutionStruct matchedRes;
     ImageCodecEnum matchedCodec;
-    uint16_t streamId = 0;
+    uint16_t streamId               = 0;
     SnapshotStream * snapshotStream = nullptr;
 
     if (streamID.IsNull())
@@ -917,7 +917,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
                 s.snapshotStreamParams.imageCodec == matchedCodec)
             {
                 snapshotStream = &s;
-                streamId = s.snapshotStreamParams.snapshotStreamID;
+                streamId       = s.snapshotStreamParams.snapshotStreamID;
                 break;
             }
         }
@@ -925,7 +925,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     else
     {
         streamId = streamID.Value();
-        auto it           = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
+        auto it  = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
             return s.snapshotStreamParams.snapshotStreamID == streamId;
         });
         if (it == mSnapshotStreams.end())
@@ -934,8 +934,8 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
         snapshotStream = &(*it);
-        matchedRes   = it->snapshotStreamParams.minResolution;
-        matchedCodec = it->snapshotStreamParams.imageCodec;
+        matchedRes     = it->snapshotStreamParams.minResolution;
+        matchedCodec   = it->snapshotStreamParams.imageCodec;
     }
 
     if (snapshotStream == nullptr)
@@ -945,7 +945,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     }
 
     GstElement * snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
-    bool startedOnDemand = false;
+    bool startedOnDemand          = false;
 
     if (snapshotPipeline == nullptr)
     {
@@ -957,7 +957,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
         snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
-        startedOnDemand = true;
+        startedOnDemand  = true;
     }
 
     if (snapshotPipeline == nullptr)
@@ -1474,8 +1474,6 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
             return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
         }
     }
-
-
 
     return CameraError::SUCCESS;
 }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -419,6 +419,65 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
 
     return pipeline;
 }
+
+GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & config, CameraError & error)
+{
+    GstElement * pipeline   = gst_pipeline_new("snapshot-pipeline-test");
+    GstElement * source     = gst_element_factory_make("videotestsrc", "source");
+    GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
+    GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
+    GstElement * queue      = gst_element_factory_make("queue", "queue");
+    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
+
+    const std::vector<std::pair<GstElement *, const char *>> elements = {
+        { pipeline, "pipeline" },     //
+        { source, "source" },         //
+        { capsfilter, "capsfilter" }, //
+        { jpegenc, "jpegenc" },       //
+        { queue, "queue" },           //
+        { appsink, "appsink" }        //
+    };
+    const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
+
+    if (isElementFactoryMakeFailed)
+    {
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, queue, appsink);
+        error = CameraError::ERROR_INIT_FAILED;
+        return nullptr;
+    }
+
+    // Configure videotestsrc: pattern=18 (ball animation), live=true
+    g_object_set(source, "pattern", 18, "is-live", TRUE, nullptr);
+
+    // Set resolution and framerate caps
+    GstCaps * caps = gst_caps_new_simple(                    //
+        "video/x-raw",                                       //
+        "width", G_TYPE_INT, config.width,                   //
+        "height", G_TYPE_INT, config.height,                 //
+        "framerate", GST_TYPE_FRACTION, config.framerate, 1, //
+        nullptr                                              //
+    );
+    g_object_set(capsfilter, "caps", caps, nullptr);
+    gst_caps_unref(caps);
+
+    // Set JPEG quality
+    g_object_set(jpegenc, "quality", config.quality, nullptr);
+
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+
+    // Add and link elements
+    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
+    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, appsink, nullptr))
+    {
+        ChipLogError(Camera, "Elements could not be linked.");
+        gst_object_unref(pipeline);
+        error = CameraError::ERROR_INIT_FAILED;
+        return nullptr;
+    }
+
+    return pipeline;
+}
 } // namespace Snapshot
 
 } // namespace GstreamerPipepline
@@ -511,8 +570,6 @@ CameraError CameraDevice::InitializeStreams()
 GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, int width, int height, int quality, int framerate,
                                                   const std::string & filename, CameraError & error)
 {
-    const auto cameraType = GstreamerPipepline::detectCameraType(device);
-
     const GstreamerPipepline::Snapshot::SnapshotPipelineConfig config = {
         .device    = device,
         .width     = width,
@@ -521,6 +578,14 @@ GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, in
         .framerate = framerate,
         .filename  = filename,
     };
+
+    if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
+    {
+        ChipLogProgress(Camera, "Using test video source for snapshot pipeline");
+        return GstreamerPipepline::Snapshot::CreateSnapshotPipelineTestVideosrc(config, error);
+    }
+
+    const auto cameraType = GstreamerPipepline::detectCameraType(device);
 
     switch (cameraType)
     {
@@ -915,12 +980,12 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 
     // Pull sample from appsink
     ChipLogProgress(Camera, "Pulling sample from appsink...");
-    GstSample * sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    GstSample * sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink), 2 * GST_SECOND);
     gst_object_unref(appsink);
 
     if (!sample)
     {
-        ChipLogError(Camera, "Failed to pull sample from appsink");
+        ChipLogError(Camera, "Failed to pull sample from appsink (timeout or error)");
         if (startedOnDemand)
         {
             StopSnapshotStream(streamId);
@@ -929,6 +994,17 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     }
 
     GstBuffer * buffer = gst_sample_get_buffer(sample);
+    if (!buffer)
+    {
+        ChipLogError(Camera, "Failed to get buffer from sample");
+        gst_sample_unref(sample);
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
     GstMapInfo map;
 
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
@@ -1151,7 +1227,7 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
 
     // Wait for the pipeline to reach the PLAYING state
     GstState state;
-    gst_element_get_state(audioPipeline, &state, nullptr, GST_CLOCK_TIME_NONE);
+    gst_element_get_state(audioPipeline, &state, nullptr, 5 * GST_SECOND);
     if (state != GST_STATE_PLAYING)
     {
         ChipLogError(Camera, "Audio pipeline did not reach PLAYING state.");
@@ -1193,12 +1269,15 @@ CameraError CameraDevice::StopAudioStream(uint16_t streamID)
     if (audioPipeline != nullptr)
     {
         GstStateChangeReturn result = gst_element_set_state(audioPipeline, GST_STATE_NULL);
-        if (result == GST_STATE_CHANGE_FAILURE)
-        {
-            return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
-        }
+
+        // Always clean up, regardless of state change result
         gst_object_unref(audioPipeline);
         it->audioContext = nullptr;
+
+        if (result == GST_STATE_CHANGE_FAILURE)
+        {
+            return CameraError::ERROR_AUDIO_STREAM_STOP_FAILED;
+        }
     }
 
     // Stop the audio playback pipeline
@@ -1327,10 +1406,37 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
 
     // Wait for the pipeline to reach the PLAYING state
     GstState state;
-    gst_element_get_state(snapshotPipeline, &state, nullptr, GST_CLOCK_TIME_NONE);
-    if (state != GST_STATE_PLAYING)
+    GstStateChangeReturn state_result = gst_element_get_state(snapshotPipeline, &state, nullptr, 5 * GST_SECOND);
+    if (state_result == GST_STATE_CHANGE_FAILURE || state != GST_STATE_PLAYING)
     {
-        ChipLogError(Camera, "Snapshot pipeline did not reach PLAYING state.");
+        ChipLogError(Camera, "Snapshot pipeline did not reach PLAYING state. Result: %d, State: %d", state_result, state);
+
+        // Try to get error message from GStreamer bus
+        GstBus * bus = gst_element_get_bus(snapshotPipeline);
+        if (bus)
+        {
+            GstMessage * msg = gst_bus_pop_filtered(bus, (GstMessageType) (GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+            if (msg)
+            {
+                GError * err       = nullptr;
+                gchar * debug_info = nullptr;
+
+                if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR)
+                {
+                    gst_message_parse_error(msg, &err, &debug_info);
+                    ChipLogError(Camera, "GStreamer Error: %s", err ? err->message : "unknown");
+                    if (debug_info)
+                    {
+                        ChipLogError(Camera, "Debug info: %s", debug_info);
+                    }
+                }
+                g_error_free(err);
+                g_free(debug_info);
+                gst_message_unref(msg);
+            }
+            gst_object_unref(bus);
+        }
+
         gst_element_set_state(snapshotPipeline, GST_STATE_NULL);
         gst_object_unref(snapshotPipeline);
         it->snapshotContext = nullptr;
@@ -1358,14 +1464,15 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
     {
         // Stop the pipeline
         GstStateChangeReturn result = gst_element_set_state(snapshotPipeline, GST_STATE_NULL);
+
+        // Always clean up, regardless of state change result
+        gst_object_unref(snapshotPipeline);
+        it->snapshotContext = nullptr;
+
         if (result == GST_STATE_CHANGE_FAILURE)
         {
             return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
         }
-
-        // Unreference the pipeline
-        gst_object_unref(snapshotPipeline);
-        it->snapshotContext = nullptr;
     }
 
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -67,6 +67,7 @@ struct AudioAppSinkContext
 
 // Using Gstreamer video test source's ball animation pattern for the live streaming visual verification.
 // Refer https://gstreamer.freedesktop.org/documentation/videotestsrc/index.html?gi-language=c#GstVideoTestSrcPattern
+constexpr int kBallAnimationPattern = 18;
 
 // Callback function for GStreamer app sink
 GstFlowReturn OnNewVideoSampleFromAppSink(GstAppSink * appsink, gpointer user_data)
@@ -289,7 +290,6 @@ struct SnapshotPipelineConfig
     int height;
     int quality;
     int framerate;
-    std::string filename;
 };
 
 GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, CameraError & error)
@@ -446,8 +446,8 @@ GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & c
         return nullptr;
     }
 
-    // Configure videotestsrc: pattern=18 (ball animation), live=true
-    g_object_set(source, "pattern", 18, "is-live", TRUE, nullptr);
+    // Configure videotestsrc: pattern=kBallAnimationPattern (ball animation), live=true
+    g_object_set(source, "pattern", kBallAnimationPattern, "is-live", TRUE, nullptr);
 
     // Set resolution and framerate caps
     GstCaps * caps = gst_caps_new_simple(                    //
@@ -574,7 +574,7 @@ CameraError CameraDevice::InitializeStreams()
 
 // Function to create the GStreamer pipeline
 GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, int width, int height, int quality, int framerate,
-                                                  const std::string & filename, CameraError & error)
+                                                  CameraError & error)
 {
     const GstreamerPipepline::Snapshot::SnapshotPipelineConfig config = {
         .device    = device,
@@ -582,7 +582,6 @@ GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, in
         .height    = height,
         .quality   = quality,
         .framerate = framerate,
-        .filename  = filename,
     };
 
     if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
@@ -631,8 +630,7 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
 
     if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
     {
-        const int kBallAnimationPattern = 18;
-        source                          = gst_element_factory_make("videotestsrc", "source");
+        source = gst_element_factory_make("videotestsrc", "source");
         g_object_set(source, "pattern", kBallAnimationPattern, nullptr);
         ChipLogProgress(Camera, "Video piepline: using test video source");
     }
@@ -972,15 +970,23 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
+    auto stopOnDemandStream = [this, streamId, startedOnDemand]() {
+        if (startedOnDemand)
+        {
+            ChipLogProgress(Camera, "Stopping snapshot stream that was started on demand");
+            if (StopSnapshotStream(streamId) != CameraError::SUCCESS)
+            {
+                ChipLogError(Camera, "Failed to stop snapshot stream %u that was started on demand", streamId);
+            }
+        }
+    };
+
     // Get the appsink
     GstElement * appsink = gst_bin_get_by_name(GST_BIN(snapshotPipeline), "sink");
     if (!appsink)
     {
         ChipLogError(Camera, "Failed to get appsink from snapshot pipeline");
-        if (startedOnDemand)
-        {
-            StopSnapshotStream(streamId);
-        }
+        stopOnDemandStream();
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
@@ -992,10 +998,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     if (!sample)
     {
         ChipLogError(Camera, "Failed to pull sample from appsink (timeout or error)");
-        if (startedOnDemand)
-        {
-            StopSnapshotStream(streamId);
-        }
+        stopOnDemandStream();
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
@@ -1004,10 +1007,7 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     {
         ChipLogError(Camera, "Failed to get buffer from sample");
         gst_sample_unref(sample);
-        if (startedOnDemand)
-        {
-            StopSnapshotStream(streamId);
-        }
+        stopOnDemandStream();
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
@@ -1023,20 +1023,13 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
     {
         ChipLogError(Camera, "Failed to map buffer");
         gst_sample_unref(sample);
-        if (startedOnDemand)
-        {
-            StopSnapshotStream(streamId);
-        }
+        stopOnDemandStream();
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
     gst_sample_unref(sample);
 
-    if (startedOnDemand)
-    {
-        ChipLogProgress(Camera, "Stopping snapshot stream that was started on demand");
-        StopSnapshotStream(streamId);
-    }
+    stopOnDemandStream();
 
     outImageSnapshot.imageRes   = matchedRes;
     outImageSnapshot.imageCodec = matchedCodec;
@@ -1392,7 +1385,7 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
     CameraError error             = CameraError::SUCCESS;
     GstElement * snapshotPipeline = CreateSnapshotPipeline(
         mVideoDevicePath, it->snapshotStreamParams.minResolution.width, it->snapshotStreamParams.minResolution.height,
-        it->snapshotStreamParams.quality, it->snapshotStreamParams.frameRate, "capture_snapshot.jpg", error);
+        it->snapshotStreamParams.quality, it->snapshotStreamParams.frameRate, error);
     if (snapshotPipeline == nullptr)
     {
         ChipLogError(Camera, "Failed to create snapshot pipeline.");
@@ -1435,9 +1428,18 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
                     {
                         ChipLogError(Camera, "Debug info: %s", debug_info);
                     }
-                    g_error_free(err);
-                    g_free(debug_info);
                 }
+                else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_WARNING)
+                {
+                    gst_message_parse_warning(msg, &err, &debug_info);
+                    ChipLogProgress(Camera, "GStreamer Warning: %s", err ? err->message : "unknown");
+                    if (debug_info)
+                    {
+                        ChipLogProgress(Camera, "Debug info: %s", debug_info);
+                    }
+                }
+                g_clear_error(&err);
+                g_free(debug_info);
                 gst_message_unref(msg);
             }
             gst_object_unref(bus);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -302,7 +302,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     GstElement * videorate      = gst_element_factory_make("videorate", "videorate");
     GstElement * videorate_caps = gst_element_factory_make("capsfilter", "timelapse_framerate");
     GstElement * queue          = gst_element_factory_make("queue", "queue");
-    GstElement * filesink       = gst_element_factory_make("multifilesink", "sink");
+    GstElement * appsink        = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -312,7 +312,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
         { videorate, "videorate" },           //
         { videorate_caps, "videorate_caps" }, //
         { queue, "queue" },                   //
-        { filesink, "filesink" }              //
+        { appsink, "appsink" }              //
     };
     bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -320,7 +320,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     if (isElementFactoryMakeFailed)
     {
         // Unreference the elements that were created
-        GstreamerPipepline::unrefGstElements(pipeline, source, jpeg_caps, videorate, videorate_caps, queue, filesink);
+        GstreamerPipepline::unrefGstElements(pipeline, source, jpeg_caps, videorate, videorate_caps, queue, appsink);
 
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
@@ -340,14 +340,14 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     g_object_set(jpeg_caps, "caps", caps, nullptr);
     gst_caps_unref(caps);
 
-    // Set the output file location
-    g_object_set(filesink, "location", config.filename.c_str(), nullptr);
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
 
     // Add elements to the pipeline
-    gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, filesink, nullptr);
+    gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr);
 
     // Link the elements
-    if (gst_element_link_many(source, jpeg_caps, videorate, videorate_caps, queue, filesink, nullptr) != TRUE)
+    if (gst_element_link_many(source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr) != TRUE)
     {
         ChipLogError(Camera, "Elements could not be linked.");
 
@@ -368,7 +368,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     GstElement * capsfilter = gst_element_factory_make("capsfilter", "capsfilter");
     GstElement * jpegenc    = gst_element_factory_make("jpegenc", "jpegenc");
     GstElement * queue      = gst_element_factory_make("queue", "queue");
-    GstElement * filesink   = gst_element_factory_make("multifilesink", "sink");
+    GstElement * appsink     = gst_element_factory_make("appsink", "sink");
 
     // Check for any nullptr among the created elements
     const std::vector<std::pair<GstElement *, const char *>> elements = {
@@ -377,7 +377,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
         { capsfilter, "capsfilter" }, //
         { jpegenc, "jpegenc" },       //
         { queue, "queue" },           //
-        { filesink, "filesink" }      //
+        { appsink, "appsink" }        //
     };
     const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
@@ -385,7 +385,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     if (isElementFactoryMakeFailed)
     {
         // Unreference the elements that were created
-        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, filesink);
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegenc, queue, appsink);
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
     }
@@ -404,12 +404,12 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     // Set JPEG quality
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
-    // Set multifilesink to write only one file
-    g_object_set(filesink, "location", config.filename.c_str(), nullptr);
+    // Configure appsink
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
 
     // Add and link elements
-    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, filesink, nullptr);
-    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, filesink, nullptr))
+    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
+    if (!gst_element_link_many(source, capsfilter, jpegenc, queue, appsink, nullptr))
     {
         ChipLogError(Camera, "Elements could not be linked.");
         gst_object_unref(pipeline);
@@ -833,6 +833,8 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
 {
     VideoResolutionStruct matchedRes;
     ImageCodecEnum matchedCodec;
+    uint16_t streamId = 0;
+    SnapshotStream * snapshotStream = nullptr;
 
     if (streamID.IsNull())
     {
@@ -842,10 +844,22 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
                          resolution.height);
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
+        // Find the stream that matched
+        for (auto & s : mSnapshotStreams)
+        {
+            if (s.snapshotStreamParams.minResolution.width == matchedRes.width &&
+                s.snapshotStreamParams.minResolution.height == matchedRes.height &&
+                s.snapshotStreamParams.imageCodec == matchedCodec)
+            {
+                snapshotStream = &s;
+                streamId = s.snapshotStreamParams.snapshotStreamID;
+                break;
+            }
+        }
     }
     else
     {
-        uint16_t streamId = streamID.Value();
+        streamId = streamID.Value();
         auto it           = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
             return s.snapshotStreamParams.snapshotStreamID == streamId;
         });
@@ -854,32 +868,93 @@ CameraError CameraDevice::CaptureSnapshot(const chip::app::DataModel::Nullable<u
             ChipLogError(Camera, "Snapshot stream not found for stream ID %u", streamId);
             return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
         }
+        snapshotStream = &(*it);
         matchedRes   = it->snapshotStreamParams.minResolution;
         matchedCodec = it->snapshotStreamParams.imageCodec;
     }
 
-    // Read from image file stored from snapshot stream.
-    std::ifstream file(SNAPSHOT_FILE_PATH, std::ios::binary | std::ios::ate);
-    if (!file.is_open())
+    if (snapshotStream == nullptr)
     {
-        ChipLogError(Camera, "Error opening snapshot image file: ");
+        ChipLogError(Camera, "Failed to determine snapshot stream");
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
-    std::streamsize size = file.tellg();
-    file.seekg(0, std::ios::beg);
+    GstElement * snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
+    bool startedOnDemand = false;
 
-    // Ensure space for image snapshot data in outImageSnapshot
-    outImageSnapshot.data.resize(static_cast<size_t>(size));
-
-    if (!file.read(reinterpret_cast<char *>(outImageSnapshot.data.data()), size))
+    if (snapshotPipeline == nullptr)
     {
-        ChipLogError(Camera, "Error reading image file: ");
-        file.close();
+        // Stream is not running, start it temporarily
+        ChipLogProgress(Camera, "Snapshot stream not running, starting on demand");
+        if (StartSnapshotStream(streamId) != CameraError::SUCCESS)
+        {
+            ChipLogError(Camera, "Failed to start snapshot stream on demand");
+            return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+        }
+        snapshotPipeline = reinterpret_cast<GstElement *>(snapshotStream->snapshotContext);
+        startedOnDemand = true;
+    }
+
+    if (snapshotPipeline == nullptr)
+    {
+        ChipLogError(Camera, "Snapshot pipeline is still null after trying to start");
         return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
     }
 
-    file.close();
+    // Get the appsink
+    GstElement * appsink = gst_bin_get_by_name(GST_BIN(snapshotPipeline), "sink");
+    if (!appsink)
+    {
+        ChipLogError(Camera, "Failed to get appsink from snapshot pipeline");
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    // Pull sample from appsink
+    ChipLogProgress(Camera, "Pulling sample from appsink...");
+    GstSample * sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    gst_object_unref(appsink);
+
+    if (!sample)
+    {
+        ChipLogError(Camera, "Failed to pull sample from appsink");
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    GstBuffer * buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+
+    if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+    {
+        outImageSnapshot.data.resize(map.size);
+        memcpy(outImageSnapshot.data.data(), map.data, map.size);
+        gst_buffer_unmap(buffer, &map);
+    }
+    else
+    {
+        ChipLogError(Camera, "Failed to map buffer");
+        gst_sample_unref(sample);
+        if (startedOnDemand)
+        {
+            StopSnapshotStream(streamId);
+        }
+        return CameraError::ERROR_CAPTURE_SNAPSHOT_FAILED;
+    }
+
+    gst_sample_unref(sample);
+
+    if (startedOnDemand)
+    {
+        ChipLogProgress(Camera, "Stopping snapshot stream that was started on demand");
+        StopSnapshotStream(streamId);
+    }
 
     outImageSnapshot.imageRes   = matchedRes;
     outImageSnapshot.imageCodec = matchedCodec;
@@ -1293,13 +1368,7 @@ CameraError CameraDevice::StopSnapshotStream(uint16_t streamID)
         it->snapshotContext = nullptr;
     }
 
-    // Remove the snapshot file
-    std::string fileName = SNAPSHOT_FILE_PATH;
-    if (unlink(fileName.c_str()) == -1)
-    {
-        ChipLogError(Camera, "Failed to remove snapshot file after stopping stream (err = %s).", strerror(errno));
-        return CameraError::ERROR_SNAPSHOT_STREAM_STOP_FAILED;
-    }
+
 
     return CameraError::SUCCESS;
 }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -341,7 +341,7 @@ GstElement * CreateSnapshotPipelineV4l2(const SnapshotPipelineConfig & config, C
     gst_caps_unref(caps);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add elements to the pipeline
     gst_bin_add_many(GST_BIN(pipeline), source, jpeg_caps, videorate, videorate_caps, queue, appsink, nullptr);
@@ -405,7 +405,7 @@ GstElement * CreateSnapshotPipelineLibcamerasrc(const SnapshotPipelineConfig & c
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add and link elements
     gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
@@ -464,7 +464,7 @@ GstElement * CreateSnapshotPipelineTestVideosrc(const SnapshotPipelineConfig & c
     g_object_set(jpegenc, "quality", config.quality, nullptr);
 
     // Configure appsink
-    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, nullptr);
+    g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 1, "drop", TRUE, nullptr);
 
     // Add and link elements
     gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, jpegenc, queue, appsink, nullptr);
@@ -1429,9 +1429,9 @@ CameraError CameraDevice::StartSnapshotStream(uint16_t streamID)
                     {
                         ChipLogError(Camera, "Debug info: %s", debug_info);
                     }
+                    g_error_free(err);
+                    g_free(debug_info);
                 }
-                g_error_free(err);
-                g_free(debug_info);
                 gst_message_unref(msg);
             }
             gst_object_unref(bus);

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -1,0 +1,86 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+from mobly import asserts
+import matter.clusters as Clusters
+from matter import ChipDeviceCtrl
+from matter.interaction_model import InteractionModelError
+from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+class TC_AVSM_Snapshot_Simple(MatterBaseTest):
+    async def test_snapshot(self):
+        endpoint = self.user_params.get("endpoint", 1)
+        cluster = Clusters.CameraAvStreamManagement
+        attr = Clusters.CameraAvStreamManagement.Attributes
+        commands = Clusters.CameraAvStreamManagement.Commands
+
+        # Read FeatureMap
+        feature_map = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap
+        )
+        asserts.assert_true((feature_map & cluster.Bitmaps.Feature.kSnapshot) > 0, "Snapshot feature not supported")
+
+        # Read Capabilities
+        caps = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.SnapshotCapabilities
+        )
+        asserts.assert_greater(len(caps), 0, "SnapshotCapabilities list is empty")
+
+        # Allocate Snapshot Stream
+        try:
+            allocate_cmd = commands.SnapshotStreamAllocate(
+                imageCodec=caps[0].imageCodec,
+                maxFrameRate=caps[0].maxFrameRate,
+                minResolution=caps[0].resolution,
+                maxResolution=caps[0].resolution,
+                quality=90
+            )
+            response = await self.send_single_cmd(endpoint=endpoint, cmd=allocate_cmd)
+            stream_id = response.snapshotStreamID
+            log.info(f"Allocated snapshot stream ID: {stream_id}")
+        except InteractionModelError as e:
+            asserts.fail(f"Failed to allocate snapshot stream: {e}")
+
+        # Capture Snapshot
+        try:
+            capture_cmd = commands.CaptureSnapshot(
+                snapshotStreamID=stream_id,
+                requestedResolution=caps[0].resolution
+            )
+            capture_response = await self.send_single_cmd(
+                cmd=capture_cmd,
+                endpoint=endpoint,
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD
+            )
+            log.info(f"CaptureSnapshotResponse resolution: {capture_response.resolution}")
+            log.info(f"CaptureSnapshotResponse codec: {capture_response.imageCodec}")
+            log.info(f"CaptureSnapshotResponse data size: {len(capture_response.data)}")
+            asserts.assert_greater(len(capture_response.data), 0, "Captured image data is empty")
+        except InteractionModelError as e:
+            asserts.fail(f"CaptureSnapshot failed: {e}")
+        finally:
+            # Deallocate Stream
+            await self.send_single_cmd(
+                endpoint=endpoint,
+                cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id)
+            )
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -22,12 +22,15 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+from matter.testing.decorators import async_test_body
 
 log = logging.getLogger(__name__)
 
 
 class TC_AVSM_Snapshot_Simple(MatterBaseTest):
+    @async_test_body
     async def test_snapshot(self):
         endpoint = self.user_params.get("endpoint", 1)
         cluster = Clusters.CameraAvStreamManagement
@@ -40,6 +43,8 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
         )
         if not (feature_map & cluster.Bitmaps.Feature.kSnapshot):
             asserts.skip("Snapshot feature not supported, skipping test")
+        watermark_supported = feature_map & cluster.Bitmaps.Feature.kWatermark
+        osd_supported = feature_map & cluster.Bitmaps.Feature.kOnScreenDisplay
 
         # Read Capabilities
         caps = await self.read_single_attribute_check_success(
@@ -54,13 +59,18 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
         last_error = None
         for cap in caps:
             try:
-                allocate_cmd = commands.SnapshotStreamAllocate(
-                    imageCodec=cap.imageCodec,
-                    maxFrameRate=cap.maxFrameRate,
-                    minResolution=cap.resolution,
-                    maxResolution=cap.resolution,
-                    quality=90,
-                )
+                args = {
+                    "imageCodec": cap.imageCodec,
+                    "maxFrameRate": cap.maxFrameRate,
+                    "minResolution": cap.resolution,
+                    "maxResolution": cap.resolution,
+                    "quality": 90,
+                }
+                if watermark_supported:
+                    args["watermarkEnabled"] = False
+                if osd_supported:
+                    args["OSDEnabled"] = False
+                allocate_cmd = commands.SnapshotStreamAllocate(**args)
                 response = await self.send_single_cmd(endpoint=endpoint, cmd=allocate_cmd)
                 stream_id = response.snapshotStreamID
                 selected_cap = cap

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -22,9 +22,9 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import InteractionModelError
+from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main
-from matter.testing.decorators import async_test_body
 
 log = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -38,13 +38,15 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
         feature_map = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap
         )
-        asserts.assert_true((feature_map & cluster.Bitmaps.Feature.kSnapshot) > 0, "Snapshot feature not supported")
+        if not (feature_map & cluster.Bitmaps.Feature.kSnapshot):
+            asserts.skip("Snapshot feature not supported, skipping test")
 
         # Read Capabilities
         caps = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.SnapshotCapabilities
         )
-        asserts.assert_greater(len(caps), 0, "SnapshotCapabilities list is empty")
+        if not caps:
+            asserts.skip("SnapshotCapabilities list is empty, skipping snapshot test")
 
         # Allocate Snapshot Stream
         try:
@@ -80,10 +82,14 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             asserts.fail(f"CaptureSnapshot failed: {e}")
         finally:
             # Deallocate Stream
-            await self.send_single_cmd(
-                endpoint=endpoint,
-                cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id)
-            )
+            if 'stream_id' in locals():
+                try:
+                    await self.send_single_cmd(
+                        endpoint=endpoint,
+                        cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id)
+                    )
+                except Exception as e:
+                    log.warning("Failed to deallocate snapshot stream %s: %s", stream_id, e)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -49,30 +49,40 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             asserts.skip("SnapshotCapabilities list is empty, skipping snapshot test")
 
         # Allocate Snapshot Stream
-        try:
-            allocate_cmd = commands.SnapshotStreamAllocate(
-                imageCodec=caps[0].imageCodec,
-                maxFrameRate=caps[0].maxFrameRate,
-                minResolution=caps[0].resolution,
-                maxResolution=caps[0].resolution,
-                quality=90
-            )
-            response = await self.send_single_cmd(endpoint=endpoint, cmd=allocate_cmd)
-            stream_id = response.snapshotStreamID
-            log.info("Allocated snapshot stream ID: %s", stream_id)
-        except InteractionModelError as e:
-            asserts.fail(f"Failed to allocate snapshot stream: {e}")
+        stream_id = None
+        selected_cap = None
+        last_error = None
+        for cap in caps:
+            try:
+                allocate_cmd = commands.SnapshotStreamAllocate(
+                    imageCodec=cap.imageCodec,
+                    maxFrameRate=cap.maxFrameRate,
+                    minResolution=cap.resolution,
+                    maxResolution=cap.resolution,
+                    quality=90,
+                )
+                response = await self.send_single_cmd(endpoint=endpoint, cmd=allocate_cmd)
+                stream_id = response.snapshotStreamID
+                selected_cap = cap
+                log.info("Allocated snapshot stream ID: %s", stream_id)
+                break
+            except InteractionModelError as e:
+                last_error = e
+                log.warning("SnapshotStreamAllocate failed for capability %s: %s", cap, e)
+
+        if stream_id is None:
+            asserts.fail(f"Failed to allocate snapshot stream using any advertised capability: {last_error}")
 
         # Capture Snapshot
         try:
             capture_cmd = commands.CaptureSnapshot(
                 snapshotStreamID=stream_id,
-                requestedResolution=caps[0].resolution
+                requestedResolution=selected_cap.resolution,
             )
             capture_response = await self.send_single_cmd(
                 cmd=capture_cmd,
                 endpoint=endpoint,
-                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
             )
             log.info("CaptureSnapshotResponse resolution: %s", capture_response.resolution)
             log.info("CaptureSnapshotResponse codec: %s", capture_response.imageCodec)
@@ -82,11 +92,11 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             asserts.fail(f"CaptureSnapshot failed: {e}")
         finally:
             # Deallocate Stream
-            if 'stream_id' in locals():
+            if stream_id is not None:
                 try:
                     await self.send_single_cmd(
                         endpoint=endpoint,
-                        cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id)
+                        cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id),
                     )
                 except Exception as e:
                     log.warning("Failed to deallocate snapshot stream %s: %s", stream_id, e)

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -57,7 +57,7 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             )
             response = await self.send_single_cmd(endpoint=endpoint, cmd=allocate_cmd)
             stream_id = response.snapshotStreamID
-            log.info(f"Allocated snapshot stream ID: {stream_id}")
+            log.info("Allocated snapshot stream ID: %s", stream_id)
         except InteractionModelError as e:
             asserts.fail(f"Failed to allocate snapshot stream: {e}")
 
@@ -72,9 +72,9 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
                 endpoint=endpoint,
                 payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD
             )
-            log.info(f"CaptureSnapshotResponse resolution: {capture_response.resolution}")
-            log.info(f"CaptureSnapshotResponse codec: {capture_response.imageCodec}")
-            log.info(f"CaptureSnapshotResponse data size: {len(capture_response.data)}")
+            log.info("CaptureSnapshotResponse resolution: %s", capture_response.resolution)
+            log.info("CaptureSnapshotResponse codec: %s", capture_response.imageCodec)
+            log.info("CaptureSnapshotResponse data size: %d", len(capture_response.data))
             asserts.assert_greater(len(capture_response.data), 0, "Captured image data is empty")
         except InteractionModelError as e:
             asserts.fail(f"CaptureSnapshot failed: {e}")

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -14,6 +14,24 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --camera-test-videosrc
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -16,13 +16,16 @@
 #
 
 import logging
+
 from mobly import asserts
+
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import InteractionModelError
 from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
 
 log = logging.getLogger(__name__)
+
 
 class TC_AVSM_Snapshot_Simple(MatterBaseTest):
     async def test_snapshot(self):
@@ -81,6 +84,7 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
                 endpoint=endpoint,
                 cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id)
             )
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -31,6 +31,8 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
+#     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -121,7 +121,8 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             asserts.assert_equal(capture_response.imageCodec, selected_cap.imageCodec, "Image codec mismatch")
             asserts.assert_equal(capture_response.resolution, selected_cap.resolution, "Image resolution mismatch")
             if capture_response.imageCodec == cluster.Enums.ImageCodecEnum.kJpeg:
-                asserts.assert_true(capture_response.data.startswith(b'\xff\xd8'), "Captured image does not start with JPEG SOI marker")
+                asserts.assert_true(capture_response.data.startswith(b'\xff\xd8'),
+                                    "Captured image does not start with JPEG SOI marker")
                 asserts.assert_true(capture_response.data.endswith(b'\xff\xd9'), "Captured image does not end with JPEG EOI marker")
         except InteractionModelError as e:
             asserts.fail(f"CaptureSnapshot failed: {e}")

--- a/src/python_testing/TC_AVSM_Snapshot_Simple.py
+++ b/src/python_testing/TC_AVSM_Snapshot_Simple.py
@@ -118,6 +118,11 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
             log.info("CaptureSnapshotResponse codec: %s", capture_response.imageCodec)
             log.info("CaptureSnapshotResponse data size: %d", len(capture_response.data))
             asserts.assert_greater(len(capture_response.data), 0, "Captured image data is empty")
+            asserts.assert_equal(capture_response.imageCodec, selected_cap.imageCodec, "Image codec mismatch")
+            asserts.assert_equal(capture_response.resolution, selected_cap.resolution, "Image resolution mismatch")
+            if capture_response.imageCodec == cluster.Enums.ImageCodecEnum.kJpeg:
+                asserts.assert_true(capture_response.data.startswith(b'\xff\xd8'), "Captured image does not start with JPEG SOI marker")
+                asserts.assert_true(capture_response.data.endswith(b'\xff\xd9'), "Captured image does not end with JPEG EOI marker")
         except InteractionModelError as e:
             asserts.fail(f"CaptureSnapshot failed: {e}")
         finally:
@@ -129,7 +134,7 @@ class TC_AVSM_Snapshot_Simple(MatterBaseTest):
                         cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=stream_id),
                     )
                 except Exception as e:
-                    log.warning("Failed to deallocate snapshot stream %s: %s", stream_id, e)
+                    asserts.fail(f"Failed to deallocate snapshot stream {stream_id}: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
Use app sink to generate in-memory snapshot during CaptureSnapshot.
    - Fixes to blocking GStreamer `appsink` pulls and pipeline state
      transitions with timeouts.
    - Fix resource leaks where GStreamer pipelines were not unreffed
      on state transition failures in `StopSnapshotStream` and
      `StopAudioStream`.
    - Implement `CreateSnapshotPipelineTestVideosrc` to enable testing
      snapshot functionality using virtual video source (`videotestsrc`)
      when `--camera-test-videosrc` flag is set.

### Related issues

### Testing
Execute Snapshot Test in TC_AVSM_2_10.py
