### PR TITLE
[PASE] Validate initiatorRandom length in HandlePBKDFParamResponse

### DIFF
--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -547,6 +547,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
 
     // Initiator's random value
     SuccessOrExit(err = tlvReader.Next(AsTlvContextTag(PBKDFParamResponseTags::kInitiatorRandom)));
+    VerifyOrExit(tlvReader.GetLength() == kPBKDFParamRandomNumberSize, err = CHIP_ERROR_INVALID_TLV_ELEMENT);
     SuccessOrExit(err = tlvReader.GetBytes(random, sizeof(random)));
     VerifyOrExit(ByteSpan(random).data_equal(ByteSpan(mPBKDFLocalRandomData)), err = CHIP_ERROR_INVALID_PASE_PARAMETER);
 


### PR DESCRIPTION
#### Problem

`PASESession::HandlePBKDFParamResponse()` reads the peer's `initiatorRandom` field into a fixed-size 32-byte buffer:

```cpp
uint8_t random[kPBKDFParamRandomNumberSize];
...
SuccessOrExit(err = tlvReader.Next(AsTlvContextTag(PBKDFParamResponseTags::kInitiatorRandom)));
SuccessOrExit(err = tlvReader.GetBytes(random, sizeof(random)));
VerifyOrExit(ByteSpan(random).data_equal(ByteSpan(mPBKDFLocalRandomData)), err = CHIP_ERROR_INVALID_PASE_PARAMETER);
```

`TLVReader::GetBytes(buf, bufSize)` copies only the element's actual length and does not zero the remainder of the buffer. If the received `initiatorRandom` element is shorter than `kPBKDFParamRandomNumberSize`, `random[len..32)` is left uninitialized and is then read by the `data_equal()` comparison — an uninitialized-stack read (surfaced by MemorySanitizer).

The two analogous reads already validate the element length before reading:

- the `responderRandom` field a few lines below in the same function, and
- the `initiatorRandom` field in `HandlePBKDFParamRequest()`.

Only the `initiatorRandom` read in `HandlePBKDFParamResponse()` was missing the check.

#### Change

Add the same `GetLength() == kPBKDFParamRandomNumberSize` guard before reading the buffer, so a malformed message is rejected with `CHIP_ERROR_INVALID_TLV_ELEMENT` before the read, consistent with the surrounding code.

#### Impact

Low / defense-in-depth. A conformant peer always sends a 32-byte `initiatorRandom`, so the new check never affects a valid handshake; it only hardens the malformed-input path, which was already rejected — just after the uninitialized read instead of before it.

#### Testing

No new test added: the change is a one-line guard identical to the `responderRandom` length check already present (and exercised by the existing `TestPASESession` PASE handshake tests) a few lines below in the same function, and it does not change behavior for valid handshakes (a conformant peer always sends a 32-byte `initiatorRandom`). Build and the existing PASE unit tests run in CI.
