### PR TITLE
[WiFi-PAF] Initialize Rx sequence-history index in WiFiPAFTP::Init

### DIFF
--- a/src/wifipaf/WiFiPAFTP.cpp
+++ b/src/wifipaf/WiFiPAFTP.cpp
@@ -80,6 +80,8 @@ CHIP_ERROR WiFiPAFTP::Init(void * an_app_state, bool expect_first_ack)
     mRxNewestUnackedSeqNum = 0;
     mRxOldestUnackedSeqNum = 0;
     mRxFragmentSize        = sDefaultFragmentSize;
+    mRxSeqHistId           = 0;
+    memset(mRxSeqHist, 0, sizeof(mRxSeqHist));
     mTxState               = kState_Idle;
     mTxBuf                 = nullptr;
     mTxFragmentSize        = sDefaultFragmentSize;

--- a/src/wifipaf/tests/TestWiFiPAFTP.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFTP.cpp
@@ -209,5 +209,23 @@ TEST_F(TestWiFiPAFTP, EnforcesMinFragmentSize)
     EXPECT_EQ(GetTxFragmentSize(), WiFiPAFTP::sMaxFragmentSize);
     EXPECT_EQ(GetRxFragmentSize(), WiFiPAFTP::sMaxFragmentSize);
 }
+
+// Init() must reset the Rx sequence-history ring index. HandleCharacteristicReceived() uses it to index
+// mRxSeqHist[] on every received fragment, so a stale/uninitialized value (e.g. a non-zeroed engine) would
+// write out of bounds. Seed it out of range, re-init, and confirm it lands back inside the array.
+TEST_F(TestWiFiPAFTP, InitResetsRxSeqHistoryIndex)
+{
+    mRxSeqHistId = static_cast<uint8_t>(CHIP_PAFTP_RXHIST_SIZE + 100);
+    ASSERT_EQ(Init(nullptr, false), CHIP_NO_ERROR);
+    EXPECT_LT(mRxSeqHistId, CHIP_PAFTP_RXHIST_SIZE);
+
+    // Exercise the indexed write in HandleCharacteristicReceived; in bounds now, ASan would catch otherwise.
+    const uint8_t frag[] = { 0x00, 0x00 };
+    auto buf             = System::PacketBufferHandle::NewWithData(frag, sizeof(frag));
+    ASSERT_FALSE(buf.IsNull());
+    SequenceNumber_t receivedAck = 0;
+    bool didReceiveAck           = false;
+    EXPECT_EQ(HandleCharacteristicReceived(std::move(buf), receivedAck, didReceiveAck), CHIP_NO_ERROR);
+}
 }; // namespace WiFiPAF
 }; // namespace chip


### PR DESCRIPTION
#### Found by fuzzing

Reported by the `fuzz-wifipaf-tp-pw` pw_fuzztest harness running under OSS-Fuzz / AddressSanitizer, which flagged a 1-byte out-of-bounds write in `WiFiPAFTP::HandleCharacteristicReceived`:

```
==ERROR: AddressSanitizer: stack-use-after-return   WRITE of size 1
    #0 chip::WiFiPAF::WiFiPAFTP::HandleCharacteristicReceived(...)  src/wifipaf/WiFiPAFTP.cpp:275:34
    #1 (anonymous namespace)::WiFiPAFTPDoesNotCrash(...)            src/wifipaf/tests/FuzzWiFiPAFTPPW.cpp:87
  This frame has 4 object(s):
    [48, 88) 'reader' <== Memory access at offset 46 underflows this variable
```

(ASan labels it `stack-use-after-return` because the out-of-bounds index landed in a returned function's frame; the actual fault is the out-of-bounds array index described below.)

#### Root cause

`WiFiPAFTP::Init()` initializes every Rx/Tx state member **except** the sequence-history ring index `mRxSeqHistId` and the `mRxSeqHist[]` array. There is no constructor and no in-class initializers either, so after `Init()` the index holds whatever was in the engine's storage. `HandleCharacteristicReceived()` then uses it directly as an array index on every received fragment:

```cpp
mRxSeqHist[mRxSeqHistId] = mRxNewestUnackedSeqNum;   // line 275
```

`mRxSeqHist` is `uint8_t[CHIP_PAFTP_RXHIST_SIZE]` (8). If the engine's storage was not zero-initialized, `mRxSeqHistId` can be `>= 8` and this writes out of bounds. `LogState()` similarly reads the whole uninitialized array.

In the current stack this is latent rather than exploitable: the only `WiFiPAFTP` instance lives inside the `static` `WiFiPAFEndPoint` pool, which is zero-initialized at startup, and the only other writer keeps the index in range via `(x + 1) % CHIP_PAFTP_RXHIST_SIZE`. But the engine relies on its storage being zeroed instead of initializing its own members, so a stack- or heap-allocated engine (a unit test or the fuzz harness above) indexes with garbage.

#### Change

- Initialize `mRxSeqHistId = 0` and clear `mRxSeqHist` in `Init()`, next to the other Rx state.
- Add a regression test that seeds `mRxSeqHistId` out of range, re-inits, and confirms it is back in bounds and the receive path stays within the array.

#### Testing

`TestWiFiPAFTP.InitResetsRxSeqHistoryIndex` fails (index stays out of range) before the change and passes after, under the ASan test build.