### PR TITLE
[core] Delete Cancelable::operator= to complete its rule-of-three

### DIFF
--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -90,6 +90,11 @@ public:
     ~Cancelable() { Cancel(); }
 
     Cancelable(const Cancelable &) = delete;
+    // A Cancelable links itself into intrusive cancelable lists via mNext/mPrev, so it must not be
+    // copy-assigned either: a shallow assignment would copy those list links and corrupt the lists
+    // (and silently shallow-copy any Callback subclass). Complete the rule-of-three; copy construction
+    // is already deleted above.
+    Cancelable & operator=(const Cancelable &) = delete;
 };
 
 typedef void (*CallFn)(void *);


### PR DESCRIPTION
#### Summary

##### Problem

- `chip::Callback::Cancelable` (`src/lib/core/CHIPCallback.h`) deletes its copy constructor but not its copy-assignment operator. Its data members are intrusive cancelable-list links (`mNext`/`mPrev`), so it is non-copy-constructible yet **still copy-assignable** via a defaulted, shallow `operator=` that copies those links.
- That asymmetry propagates to every class holding a `Callback` by value: such a class is non-copy-constructible (its implicit copy-ctor is deleted) but **still copy-assignable** — its implicit copy-assignment shallow-copies the `Callback` member's list links, and any self-referential buffer view the class owns. Examples: `DefaultOTARequestor`, `CommissioningWindowOpener`, `AndroidLogDownloadFromNode`.

##### Impact

- A copy-assignment of such an object would corrupt the intrusive cancelable lists (two nodes sharing `mNext`/`mPrev`) and shallow-copy any self-referential span. No code does this today, but nothing prevents it, and the deleted copy-constructor gives a false impression that these types are non-copyable.

##### Solution

- Delete `Cancelable::operator=` as well, completing the rule-of-three (copy construction is already deleted). `Cancelable` becomes fully non-copyable, and every `Callback`-holding class becomes non-copy-assignable automatically — one root fix rather than per-class `= delete`s, and it also covers future `Callback` holders.

##### Caveats

- Hardening only; no behavior change. Nothing in the tree currently copy-assigns a `Callback`/`Cancelable`.

#### Testing

- Rebuilt the device-side tree under AddressSanitizer with the change — `examples/energy-gateway-app/linux` plus the `src/` unit tests and `src/controller` controller wheels it pulls in (~2250 targets): everything compiles, confirming nothing copy-assigns a `Callback` today. A repo-wide grep for `Callback` copy-assignment also found none.
- Confirmed with a `static_assert(!std::is_copy_assignable<...>)` probe that a representative holder (`DefaultOTARequestor`) changes from copy-assignable to non-copy-assignable with this change.
