### PR TITLE
[app] Make self-referential span-owning helpers non-copyable

### DIFF
--- a/src/app/clusters/meter-identification-server/meter-identification-server.h
+++ b/src/app/clusters/meter-identification-server/meter-identification-server.h
@@ -40,6 +40,13 @@ public:
     {}
     ~Instance() override;
 
+    // mPointOfDelivery / mMeterSerialNumber / mProtocolVersion are CharSpans bound (in the setters) to
+    // this object's own m*Buf[] buffers, so a defaulted copy would leave them aliasing the source's
+    // buffers. The instance is a single registered AttributeAccessInterface and is never copied; forbid
+    // copying so an accidental copy is a compile error rather than a dangling-span alias.
+    Instance(const Instance &)             = delete;
+    Instance & operator=(const Instance &) = delete;
+
     CHIP_ERROR Init();
     void Shutdown();
 

--- a/src/app/server/ThreadRendezvousAnnouncement.h
+++ b/src/app/server/ThreadRendezvousAnnouncement.h
@@ -36,6 +36,12 @@ class TxtStringsBuilder
 public:
     TxtStringsBuilder() = default;
 
+    // mNextStart and the mTxtStrings entries point into this object's own mTxtBuffer, so a defaulted
+    // copy would leave them aliasing the source's buffer. The builder is used as a single local and is
+    // never copied; forbid copying so an accidental copy is a compile error rather than a dangling alias.
+    TxtStringsBuilder(const TxtStringsBuilder &)             = delete;
+    TxtStringsBuilder & operator=(const TxtStringsBuilder &) = delete;
+
     /**
      * @brief Fills the TXT record entries from the given advertising parameters.
      *


### PR DESCRIPTION
#### Summary

##### Problem

- Two classes hold a view (span / pointer) that points into their own inline buffer but rely on the compiler-generated copy, which shallow-copies the view so a copy's view aliases the **source object's** buffer:
  - `TxtStringsBuilder` (`src/app/server/ThreadRendezvousAnnouncement.h`) — `mNextStart` and the `mTxtStrings[]` entries point into `mTxtBuffer`.
  - `MeterIdentification::Instance` (`src/app/clusters/meter-identification-server/`) — `mPointOfDelivery` / `mMeterSerialNumber` / `mProtocolVersion` are `CharSpan`s bound (in the setters) to the object's own `m*Buf[]` buffers.
- Both are fully copyable today and neither is ever copied, so there is no bug in current code — but a future copy or pass-by-value would silently produce a dangling-span alias.

##### Solution

- Delete the copy constructor and copy-assignment operator on both classes, so any accidental copy is a compile error rather than a dangling alias. (Deleting the copy operations also suppresses the implicit move, making the types non-copyable/non-movable.)
- Neither type needs to be copyable: `TxtStringsBuilder` is used as a single local, and `MeterIdentification::Instance` is a single registered `AttributeAccessInterface`.

##### Caveats

- Hardening only; no behavior change. This is a defensive guard against a future copy introducing a dangling-span alias, not a fix for a reachable bug.

#### Testing

- Built `examples/energy-gateway-app/linux` under AddressSanitizer (it includes the Meter Identification cluster) to confirm `MeterIdentification::Instance` compiles with the `= delete` — i.e. nothing copies it.
- Built and ran `TestThreadRendezvousAnnouncement` (which exercises `TxtStringsBuilder` via `BuildThreadRendezvousAnnouncement`) under ASan — it compiles with the `= delete` and all 3 cases pass.
  ```
  ./scripts/examples/gn_build_example.sh examples/energy-gateway-app/linux out/energy-gw-asan 'is_asan=true is_clang=true'
  gn gen out/energy-gw-asan --args='is_asan=true is_clang=true chip_device_config_enable_thread_meshcop=true'
  ninja -C out/energy-gw-asan tests/TestThreadRendezvousAnnouncement
  ./out/energy-gw-asan/tests/TestThreadRendezvousAnnouncement
  ```
