### PR TITLE
[Silabs] Removing WPA3 transistion mode option for SiWx devices

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -107,8 +107,6 @@ if [ "$#" == "0" ]; then
             Use to build the example with pigweed RPC
         ota_periodic_query_timeout_sec
             Periodic query timeout variable for OTA in seconds
-        rs91x_wpa3_transition
-            Support for WPA3 transition mode on RS91x
         slc_gen_path
             Allow users to define a path where slc generates board files. (requires --slc_generate or --slc_reuse_files)
             (default: /third_party/silabs/slc_gen/<board>/)

--- a/src/platform/silabs/SiWx/ble/ble_config.h
+++ b/src/platform/silabs/SiWx/ble/ble_config.h
@@ -275,14 +275,9 @@ extern "C" {
 #endif
 
 #ifdef SLI_SI917
-#if WIFI_ENABLE_SECURITY_WPA3_TRANSITION // Adding Support for WPA3 transition
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP                                                                                             \
     (SL_SI91X_EXT_FEAT_LOW_POWER_MODE | SL_SI91X_CLK | SL_SI91X_RAM_LEVEL_NWP_BASIC_MCU_ADV | FRONT_END_SWITCH_CTRL |              \
      SL_SI91X_EXT_FEAT_IEEE_80211W)
-#else
-#define RSI_EXT_CUSTOM_FEATURE_BIT_MAP                                                                                             \
-    (SL_SI91X_EXT_FEAT_LOW_POWER_MODE | SL_SI91X_CLK | SL_SI91X_RAM_LEVEL_NWP_BASIC_MCU_ADV | FRONT_END_SWITCH_CTRL)
-#endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
 #else  // EXP_BOARD
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP (SL_SI91X_EXT_FEAT_LOW_POWER_MODE | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2))
 #endif /* SLI_SI917 */

--- a/src/platform/silabs/SiWx/ble/ble_config.h
+++ b/src/platform/silabs/SiWx/ble/ble_config.h
@@ -278,7 +278,7 @@ extern "C" {
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP                                                                                             \
     (SL_SI91X_EXT_FEAT_LOW_POWER_MODE | SL_SI91X_CLK | SL_SI91X_RAM_LEVEL_NWP_BASIC_MCU_ADV | FRONT_END_SWITCH_CTRL |              \
      SL_SI91X_EXT_FEAT_IEEE_80211W)
-#else  // EXP_BOARD
+#else // EXP_BOARD
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP (SL_SI91X_EXT_FEAT_LOW_POWER_MODE | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2))
 #endif /* SLI_SI917 */
 

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -23,9 +23,6 @@ declare_args() {
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   sl_wfx_config_softap = false
 
-  # Argument to force enable WPA3 security on rs91x
-  rs91x_wpa3_transition = true
-
   #default WiFi SSID
   chip_default_wifi_ssid = ""
 
@@ -75,11 +72,6 @@ config("wifi-platform-config") {
 
   if (chip_enable_wifi_ipv4) {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
-
-  if (rs91x_wpa3_transition) {
-    # TODO: Change this macro once WF200 support is provided
-    defines += [ "WIFI_ENABLE_SECURITY_WPA3_TRANSITION=1" ]
   }
 
   # TODO: This defines needs to be here for the spi_multiplex.h configuration header.

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -386,11 +386,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
         }
         // SET FALLBACK VALUES FOR THE SCAN
         wfx_rsi.ap_chan = SL_WIFI_AUTO_CHANNEL;
-#if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         security = SL_WIFI_WPA3_TRANSITION;
-#else
-        security = SL_WIFI_WPA_WPA2_MIXED;
-#endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
     }
     else
     {

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -386,7 +386,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
         }
         // SET FALLBACK VALUES FOR THE SCAN
         wfx_rsi.ap_chan = SL_WIFI_AUTO_CHANNEL;
-        security = SL_WIFI_WPA3_TRANSITION;
+        security        = SL_WIFI_WPA3_TRANSITION;
     }
     else
     {


### PR DESCRIPTION
### Summary
Remove the `rs91x_wpa3_transition` GN argument. WPA3 transition support isenabled by default on SiWx, and that is the intended baseline. There is no supported use case for building without WPA3, so the toggle is unnecessary.

### Related issues
NA

### Testing
CI and test with 917SoC commissioning 