### PR TITLE
[V1.5][Cherry-pick][ESP32] Fix compile flag parsing in create_args_gn.py for ESP-IDF v5.5.4

### DIFF
--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2021-2026 Project CHIP Authors
 #    Copyright (c) 2018 Nest Labs, Inc.
 #    All rights reserved.
 #
@@ -22,6 +22,7 @@
 import argparse
 import json
 import os
+import shlex
 
 # Parse the build's compile_commands.json to generate
 # final args file for CHIP build.
@@ -40,6 +41,30 @@ args = argparser.parse_args()
 
 compile_commands_path = os.path.join(args.build_dir, "compile_commands.json")
 
+# From esp-idf v6.0 and onwards, compile flags are stored in files, so we need to explicitly expand them
+# eg: @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/asmflags\"
+#     @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/cflags\"
+# this function reads that file and returns the flags
+
+
+def expand_response_file(flag):
+    """Expand response file references (flags starting with @) into their contents."""
+    # Handle both @path and @"path" formats
+    if flag.startswith('@"') and flag.endswith('"'):
+        response_file_path = flag[2:-1]  # Remove @" and trailing "
+    elif flag.startswith('@'):
+        response_file_path = flag[1:]  # Remove @
+    else:
+        return [flag]
+
+    try:
+        with open(response_file_path, 'r') as f:
+            content = f.read()
+            return shlex.split(content)
+    except (IOError, OSError) as e:
+        raise Exception(f"Failed to read response file '{response_file_path}': {e}")
+
+
 with open(compile_commands_path) as compile_commands_json:
     compile_commands = json.load(compile_commands_json)
 
@@ -53,19 +78,31 @@ with open(compile_commands_path) as compile_commands_json:
             raise Exception(f"Failed to resolve compile flags for {src_file}")
 
         compile_command = compile_command[0]
+        compile_parts = shlex.split(compile_command)
         # Trim compiler, input and output
-        compile_flags = compile_command.split()[1:-4]
+        compile_flags = compile_parts[1:-4]
+
+        # Expand any response file references
+        expanded_flags = []
+        for flag in compile_flags:
+            expanded_flags.extend(expand_response_file(flag))
 
         replace = "-I%s" % args.idf_path
         replace_with = "-isystem%s" % args.idf_path
 
-        compile_flags = [f'"{f}"'.replace(replace, replace_with) for f in compile_flags]
+        # Escape any embedded double quotes for GN string syntax, then wrap in quotes
+        def quote_for_gn(flag):
+            # Escape backslashes first, then escape double quotes
+            escaped = flag.replace('\\', '\\\\').replace('"', '\\"')
+            return f'"{escaped}"'
+
+        expanded_flags = [quote_for_gn(f).replace(replace, replace_with) for f in expanded_flags]
 
         if args.filter_out:
             filter_out = [f'"{f}"' for f in args.filter_out.split(';')]
-            compile_flags = [c for c in compile_flags if c not in filter_out]
+            expanded_flags = [c for c in expanded_flags if c not in filter_out]
 
-        return compile_flags
+        return expanded_flags
 
     c_flags = get_compile_flags(args.c_file)
     cpp_flags = get_compile_flags(args.cpp_file)


### PR DESCRIPTION
Cherry pick (#43668) to v1.5-branch to fix idf v5.5.4 compile issue

* [ESP32] Fix compile flag parsing in create_args_gn.py for ESP-IDF v6.0

ESP-IDF v6.0 stores compile flags in response files (e.g. @"/path/to/cflags") rather than inline in compile_commands.json. This breaks the GN args generation as the script was splitting on whitespace without expanding these references.

- Add `expand_response_file()` to read and expand @file references
- Use `shlex.split()` instead of `str.split()` for proper command parsing
- Add `quote_for_gn()` to correctly escape embedded quotes and backslashes for GN string syntax

* Fix expand_response_file to raise on unreadable response files

Silently returning an empty list would drop compile flags and produce a broken build that is hard to debug. Raise an exception instead so the error is immediately visible.


### Testing
- ESP32 build fails without this change, verified locally.
