### PR TITLE
[tv-casting] Fix dangling MAC-address span when copying TargetVideoPlayerInfo

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/tests/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/core/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
   test_sources = [
     "TestCastingPlayerFabricCleanup.cpp",
     "TestCastingPlayerNullPointerFix.cpp",
+    "TestTargetVideoPlayerInfoCopy.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/examples/tv-casting-app/tv-casting-common/core/tests/TestTargetVideoPlayerInfoCopy.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/tests/TestTargetVideoPlayerInfoCopy.cpp
@@ -1,0 +1,71 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/support/Span.h>
+
+#include "../../include/TargetVideoPlayerInfo.h"
+
+#include <cstring>
+
+using namespace chip;
+
+namespace {
+
+// SetMACAddress() copies sizeof(mMACAddressBuf) (== 2 * kPrimaryMACAddressLength, at most 16) bytes
+// from the input regardless of the passed span length, so the seeds must be at least that long.
+constexpr char kMacA[] = "AABBCCDDEEFF0011223344556677";
+constexpr char kMacB[] = "ffffffffffffffffffffffffffff";
+
+// Before the rule-of-three fix, the implicitly-defaulted copy duplicated mMACAddress's {ptr,len}
+// verbatim, so the copy's span aliased the SOURCE's mMACAddressBuf. These assert the copy's span is
+// re-bound into its OWN buffer (independent of the source).
+
+TEST(TestTargetVideoPlayerInfoCopy, CopyAssignReBindsMacSpanToOwnBuffer)
+{
+    TargetVideoPlayerInfo source;
+    source.SetMACAddress(CharSpan(kMacA, strlen(kMacA)));
+
+    TargetVideoPlayerInfo copy;
+    copy = source;
+
+    // The copy's MAC span must point into the copy's own buffer, not the source's.
+    EXPECT_NE(copy.GetMACAddress()->data(), source.GetMACAddress()->data());
+
+    // ...and it must keep its own bytes after the source's buffer is overwritten.
+    const size_t macLen = copy.GetMACAddress()->size();
+    source.SetMACAddress(CharSpan(kMacB, strlen(kMacB)));
+    EXPECT_EQ(0, memcmp(copy.GetMACAddress()->data(), kMacA, macLen));
+}
+
+TEST(TestTargetVideoPlayerInfoCopy, CopyConstructReBindsMacSpanToOwnBuffer)
+{
+    TargetVideoPlayerInfo source;
+    source.SetMACAddress(CharSpan(kMacA, strlen(kMacA)));
+
+    TargetVideoPlayerInfo copy(source);
+
+    EXPECT_NE(copy.GetMACAddress()->data(), source.GetMACAddress()->data());
+
+    const size_t macLen = copy.GetMACAddress()->size();
+    source.SetMACAddress(CharSpan(kMacB, strlen(kMacB)));
+    EXPECT_EQ(0, memcmp(copy.GetMACAddress()->data(), kMacA, macLen));
+}
+
+} // namespace

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -72,6 +72,51 @@ class TargetVideoPlayerInfo
 public:
     TargetVideoPlayerInfo() {}
 
+    // mMACAddress is a CharSpan that points into this object's own mMACAddressBuf, and mDeviceProxy is
+    // a raw pointer to a live connection. The compiler-generated copy would (a) duplicate mMACAddress's
+    // pointer verbatim, leaving the copy's span aliasing the SOURCE's buffer (a later read then
+    // serializes the wrong/destroyed MAC — see the cached-player shift in PersistenceManager), and
+    // (b) shallow-copy mDeviceProxy so two infos point at one proxy. Deep-copy the buffer and re-bind
+    // the span to this object, and do not adopt the source's proxy.
+    TargetVideoPlayerInfo(const TargetVideoPlayerInfo & other) { *this = other; }
+
+    TargetVideoPlayerInfo & operator=(const TargetVideoPlayerInfo & other)
+    {
+        if (this == &other)
+        {
+            return *this;
+        }
+
+        for (size_t i = 0; i < kMaxNumberOfEndpoints; i++)
+        {
+            mEndpoints[i] = other.mEndpoints[i];
+        }
+        mNodeId      = other.mNodeId;
+        mFabricIndex = other.mFabricIndex;
+        mDeviceProxy = nullptr; // a cached copy does not own or share the source's live device proxy
+        mVendorId    = other.mVendorId;
+        mProductId   = other.mProductId;
+        mDeviceType  = other.mDeviceType;
+        memcpy(mDeviceName, other.mDeviceName, sizeof(mDeviceName));
+        memcpy(mHostName, other.mHostName, sizeof(mHostName));
+        mNumIPs = other.mNumIPs;
+        for (size_t i = 0; i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
+        {
+            mIpAddress[i] = other.mIpAddress[i];
+        }
+        memcpy(mInstanceName, other.mInstanceName, sizeof(mInstanceName));
+        mPort = other.mPort;
+
+        // Re-bind the self-referential MAC span into THIS object's buffer.
+        memcpy(mMACAddressBuf, other.mMACAddressBuf, sizeof(mMACAddressBuf));
+        mMACAddress = chip::CharSpan(mMACAddressBuf, other.mMACAddress.size());
+
+        mLastDiscovered = other.mLastDiscovered;
+        mIsAsleep       = other.mIsAsleep;
+        mInitialized    = other.mInitialized;
+        return *this;
+    }
+
     bool operator==(const TargetVideoPlayerInfo & other) const { return this->mNodeId == other.mNodeId; }
 
     bool IsInitialized() { return mInitialized; }


### PR DESCRIPTION
#### Summary

##### Problem

- `TargetVideoPlayerInfo::mMACAddress` is a `CharSpan` that `SetMACAddress()` binds to the object's own inline `mMACAddressBuf`. The class declares no copy constructor or copy-assignment operator, so the implicitly-defaulted copy duplicates the span's `{ptr, len}` verbatim — the copy's span points into the **source object's** buffer, not its own.
- `PersistenceManager` copies `TargetVideoPlayerInfo` **by value** into a stack array, including the cached-player delete-shift:
  ```cpp
  cachedVideoPlayers[i] = cachedVideoPlayers[i + 1];
  ```
  After the shift, each element's `mMACAddress` aliases a neighbour's `mMACAddressBuf`, and `WriteAllVideoPlayers()` serializes those spans.
- The same defaulted copy also shallow-copies the raw `mDeviceProxy` pointer, leaving two objects referencing one proxy.

##### Impact

- After a cached video player is removed, the MAC addresses persisted to KVS for the shifted entries are wrong: each takes a neighbour's MAC, and the last reads from a reset buffer. No memory-safety violation is reachable today (the aliasing stays within a live stack array), but the persisted data is corrupted.

##### Solution

- Add a copy constructor and copy-assignment operator that deep-copy `mMACAddressBuf` and re-bind `mMACAddress` into the destination object's own buffer.
- The copy does not adopt the source's `mDeviceProxy` (it is set to `nullptr`); a cached copy is not a live connection and must not share or own another object's proxy.

##### Caveats

- The `examples/tv-casting-app/tv-casting-common/core/tests` suite is not currently wired into CI, so the new test — like the existing tests in that directory — only runs when built and executed locally.

#### Testing

- Added `TestTargetVideoPlayerInfoCopy.cpp` (cases `CopyAssignReBindsMacSpanToOwnBuffer`, `CopyConstructReBindsMacSpanToOwnBuffer`) under `examples/tv-casting-app/tv-casting-common/core/tests`.
- Verified red→green under AddressSanitizer: 2 failures before the fix (the copy's span aliases the source's buffer), 2 passes after, no ASan abort.
  ```
  ./scripts/examples/gn_build_example.sh examples/tv-casting-app/linux out/tv-casting-asan 'is_asan=true is_clang=true'
  ninja -C out/tv-casting-asan tests/TestTargetVideoPlayerInfoCopy
  ./out/tv-casting-asan/tests/TestTargetVideoPlayerInfoCopy
  ```
