### PR TITLE
[Camera] Re-order Init of Clusters to avoid seg fault on startup

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -45,14 +45,6 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
     // Instantiate Chime Server
     mChimeServerPtr = std::make_unique<ChimeServer>(mEndpoint, mCameraDevice->GetChimeDelegate());
 
-    Clusters::PushAvStreamTransport::SetDelegate(mEndpoint, &(mCameraDevice->GetPushAVTransportDelegate()));
-
-    Clusters::PushAvStreamTransport::SetTLSClientManagementDelegate(mEndpoint,
-                                                                    &Clusters::TlsClientManagementCommandDelegate::GetInstance());
-
-    Clusters::PushAvStreamTransport::SetTLSCertificateManagementDelegate(
-        mEndpoint, &Clusters::TlsCertificateManagementCommandDelegate::GetInstance());
-
     // Fetch all initialization parameters for CameraAVSettingsUserLevelMgmt Server
     BitFlags<CameraAvSettingsUserLevelManagement::Feature, uint32_t> avsumFeatures(
         CameraAvSettingsUserLevelManagement::Feature::kDigitalPTZ, CameraAvSettingsUserLevelManagement::Feature::kMechanicalPan,
@@ -329,6 +321,15 @@ void CameraApp::InitCameraDeviceClusters()
 
     CreateAndInitializeCameraAVStreamMgmt();
 
+    // Only init PushAV once AVSM is init
+    Clusters::PushAvStreamTransport::SetDelegate(mEndpoint, &(mCameraDevice->GetPushAVTransportDelegate()));
+
+    Clusters::PushAvStreamTransport::SetTLSClientManagementDelegate(mEndpoint,
+                                                                    &Clusters::TlsClientManagementCommandDelegate::GetInstance());
+
+    Clusters::PushAvStreamTransport::SetTLSCertificateManagementDelegate(
+        mEndpoint, &Clusters::TlsCertificateManagementCommandDelegate::GetInstance());
+        
     // Set the WebRTCTransportProvider server in the manager
     mCameraDevice->SetWebRTCTransportProvider(&mWebRTCTransportProviderServer.Cluster());
 

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -329,7 +329,7 @@ void CameraApp::InitCameraDeviceClusters()
 
     Clusters::PushAvStreamTransport::SetTLSCertificateManagementDelegate(
         mEndpoint, &Clusters::TlsCertificateManagementCommandDelegate::GetInstance());
-        
+
     // Set the WebRTCTransportProvider server in the manager
     mCameraDevice->SetWebRTCTransportProvider(&mWebRTCTransportProviderServer.Cluster());
 

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -146,13 +146,29 @@ CHIP_ERROR CameraAVStreamManager::ValidateStreamUsage(StreamUsageEnum streamUsag
 const std::vector<chip::app::Clusters::CameraAvStreamManagement::VideoStreamStruct> &
 CameraAVStreamManager::GetAllocatedVideoStreams() const
 {
-    return GetCameraAVStreamManagementCluster()->GetAllocatedVideoStreams();
+    auto * cluster = GetCameraAVStreamManagementCluster();
+    if (cluster == nullptr)
+    {
+        ChipLogError(Camera, "CameraAVStreamManagementCluster is null in GetAllocatedVideoStreams");
+        static const std::vector<chip::app::Clusters::CameraAvStreamManagement::VideoStreamStruct> kEmptyVideoStreams;
+        return kEmptyVideoStreams;
+    }
+
+    return cluster->GetAllocatedVideoStreams();
 }
 
 const std::vector<chip::app::Clusters::CameraAvStreamManagement::AudioStreamStruct> &
 CameraAVStreamManager::GetAllocatedAudioStreams() const
 {
-    return GetCameraAVStreamManagementCluster()->GetAllocatedAudioStreams();
+    auto * cluster = GetCameraAVStreamManagementCluster();
+    if (cluster == nullptr)
+    {
+        ChipLogError(Camera, "CameraAVStreamManagementCluster is null in GetAllocatedAudioStreams");
+        static const std::vector<chip::app::Clusters::CameraAvStreamManagement::AudioStreamStruct> kEmptyAudioStreams;
+        return kEmptyAudioStreams;
+    }
+
+    return cluster->GetAllocatedAudioStreams();
 }
 
 void CameraAVStreamManager::GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
@@ -161,10 +177,18 @@ void CameraAVStreamManager::GetBandwidthForStreams(const Optional<DataModel::Nul
 {
 
     outBandwidthbps = 0;
+    
+    auto * cluster = GetCameraAVStreamManagementCluster();
+    if (cluster == nullptr)
+    {
+        ChipLogError(Camera, "CameraAVStreamManagementCluster is null in GetBandwidthForStreams");
+        return;
+    }
+
     if (videoStreamId.HasValue() && !videoStreamId.Value().IsNull())
     {
         uint16_t vStreamId           = videoStreamId.Value().Value();
-        auto & allocatedVideoStreams = GetCameraAVStreamManagementCluster()->GetAllocatedVideoStreams();
+        auto & allocatedVideoStreams = cluster->GetAllocatedVideoStreams();
         for (const chip::app::Clusters::CameraAvStreamManagement::Structs::VideoStreamStruct::Type & stream : allocatedVideoStreams)
         {
             if (stream.videoStreamID == vStreamId)
@@ -178,7 +202,7 @@ void CameraAVStreamManager::GetBandwidthForStreams(const Optional<DataModel::Nul
     if (audioStreamId.HasValue() && !audioStreamId.Value().IsNull())
     {
         uint16_t aStreamId           = audioStreamId.Value().Value();
-        auto & allocatedAudioStreams = GetCameraAVStreamManagementCluster()->GetAllocatedAudioStreams();
+        auto & allocatedAudioStreams = cluster->GetAllocatedAudioStreams();
         for (const chip::app::Clusters::CameraAvStreamManagement::Structs::AudioStreamStruct::Type & stream : allocatedAudioStreams)
         {
             if (stream.audioStreamID == aStreamId)

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -177,7 +177,7 @@ void CameraAVStreamManager::GetBandwidthForStreams(const Optional<DataModel::Nul
 {
 
     outBandwidthbps = 0;
-    
+
     auto * cluster = GetCameraAVStreamManagementCluster();
     if (cluster == nullptr)
     {


### PR DESCRIPTION
### Summary

Camera app cluster init order means that an app instance that restarts after a stream has been allocated and associated with a push AV transport will experience a segmentation fault as the PushAV server initializes before the needed AV Stream Management server. 

This PR re-orders the init order in the app, and adds some defensive code. 

### Related issues

Fixes #72546 

### Testing

Created a specialized Python script that established a video stream, associated it with a Push AV transport, then restarted the app. Verified that without this PR there is a memory fault, and with this PR the fault no longer is exhibited.
