### PR TITLE
Linux: Allow selecting the Wi-Fi interface via --wifi

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -637,6 +637,16 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     pthread_sigmask(SIG_BLOCK, &set, nullptr);
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Apply the WiFi interface name override (from --wifi=<interface>) before initializing the
+    // CHIP stack, so that ConnectivityManager picks it up instead of auto-detecting an interface.
+    if (LinuxDeviceOptions::GetInstance().mWiFiInterface.HasValue())
+    {
+        SuccessOrExit(err = DeviceLayer::ConnectivityMgrImpl().SetWiFiIfName(
+                          LinuxDeviceOptions::GetInstance().mWiFiInterface.Value().c_str()));
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
     err = DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -637,15 +637,15 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     pthread_sigmask(SIG_BLOCK, &set, nullptr);
 #endif
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    // Apply the WiFi interface name override (from --wifi=<interface>) before initializing the
-    // CHIP stack, so that ConnectivityManager picks it up instead of auto-detecting an interface.
+#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Apply the WiFi interface name override (from --wifi=<interface>) before initializing the CHIP
+    // stack, so that ConnectivityManager picks it up instead of auto-detecting an interface.
     if (LinuxDeviceOptions::GetInstance().mWiFiInterface.HasValue())
     {
         SuccessOrExit(err = DeviceLayer::ConnectivityMgrImpl().SetWiFiIfName(
                           LinuxDeviceOptions::GetInstance().mWiFiInterface.Value().c_str()));
     }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
     err = DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -275,12 +275,10 @@ const char * sDeviceOptionHelp =
     "  --ble-controller <selector>\n"
     "       BLE controller selector, see example or platform docs for details\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     "\n"
     "  --wifi[=interface]\n"
     "       Enable Wi-Fi management via wpa_supplicant, optionally specifying the interface name.\n"
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     "\n"
     "  --wifi-supports-5g\n"
     "       Indicate that local Wi-Fi hardware should report 5GHz support.\n"
@@ -563,6 +561,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         }
         break;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     case kDeviceOption_WiFi:
         LinuxDeviceOptions::GetInstance().mWiFi = true;
         if (aValue != nullptr && *aValue != 0)
@@ -574,6 +573,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     case kDeviceOption_WiFiSupports5g:
         LinuxDeviceOptions::GetInstance().wifiSupports5g = true;
         break;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -170,7 +170,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "ble-controller", kArgumentRequired, kDeviceOption_BleDevice },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    { "wifi", kNoArgument, kDeviceOption_WiFi },
+    { "wifi", kArgumentOptional, kDeviceOption_WiFi },
     { "wifi-supports-5g", kNoArgument, kDeviceOption_WiFiSupports5g },
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     { "wifipaf", kArgumentRequired, kDeviceOption_WiFi_PAF },
@@ -277,8 +277,8 @@ const char * sDeviceOptionHelp =
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     "\n"
-    "  --wifi\n"
-    "       Enable Wi-Fi management via wpa_supplicant.\n"
+    "  --wifi[=interface]\n"
+    "       Enable Wi-Fi management via wpa_supplicant, optionally specifying the interface name.\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     "\n"
@@ -565,6 +565,10 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_WiFi:
         LinuxDeviceOptions::GetInstance().mWiFi = true;
+        if (aValue != nullptr && *aValue != 0)
+        {
+            LinuxDeviceOptions::GetInstance().mWiFiInterface.Emplace(aValue);
+        }
         break;
 
     case kDeviceOption_WiFiSupports5g:

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -170,7 +170,12 @@ OptionDef sDeviceOptionDefs[] = {
     { "ble-controller", kArgumentRequired, kDeviceOption_BleDevice },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
+    // On Linux the interface managed by wpa_supplicant can be selected via --wifi=<interface>.
     { "wifi", kArgumentOptional, kDeviceOption_WiFi },
+#else
+    { "wifi", kNoArgument, kDeviceOption_WiFi },
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
     { "wifi-supports-5g", kNoArgument, kDeviceOption_WiFiSupports5g },
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     { "wifipaf", kArgumentRequired, kDeviceOption_WiFi_PAF },
@@ -277,8 +282,13 @@ const char * sDeviceOptionHelp =
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     "\n"
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
     "  --wifi[=interface]\n"
     "       Enable Wi-Fi management via wpa_supplicant, optionally specifying the interface name.\n"
+#else
+    "  --wifi\n"
+    "       Enable Wi-Fi management via wpa_supplicant.\n"
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
     "\n"
     "  --wifi-supports-5g\n"
     "       Indicate that local Wi-Fi hardware should report 5GHz support.\n"
@@ -564,10 +574,12 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     case kDeviceOption_WiFi:
         LinuxDeviceOptions::GetInstance().mWiFi = true;
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
         if (aValue != nullptr && *aValue != 0)
         {
             LinuxDeviceOptions::GetInstance().mWiFiInterface.Emplace(aValue);
         }
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
         break;
 
     case kDeviceOption_WiFiSupports5g:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -58,7 +58,9 @@ struct LinuxDeviceOptions
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     bool wifiSupports5g = false;
     bool mWiFi          = false;
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
     chip::Optional<std::string> mWiFiInterface; // WiFi interface name override (from --wifi=<interface>)
+#endif
 #endif
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -55,9 +55,11 @@ struct LinuxDeviceOptions
     chip::Optional<std::string> dacProviderFile;
     uint32_t spake2pIterations = 0; // When not provided (0), will default elsewhere
     uint32_t mBleDevice        = 0;
-    bool wifiSupports5g        = false;
-    bool mWiFi                 = false;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    bool wifiSupports5g = false;
+    bool mWiFi          = false;
     chip::Optional<std::string> mWiFiInterface; // WiFi interface name override (from --wifi=<interface>)
+#endif
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     uint16_t mThreadNodeId = 0;

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -57,6 +57,7 @@ struct LinuxDeviceOptions
     uint32_t mBleDevice        = 0;
     bool wifiSupports5g        = false;
     bool mWiFi                 = false;
+    chip::Optional<std::string> mWiFiInterface; // WiFi interface name override (from --wifi=<interface>)
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     uint16_t mThreadNodeId = 0;

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -54,9 +54,9 @@ typedef bool (*NonOptionArgHandlerFunct)(const char * progName, int argc, char *
  */
 enum OptionArgumentType
 {
-    kNoArgument       = 0,
-    kArgumentRequired = 1,
-    kArgumentOptional = 2,
+    kNoArgument       = 0, // == getopt.h no_argument
+    kArgumentRequired = 1, // == getopt.h required_argument
+    kArgumentOptional = 2, // == getopt.h optional_argument
 };
 
 /**

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include <lib/core/Optional.h>
+#include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceConfig.h>
@@ -95,6 +96,18 @@ void ConnectivityManagerImpl::UpdateEthernetNetworkingStatus()
     }
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+CHIP_ERROR ConnectivityManagerImpl::SetWiFiIfName(const char * ifName)
+{
+    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    size_t ifNameLen = strlen(ifName);
+    VerifyOrReturnError(1 <= ifNameLen && ifNameLen < sizeof(sWiFiIfName), CHIP_ERROR_INVALID_ARGUMENT);
+    Platform::CopyString(sWiFiIfName, ifName);
+    ChipLogProgress(DeviceLayer, "Using WiFi interface: %s", sWiFiIfName);
+    return CHIP_NO_ERROR;
+}
+#endif
+
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -130,7 +143,14 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (ConnectivityUtils::GetWiFiInterfaceName(sWiFiIfName, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
+    // A WiFi interface name may have been configured explicitly (e.g. via the --wifi=<interface>
+    // command line option), in which case it has already been stored in sWiFiIfName. Only fall
+    // back to auto-detection when no interface has been set.
+    if (sWiFiIfName[0] != '\0')
+    {
+        ChipLogProgress(DeviceLayer, "Using WiFi interface: %s", sWiFiIfName);
+    }
+    else if (ConnectivityUtils::GetWiFiInterfaceName(sWiFiIfName, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
     {
         ChipLogProgress(DeviceLayer, "Got WiFi interface: %s", sWiFiIfName);
     }

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -99,9 +99,8 @@ void ConnectivityManagerImpl::UpdateEthernetNetworkingStatus()
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR ConnectivityManagerImpl::SetWiFiIfName(const char * ifName)
 {
-    VerifyOrReturnError(ifName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    size_t ifNameLen = strlen(ifName);
-    VerifyOrReturnError(1 <= ifNameLen && ifNameLen < sizeof(sWiFiIfName), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(ifName != nullptr && strlen(ifName) < sizeof(sWiFiIfName), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(ConnectivityUtils::IsValidInterface(ifName), CHIP_ERROR_INVALID_ARGUMENT);
     Platform::CopyString(sWiFiIfName, ifName);
     ChipLogProgress(DeviceLayer, "Using WiFi interface: %s", sWiFiIfName);
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -158,6 +158,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
+    CHIP_ERROR SetWiFiIfName(const char * ifName);
 #endif
 
 private:

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -169,6 +169,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
+    CHIP_ERROR SetWiFiIfName(const char * ifName);
 #endif
 
 private:

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -31,6 +31,7 @@
 #include <linux/sockios.h>
 #include <linux/types.h> /* for "caddr_t" et al */
 #include <linux/wireless.h>
+#include <net/if.h>
 #include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -277,6 +278,11 @@ uint8_t MapFrequencyToChannel(const uint16_t frequency)
         return 14;
 
     return frequency / 5 - 1000;
+}
+
+bool IsValidInterface(const char * ifname)
+{
+    return ifname != nullptr && if_nametoindex(ifname) != 0;
 }
 
 InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname)

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -26,12 +26,14 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <ifaddrs.h>
+#include <net/if.h> // must precede <linux/*.h>
+
 #include <linux/ethtool.h>
 #include <linux/if_link.h>
 #include <linux/sockios.h>
 #include <linux/types.h> /* for "caddr_t" et al */
 #include <linux/wireless.h>
-#include <net/if.h>
+
 #include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -37,6 +37,8 @@ namespace ConnectivityUtils {
 
 uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
 uint8_t MapFrequencyToChannel(const uint16_t frequency);
+
+bool IsValidInterface(const char * ifname);
 app::Clusters::GeneralDiagnostics::InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname);
 CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t bufSize);
 CHIP_ERROR GetInterfaceIPv4Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);


### PR DESCRIPTION
### Summary

The Linux example platform previously always auto-selected the Wi-Fi interface used by the CHIP stack. Make it configurable by accepting an optional argument to the existing --wifi option (e.g. --wifi=wlan1).

The interface is applied via the new ConnectivityManagerImpl::SetWiFiIfName() method before InitChipStack(), so that ConnectivityManager._Init() uses the configured name instead of auto-detecting one. When --wifi is given without a value, behavior is unchanged (the interface is auto-detected).

### Testing

Manually tested with lighting-app example on a Linux machine with two WiFi interfaces; interacting with the Network Commissioning cluster of the example app using chip-tool I can see Wi-Fi scans working and using the selected interface via wpa_supplicant / DBus.