### PR TITLE
examples/minimal-mdns: force chip_mdns="minimal"

### DIFF
--- a/examples/minimal-mdns/args.gni
+++ b/examples/minimal-mdns/args.gni
@@ -15,3 +15,5 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+chip_mdns = "minimal"


### PR DESCRIPTION
### Summary

The example uses the minimal mDNS library directly (mdns::Minimal::* and GlobalMinimalMdnsServer) and cannot build against the other backends. Pin chip_mdns="minimal" in args.gni so it builds on platforms (e.g. Darwin) where the default is "platform".

### Testing

Now builds on Darwin without link errors.
