### PR TITLE
bound meter identification strings against their own buffers

### DIFF
--- a/src/app/clusters/meter-identification-server/meter-identification-server.cpp
+++ b/src/app/clusters/meter-identification-server/meter-identification-server.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR Instance::SetMeterSerialNumber(const DataModel::Nullable<CharSpan> & 
     }
 
     const size_t len = newValue.IsNull() ? 0 : newValue.Value().size();
-    if (sizeof(mPointOfDeliveryBuf) < len)
+    if (sizeof(mMeterSerialNumberBuf) < len)
     {
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
@@ -155,7 +155,7 @@ CHIP_ERROR Instance::SetProtocolVersion(const DataModel::Nullable<CharSpan> & ne
     }
 
     const size_t len = newValue.IsNull() ? 0 : newValue.Value().size();
-    if (sizeof(mPointOfDeliveryBuf) < len)
+    if (sizeof(mProtocolVersionBuf) < len)
     {
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }


### PR DESCRIPTION
### Summary

`Instance::SetMeterSerialNumber` and `Instance::SetProtocolVersion` validate the incoming attribute-write length against `sizeof(mPointOfDeliveryBuf)`, but they copy the value into `mMeterSerialNumberBuf` and `mProtocolVersionBuf`. The three buffers are each `char[kMaximumStringSize]` today, so the guard currently holds, but the length check should bound against the buffer it actually writes so it stays correct if any of these sizes ever diverges. `SetPointOfDelivery` already checks its own buffer; this brings the other two setters in line.

### Related issues

None.

### Testing

No behavioral change: all three buffers are `kMaximumStringSize`, so the existing guard already accepted exactly the same inputs. Confirmed by inspection that each setter now sizes its bounds check against the buffer it writes to.