### PR TITLE
[app][cluster] Extend FindIdentifyClusterOnEndpoint to discover code-driven identify cluster via data-model registry

### DIFF
--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -143,6 +143,18 @@ IdentifyCluster * FindIdentifyClusterOnEndpoint(EndpointId endpointId)
     {
         return &legacyInstance->mCluster.Cluster();
     }
+
+    // Fallback for the recommended bare RegisteredServerCluster<IdentifyCluster>, which registers
+    // only with the data-model provider and is not on the legacy list. Recover it from the cluster
+    // registry so dependent clusters (e.g. codegen Groups for AddGroupIfIdentifying) can find it.
+    ServerClusterInterface * registeredCluster =
+        CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id });
+    if (registeredCluster != nullptr)
+    {
+        VerifyOrDie(registeredCluster->PathsContains({ endpointId, Clusters::Identify::Id }));
+        return static_cast<IdentifyCluster *>(registeredCluster);
+    }
+
     return nullptr;
 }
 

--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -149,9 +149,8 @@ IdentifyCluster * FindIdentifyClusterOnEndpoint(EndpointId endpointId)
     // registry so dependent clusters (e.g. codegen Groups for AddGroupIfIdentifying) can find it.
     ServerClusterInterface * registeredCluster =
         CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id });
-    if (registeredCluster != nullptr)
+    if (registeredCluster != nullptr && registeredCluster->PathsContains({ endpointId, Clusters::Identify::Id }))
     {
-        VerifyOrDie(registeredCluster->PathsContains({ endpointId, Clusters::Identify::Id }));
         return static_cast<IdentifyCluster *>(registeredCluster);
     }
 


### PR DESCRIPTION

### Summary

`FindIdentifyClusterOnEndpoint()` currently only discovers Identify instances registered via the legacy `::Identify` wrapper, a bare `RegisteredServerCluster<IdentifyCluster>` registered via the data-model registry is never discovered, so the lookup returns `nullptr`.

The code-driven Groups cluster captures this pointer once at init as `mIdentifyIntegration`. When it is nullptr, `AddGroupIfIdentifying` silently returns Success without adding the group — causing **TC-G-2.3 Step 11** to fail.

### Root Cause

The bug surfaces specifically when a ZAP-based app registers Identify as a bare code-driven cluster:

- ZAP/codegen path: Groups is auto-created via `MatterGroupsClusterInitCallback` and must discover Identify through `FindIdentifyClusterOnEndpoint()` (gated on `ZCL_USING_IDENTIFY_CLUSTER_SERVER`). It has no opportunity to inject the pointer manually.
- Pure code-driven path: the app wires `.identifyIntegration` directly into `GroupsCluster::Context` - `FindIdentifyClusterOnEndpoint()` is never called, so the bug cannot occur there.

Any app combining ZAP-driven Groups with a bare code-driven Identify - following the "Recommended Usage" from the identify-server README - falls into this gap.

### Fix

During the ongoing migration from legacy `::Identify` wrapper to bare code-driven clusters,
`FindIdentifyClusterOnEndpoint()` has not yet been extended to cover the new registration path.
This adds a fallback to the data-model registry so that both registration styles are discoverable for the duration of the transition — preserving full backwards compatibility while unblocking apps that have already adopted the recommended bare cluster pattern.

#### Impact
- No behaviour change for legacy ::Identify wrapper users or pure code-driven apps.
- Fixes AddGroupIfIdentifying for ZAP-based apps using the recommended bare cluster pattern.
- Allows ZAP-based apps to drop the legacy wrapper without losing Groups interoperability.

### Testing

Tested on Zephyr RW612 Thermostat application by running TC-G-2.3 which passes sucessfully step 11.
Build command to reproduce: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr"
