### PR TITLE
Update TC_SC_5_2 With Group Session ID Collision Steps

### DIFF
--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -499,6 +499,11 @@ DiscoveryType: typing.TypeAlias = discovery.DiscoveryType
 
 
 class ChipDeviceControllerBase:
+    # GroupInfo flags bitmask
+    GROUP_INFO_FLAG_NONE = 0x00
+    GROUP_INFO_FLAG_HAS_AUXILIARY_ACL = 0x01
+    GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY = 0x02
+
     activeList: set = set()
 
     def __init__(self, name: str = ''):
@@ -2573,7 +2578,7 @@ class ChipDeviceControllerBase:
                 epoch_key2, epoch_start_time2)
         ).raise_on_error()
 
-    def SetGroupInfo(self, group_id: int, group_name: str, flags: int = 0x02):
+    def SetGroupInfo(self, group_id: int, group_name: str, flags: int = GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY):
         '''
         Adds or updates a group entry in the controller's GroupDataProvider for this fabric.
 

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -64,8 +64,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import asyncio
 import logging
+import queue
 
 from mobly import asserts
 from TC_GC_common import get_feature_map, get_operate_only_commands, is_groupcast_on_root_node
@@ -93,26 +93,48 @@ class TC_SC_5_2(MatterBaseTest):
         return [
             TestStep("0a", "Commissioning, already done", is_commissioning=True),
             TestStep("0b", "Run the remaining steps once for each endpoint with a groups cluster"),
-            TestStep("1", "TH writes the ACL attribute in the Access Control cluster to add Manage privileges for group 0x0103."),
-            TestStep("2", "TH sends KeySetWrite command with pre-installed key."),
-            TestStep("3", "If Groupcast enabled on RootNode, skip to step 12. Otherwise, TH binds GroupId 0x0103 and 0x0101 with GroupKeySetID 0x01a3 in GroupKeyMap."),
-            TestStep("4", "TH sends RemoveAllGroups command to DUT on the current endpoint under test."),
-            TestStep("5", "TH sends AddGroup Command with GroupID 0x0103 to DUT on the current endpoint under test."),
-            TestStep("6", "TH sends AddGroup command for GroupID 0x0101 as a group command using GroupID 0x0103."),
-            TestStep("7", "TH sends ViewGroup with GroupID 0x0101 (GroupNames supported)."),
-            TestStep("8", "TH sends ViewGroup with GroupID 0x0101 (GroupNames not supported)."),
-            TestStep("9", "TH sends RemoveGroup with GroupID 0x0101."),
-            TestStep("10", "TH sends ViewGroup with GroupID 0x0101 to confirm removal."),
-            TestStep("11", "TH sends RemoveAllGroups to clean up legacy groups."),
-            TestStep("12", "If Groupcast NOT enabled or Listener disabled, skip to step 17. TH sends LeaveGroup(groupID=0)."),
-            TestStep("13", "TH sends JoinGroup command with GroupID 0x0103."),
-            TestStep("14", "TH reads Membership attribute from Groupcast cluster."),
+            TestStep("1", "TH writes the ACL attribute in the Access Control cluster to add Manage privileges for groups 0x0101, 0x0102, and 0x0300, and maintain the current administrative privileges for the TH."),
+            TestStep("2a", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT to write GroupKeySetID 0x01a3."),
+            TestStep("2b", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT to write GroupKeySetID 0x01a4 with the exact same key material."),
+            TestStep("2c", "As part of test setup on the TH side, configure the local GroupKeyMap on the TH with 3 key mappings that will be used throughout the test and never changed: GroupId 0x0300 bound to GroupKeySetID 0x01a3, GroupId 0x0101 bound to GroupKeySetID 0x01a4, GroupId 0x0102 bound to GroupKeySetID 0x01a4."),
+            TestStep("3", "If Groupcast cluster is enabled on the RootNode endpoint of the DUT, skip to step 12. Otherwise, TH binds GroupId 0x0300 with GroupKeySetID 0x01a3, and GroupId 0x0101 with GroupKeySetID 0x01a4 on the DUT in the GroupKeyMap attribute list on GroupKeyManagement cluster."),
+            TestStep("4", "TH cleans up the groups by sending the RemoveAllGroups command to the DUT on the current endpoint under test."),
+            TestStep("5a", "TH sends AddGroup Command over CASE to DUT on the current endpoint under test with GroupID 0x0300."),
+            TestStep("5b", "TH sends AddGroup Command over CASE to DUT on the current endpoint under test with GroupID 0x0101."),
+            TestStep("6a", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0201. The command is sent as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
+            TestStep("6b", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0201 to confirm that the AddGroup command from step 6a was successful."),
+            TestStep("7a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0102 to GroupKeySetID 0x01a4 (replacing the entry for GroupID 0x0101), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("7b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0202. The command is sent as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
+            TestStep("7c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0202 to confirm that the AddGroup command from step 7b was rejected."),
+            TestStep("8a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0101 to GroupKeySetID 0x01a4 (replacing GroupID 0x0102), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("8b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0203. The command is sent as a group command using GroupID 0x0102 (encrypted using KeySet 0x01a4)."),
+            TestStep("8c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0203 to confirm that the AddGroup command from step 8b was rejected."),
+            TestStep("9a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to include entries mapping GroupId 0x0101 to GroupKeySetID 0x01a4, GroupId 0x0102 to GroupKeySetID 0x01a4, and GroupId 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("9b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0204. The command is sent as a group command using GroupID 0x0102."),
+            TestStep("9c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0204 to confirm that the AddGroup command from step 9b was rejected."),
+            TestStep("10a", "TH sends a RemoveGroup Command to the Groups cluster with the GroupID field set to 0x0101. The command is sent as a group command using GroupID 0x0300."),
+            TestStep("10b", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0101 to confirm that the RemoveGroup command from step 10a was successful."),
+            TestStep("11", "TH cleans up the groups by sending the RemoveAllGroups command to the DUT on the current endpoint under test."),
+            TestStep("12", "If Groupcast cluster is NOT enabled on the RootNode endpoint of the DUT or its Listener feature is disabled, skip to step 17. Otherwise, TH sends the Groupcast cluster's LeaveGroup command on the DUT on EP0 with GroupID 0 (leave all groups)."),
+            TestStep("13a", "TH sends the Groupcast cluster's JoinGroup command on the DUT on EP0 with GroupID field set to 0x0300, KeySetID field set to 0x01a3, and Endpoints field set to the current endpoint under test."),
+            TestStep("13b", "TH sends the Groupcast cluster's JoinGroup command on the DUT on EP0 to join GroupID 0x0101, KeySetID field set to 0x01a4, and Endpoints field set to the current endpoint under test."),
+            TestStep("14", "TH reads the Groupcast 'membership' attribute on the DUT on EP0."),
             TestStep("15a", "TH subscribes to the Groupcast cluster's GroupcastTesting event on the RootNode endpoint."),
-            TestStep("15b", "TH sends GroupcastTesting command with TestOperation=EnableListenerTesting and DurationSeconds=120."),
-            TestStep("15c", "TH sends a command requiring Operate privilege available on the endpoint provided in step 13 as a group command using GroupID 0x0103."),
-            TestStep("16a", "TH validates the group message was received by checking the GroupcastTesting event from DUT (AccessAllowed: true)."),
-            TestStep("16b", "TH sends GroupcastTesting command with DisableTesting to restore normal operation."),
-            TestStep("17", "TH sends KeySetRemove with GroupKeySetID 0x01a3."),
+            TestStep("15b", "TH sends the GroupcastTesting command on EP0 with TestOperation field set to EnableListenerTesting and DurationSeconds field set to 120."),
+            TestStep("16a", "TH sends a group command requiring Operate privilege available on the current endpoint under test as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
+            TestStep("16b", "TH waits for and verifies the GroupcastTesting event from DUT (AccessAllowed: true, GroupcastTestResult: Success)."),
+            TestStep("16c", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0102 to GroupKeySetID 0x01a4 (replacing the entry for GroupID 0x0101), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16d", "TH sends the same group command destined for Group 0x0101 (encrypted using KeySet 0x01a4)."),
+            TestStep("16e", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: null, AccessAllowed: null, GroupcastTestResult: FailedAuth)."),
+            TestStep("16f", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0101 to GroupKeySetID 0x01a4 (replacing GroupID 0x0102), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16g", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
+            TestStep("16h", "TH verifies that no GroupcastTesting event is received from DUT within the response timeout."),
+            TestStep("16i", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to include entries mapping GroupId 0x0101 to GroupKeySetID 0x01a4, GroupId 0x0102 to GroupKeySetID 0x01a4, and GroupId 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16j", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
+            TestStep("16k", "TH verifies that no GroupcastTesting event is received from DUT within the response timeout."),
+            TestStep("16l", "TH sends Groupcast cluster's GroupcastTesting command on EP0 with TestOperation field set to DisableTesting."),
+            TestStep("17a", "TH removes GroupKeySetID 0x01a3 by sending a KeySetRemove command to the GroupKeyManagement cluster."),
+            TestStep("17b", "TH removes GroupKeySetID 0x01a4 by sending a KeySetRemove command to the GroupKeyManagement cluster."),
             TestStep("18", "TH writes ACL to restore default access."),
         ]
 
@@ -145,6 +167,21 @@ class TC_SC_5_2(MatterBaseTest):
         node_id = self.dut_node_id
         groupcast_enabled = await is_groupcast_on_root_node(self)
 
+        keySetID1 = 0x01a3
+        keySetID2 = 0x01a4
+        epochKeyForKeySets = bytes.fromhex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
+
+        groupID1 = 0x0101
+        groupID2 = 0x0102
+        groupID3 = 0x0300
+        groupID4 = 0x0201
+        groupID5 = 0x0202
+        groupID6 = 0x0203
+        groupID7 = 0x0204
+
+        GROUP_INFO_FLAG_USE_IANA_ADDR = dev_ctrl.GROUP_INFO_FLAG_NONE
+        GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY = dev_ctrl.GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY
+
         # Step 1: Write ACL
         self.step("1")
         acl = [
@@ -156,88 +193,183 @@ class TC_SC_5_2(MatterBaseTest):
             Clusters.AccessControl.Structs.AccessControlEntryStruct(
                 privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kManage,
                 authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kGroup,
-                subjects=[0x0103],
+                subjects=[groupID1, groupID2, groupID3],
                 targets=NullValue),
         ]
         await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.AccessControl.Attributes.Acl(acl))])
 
-        # Step 2: KeySetWrite
-        self.step("2")
-        key_set = Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
-            groupKeySetID=0x01a3,
-            groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
-            epochKey0=bytes.fromhex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
-            epochStartTime0=2220000,
-            epochKey1=bytes.fromhex("d1d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
-            epochStartTime1=2220001,
-            epochKey2=bytes.fromhex("d2d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
-            epochStartTime2=2220002)
-        await dev_ctrl.SendCommand(node_id, 0, Clusters.GroupKeyManagement.Commands.KeySetWrite(key_set))
+        # Step 2a: Write KeySet 0x01a3 (only one key present, slots 1 and 2 set to NullValue)
+        self.step("2a")
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
+            groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
+                groupKeySetID=keySetID1,
+                groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
+                epochKey0=epochKeyForKeySets,
+                epochStartTime0=2220000,
+                epochKey1=NullValue,
+                epochStartTime1=NullValue,
+                epochKey2=NullValue,
+                epochStartTime2=NullValue
+            )
+        ))
+
+        # Step 2b: Write KeySet 0x01a4 with the exact same key material
+        self.step("2b")
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
+            groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
+                groupKeySetID=keySetID2,
+                groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
+                epochKey0=epochKeyForKeySets,
+                epochStartTime0=2220000,
+                epochKey1=NullValue,
+                epochStartTime1=NullValue,
+                epochKey2=NullValue,
+                epochStartTime2=NullValue
+            )
+        ))
+
+        # Step 2c: Configure local GroupKeyMap on the TH
+        self.step("2c")
+        dev_ctrl.SetGroupKeySet(
+            keyset_id=keySetID1, 
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst, 
+            num_keys=1,
+            epoch_key0=epochKeyForKeySets, 
+            epoch_start_time0=2220000,
+            epoch_key1=None, 
+            epoch_start_time1=0,
+            epoch_key2=None, 
+            epoch_start_time2=0
+        )
+        
+        dev_ctrl.SetGroupKeySet(
+            keyset_id=keySetID2, 
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst, 
+            num_keys=1,
+            epoch_key0=epochKeyForKeySets, 
+            epoch_start_time0=2220000,
+            epoch_key1=None, 
+            epoch_start_time1=0,
+            epoch_key2=None, 
+            epoch_start_time2=0
+        )
+
+        group_addr_policy = GROUP_INFO_FLAG_USE_IANA_ADDR if groupcast_enabled else GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY
+        
+        dev_ctrl.SetGroupInfo(groupID1, "Group 0x0101", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupID1, keySetID2)
+        
+        dev_ctrl.SetGroupInfo(groupID2, "Group 0x0102", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupID2, keySetID2)
+
+        dev_ctrl.SetGroupInfo(groupID3, "Group 0x0300", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupID3, keySetID1)
 
         if groupcast_enabled:
             self.mark_step_range_skipped("3", "11")
         else:
-            dev_ctrl.SetGroupInfo(0x0103, "Group #3")
             # Step 3: GroupKeyMap binding
             self.step("3")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=0x0103, groupKeySetID=0x01a3, fabricIndex=1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=0x0101, groupKeySetID=0x01a3, fabricIndex=1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 4: RemoveAllGroups
             self.step("4")
-            await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.RemoveAllGroups())
+            await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.RemoveAllGroups())
 
-            # Step 5: AddGroup 0x0103
-            self.step("5")
-            result = await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.AddGroup(0x0103, "Test Group 0103"))
-            asserts.assert_equal(result.status, Status.Success, "AddGroup 0x0103 failed")
+            # Step 5a: AddGroup 0x0300
+            self.step("5a")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupID3))
+            asserts.assert_equal(result.status, Status.Success, "AddGroup 0x0300 failed")
+            asserts.assert_equal(result.groupID, groupID3, "AddGroup 0x0300 groupID mismatch")
 
-            # Step 6: AddGroup 0x0101 as group command via GroupID 0x0103
-            self.step("6")
-            dev_ctrl.SendGroupCommand(0x0103, Clusters.Groups.Commands.AddGroup(0x0101, "Test Group 0101"))
-            await asyncio.sleep(3)
+            # Step 5b: AddGroup 0x0101
+            self.step("5b")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupID1))
+            asserts.assert_equal(result.status, Status.Success, "AddGroup 0x0101 failed")
+            asserts.assert_equal(result.groupID, groupID1, "AddGroup 0x0101 groupID mismatch")
 
-            # Check if GroupNames are supported
-            group_feature_map = await self.read_single_attribute_check_success(
-                cluster=Clusters.Groups,
-                attribute=Clusters.Groups.Attributes.FeatureMap,
-                endpoint=groups_endpoint)
-            group_names_supported = bool(group_feature_map & Clusters.Groups.Bitmaps.Feature.kGroupNames)
+            # Step 6a: AddGroup 0x0201 as group command via GroupID 0x0101
+            self.step("6a")
+            dev_ctrl.SendGroupCommand(groupID1, Clusters.Groups.Commands.AddGroup(groupID4))
 
-            # Step 7: ViewGroup 0x0101 with GroupNames
-            if group_names_supported:
-                self.step("7")
-                result = await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.ViewGroup(0x0101))
-                asserts.assert_equal(result.status, Status.Success, "ViewGroup failed")
-                asserts.assert_equal(result.groupID, 0x0101, "ViewGroup groupID mismatch")
-                asserts.assert_equal(result.groupName, "Test Group 0101", "ViewGroup groupName mismatch")
-                self.skip_step("8")
-            # Step 8: ViewGroup 0x0101 without GroupNames
-            else:
-                self.skip_step("7")
-                self.step("8")
-                result = await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.ViewGroup(0x0101))
-                asserts.assert_equal(result.status, Status.Success, "ViewGroup failed")
-                asserts.assert_equal(result.groupID, 0x0101, "ViewGroup groupID mismatch")
-                asserts.assert_equal(result.groupName, "", "ViewGroup groupName mismatch")
+            # Step 6b: ViewGroup 0x0201 to confirm success
+            self.step("6b")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID4))
+            asserts.assert_equal(result.status, Status.Success, "ViewGroup 0x0201 failed")
+            asserts.assert_equal(result.groupID, groupID4, "ViewGroup groupID mismatch")
 
-            # Step 9: RemoveGroup 0x0101
-            self.step("9")
-            result = await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.RemoveGroup(0x0101))
-            asserts.assert_equal(result.status, Status.Success, "RemoveGroup failed")
+            # Step 7a: Update GroupKeyMap to map 0x0102 to 0x01a4, maintaining 0x0300 to 0x01a3
+            self.step("7a")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
-            # Step 10: ViewGroup 0x0101 confirm removed
-            self.step("10")
-            result = await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.ViewGroup(0x0101))
-            asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND after removal")
+            # Step 7b: AddGroup 0x0202 as group command via GroupID 0x0101
+            self.step("7b")
+            dev_ctrl.SendGroupCommand(groupID1, Clusters.Groups.Commands.AddGroup(groupID5))
+
+            # Step 7c: ViewGroup 0x0202 to confirm rejection
+            self.step("7c")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID5))
+            asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0202")
+
+            # Step 8a: Update GroupKeyMap to map 0x0101 to 0x01a4, maintaining 0x0300 to 0x01a3
+            self.step("8a")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
+
+            # Step 8b: AddGroup 0x0203 as group command via GroupID 0x0102
+            self.step("8b")
+            dev_ctrl.SendGroupCommand(groupID2, Clusters.Groups.Commands.AddGroup(groupID6))
+
+            # Step 8c: ViewGroup 0x0203 to confirm rejection
+            self.step("8c")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID6))
+            asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0203")
+
+            # Step 9a: Update GroupKeyMap to include 0x0101->0x01a4, 0x0102->0x01a4, 0x0300->0x01a3
+            self.step("9a")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
+
+            # Step 9b: AddGroup 0x0204 as group command via GroupID 0x0102
+            self.step("9b")
+            dev_ctrl.SendGroupCommand(groupID2, Clusters.Groups.Commands.AddGroup(groupID7))
+
+            # Step 9c: ViewGroup 0x0204 to confirm rejection
+            self.step("9c")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID7))
+            asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0204")
+
+            # Step 10a: RemoveGroup 0x0101 as group command via GroupID 0x0300
+            self.step("10a")
+            dev_ctrl.SendGroupCommand(groupID3, Clusters.Groups.Commands.RemoveGroup(groupID1))
+
+            # Step 10b: ViewGroup 0x0101 to confirm removal
+            self.step("10b")
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID1))
+            asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND after RemoveGroup 0x0101")
 
             # Step 11: RemoveAllGroups cleanup
             self.step("11")
-            await dev_ctrl.SendCommand(node_id, groups_endpoint, Clusters.Groups.Commands.RemoveAllGroups())
+            await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.RemoveAllGroups())
 
         is_groupcast_listener = False
         if groupcast_enabled:
@@ -245,29 +377,30 @@ class TC_SC_5_2(MatterBaseTest):
             is_groupcast_listener = ln_enabled
 
         if not is_groupcast_listener:
-            self.mark_step_range_skipped("12", "16b")
+            self.mark_step_range_skipped("12", "16l")
         else:
-            # update the controller GroupInfo for groupID 0x0103 to use IANA address policy
-            dev_ctrl.SetGroupInfo(0x0103, "Group #3", 0)
             # Step 12: LeaveGroup
             self.step("12")
-            # Check if there are any groups on the DUT.
             membership = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Groupcast, attribute=Clusters.Groupcast.Attributes.Membership)
             if membership:
-                # LeaveGroup with groupID 0 will leave all groups on the fabric.
-                await dev_ctrl.SendCommand(node_id, 0, Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+                await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
 
-            # Step 13: JoinGroup
-            self.step("13")
-            await dev_ctrl.SendCommand(node_id, 0, Clusters.Groupcast.Commands.JoinGroup(
-                groupID=0x0103, endpoints=[groups_endpoint], keySetID=0x01a3))
+            # Step 13a: JoinGroup 0x0300
+            self.step("13a")
+            await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID3, endpoints=[groups_endpoint], keySetID=keySetID1))
+
+            # Step 13b: JoinGroup 0x0101
+            self.step("13b")
+            await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID1, endpoints=[groups_endpoint], keySetID=keySetID2))
 
             # Step 14: Read Membership
             self.step("14")
-            membership = await self.read_single_attribute_check_success(
-                cluster=Clusters.Groupcast, attribute=Clusters.Groupcast.Attributes.Membership, endpoint=0)
+            membership = await self.read_single_attribute_check_success(cluster=Clusters.Groupcast, attribute=Clusters.Groupcast.Attributes.Membership, endpoint=0)
             group_ids = [entry.groupID for entry in membership]
-            asserts.assert_in(0x0103, group_ids, "GroupID 0x0103 not found in Membership")
+            asserts.assert_in(groupID3, group_ids, "GroupID 0x0300 not found in Membership")
+            asserts.assert_in(groupID1, group_ids, "GroupID 0x0101 not found in Membership")
 
             # Step 15a: Subscribe to GroupcastTesting events on the RootNode.
             self.step("15a")
@@ -278,7 +411,7 @@ class TC_SC_5_2(MatterBaseTest):
 
             # Step 15b: Enable listener testing on the DUT.
             self.step("15b")
-            await dev_ctrl.SendCommand(node_id, 0, Clusters.Groupcast.Commands.GroupcastTesting(
+            await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.GroupcastTesting(
                 testOperation=Clusters.Groupcast.Enums.GroupcastTestingEnum.kEnableListenerTesting,
                 durationSeconds=120))
 
@@ -293,32 +426,100 @@ class TC_SC_5_2(MatterBaseTest):
                 operate_only_command.cluster_object.__name__, operate_only_command.command_object.__name__,
                 groups_endpoint)
 
-            # Step 15c: Send the operate-only command as a group command to GroupID 0x0103.
-            self.step("15c")
-            dev_ctrl.SendGroupCommand(0x0103, operate_only_command.command_object())
-            await asyncio.sleep(3)
-
-            # Step 16a: Validate the DUT received the group command via the GroupcastTesting event.
+            # Step 16a: Send the operate-only command as a group command to GroupID 0x0101.
             self.step("16a")
+            dev_ctrl.SendGroupCommand(groupID1, operate_only_command.command_object())
+
+            # Step 16b: Validate the DUT received the group command via the GroupcastTesting event.
+            self.step("16b")
             event_data = event_sub.wait_for_event_report(
                 Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
-            asserts.assert_equal(event_data.groupID, 0x0103, "Incorrect group ID in GroupcastTesting event")
+            asserts.assert_equal(event_data.groupID, groupID1, "Incorrect group ID in GroupcastTesting event")
             asserts.assert_true(event_data.accessAllowed, "AccessAllowed should be true")
             asserts.assert_equal(event_data.groupcastTestResult,
                                  Clusters.Groupcast.Enums.GroupcastTestResultEnum.kSuccess,
                                  "GroupcastTesting event should report Success")
 
-            # Step 16b: Disable GroupcastTesting to restore normal operation.
-            self.step("16b")
-            await dev_ctrl.SendCommand(node_id, 0, Clusters.Groupcast.Commands.GroupcastTesting(
+            # Step 16c: Update GroupKeyMap to map 0x0102 to 0x01a4, maintaining 0x0300 to 0x01a3
+            self.step("16c")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
+
+            # Step 16d: Send the operate-only command as a group command to GroupID 0x0101.
+            self.step("16d")
+            dev_ctrl.SendGroupCommand(groupID1, operate_only_command.command_object())
+
+            # Step 16e: Validate the DUT rejected the group command via the GroupcastTesting event.
+            self.step("16e")
+            event_data = event_sub.wait_for_event_report(
+                Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
+            asserts.assert_true(event_data.groupID is None or event_data.groupID == NullValue,
+                                f"Expected GroupID to be null, got {event_data.groupID}")
+            asserts.assert_true(event_data.accessAllowed is None or event_data.accessAllowed == NullValue,
+                                f"Expected AccessAllowed to be null, got {event_data.accessAllowed}")
+            asserts.assert_equal(event_data.groupcastTestResult,
+                                 Clusters.Groupcast.Enums.GroupcastTestResultEnum.kFailedAuth,
+                                 "GroupcastTesting event should report FailedAuth")
+
+            # Step 16f: Update GroupKeyMap to map 0x0101 to 0x01a4, maintaining 0x0300 to 0x01a3
+            self.step("16f")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
+
+            # Step 16g: Send the operate-only command as a group command to GroupID 0x0102.
+            self.step("16g")
+            dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
+
+            # Step 16h: Verify that no GroupcastTesting event is received from DUT within response timeout.
+            self.step("16h")
+            try:
+                event_sub.wait_for_event_report(Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=5)
+                asserts.fail("Received unexpected GroupcastTesting event")
+            except queue.Empty:
+                pass
+
+            # Step 16i: Update GroupKeyMap to include 0x0101->0x01a4, 0x0102->0x01a4, 0x0300->0x01a3
+            self.step("16i")
+            mapping = [
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+            ]
+            result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
+            asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
+
+            # Step 16j: Send the operate-only command as a group command to GroupID 0x0102.
+            self.step("16j")
+            dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
+
+            # Step 16k: Verify that no GroupcastTesting event is received from DUT within response timeout.
+            self.step("16k")
+            try:
+                event_sub.wait_for_event_report(Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=5)
+                asserts.fail("Received unexpected GroupcastTesting event")
+            except queue.Empty:
+                pass
+
+            # Step 16l: Disable GroupcastTesting to restore normal operation.
+            self.step("16l")
+            await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.GroupcastTesting(
                 testOperation=Clusters.Groupcast.Enums.GroupcastTestingEnum.kDisableTesting))
 
-            # restore the GroupInfo for groupID 0x0103 to use Per-Group address policy
-            dev_ctrl.SetGroupInfo(0x0103, "Group #3")
+        # Step 17a: KeySetRemove 0x01a3
+        self.step("17a")
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetID1))
 
-        # Step 17: KeySetRemove
-        self.step("17")
-        await dev_ctrl.SendCommand(node_id, 0, Clusters.GroupKeyManagement.Commands.KeySetRemove(0x01a3))
+        # Step 17b: KeySetRemove 0x01a4
+        self.step("17b")
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetID2))
 
         # Step 18: Restore ACL
         self.step("18")

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -65,7 +65,6 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
-import queue
 
 from mobly import asserts
 from TC_GC_common import get_feature_map, get_operate_only_commands, is_groupcast_on_root_node
@@ -230,34 +229,34 @@ class TC_SC_5_2(MatterBaseTest):
         # Step 2c: Configure local GroupKeyMap on the TH
         self.step("2c")
         dev_ctrl.SetGroupKeySet(
-            keyset_id=keySetID1, 
-            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst, 
+            keyset_id=keySetID1,
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
             num_keys=1,
-            epoch_key0=epochKeyForKeySets, 
+            epoch_key0=epochKeyForKeySets,
             epoch_start_time0=2220000,
-            epoch_key1=None, 
+            epoch_key1=None,
             epoch_start_time1=0,
-            epoch_key2=None, 
+            epoch_key2=None,
             epoch_start_time2=0
         )
-        
+
         dev_ctrl.SetGroupKeySet(
-            keyset_id=keySetID2, 
-            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst, 
+            keyset_id=keySetID2,
+            policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
             num_keys=1,
-            epoch_key0=epochKeyForKeySets, 
+            epoch_key0=epochKeyForKeySets,
             epoch_start_time0=2220000,
-            epoch_key1=None, 
+            epoch_key1=None,
             epoch_start_time1=0,
-            epoch_key2=None, 
+            epoch_key2=None,
             epoch_start_time2=0
         )
 
         group_addr_policy = GROUP_INFO_FLAG_USE_IANA_ADDR if groupcast_enabled else GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY
-        
+
         dev_ctrl.SetGroupInfo(groupID1, "Group 0x0101", group_addr_policy)
         dev_ctrl.SetGroupKey(groupID1, keySetID2)
-        
+
         dev_ctrl.SetGroupInfo(groupID2, "Group 0x0102", group_addr_policy)
         dev_ctrl.SetGroupKey(groupID2, keySetID2)
 

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -96,20 +96,20 @@ class TC_SC_5_2(MatterBaseTest):
             TestStep("1", "TH writes the ACL attribute in the Access Control cluster to add Manage privileges for groups 0x0101, 0x0102, and 0x0300, and maintain the current administrative privileges for the TH."),
             TestStep("2a", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT to write GroupKeySetID 0x01a3."),
             TestStep("2b", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT to write GroupKeySetID 0x01a4 with the exact same key material."),
-            TestStep("2c", "As part of test setup on the TH side, configure the local GroupKeyMap on the TH with 3 key mappings that will be used throughout the test and never changed: GroupId 0x0300 bound to GroupKeySetID 0x01a3, GroupId 0x0101 bound to GroupKeySetID 0x01a4, GroupId 0x0102 bound to GroupKeySetID 0x01a4."),
-            TestStep("3", "If Groupcast cluster is enabled on the RootNode endpoint of the DUT, skip to step 12. Otherwise, TH binds GroupId 0x0300 with GroupKeySetID 0x01a3, and GroupId 0x0101 with GroupKeySetID 0x01a4 on the DUT in the GroupKeyMap attribute list on GroupKeyManagement cluster."),
+            TestStep("2c", "As part of test setup on the TH side, configure the local GroupKeyMap on the TH with 4 key mappings that will be used throughout the test and never changed: GroupId 0x0300 bound to GroupKeySetID 0x01a3, GroupId 0x0101 bound to GroupKeySetID 0x01a4, GroupId 0x0102 bound to GroupKeySetID 0x01a4, GroupId 0x0201 bound to GroupKeySetID 0x01a4."),
+            TestStep("3", "If Groupcast cluster is enabled on the RootNode endpoint of the DUT, skip to step 12. Otherwise, TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0101 -> KeySetId 0x01a4, GroupId 0x0201 -> KeySetId 0x01a4. Note: No entries are removed."),
             TestStep("4", "TH cleans up the groups by sending the RemoveAllGroups command to the DUT on the current endpoint under test."),
             TestStep("5a", "TH sends AddGroup Command over CASE to DUT on the current endpoint under test with GroupID 0x0300."),
             TestStep("5b", "TH sends AddGroup Command over CASE to DUT on the current endpoint under test with GroupID 0x0101."),
             TestStep("6a", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0201. The command is sent as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
             TestStep("6b", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0201 to confirm that the AddGroup command from step 6a was successful."),
-            TestStep("7a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0102 to GroupKeySetID 0x01a4 (replacing the entry for GroupID 0x0101), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("7a", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0102 -> KeySetId 0x01a4. Note: Removes GroupId 0x0101 and 0x0201."),
             TestStep("7b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0202. The command is sent as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
             TestStep("7c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0202 to confirm that the AddGroup command from step 7b was rejected."),
-            TestStep("8a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0101 to GroupKeySetID 0x01a4 (replacing GroupID 0x0102), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("8a", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0101 -> KeySetId 0x01a4. Note: Removes GroupId 0x0102."),
             TestStep("8b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0203. The command is sent as a group command using GroupID 0x0102 (encrypted using KeySet 0x01a4)."),
             TestStep("8c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0203 to confirm that the AddGroup command from step 8b was rejected."),
-            TestStep("9a", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to include entries mapping GroupId 0x0101 to GroupKeySetID 0x01a4, GroupId 0x0102 to GroupKeySetID 0x01a4, and GroupId 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("9a", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0101 -> KeySetId 0x01a4, GroupId 0x0102 -> KeySetId 0x01a4. Note: No entries are removed."),
             TestStep("9b", "TH sends an AddGroup Command to the Groups cluster with the GroupID field set to 0x0204. The command is sent as a group command using GroupID 0x0102."),
             TestStep("9c", "TH sends a ViewGroup Command to the Groups cluster on the current endpoint under test over CASE with the GroupID set to 0x0204 to confirm that the AddGroup command from step 9b was rejected."),
             TestStep("10a", "TH sends a RemoveGroup Command to the Groups cluster with the GroupID field set to 0x0101. The command is sent as a group command using GroupID 0x0300."),
@@ -123,13 +123,13 @@ class TC_SC_5_2(MatterBaseTest):
             TestStep("15b", "TH sends the GroupcastTesting command on EP0 with TestOperation field set to EnableListenerTesting and DurationSeconds field set to 120."),
             TestStep("16a", "TH sends a group command requiring Operate privilege available on the current endpoint under test as a group command using GroupID 0x0101 (encrypted using KeySet 0x01a4)."),
             TestStep("16b", "TH waits for and verifies the GroupcastTesting event from DUT (AccessAllowed: true, GroupcastTestResult: Success)."),
-            TestStep("16c", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0102 to GroupKeySetID 0x01a4 (replacing the entry for GroupID 0x0101), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16c", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0102 -> KeySetId 0x01a4. Note: Removes GroupId 0x0101."),
             TestStep("16d", "TH sends the same group command destined for Group 0x0101 (encrypted using KeySet 0x01a4)."),
             TestStep("16e", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: null, AccessAllowed: null, GroupcastTestResult: FailedAuth)."),
-            TestStep("16f", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0101 to GroupKeySetID 0x01a4 (replacing GroupID 0x0102), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16f", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0101 -> KeySetId 0x01a4. Note: Removes GroupId 0x0102."),
             TestStep("16g", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
             TestStep("16h", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: null, AccessAllowed: null, GroupcastTestResult: FailedAuth)."),
-            TestStep("16i", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to include entries mapping GroupId 0x0101 to GroupKeySetID 0x01a4, GroupId 0x0102 to GroupKeySetID 0x01a4, and GroupId 0x0300 to GroupKeySetID 0x01a3."),
+            TestStep("16i", "TH writes GroupKeyMap on DUT with entries: GroupId 0x0300 -> KeySetId 0x01a3, GroupId 0x0101 -> KeySetId 0x01a4, GroupId 0x0102 -> KeySetId 0x01a4. Note: No entries are removed."),
             TestStep("16j", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
             TestStep("16k", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: 0x0102, AccessAllowed: null, GroupcastTestResult: Success)."),
             TestStep("16l", "TH sends Groupcast cluster's GroupcastTesting command on EP0 with TestOperation field set to DisableTesting."),
@@ -163,7 +163,6 @@ class TC_SC_5_2(MatterBaseTest):
 
     async def run_test_against_endpoint(self, groups_endpoint: int):
         dev_ctrl = self.default_controller
-        dev_ctrl.InitGroupTestingData()
         node_id = self.dut_node_id
         groupcast_enabled = await is_groupcast_on_root_node(self)
 
@@ -265,6 +264,9 @@ class TC_SC_5_2(MatterBaseTest):
         dev_ctrl.SetGroupInfo(groupID3, "Group 0x0300", group_addr_policy)
         dev_ctrl.SetGroupKey(groupID3, keySetID1)
 
+        dev_ctrl.SetGroupInfo(groupID4, "Group 0x0201", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupID4, keySetID2)
+
         if groupcast_enabled:
             self.mark_step_range_skipped("3", "11")
         else:
@@ -273,6 +275,7 @@ class TC_SC_5_2(MatterBaseTest):
             mapping = [
                 Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
                 Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID4, groupKeySetID=keySetID2),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -128,10 +128,10 @@ class TC_SC_5_2(MatterBaseTest):
             TestStep("16e", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: null, AccessAllowed: null, GroupcastTestResult: FailedAuth)."),
             TestStep("16f", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to map GroupID 0x0101 to GroupKeySetID 0x01a4 (replacing GroupID 0x0102), while maintaining the mapping of GroupID 0x0300 to GroupKeySetID 0x01a3."),
             TestStep("16g", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
-            TestStep("16h", "TH verifies that no GroupcastTesting event is received from DUT within the response timeout."),
+            TestStep("16h", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: null, AccessAllowed: null, GroupcastTestResult: FailedAuth)."),
             TestStep("16i", "TH updates the GroupKeyMap attribute list on the DUT's GroupKeyManagement cluster to include entries mapping GroupId 0x0101 to GroupKeySetID 0x01a4, GroupId 0x0102 to GroupKeySetID 0x01a4, and GroupId 0x0300 to GroupKeySetID 0x01a3."),
             TestStep("16j", "TH sends the same group command destined for Group 0x0102 (encrypted using KeySet 0x01a4)."),
-            TestStep("16k", "TH verifies that no GroupcastTesting event is received from DUT within the response timeout."),
+            TestStep("16k", "TH waits for and verifies the GroupcastTesting event from DUT (GroupID: 0x0102, AccessAllowed: null, GroupcastTestResult: Success)."),
             TestStep("16l", "TH sends Groupcast cluster's GroupcastTesting command on EP0 with TestOperation field set to DisableTesting."),
             TestStep("17a", "TH removes GroupKeySetID 0x01a3 by sending a KeySetRemove command to the GroupKeyManagement cluster."),
             TestStep("17b", "TH removes GroupKeySetID 0x01a4 by sending a KeySetRemove command to the GroupKeyManagement cluster."),
@@ -478,13 +478,17 @@ class TC_SC_5_2(MatterBaseTest):
             self.step("16g")
             dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
 
-            # Step 16h: Verify that no GroupcastTesting event is received from DUT within response timeout.
+            # Step 16h: Validate the DUT rejected the group command via the GroupcastTesting event.
             self.step("16h")
-            try:
-                event_sub.wait_for_event_report(Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=5)
-                asserts.fail("Received unexpected GroupcastTesting event")
-            except queue.Empty:
-                pass
+            event_data = event_sub.wait_for_event_report(
+                Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
+            asserts.assert_true(event_data.groupID is None or event_data.groupID == NullValue,
+                                f"Expected GroupID to be null, got {event_data.groupID}")
+            asserts.assert_true(event_data.accessAllowed is None or event_data.accessAllowed == NullValue,
+                                f"Expected AccessAllowed to be null, got {event_data.accessAllowed}")
+            asserts.assert_equal(event_data.groupcastTestResult,
+                                 Clusters.Groupcast.Enums.GroupcastTestResultEnum.kFailedAuth,
+                                 "GroupcastTesting event should report FailedAuth")
 
             # Step 16i: Update GroupKeyMap to include 0x0101->0x01a4, 0x0102->0x01a4, 0x0300->0x01a3
             self.step("16i")
@@ -500,13 +504,16 @@ class TC_SC_5_2(MatterBaseTest):
             self.step("16j")
             dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
 
-            # Step 16k: Verify that no GroupcastTesting event is received from DUT within response timeout.
+            # Step 16k: Validate the DUT received the group command via the GroupcastTesting event.
             self.step("16k")
-            try:
-                event_sub.wait_for_event_report(Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=5)
-                asserts.fail("Received unexpected GroupcastTesting event")
-            except queue.Empty:
-                pass
+            event_data = event_sub.wait_for_event_report(
+                Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
+            asserts.assert_equal(event_data.groupID, groupID2, "Incorrect group ID in GroupcastTesting event")
+            asserts.assert_true(event_data.accessAllowed is None or event_data.accessAllowed == NullValue,
+                                f"Expected AccessAllowed to be null, got {event_data.accessAllowed}")
+            asserts.assert_equal(event_data.groupcastTestResult,
+                                 Clusters.Groupcast.Enums.GroupcastTestResultEnum.kSuccess,
+                                 "GroupcastTesting event should report Success")
 
             # Step 16l: Disable GroupcastTesting to restore normal operation.
             self.step("16l")

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -165,17 +165,17 @@ class TC_SC_5_2(MatterBaseTest):
         node_id = self.dut_node_id
         groupcast_enabled = await is_groupcast_on_root_node(self)
 
-        keySetID1 = 0x01a3
-        keySetID2 = 0x01a4
+        keySetId01a3 = 0x01a3
+        keySetId01a4 = 0x01a4
         epochKeyForKeySets = bytes.fromhex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf")
 
-        groupID1 = 0x0101
-        groupID2 = 0x0102
-        groupID3 = 0x0300
-        groupID4 = 0x0201
-        groupID5 = 0x0202
-        groupID6 = 0x0203
-        groupID7 = 0x0204
+        groupId0101 = 0x0101
+        groupId0102 = 0x0102
+        groupId0300 = 0x0300
+        groupId0201 = 0x0201
+        groupId0202 = 0x0202
+        groupId0203 = 0x0203
+        groupId0204 = 0x0204
 
         GROUP_INFO_FLAG_USE_IANA_ADDR = dev_ctrl.GROUP_INFO_FLAG_NONE
         GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY = dev_ctrl.GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY
@@ -191,7 +191,7 @@ class TC_SC_5_2(MatterBaseTest):
             Clusters.AccessControl.Structs.AccessControlEntryStruct(
                 privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kManage,
                 authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kGroup,
-                subjects=[groupID1, groupID2, groupID3],
+                subjects=[groupId0101, groupId0102, groupId0300],
                 targets=NullValue),
         ]
         await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.AccessControl.Attributes.Acl(acl))])
@@ -200,7 +200,7 @@ class TC_SC_5_2(MatterBaseTest):
         self.step("2a")
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
             groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
-                groupKeySetID=keySetID1,
+                groupKeySetID=keySetId01a3,
                 groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
                 epochKey0=epochKeyForKeySets,
                 epochStartTime0=2220000,
@@ -215,7 +215,7 @@ class TC_SC_5_2(MatterBaseTest):
         self.step("2b")
         await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetWrite(
             groupKeySet=Clusters.GroupKeyManagement.Structs.GroupKeySetStruct(
-                groupKeySetID=keySetID2,
+                groupKeySetID=keySetId01a4,
                 groupKeySecurityPolicy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
                 epochKey0=epochKeyForKeySets,
                 epochStartTime0=2220000,
@@ -229,7 +229,7 @@ class TC_SC_5_2(MatterBaseTest):
         # Step 2c: Configure local GroupKeyMap on the TH
         self.step("2c")
         dev_ctrl.SetGroupKeySet(
-            keyset_id=keySetID1,
+            keyset_id=keySetId01a3,
             policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
             num_keys=1,
             epoch_key0=epochKeyForKeySets,
@@ -241,7 +241,7 @@ class TC_SC_5_2(MatterBaseTest):
         )
 
         dev_ctrl.SetGroupKeySet(
-            keyset_id=keySetID2,
+            keyset_id=keySetId01a4,
             policy=Clusters.GroupKeyManagement.Enums.GroupKeySecurityPolicyEnum.kTrustFirst,
             num_keys=1,
             epoch_key0=epochKeyForKeySets,
@@ -254,17 +254,17 @@ class TC_SC_5_2(MatterBaseTest):
 
         group_addr_policy = GROUP_INFO_FLAG_USE_IANA_ADDR if groupcast_enabled else GROUP_INFO_FLAG_PER_GROUP_ADDRESS_POLICY
 
-        dev_ctrl.SetGroupInfo(groupID1, "Group 0x0101", group_addr_policy)
-        dev_ctrl.SetGroupKey(groupID1, keySetID2)
+        dev_ctrl.SetGroupInfo(groupId0101, "Group 0x0101", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupId0101, keySetId01a4)
 
-        dev_ctrl.SetGroupInfo(groupID2, "Group 0x0102", group_addr_policy)
-        dev_ctrl.SetGroupKey(groupID2, keySetID2)
+        dev_ctrl.SetGroupInfo(groupId0102, "Group 0x0102", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupId0102, keySetId01a4)
 
-        dev_ctrl.SetGroupInfo(groupID3, "Group 0x0300", group_addr_policy)
-        dev_ctrl.SetGroupKey(groupID3, keySetID1)
+        dev_ctrl.SetGroupInfo(groupId0300, "Group 0x0300", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupId0300, keySetId01a3)
 
-        dev_ctrl.SetGroupInfo(groupID4, "Group 0x0201", group_addr_policy)
-        dev_ctrl.SetGroupKey(groupID4, keySetID2)
+        dev_ctrl.SetGroupInfo(groupId0201, "Group 0x0201", group_addr_policy)
+        dev_ctrl.SetGroupKey(groupId0201, keySetId01a4)
 
         if groupcast_enabled:
             self.mark_step_range_skipped("3", "11")
@@ -272,9 +272,9 @@ class TC_SC_5_2(MatterBaseTest):
             # Step 3: GroupKeyMap binding
             self.step("3")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID4, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0101, groupKeySetID=keySetId01a4),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0201, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
@@ -285,88 +285,88 @@ class TC_SC_5_2(MatterBaseTest):
 
             # Step 5a: AddGroup 0x0300
             self.step("5a")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupID3))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupId0300))
             asserts.assert_equal(result.status, Status.Success, "AddGroup 0x0300 failed")
-            asserts.assert_equal(result.groupID, groupID3, "AddGroup 0x0300 groupID mismatch")
+            asserts.assert_equal(result.groupID, groupId0300, "AddGroup 0x0300 groupID mismatch")
 
             # Step 5b: AddGroup 0x0101
             self.step("5b")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupID1))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.AddGroup(groupId0101))
             asserts.assert_equal(result.status, Status.Success, "AddGroup 0x0101 failed")
-            asserts.assert_equal(result.groupID, groupID1, "AddGroup 0x0101 groupID mismatch")
+            asserts.assert_equal(result.groupID, groupId0101, "AddGroup 0x0101 groupID mismatch")
 
             # Step 6a: AddGroup 0x0201 as group command via GroupID 0x0101
             self.step("6a")
-            dev_ctrl.SendGroupCommand(groupID1, Clusters.Groups.Commands.AddGroup(groupID4))
+            dev_ctrl.SendGroupCommand(groupId0101, Clusters.Groups.Commands.AddGroup(groupId0201))
 
             # Step 6b: ViewGroup 0x0201 to confirm success
             self.step("6b")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID4))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupId0201))
             asserts.assert_equal(result.status, Status.Success, "ViewGroup 0x0201 failed")
-            asserts.assert_equal(result.groupID, groupID4, "ViewGroup groupID mismatch")
+            asserts.assert_equal(result.groupID, groupId0201, "ViewGroup groupID mismatch")
 
             # Step 7a: Update GroupKeyMap to map 0x0102 to 0x01a4, maintaining 0x0300 to 0x01a3
             self.step("7a")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0102, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 7b: AddGroup 0x0202 as group command via GroupID 0x0101
             self.step("7b")
-            dev_ctrl.SendGroupCommand(groupID1, Clusters.Groups.Commands.AddGroup(groupID5))
+            dev_ctrl.SendGroupCommand(groupId0101, Clusters.Groups.Commands.AddGroup(groupId0202))
 
             # Step 7c: ViewGroup 0x0202 to confirm rejection
             self.step("7c")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID5))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupId0202))
             asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0202")
 
             # Step 8a: Update GroupKeyMap to map 0x0101 to 0x01a4, maintaining 0x0300 to 0x01a3
             self.step("8a")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0101, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 8b: AddGroup 0x0203 as group command via GroupID 0x0102
             self.step("8b")
-            dev_ctrl.SendGroupCommand(groupID2, Clusters.Groups.Commands.AddGroup(groupID6))
+            dev_ctrl.SendGroupCommand(groupId0102, Clusters.Groups.Commands.AddGroup(groupId0203))
 
             # Step 8c: ViewGroup 0x0203 to confirm rejection
             self.step("8c")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID6))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupId0203))
             asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0203")
 
             # Step 9a: Update GroupKeyMap to include 0x0101->0x01a4, 0x0102->0x01a4, 0x0300->0x01a3
             self.step("9a")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0101, groupKeySetID=keySetId01a4),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0102, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 9b: AddGroup 0x0204 as group command via GroupID 0x0102
             self.step("9b")
-            dev_ctrl.SendGroupCommand(groupID2, Clusters.Groups.Commands.AddGroup(groupID7))
+            dev_ctrl.SendGroupCommand(groupId0102, Clusters.Groups.Commands.AddGroup(groupId0204))
 
             # Step 9c: ViewGroup 0x0204 to confirm rejection
             self.step("9c")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID7))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupId0204))
             asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND for rejected AddGroup 0x0204")
 
             # Step 10a: RemoveGroup 0x0101 as group command via GroupID 0x0300
             self.step("10a")
-            dev_ctrl.SendGroupCommand(groupID3, Clusters.Groups.Commands.RemoveGroup(groupID1))
+            dev_ctrl.SendGroupCommand(groupId0300, Clusters.Groups.Commands.RemoveGroup(groupId0101))
 
             # Step 10b: ViewGroup 0x0101 to confirm removal
             self.step("10b")
-            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupID1))
+            result = await self.send_single_cmd(endpoint=groups_endpoint, cmd=Clusters.Groups.Commands.ViewGroup(groupId0101))
             asserts.assert_equal(result.status, Status.NotFound, "ViewGroup should return NOT_FOUND after RemoveGroup 0x0101")
 
             # Step 11: RemoveAllGroups cleanup
@@ -390,19 +390,19 @@ class TC_SC_5_2(MatterBaseTest):
             # Step 13a: JoinGroup 0x0300
             self.step("13a")
             await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID3, endpoints=[groups_endpoint], keySetID=keySetID1))
+                groupID=groupId0300, endpoints=[groups_endpoint], keySetID=keySetId01a3))
 
             # Step 13b: JoinGroup 0x0101
             self.step("13b")
             await self.send_single_cmd(endpoint=0, cmd=Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID1, endpoints=[groups_endpoint], keySetID=keySetID2))
+                groupID=groupId0101, endpoints=[groups_endpoint], keySetID=keySetId01a4))
 
             # Step 14: Read Membership
             self.step("14")
             membership = await self.read_single_attribute_check_success(cluster=Clusters.Groupcast, attribute=Clusters.Groupcast.Attributes.Membership, endpoint=0)
             group_ids = [entry.groupID for entry in membership]
-            asserts.assert_in(groupID3, group_ids, "GroupID 0x0300 not found in Membership")
-            asserts.assert_in(groupID1, group_ids, "GroupID 0x0101 not found in Membership")
+            asserts.assert_in(groupId0300, group_ids, "GroupID 0x0300 not found in Membership")
+            asserts.assert_in(groupId0101, group_ids, "GroupID 0x0101 not found in Membership")
 
             # Step 15a: Subscribe to GroupcastTesting events on the RootNode.
             self.step("15a")
@@ -430,13 +430,13 @@ class TC_SC_5_2(MatterBaseTest):
 
             # Step 16a: Send the operate-only command as a group command to GroupID 0x0101.
             self.step("16a")
-            dev_ctrl.SendGroupCommand(groupID1, operate_only_command.command_object())
+            dev_ctrl.SendGroupCommand(groupId0101, operate_only_command.command_object())
 
             # Step 16b: Validate the DUT received the group command via the GroupcastTesting event.
             self.step("16b")
             event_data = event_sub.wait_for_event_report(
                 Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
-            asserts.assert_equal(event_data.groupID, groupID1, "Incorrect group ID in GroupcastTesting event")
+            asserts.assert_equal(event_data.groupID, groupId0101, "Incorrect group ID in GroupcastTesting event")
             asserts.assert_true(event_data.accessAllowed, "AccessAllowed should be true")
             asserts.assert_equal(event_data.groupcastTestResult,
                                  Clusters.Groupcast.Enums.GroupcastTestResultEnum.kSuccess,
@@ -445,15 +445,15 @@ class TC_SC_5_2(MatterBaseTest):
             # Step 16c: Update GroupKeyMap to map 0x0102 to 0x01a4, maintaining 0x0300 to 0x01a3
             self.step("16c")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0102, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 16d: Send the operate-only command as a group command to GroupID 0x0101.
             self.step("16d")
-            dev_ctrl.SendGroupCommand(groupID1, operate_only_command.command_object())
+            dev_ctrl.SendGroupCommand(groupId0101, operate_only_command.command_object())
 
             # Step 16e: Validate the DUT rejected the group command via the GroupcastTesting event.
             self.step("16e")
@@ -470,15 +470,15 @@ class TC_SC_5_2(MatterBaseTest):
             # Step 16f: Update GroupKeyMap to map 0x0101 to 0x01a4, maintaining 0x0300 to 0x01a3
             self.step("16f")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0101, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 16g: Send the operate-only command as a group command to GroupID 0x0102.
             self.step("16g")
-            dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
+            dev_ctrl.SendGroupCommand(groupId0102, operate_only_command.command_object())
 
             # Step 16h: Validate the DUT rejected the group command via the GroupcastTesting event.
             self.step("16h")
@@ -495,22 +495,22 @@ class TC_SC_5_2(MatterBaseTest):
             # Step 16i: Update GroupKeyMap to include 0x0101->0x01a4, 0x0102->0x01a4, 0x0300->0x01a3
             self.step("16i")
             mapping = [
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID3, groupKeySetID=keySetID1),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID1, groupKeySetID=keySetID2),
-                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupID2, groupKeySetID=keySetID2),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0300, groupKeySetID=keySetId01a3),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0101, groupKeySetID=keySetId01a4),
+                Clusters.GroupKeyManagement.Structs.GroupKeyMapStruct(groupId=groupId0102, groupKeySetID=keySetId01a4),
             ]
             result = await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.GroupKeyManagement.Attributes.GroupKeyMap(mapping))])
             asserts.assert_equal(result[0].Status, Status.Success, "GroupKeyMap write failed")
 
             # Step 16j: Send the operate-only command as a group command to GroupID 0x0102.
             self.step("16j")
-            dev_ctrl.SendGroupCommand(groupID2, operate_only_command.command_object())
+            dev_ctrl.SendGroupCommand(groupId0102, operate_only_command.command_object())
 
             # Step 16k: Validate the DUT received the group command via the GroupcastTesting event.
             self.step("16k")
             event_data = event_sub.wait_for_event_report(
                 Clusters.Groupcast.Events.GroupcastTesting, timeout_sec=30)
-            asserts.assert_equal(event_data.groupID, groupID2, "Incorrect group ID in GroupcastTesting event")
+            asserts.assert_equal(event_data.groupID, groupId0102, "Incorrect group ID in GroupcastTesting event")
             asserts.assert_true(event_data.accessAllowed is None or event_data.accessAllowed == NullValue,
                                 f"Expected AccessAllowed to be null, got {event_data.accessAllowed}")
             asserts.assert_equal(event_data.groupcastTestResult,
@@ -524,11 +524,11 @@ class TC_SC_5_2(MatterBaseTest):
 
         # Step 17a: KeySetRemove 0x01a3
         self.step("17a")
-        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetID1))
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetId01a3))
 
         # Step 17b: KeySetRemove 0x01a4
         self.step("17b")
-        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetID2))
+        await self.send_single_cmd(endpoint=0, cmd=Clusters.GroupKeyManagement.Commands.KeySetRemove(keySetId01a4))
 
         # Step 18: Restore ACL
         self.step("18")


### PR DESCRIPTION
### Summary

This PR updates test TC_SC_5_2 to match the test plan. These new steps are to ensure when there are multiple candidate keys that result in the same group session ids (collision after applying KDF), that decryption only proceeds when the right operational group key is found for the targeted group. It also means that authentication succeeds only when the operational group key used for decryption maps to the right group. The test mimics this by using the same epoch key for 2 separate key sets (which means they both will result in the same group session ID). This PR builds upon the work started in https://github.com/project-chip/connectedhomeip/pull/72673

### Testing

- CI should still pass
- Ran test locally with all devices app with and without groupcast. Passed successfully 
