### PR TITLE
[TC-CGEN-2.2] Change default failsafe value from 1 to 20

### DIFF
--- a/src/python_testing/TC_CGEN_2_2.py
+++ b/src/python_testing/TC_CGEN_2_2.py
@@ -59,7 +59,7 @@ class TC_CGEN_2_2(MatterBaseTest):
     cluster_opcreds = Clusters.OperationalCredentials
     cluster_cgen = Clusters.GeneralCommissioning
 
-    default_failsafe = 1
+    default_failsafe = 20
     RUN_TEST_CI = "CI Test"
     RUN_TEST_CERT = "Cert Test"
 


### PR DESCRIPTION
### Summary
The variable default_failsafe is currently set to 1 (Line 62 of the script), whereas the Test Plan specifies a value of 20. This discrepancy is the cause of the observed test failure when the PIXIT.CGEN.FailsafeExpiryLengthSeconds argument is not explicitly provided.

### Related issues

- Fix for CCB: https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool#home/ccbs/ccbdetails2/6a38e09b4f1927f6891817ac/
- Related Script Issue: https://github.com/project-chip/connectedhomeip/issues/42574

### Testing
Tested on the Nordic platform using the BLE-Thread commissioning method.

