### PR TITLE
[pw_fuzzer] Fix OSS-Fuzz coverage: emit absolute source paths for the FuzzTest toolchain

### DIFF
--- a/build/toolchain/pw_fuzzer/BUILD.gn
+++ b/build/toolchain/pw_fuzzer/BUILD.gn
@@ -139,10 +139,16 @@ gcc_toolchain("chip_pw_fuzztest") {
     # to every target via chip's global fuzzing_default -> oss_fuzz config). Drop pigweed's
     # local ASan + -fsanitize=fuzzer-no-link instrumentation here so they don't conflict
     # (pigweed's ASan requires a field-padding-instrumented libc++ that OSS-Fuzz does not use).
+    #
+    # Also drop pigweed's relative_paths config: its -ffile-prefix-map rewrites source paths to
+    # repo-relative (src/..., out/...), but OSS-Fuzz's coverage report resolves only absolute
+    # paths (llvm-cov -path-equivalence=/,$OUT), so the rewritten paths break report generation.
+    # Keep absolute paths here, matching the legacy (non-pigweed) chip fuzz toolchain.
     if (oss_fuzz) {
       remove_default_configs += [
         "$dir_pw_fuzzer:instrumentation",
         "$dir_pw_toolchain/host_clang:sanitize_address",
+        "$dir_pw_build:relative_paths",
       ]
     } else {
       # Local builds keep pigweed's base -fsanitize=address. Optional UBSan on top via the


### PR DESCRIPTION
#### Summary

##### Problem

After the pw_fuzzer / Google FuzzTest OSS-Fuzz integration (#72573) landed, OSS-Fuzz's periodic **coverage** build started failing during report generation (the `address`/`undefined` builds and `check_build` are unaffected):

```
AssertionError: File path "out/usr/include/glib-2.0/glib/glib-autocleanups.h" in coverage summary is outside source checkout.
Code coverage report generation failed.
```

- OSS-Fuzz resolves coverage source files with `llvm-cov -path-equivalence=/,$OUT` — i.e. it expects **absolute** paths (the builder's `$SRC` is copied into `$OUT/$SRC`).
- The `chip_pw_fuzztest` toolchain inherits pigweed's `$dir_pw_build:relative_paths` config, whose `-ffile-prefix-map` transforms rewrite source paths to **repo-relative** (`src/...`, out-dir files to `out/...`). So the FuzzTest binaries record relative paths that don't remap, and the report aborts on an out-of-tree path.
- The legacy chip fuzz targets build in chip's own (non-pigweed) toolchain, which has no `relative_paths`, so they record absolute paths — which is why coverage worked before the integration.

##### Solution

Drop the `relative_paths` config from the `chip_pw_fuzztest` toolchain under `oss_fuzz`, so it records absolute source paths like the legacy chip fuzz targets. Local builds are unchanged (they keep `relative_paths`; local coverage resolves relative paths from the repo root).

#### Related issues

Follow-up to #72573 (the FuzzTest OSS-Fuzz integration that introduced the regression).

#### Testing

Reproduced the OSS-Fuzz coverage build end-to-end against this change:

```
python infra/helper.py build_fuzzers --sanitizer coverage connectedhomeip
python infra/helper.py coverage connectedhomeip
```

- Before: report generation aborts with the `AssertionError` above (non-zero exit).
- After: `Successfully generated clang code coverage report`; the FuzzTest sources now resolve and the previously-fatal `glib` path no longer appears in the summary.
