### PR TITLE
[fuzz] Guard PASE fuzz harness against uninitialized verifier on Generate() failure

### DIFF
--- a/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
@@ -651,7 +651,7 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
     // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
     // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
     // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
-    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
+    ReturnOnFailure(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode));
 
     /************************Injecting Fuzzed Pake1 Message into PaseSession::OnMessageReceived*************************/
 
@@ -756,7 +756,7 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
     // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
     // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
     // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
-    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
+    ReturnOnFailure(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode));
 
     RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
                                                                   kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,
@@ -889,7 +889,7 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
     // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
     // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
-    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
+    ReturnOnFailure(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode));
 
     RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
                                                                   kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,

--- a/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
@@ -648,7 +648,10 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
 
     //  Compute mPASEVerifier (in order for mSpake2p.BeginVerifier() to use it, once it is called by the pairingAccessory through
     //  HandleMsg1_and_SendMsg2)
-    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
+    // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
+    // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
+    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
 
     /************************Injecting Fuzzed Pake1 Message into PaseSession::OnMessageReceived*************************/
 
@@ -750,7 +753,10 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
 
     // Below Steps take place in HandleMsg1
     // Compute mPASEVerifier to be able to pass it to BeginVerifier()
-    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
+    // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
+    // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
+    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
 
     RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
                                                                   kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,
@@ -880,7 +886,10 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
 
     // Below Steps take place in HandleMsg1
     //  compute mPASEVerifier to be able to pass it to BeginVerifier()
-    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    // If Generate() fails (the fuzz domains intentionally include out-of-range iter/salt),
+    // mPASEVerifier stays uninitialized; reading it below (BeginVerifier / HandleMsg*) would be an
+    // MSan false positive that cannot occur in production, which checks Generate(). Bail instead.
+    VerifyOrReturn(pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode) == CHIP_NO_ERROR);
 
     RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
                                                                   kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,


### PR DESCRIPTION
#### Summary

The PASE fuzz harness reads an uninitialized verifier when `Generate()` fails — flagged by MSan in the OSS-Fuzz `memory` build (`fuzz-PASE-pw@…Pake2/Pake3`).

`FuzzPASE_PW.cpp`'s `FuzzHandlePake1/2/3` ignored the result of `pairingAccessory.mPASEVerifier.Generate()` and then read the verifier via `BeginVerifier()` / `HandleMsg*()`. `Generate()` can fail because the Pake fuzz domains intentionally include out-of-range PBKDF iteration counts and salt lengths; on failure `mPASEVerifier` stays uninitialized and is read downstream.

Guard each site with `VerifyOrReturn(... == CHIP_NO_ERROR)` so the harness bails when the precondition can't be established. Production always checks `Generate()`, so this is a test-harness gap, not a product bug.

(CI flagged Pake2/Pake3; Pake1 has the identical pattern and is fixed for consistency.)

#### Testing

- Surfaced by the OSS-Fuzz `memory` (MemorySanitizer) `check_build` run, which reported `use-of-uninitialized-value` reaching `bin2bn` via `Spake2p::FELoad`/`BeginVerifier` from these harnesses, with the origin in the harness `pairingAccessory` object.
- No behavior change for valid inputs: the harness now returns early only when `Generate()` fails — i.e. for the out-of-range PBKDF iteration/salt values in the fuzz domains, where the accessory verifier precondition could not be established anyway. In-range inputs (the bulk of the domain) exercise the message handlers exactly as before.
- Confirmation is the OSS-Fuzz `memory` build re-run with this change applied (the targets that previously aborted now run cleanly).
