### PR TITLE
[Zephyr] OTA Support external SPI and remove deprecated APIs

### DIFF
--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -103,6 +103,7 @@ static_library("Zephyr") {
       "OTAImageProcessorImpl.cpp",
       "OTAImageProcessorImpl.h",
     ]
+    deps += [ "${chip_root}/src/app/clusters/ota-requestor:interface" ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/platform/Zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.cpp
@@ -23,6 +23,7 @@
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/reboot.h>
+#include <zephyr/version.h>
 
 #ifdef CONFIG_CHIP_OTA_REQUEST_UPGRADE_PERMANENT
 #define UPDATE_TYPE BOOT_UPGRADE_PERMANENT
@@ -58,15 +59,26 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
     mHeaderParser.Init();
     mParams = {};
 
+// The FIXED_PARTITION_*() macros were deprecated in Zephyr 4.4. 
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0)
     const struct device * flash_dev = PARTITION_DEVICE(slot1_partition);
+#else
+    const struct device * flash_dev = FIXED_PARTITION_DEVICE(slot1_partition);
+#endif
+
     if (flash_dev == NULL || !device_is_ready(flash_dev))
     {
-        ChipLogError(SoftwareUpdate, "Failed to get flash device or device not ready");
+        ChipLogError(SoftwareUpdate, "Failed to get flash device");
         return System::MapErrorZephyr(-EFAULT);
     }
 
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0)  
     int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), PARTITION_OFFSET(slot1_partition),
-                                PARTITION_SIZE(slot1_partition), NULL);
+    PARTITION_SIZE(slot1_partition), NULL);
+#else
+    int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), FIXED_PARTITION_OFFSET(slot1_partition),
+    FIXED_PARTITION_SIZE(slot1_partition), NULL);
+#endif
 
     if (err)
     {

--- a/src/platform/Zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
     mHeaderParser.Init();
     mParams = {};
 
-// The FIXED_PARTITION_*() macros were deprecated in Zephyr 4.4. 
+// The FIXED_PARTITION_*() macros were deprecated in Zephyr 4.4.
 #if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0)
     const struct device * flash_dev = PARTITION_DEVICE(slot1_partition);
 #else
@@ -72,12 +72,12 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
         return System::MapErrorZephyr(-EFAULT);
     }
 
-#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0)  
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0)
     int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), PARTITION_OFFSET(slot1_partition),
-    PARTITION_SIZE(slot1_partition), NULL);
+                                PARTITION_SIZE(slot1_partition), NULL);
 #else
     int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), FIXED_PARTITION_OFFSET(slot1_partition),
-    FIXED_PARTITION_SIZE(slot1_partition), NULL);
+                                FIXED_PARTITION_SIZE(slot1_partition), NULL);
 #endif
 
     if (err)

--- a/src/platform/Zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
     const struct device * flash_dev = PARTITION_DEVICE(slot1_partition);
 #else
     const struct device * flash_dev = FIXED_PARTITION_DEVICE(slot1_partition);
-#endif
+#endif /* ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0) */
 
     if (flash_dev == NULL || !device_is_ready(flash_dev))
     {
@@ -78,7 +78,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
 #else
     int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), FIXED_PARTITION_OFFSET(slot1_partition),
                                 FIXED_PARTITION_SIZE(slot1_partition), NULL);
-#endif
+#endif /* ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 4, 0) */
 
     if (err)
     {

--- a/src/platform/Zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.cpp
@@ -58,17 +58,15 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
     mHeaderParser.Init();
     mParams = {};
 
-    const struct device * flash_dev;
-
-    flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+    const struct device * flash_dev = PARTITION_DEVICE(slot1_partition);
     if (flash_dev == NULL)
     {
         ChipLogError(SoftwareUpdate, "Failed to get flash device");
         return System::MapErrorZephyr(-EFAULT);
     }
 
-    int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), FIXED_PARTITION_OFFSET(slot1_partition),
-                                FIXED_PARTITION_SIZE(slot1_partition), NULL);
+    int err = stream_flash_init(&mStream, flash_dev, mBuffer, sizeof(mBuffer), PARTITION_OFFSET(slot1_partition),
+                                PARTITION_SIZE(slot1_partition), NULL);
 
     if (err)
     {

--- a/src/platform/Zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.cpp
@@ -59,9 +59,9 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
     mParams = {};
 
     const struct device * flash_dev = PARTITION_DEVICE(slot1_partition);
-    if (flash_dev == NULL)
+    if (flash_dev == NULL || !device_is_ready(flash_dev))
     {
-        ChipLogError(SoftwareUpdate, "Failed to get flash device");
+        ChipLogError(SoftwareUpdate, "Failed to get flash device or device not ready");
         return System::MapErrorZephyr(-EFAULT);
     }
 


### PR DESCRIPTION
### Summary

This PR contains the common code changes required for OTA support on Silabs Zephyr device.
The two changes are changing the way slot1 is selected. 
* The previous implementation selected trough the internal flash. New implementation selects slot1 directly regardless of where it is, allowing for a slot1 on external flash.
* Changed deprecated `FIXED_PARTITION_*` calls to `PARTITION_*` [(was deprecated in Zephyr v4.4.0)](https://github.com/zephyrproject-rtos/zephyr/issues/103355)

### Related issues

Silabs Zephyr OTA PR which depends on this PR https://github.com/project-chip/connectedhomeip/pull/72698

### Testing

Tested with this and changes in #72698 
Able to perform 2 subsequent OTAs on 4187C sucesfully. 
