### PR TITLE
[app][controller] Forbid copying self-referential classes that are only incidentally non-copyable

### DIFF
--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -77,6 +77,11 @@ public:
         mDelegate.SetEndpointId(config.endpointId);
     }
 
+    // mVehicleID spans into this object's own mVehicleIDBuffer, so a copy would alias the source's.
+    // Forbid copying explicitly (closes the still-open copy ctor; assign is already implicitly deleted).
+    EnergyEvseCluster(const EnergyEvseCluster &)             = delete;
+    EnergyEvseCluster & operator=(const EnergyEvseCluster &) = delete;
+
     const BitFlags<EnergyEvse::Feature> & Features() const { return mFeatureFlags; }
     const BitFlags<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
     const BitFlags<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -41,6 +41,12 @@ class DefaultOTARequestor : public OTARequestorInterface, public BDXDownloader::
 public:
     DefaultOTARequestor() : mOnConnectedCallback(OnConnected, this), mOnConnectionFailureCallback(OnConnectionFailure, this) {}
 
+    // mUpdateToken / mFileDesignator span into this object's own buffers, so a copy would alias the
+    // source's. Forbid copying explicitly, pinning the invariant to the buffers rather than to the
+    // Callback members.
+    DefaultOTARequestor(const DefaultOTARequestor &)             = delete;
+    DefaultOTARequestor & operator=(const DefaultOTARequestor &) = delete;
+
     //////////// OTARequestorInterface Implementation ///////////////
     void Reset(void) override;
 

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
@@ -100,6 +100,12 @@ public:
                                const OptionalAttributeSet & optionalAttributeSet, const StartupConfiguration & config,
                                Context context);
 
+    // mTimeZoneObj / mDstOffsetObj hold list views into this object's own mTz[] / mDst[] arrays, so a
+    // copy would alias the source's. Forbid copying explicitly (closes the still-open copy ctor; assign
+    // is already implicitly deleted).
+    TimeSynchronizationCluster(const TimeSynchronizationCluster &)             = delete;
+    TimeSynchronizationCluster & operator=(const TimeSynchronizationCluster &) = delete;
+
     CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown(ClusterShutdownType type) override;
 

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -43,6 +43,11 @@ public:
         mDeviceConnectionFailure(&OnDeviceConnectionFailureCallback, this)
     {}
 
+    // mPBKDFSalt spans into this object's own mPBKDFSaltBuffer, so a copy would alias the source's.
+    // Forbid copying explicitly, pinning the invariant to the buffer rather than to the Callback members.
+    CommissioningWindowOpener(const CommissioningWindowOpener &)             = delete;
+    CommissioningWindowOpener & operator=(const CommissioningWindowOpener &) = delete;
+
     enum class CommissioningWindowOption : uint8_t
     {
         kOriginalSetupCode = 0,

--- a/src/controller/java/AndroidLogDownloadFromNode.h
+++ b/src/controller/java/AndroidLogDownloadFromNode.h
@@ -50,6 +50,12 @@ public:
                                           app::Clusters::DiagnosticLogs::IntentEnum intent, uint16_t timeout,
                                           jobject jCallbackObject);
 
+    // mFileDesignator spans into this object's own mFileDesignatorBuffer, so a copy would alias the
+    // source's. Forbid copying explicitly, pinning the invariant to the buffer rather than to the
+    // Callback members.
+    AndroidLogDownloadFromNode(const AndroidLogDownloadFromNode &)             = delete;
+    AndroidLogDownloadFromNode & operator=(const AndroidLogDownloadFromNode &) = delete;
+
 private:
     AndroidLogDownloadFromNode(DeviceController * controller, NodeId remoteNodeId, app::Clusters::DiagnosticLogs::IntentEnum intent,
                                uint16_t timeout, jobject javaCallback);


### PR DESCRIPTION
#### Summary

These classes own an inline buffer and hold a span/pointer into it, so a defaulted copy shallow-copies the view, leaving it aliasing the **source object's** buffer. Each is non-copyable today only **incidentally** — one copy operation is blocked by an unrelated member, but the other is still open.

##### Problem

- Copy *constructor* blocked (a non-copyable `Callback` member), copy *assignment* still open:
  - `DefaultOTARequestor` (`src/app/clusters/ota-requestor/`) — `mUpdateToken` / `mFileDesignator`.
  - `CommissioningWindowOpener` (`src/controller/`) — `mPBKDFSalt`.
  - `AndroidLogDownloadFromNode` (`src/controller/java/`) — `mFileDesignator`.
- Copy *assignment* blocked (a `const` / reference member), copy *constructor* still open:
  - `TimeSynchronizationCluster` (`src/app/clusters/time-synchronization-server/`) — `mTimeZoneObj` / `mDstOffsetObj` view into `mTz[]` / `mDst[]`.
  - `EnergyEvseCluster` (`src/app/clusters/energy-evse-server/`) — `mVehicleID` into `mVehicleIDBuffer`.

In every case the still-open copy operation would alias the self-referential spans, and the incidental protection would disappear if that member were ever changed (e.g. the callback mechanism refactored away, or a `const` dropped).

##### Solution

- Explicitly delete the copy constructor and copy-assignment operator on each, closing the open operation and pinning the non-copyability to the self-referential buffers rather than to an incidental member property. None of these types is ever copied — they are single registered or heap-allocated instances.

##### Caveats

- Hardening only; no behavior change (each is already non-copyable in one direction today).

#### Testing

- Built `examples/energy-gateway-app/linux` under AddressSanitizer — including the `src/controller` wheels it pulls in — compiling `DefaultOTARequestor`, `CommissioningWindowOpener`, `TimeSynchronizationCluster`, and `EnergyEvseCluster` (and the TimeSync/EnergyEvse unit tests) with the `= delete`s, confirming nothing copies these types. `AndroidLogDownloadFromNode` is Android/JNI-only and is covered by CI.
