### PR TITLE
size tariff component work array to validated max

### DIFF
--- a/src/app/clusters/commodity-tariff-server/commodity-tariff-server.cpp
+++ b/src/app/clusters/commodity-tariff-server/commodity-tariff-server.cpp
@@ -523,9 +523,9 @@ CHIP_ERROR UpdateTariffComponentAttrsDayEntryById(Instance * aInstance, CurrentT
     CHIP_ERROR err                                   = CHIP_NO_ERROR;
     const Structs::TariffPeriodStruct::Type * period = FindTariffPeriodByDayEntryId(aCtx, dayEntryID);
 
-    // Use a fixed-size array with maximum expected components
-    constexpr size_t MAX_COMPONENTS = 16; // Adjust this based on your maximum expected components
-    std::array<Structs::TariffComponentStruct::Type, MAX_COMPONENTS> tempArray;
+    // A tariff period references at most kTariffPeriodItemMaxIDs tariff components, enforced when the
+    // TariffPeriods attribute is validated, so size the working array to that same bound.
+    std::array<Structs::TariffComponentStruct::Type, CommodityTariffConsts::kTariffPeriodItemMaxIDs> tempArray;
     size_t componentCount = 0;
 
     if (period == nullptr)


### PR DESCRIPTION
### Summary

`UpdateTariffComponentAttrsDayEntryById` builds the per-period list of tariff components in a stack `std::array` that was hardcoded to 16 entries. The number of `tariffComponentIDs` a `TariffPeriod` may carry is validated against `kTariffPeriodItemMaxIDs`, which is 20 (CommodityTariffAttrsDataMgmt.cpp), so a period holding 17 to 20 component IDs passes validation but writes past the end of that array when its components are resolved during `UpdateCurrentAttrs`. The loop appends one element per resolved ID with no check against the array size, so this is an out-of-bounds stack write of up to four elements. I noticed it because the sibling loop a few lines down that gathers `dayEntryIDs` sizes its array to the matching constant and also guards the index, while this one used a magic `16` with a comment admitting the size was a guess. Sizing the array to `kTariffPeriodItemMaxIDs` ties it to the same bound the validator enforces so the two cannot drift, and there is no behavior change for conforming tariffs.

### Related issues

None.

### Testing

Traced the path by hand: `TariffPeriodsDataClass` validation accepts `tariffComponentIDs.size()` up to `kTariffPeriodItemMaxIDs` (20) at CommodityTariffAttrsDataMgmt.cpp:515, while `UpdateTariffComponentAttrsDayEntryById` wrote into a 16-element `tempArray` at commodity-tariff-server.cpp:564 with no index guard, reached from `Instance::UpdateCurrentAttrs`. A period with 17-20 component IDs that resolve to existing `TariffComponents` drives `componentCount` past 16. After the change the array holds the validated maximum, so every accepted period fits. The function is an internal static helper exercised only through the full attribute-update flow (delegate plus current-day plus tariff data), so the existing unit suite, which targets the data-management class, has no isolated entry point for it.
