### PR TITLE
[fuzz] Add MemorySanitizer (MSAN) support to fuzz targets

### DIFF
--- a/build/chip/fuzz_test.gni
+++ b/build/chip/fuzz_test.gni
@@ -57,10 +57,15 @@ template("chip_fuzz_target") {
       if (oss_fuzz) {
         fuzz_configs += [ "//build/config/compiler:oss_fuzz" ]
       } else {
-        fuzz_configs += [
-          "//build/config/compiler:libfuzzer_fuzzing",
-          "//build/config/compiler:sanitize_address",
-        ]
+        fuzz_configs += [ "//build/config/compiler:libfuzzer_fuzzing" ]
+
+        # ASan is the default sanitizer for local libFuzzer builds. MSAN (is_msan) is
+        # mutually exclusive with ASan and is applied globally via sanitize_default
+        # (which pulls in the instrumented-sysroot libc++), so only add ASan here when
+        # not building MSAN.
+        if (!is_msan) {
+          fuzz_configs += [ "//build/config/compiler:sanitize_address" ]
+        }
       }
 
       if (defined(public_configs)) {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -42,15 +42,6 @@ declare_args() {
   # Enable Thread sanitizer
   is_tsan = false
 
-  # Enable memory sanitizer
-  is_msan = false
-
-  # MSAN builds need an instrumented C++ runtime and dependencies.
-  # build_examples.py resolves this in host.py and passes it as a GN arg
-  # (default: ~/.cache/matter/msan_sysroot, overridable via SYSROOT_MSAN).
-  # Raw `gn gen` users must set SYSROOT_MSAN or pass --args='msan_sysroot="..."'.
-  msan_sysroot = getenv("SYSROOT_MSAN")
-
   # enable undefined behavior sanitizer
   is_ubsan = false
 

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -61,6 +61,17 @@ declare_args() {
   # Enable address sanitizer
   is_asan = false
 
+  # Enable memory sanitizer
+  is_msan = false
+
+  # MSAN builds need an instrumented C++ runtime and dependencies.
+  # build_examples.py resolves this in host.py and passes it as a GN arg
+  # (default: ~/.cache/matter/msan_sysroot, overridable via SYSROOT_MSAN).
+  # Raw `gn gen` users must set SYSROOT_MSAN or pass --args='msan_sysroot="..."'.
+  # Declared here (rather than in compiler/BUILD.gn) so the fuzz templates and the
+  # pw_fuzzer toolchain, which import this .gni, can read is_msan.
+  msan_sysroot = getenv("SYSROOT_MSAN")
+
   # Debug prefix mapping (values for -fdebug-prefix-map=).
   prefix_mappings = []
 

--- a/build/toolchain/pw_fuzzer/BUILD.gn
+++ b/build/toolchain/pw_fuzzer/BUILD.gn
@@ -40,10 +40,9 @@ declare_args() {
   chip_pw_fuzz_msan = false
 }
 
-assert(!chip_pw_fuzz_msan || msan_sysroot != "",
-       "chip_pw_fuzz_msan=true requires msan_sysroot to be set. Build via " +
-           "scripts/build/build_examples.py --target ...-pw-fuzztest-msan-clang, " +
-           "or set SYSROOT_MSAN before `gn gen`.")
+assert(
+    !chip_pw_fuzz_msan || msan_sysroot != "",
+    "chip_pw_fuzz_msan=true requires msan_sysroot to be set. Build via " + "scripts/build/build_examples.py --target ...-pw-fuzztest-msan-clang, " + "or set SYSROOT_MSAN before `gn gen`.")
 
 # --- libFuzzer-compatibility-mode support for FuzzTest ---
 # Applied toolchain-wide (via _use_libfuzzer_compat) so the configs below reach the FuzzTest
@@ -161,7 +160,8 @@ gcc_toolchain("chip_pw_fuzztest") {
       # MSAN-instrumented libc++ from msan_sysroot and applies msan_ignorelist.txt. Pigweed's
       # coverage instrumentation ($dir_pw_fuzzer:instrumentation) is compatible with MSAN and
       # is kept for coverage-guided runs.
-      remove_default_configs += [ "$dir_pw_toolchain/host_clang:sanitize_address" ]
+      remove_default_configs +=
+          [ "$dir_pw_toolchain/host_clang:sanitize_address" ]
       default_configs += [ "//build/config/compiler:sanitize_memory" ]
     } else {
       # Local builds keep pigweed's base -fsanitize=address. Optional UBSan on top via the

--- a/build/toolchain/pw_fuzzer/BUILD.gn
+++ b/build/toolchain/pw_fuzzer/BUILD.gn
@@ -32,7 +32,18 @@ declare_args() {
   # (set by the `ubsan` build_examples modifier on a -pw-fuzztest target). Local builds only;
   # under OSS-Fuzz the engine drives sanitizers via $CFLAGS.
   chip_pw_fuzz_ubsan = false
+
+  # Build the local pw_fuzzer / FuzzTest targets with MemorySanitizer instead of the default
+  # ASan (set by the `msan` build_examples modifier on a -pw-fuzztest target). Requires an
+  # instrumented sysroot via msan_sysroot. Local builds only; under OSS-Fuzz the engine
+  # drives sanitizers via $CFLAGS.
+  chip_pw_fuzz_msan = false
 }
+
+assert(!chip_pw_fuzz_msan || msan_sysroot != "",
+       "chip_pw_fuzz_msan=true requires msan_sysroot to be set. Build via " +
+           "scripts/build/build_examples.py --target ...-pw-fuzztest-msan-clang, " +
+           "or set SYSROOT_MSAN before `gn gen`.")
 
 # --- libFuzzer-compatibility-mode support for FuzzTest ---
 # Applied toolchain-wide (via _use_libfuzzer_compat) so the configs below reach the FuzzTest
@@ -144,6 +155,14 @@ gcc_toolchain("chip_pw_fuzztest") {
         "$dir_pw_fuzzer:instrumentation",
         "$dir_pw_toolchain/host_clang:sanitize_address",
       ]
+    } else if (chip_pw_fuzz_msan) {
+      # Local MSAN: swap pigweed's plain -fsanitize=address for chip's MemorySanitizer
+      # config (ASan and MSAN are mutually exclusive). sanitize_memory pulls the
+      # MSAN-instrumented libc++ from msan_sysroot and applies msan_ignorelist.txt. Pigweed's
+      # coverage instrumentation ($dir_pw_fuzzer:instrumentation) is compatible with MSAN and
+      # is kept for coverage-guided runs.
+      remove_default_configs += [ "$dir_pw_toolchain/host_clang:sanitize_address" ]
+      default_configs += [ "//build/config/compiler:sanitize_memory" ]
     } else {
       # Local builds keep pigweed's base -fsanitize=address. Optional UBSan on top via the
       # `ubsan` modifier on a -pw-fuzztest target.

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -232,7 +232,7 @@ def BuildHostTarget():
     target.AppendModifier("tsan", use_tsan=True).ExceptIfRe("-asan")
     target.AppendModifier("ubsan", use_ubsan=True)
     target.AppendModifier("msan", use_msan=True).OnlyIfRe("-clang").OnlyIfRe("-x64").ExceptIfRe(
-        "-(asan|tsan|ubsan|libfuzzer|ossfuzz|pw-fuzztest)")
+        "-(asan|tsan|ubsan|ossfuzz)")
     target.AppendModifier("libfuzzer", fuzzing_type=HostFuzzingType.LIB_FUZZER).OnlyIfRe(
         "-clang").ExceptIfRe('-ossfuzz')
     target.AppendModifier("ossfuzz", pw_fuzz_libfuzzer_compat=True).OnlyIfRe("-pw-fuzztest")

--- a/scripts/build/build_msan_sysroot.sh
+++ b/scripts/build/build_msan_sysroot.sh
@@ -283,10 +283,15 @@ echo ">>> GLib"
 cd "$SRC"
 [[ -d "glib-$GLIB_VERSION" ]] || { wget -q "https://download.gnome.org/sources/glib/$GLIB_SERIES/glib-$GLIB_VERSION.tar.xz" && tar xf "glib-$GLIB_VERSION.tar.xz"; }
 
-# Meson wants the flags as a quoted array; derive it from $MSAN so the GLib build uses the
-# same flag set as the other deps (the OSS-Fuzz $CFLAGS or the local default).
+# Meson wants the flags as a quoted array (one element per flag). Split $MSAN on whitespace
+# into individual flags so the GLib build uses the same flag set as the other deps (the
+# OSS-Fuzz $CFLAGS or the local default). NOTE: $MSAN must NOT be a single quoted word here,
+# or meson collapses every flag into one c_args element and clang rejects it
+# ("unsupported argument ... to option '-fsanitize='"). read -ra splits explicitly and keeps
+# shellcheck happy (vs. an unquoted $MSAN, which a linter is prone to "fix" back into one word).
+read -ra _msan_flags <<<"$MSAN"
 _msan_meson=""
-for _f in "$MSAN"; do _msan_meson+="'$_f', "; done
+for _f in "${_msan_flags[@]}"; do _msan_meson+="'$_f', "; done
 
 cat >"$SRC/msan-native.ini" <<EOF
 [binaries]

--- a/scripts/build/build_msan_sysroot.sh
+++ b/scripts/build/build_msan_sysroot.sh
@@ -257,7 +257,7 @@ echo ">>> zlib"
 cd "$SRC"
 [[ -d "zlib-$ZLIB_VERSION" ]] || { wget -q -O - "https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz" | tar xz; }
 cd "zlib-$ZLIB_VERSION"
-CC="$CC_BIN" CFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" ./configure --prefix="$SYSROOT" --static
+CC="$CC_BIN" CFLAGS="$MSAN" LDFLAGS="-fsanitize=memory ${LDFLAGS:-}" ./configure --prefix="$SYSROOT" --static
 make -j"$(nproc)" && make install
 
 # libffi
@@ -265,7 +265,7 @@ echo ">>> libffi"
 cd "$SRC"
 [[ -d "libffi-$LIBFFI_VERSION" ]] || { wget -q "https://github.com/libffi/libffi/releases/download/v$LIBFFI_VERSION/libffi-$LIBFFI_VERSION.tar.gz" && tar xzf "libffi-$LIBFFI_VERSION.tar.gz"; }
 cd "libffi-$LIBFFI_VERSION"
-CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
+CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory ${LDFLAGS:-}" \
     ./configure --prefix="$SYSROOT" --disable-shared --enable-static --quiet
 make -j"$(nproc)" && make install
 
@@ -274,7 +274,7 @@ echo ">>> pcre2"
 cd "$SRC"
 [[ -d "pcre2-$PCRE2_VERSION" ]] || { wget -q "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz" && tar xzf "pcre2-$PCRE2_VERSION.tar.gz"; }
 cd "pcre2-$PCRE2_VERSION"
-CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
+CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory ${LDFLAGS:-}" \
     ./configure --prefix="$SYSROOT" --disable-shared --enable-static --quiet
 make -j"$(nproc)" && make install
 

--- a/scripts/build/build_msan_sysroot.sh
+++ b/scripts/build/build_msan_sysroot.sh
@@ -41,7 +41,8 @@ DEFAULT_SYSROOT="$HOME/.cache/matter/msan_sysroot"
 IGNORELIST="$CHIP_ROOT/build/config/compiler/msan_ignorelist.txt"
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 SRC="${TMPDIR:-/tmp}/msan-build"
-MSAN="-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -fPIC"
+# MSAN flags and the dep compiler are mode-dependent (local vs --oss-fuzz); computed below
+# once arguments and the environment have been parsed.
 
 # Pinned for reproducibility and to keep msan_ignorelist.txt source paths
 # matching. On bump: verify clean MSAN build, no new false positives, and
@@ -55,7 +56,7 @@ GLIB_SERIES="${GLIB_VERSION%.*}" # GNOME download path uses major.minor (e.g. 2.
 
 usage() {
     cat <<EOF
-Usage: $(basename "$0") [--out-dir PATH] [--force] [--check] [--help]
+Usage: $(basename "$0") [--out-dir PATH] [--force] [--check] [--oss-fuzz] [--help]
 
 Builds an MSan-instrumented sysroot for Matter MSAN tests.
 
@@ -64,6 +65,10 @@ Options:
   --force          Rebuild even if the existing sysroot is current
   --check          Report freshness only; exit 0 if current, 2 if missing,
                    3 if stale. Does not start a build.
+  --oss-fuzz       Build for an OSS-Fuzz container: use the OSS-Fuzz compiler
+                   (\$CC/\$CXX) and \$CFLAGS (which already carry -fsanitize=memory),
+                   and SKIP building libc++ (OSS-Fuzz ships its own instrumented
+                   libc++ at /usr/msan). Builds only the C dependencies.
   --help           Show this message
 
 Environment:
@@ -82,6 +87,7 @@ EOF
 
 FORCE=0
 CHECK_ONLY=0
+OSS_FUZZ=0
 OUT_DIR=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -95,6 +101,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --check)
             CHECK_ONLY=1
+            shift
+            ;;
+        --oss-fuzz)
+            OSS_FUZZ=1
             shift
             ;;
         --help | -h)
@@ -113,20 +123,36 @@ SYSROOT="${OUT_DIR:-${SYSROOT_MSAN:-$DEFAULT_SYSROOT}}"
 STAMP="$SYSROOT/.build_complete"
 LOCKFILE="$SYSROOT/.build.lock"
 
-if [[ ! -x "$PW_CLANG" ]] || [[ ! -x "$PW_CLANGXX" ]]; then
-    echo "ERROR: Pigweed clang/clang++ not found on PATH" >&2
-    echo "  clang:   ${PW_CLANG:-<none>}" >&2
-    echo "  clang++: ${PW_CLANGXX:-<none>}" >&2
-    echo "Run: source scripts/activate.sh" >&2
-    exit 1
-fi
+# Resolve the dependency compiler and the MSAN compile flags.
+#   Local:    Pigweed's clang builds an instrumented libc++ and the C deps; the
+#             "is this Pigweed's clang" guard below catches a forgotten activate.sh.
+#   OSS-Fuzz: the container provides $CC/$CXX and $CFLAGS (already carrying
+#             -fsanitize=memory -fsanitize-memory-track-origins). libc++ is shipped
+#             instrumented at /usr/msan, so it is NOT built here.
+if [[ "$OSS_FUZZ" -eq 1 ]]; then
+    CC_BIN="${CC:-clang}"
+    CXX_BIN="${CXX:-clang++}"
+    MSAN="${CFLAGS:-} -fPIC"
+else
+    if [[ ! -x "$PW_CLANG" ]] || [[ ! -x "$PW_CLANGXX" ]]; then
+        echo "ERROR: Pigweed clang/clang++ not found on PATH" >&2
+        echo "  clang:   ${PW_CLANG:-<none>}" >&2
+        echo "  clang++: ${PW_CLANGXX:-<none>}" >&2
+        echo "Run: source scripts/activate.sh" >&2
+        exit 1
+    fi
 
-LLVM_COMMIT="$("$PW_CLANG" --version | grep -oP '[0-9a-f]{40}' || true)"
-if [[ -z "$LLVM_COMMIT" ]]; then
-    echo "ERROR: clang on PATH is not Pigweed's (no LLVM commit in --version)" >&2
-    echo "  clang: $PW_CLANG" >&2
-    echo "Run: source scripts/activate.sh" >&2
-    exit 1
+    LLVM_COMMIT="$("$PW_CLANG" --version | grep -oP '[0-9a-f]{40}' || true)"
+    if [[ -z "$LLVM_COMMIT" ]]; then
+        echo "ERROR: clang on PATH is not Pigweed's (no LLVM commit in --version)" >&2
+        echo "  clang: $PW_CLANG" >&2
+        echo "Run: source scripts/activate.sh" >&2
+        exit 1
+    fi
+
+    CC_BIN="$PW_CLANG"
+    CXX_BIN="$PW_CLANGXX"
+    MSAN="-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -fPIC"
 fi
 
 if [[ ! -f "$IGNORELIST" ]]; then
@@ -143,7 +169,7 @@ compute_input_hash() {
     {
         sha256sum <"$SCRIPT_PATH" | cut -d' ' -f1
         sha256sum <"$IGNORELIST" | cut -d' ' -f1
-        "$PW_CLANG" --version
+        "$CC_BIN" --version
     } | sha256sum | cut -d' ' -f1
 }
 
@@ -197,28 +223,32 @@ trap on_error ERR
 
 echo ">>> Building MSAN sysroot at $SYSROOT (this takes 5-15 min)"
 
-# libc++ / libc++abi (MSan-instrumented)
-echo ">>> libc++ / libc++abi"
-if [[ ! -d "$SRC/llvm-project" ]]; then
-    git clone --depth 1 https://llvm.googlesource.com/llvm-project "$SRC/llvm-project"
+# libc++ / libc++abi (MSan-instrumented). Skipped under --oss-fuzz: the OSS-Fuzz base image
+# already ships an instrumented libc++ at /usr/msan built with its own clang, and reusing
+# ours (built with Pigweed clang) would mismatch the fuzzer's compiler.
+if [[ "$OSS_FUZZ" -eq 0 ]]; then
+    echo ">>> libc++ / libc++abi"
+    if [[ ! -d "$SRC/llvm-project" ]]; then
+        git clone --depth 1 https://llvm.googlesource.com/llvm-project "$SRC/llvm-project"
+    fi
+    cd "$SRC/llvm-project"
+    git fetch --depth 1 origin "$LLVM_COMMIT"
+    git checkout FETCH_HEAD
+    cmake -GNinja -S "$SRC/llvm-project/runtimes" -B "$SRC/libcxx" \
+        -DCMAKE_C_COMPILER="$CC_BIN" -DCMAKE_CXX_COMPILER="$CXX_BIN" \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_USE_SANITIZER=MemoryWithOrigins -DCMAKE_INSTALL_PREFIX="$SYSROOT" \
+        -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXXABI_ENABLE_SHARED=OFF -DLIBCXXABI_USE_LLVM_UNWINDER=OFF
+    ninja -C "$SRC/libcxx" -j"$(nproc)" cxx cxxabi
+    ninja -C "$SRC/libcxx" install-cxx install-cxxabi
 fi
-cd "$SRC/llvm-project"
-git fetch --depth 1 origin "$LLVM_COMMIT"
-git checkout FETCH_HEAD
-cmake -GNinja -S "$SRC/llvm-project/runtimes" -B "$SRC/libcxx" \
-    -DCMAKE_C_COMPILER="$PW_CLANG" -DCMAKE_CXX_COMPILER="$PW_CLANGXX" \
-    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_USE_SANITIZER=MemoryWithOrigins -DCMAKE_INSTALL_PREFIX="$SYSROOT" \
-    -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXXABI_ENABLE_SHARED=OFF -DLIBCXXABI_USE_LLVM_UNWINDER=OFF
-ninja -C "$SRC/libcxx" -j"$(nproc)" cxx cxxabi
-ninja -C "$SRC/libcxx" install-cxx install-cxxabi
 
 # OpenSSL
 echo ">>> OpenSSL"
 cd "$SRC"
 [[ -d "openssl-$OPENSSL_VERSION" ]] || { wget -q "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && tar xzf "openssl-$OPENSSL_VERSION.tar.gz"; }
 cd "openssl-$OPENSSL_VERSION"
-CC="$PW_CLANG $MSAN" ./Configure linux-x86_64 --prefix="$SYSROOT" --openssldir="$SYSROOT/ssl" no-asm no-shared -DPURIFY
+CC="$CC_BIN $MSAN" ./Configure linux-x86_64 --prefix="$SYSROOT" --openssldir="$SYSROOT/ssl" no-asm no-shared -DPURIFY
 make -j"$(nproc)" build_libs
 make install_dev
 
@@ -227,7 +257,7 @@ echo ">>> zlib"
 cd "$SRC"
 [[ -d "zlib-$ZLIB_VERSION" ]] || { wget -q -O - "https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz" | tar xz; }
 cd "zlib-$ZLIB_VERSION"
-CC="$PW_CLANG" CFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" ./configure --prefix="$SYSROOT" --static
+CC="$CC_BIN" CFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" ./configure --prefix="$SYSROOT" --static
 make -j"$(nproc)" && make install
 
 # libffi
@@ -235,7 +265,7 @@ echo ">>> libffi"
 cd "$SRC"
 [[ -d "libffi-$LIBFFI_VERSION" ]] || { wget -q "https://github.com/libffi/libffi/releases/download/v$LIBFFI_VERSION/libffi-$LIBFFI_VERSION.tar.gz" && tar xzf "libffi-$LIBFFI_VERSION.tar.gz"; }
 cd "libffi-$LIBFFI_VERSION"
-CC="$PW_CLANG" CXX="$PW_CLANGXX" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
+CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
     ./configure --prefix="$SYSROOT" --disable-shared --enable-static --quiet
 make -j"$(nproc)" && make install
 
@@ -244,7 +274,7 @@ echo ">>> pcre2"
 cd "$SRC"
 [[ -d "pcre2-$PCRE2_VERSION" ]] || { wget -q "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz" && tar xzf "pcre2-$PCRE2_VERSION.tar.gz"; }
 cd "pcre2-$PCRE2_VERSION"
-CC="$PW_CLANG" CXX="$PW_CLANGXX" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
+CC="$CC_BIN" CXX="$CXX_BIN" CFLAGS="$MSAN" CXXFLAGS="$MSAN" LDFLAGS="-fsanitize=memory" \
     ./configure --prefix="$SYSROOT" --disable-shared --enable-static --quiet
 make -j"$(nproc)" && make install
 
@@ -253,17 +283,22 @@ echo ">>> GLib"
 cd "$SRC"
 [[ -d "glib-$GLIB_VERSION" ]] || { wget -q "https://download.gnome.org/sources/glib/$GLIB_SERIES/glib-$GLIB_VERSION.tar.xz" && tar xf "glib-$GLIB_VERSION.tar.xz"; }
 
+# Meson wants the flags as a quoted array; derive it from $MSAN so the GLib build uses the
+# same flag set as the other deps (the OSS-Fuzz $CFLAGS or the local default).
+_msan_meson=""
+for _f in $MSAN; do _msan_meson+="'$_f', "; done
+
 cat >"$SRC/msan-native.ini" <<EOF
 [binaries]
-c = '$PW_CLANG'
-cpp = '$PW_CLANGXX'
+c = '$CC_BIN'
+cpp = '$CXX_BIN'
 ar = 'ar'
 strip = 'strip'
 pkgconfig = 'pkg-config'
 
 [built-in options]
-c_args = ['-fsanitize=memory', '-fsanitize-memory-track-origins', '-fno-omit-frame-pointer', '-fPIC', '-Wno-error=implicit-function-declaration', '-fsanitize-ignorelist=$IGNORELIST']
-cpp_args = ['-fsanitize=memory', '-fsanitize-memory-track-origins', '-fno-omit-frame-pointer', '-fPIC', '-fsanitize-ignorelist=$IGNORELIST']
+c_args = [${_msan_meson}'-fsanitize-ignorelist=$IGNORELIST', '-Wno-error=implicit-function-declaration']
+cpp_args = [${_msan_meson}'-fsanitize-ignorelist=$IGNORELIST']
 c_link_args = ['-fsanitize=memory']
 cpp_link_args = ['-fsanitize=memory']
 

--- a/scripts/build/build_msan_sysroot.sh
+++ b/scripts/build/build_msan_sysroot.sh
@@ -286,7 +286,7 @@ cd "$SRC"
 # Meson wants the flags as a quoted array; derive it from $MSAN so the GLib build uses the
 # same flag set as the other deps (the OSS-Fuzz $CFLAGS or the local default).
 _msan_meson=""
-for _f in $MSAN; do _msan_meson+="'$_f', "; done
+for _f in "$MSAN"; do _msan_meson+="'$_f', "; done
 
 cat >"$SRC/msan-native.ini" <<EOF
 [binaries]

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -550,7 +550,13 @@ class HostBuilder(GnBuilder):
         if use_msan:
             if not runner.dry_run:
                 _msan_validate_sysroot(chip_root)
-            self.extra_gn_options.append('is_msan=true')
+            if fuzzing_type == HostFuzzingType.PW_FUZZTEST:
+                # pw_fuzzer FuzzTest targets build in the chip_pw_fuzztest secondary toolchain,
+                # which does not consume chip's global is_msan/sanitize_default. Drive MSAN via
+                # the toolchain arg instead (it swaps pigweed's ASan for chip's sanitize_memory).
+                self.extra_gn_options.append('chip_pw_fuzz_msan=true')
+            else:
+                self.extra_gn_options.append('is_msan=true')
             # Tell GN to build against the same sysroot we just validated.
             self.extra_gn_options.append(f'msan_sysroot="{_msan_sysroot_path()}"')
 


### PR DESCRIPTION
#### Summary

Adds MemorySanitizer (MSAN) support to the fuzz targets, building on the MSAN unit-test infrastructure from #71784. This makes both the legacy libFuzzer harnesses (`chip_fuzz_target`) and the pw_fuzzer / Google FuzzTest harnesses (`chip_pw_fuzz_target`) buildable and runnable under MSAN — locally for reproduction, and on OSS-Fuzz (which previously had the `memory` sanitizer disabled for this project due to uninstrumented dependencies).

MSAN requires every linked object to be instrumented, including the C++ runtime and third-party dependencies. The unit-test work (#71784) already provides an instrumented dependency sysroot (`build_msan_sysroot.sh`) and the `sanitize_memory` config; this change wires that into the fuzz build paths.

#### Changes

- **`build_msan_sysroot.sh`**: add an `--oss-fuzz` mode that builds only the C dependencies (OpenSSL, zlib, libffi, pcre2, GLib) using the OSS-Fuzz compiler (`$CC`/`$CXX`) and `$CFLAGS`, and skips building libc++ — OSS-Fuzz ships its own instrumented libc++ (`/usr/msan`, applied via `-stdlib=libc++`), and reusing a libc++ built with a different clang would mismatch. The default local mode is unchanged.
- **Move `is_msan` / `msan_sysroot`** declare_args from `build/config/compiler/BUILD.gn` to `build/config/compiler/compiler.gni`, so the fuzz templates and the `pw_fuzzer` toolchain (which import the `.gni`, but cannot import a `BUILD.gn`) can read `is_msan`.
- **Local libFuzzer targets** (`chip_fuzz_target`): apply `sanitize_memory` instead of `sanitize_address` when `is_msan` is set. ASan and MSAN are mutually exclusive, and `sanitize_memory` is already applied globally via `sanitize_default`.
- **Local pw_fuzzer / FuzzTest targets**: add a `chip_pw_fuzz_msan` toolchain arg that swaps pigweed's ASan for chip's `sanitize_memory` in the `chip_pw_fuzztest` toolchain (which does not consume chip's global `sanitize_default`).
- **`build_examples`**: the `msan` modifier now composes with `libfuzzer` and `pw-fuzztest`; `host.py` drives the pw_fuzzer path via `chip_pw_fuzz_msan` and the libFuzzer / unit-test path via `is_msan`.

New buildable targets, e.g.:

```
scripts/build/build_examples.py --target linux-x64-tests-clang-pw-fuzztest-msan build
scripts/build/build_examples.py --target linux-x64-tests-clang-libfuzzer-msan build
```

(The OSS-Fuzz `connectedhomeip` project configuration — Dockerfile/build.sh/`project.yaml` — is updated in a companion change in the OSS-Fuzz repository; it invokes `build_msan_sysroot.sh --oss-fuzz` and re-enables the `memory` sanitizer.)

#### Testing

- Built and ran the local targets under MSAN against the instrumented sysroot:
  - `linux-x64-tests-clang-libfuzzer-msan` — `fuzz-tlv-reader` ran 30000 inputs to a clean `Done`, no MSAN report (links the instrumented libc++ and OpenSSL).
  - `linux-x64-tests-clang-pw-fuzztest-msan` — `fuzz-tlv-reader-pw` fuzzed cleanly under MSAN.
- Validated the `--oss-fuzz` path end-to-end in the OSS-Fuzz base image (`SANITIZER=memory`): the dependency sysroot builds with the OSS-Fuzz clang, all fuzz targets compile (legacy libFuzzer + per-case FuzzTest wrappers), and `check_build` passes.
- `gn gen` succeeds for both new target flavors with `--fail-on-unused-args`; the default (non-MSAN) build paths are unchanged.
