### PR TITLE
fix: Use correct format output for ThreadStackManagerImpl_OpenThread

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1013,7 +1013,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRId32 " ms",
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRIu32 " ms",
                             mRendezvousRetransmissionCount, kRendezvousRetransmissionIntervalMs);
             err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
                                                         _HandleRendezvousRetransmissionTimer, this);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1013,8 +1013,8 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRId32 " ms", mRendezvousRetransmissionCount,
-                            kRendezvousRetransmissionIntervalMs);
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRId32 " ms",
+                            mRendezvousRetransmissionCount, kRendezvousRetransmissionIntervalMs);
             err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
                                                         _HandleRendezvousRetransmissionTimer, this);
             if (err != CHIP_NO_ERROR)

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1013,7 +1013,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRIu32 " ms",
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu16 " in %" PRIu32 " ms",
                             mRendezvousRetransmissionCount, kRendezvousRetransmissionIntervalMs);
             err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
                                                         _HandleRendezvousRetransmissionTimer, this);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1013,7 +1013,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::SendRendezvousAnnounce
         if (mRendezvousRetransmissionCount < kMaxRendezvousRetransmissions)
         {
             const uint32_t kRendezvousRetransmissionIntervalMs = 1250;
-            ChipLogProgress(DeviceLayer, "Try the current Thread network #%u in %d ms", mRendezvousRetransmissionCount,
+            ChipLogProgress(DeviceLayer, "Try the current Thread network #%" PRIu8 " in %" PRId32 " ms", mRendezvousRetransmissionCount,
                             kRendezvousRetransmissionIntervalMs);
             err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kRendezvousRetransmissionIntervalMs),
                                                         _HandleRendezvousRetransmissionTimer, this);


### PR DESCRIPTION
### Summary

Small fix to fix the format output in src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp

### Related issues

NA

### Testing

Small fix, no test required