### PR TITLE
[Fix] Log lines >256 chars will be split across multiple lines

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -263,6 +263,7 @@ static_library("support") {
     "CHIPCounter.h",
     "CHIPMemString.h",
     "CharSpanToStdString.h",
+    "ChunkSplitter.h",
     "CommonIterator.h",
     "CommonPersistentData.h",
     "DLLUtil.h",

--- a/src/lib/support/ChunkSplitter.h
+++ b/src/lib/support/ChunkSplitter.h
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/support/Span.h>
+
+namespace chip {
+
+/// Provides the ability to split a given span into spans of or below a given size
+template <size_t kSize>
+class ChunkSplitter
+{
+public:
+    ChunkSplitter(CharSpan s) : span(s)
+    {
+    }
+
+    /// Returns the next character span
+    ///
+    /// out - contains the next span of size at most kSize or an empty span if no more elements are available
+    ///
+    /// Returns true if an element is available, false otherwise.
+    bool Next(CharSpan & out)
+    {
+        if (offset >= span.size())
+        {
+            out = CharSpan();
+            return false; // nothing left
+        } else
+        {
+            size_t nextSize = std::min(kSize, span.size() - offset);
+            out = span.SubSpan(offset, nextSize);
+            offset += nextSize;
+            return true;
+        }
+    }
+
+protected:
+    const CharSpan span; // the full span to split
+    size_t offset = 0; // the start of the next chunk to return
+};
+
+} // namespace chip

--- a/src/lib/support/ChunkSplitter.h
+++ b/src/lib/support/ChunkSplitter.h
@@ -26,9 +26,7 @@ template <size_t kSize>
 class ChunkSplitter
 {
 public:
-    ChunkSplitter(CharSpan s) : span(s)
-    {
-    }
+    ChunkSplitter(CharSpan s) : span(s) {}
 
     /// Returns the next character span
     ///
@@ -41,10 +39,11 @@ public:
         {
             out = CharSpan();
             return false; // nothing left
-        } else
+        }
+        else
         {
             size_t nextSize = std::min(kSize, span.size() - offset);
-            out = span.SubSpan(offset, nextSize);
+            out             = span.SubSpan(offset, nextSize);
             offset += nextSize;
             return true;
         }
@@ -52,7 +51,7 @@ public:
 
 protected:
     const CharSpan span; // the full span to split
-    size_t offset = 0; // the start of the next chunk to return
+    size_t offset = 0;   // the start of the next chunk to return
 };
 
 } // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -43,6 +43,7 @@ chip_test_suite("tests") {
     "TestCHIPMem.cpp",
     "TestCHIPMemString.cpp",
     "TestCharSpanToStdString.cpp",
+    "TestChunkSplitter.cpp",
     "TestDefer.cpp",
     "TestErrorStr.cpp",
     "TestFixedBuffer.cpp",

--- a/src/lib/support/tests/TestChunkSplitter.cpp
+++ b/src/lib/support/tests/TestChunkSplitter.cpp
@@ -85,7 +85,6 @@ TEST(TestChunkSplitter, TestSplitter)
     }
 
     // some edge cases
-
 }
 
 } // namespace

--- a/src/lib/support/tests/TestChunkSplitter.cpp
+++ b/src/lib/support/tests/TestChunkSplitter.cpp
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/ChunkSplitter.h>
+
+namespace {
+
+using namespace chip;
+
+TEST(TestChunkSplitter, TestSplitter)
+{
+    CharSpan out;
+    size_t zero = 0;
+
+    // empty string handling
+    {
+        ChunkSplitter<5> splitter(""_span);
+
+        // next stays at nullptr
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+    }
+
+    // single item
+    {
+        ChunkSplitter<6> splitter("single"_span);
+
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("single"_span));
+
+        // next stays at nullptr also after valid data
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+    }
+
+    // multi-item
+    {
+        ChunkSplitter<3> splitter("onetwo3rd"_span);
+
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("one"_span));
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("two"_span));
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("3rd"_span));
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+    }
+
+    // last item smaller than chunk size
+    {
+        ChunkSplitter<4> splitter("fourfourii"_span);
+
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("four"_span));
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("four"_span));
+        EXPECT_TRUE(splitter.Next(out));
+        EXPECT_TRUE(out.data_equal("ii"_span));
+        EXPECT_FALSE(splitter.Next(out));
+        EXPECT_EQ(out.size(), zero);
+    }
+
+    // some edge cases
+
+}
+
+} // namespace

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -21,9 +21,9 @@
 #include <lib/address_resolve/TracingStructs.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/ChunkSplitter.h>
 #include <lib/support/StringBuilder.h>
 #include <lib/support/StringSplitter.h>
-#include <lib/support/ChunkSplitter.h>
 #include <log_json/log_json_build_config.h>
 #include <tracing/metric_event.h>
 #include <transport/TracingStructs.h>
@@ -521,8 +521,7 @@ void JsonBackend::OutputValue(::Json::Value & value)
             chip::CharSpan chunk;
             while (chunkSplitter.Next(chunk))
             {
-                ChipLogProgress(Automation, "%s",
-                                            StringBuilder<kMaxLogLineLength + 1>(chunk).c_str());
+                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength + 1>(chunk).c_str());
             }
         }
     }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -531,7 +531,7 @@ void JsonBackend::OutputValue(::Json::Value & value)
             }
             else
             {
-                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength>(line).c_str());
+                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength+1>(line).c_str());
             }
         }
     }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -513,9 +513,25 @@ void JsonBackend::OutputValue(::Json::Value & value)
         chip::StringSplitter splitter(data_string.c_str(), '\n');
 
         chip::CharSpan line;
+        constexpr size_t kMaxLogLineLength = 256;
         while (splitter.Next(line))
         {
-            ChipLogProgress(Automation, "%s", NullTerminated(line).c_str());
+            // if the line is longer than 256 characters and would be truncated,
+            // instead loop over 256-char long slices and log each separately
+            if (line.size() > kMaxLogLineLength)
+            {
+                size_t offset = 0;
+                while (offset < line.size())
+                {
+                    size_t slice_size = std::min(kMaxLogLineLength, static_cast<size_t>(line.size() - offset));
+                    ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength+1>(line.SubSpan(offset, slice_size)).c_str());
+                    offset += slice_size;
+                }
+            }
+            else
+            {
+                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength>(line).c_str());
+            }
         }
     }
 }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -524,7 +524,8 @@ void JsonBackend::OutputValue(::Json::Value & value)
                 while (offset < line.size())
                 {
                     size_t slice_size = std::min(kMaxLogLineLength, static_cast<size_t>(line.size() - offset));
-                    ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength+1>(line.SubSpan(offset, slice_size)).c_str());
+                    ChipLogProgress(Automation, "%s",
+                                    StringBuilder<kMaxLogLineLength + 1>(line.SubSpan(offset, slice_size)).c_str());
                     offset += slice_size;
                 }
             }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -531,7 +531,7 @@ void JsonBackend::OutputValue(::Json::Value & value)
             }
             else
             {
-                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength+1>(line).c_str());
+                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength + 1>(line).c_str());
             }
         }
     }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -23,6 +23,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/StringBuilder.h>
 #include <lib/support/StringSplitter.h>
+#include <lib/support/ChunkSplitter.h>
 #include <log_json/log_json_build_config.h>
 #include <tracing/metric_event.h>
 #include <transport/TracingStructs.h>
@@ -513,25 +514,15 @@ void JsonBackend::OutputValue(::Json::Value & value)
         chip::StringSplitter splitter(data_string.c_str(), '\n');
 
         chip::CharSpan line;
-        constexpr size_t kMaxLogLineLength = 256;
         while (splitter.Next(line))
         {
-            // if the line is longer than 256 characters and would be truncated,
-            // instead loop over 256-char long slices and log each separately
-            if (line.size() > kMaxLogLineLength)
+            constexpr size_t kMaxLogLineLength = 256;
+            chip::ChunkSplitter<kMaxLogLineLength> chunkSplitter(line); // we try to log smaller chunks, to not allocate huge arrays
+            chip::CharSpan chunk;
+            while (chunkSplitter.Next(chunk))
             {
-                size_t offset = 0;
-                while (offset < line.size())
-                {
-                    size_t slice_size = std::min(kMaxLogLineLength, static_cast<size_t>(line.size() - offset));
-                    ChipLogProgress(Automation, "%s",
-                                    StringBuilder<kMaxLogLineLength + 1>(line.SubSpan(offset, slice_size)).c_str());
-                    offset += slice_size;
-                }
-            }
-            else
-            {
-                ChipLogProgress(Automation, "%s", StringBuilder<kMaxLogLineLength + 1>(line).c_str());
+                ChipLogProgress(Automation, "%s",
+                                            StringBuilder<kMaxLogLineLength + 1>(chunk).c_str());
             }
         }
     }


### PR DESCRIPTION
### Summary

Currently, log lines from the test harness longer than 256 characters will get truncated. This comes down to the use of a `StringBuilder` with a fixed width. 

With this fix, lines that would be longer will be broken up and split across multiple log lines.

Current behavior:
```
PYTHON_TEST | 2026-04-03 13:44:08.795618 | [MatterTest] 04-03 13:44:03.451 INFO 				"responder_random": "hex:3A2A0F9400D0373A92FEFA7201B111DD593C62CD53457B1CC000BC01F1B3E935",
PYTHON_TEST | 2026-04-03 13:44:08.795935 | [MatterTest] 04-03 13:44:03.451 INFO 				"responder_session_id" : "41286"
PYTHON_TEST | 2026-04-03 13:44:08.796643 | [MatterTest] 04-03 13:44:03.452 INFO 			}
PYTHON_TEST | 2026-04-03 13:44:08.796965 | [MatterTest] 04-03 13:44:03.452 INFO 		},
PYTHON_TEST | 2026-04-03 13:44:08.797272 | [MatterTest] 04-03 13:44:03.452 INFO 		"hex" : "15300120539A0CA1C91506591E6435E05CBF00E0967E03A5BA302B19F363BB6F432515683002203A2A0F9400D0373A92FEFA7201B111DD593C62CD53457B1CC000BC01F1B3E935250346A135042601E80300003002208089C852EBD816473C5A217B8D79FC03160D7F194A3DD557A0D7448B6070A36C183505.. 
```

With change:
```
06-24 16:36:50.085 INFO                                 "interaction_model_revison" : "12",
06-24 16:36:50.085 INFO                                 "suppress_response" : "true"
06-24 16:36:50.085 INFO                         }
06-24 16:36:50.085 INFO                 },
06-24 16:36:50.085 INFO                 "hex" : "15360115350126003414C44A370124020024033824040018270200F2491E07F80200181815350126003414C44A370124020024033824040118240203181815350126003414C44A3701240200240338240403183402181815350126003414C44A3701240200240338240404183402181815350126003414C44A37
06-24 16:36:50.085 INFO 1240200240338240405183602152000002401001818181815350126003414C44A370124020024033824040618360218181815350126003414C44A3701240200240338240407183402181815350126003414C44A370124020024033824040818240200181815350126003414C44A370124020024033824040A18240202181815
06-24 16:36:50.085 INFO 50126003414C44A370124020024033824040B18240202181815350126003414C44A370124020024033824040C182902181815350126003414C44A370124020024033824040218240208181815350126003414C44A37012402002403382504FCFF1824020B181815350126003414C44A37012402002403382504FDFF18240202
06-24 16:36:50.085 INFO 81815350126003414C44A37012402002403382504F8FF183602040318181815350126003414C44A37012402002403382504F9FF1836020401040204040405040018181815350126003414C44A37012402002403382504FBFF18360204000401040304040405040604070408040A040B040C040205FCFF05FDFF05F8FF05F9FF
06-24 16:36:50.085 INFO 5FBFF1818181535012600C263E4C33701240200240328240404182502018018181535012600C263E4C33701240200240328240402182502F1FF1818153500370024020024033024040C18350124008618181815350126001F75EEFE370124020024033024040318240202181815350126001F75EEFE37012402002403302404
06-24 16:36:50.085 INFO 218240200181815350126001F75EEFE370124020024033024040118350224003C2501840318181815350126001F75EEFE370124020024033024040018240200181815350126001F75EEFE3701240200240330240404182902181818290424FF0C18",
06-24 16:36:50.085 INFO                 "size" : 732
```

**Caveat:** When running in a context where logging is happening from multiple sources (e.g. using `run_python_test`), since the output is not atomic, the lines can be interleaved.

### Related issues

Fixes https://github.com/project-chip/certification-tool/issues/972

### Testing

Run locally using example apps against `TC_CGEN_2_4.py`.
