### PR TITLE
[Messaging] Force idle timeout for first message of exchange

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -541,29 +541,16 @@ void ReliableMessageMgr::SetAdditionalMRPBackoffTime(const Optional<System::Cloc
 void ReliableMessageMgr::CalculateNextRetransTime(RetransTableEntry & entry)
 {
     const auto sessionHandle = entry.ec->GetSessionHandle();
-
-    // Per Matter Core spec §4.11.2.1 Retransmissions: choose the Active or Idle
-    // base timeout based on the peer's CURRENT activity mode at the moment we
-    // schedule the retransmit. The peer may have been Active when it last sent
-    // us a message in this exchange, but transitioned back to Idle once its
-    // Session Active Threshold (SAT) elapsed.
-    //
-    // For Intermittently Connected Devices (ICDs) where SAI ≪ SII, an earlier
-    // shortcut here pinned to ActiveRetransTimeout (SAI) for the remainder of
-    // the exchange as soon as one message had been received. That caused every
-    // subsequent retransmit to be scheduled well inside the peer's sleep
-    // window, defeating reliable delivery. A common failure mode is CASE Sigma3
-    // to a sleepy device: the just-received Sigma2 marks the exchange "has
-    // received a message", so Sigma3 retransmits were spaced on SAI-derived
-    // backoff (sub-second to a few seconds) instead of the SII-derived spacing
-    // the ICD actually polls on (multiple seconds), and the device never
-    // observed any of them.
-    //
-    // GetMRPBaseTimeout() re-evaluates IsPeerActive() against SAT on every
-    // call, returning ActiveRetransTimeout (SAI) while the peer is in its
-    // Active window and IdleRetransTimeout (SII) afterward, which is the
-    // behavior the spec actually prescribes.
-    System::Clock::Timeout baseTimeout = sessionHandle->GetMRPBaseTimeout();
+    // Per Matter Core spec §4.12.2.1 Retransmissions:
+    // - For the first message of a new exchange, the base interval, i, SHALL be
+    //   set according to the idle state of the peer node (SII).
+    // - For all subsequent messages of the exchange, the base interval, i,
+    //   SHOULD be set according to the active state of the peer node (which is
+    //   dynamic based on PeerActiveMode).
+    bool isFirstMessageOfExchange = entry.ec->IsInitiator() && !entry.ec->HasReceivedAtLeastOneMessage();
+    System::Clock::Timeout baseTimeout =
+        isFirstMessageOfExchange ? sessionHandle->GetRemoteMRPConfig().mIdleRetransTimeout
+                                 : std::chrono::duration_cast<System::Clock::Timeout>(sessionHandle->GetMRPBaseTimeout());
 
     System::Clock::Timeout backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry.sendCount);
     entry.nextRetransTime          = System::SystemClock().GetMonotonicTimestamp() + backoff;


### PR DESCRIPTION
#### Summary

##### Problem
The Matter specification (§4.12.2.1) requires that the first message of a new exchange SHALL use the peer's idle retransmission timeout (SII) as the base interval. This is because we cannot assume the peer is awake when initiating an exchange.
PR #72230 introduced a regression where the first message of an exchange could use the active timeout (SAI) if the session was considered active (e.g., a fresh session, where the active window is initialized to the session creation time). This violates the "SHALL" requirement in the spec.

##### Impact
For Intermittently Connected Devices (ICDs), if the first message of an exchange (like a subscription request or command) is sent using SAI, and it gets lost, the retransmissions will be scheduled too quickly (sub-second spacing instead of multiple seconds). The sleepy device, which only polls at the SII interval, will miss all retransmissions, leading to message delivery failure.

##### Solution
Modify `CalculateNextRetransTime` to force the use of the remote peer's idle retransmission timeout (SII) for the first message of a new exchange, regardless of the session activity state. Subsequent messages continue to use the dynamic active/idle timeout based on session activity (preserving the ICD fix from PR #72230).
An exchange is identified as having its first message sent if it is the initiator and no messages have been received from the peer yet.

#### Testing
- Ran unit tests: `./out/linux-x64-tests-clang/tests/TestReliableMessageProtocol`
- Confirmed that `Test 20` (`CheckPeerRetxUsesIdleBackoffWhenNoMessagesReceived`) and all other tests pass.
- Verified that the first message indeed uses the idle timeout (SII) backoff.
