### PR TITLE
[TC-DD-3.23] Update test script to verify commissioning window

### DIFF
--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -119,7 +119,8 @@ class TC_DD_3_23(MatterBaseTest):
 
         # Step 3: Perform the commissioning again to check if the device is already commissioned and commissioning fails
         self.step(3)
-        commissioning_success = await self.commission_devices()
+        self.wait_for_user_input(prompt_msg="Remove the device from the RF field and place it back again")
+        commissioning_success = await self.commission_ntl_devices(payload)
         asserts.assert_false(
             commissioning_success,
             "Device Commissioning using nfc transport has succeeded when it should have failed"
@@ -130,7 +131,8 @@ class TC_DD_3_23(MatterBaseTest):
 
         # Step 5: Perform the commissioning again to check if the device is already commissioned and commissioning fails
         self.step(5)
-        commissioning_success = await self.commission_devices()
+        self.wait_for_user_input(prompt_msg="Remove the device from the RF field and place it back again")
+        commissioning_success = await self.commission_ntl_devices(payload)
         asserts.assert_false(
             commissioning_success,
             "Device Commissioning using nfc transport has succeeded when it should have failed"

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -40,7 +40,8 @@ class TC_DD_3_23(MatterBaseTest):
             TestStep(1, "Detecting the NFC Tag and reading the Payload", is_commissioning=False),
             TestStep(2, "Validate the NFC bit in payload and Perform the commissioning"),
             TestStep(3, "Perform the commissioning again to check if the device is already commissioned and commissioning fails"),
-            TestStep(4, "Perform the commissioning again to check if the device is already commissioned and commissioning fails"),
+            TestStep(4, "DUT is powered OFF."),
+            TestStep(5, "Perform the commissioning again to check if the device is already commissioned and commissioning fails"),
         ]
 
     def setup_test(self):

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -38,7 +38,9 @@ class TC_DD_3_23(MatterBaseTest):
     def steps_TC_DD_3_23(self) -> list[TestStep]:
         return [
             TestStep(1, "Detecting the NFC Tag and reading the Payload", is_commissioning=False),
-            TestStep(2, 'Validate the NFC bit in payload and Perform the commissioning')
+            TestStep(2, "Validate the NFC bit in payload and Perform the commissioning"),
+            TestStep(3, "Perform the commissioning again to check if the device is already commissioned and commissioning fails"),
+            TestStep(4, "Perform the commissioning again to check if the device is already commissioned and commissioning fails"),
         ]
 
     def setup_test(self):
@@ -113,6 +115,25 @@ class TC_DD_3_23(MatterBaseTest):
 
         asserts.assert_false(self.unpowered_phase_complete_seen, "Stage 'UnpoweredPhaseComplete' was seen which is not expected!")
         asserts.assert_true(self.send_complete_seen, "Stage 'send_complete_seen' was not seen!")
+
+        # Step 3: Perform the commissioning again to check if the device is already commissioned and commissioning fails
+        self.step(3)
+        commissioning_success = await self.commission_devices()
+        asserts.assert_false(
+            commissioning_success,
+            "Device Commissioning using nfc transport has succeeded when it should have failed"
+        )
+
+        self.step(4)
+        self.wait_for_user_input(prompt_msg="Power OFF the device")
+
+        # Step 5: Perform the commissioning again to check if the device is already commissioned and commissioning fails
+        self.step(5)
+        commissioning_success = await self.commission_devices()
+        asserts.assert_false(
+            commissioning_success,
+            "Device Commissioning using nfc transport has succeeded when it should have failed"
+        )
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -120,7 +120,7 @@ class TC_DD_3_23(MatterBaseTest):
         # Step 3: Perform the commissioning again to check if the device is already commissioned and commissioning fails
         self.step(3)
         self.wait_for_user_input(prompt_msg="Remove the device from the RF field and place it back again")
-        commissioning_success = await self.commission_ntl_devices(payload)
+        commissioning_success = await self.commission_ntl_device(payload, expected_failure=True)
         asserts.assert_false(
             commissioning_success,
             "Device Commissioning using nfc transport has succeeded when it should have failed"
@@ -132,7 +132,7 @@ class TC_DD_3_23(MatterBaseTest):
         # Step 5: Perform the commissioning again to check if the device is already commissioned and commissioning fails
         self.step(5)
         self.wait_for_user_input(prompt_msg="Remove the device from the RF field and place it back again")
-        commissioning_success = await self.commission_ntl_devices(payload)
+        commissioning_success = await self.commission_ntl_device(payload, expected_failure=True)
         asserts.assert_false(
             commissioning_success,
             "Device Commissioning using nfc transport has succeeded when it should have failed"

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -221,7 +221,12 @@ class Commission:
 
 
 async def commission_device(
-    dev_ctrl: ChipDeviceCtrl.ChipDeviceController, node_id: int, info: SetupPayloadInfo, commissioning_info: CommissioningInfo
+    dev_ctrl: ChipDeviceCtrl.ChipDeviceController,
+    node_id: int,
+    info: SetupPayloadInfo,
+    commissioning_info: CommissioningInfo,
+    *,
+    expected_failure: bool = False,
 ) -> PairingStatus:
     """
     Starts the commissioning process of a chip device.
@@ -234,6 +239,7 @@ async def commission_device(
         node_id: Unique identifier for the chip node.
         info: Contains setup information including passcode, filter_type, and filter_value.
         commissioning_info: Specifies the type of commissioning method to use.
+        expected_failure: If True, commissioning failures are logged without a traceback.
 
     Returns:
         PairingStatus object which can evaluated in conditional statements
@@ -247,7 +253,10 @@ async def commission_device(
         return PairingStatus()
 
     except ChipStackError as e:  # chipstack-ok: Can not use 'with' because we handle and return the exception, not assert it
-        LOGGER.exception("Commissioning failed")
+        if expected_failure:
+            LOGGER.info("Commissioning failed as expected: %s", e)
+        else:
+            LOGGER.exception("Commissioning failed")
         return PairingStatus(exception=e)
 
     except Exception as e:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -2249,12 +2249,16 @@ class MatterBaseTest(base_test.BaseTestClass):
             self._dut_confirmed_available = True
         return result
 
-    async def commission_ntl_device(self, setup_payload: SetupPayload) -> bool:
+    async def commission_ntl_device(self, setup_payload: SetupPayload, *, expected_failure: bool = False) -> bool:
         """Commission a single DUT devices over NTL.
         The discovery_cap_bitmask is patched to keep only the NTL bit ON.
 
         Uses the default controller to commission a device over NTL based on setup payload
         and commissioning configuration.
+
+        Args:
+            setup_payload: Parsed setup payload read from onboarding data.
+            expected_failure: If True, expected commissioning failure is logged without traceback.
 
         Returns:
             True if commissioning succeeded, False otherwise.
@@ -2313,7 +2317,13 @@ class MatterBaseTest(base_test.BaseTestClass):
             thread_ba_port=self.matter_test_config.thread_ba_port,
         )
 
-        pairing_status = await commission_device(dev_ctrl, dut_node_id, ntl_setup_payload_info, commissioning_info)
+        pairing_status = await commission_device(
+            dev_ctrl,
+            dut_node_id,
+            ntl_setup_payload_info,
+            commissioning_info,
+            expected_failure=expected_failure,
+        )
         result = bool(pairing_status)
         if result:
             self._dut_confirmed_available = True


### PR DESCRIPTION
### Summary

Update python script to validate Commissioning Window close after DUT commissioned successfully through NFC based commissioning.
Cover DUT power up and power off situations.

### Related issues

Test Plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6195/

### Testing
Run TC-DD-3.23.
