### PR TITLE
Implement revision 4 of GroupKeyManagement with `C` on GroupKeyMap

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -683,11 +683,10 @@ CHIP_ERROR GroupKeyManagementCluster::Attributes(const ConcreteClusterPath & pat
 {
     // TODO(#72714): remove this override once the AttributeQualityFlags::kChangesOmitted quality is honored by the generator.
     static constexpr DataModel::AttributeEntry kMandatoryMetadataWithChangesOmitted[] = {
-        DataModel::AttributeEntry(
-            GroupKeyMap::Id,
-            BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
-                                                       DataModel::AttributeQualityFlags::kChangesOmitted),
-            Access::Privilege::kView, Access::Privilege::kManage),
+        DataModel::AttributeEntry(GroupKeyMap::Id,
+                                  BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
+                                                                             DataModel::AttributeQualityFlags::kChangesOmitted),
+                                  Access::Privilege::kView, Access::Privilege::kManage),
         GroupTable::kMetadataEntry,
         MaxGroupsPerFabric::kMetadataEntry,
         MaxGroupKeysPerFabric::kMetadataEntry,

--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -671,7 +671,9 @@ DataModel::ActionReturnStatus GroupKeyManagementCluster::WriteAttribute(const Da
     switch (request.path.mAttributeId)
     {
     case GroupKeyMap::Id: {
-        return WriteGroupKeyMap(mContext.groupDataProvider, request.path, decoder);
+        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId,
+                                               WriteGroupKeyMap(mContext.groupDataProvider, request.path, decoder),
+                                               DataModel::AttributeChangeType::kQuiet);
     }
     default:
         return Protocols::InteractionModel::Status::UnsupportedWrite;

--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -671,8 +671,7 @@ DataModel::ActionReturnStatus GroupKeyManagementCluster::WriteAttribute(const Da
     switch (request.path.mAttributeId)
     {
     case GroupKeyMap::Id: {
-        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId,
-                                               WriteGroupKeyMap(mContext.groupDataProvider, request.path, decoder));
+        return WriteGroupKeyMap(mContext.groupDataProvider, request.path, decoder);
     }
     default:
         return Protocols::InteractionModel::Status::UnsupportedWrite;
@@ -682,8 +681,20 @@ DataModel::ActionReturnStatus GroupKeyManagementCluster::WriteAttribute(const Da
 CHIP_ERROR GroupKeyManagementCluster::Attributes(const ConcreteClusterPath & path,
                                                  ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
+    // TODO(#72714): remove this override once the AttributeQualityFlags::kChangesOmitted quality is honored by the generator.
+    static constexpr DataModel::AttributeEntry kMandatoryMetadataWithChangesOmitted[] = {
+        DataModel::AttributeEntry(
+            GroupKeyMap::Id,
+            BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
+                                                       DataModel::AttributeQualityFlags::kChangesOmitted),
+            Access::Privilege::kView, Access::Privilege::kManage),
+        GroupTable::kMetadataEntry,
+        MaxGroupsPerFabric::kMetadataEntry,
+        MaxGroupKeysPerFabric::kMetadataEntry,
+    };
+
     AttributeListBuilder listBuilder(builder);
-    return listBuilder.Append(Span(GroupKeyManagement::Attributes::kMandatoryMetadata), {});
+    return listBuilder.Append(Span(kMandatoryMetadataWithChangesOmitted), {});
 }
 
 CHIP_ERROR GroupKeyManagementCluster::AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -170,11 +170,10 @@ TEST_F(TestGroupKeyManagementCluster, CommandsTest)
 TEST_F(TestGroupKeyManagementCluster, AttributesTest)
 {
     std::vector<app::DataModel::AttributeEntry> expectedAttributes = {
-        DataModel::AttributeEntry(
-            GroupKeyManagement::Attributes::GroupKeyMap::Id,
-            BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
-                                                       DataModel::AttributeQualityFlags::kChangesOmitted),
-            Access::Privilege::kView, Access::Privilege::kManage),
+        DataModel::AttributeEntry(GroupKeyManagement::Attributes::GroupKeyMap::Id,
+                                  BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
+                                                                             DataModel::AttributeQualityFlags::kChangesOmitted),
+                                  Access::Privilege::kView, Access::Privilege::kManage),
         GroupKeyManagement::Attributes::GroupTable::kMetadataEntry,
         GroupKeyManagement::Attributes::MaxGroupsPerFabric::kMetadataEntry,
         GroupKeyManagement::Attributes::MaxGroupKeysPerFabric::kMetadataEntry,

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -169,13 +169,18 @@ TEST_F(TestGroupKeyManagementCluster, CommandsTest)
 }
 TEST_F(TestGroupKeyManagementCluster, AttributesTest)
 {
-    std::vector<app::DataModel::AttributeEntry> mandatoryAttributes(GroupKeyManagement::Attributes::kMandatoryMetadata.begin(),
-                                                                    GroupKeyManagement::Attributes::kMandatoryMetadata.end());
+    std::vector<app::DataModel::AttributeEntry> expectedAttributes = {
+        DataModel::AttributeEntry(
+            GroupKeyManagement::Attributes::GroupKeyMap::Id,
+            BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute,
+                                                       DataModel::AttributeQualityFlags::kChangesOmitted),
+            Access::Privilege::kView, Access::Privilege::kManage),
+        GroupKeyManagement::Attributes::GroupTable::kMetadataEntry,
+        GroupKeyManagement::Attributes::MaxGroupsPerFabric::kMetadataEntry,
+        GroupKeyManagement::Attributes::MaxGroupKeysPerFabric::kMetadataEntry,
+    };
 
-    // There are only mandatory attributes in this cluster, so it should match the ones in Metadata exactly
-    // TODO: Fix the assert below including the optional attribute.
-    // The assert is disabled because an optional attribute, GroupcastAdoption, was added to the cluster.
-    // ASSERT_TRUE(chip::Testing::IsAttributesListEqualTo(mCluster, std::move(mandatoryAttributes)));
+    ASSERT_TRUE(chip::Testing::IsAttributesListEqualTo(mCluster, expectedAttributes));
 }
 
 // Cluster should accept writing multiple group keys with the same KeySetID but different Group IDs

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -133,11 +133,12 @@ CHIP_ERROR DefaultServerCluster::GeneratedCommands(const ConcreteClusterPath & p
 }
 
 DataModel::ActionReturnStatus DefaultServerCluster::NotifyAttributeChangedIfSuccess(AttributeId attributeId,
-                                                                                    DataModel::ActionReturnStatus status)
+                                                                                    DataModel::ActionReturnStatus status,
+                                                                                    DataModel::AttributeChangeType type)
 {
     if (status.IsSuccess() && !status.IsNoOpSuccess())
     {
-        NotifyAttributeChanged(attributeId);
+        NotifyAttributeChanged(attributeId, type);
     }
     return status;
 }

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -159,7 +159,8 @@ protected:
     /// Marks that a specific attribute has changed value, if `status` is success.
     ///
     /// Will return `status`
-    DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status);
+    DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status,
+                                                                  DataModel::AttributeChangeType type = DataModel::AttributeChangeType::kReportable);
 
 private:
     DataVersion mDataVersion; // will be random-initialized as per spec

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -159,8 +159,9 @@ protected:
     /// Marks that a specific attribute has changed value, if `status` is success.
     ///
     /// Will return `status`
-    DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status,
-                                                                  DataModel::AttributeChangeType type = DataModel::AttributeChangeType::kReportable);
+    DataModel::ActionReturnStatus
+    NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status,
+                                    DataModel::AttributeChangeType type = DataModel::AttributeChangeType::kReportable);
 
 private:
     DataVersion mDataVersion; // will be random-initialized as per spec

--- a/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
+++ b/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
@@ -244,6 +244,25 @@ TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
     ASSERT_EQ(cluster.NotifyAttributeChangedIfSuccess(345, Status::Failure), Status::Failure);
     ASSERT_EQ(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
     ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
+
+    // test kQuiet success - version should change, changed list populated, dirty list empty
+    oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    context.ChangeListener().DirtyList().clear();
+    context.ChangeListener().ChangedList().clear();
+    ASSERT_EQ(cluster.NotifyAttributeChangedIfSuccess(456, Status::Success, AttributeChangeType::kQuiet), Status::Success);
+    ASSERT_NE(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
+    ASSERT_EQ(context.ChangeListener().ChangedList().size(), 1u);
+    ASSERT_EQ(context.ChangeListener().ChangedList()[0], ConcreteAttributePath(kEndpointId, kClusterId, 456));
+    ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
+
+    // test kQuiet failure - nothing should change, lists should be empty
+    oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    context.ChangeListener().DirtyList().clear();
+    context.ChangeListener().ChangedList().clear();
+    ASSERT_EQ(cluster.NotifyAttributeChangedIfSuccess(456, Status::Failure, AttributeChangeType::kQuiet), Status::Failure);
+    ASSERT_EQ(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
+    ASSERT_TRUE(context.ChangeListener().ChangedList().empty());
+    ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
 }
 
 TEST(TestDefaultServerCluster, SetAttributeValueNullable)


### PR DESCRIPTION
### Summary

- Stop reporting changes to GroupKeyMap

### Related issues
- Fixes #72717

### Testing

- Updated unit test for the GroupKeyManagementCluster