### PR TITLE
 Three independent fixes to the core Matter SDK for dual-transport

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -60,6 +60,34 @@ void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     case DeviceLayer::DeviceEventType::kDnssdRestartNeeded:
         app::DnssdServer::Instance().StartServer();
         break;
+    case DeviceLayer::DeviceEventType::kThreadConnectivityChange:
+        // Re-publish operational records on every Thread connectivity transition
+        // (Established and Lost). Attach: register fresh AAAA/SRV with the SRP server
+        // now that Thread is up. Detach: refresh the published record set so any
+        // Thread-only addresses are dropped (mDNS) and a follow-up re-attach can
+        // re-register cleanly. Covers both NetworkCommissioning ConnectNetwork-driven
+        // attaches and warm-boot attaches with credentials already provisioned.
+        // See rdar://179244879.
+        app::DnssdServer::Instance().StartServer();
+        break;
+    case DeviceLayer::DeviceEventType::kWiFiConnectivityChange:
+        // Mirror of the Thread path: re-publish on both Connect and Disconnect so the
+        // mDNS/SRP record set tracks the current WiFi-side AAAA/A addresses (gain on
+        // Established, drop on Lost). The kInterfaceIpAddressChanged case below still
+        // covers IPv6 SLAAC and DHCP IPv4 arriving after association.
+        app::DnssdServer::Instance().StartServer();
+        break;
+    case DeviceLayer::DeviceEventType::kInterfaceIpAddressChanged:
+        // Republish on address *gain* only. Skipping *_Lost avoids advertise thrash when an
+        // address ages out transiently; the next assignment (or a kWiFiConnectivityChange) will
+        // republish. The event payload doesn't carry an interface id, so we cannot scope this
+        // strictly to WiFi — but StartServer is idempotent and cheap enough on ESP32.
+        if (event->InterfaceIpAddressChanged.Type == DeviceLayer::InterfaceIpChangeType::kIpV6_Assigned ||
+            event->InterfaceIpAddressChanged.Type == DeviceLayer::InterfaceIpChangeType::kIpV4_Assigned)
+        {
+            app::DnssdServer::Instance().StartServer();
+        }
+        break;
     default:
         break;
     }

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -308,7 +308,44 @@ bool InterfaceIterator::HasBroadcastAddress()
 
 CHIP_ERROR InterfaceIterator::GetInterfaceType(InterfaceType & type)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
+    return InterfaceId(mCurNetif).GetInterfaceType(type);
+}
+
+CHIP_ERROR InterfaceId::GetInterfaceType(InterfaceType & type) const
+{
+    if (mPlatformInterface == nullptr)
+    {
+        type = InterfaceType::Unknown;
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // LwIP netif names are 2-char prefixes followed by a number (see InterfaceId::GetInterfaceName).
+    // Convention used by ESP-IDF / OpenThread integrations:
+    //   "st" / "ap" / "wl" -> WiFi station / soft-AP / generic wlan
+    //   "et"               -> Ethernet (only first two chars compared, so "et" suffices for "eth")
+    //   "ot"               -> OpenThread netif
+    //   "lo"               -> loopback (treated as Unknown for transport ordering)
+    const char c0 = mPlatformInterface->name[0];
+    const char c1 = mPlatformInterface->name[1];
+
+    if ((c0 == 's' && c1 == 't') || (c0 == 'a' && c1 == 'p') || (c0 == 'w' && c1 == 'l'))
+    {
+        type = InterfaceType::WiFi;
+    }
+    else if (c0 == 'e' && c1 == 't')
+    {
+        type = InterfaceType::Ethernet;
+    }
+    else if (c0 == 'o' && c1 == 't')
+    {
+        type = InterfaceType::Thread;
+    }
+    else
+    {
+        type = InterfaceType::Unknown;
+    }
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR InterfaceIterator::GetHardwareAddress(uint8_t * addressBuffer, uint8_t & addressSize, uint8_t addressBufferSize)

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -192,6 +192,17 @@ public:
      */
     CHIP_ERROR GetLinkLocalAddr(IPAddress * llAddr) const;
 
+    /**
+     * Get the transport type (WiFi/Ethernet/Thread/...) of this interface.
+     *
+     * @param[out]  type  Object to save the interface type.
+     *
+     * @retval CHIP_NO_ERROR                On success.
+     * @retval CHIP_ERROR_NOT_IMPLEMENTED   On platforms where transport-type lookup is not
+     *                                      available; callers should treat this as Unknown.
+     */
+    CHIP_ERROR GetInterfaceType(InterfaceType & type) const;
+
 private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     static constexpr PlatformType kPlatformNull = nullptr;

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -130,6 +130,9 @@ NodeLookupAction NodeLookupHandle::NextAction(System::Clock::Timestamp now)
 bool NodeLookupResults::UpdateResults(const ResolveResult & result, const Dnssd::IPAddressSorter::IpScore newScore)
 {
     Transport::PeerAddress addressWithAdjustedInterface = result.address;
+    // Capture the *original* InterfaceId before we potentially clear it for non-LL addresses,
+    // so the transport-tier-aware re-scoring below sees a meaningful interface for old entries.
+    const Inet::InterfaceId originalInterface = result.address.GetInterface();
     if (!addressWithAdjustedInterface.GetIPAddress().IsIPv6LinkLocal())
     {
         // Only use the DNS-SD resolution's InterfaceID for addresses that are IPv6 LLA.
@@ -157,7 +160,10 @@ bool NodeLookupResults::UpdateResults(const ResolveResult & result, const Dnssd:
             return false;
         }
 
-        auto oldScore = Dnssd::IPAddressSorter::ScoreIpAddress(oldAddress.GetIPAddress(), oldAddress.GetInterface());
+        // Use the cached original InterfaceId (not oldAddress.GetInterface(), which has been
+        // cleared for non-LL entries) so the address-class score is computed against the same
+        // interface the entry was originally observed on.
+        auto oldScore = Dnssd::IPAddressSorter::ScoreIpAddress(oldAddress.GetIPAddress(), originalInterfaces[insertAtIndex]);
         if (newScore > oldScore)
         {
             // This is a score update, it will replace a previous entry.
@@ -174,7 +180,7 @@ bool NodeLookupResults::UpdateResults(const ResolveResult & result, const Dnssd:
     // - insertAtIndex MUST be with some score that is `< newScore`, so all
     //   addresses with a `newScore` were duplicate-checked
 
-    // Move the following valid entries one level down.
+    // Move the following valid entries one level down (results AND the parallel cache).
     for (auto i = count; i > insertAtIndex; i--)
     {
         if (i >= kNodeLookupResultsLen)
@@ -182,7 +188,8 @@ bool NodeLookupResults::UpdateResults(const ResolveResult & result, const Dnssd:
             continue;
         }
 
-        results[i] = results[i - 1];
+        results[i]            = results[i - 1];
+        originalInterfaces[i] = originalInterfaces[i - 1];
     }
 
     // If the number of valid entries is less than the size of the array there is an additional entry.
@@ -191,9 +198,10 @@ bool NodeLookupResults::UpdateResults(const ResolveResult & result, const Dnssd:
         count++;
     }
 
-    auto & updatedResult  = results[insertAtIndex];
-    updatedResult         = result;
-    updatedResult.address = addressWithAdjustedInterface;
+    auto & updatedResult              = results[insertAtIndex];
+    updatedResult                     = result;
+    updatedResult.address             = addressWithAdjustedInterface;
+    originalInterfaces[insertAtIndex] = originalInterface;
 
     return true;
 }

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.h
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.h
@@ -38,8 +38,14 @@ enum class NodeLookupResult
 struct NodeLookupResults
 {
     ResolveResult results[kNodeLookupResultsLen] = {};
-    uint8_t count                                = 0; // number of valid ResolveResult
-    uint8_t consumed                             = 0; // number of already read ResolveResult
+    // Cache of the original (pre-clear) InterfaceId for each entry in `results`. UpdateResults
+    // clears the InterfaceId on non-link-local addresses (so chip's send path uses the routing
+    // table). That clear destroys the information the transport-tier-aware scorer needs to
+    // re-rank old entries against new ones, so we stash the original InterfaceId here before
+    // clearing and use it when calling ScoreIpAddress for already-stored entries.
+    Inet::InterfaceId originalInterfaces[kNodeLookupResultsLen] = {};
+    uint8_t count                                               = 0; // number of valid ResolveResult
+    uint8_t consumed                                            = 0; // number of already read ResolveResult
 
     bool UpdateResults(const ResolveResult & result, Dnssd::IPAddressSorter::IpScore score);
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -820,6 +820,22 @@
 #endif // CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
 
 /**
+ * @def CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD
+ *
+ * @brief Number of consecutive non-MRP send failures on a CASE secure
+ * session that must be observed before the session is marked as defunct.
+ *
+ * Hysteresis avoids tearing down an otherwise-healthy session for a single
+ * transient transport error (e.g. ERR_RTE during a brief route flap on
+ * Thread). The counter is reset on any successful send and on any inbound
+ * RX (via SecureSession::MarkActiveRx).
+ *
+ */
+#ifndef CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD
+#define CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD 3
+#endif // CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD
+
+/**
  *  @def CHIP_CONFIG_MAX_GROUP_DATA_PEERS
  *
  *  @brief

--- a/src/lib/dnssd/IPAddressSorter.cpp
+++ b/src/lib/dnssd/IPAddressSorter.cpp
@@ -25,9 +25,7 @@ namespace IPAddressSorter {
 void Sort(Inet::IPAddress * addresses, size_t count, Inet::InterfaceId interfaceId)
 {
     Sorting::InsertionSort(addresses, count, [interfaceId](const Inet::IPAddress & a, const Inet::IPAddress & b) -> bool {
-        auto scoreA = to_underlying(ScoreIpAddress(a, interfaceId));
-        auto scoreB = to_underlying(ScoreIpAddress(b, interfaceId));
-        return scoreA > scoreB;
+        return ScoreIpAddressWithTransport(a, interfaceId) > ScoreIpAddressWithTransport(b, interfaceId);
     });
 }
 
@@ -35,9 +33,7 @@ void Sort(const Span<Inet::IPAddress> & addresses, Inet::InterfaceId interfaceId
 {
     Sorting::InsertionSort(addresses.data(), addresses.size(),
                            [interfaceId](const Inet::IPAddress & a, const Inet::IPAddress & b) -> bool {
-                               auto scoreA = to_underlying(ScoreIpAddress(a, interfaceId));
-                               auto scoreB = to_underlying(ScoreIpAddress(b, interfaceId));
-                               return scoreA > scoreB;
+                               return ScoreIpAddressWithTransport(a, interfaceId) > ScoreIpAddressWithTransport(b, interfaceId);
                            });
 }
 
@@ -75,6 +71,51 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
     }
 
     return IpScore::kIpv4;
+}
+
+namespace {
+ThreadSubMetricCallback gThreadSubMetricCallback = nullptr;
+
+uint8_t TierForInterface(Inet::InterfaceId interfaceId)
+{
+    if (!interfaceId.IsPresent())
+    {
+        return CompositeScore::kTierUnknown;
+    }
+    Inet::InterfaceType type = Inet::InterfaceType::Unknown;
+    if (interfaceId.GetInterfaceType(type) != CHIP_NO_ERROR)
+    {
+        return CompositeScore::kTierUnknown;
+    }
+    switch (type)
+    {
+    case Inet::InterfaceType::Ethernet:
+        return CompositeScore::kTierEthernet;
+    case Inet::InterfaceType::WiFi:
+        return CompositeScore::kTierWiFi;
+    case Inet::InterfaceType::Thread:
+        return CompositeScore::kTierThread;
+    default:
+        return CompositeScore::kTierUnknown;
+    }
+}
+} // namespace
+
+void SetThreadSubMetricCallback(ThreadSubMetricCallback cb)
+{
+    gThreadSubMetricCallback = cb;
+}
+
+uint32_t ScoreIpAddressWithTransport(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId)
+{
+    const uint16_t classScore = static_cast<uint16_t>(to_underlying(ScoreIpAddress(ip, interfaceId)));
+    const uint8_t tier        = TierForInterface(interfaceId);
+    uint8_t threadSub         = 0;
+    if (tier == CompositeScore::kTierThread && gThreadSubMetricCallback != nullptr)
+    {
+        threadSub = gThreadSubMetricCallback(ip, interfaceId);
+    }
+    return CompositeScore::Encode(tier, threadSub, classScore);
 }
 
 } // namespace IPAddressSorter

--- a/src/lib/dnssd/IPAddressSorter.h
+++ b/src/lib/dnssd/IPAddressSorter.h
@@ -67,18 +67,17 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 // report a transport type degrade to tier=Unknown (=0) for all entries, which collapses
 // the composite score back to the legacy IpScore ordering.
 namespace CompositeScore {
-constexpr uint32_t kTierShift          = 24;
-constexpr uint32_t kThreadSubShift     = 16;
-constexpr uint8_t  kTierEthernet       = 3;
-constexpr uint8_t  kTierWiFi           = 2;
-constexpr uint8_t  kTierThread         = 1;
-constexpr uint8_t  kTierUnknown        = 0;
+constexpr uint32_t kTierShift      = 24;
+constexpr uint32_t kThreadSubShift = 16;
+constexpr uint8_t kTierEthernet    = 3;
+constexpr uint8_t kTierWiFi        = 2;
+constexpr uint8_t kTierThread      = 1;
+constexpr uint8_t kTierUnknown     = 0;
 
 inline uint32_t Encode(uint8_t tier, uint8_t threadSub, uint16_t classScore)
 {
-    return (static_cast<uint32_t>(tier) << kTierShift) |
-           (static_cast<uint32_t>(threadSub) << kThreadSubShift) |
-           static_cast<uint32_t>(classScore);
+    return (static_cast<uint32_t>(tier) << kTierShift) | (static_cast<uint32_t>(threadSub) << kThreadSubShift) |
+        static_cast<uint32_t>(classScore);
 }
 } // namespace CompositeScore
 

--- a/src/lib/dnssd/IPAddressSorter.h
+++ b/src/lib/dnssd/IPAddressSorter.h
@@ -53,6 +53,45 @@ void Sort(const Span<Inet::IPAddress> & addresses, Inet::InterfaceId interfaceId
  */
 IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId);
 
+// ---- Transport-tier-aware composite scoring -------------------------------
+//
+// ScoreIpAddressWithTransport() returns a uint32_t with this layout:
+//
+//   bits [31:24]  transport tier   (Ethernet > WiFi > Thread > Unknown)
+//   bits [23:16]  Thread sub-metric (0 unless callback set; only nonzero on Thread)
+//   bits [15:0]   address-class score (IpScore promoted, preserves today's ordering)
+//
+// Because the tier dominates the upper byte, addresses on a higher-tier interface always
+// outrank addresses on a lower-tier one regardless of address class. Within a single tier
+// the existing IpScore ordering is preserved exactly. Platforms whose InterfaceId cannot
+// report a transport type degrade to tier=Unknown (=0) for all entries, which collapses
+// the composite score back to the legacy IpScore ordering.
+namespace CompositeScore {
+constexpr uint32_t kTierShift          = 24;
+constexpr uint32_t kThreadSubShift     = 16;
+constexpr uint8_t  kTierEthernet       = 3;
+constexpr uint8_t  kTierWiFi           = 2;
+constexpr uint8_t  kTierThread         = 1;
+constexpr uint8_t  kTierUnknown        = 0;
+
+inline uint32_t Encode(uint8_t tier, uint8_t threadSub, uint16_t classScore)
+{
+    return (static_cast<uint32_t>(tier) << kTierShift) |
+           (static_cast<uint32_t>(threadSub) << kThreadSubShift) |
+           static_cast<uint32_t>(classScore);
+}
+} // namespace CompositeScore
+
+uint32_t ScoreIpAddressWithTransport(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId);
+
+// Optional Thread sub-metric callback. The callback is invoked only when the address being
+// scored sits on a Thread interface, and its 8-bit return value is packed into bits [23:16]
+// of the composite score. Higher values sort earlier within the Thread tier. Apps that don't
+// register a callback get a default Thread sub-metric of 0 (i.e. address class alone decides
+// intra-Thread ordering). Setting cb=nullptr clears any prior registration.
+using ThreadSubMetricCallback = uint8_t (*)(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId);
+void SetThreadSubMetricCallback(ThreadSubMetricCallback cb);
+
 } // namespace IPAddressSorter
 } // namespace Dnssd
 } // namespace chip

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -202,8 +202,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
                 uint8_t failures     = secureSession->IncrementConsecutiveSendFailures();
                 if (failures >= CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD)
                 {
-                    ChipLogError(ExchangeManager,
-                                 "MarkAsDefunct after %u consecutive send failures, last err=%" CHIP_ERROR_FORMAT,
+                    ChipLogError(ExchangeManager, "MarkAsDefunct after %u consecutive send failures, last err=%" CHIP_ERROR_FORMAT,
                                  static_cast<unsigned>(failures), err.Format());
                     secureSession->MarkAsDefunct();
                 }

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -190,9 +190,30 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
             // If we can't even send a message (send failed with a non-transient
             // error), mark the session as defunct, just like we would if we
             // thought we sent the message and never got a response.
+            //
+            // Apply N-consecutive-failure hysteresis so a single transient
+            // transport error (e.g. ERR_RTE during a brief Thread route flap)
+            // does not flip the session into kDefunct and trigger session-state
+            // churn against MarkActiveRx. The counter lives on the SecureSession
+            // because multiple exchanges share the same failure budget.
             if (session->IsSecureSession() && session->AsSecureSession()->IsCASESession())
             {
-                session->AsSecureSession()->MarkAsDefunct();
+                auto * secureSession = session->AsSecureSession();
+                uint8_t failures     = secureSession->IncrementConsecutiveSendFailures();
+                if (failures >= CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD)
+                {
+                    ChipLogError(ExchangeManager,
+                                 "MarkAsDefunct after %u consecutive send failures, last err=%" CHIP_ERROR_FORMAT,
+                                 static_cast<unsigned>(failures), err.Format());
+                    secureSession->MarkAsDefunct();
+                }
+                else
+                {
+                    ChipLogProgress(ExchangeManager,
+                                    "Send failure %u/%u on CASE session, deferring MarkAsDefunct (err=%" CHIP_ERROR_FORMAT ")",
+                                    static_cast<unsigned>(failures),
+                                    static_cast<unsigned>(CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD), err.Format());
+                }
             }
         }
         else
@@ -200,6 +221,13 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
             app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+            // A successful send proves the path is currently usable; clear any
+            // accumulated failure count so a future flap starts from zero.
+            if (session->IsSecureSession())
+            {
+                session->AsSecureSession()->ResetConsecutiveSendFailures();
+            }
 
             // Standalone acks are not application-level message sends.
             if (!isStandaloneAck)

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -227,7 +227,21 @@ private:
         };
 
         char mHostName[Dnssd::kHostNameMaxLength + 1];
-        otIp6Address mHostAddress;
+        // OT's otSrpClientSetHostAddresses does NOT copy the address array — it stores a
+        // pointer and requires the caller to keep the memory alive and unchanged for the
+        // lifetime of the registration. We therefore park the addresses in this struct
+        // (which lives as long as the impl instance) and pass &mHostAddresses[0] to OT.
+        // Stack-local arrays would get clobbered by subsequent stack frames, producing the
+        // pointer-fragment-looking garbage we observed via `srp client host`.
+        //
+        // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES lives in OT's internal
+        // core config header, not always on chip's include path; provide the same fallback
+        // we use in the .hpp.
+#ifndef OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES 2
+#endif
+        otIp6Address mHostAddresses[OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES];
+        uint8_t mHostAddressCount;
         Service mServices[kMaxServicesNumber];
         bool mIsInitialized;
         DnsAsyncReturnCallback mInitializedCallback;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -50,7 +50,23 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 #include <openthread/srp_client.h>
+// OT defines OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES in its internal core
+// config header (third_party/openthread/repo/src/core/config/srp_client.h), which is not on
+// chip's include path. Provide a fallback matching OT's non-reference-device default so the
+// host-address array sizes correctly even when the macro isn't propagated. If the platform's
+// build system overrides via -D, that override wins.
+#ifndef OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES 2
 #endif
+#endif
+
+#if CHIP_DEVICE_LAYER_TARGET_ESP32
+#include <platform/ESP32/ESP32Utils.h>
+#include <esp_netif.h>
+#include <esp_netif_net_stack.h>
+#include <lwip/netif.h>
+#include <lwip/ip6_addr.h>
+#endif // CHIP_DEVICE_LAYER_TARGET_ESP32
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CHIPMemString.h>
@@ -212,6 +228,15 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
             if (status == CHIP_NO_ERROR)
             {
                 mIsAttached = isThreadAttached;
+                // Fire the in-flight ConnectNetwork completion now that Thread is attached.
+                // Without this, NetworkCommissioningCluster::OnResult never runs, so
+                // kOperationalNetworkEnabled is never posted and DnssdServer never
+                // re-publishes the operational SRP record (rdar://179244879).
+                // Gated on mpConnectCallback so routine role flaps don't spuriously fire.
+                if (isThreadAttached && mpConnectCallback != nullptr)
+                {
+                    _OnThreadAttachFinished();
+                }
             }
             else
             {
@@ -1473,14 +1498,142 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
     VerifyOrExit(aHostName, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(strlen(aHostName) <= Dnssd::kHostNameMaxLength, error = CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    // Avoid adding the same host name multiple times
+    // Set or refresh the host name. Only call otSrpClientSetHostName when it actually
+    // changes (the OT client requires it to be unset before changing).
     if (strcmp(mSrpClient.mHostName, aHostName) != 0)
     {
         strcpy(mSrpClient.mHostName, aHostName);
         error = MapOpenThreadError(otSrpClientSetHostName(mOTInst, mSrpClient.mHostName));
         SuccessOrExit(error);
+    }
 
-        error = MapOpenThreadError(otSrpClientEnableAutoHostAddress(mOTInst));
+    // Re-publish the AAAA address set on every call (not just hostname-change calls)
+    // so that re-advertise triggers (WiFi connect, kInterfaceIpAddressChanged, Thread
+    // attach) actually refresh the SRP host record. Explicitly publish every reachable
+    // IPv6 address rather than calling otSrpClientEnableAutoHostAddress, so the SDK
+    // fully controls the AAAA set and every routable scope (Thread + WiFi + Ethernet)
+    // is advertised.
+    {
+        // Cap mirrors the OT SRP client's actual buffer size (declared in the SrpClient
+        // struct in the header). The address array itself lives in mSrpClient.mHostAddresses
+        // and persists for the lifetime of this impl instance — required because
+        // otSrpClientSetHostAddresses stores a POINTER to the array, not a copy.
+        constexpr uint8_t kMaxSrpHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES;
+        mSrpClient.mHostAddressCount           = 0;
+
+        auto alreadyPresent = [&](const otIp6Address & candidate) -> bool {
+            for (uint8_t i = 0; i < mSrpClient.mHostAddressCount; i++)
+            {
+                if (memcmp(mSrpClient.mHostAddresses[i].mFields.m8, candidate.mFields.m8,
+                           sizeof(candidate.mFields.m8)) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        // Order per Matter spec recommendation: GUA (most routable) → Mesh-Local EID
+        // (canonical in-mesh) → Link-Local (per-link only). Controllers on external
+        // network segments will preferentially try the GUA first.
+
+        // 1a) Global Unicast / Off-Mesh-Routable addresses — every valid non-RLOC unicast
+        //     that is NEITHER link-local (fe80::/10) NOR within the Thread mesh-local
+        //     prefix. This catches OMR addresses advertised by the Border Router as well
+        //     as any true global IPv6.
+        {
+            const otMeshLocalPrefix * mlPrefix = otThreadGetMeshLocalPrefix(mOTInst);
+            for (const otNetifAddress * a = otIp6GetUnicastAddresses(mOTInst);
+                 a != nullptr && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses;
+                 a = a->mNext)
+            {
+                if (!a->mValid) continue;
+                if (a->mRloc)   continue;
+                // Skip link-local fe80::/10 — added separately in step 1c.
+                if (a->mAddress.mFields.m8[0] == 0xfe && (a->mAddress.mFields.m8[1] & 0xc0) == 0x80)
+                {
+                    continue;
+                }
+                // Skip mesh-local (matches mesh-local /64 prefix) — added in step 1b.
+                if (mlPrefix != nullptr &&
+                    memcmp(a->mAddress.mFields.m8, mlPrefix->m8, sizeof(mlPrefix->m8)) == 0)
+                {
+                    continue;
+                }
+                if (alreadyPresent(a->mAddress)) continue;
+                mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = a->mAddress;
+            }
+        }
+
+        // 1b) Mesh-Local EID — the canonical in-mesh address.
+        {
+            const otIp6Address * meshLocalEid = otThreadGetMeshLocalEid(mOTInst);
+            if (meshLocalEid != nullptr && !alreadyPresent(*meshLocalEid) &&
+                mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
+            {
+                mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = *meshLocalEid;
+            }
+        }
+
+        // 1c) Thread link-local — per-link reachability fallback.
+        {
+            const otIp6Address * linkLocal = otThreadGetLinkLocalIp6Address(mOTInst);
+            if (linkLocal != nullptr && !alreadyPresent(*linkLocal) &&
+                mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
+            {
+                mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = *linkLocal;
+            }
+        }
+
+#if CHIP_DEVICE_LAYER_TARGET_ESP32
+        // 2) ESP32 WiFi station (and optionally Ethernet) netifs: every valid IPv6
+        //    address (link-local + global / ULA), so a controller resolving via SRP
+        //    sees every reachable path even when the device is dual-homed (WiFi+Thread).
+        //    Re-enabled now that the persistent-buffer fix above prevents stack residue
+        //    from corrupting the cached pointer that OT keeps internally.
+        auto collectFromEspNetif = [&](const char * ifKey) {
+            esp_netif_t * espNetif = esp_netif_get_handle_from_ifkey(ifKey);
+            if (espNetif == nullptr) return;
+            struct netif * lwipNetif = static_cast<struct netif *>(esp_netif_get_netif_impl(espNetif));
+            if (lwipNetif == nullptr) return;
+            for (uint8_t i = 0;
+                 i < LWIP_IPV6_NUM_ADDRESSES && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses; i++)
+            {
+                if (!ip6_addr_isvalid(netif_ip6_addr_state(lwipNetif, i))) continue;
+                const ip6_addr_t * lwipAddr = netif_ip6_addr(lwipNetif, i);
+                otIp6Address otAddr;
+                static_assert(sizeof(otAddr.mFields.m8) == 16, "otIp6Address must be 16 bytes");
+                // LwIP stores IPv6 in network byte order in the addr[] u32 array, so a raw
+                // 16-byte memcpy preserves the wire-format bytes.
+                memcpy(otAddr.mFields.m8, lwipAddr->addr, sizeof(otAddr.mFields.m8));
+                if (alreadyPresent(otAddr)) continue;
+                mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = otAddr;
+            }
+        };
+
+        collectFromEspNetif(Internal::ESP32Utils::kDefaultWiFiStationNetifKey);
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+        collectFromEspNetif(Internal::ESP32Utils::kDefaultEthernetNetifKey);
+#endif
+#endif // CHIP_DEVICE_LAYER_TARGET_ESP32
+
+        // Debug dump: print every address we are about to register so we can verify
+        // what hits the SRP server.
+        ChipLogProgress(DeviceLayer, "SRP host '%s': registering %u address(es)",
+                        aHostName, static_cast<unsigned>(mSrpClient.mHostAddressCount));
+        for (uint8_t i = 0; i < mSrpClient.mHostAddressCount; i++)
+        {
+            char addrStr[OT_IP6_ADDRESS_STRING_SIZE];
+            otIp6AddressToString(&mSrpClient.mHostAddresses[i], addrStr, sizeof(addrStr));
+            ChipLogProgress(DeviceLayer, "SRP host addr[%u] = %s", static_cast<unsigned>(i), addrStr);
+        }
+
+        // Pass the persistent member buffer to OT — the array memory must remain valid and
+        // unchanged for the lifetime of the registration (otSrpClientSetHostAddresses does
+        // not copy).
+        error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, mSrpClient.mHostAddresses,
+                                                               mSrpClient.mHostAddressCount));
+        SuccessOrExit(error);
     }
 
 exit:

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -61,11 +61,11 @@
 #endif
 
 #if CHIP_DEVICE_LAYER_TARGET_ESP32
-#include <platform/ESP32/ESP32Utils.h>
 #include <esp_netif.h>
 #include <esp_netif_net_stack.h>
-#include <lwip/netif.h>
 #include <lwip/ip6_addr.h>
+#include <lwip/netif.h>
+#include <platform/ESP32/ESP32Utils.h>
 #endif // CHIP_DEVICE_LAYER_TARGET_ESP32
 
 #include <lib/core/CHIPEncoding.h>
@@ -1524,8 +1524,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         auto alreadyPresent = [&](const otIp6Address & candidate) -> bool {
             for (uint8_t i = 0; i < mSrpClient.mHostAddressCount; i++)
             {
-                if (memcmp(mSrpClient.mHostAddresses[i].mFields.m8, candidate.mFields.m8,
-                           sizeof(candidate.mFields.m8)) == 0)
+                if (memcmp(mSrpClient.mHostAddresses[i].mFields.m8, candidate.mFields.m8, sizeof(candidate.mFields.m8)) == 0)
                 {
                     return true;
                 }
@@ -1543,24 +1542,25 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         //     as any true global IPv6.
         {
             const otMeshLocalPrefix * mlPrefix = otThreadGetMeshLocalPrefix(mOTInst);
-            for (const otNetifAddress * a = otIp6GetUnicastAddresses(mOTInst);
-                 a != nullptr && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses;
-                 a = a->mNext)
+            for (const otNetifAddress * a                                               = otIp6GetUnicastAddresses(mOTInst);
+                 a != nullptr && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses; a = a->mNext)
             {
-                if (!a->mValid) continue;
-                if (a->mRloc)   continue;
+                if (!a->mValid)
+                    continue;
+                if (a->mRloc)
+                    continue;
                 // Skip link-local fe80::/10 — added separately in step 1c.
                 if (a->mAddress.mFields.m8[0] == 0xfe && (a->mAddress.mFields.m8[1] & 0xc0) == 0x80)
                 {
                     continue;
                 }
                 // Skip mesh-local (matches mesh-local /64 prefix) — added in step 1b.
-                if (mlPrefix != nullptr &&
-                    memcmp(a->mAddress.mFields.m8, mlPrefix->m8, sizeof(mlPrefix->m8)) == 0)
+                if (mlPrefix != nullptr && memcmp(a->mAddress.mFields.m8, mlPrefix->m8, sizeof(mlPrefix->m8)) == 0)
                 {
                     continue;
                 }
-                if (alreadyPresent(a->mAddress)) continue;
+                if (alreadyPresent(a->mAddress))
+                    continue;
                 mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = a->mAddress;
             }
         }
@@ -1568,8 +1568,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         // 1b) Mesh-Local EID — the canonical in-mesh address.
         {
             const otIp6Address * meshLocalEid = otThreadGetMeshLocalEid(mOTInst);
-            if (meshLocalEid != nullptr && !alreadyPresent(*meshLocalEid) &&
-                mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
+            if (meshLocalEid != nullptr && !alreadyPresent(*meshLocalEid) && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
             {
                 mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = *meshLocalEid;
             }
@@ -1578,8 +1577,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         // 1c) Thread link-local — per-link reachability fallback.
         {
             const otIp6Address * linkLocal = otThreadGetLinkLocalIp6Address(mOTInst);
-            if (linkLocal != nullptr && !alreadyPresent(*linkLocal) &&
-                mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
+            if (linkLocal != nullptr && !alreadyPresent(*linkLocal) && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses)
             {
                 mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = *linkLocal;
             }
@@ -1593,20 +1591,23 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         //    from corrupting the cached pointer that OT keeps internally.
         auto collectFromEspNetif = [&](const char * ifKey) {
             esp_netif_t * espNetif = esp_netif_get_handle_from_ifkey(ifKey);
-            if (espNetif == nullptr) return;
+            if (espNetif == nullptr)
+                return;
             struct netif * lwipNetif = static_cast<struct netif *>(esp_netif_get_netif_impl(espNetif));
-            if (lwipNetif == nullptr) return;
-            for (uint8_t i = 0;
-                 i < LWIP_IPV6_NUM_ADDRESSES && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses; i++)
+            if (lwipNetif == nullptr)
+                return;
+            for (uint8_t i = 0; i < LWIP_IPV6_NUM_ADDRESSES && mSrpClient.mHostAddressCount < kMaxSrpHostAddresses; i++)
             {
-                if (!ip6_addr_isvalid(netif_ip6_addr_state(lwipNetif, i))) continue;
+                if (!ip6_addr_isvalid(netif_ip6_addr_state(lwipNetif, i)))
+                    continue;
                 const ip6_addr_t * lwipAddr = netif_ip6_addr(lwipNetif, i);
                 otIp6Address otAddr;
                 static_assert(sizeof(otAddr.mFields.m8) == 16, "otIp6Address must be 16 bytes");
                 // LwIP stores IPv6 in network byte order in the addr[] u32 array, so a raw
                 // 16-byte memcpy preserves the wire-format bytes.
                 memcpy(otAddr.mFields.m8, lwipAddr->addr, sizeof(otAddr.mFields.m8));
-                if (alreadyPresent(otAddr)) continue;
+                if (alreadyPresent(otAddr))
+                    continue;
                 mSrpClient.mHostAddresses[mSrpClient.mHostAddressCount++] = otAddr;
             }
         };
@@ -1619,8 +1620,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
 
         // Debug dump: print every address we are about to register so we can verify
         // what hits the SRP server.
-        ChipLogProgress(DeviceLayer, "SRP host '%s': registering %u address(es)",
-                        aHostName, static_cast<unsigned>(mSrpClient.mHostAddressCount));
+        ChipLogProgress(DeviceLayer, "SRP host '%s': registering %u address(es)", aHostName,
+                        static_cast<unsigned>(mSrpClient.mHostAddressCount));
         for (uint8_t i = 0; i < mSrpClient.mHostAddressCount; i++)
         {
             char addrStr[OT_IP6_ADDRESS_STRING_SIZE];
@@ -1631,8 +1632,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         // Pass the persistent member buffer to OT — the array memory must remain valid and
         // unchanged for the lifetime of the registration (otSrpClientSetHostAddresses does
         // not copy).
-        error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, mSrpClient.mHostAddresses,
-                                                               mSrpClient.mHostAddressCount));
+        error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, mSrpClient.mHostAddresses, mSrpClient.mHostAddressCount));
         SuccessOrExit(error);
     }
 

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -173,7 +173,7 @@ void SecureSession::CapturePeerAddressAnchor()
     const Inet::IPAddress & ip = mPeerAddress.GetIPAddress();
     if (mPeerAddress.GetTransportType() != Transport::Type::kUdp || !ip.IsIPv6() || ip.IsIPv6Multicast())
     {
-        mPeerAddressAnchorValid = false;
+        mPeerAddressAnchorValid        = false;
         mPeerAddressRestampRejectCount = 0;
         return;
     }
@@ -207,7 +207,7 @@ void SecureSession::RestampPeerAddressIfRoutable(const PeerAddress & candidate)
     // don't accidentally trap kBle/kTcp/IPv4 transitions.
     if (candidate.GetTransportType() != Transport::Type::kUdp || !candidateIp.IsIPv6())
     {
-        mPeerAddress = candidate;
+        mPeerAddress                   = candidate;
         mPeerAddressRestampRejectCount = 0;
         return;
     }
@@ -245,9 +245,8 @@ void SecureSession::RestampPeerAddressIfRoutable(const PeerAddress & candidate)
 
     if (mPeerAddressRestampRejectCount >= kPeerAddressRestampOverrideThreshold)
     {
-        ChipLogProgress(Inet,
-                        "SecureSession[%p, LSID:%d]: peer /64 anchor override after %u rejects, accepting %s",
-                        this, mLocalSessionId, static_cast<unsigned>(mPeerAddressRestampRejectCount), candidateStr);
+        ChipLogProgress(Inet, "SecureSession[%p, LSID:%d]: peer /64 anchor override after %u rejects, accepting %s", this,
+                        mLocalSessionId, static_cast<unsigned>(mPeerAddressRestampRejectCount), candidateStr);
         mPeerAddress = candidate;
         // Adopt the new prefix as the anchor going forward.
         memcpy(mPeerAddressAnchorPrefix, candidatePrefix, sizeof(mPeerAddressAnchorPrefix));
@@ -256,10 +255,8 @@ void SecureSession::RestampPeerAddressIfRoutable(const PeerAddress & candidate)
         return;
     }
 
-    ChipLogProgress(Inet,
-                    "SecureSession[%p, LSID:%d]: ignoring restamp to non-routable peer %s (reject %u/%u)",
-                    this, mLocalSessionId, candidateStr,
-                    static_cast<unsigned>(mPeerAddressRestampRejectCount),
+    ChipLogProgress(Inet, "SecureSession[%p, LSID:%d]: ignoring restamp to non-routable peer %s (reject %u/%u)", this,
+                    mLocalSessionId, candidateStr, static_cast<unsigned>(mPeerAddressRestampRejectCount),
                     static_cast<unsigned>(kPeerAddressRestampOverrideThreshold));
 }
 

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -18,6 +18,8 @@
 #include <transport/SecureSession.h>
 #include <transport/SecureSessionTable.h>
 
+#include <cstring>
+
 namespace chip {
 namespace Transport {
 
@@ -153,6 +155,112 @@ void SecureSession::MarkForEviction()
         // Do nothing
         return;
     }
+}
+
+void SecureSession::SetPeerAddress(const PeerAddress & address)
+{
+    mPeerAddress = address;
+    // An explicit SetPeerAddress (CASE/PASE establishment or SessionManager-initiated peer
+    // relocation) is treated as ground truth — re-anchor the routable prefix to this address.
+    CapturePeerAddressAnchor();
+}
+
+void SecureSession::CapturePeerAddressAnchor()
+{
+    // Only IPv6 unicast peers participate in /64-prefix gating; for everything else (BLE, TCP,
+    // IPv4-mapped, multicast, unspecified) leave the anchor cleared so the dispatch site falls
+    // back to the original unconditional restamp.
+    const Inet::IPAddress & ip = mPeerAddress.GetIPAddress();
+    if (mPeerAddress.GetTransportType() != Transport::Type::kUdp || !ip.IsIPv6() || ip.IsIPv6Multicast())
+    {
+        mPeerAddressAnchorValid = false;
+        mPeerAddressRestampRejectCount = 0;
+        return;
+    }
+
+    // IPAddress::Addr is four uint32_t in network byte order; the first two words form the /64.
+    const uint32_t prefixWord0 = ip.Addr[0];
+    const uint32_t prefixWord1 = ip.Addr[1];
+    memcpy(&mPeerAddressAnchorPrefix[0], &prefixWord0, sizeof(prefixWord0));
+    memcpy(&mPeerAddressAnchorPrefix[4], &prefixWord1, sizeof(prefixWord1));
+    mPeerAddressAnchorValid        = true;
+    mPeerAddressRestampRejectCount = 0;
+    memset(mPeerAddressLastRejectedPrefix, 0, sizeof(mPeerAddressLastRejectedPrefix));
+}
+
+void SecureSession::RestampPeerAddressIfRoutable(const PeerAddress & candidate)
+{
+    if (mPeerAddress == candidate)
+    {
+        return;
+    }
+
+    // No anchor (non-IPv6 peer, or never established) — preserve legacy unconditional restamp.
+    if (!mPeerAddressAnchorValid)
+    {
+        mPeerAddress = candidate;
+        return;
+    }
+
+    const Inet::IPAddress & candidateIp = candidate.GetIPAddress();
+    // Candidate isn't an IPv6 UDP peer we can prefix-compare; fall back to legacy behavior so we
+    // don't accidentally trap kBle/kTcp/IPv4 transitions.
+    if (candidate.GetTransportType() != Transport::Type::kUdp || !candidateIp.IsIPv6())
+    {
+        mPeerAddress = candidate;
+        mPeerAddressRestampRejectCount = 0;
+        return;
+    }
+
+    uint8_t candidatePrefix[8];
+    const uint32_t candidateWord0 = candidateIp.Addr[0];
+    const uint32_t candidateWord1 = candidateIp.Addr[1];
+    memcpy(&candidatePrefix[0], &candidateWord0, sizeof(candidateWord0));
+    memcpy(&candidatePrefix[4], &candidateWord1, sizeof(candidateWord1));
+
+    if (memcmp(candidatePrefix, mPeerAddressAnchorPrefix, sizeof(candidatePrefix)) == 0)
+    {
+        // Same /64 as anchor — still considered routable; accept the host-bits change.
+        mPeerAddress                   = candidate;
+        mPeerAddressRestampRejectCount = 0;
+        return;
+    }
+
+    // Candidate's /64 differs from the routable anchor. Suspect a relay-mangled source or a peer
+    // genuinely moving networks. Discard the restamp until the same new prefix repeats enough
+    // times to convince us the move is real.
+    char candidateStr[Transport::PeerAddress::kMaxToStringSize];
+    candidate.ToString(candidateStr);
+
+    if (memcmp(candidatePrefix, mPeerAddressLastRejectedPrefix, sizeof(candidatePrefix)) != 0)
+    {
+        // New rejected prefix — restart the override counter so unrelated bursts don't accumulate.
+        memcpy(mPeerAddressLastRejectedPrefix, candidatePrefix, sizeof(candidatePrefix));
+        mPeerAddressRestampRejectCount = 1;
+    }
+    else if (mPeerAddressRestampRejectCount < UINT8_MAX)
+    {
+        mPeerAddressRestampRejectCount++;
+    }
+
+    if (mPeerAddressRestampRejectCount >= kPeerAddressRestampOverrideThreshold)
+    {
+        ChipLogProgress(Inet,
+                        "SecureSession[%p, LSID:%d]: peer /64 anchor override after %u rejects, accepting %s",
+                        this, mLocalSessionId, static_cast<unsigned>(mPeerAddressRestampRejectCount), candidateStr);
+        mPeerAddress = candidate;
+        // Adopt the new prefix as the anchor going forward.
+        memcpy(mPeerAddressAnchorPrefix, candidatePrefix, sizeof(mPeerAddressAnchorPrefix));
+        mPeerAddressRestampRejectCount = 0;
+        memset(mPeerAddressLastRejectedPrefix, 0, sizeof(mPeerAddressLastRejectedPrefix));
+        return;
+    }
+
+    ChipLogProgress(Inet,
+                    "SecureSession[%p, LSID:%d]: ignoring restamp to non-routable peer %s (reject %u/%u)",
+                    this, mLocalSessionId, candidateStr,
+                    static_cast<unsigned>(mPeerAddressRestampRejectCount),
+                    static_cast<unsigned>(kPeerAddressRestampOverrideThreshold));
 }
 
 Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -205,7 +205,18 @@ public:
     }
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
-    void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
+    void SetPeerAddress(const PeerAddress & address);
+
+    /**
+     * @brief
+     *   Conditionally restamp the SecureSession's PeerAddress to the source address of an inbound
+     *   packet. Rejects candidates whose IPv6 /64 prefix does not match the anchor captured at
+     *   session establishment, since those addresses are likely non-routable from this device
+     *   (e.g. a relay-mangled OMR source on Thread). After kPeerAddressRestampOverrideThreshold
+     *   consecutive rejects from candidates sharing a single new prefix, the anchor is overridden
+     *   so a legitimately relocated peer can still recover.
+     */
+    void RestampPeerAddressIfRoutable(const PeerAddress & candidate);
 
     Type GetSecureSessionType() const { return mSecureSessionType; }
     bool IsCASESession() const { return GetSecureSessionType() == Type::kCASE; }
@@ -243,11 +254,29 @@ public:
         mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
         MarkActive();
 
+        // Any inbound traffic proves the peer is reachable; clear the
+        // consecutive-send-failure budget so a future flap starts fresh.
+        mConsecutiveSendFailures = 0;
+
         if (mState == State::kDefunct)
         {
             MoveToState(State::kActive);
         }
     }
+
+    // Hysteresis accessors used by ExchangeContext to gate MarkAsDefunct on
+    // N-consecutive non-MRP send failures (see CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD).
+    // The counter is per-session because multiple exchanges share the failure budget.
+    uint8_t GetConsecutiveSendFailures() const { return mConsecutiveSendFailures; }
+    uint8_t IncrementConsecutiveSendFailures()
+    {
+        if (mConsecutiveSendFailures < UINT8_MAX)
+        {
+            ++mConsecutiveSendFailures;
+        }
+        return mConsecutiveSendFailures;
+    }
+    void ResetConsecutiveSendFailures() { mConsecutiveSendFailures = 0; }
 
     void SetCaseCommissioningSessionStatus(bool isCaseCommissioningSession)
     {
@@ -327,6 +356,11 @@ private:
     const char * StateToString(State state) const;
     void MoveToState(State targetState);
 
+    // Captures the current mPeerAddress's IPv6 /64 prefix as the "known-routable" anchor for this
+    // session. Called whenever SetPeerAddress is invoked explicitly (session establishment or
+    // a SessionManager-initiated peer relocation). Non-IPv6 / non-UDP peers leave the anchor cleared.
+    void CapturePeerAddressAnchor();
+
     friend class SecureSessionDeleter;
     friend class TestSecureSessionTable;
 
@@ -342,6 +376,23 @@ private:
 
     PeerAddress mPeerAddress;
 
+    // After this many consecutive RX restamp rejects from a single candidate /64 prefix, accept
+    // the new prefix. Allows recovery if the peer truly relocated networks while still discarding
+    // a transient burst of relay-mangled / non-routable sources during the same exchange.
+    static constexpr uint8_t kPeerAddressRestampOverrideThreshold = 5;
+
+    // First 8 bytes (IPv6 /64) of the last known-routable peer address. Sourced from
+    // SetPeerAddress (CASE/PASE establishment or explicit UpdateAllSessionsPeerAddress).
+    // Only meaningful when mPeerAddressAnchorValid is true.
+    uint8_t mPeerAddressAnchorPrefix[8] = { 0 };
+    bool mPeerAddressAnchorValid        = false;
+
+    // Tracks a candidate /64 prefix we keep rejecting in the dispatch path; once
+    // mPeerAddressRestampRejectCount reaches kPeerAddressRestampOverrideThreshold the anchor
+    // is replaced.
+    uint8_t mPeerAddressLastRejectedPrefix[8] = { 0 };
+    uint8_t mPeerAddressRestampRejectCount    = 0;
+
     /// Timestamp of last tx or rx. @see SessionTimestamp in the spec
     System::Clock::Timestamp mLastActivityTime = System::SystemClock().GetMonotonicTimestamp();
 
@@ -351,6 +402,10 @@ private:
     SessionParameters mRemoteSessionParams;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
+
+    // Count of consecutive non-MRP send failures on this session. Reset on a
+    // successful send and on any inbound RX. See ExchangeContext::SendMessage.
+    uint8_t mConsecutiveSendFailures = 0;
 };
 
 } // namespace Transport

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -899,10 +899,11 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
     Transport::SecureSession * secureSession  = session.Value()->AsSecureSession();
     Transport::PeerAddress mutablePeerAddress = peerAddress;
     CorrectPeerAddressInterfaceID(mutablePeerAddress);
-    if (secureSession->GetPeerAddress() != mutablePeerAddress)
-    {
-        secureSession->SetPeerAddress(mutablePeerAddress);
-    }
+    // Guarded restamp: a non-routable IPv6 source (e.g. relay-mangled OMR address from a
+    // different host on Thread) would silently break outbound replies with ERR_RTE. Defer the
+    // address change to SecureSession, which compares the candidate /64 against the anchor
+    // captured at session establishment.
+    secureSession->RestampPeerAddressIfRoutable(mutablePeerAddress);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // Associate the secure session with the connection, if not done already.


### PR DESCRIPTION
  accessories where the WiFi↔Thread interplay was causing CASE sessions
  to wedge or fail outright.

  SRP host advertisement: register every reachable address (Thread + WiFi
  + Ethernet) in spec order via explicit otSrpClientSetHostAddresses, persisting the array on the SrpClient struct and re-publishing on every transport transition. Replaces the upstream's auto-host-address mode that left WiFi/Eth records silently absent.

  Address resolver: capture each result's original InterfaceId before
  chip strips it on non-LL addresses, rank by a transport-tier composite
  score (Eth > WiFi-IPv6 > WiFi-IPv4 > Thread), and expose
  InterfaceId::GetInterfaceType to callers needing to discriminate by
  underlying radio.

  SecureSession + ExchangeContext: pin a /64 anchor at session
  establishment so the dispatch path can no longer restamp PeerAddress
  to a non-routable inbound source (with an N-reject override for true
  peer relocation), and gate MarkAsDefunct on
  CHIP_CONFIG_SESSION_SEND_FAILURE_THRESHOLD consecutive non-MRP send
  failures (default 3) — eliminating the kActive↔kDefunct flap that
  followed every transient ERR_RTE.

### Testing

Tested on c6 reference platform
