### PR TITLE
[mergify] Backport to v1.6-branch on request-backport-supported

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,6 +56,18 @@ pull_request_rules:
               labels:
                   - backport-v1.6-sve-branch
 
+    - name: Backport to v1.6-branch
+      conditions:
+          - merged
+          - base=master
+          - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.6-branch
+              labels:
+                  - backport-v1.6-branch
+
     - name: Backport to v1.5-branch
       conditions:
           - merged
@@ -88,6 +100,7 @@ pull_request_rules:
       conditions:
           - or:
                 - label="backport-v1.6-sve-branch"
+                - label="backport-v1.6-branch"
                 - label="backport-v1.5-branch"
                 - label="backport-v1.4.2-branch"
           - author=mergify[bot]


### PR DESCRIPTION
#### Problem

The `request-backport-supported` label currently triggers backports only to `v1.5-branch` and `v1.4.2-branch`. There is no rule to backport to `v1.6-branch`, even though it is a maintained release branch.

#### Change overview

- Add a new `Backport to v1.6-branch` rule that cherry-picks the squashed master commit to `v1.6-branch` when a PR carries the `request-backport-supported` label (same trigger as the existing v1.5 / v1.4.2 rules).
- Add `backport-v1.6-branch` to the `Auto-merge clean backport PRs` rule so the resulting backport PRs auto-merge when CI is green and there are no conflicts, consistent with the other backport targets.

The existing `request-backport-sve` -> `v1.6-sve-branch` rule is unchanged.

#### Testing

- Validated `.mergify.yml` parses as well-formed YAML.