### PR TITLE
[OperationalSessionSetup] Re-resolve operational address on CASE timeout

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -468,6 +468,45 @@ void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error, Sess
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
         mTryingNextResultDueToSessionEstablishmentError = true;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
+        // On CHIP_ERROR_TIMEOUT we never even got a Sigma2 back: the cached
+        // address may be stale (e.g. a Thread sleepy end device whose
+        // operational SRP record was published only after our initial lookup
+        // completed, so it advertises a new address while we kept retransmitting
+        // Sigma1 to the pre-operational one). Before exhausting the cached
+        // snapshot, kick off a fresh DNS-SD lookup so a newer operational
+        // advertisement can be picked up, rather than walking only the stale
+        // results until the full commissioning watchdog fires. A fresh lookup
+        // both re-queries DNS-SD and discards the stale cached snapshot
+        // (LookupNode resets the handle), so any newer address wins. BUSY is a
+        // live response from the current address, so for BUSY we keep the
+        // existing behavior of trying the cached results first.
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+        if (CHIP_ERROR_TIMEOUT == error && mResolveAttemptsAllowed > 0)
+        {
+            // The fresh lookup drives its own success/failure handling via
+            // OnNodeAddressResolved / OnNodeAddressResolutionFailed and its own
+            // retry-handler notification below, so it must NOT be treated as the
+            // synchronous "try next cached result" path.
+            mTryingNextResultDueToSessionEstablishmentError = false;
+            CHIP_ERROR lookupErr                            = LookupPeerAddress();
+            if (lookupErr == CHIP_NO_ERROR)
+            {
+                // A fresh lookup is in flight; OnNodeAddressResolved (or
+                // OnNodeAddressResolutionFailed) will drive us forward. We have
+                // to notify our consumer that the resolve will take more time,
+                // but we don't know how much; mirror the estimate used by
+                // OnNodeAddressResolutionFailed's re-resolve path.
+                using namespace chip::System::Clock::Literals;
+                NotifyRetryHandlers(error, remoteMprConfig, 60_s16);
+                return;
+            }
+            // Could not start a fresh lookup; restore the flag and fall through
+            // to the cached snapshot / backoff handling below.
+            mTryingNextResultDueToSessionEstablishmentError = true;
+        }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
         if (CHIP_NO_ERROR == Resolver::Instance().TryNextResult(mAddressLookupHandle))
         {
             // Whatever work we needed to do has been handled by our

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -482,7 +482,7 @@ void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error, Sess
         // live response from the current address, so for BUSY we keep the
         // existing behavior of trying the cached results first.
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
-        if (CHIP_ERROR_TIMEOUT == error && mResolveAttemptsAllowed > 0)
+        if (CHIP_ERROR_TIMEOUT == error && mRemainingAttempts > 0 && mResolveAttemptsAllowed > 0)
         {
             // The fresh lookup drives its own success/failure handling via
             // OnNodeAddressResolved / OnNodeAddressResolutionFailed and its own
@@ -493,9 +493,16 @@ void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error, Sess
             if (lookupErr == CHIP_NO_ERROR)
             {
                 // A fresh lookup is in flight; OnNodeAddressResolved (or
-                // OnNodeAddressResolutionFailed) will drive us forward. We have
-                // to notify our consumer that the resolve will take more time,
-                // but we don't know how much; mirror the estimate used by
+                // OnNodeAddressResolutionFailed) will drive us forward.
+                // LookupPeerAddress() has already consumed an attempt from both
+                // mRemainingAttempts and mResolveAttemptsAllowed, so a peer that
+                // keeps re-resolving (DNS-SD answers) while CASE keeps timing out
+                // cannot loop here forever: each fresh-lookup re-resolve costs one
+                // attempt, and the guard above stops taking this path once either
+                // counter hits 0.
+                //
+                // We have to notify our consumer that the resolve will take more
+                // time, but we don't know how much; mirror the estimate used by
                 // OnNodeAddressResolutionFailed's re-resolve path.
                 using namespace chip::System::Clock::Literals;
                 NotifyRetryHandlers(error, remoteMprConfig, 60_s16);

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -52,6 +52,9 @@ namespace chip {
 
 class OperationalSessionSetup;
 
+// Test-only access shim (see src/app/tests/OperationalSessionSetupTestAccess.h).
+class OperationalSessionSetupTestAccess;
+
 /**
  * @brief Delegate provided when creating OperationalSessionSetup.
  *
@@ -293,6 +296,10 @@ public:
 #endif // CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
 
 private:
+    // Grants the test access shim access to private state for re-resolve-on-timeout
+    // regression coverage. See src/app/tests/OperationalSessionSetupTestAccess.h.
+    friend class OperationalSessionSetupTestAccess;
+
     enum class State : uint8_t
     {
         Uninitialized,    // Error state: OperationalSessionSetup is useless

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -188,6 +188,8 @@ chip_test_suite("tests") {
     "TestMessageDef.cpp",
     "TestNumericAttributeTraits.cpp",
     "TestOperationalSessionSetupFallback.cpp",
+    "TestOperationalSessionSetupReresolve.cpp",
+    "OperationalSessionSetupTestAccess.h",
     "TestOperationalStateClusterObjects.cpp",
     "TestPendingResponseTrackerImpl.cpp",
     "TestPowerSourceCluster.cpp",

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -189,7 +189,6 @@ chip_test_suite("tests") {
     "TestNumericAttributeTraits.cpp",
     "TestOperationalSessionSetupFallback.cpp",
     "TestOperationalSessionSetupReresolve.cpp",
-    "OperationalSessionSetupTestAccess.h",
     "TestOperationalStateClusterObjects.cpp",
     "TestPendingResponseTrackerImpl.cpp",
     "TestPowerSourceCluster.cpp",
@@ -207,6 +206,8 @@ chip_test_suite("tests") {
   ]
 
   cflags = [ "-Wconversion" ]
+
+  sources = [ "OperationalSessionSetupTestAccess.h" ]
 
   public_deps = [
     ":app-test-stubs",

--- a/src/app/tests/OperationalSessionSetupTestAccess.h
+++ b/src/app/tests/OperationalSessionSetupTestAccess.h
@@ -1,0 +1,106 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/OperationalSessionSetup.h>
+#include <lib/address_resolve/AddressResolve.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/PeerId.h>
+#include <system/SystemClock.h>
+
+namespace chip {
+
+// Minimal, test-owned access to the private members of OperationalSessionSetup
+// needed to drive OnSessionEstablishmentError() directly (regression coverage
+// for the stale-operational-address re-resolve fix) without standing up a real
+// CASE handshake. Granted via a single `friend class` in OperationalSessionSetup.h.
+class OperationalSessionSetupTestAccess
+{
+public:
+    // Set the peer id so LookupPeerAddress() can target the right node.
+    static void SetPeerId(OperationalSessionSetup & setup, const ScopedNodeId & peerId) { setup.mPeerId = peerId; }
+
+    // Force the setup into the Connecting state with an allocated CASE client, so
+    // that OnSessionEstablishmentError() (which requires mState == Connecting and
+    // dereferences mCASEClient) can be invoked directly. The init params (in
+    // particular the fabric table, needed by LookupPeerAddress) and the client
+    // pool are set directly so the setup need not pass full CASEClientInitParams
+    // validation (which requires a group data provider not present in this
+    // harness).
+    static CHIP_ERROR EnterConnectingWithCaseClient(OperationalSessionSetup & setup, const CASEClientInitParams & params,
+                                                    CASEClientPoolDelegate & clientPool,
+                                                    OperationalSessionReleaseDelegate & releaseDelegate)
+    {
+        setup.mInitParams      = params;
+        setup.mClientPool      = &clientPool;
+        setup.mReleaseDelegate = &releaseDelegate;
+        setup.mAddressLookupHandle.SetListener(&setup);
+        if (setup.mCASEClient == nullptr)
+        {
+            setup.mCASEClient = setup.mClientPool->Allocate();
+            VerifyOrReturnError(setup.mCASEClient != nullptr, CHIP_ERROR_NO_MEMORY);
+        }
+        setup.mState = OperationalSessionSetup::State::Connecting;
+        return CHIP_NO_ERROR;
+    }
+
+    // Set the number of fresh DNS-SD resolve attempts the setup is allowed to make.
+    static void SetResolveAttemptsAllowed(OperationalSessionSetup & setup, uint8_t attempts)
+    {
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+        setup.mResolveAttemptsAllowed = attempts;
+        if (attempts > setup.mRemainingAttempts)
+        {
+            setup.mRemainingAttempts = attempts;
+        }
+#else
+        (void) setup;
+        (void) attempts;
+#endif
+    }
+
+    // Seed the setup's address-lookup handle with a (stale) cached result, as if
+    // a prior resolution had completed. This mirrors the pre-operational address
+    // that CASE locked onto in the stale-address timeout scenario.
+    static void SeedCachedLookupResult(OperationalSessionSetup & setup, const AddressResolve::ResolveResult & result)
+    {
+        auto now = System::SystemClock().GetMonotonicTimestamp();
+        AddressResolve::NodeLookupRequest request(PeerId(0, setup.mPeerId.GetNodeId()));
+        setup.mAddressLookupHandle.ResetForLookup(now, request);
+        setup.mAddressLookupHandle.LookupResult(result);
+    }
+
+    static bool HasCachedLookupResult(const OperationalSessionSetup & setup)
+    {
+        return setup.mAddressLookupHandle.HasLookupResult();
+    }
+
+    static OperationalSessionSetup::State GetState(const OperationalSessionSetup & setup) { return setup.mState; }
+
+    static AddressResolve::NodeLookupHandle & GetAddressLookupHandle(OperationalSessionSetup & setup)
+    {
+        return setup.mAddressLookupHandle;
+    }
+
+    static void InvokeOnSessionEstablishmentError(OperationalSessionSetup & setup, CHIP_ERROR error)
+    {
+        setup.OnSessionEstablishmentError(error, SessionEstablishmentStage::kSentSigma1);
+    }
+};
+
+} // namespace chip

--- a/src/app/tests/TestOperationalSessionSetupReresolve.cpp
+++ b/src/app/tests/TestOperationalSessionSetupReresolve.cpp
@@ -1,0 +1,203 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// Regression coverage for stale-operational-address re-resolve on CASE timeout:
+//
+// A controller commissioning a Thread Sleepy End Device locks CASE onto the
+// device's STALE pre-operational address and, on CASE Sigma1 timeout, kept
+// retransmitting to that dead address (walking only the cached resolve
+// snapshot) instead of re-resolving. The device's real operational SRP record
+// (a NEW address) was published ~12s later but never picked up, so commissioning
+// hung until the watchdog fired.
+//
+// The fix: OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT)
+// now starts a FRESH DNS-SD lookup (LookupPeerAddress -> Resolver::LookupNode ->
+// Dnssd::Resolver::ResolveNodeId) before exhausting the stale cached snapshot,
+// so a newer operational advertisement can be obtained.
+//
+// This test drives OnSessionEstablishmentError(TIMEOUT) directly on a setup that
+// has a stale cached result and asserts that a fresh DNS-SD query is issued.
+//
+// Fail-without-fix: the pre-fix code calls Resolver::TryNextResult() first, which
+// re-delivers the stale cached address synchronously (no fresh ResolveNodeId),
+// so mResolveNodeIdCount stays 0 and the assertion fails.
+
+#include <pw_unit_test/framework.h>
+
+#include <app/CASEClientPool.h>
+#include <app/OperationalSessionSetup.h>
+#include <app/OperationalSessionSetupPool.h>
+#include <app/tests/AppTestContext.h>
+#include <app/tests/OperationalSessionSetupTestAccess.h>
+#include <lib/address_resolve/AddressResolve.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/ScopedNodeId.h>
+#include <lib/dnssd/Resolver.h>
+#include <lib/support/CodeUtils.h>
+#include <transport/raw/PeerAddress.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::Inet;
+using namespace chip::Transport;
+
+namespace {
+
+using OSSAccess = chip::OperationalSessionSetupTestAccess;
+
+using TestSetupPool  = OperationalSessionSetupPool<2>;
+using TestClientPool = CASEClientPool<2>;
+
+constexpr NodeId kTestNodeId = 0x123456789abcdefULL;
+
+// A no-op release delegate. The re-resolve success path of
+// OnSessionEstablishmentError() never releases the setup (it starts a fresh
+// lookup and returns), so this is only the delegate the pool requires to
+// allocate a setup; the test releases the pool directly at teardown.
+class NoopReleaseDelegate : public OperationalSessionReleaseDelegate
+{
+public:
+    void ReleaseSession(OperationalSessionSetup *) override {}
+};
+
+// A Dnssd::Resolver mock that counts ResolveNodeId calls. A fresh operational
+// DNS-SD lookup is what surfaces a newer SRP/operational advertisement, so a
+// bump in this counter is the observable signal that we re-resolved rather than
+// reusing the stale cached snapshot.
+class CountingDnssdResolver : public chip::Dnssd::Resolver
+{
+public:
+    CHIP_ERROR Init(chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> *) override { return CHIP_NO_ERROR; }
+    bool IsInitialized() override { return true; }
+    void Shutdown() override {}
+    void SetOperationalDelegate(chip::Dnssd::OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId) override
+    {
+        mResolveNodeIdCount++;
+        mLastResolvedPeer = peerId;
+        return CHIP_NO_ERROR;
+    }
+    void NodeIdResolutionNoLongerNeeded(const PeerId &) override {}
+    CHIP_ERROR StartDiscovery(chip::Dnssd::DiscoveryType, chip::Dnssd::DiscoveryFilter, chip::Dnssd::DiscoveryContext &) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR StopDiscovery(chip::Dnssd::DiscoveryContext &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR ReconfirmRecord(const char *, Inet::IPAddress, Inet::InterfaceId) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    int mResolveNodeIdCount                                        = 0;
+    PeerId mLastResolvedPeer                                       = PeerId();
+    chip::Dnssd::OperationalResolveDelegate * mOperationalDelegate = nullptr;
+};
+
+class TestOperationalSessionSetupReresolve : public chip::Testing::AppContext
+{
+public:
+    void SetUp() override
+    {
+        AppContext::SetUp();
+        // A fabric is required for LookupPeerAddress() (it resolves the
+        // compressed fabric id). Alice's fabric is provided by the harness.
+        ASSERT_EQ(CreateAliceFabric(), CHIP_NO_ERROR);
+
+        // Route the address resolver's underlying DNS-SD queries to our counting
+        // mock and (re)initialize the global address resolver against the test
+        // system layer so LookupNode is functional.
+        mPreviousDnssdResolver = &chip::Dnssd::Resolver::Instance();
+        chip::Dnssd::Resolver::SetInstance(mDnssdResolver);
+        ASSERT_EQ(AddressResolve::Resolver::Instance().Init(&GetSystemLayer()), CHIP_NO_ERROR);
+    }
+
+    void TearDown() override
+    {
+        AddressResolve::Resolver::Instance().Shutdown();
+        if (mPreviousDnssdResolver != nullptr)
+        {
+            chip::Dnssd::Resolver::SetInstance(*mPreviousDnssdResolver);
+        }
+        AppContext::TearDown();
+    }
+
+protected:
+    CountingDnssdResolver mDnssdResolver;
+    chip::Dnssd::Resolver * mPreviousDnssdResolver = nullptr;
+
+    AddressResolve::ResolveResult StaleResult()
+    {
+        AddressResolve::ResolveResult result;
+        IPAddress addr;
+        // The stale, pre-operational address (matches the scenario's
+        // fd72:...:7ecd:... record that CASE locked onto).
+        EXPECT_TRUE(IPAddress::FromString("fd72:71b4:b243:1:7ecd:2485:9aeb:f3b0", addr));
+        result.address         = PeerAddress::UDP(addr, CHIP_PORT);
+        result.mrpRemoteConfig = GetDefaultMRPConfig();
+        return result;
+    }
+};
+
+// On CASE timeout, with resolve attempts remaining and a stale cached result,
+// OnSessionEstablishmentError must trigger a FRESH DNS-SD lookup so a newer
+// operational advertisement can be obtained -- instead of only re-trying the
+// stale cached address.
+TEST_F(TestOperationalSessionSetupReresolve, TimeoutWithResolveAttemptsTriggersFreshLookup)
+{
+    TestSetupPool pool;
+    TestClientPool clientPool;
+    NoopReleaseDelegate releaseDelegate;
+
+    ScopedNodeId peerId(kTestNodeId, GetAliceFabricIndex());
+
+    CASEClientInitParams params;
+    params.sessionManager = &GetSecureSessionManager();
+    params.exchangeMgr    = &GetExchangeManager();
+    params.fabricTable    = &GetFabricTable();
+
+    auto * setup = pool.Allocate(params, &clientPool, peerId, &releaseDelegate);
+    ASSERT_NE(setup, nullptr);
+    OSSAccess::SetPeerId(*setup, peerId);
+
+    // Arrange: a stale cached resolve result (as if CASE had locked onto the
+    // pre-operational address), at least one fresh resolve attempt allowed, and
+    // the setup mid-handshake (Connecting) with an allocated CASE client.
+    OSSAccess::SeedCachedLookupResult(*setup, StaleResult());
+    ASSERT_TRUE(OSSAccess::HasCachedLookupResult(*setup));
+    OSSAccess::SetResolveAttemptsAllowed(*setup, 2);
+    ASSERT_EQ(OSSAccess::EnterConnectingWithCaseClient(*setup, params, clientPool, releaseDelegate), CHIP_NO_ERROR);
+
+    const int resolvesBefore = mDnssdResolver.mResolveNodeIdCount;
+
+    // Act: CASE Sigma1 timed out.
+    OSSAccess::InvokeOnSessionEstablishmentError(*setup, CHIP_ERROR_TIMEOUT);
+
+    // Assert: a fresh DNS-SD query was issued (re-resolve), rather than only
+    // re-walking the stale cached snapshot. This is the crux of the fix.
+    EXPECT_GT(mDnssdResolver.mResolveNodeIdCount, resolvesBefore);
+    EXPECT_EQ(mDnssdResolver.mLastResolvedPeer.GetNodeId(), kTestNodeId);
+
+    // The fresh lookup is now in flight on the global resolver; cancel it before
+    // the setup and resolver are torn down so no callback fires into freed state.
+    if (OSSAccess::GetAddressLookupHandle(*setup).IsActive())
+    {
+        LogErrorOnFailure(AddressResolve::Resolver::Instance().CancelLookup(OSSAccess::GetAddressLookupHandle(*setup),
+                                                                            AddressResolve::Resolver::FailureCallback::Skip));
+    }
+
+    pool.ReleaseAllSessionSetupsForFabric(GetAliceFabricIndex());
+}
+
+} // namespace

--- a/src/lib/address_resolve/tests/TestAddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/tests/TestAddressResolve_DefaultImpl.cpp
@@ -865,4 +865,161 @@ TEST_F(TestAddressResolveDefaultImplWithSystemLayerAndNodeListener, ResolverShut
     EXPECT_EQ(expectedError, CHIP_ERROR_SHUT_DOWN);
 }
 
+// Regression test for stale-operational-address re-resolve on CASE timeout.
+//
+// Scenario: a controller commissions a Thread Sleepy End Device. The device
+// first advertises a pre-operational address (A). The initial operational
+// lookup resolves to A, so the resolver delivers A and erases the lookup
+// handle (just like CASE locking onto A). The device then publishes its real
+// operational SRP record (~12s later) advertising a NEW address (B).
+//
+// Before the fix, OperationalSessionSetup only walked the stale cached snapshot
+// (containing A) on CASE timeout, so a fresh OnOperationalNodeResolved carrying
+// B was dropped because no lookup was active, and CASE kept retransmitting
+// Sigma1 to the dead address A until the commissioning watchdog timed out.
+//
+// After the fix, OperationalSessionSetup::OnSessionEstablishmentError(TIMEOUT)
+// starts a FRESH LookupNode rather than only consuming the stale snapshot. This
+// test exercises the resolver behavior that fix relies on: a fresh lookup for
+// the same peer after a prior resolution must surface the newer address B (and
+// must NOT re-deliver the stale address A from a leftover cached snapshot).
+TEST_F(TestAddressResolveDefaultImplWithSystemLayerAndNodeListener, FreshLookupAfterTimeoutSurfacesNewerOperationalAddress)
+{
+    chip::Dnssd::Resolver::SetInstance(mMockResolver);
+
+    chip::AddressResolve::Impl::Resolver resolver;
+    ASSERT_EQ(resolver.Init(&mSystemLayer), CHIP_NO_ERROR);
+
+    System::Clock::Internal::RAIIMockClock clock;
+
+    auto request = NodeLookupRequest(chip::PeerId(1, 2));
+    request.SetMinLookupTime(0_ms32); // Deliver as soon as the first reply arrives.
+    request.SetMaxLookupTime(200_ms32);
+
+    AddressResolve::NodeLookupHandle handle;
+    handle.SetListener(&mNodeListener);
+
+    // The pre-operational (stale) address A and the operational (live) address B.
+    const Transport::PeerAddress staleAddressA = GetAddressWithLowScore(static_cast<uint16_t>(0x1111));
+    const Transport::PeerAddress liveAddressB  = GetAddressWithLowScore(static_cast<uint16_t>(0x2222));
+    ASSERT_NE(staleAddressA, liveAddressB);
+
+    int resolvedCount = 0;
+    Transport::PeerAddress lastResolvedAddress;
+    mNodeListener.SetOnNodeAddressResolved([&](const chip::PeerId &, const chip::AddressResolve::ResolveResult & result) {
+        ++resolvedCount;
+        lastResolvedAddress = result.address;
+    });
+
+    auto MakeNodeData = [&](const Transport::PeerAddress & address) {
+        Dnssd::ResolvedNodeData nodeData;
+        nodeData.resolutionData.numIPs       = 1;
+        nodeData.resolutionData.ipAddress[0] = address.GetIPAddress();
+        nodeData.resolutionData.interfaceId  = address.GetInterface();
+        nodeData.resolutionData.port         = address.GetPort();
+        nodeData.operationalData.peerId      = request.GetPeerId();
+        return nodeData;
+    };
+
+    // --- Initial lookup resolves to the stale pre-operational address A. ---
+    ASSERT_EQ(resolver.LookupNode(request, handle), CHIP_NO_ERROR);
+    resolver.OnOperationalNodeResolved(MakeNodeData(staleAddressA));
+
+    ASSERT_EQ(resolvedCount, 1);
+    EXPECT_EQ(lastResolvedAddress, staleAddressA);
+    // The handle has been delivered and is no longer active (CASE now owns A).
+    EXPECT_FALSE(handle.IsActive());
+
+    // --- The live operational address B is published ~12s later. ---
+    // Simulate the stale-address CASE attempt timing out by advancing the clock,
+    // then doing what OnSessionEstablishmentError(TIMEOUT) now does: a fresh
+    // LookupNode for the same peer.
+    clock.AdvanceMonotonic(12000_ms64);
+
+    ASSERT_EQ(resolver.LookupNode(request, handle), CHIP_NO_ERROR);
+    EXPECT_TRUE(handle.IsActive());
+
+    // The newer operational advertisement arrives and must be delivered.
+    resolver.OnOperationalNodeResolved(MakeNodeData(liveAddressB));
+
+    ASSERT_EQ(resolvedCount, 2);
+    // Crux of the regression: we must now be targeting the LIVE address B, not
+    // the stale address A. Before the fix the setup path would have kept
+    // retrying only A from the cached snapshot.
+    EXPECT_EQ(lastResolvedAddress, liveAddressB);
+    EXPECT_NE(lastResolvedAddress, staleAddressA);
+
+    chip::Dnssd::Resolver::SetInstance(mockResolver);
+}
+
+// Focused coverage: a fresh operational advertisement for a peer that still has
+// an in-flight lookup must surface the refreshed address. This is the resolver
+// half of the re-resolve fix: while a lookup is active, OnOperationalNode-
+// Resolved must accept a newer/better address rather than ignoring it.
+TEST_F(TestAddressResolveDefaultImplWithSystemLayerAndNodeListener,
+       OnOperationalNodeResolvedAcceptsRefreshedAddressForInFlightLookup)
+{
+    chip::Dnssd::Resolver::SetInstance(mMockResolver);
+
+    chip::AddressResolve::Impl::Resolver resolver;
+    ASSERT_EQ(resolver.Init(&mSystemLayer), CHIP_NO_ERROR);
+
+    System::Clock::Internal::RAIIMockClock clock;
+
+    auto request = NodeLookupRequest(chip::PeerId(1, 2));
+    // Keep the lookup active across multiple advertisements: do not deliver
+    // until the min lookup time elapses.
+    request.SetMinLookupTime(100_ms32);
+    request.SetMaxLookupTime(2000_ms32);
+
+    AddressResolve::NodeLookupHandle handle;
+    handle.SetListener(&mNodeListener);
+
+    // A low-score (pre-operational) address arrives first, then a higher-score
+    // (operational) address arrives while the lookup is still in flight. The
+    // higher-score address must be the one delivered.
+    const Transport::PeerAddress firstAddress  = GetAddressWithLowScore(static_cast<uint16_t>(0x3333));
+    const Transport::PeerAddress betterAddress = GetAddressWithHighScore();
+
+    int resolvedCount = 0;
+    Transport::PeerAddress lastResolvedAddress;
+    mNodeListener.SetOnNodeAddressResolved([&](const chip::PeerId &, const chip::AddressResolve::ResolveResult & result) {
+        ++resolvedCount;
+        lastResolvedAddress = result.address;
+    });
+
+    auto MakeNodeData = [&](const Transport::PeerAddress & address) {
+        Dnssd::ResolvedNodeData nodeData;
+        nodeData.resolutionData.numIPs       = 1;
+        nodeData.resolutionData.ipAddress[0] = address.GetIPAddress();
+        nodeData.resolutionData.interfaceId  = address.GetInterface();
+        nodeData.resolutionData.port         = address.GetPort();
+        nodeData.operationalData.peerId      = request.GetPeerId();
+        return nodeData;
+    };
+
+    ASSERT_EQ(resolver.LookupNode(request, handle), CHIP_NO_ERROR);
+
+    // First advertisement, still within min lookup time: must NOT deliver yet
+    // (the lookup stays active so it can pick up a better address).
+    resolver.OnOperationalNodeResolved(MakeNodeData(firstAddress));
+    EXPECT_EQ(resolvedCount, 0);
+    EXPECT_TRUE(handle.IsActive());
+
+    // A refreshed, higher-score advertisement arrives while still in flight.
+    resolver.OnOperationalNodeResolved(MakeNodeData(betterAddress));
+    EXPECT_EQ(resolvedCount, 0);
+    EXPECT_TRUE(handle.IsActive());
+
+    // After the min lookup time elapses, the lookup completes with the better
+    // (refreshed) address at the top of the result list.
+    clock.AdvanceMonotonic(150_ms64);
+    resolver.OnOperationalNodeResolved(MakeNodeData(betterAddress)); // re-arms HandleAction
+
+    ASSERT_EQ(resolvedCount, 1);
+    EXPECT_EQ(lastResolvedAddress, betterAddress);
+
+    chip::Dnssd::Resolver::SetInstance(mockResolver);
+}
+
 } // namespace


### PR DESCRIPTION
#### Problem

When commissioning or reconnecting to a Thread Sleepy End Device, the device's pre-operational address can be the only address resolvable at the instant CASE begins — the operational SRP record often registers a few seconds later. On a CASE `CHIP_ERROR_TIMEOUT`, `OperationalSessionSetup` today only re-walks the **stale cached resolve snapshot** (`TryNextResult`) before reattempting. If every cached address is now dead, the controller keeps retransmitting Sigma1 to an unreachable address until the overall commissioning watchdog fires — even though a fresh operational advertisement is already on the network.

#### Fix

On CASE timeout with resolve attempts remaining, start a **fresh DNS-SD node lookup** (`LookupPeerAddress()` resets the lookup handle, discarding the stale snapshot) before re-walking cached results, so a newly-registered operational/SRP advertisement is picked up promptly and any newer address wins.

#### Testing

Adds `TestOperationalSessionSetupReresolve.cpp` (with an `OperationalSessionSetup`-owned test-access shim) asserting that on `CHIP_ERROR_TIMEOUT` with attempts remaining a fresh `ResolveNodeId` is issued — fails before the fix (count stays 0; only the stale snapshot is re-walked), passes after. Extends `TestAddressResolve_DefaultImpl` refresh-on-timeout coverage.
