### PR TITLE
[Tools] Implement automated platform maintainers merge bot and configuration

### DIFF
--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -19,6 +19,7 @@ nxp:
     - "examples/platform/nxp/**"
     - "examples/**/nxp/**"
     - "third_party/nxp/**"
+    - "config/nxp/**"
 
 silabs:
   maintainers:
@@ -35,6 +36,8 @@ silabs:
     - "examples/platform/silabs/**"
     - "examples/**/silabs/**"
     - "third_party/silabs/**"
+    - "config/silabs/**"
+    - "config/efr32/**"
 
 # --- Proposals / Opt-In Templates ---
 
@@ -48,6 +51,7 @@ silabs:
 #     - "src/platform/ESP32/**"
 #     - "examples/platform/esp32/**"
 #     - "examples/**/esp32/**"
+#     - "config/esp32/**"
 # 
 # telink:
 #   maintainers:
@@ -57,6 +61,7 @@ silabs:
 #     - "src/platform/telink/**"
 #     - "examples/platform/telink/**"
 #     - "examples/**/telink/**"
+#     - "config/telink/**"
 # 
 # nrfconnect:
 #   maintainers:
@@ -67,6 +72,7 @@ silabs:
 #     - "src/platform/nrfconnect/**"
 #     - "examples/platform/nrfconnect/**"
 #     - "examples/**/nrfconnect/**"
+#     - "config/nrfconnect/**"
 # 
 # tizen:
 #   maintainers:
@@ -76,6 +82,7 @@ silabs:
 #     - "src/platform/Tizen/**"
 #     - "examples/platform/tizen/**"
 #     - "examples/**/tizen/**"
+#     - "config/tizen/**"
 # 
 # realtek:
 #   maintainers:
@@ -87,6 +94,8 @@ silabs:
 #     - "examples/platform/ameba/**"
 #     - "examples/**/realtek/**"
 #     - "examples/**/ameba/**"
+#     - "config/realtek/**"
+#     - "config/ameba/**"
 # 
 # asr:
 #   maintainers:
@@ -95,6 +104,7 @@ silabs:
 #     - "src/platform/ASR/**"
 #     - "examples/platform/asr/**"
 #     - "examples/**/asr/**"
+#     - "config/asr/**"
 # 
 # beken:
 #   maintainers:
@@ -103,6 +113,7 @@ silabs:
 #     - "src/platform/Beken/**"
 #     - "examples/platform/beken/**"
 #     - "examples/**/beken/**"
+#     - "config/beken/**"
 # 
 # bouffalolab:
 #   maintainers:
@@ -111,6 +122,7 @@ silabs:
 #     - "src/platform/bouffalolab/**"
 #     - "examples/platform/bouffalolab/**"
 #     - "examples/**/bouffalolab/**"
+#     - "config/bouffalolab/**"
 # 
 # qpg:
 #   maintainers:
@@ -121,6 +133,7 @@ silabs:
 #     - "src/platform/qpg/**"
 #     - "examples/platform/qpg/**"
 #     - "examples/**/qpg/**"
+#     - "config/qpg/**"
 # 
 # stm32:
 #   maintainers:
@@ -129,6 +142,7 @@ silabs:
 #     - "src/platform/stm32/**"
 #     - "examples/platform/stm32/**"
 #     - "examples/**/stm32/**"
+#     - "config/stm32/**"
 # 
 # webos:
 #   maintainers:
@@ -154,3 +168,5 @@ silabs:
 #     - "examples/platform/cc32xx/**"
 #     - "examples/**/ti/**"
 #     - "examples/**/cc32xx/**"
+#     - "config/ti/**"
+#     - "config/cc32xx/**"

--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -1,15 +1,19 @@
 # Platform groups defining maintainers and their corresponding paths.
 # Git-style wildmatch globs are supported (via python pathspec).
+#
+# Platforms must OPT-IN to this system. Active platforms are listed
+# uncommented below. Proposals/examples for other platforms are commented out.
 
 nxp:
   maintainers:
-    - Martin-NXP
-    - dinabenamar
-    - marian-chereji-nxp
-    - chapongatien
     - doru91
-    - andrei-menzopol
-    - sujaygkulkarni-nxp
+    # Proposed maintainers (uncomment to activate):
+    # - Martin-NXP
+    # - dinabenamar
+    # - marian-chereji-nxp
+    # - chapongatien
+    # - andrei-menzopol
+    # - sujaygkulkarni-nxp
   paths:
     - "src/platform/nxp/**"
     - "examples/platform/nxp/**"
@@ -18,130 +22,133 @@ nxp:
 silabs:
   maintainers:
     - jmartinez-silabs
-    - mkardous-silabs
-    - chirag-silabs
-    - arun-silabs
-    - rosahay-silabs
-    - jepenven-silabs
-    - lpbeliveau-silabs
+    # Proposed maintainers (uncomment to activate):
+    # - mkardous-silabs
+    # - chirag-silabs
+    # - arun-silabs
+    # - rosahay-silabs
+    # - jepenven-silabs
+    # - lpbeliveau-silabs
   paths:
     - "src/platform/silabs/**"
     - "examples/platform/silabs/**"
     - "examples/**/silabs/**"
 
-esp32:
-  maintainers:
-    - shubhamdp
-    - wqx6
-    - shripad621git
-    - jadhavrohit924
-  paths:
-    - "src/platform/ESP32/**"
-    - "examples/platform/esp32/**"
-    - "examples/**/esp32/**"
+# --- Proposals / Opt-In Templates ---
 
-telink:
-  maintainers:
-    - s07641069
-    - interfer
-  paths:
-    - "src/platform/telink/**"
-    - "examples/platform/telink/**"
-    - "examples/**/telink/**"
-
-nrfconnect:
-  maintainers:
-    - ArekBalysNordic
-    - adigie
-    - kkasperczyk-no
-  paths:
-    - "src/platform/nrfconnect/**"
-    - "examples/platform/nrfconnect/**"
-    - "examples/**/nrfconnect/**"
-
-tizen:
-  maintainers:
-    - enkiusz
-    - arkq
-  paths:
-    - "src/platform/Tizen/**"
-    - "examples/platform/tizen/**"
-    - "examples/**/tizen/**"
-
-realtek:
-  maintainers:
-    - pankore
-  paths:
-    - "src/platform/realtek/**"
-    - "src/platform/Ameba/**"
-    - "examples/platform/realtek/**"
-    - "examples/platform/ameba/**"
-    - "examples/**/realtek/**"
-    - "examples/**/ameba/**"
-
-asr:
-  maintainers:
-    - tx2rx
-  paths:
-    - "src/platform/ASR/**"
-    - "examples/platform/asr/**"
-    - "examples/**/asr/**"
-
-beken:
-  maintainers:
-    - zhengyaohan
-  paths:
-    - "src/platform/Beken/**"
-    - "examples/platform/beken/**"
-    - "examples/**/beken/**"
-
-bouffalolab:
-  maintainers:
-    - wy-hh
-  paths:
-    - "src/platform/bouffalolab/**"
-    - "examples/platform/bouffalolab/**"
-    - "examples/**/bouffalolab/**"
-
-qpg:
-  maintainers:
-    - dvdm-qorvo
-    - kliffwong
-    - tima-q
-  paths:
-    - "src/platform/qpg/**"
-    - "examples/platform/qpg/**"
-    - "examples/**/qpg/**"
-
-stm32:
-  maintainers:
-    - STYoannZamaron
-  paths:
-    - "src/platform/stm32/**"
-    - "examples/platform/stm32/**"
-    - "examples/**/stm32/**"
-
-webos:
-  maintainers:
-    - joonhaengHeo
-  paths:
-    - "src/platform/webos/**"
-
-mt793x:
-  maintainers:
-    - pakls
-  paths:
-    - "src/platform/mt793x/**"
-    - "examples/platform/mt793x/**"
-
-ti:
-  maintainers:
-    - s-jain2022
-    - abiradarti
-  paths:
-    - "src/platform/ti/**"
-    - "src/platform/cc32xx/**"
-    - "examples/platform/ti/**"
-    - "examples/platform/cc32xx/**"
-    - "examples/**/ti/**"
-    - "examples/**/cc32xx/**"
+# esp32:
+#   maintainers:
+#     - shubhamdp
+#     - wqx6
+#     - shripad621git
+#     - jadhavrohit924
+#   paths:
+#     - "src/platform/ESP32/**"
+#     - "examples/platform/esp32/**"
+#     - "examples/**/esp32/**"
+# 
+# telink:
+#   maintainers:
+#     - s07641069
+#     - interfer
+#   paths:
+#     - "src/platform/telink/**"
+#     - "examples/platform/telink/**"
+#     - "examples/**/telink/**"
+# 
+# nrfconnect:
+#   maintainers:
+#     - ArekBalysNordic
+#     - adigie
+#     - kkasperczyk-no
+#   paths:
+#     - "src/platform/nrfconnect/**"
+#     - "examples/platform/nrfconnect/**"
+#     - "examples/**/nrfconnect/**"
+# 
+# tizen:
+#   maintainers:
+#     - enkiusz
+#     - arkq
+#   paths:
+#     - "src/platform/Tizen/**"
+#     - "examples/platform/tizen/**"
+#     - "examples/**/tizen/**"
+# 
+# realtek:
+#   maintainers:
+#     - pankore
+#   paths:
+#     - "src/platform/realtek/**"
+#     - "src/platform/Ameba/**"
+#     - "examples/platform/realtek/**"
+#     - "examples/platform/ameba/**"
+#     - "examples/**/realtek/**"
+#     - "examples/**/ameba/**"
+# 
+# asr:
+#   maintainers:
+#     - tx2rx
+#   paths:
+#     - "src/platform/ASR/**"
+#     - "examples/platform/asr/**"
+#     - "examples/**/asr/**"
+# 
+# beken:
+#   maintainers:
+#     - zhengyaohan
+#   paths:
+#     - "src/platform/Beken/**"
+#     - "examples/platform/beken/**"
+#     - "examples/**/beken/**"
+# 
+# bouffalolab:
+#   maintainers:
+#     - wy-hh
+#   paths:
+#     - "src/platform/bouffalolab/**"
+#     - "examples/platform/bouffalolab/**"
+#     - "examples/**/bouffalolab/**"
+# 
+# qpg:
+#   maintainers:
+#     - dvdm-qorvo
+#     - kliffwong
+#     - tima-q
+#   paths:
+#     - "src/platform/qpg/**"
+#     - "examples/platform/qpg/**"
+#     - "examples/**/qpg/**"
+# 
+# stm32:
+#   maintainers:
+#     - STYoannZamaron
+#   paths:
+#     - "src/platform/stm32/**"
+#     - "examples/platform/stm32/**"
+#     - "examples/**/stm32/**"
+# 
+# webos:
+#   maintainers:
+#     - joonhaengHeo
+#   paths:
+#     - "src/platform/webos/**"
+# 
+# mt793x:
+#   maintainers:
+#     - pakls
+#   paths:
+#     - "src/platform/mt793x/**"
+#     - "examples/platform/mt793x/**"
+# 
+# ti:
+#   maintainers:
+#     - s-jain2022
+#     - abiradarti
+#   paths:
+#     - "src/platform/ti/**"
+#     - "src/platform/cc32xx/**"
+#     - "examples/platform/ti/**"
+#     - "examples/platform/cc32xx/**"
+#     - "examples/**/ti/**"
+#     - "examples/**/cc32xx/**"

--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -1,0 +1,147 @@
+# Platform groups defining maintainers and their corresponding paths.
+# Git-style wildmatch globs are supported (via python pathspec).
+
+nxp:
+  maintainers:
+    - Martin-NXP
+    - dinabenamar
+    - marian-chereji-nxp
+    - chapongatien
+    - doru91
+    - andrei-menzopol
+    - sujaygkulkarni-nxp
+  paths:
+    - "src/platform/nxp/**"
+    - "examples/platform/nxp/**"
+    - "examples/**/nxp/**"
+
+silabs:
+  maintainers:
+    - jmartinez-silabs
+    - mkardous-silabs
+    - chirag-silabs
+    - arun-silabs
+    - rosahay-silabs
+    - jepenven-silabs
+    - lpbeliveau-silabs
+  paths:
+    - "src/platform/silabs/**"
+    - "examples/platform/silabs/**"
+    - "examples/**/silabs/**"
+
+esp32:
+  maintainers:
+    - shubhamdp
+    - wqx6
+    - shripad621git
+    - jadhavrohit924
+  paths:
+    - "src/platform/ESP32/**"
+    - "examples/platform/esp32/**"
+    - "examples/**/esp32/**"
+
+telink:
+  maintainers:
+    - s07641069
+    - interfer
+  paths:
+    - "src/platform/telink/**"
+    - "examples/platform/telink/**"
+    - "examples/**/telink/**"
+
+nrfconnect:
+  maintainers:
+    - ArekBalysNordic
+    - adigie
+    - kkasperczyk-no
+  paths:
+    - "src/platform/nrfconnect/**"
+    - "examples/platform/nrfconnect/**"
+    - "examples/**/nrfconnect/**"
+
+tizen:
+  maintainers:
+    - enkiusz
+    - arkq
+  paths:
+    - "src/platform/Tizen/**"
+    - "examples/platform/tizen/**"
+    - "examples/**/tizen/**"
+
+realtek:
+  maintainers:
+    - pankore
+  paths:
+    - "src/platform/realtek/**"
+    - "src/platform/Ameba/**"
+    - "examples/platform/realtek/**"
+    - "examples/platform/ameba/**"
+    - "examples/**/realtek/**"
+    - "examples/**/ameba/**"
+
+asr:
+  maintainers:
+    - tx2rx
+  paths:
+    - "src/platform/ASR/**"
+    - "examples/platform/asr/**"
+    - "examples/**/asr/**"
+
+beken:
+  maintainers:
+    - zhengyaohan
+  paths:
+    - "src/platform/Beken/**"
+    - "examples/platform/beken/**"
+    - "examples/**/beken/**"
+
+bouffalolab:
+  maintainers:
+    - wy-hh
+  paths:
+    - "src/platform/bouffalolab/**"
+    - "examples/platform/bouffalolab/**"
+    - "examples/**/bouffalolab/**"
+
+qpg:
+  maintainers:
+    - dvdm-qorvo
+    - kliffwong
+    - tima-q
+  paths:
+    - "src/platform/qpg/**"
+    - "examples/platform/qpg/**"
+    - "examples/**/qpg/**"
+
+stm32:
+  maintainers:
+    - STYoannZamaron
+  paths:
+    - "src/platform/stm32/**"
+    - "examples/platform/stm32/**"
+    - "examples/**/stm32/**"
+
+webos:
+  maintainers:
+    - joonhaengHeo
+  paths:
+    - "src/platform/webos/**"
+
+mt793x:
+  maintainers:
+    - pakls
+  paths:
+    - "src/platform/mt793x/**"
+    - "examples/platform/mt793x/**"
+
+ti:
+  maintainers:
+    - s-jain2022
+    - abiradarti
+  paths:
+    - "src/platform/ti/**"
+    - "src/platform/cc32xx/**"
+    - "examples/platform/ti/**"
+    - "examples/platform/cc32xx/**"
+    - "examples/**/ti/**"
+    - "examples/**/cc32xx/**"

--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -18,6 +18,7 @@ nxp:
     - "src/platform/nxp/**"
     - "examples/platform/nxp/**"
     - "examples/**/nxp/**"
+    - "third_party/nxp/**"
 
 silabs:
   maintainers:
@@ -33,6 +34,7 @@ silabs:
     - "src/platform/silabs/**"
     - "examples/platform/silabs/**"
     - "examples/**/silabs/**"
+    - "third_party/silabs/**"
 
 # --- Proposals / Opt-In Templates ---
 

--- a/.github/workflows/platform_merge_bot.yaml
+++ b/.github/workflows/platform_merge_bot.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Platform Maintainers Auto-Merge
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (simulate merging and commenting)'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Run every 6 hours (4 times a day)
+    - cron: "0 */6 * * *"
+
+jobs:
+  platform_merge:
+    name: Platform Auto-Merge Bot
+    runs-on: ubuntu-latest
+
+    # Limit to main repo to avoid running on forks
+    if: github.repository_owner == 'project-chip'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history so git diffs or file listings can work if needed (though PyGithub handles this)
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup pip modules
+        run: |
+          python3 -m venv venv
+          venv/bin/pip3 install \
+              click \
+              coloredlogs \
+              pyyaml \
+              pathspec \
+              pygithub \
+              && echo "DONE installing python prerequisites"
+
+      - name: Run Platform Auto-Merge Bot
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_BOT_PAT || secrets.MATTER_PAT }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        run: |
+          # If manual trigger, use the input dry_run value. Otherwise, default to false (actual run).
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "$DRY_RUN_INPUT" = "true" ]; then
+              DRY_RUN_FLAG="--dry-run"
+          fi
+          
+          venv/bin/python3 scripts/tools/platform_merge_bot.py $DRY_RUN_FLAG

--- a/.github/workflows/platform_merge_bot.yaml
+++ b/.github/workflows/platform_merge_bot.yaml
@@ -48,11 +48,11 @@ jobs:
         run: |
           python3 -m venv venv
           venv/bin/pip3 install \
-              click \
-              coloredlogs \
-              pyyaml \
-              pathspec \
-              pygithub \
+              click==8.1.7 \
+              coloredlogs==15.0.1 \
+              pyyaml==6.0.1 \
+              pathspec==0.12.1 \
+              pygithub==2.3.0 \
               && echo "DONE installing python prerequisites"
 
       - name: Run Platform Auto-Merge Bot

--- a/.github/workflows/platform_merge_bot.yaml
+++ b/.github/workflows/platform_merge_bot.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Fetch all history so git diffs or file listings can work if needed (though PyGithub handles this)
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -25,6 +25,7 @@ import coloredlogs
 import pathspec
 import yaml
 from github import Github, GithubException
+from github.Commit import Commit
 from github.PullRequest import PullRequest
 
 log = logging.getLogger(__name__)
@@ -252,17 +253,7 @@ class PlatformMergeBot:
                 log.info("PR #%d is a draft. Skipping.", pr.number)
                 return
 
-        if (
-            ValidationCheck.PULLAPPROVE not in self.skip_checks
-            and self._is_pullapprove_green(pr)
-        ):
-            log.info(
-                "PR #%d has a successful pullapprove check. Skipping bot merge (standard flow applies).",
-                pr.number,
-            )
-            self.remove_eligibility_comment(pr)
-            return
-
+        # Perform file analysis first (saves API calls for ineligible PRs)
         matched_files, uncovered_files = self.analyze_pr_files(pr)
 
         if uncovered_files:
@@ -286,6 +277,20 @@ class PlatformMergeBot:
             pr.number,
             list(active_groups.keys()),
         )
+
+        # Get the commit object once for subsequent status/CI checks
+        commit = self.repo.get_commit(sha=pr.head.sha)
+
+        if (
+            ValidationCheck.PULLAPPROVE not in self.skip_checks
+            and self._is_pullapprove_green(commit)
+        ):
+            log.info(
+                "PR #%d has a successful pullapprove check. Skipping bot merge (standard flow applies).",
+                pr.number,
+            )
+            self.remove_eligibility_comment(pr)
+            return
 
         # Get current approvals and change requests
         approvers, change_requesters = self.get_pr_review_states(pr)
@@ -325,7 +330,7 @@ class PlatformMergeBot:
 
         ci_passed = True
         if ValidationCheck.CI not in self.skip_checks:
-            ci_passed = self._has_ci_passed(pr)
+            ci_passed = self._has_ci_passed(pr, commit)
 
         is_ready = not missing_approvals and not unresolved_threads and ci_passed
 
@@ -345,9 +350,8 @@ class PlatformMergeBot:
         )
         self.merge_pr(pr, valid_approvals_per_group)
 
-    def _is_pullapprove_green(self, pr: PullRequest) -> bool:
+    def _is_pullapprove_green(self, commit: Commit) -> bool:
         """Returns True if the pullapprove check exists and is in the 'success' state."""
-        commit = self.repo.get_commit(sha=pr.head.sha)
         combined_status = commit.get_combined_status()
         for status in combined_status.statuses:
             if status.context == "pullapprove":
@@ -405,9 +409,16 @@ class PlatformMergeBot:
                         f"GraphQL API returned errors: {res_data['errors']}"
                     )
 
-                threads_data = res_data["data"]["repository"]["pullRequest"][
-                    "reviewThreads"
-                ]
+                data = res_data.get("data")
+                if (
+                    not data
+                    or not data.get("repository")
+                    or not data["repository"].get("pullRequest")
+                ):
+                    raise RuntimeError(
+                        f"GraphQL response missing PR repository/pullRequest data: {res_data}"
+                    )
+                threads_data = data["repository"]["pullRequest"]["reviewThreads"]
                 if threads_data["pageInfo"]["hasNextPage"]:
                     log.warning(
                         "PR #%d has more than 100 review threads. Gating merge to be safe.",
@@ -459,10 +470,8 @@ class PlatformMergeBot:
 
         return unresolved
 
-    def _has_ci_passed(self, pr: PullRequest) -> bool:
+    def _has_ci_passed(self, pr: PullRequest, commit: Commit) -> bool:
         """Checks if all CI checks (combined status and check runs) have passed on the PR's latest commit."""
-        commit = self.repo.get_commit(sha=pr.head.sha)
-
         combined_status = commit.get_combined_status()
         # pullapprove is ignored because it delegates normal PR approvals. Since this
         # bot bypasses standard reviews for platform-restricted changes, PullApprove
@@ -619,6 +628,8 @@ class PlatformMergeBot:
 
     def remove_eligibility_comment(self, pr: PullRequest) -> None:
         """Removes the eligibility comment if it exists on the PR."""
+        if pr.comments == 0:
+            return
         for comment in self._find_bot_comments(pr):
             if self.dry_run:
                 log.info(

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -104,9 +104,18 @@ class PlatformMergeBot:
             )
 
         for group_name, group_data in content.items():
+            if not isinstance(group_name, str):
+                raise ValueError(f"Group name '{group_name}' must be a string.")
             if not isinstance(group_data, dict):
                 raise ValueError(
                     f"Invalid data format for group '{group_name}'. Expected a dictionary."
+                )
+            allowed_keys = {"maintainers", "paths"}
+            invalid_keys = set(group_data.keys()) - allowed_keys
+            if invalid_keys:
+                raise ValueError(
+                    f"Group '{group_name}' contains unrecognized keys: {list(invalid_keys)}. "
+                    f"Only {list(allowed_keys)} are allowed."
                 )
             maintainers = group_data.get("maintainers", [])
             paths = group_data.get("paths", [])
@@ -297,26 +306,50 @@ class PlatformMergeBot:
             for glob in group.get_matched_globs(files):
                 comment_body += f"    * `{glob}`\n"
 
+        eligibility_comment_found = False
         for comment in pr.get_issue_comments():
             if comment.user and comment.user.login.lower() == self.bot_username:
                 if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
-                    if comment.body.strip() != comment_body.strip():
+                    if not eligibility_comment_found:
+                        eligibility_comment_found = True
+                        if comment.body.strip() != comment_body.strip():
+                            if self.dry_run:
+                                log.info(
+                                    "[Dry Run] Would update eligibility comment on PR #%d",
+                                    pr.number,
+                                )
+                            else:
+                                log.info(
+                                    "Updating eligibility comment on PR #%d", pr.number
+                                )
+                                comment.edit(comment_body)
+                        else:
+                            log.debug(
+                                "PR #%d already has an up-to-date eligibility comment.",
+                                pr.number,
+                            )
+                    else:
                         if self.dry_run:
                             log.info(
-                                "[Dry Run] Would update eligibility comment on PR #%d",
+                                "[Dry Run] Would delete duplicate eligibility comment on PR #%d",
                                 pr.number,
                             )
                         else:
                             log.info(
-                                "Updating eligibility comment on PR #%d", pr.number
+                                "Deleting duplicate eligibility comment on PR #%d",
+                                pr.number,
                             )
-                            comment.edit(comment_body)
-                    else:
-                        log.debug(
-                            "PR #%d already has an up-to-date eligibility comment.",
-                            pr.number,
-                        )
-                    return
+                            try:
+                                comment.delete()
+                            except GithubException as e:
+                                log.error(
+                                    "Failed to delete duplicate comment #%d: %s",
+                                    comment.id,
+                                    e,
+                                )
+
+        if eligibility_comment_found:
+            return
 
         if self.dry_run:
             log.info(
@@ -343,8 +376,12 @@ class PlatformMergeBot:
                             "Deleting stale eligibility comment on PR #%d",
                             pr.number,
                         )
-                        comment.delete()
-                    return
+                        try:
+                            comment.delete()
+                        except GithubException as e:
+                            log.error(
+                                "Failed to delete stale comment #%d: %s", comment.id, e
+                            )
 
     def merge_pr(
         self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]
@@ -376,7 +413,14 @@ class PlatformMergeBot:
             )
 
             log.info("Posting merge explanation comment to PR #%d", pr.number)
-            pr.create_issue_comment(merge_reason_comment)
+            try:
+                pr.create_issue_comment(merge_reason_comment)
+            except GithubException as e:
+                log.error(
+                    "Failed to post merge explanation comment to PR #%d: %s",
+                    pr.number,
+                    e,
+                )
 
     def run(self) -> None:
         """Scans all open pull requests and processes them."""

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -83,6 +83,8 @@ class PlatformMergeBot:
 
         # get_reviews() returns reviews chronologically
         for review in pr.get_reviews():
+            if not review.user or not review.user.login:
+                continue
             user = review.user.login.lower()
             if review.state == 'APPROVED':
                 approvers.add(user)
@@ -110,16 +112,21 @@ class PlatformMergeBot:
 
         # pr.get_files() returns PaginatedList of File objects
         for pr_file in pr.get_files():
-            filepath = pr_file.filename
-            matched_any = False
-            for group_name, group in self.groups.items():
-                if group.matches_file(filepath):
-                    matched_files_per_group[group_name].append(filepath)
-                    matched_any = True
+            filepaths_to_check = [pr_file.filename]
+            prev_filepath = getattr(pr_file, "previous_filename", None)
+            if prev_filepath:
+                filepaths_to_check.append(prev_filepath)
 
-            if not matched_any:
-                uncovered_files.append(filepath)
-                is_fully_covered = False
+            for filepath in filepaths_to_check:
+                matched_any = False
+                for group_name, group in self.groups.items():
+                    if group.matches_file(filepath):
+                        matched_files_per_group[group_name].append(filepath)
+                        matched_any = True
+
+                if not matched_any:
+                    uncovered_files.append(filepath)
+                    is_fully_covered = False
 
         return is_fully_covered, matched_files_per_group, uncovered_files
 
@@ -179,7 +186,7 @@ class PlatformMergeBot:
     def post_eligibility_comment(self, pr: PullRequest, active_groups: dict[str, list[str]], missing_approvals: dict[str, PlatformGroup]):
         # Check if eligibility comment already exists
         for comment in pr.get_issue_comments():
-            if ELIGIBILITY_COMMENT_MARKER in comment.body:
+            if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
                 log.debug("PR #%d already has an eligibility comment. Not posting duplicate.", pr.number)
                 return
 

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -396,21 +396,18 @@ class PlatformMergeBot:
 
         unresolved = []
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=30) as response:
                 res_data = json.loads(response.read().decode("utf-8"))
                 if "errors" in res_data:
-                    log.error(
-                        "GraphQL errors querying unresolved threads for PR #%d: %s",
-                        pr.number,
-                        res_data["errors"],
+                    raise RuntimeError(
+                        f"GraphQL API returned errors: {res_data['errors']}"
                     )
-                    return []
 
                 threads = res_data["data"]["repository"]["pullRequest"][
                     "reviewThreads"
                 ]["nodes"]
                 for thread in threads:
-                    if not thread["isResolved"] and not thread["isOutdated"]:
+                    if not thread["isResolved"]:
                         first_comment = (
                             thread["comments"]["nodes"][0]
                             if thread["comments"]["nodes"]
@@ -424,7 +421,9 @@ class PlatformMergeBot:
                         url = first_comment["url"] if first_comment else ""
                         body_preview = ""
                         if first_comment and first_comment.get("body"):
-                            body_preview = " ".join(first_comment["body"].split())
+                            body_preview = " ".join(
+                                first_comment["body"].split()
+                            )
                             if len(body_preview) > 40:
                                 body_preview = body_preview[:37] + "..."
                         unresolved.append(
@@ -435,9 +434,12 @@ class PlatformMergeBot:
                             }
                         )
         except Exception as e:
-            log.warning(
-                "Failed to query unresolved threads for PR #%d: %s", pr.number, e
+            log.error(
+                "Failed to query unresolved threads for PR #%d: %s",
+                pr.number,
+                e,
             )
+            raise
 
         return unresolved
 
@@ -660,6 +662,7 @@ class PlatformMergeBot:
     def run(self, pr_number: int | None = None) -> None:
         """Runs the bot, either scanning all open PRs or processing a single PR."""
         self.single_pr_mode = pr_number is not None
+        has_errors = False
         if self.single_pr_mode:
             log.info("Processing single PR #%d...", pr_number)
             try:
@@ -667,6 +670,7 @@ class PlatformMergeBot:
                 self.check_and_process_pr(pr)
             except Exception as e:
                 log.exception("Error processing PR #%d: %s", pr_number, e)
+                has_errors = True
         else:
             log.info("Scanning open pull requests...")
             open_prs = self.repo.get_pulls(state="open")
@@ -675,6 +679,9 @@ class PlatformMergeBot:
                     self.check_and_process_pr(pr)
                 except Exception as e:
                     log.exception("Error processing PR #%d: %s", pr.number, e)
+                    has_errors = True
+        if has_errors:
+            raise RuntimeError("One or more PRs encountered errors during processing.")
 
 
 @click.command()

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -217,7 +217,14 @@ class PlatformMergeBot:
 
     def check_and_process_pr(self, pr: PullRequest) -> None:
         """Checks the coverage and approvals for a single PR, and merges if eligible."""
-        pr_author = getattr(pr.user, "login", None) or "ghost"
+        if pr.user is None or not getattr(pr.user, "login", None):
+            log.info(
+                "PR #%d has no valid author (deleted account). Skipping.",
+                pr.number,
+            )
+            return
+
+        pr_author = pr.user.login
         log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr_author)
 
         if pr.state != "open":

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+from enum import Enum
 from typing import Iterable, NamedTuple
 
 import click
@@ -34,6 +35,12 @@ DEFAULT_REPOSITORY = "project-chip/connectedhomeip"
 DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
 
 ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
+
+
+class ValidationCheck(Enum):
+    CI = "ci"
+    PULLAPPROVE = "pullapprove"
+    COMMENTS = "comments"
 
 
 class GroupApproval(NamedTuple):
@@ -74,12 +81,21 @@ class PlatformMergeBot:
     """Orchestrates scanning, checking coverage, and auto-merging PRs that affect platform-maintained paths."""
 
     def __init__(
-        self, token: str, repo_name: str, config_path: str, dry_run: bool
+        self,
+        token: str,
+        repo_name: str,
+        config_path: str,
+        dry_run: bool,
+        skip_checks: list[str] | None = None,
     ) -> None:
+        self.token = token
+        self.repo_name = repo_name
         self.api = Github(token)
         self.repo = self.api.get_repo(repo_name)
         self.config_path = config_path
         self.dry_run = dry_run
+        self.skip_checks = {ValidationCheck(c) for c in (skip_checks or [])}
+        self.single_pr_mode = False
         self.groups: dict[str, PlatformGroup] = {}
         self._bot_username = None
         self.load_config()
@@ -204,8 +220,40 @@ class PlatformMergeBot:
         pr_author = getattr(pr.user, "login", None) or "ghost"
         log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr_author)
 
+        if pr.state != "open":
+            if self.dry_run and self.single_pr_mode:
+                log.info(
+                    "PR #%d state is '%s' but bypassing open check for testing in dry-run.",
+                    pr.number,
+                    pr.state,
+                )
+            else:
+                log.info(
+                    "PR #%d is not open (state: '%s'). Skipping.",
+                    pr.number,
+                    pr.state,
+                )
+                return
+
         if pr.draft:
-            log.info("PR #%d is a draft. Skipping.", pr.number)
+            if self.dry_run and self.single_pr_mode:
+                log.info(
+                    "PR #%d is draft but bypassing draft check for testing in dry-run.",
+                    pr.number,
+                )
+            else:
+                log.info("PR #%d is a draft. Skipping.", pr.number)
+                return
+
+        if (
+            ValidationCheck.PULLAPPROVE not in self.skip_checks
+            and self._is_pullapprove_green(pr)
+        ):
+            log.info(
+                "PR #%d has a successful pullapprove check. Skipping bot merge (standard flow applies).",
+                pr.number,
+            )
+            self.remove_eligibility_comment(pr)
             return
 
         matched_files, uncovered_files = self.analyze_pr_files(pr)
@@ -264,27 +312,127 @@ class PlatformMergeBot:
                     sorted(group_approvers)[0], files
                 )
 
-        if missing_approvals:
-            log.info(
-                "PR #%d is missing approvals from platform maintainers for groups: %s",
-                pr.number,
-                list(missing_approvals.keys()),
-            )
-            self.post_eligibility_comment(pr, active_groups, missing_approvals)
-            return
+        unresolved_threads = []
+        if ValidationCheck.COMMENTS not in self.skip_checks:
+            unresolved_threads = self._get_unresolved_threads(pr)
 
-        if not self._has_ci_passed(pr):
+        ci_passed = True
+        if ValidationCheck.CI not in self.skip_checks:
+            ci_passed = self._has_ci_passed(pr)
+
+        is_ready = not missing_approvals and not unresolved_threads and ci_passed
+
+        if not is_ready:
             log.info(
-                "PR #%d is fully approved but CI checks are pending or failed. Skipping merge.",
+                "PR #%d is eligible but not ready to merge. Updating status comment.",
                 pr.number,
             )
-            self.post_eligibility_comment(pr, active_groups, missing_approvals)
+            self.post_eligibility_comment(
+                pr, active_groups, missing_approvals, unresolved_threads, ci_passed
+            )
             return
 
         log.info(
-            "PR #%d is fully approved, CI passed, and ready to merge!", pr.number
+            "PR #%d is fully approved, CI passed, no unresolved comments, and ready to merge!",
+            pr.number,
         )
         self.merge_pr(pr, valid_approvals_per_group)
+
+    def _is_pullapprove_green(self, pr: PullRequest) -> bool:
+        """Returns True if the pullapprove check exists and is in the 'success' state."""
+        commit = self.repo.get_commit(sha=pr.head.sha)
+        combined_status = commit.get_combined_status()
+        for status in combined_status.statuses:
+            if status.context == "pullapprove":
+                return status.state == "success"
+        return False
+
+    def _get_unresolved_threads(self, pr: PullRequest) -> list[dict]:
+        """Queries GitHub GraphQL API to find active unresolved review threads on the PR."""
+        owner, repo_name = self.repo_name.split("/")
+        query = """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes {
+                      author { login }
+                      body
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        variables = {"owner": owner, "name": repo_name, "number": pr.number}
+
+        import json
+        import urllib.request
+
+        req = urllib.request.Request(
+            "https://api.github.com/graphql",
+            data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "platform-merge-bot",
+            },
+            method="POST",
+        )
+
+        unresolved = []
+        try:
+            with urllib.request.urlopen(req) as response:
+                res_data = json.loads(response.read().decode("utf-8"))
+                if "errors" in res_data:
+                    log.error(
+                        "GraphQL errors querying unresolved threads for PR #%d: %s",
+                        pr.number,
+                        res_data["errors"],
+                    )
+                    return []
+
+                threads = res_data["data"]["repository"]["pullRequest"][
+                    "reviewThreads"
+                ]["nodes"]
+                for thread in threads:
+                    if not thread["isResolved"] and not thread["isOutdated"]:
+                        first_comment = (
+                            thread["comments"]["nodes"][0]
+                            if thread["comments"]["nodes"]
+                            else None
+                        )
+                        author = (
+                            first_comment["author"]["login"]
+                            if first_comment and first_comment["author"]
+                            else "unknown"
+                        )
+                        url = first_comment["url"] if first_comment else ""
+                        body_preview = ""
+                        if first_comment and first_comment.get("body"):
+                            body_preview = " ".join(first_comment["body"].split())
+                            if len(body_preview) > 40:
+                                body_preview = body_preview[:37] + "..."
+                        unresolved.append(
+                            {
+                                "author": author,
+                                "body_preview": body_preview,
+                                "url": url,
+                            }
+                        )
+        except Exception as e:
+            log.warning(
+                "Failed to query unresolved threads for PR #%d: %s", pr.number, e
+            )
+
+        return unresolved
 
     def _has_ci_passed(self, pr: PullRequest) -> bool:
         """Checks if all CI checks (combined status and check runs) have passed on the PR's latest commit."""
@@ -347,6 +495,8 @@ class PlatformMergeBot:
         pr: PullRequest,
         active_groups: dict[str, set[str]],
         missing_approvals: dict[str, PlatformGroup],
+        unresolved_threads: list[dict],
+        ci_passed: bool,
     ) -> None:
         """Posts or updates a comment stating the auto-merge status of the PR."""
         # Generate comment body first so we can compare it
@@ -369,6 +519,30 @@ class PlatformMergeBot:
             comment_body += "  *Paths matched:*\n"
             for glob in group.get_matched_globs(files):
                 comment_body += f"    * `{glob}`\n"
+
+        comment_body += "\n### Merge Requirements Status\n"
+        if not missing_approvals and not unresolved_threads and ci_passed:
+            comment_body += "✅ **All checks passed. PR is ready for merge.**\n"
+        else:
+            comment_body += "⚠️ **PR is not ready to merge yet:**\n"
+            if missing_approvals:
+                comment_body += "- ❌ Needs platform maintainer approvals (see above).\n"
+            else:
+                comment_body += "- ✅ Has all platform maintainer approvals.\n"
+
+            if unresolved_threads:
+                comment_body += "- ❌ Has unresolved review conversations:\n"
+                for thread in unresolved_threads:
+                    link_part = f" ([Link]({thread['url']}))" if thread["url"] else ""
+                    comment_preview = f': *"{thread["body_preview"]}"*' if thread["body_preview"] else ""
+                    comment_body += f"  * Unresolved thread by @{thread['author']}{link_part}{comment_preview}\n"
+            else:
+                comment_body += "- ✅ All review conversations resolved.\n"
+
+            if ci_passed:
+                comment_body += "- ✅ All CI status and check suites passed.\n"
+            else:
+                comment_body += "- ❌ CI checks are pending or failed.\n"
 
         bot_comments = self._find_bot_comments(pr)
         if bot_comments:
@@ -476,15 +650,24 @@ class PlatformMergeBot:
                     e,
                 )
 
-    def run(self) -> None:
-        """Scans all open pull requests and processes them."""
-        log.info("Scanning open pull requests...")
-        open_prs = self.repo.get_pulls(state="open")
-        for pr in open_prs:
+    def run(self, pr_number: int | None = None) -> None:
+        """Runs the bot, either scanning all open PRs or processing a single PR."""
+        self.single_pr_mode = pr_number is not None
+        if self.single_pr_mode:
+            log.info("Processing single PR #%d...", pr_number)
             try:
+                pr = self.repo.get_pull(pr_number)
                 self.check_and_process_pr(pr)
             except Exception as e:
-                log.exception("Error processing PR #%d: %s", pr.number, e)
+                log.exception("Error processing PR #%d: %s", pr_number, e)
+        else:
+            log.info("Scanning open pull requests...")
+            open_prs = self.repo.get_pulls(state="open")
+            for pr in open_prs:
+                try:
+                    self.check_and_process_pr(pr)
+                except Exception as e:
+                    log.exception("Error processing PR #%d: %s", pr.number, e)
 
 
 @click.command()
@@ -520,6 +703,17 @@ class PlatformMergeBot:
     is_flag=True,
     help="Simulate merging and commenting without executing",
 )
+@click.option(
+    "--pr",
+    type=int,
+    help="Process only this specific pull request number.",
+)
+@click.option(
+    "--skip-check",
+    multiple=True,
+    type=click.Choice(["ci", "pullapprove", "comments"]),
+    help="Validation check to skip. Can be specified multiple times.",
+)
 def main(
     log_level: str,
     token_env: str,
@@ -527,8 +721,19 @@ def main(
     repo: str,
     config: str,
     dry_run: bool,
+    pr: int | None,
+    skip_check: tuple[str, ...],
 ) -> None:
-    """Platform Merge Bot entry point."""
+    """Platform Merge Bot entry point.
+
+    Example Dry-Run and Validation Testing:
+    ---------------------------------------
+    # Run the bot in dry-run mode on a specific PR (even if closed/merged) to see what it would do:
+    GITHUB_TOKEN=$(gh auth token) python3 scripts/tools/platform_merge_bot.py --dry-run --pr 72779
+
+    # Run in dry-run mode, skipping CI and PullApprove status validations:
+    GITHUB_TOKEN=$(gh auth token) python3 scripts/tools/platform_merge_bot.py --dry-run --pr 72779 --skip-check ci --skip-check pullapprove
+    """
     coloredlogs.install(
         level=_LOG_LEVELS[log_level.upper()],
         fmt="%(asctime)s %(levelname)-7s %(message)s",
@@ -548,8 +753,10 @@ def main(
                 f"Require a token. Set environment variable '{token_env}' (or 'GITHUB_TOKEN') or provide --token-file"
             )
 
-    bot = PlatformMergeBot(gh_token, repo, config, dry_run)
-    bot.run()
+    bot = PlatformMergeBot(
+        gh_token, repo, config, dry_run, skip_checks=list(skip_check)
+    )
+    bot.run(pr_number=pr)
 
 
 if __name__ == "__main__":

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -17,7 +17,7 @@
 
 import logging
 import os
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 
 import click
 import coloredlogs
@@ -40,7 +40,7 @@ class GroupApproval(NamedTuple):
     """Represents an approval for a platform group."""
 
     approver: str
-    files: list[str]
+    files: set[str]
 
 
 class PlatformGroup:
@@ -60,7 +60,7 @@ class PlatformGroup:
         """Checks if a file path matches this group's configured paths."""
         return self.spec.match_file(filepath)
 
-    def get_matched_globs(self, files: list[str]) -> list[str]:
+    def get_matched_globs(self, files: Iterable[str]) -> list[str]:
         """Returns the list of glob patterns in this group that match any of the given files."""
         matched_globs = set()
         for f in files:
@@ -102,49 +102,45 @@ class PlatformMergeBot:
         with open(self.config_path, encoding="utf-8") as f:
             content = yaml.safe_load(f)
 
-        if not content or not isinstance(content, dict):
+        if not isinstance(content, dict):
             raise ValueError(
                 "Invalid config file format. Expected a YAML dictionary of groups."
             )
 
-        for group_name, group_data in content.items():
-            if not isinstance(group_name, str):
-                raise ValueError(f"Group name '{group_name}' must be a string.")
-            if not isinstance(group_data, dict):
+        for name, data in content.items():
+            if not isinstance(name, str):
+                raise ValueError(f"Group name '{name}' must be a string.")
+            if not isinstance(data, dict):
                 raise ValueError(
-                    f"Invalid data format for group '{group_name}'. Expected a dictionary."
+                    f"Invalid data format for group '{name}'. Expected a dictionary."
                 )
-            allowed_keys = {"maintainers", "paths"}
-            invalid_keys = set(group_data.keys()) - allowed_keys
+
+            invalid_keys = set(data.keys()) - {"maintainers", "paths"}
             if invalid_keys:
                 raise ValueError(
-                    f"Group '{group_name}' contains unrecognized keys: {list(invalid_keys)}. "
-                    f"Only {list(allowed_keys)} are allowed."
+                    f"Group '{name}' contains unrecognized keys: {list(invalid_keys)}"
                 )
-            maintainers = group_data.get("maintainers", [])
-            paths = group_data.get("paths", [])
-            if not isinstance(maintainers, list) or not isinstance(paths, list):
-                raise ValueError(
-                    f"Group '{group_name}' must contain 'maintainers' and 'paths' lists."
-                )
-            if not maintainers:
-                raise ValueError(
-                    f"Group '{group_name}' maintainers list cannot be empty."
-                )
-            if not paths:
-                raise ValueError(f"Group '{group_name}' paths list cannot be empty.")
 
-            for m in maintainers:
-                if not isinstance(m, str) or not m.strip():
-                    raise ValueError(
-                        f"Group '{group_name}' maintainer '{m}' must be a non-empty string."
-                    )
-            for p in paths:
-                if not isinstance(p, str) or not p.strip():
-                    raise ValueError(
-                        f"Group '{group_name}' path '{p}' must be a non-empty string."
-                    )
-            self.groups[group_name] = PlatformGroup(group_name, maintainers, paths)
+            maintainers = data.get("maintainers")
+            paths = data.get("paths")
+
+            if not isinstance(maintainers, list) or not maintainers:
+                raise ValueError(
+                    f"Group '{name}' must contain a non-empty 'maintainers' list."
+                )
+            if not isinstance(paths, list) or not paths:
+                raise ValueError(
+                    f"Group '{name}' must contain a non-empty 'paths' list."
+                )
+
+            if not all(isinstance(m, str) and m.strip() for m in maintainers):
+                raise ValueError(
+                    f"Group '{name}' maintainers must be non-empty strings."
+                )
+            if not all(isinstance(p, str) and p.strip() for p in paths):
+                raise ValueError(f"Group '{name}' paths must be non-empty strings.")
+
+            self.groups[name] = PlatformGroup(name, maintainers, paths)
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
 
@@ -153,9 +149,10 @@ class PlatformMergeBot:
         user_reviews = {}
         # get_reviews() returns reviews chronologically
         for review in pr.get_reviews():
-            if not review.user or not review.user.login:
+            review_user = getattr(review.user, "login", None)
+            if not review_user:
                 continue
-            user = review.user.login.lower()
+            user = review_user.lower()
             if review.state in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
                 user_reviews[user] = review.state
 
@@ -163,26 +160,25 @@ class PlatformMergeBot:
             user for user, state in user_reviews.items() if state == "APPROVED"
         }
         # Exclude author from self-approval
-        author = pr.user.login.lower() if pr.user and pr.user.login else ""
+        pr_author = getattr(pr.user, "login", None)
+        author = pr_author.lower() if pr_author else ""
         approvers.discard(author)
         change_requesters = {
             user for user, state in user_reviews.items() if state == "CHANGES_REQUESTED"
         }
         return approvers, change_requesters
 
-    def analyze_pr_files(
-        self, pr: PullRequest
-    ) -> tuple[dict[str, list[str]], list[str]]:
+    def analyze_pr_files(self, pr: PullRequest) -> tuple[dict[str, set[str]], set[str]]:
         """Analyzes the files changed in the PR.
 
         Returns:
           - matched_files_per_group: Map of group_name -> list of files matching it.
           - uncovered_files: List of files that matched no group.
         """
-        matched_files_per_group: dict[str, list[str]] = {
-            name: [] for name in self.groups
+        matched_files_per_group: dict[str, set[str]] = {
+            name: set() for name in self.groups
         }
-        uncovered_files = []
+        uncovered_files = set()
 
         # pr.get_files() returns PaginatedList of File objects
         for pr_file in pr.get_files():
@@ -195,19 +191,18 @@ class PlatformMergeBot:
                 matched_any = False
                 for group_name, group in self.groups.items():
                     if group.matches_file(filepath):
-                        matched_files_per_group[group_name].append(filepath)
+                        matched_files_per_group[group_name].add(filepath)
                         matched_any = True
 
                 if not matched_any:
-                    uncovered_files.append(filepath)
+                    uncovered_files.add(filepath)
 
         return matched_files_per_group, uncovered_files
 
     def check_and_process_pr(self, pr: PullRequest) -> None:
         """Checks the coverage and approvals for a single PR, and merges if eligible."""
-        log.info(
-            "Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr.user.login
-        )
+        pr_author = getattr(pr.user, "login", None) or "ghost"
+        log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr_author)
 
         if pr.draft:
             log.info("PR #%d is a draft. Skipping.", pr.number)
@@ -219,7 +214,7 @@ class PlatformMergeBot:
             log.info(
                 "PR #%d contains files outside the platform-maintained scope. Skipping. Uncovered files: %s",
                 pr.number,
-                uncovered_files[:5],
+                list(uncovered_files)[:5],
             )
             self.remove_eligibility_comment(pr)
             return
@@ -266,7 +261,7 @@ class PlatformMergeBot:
             else:
                 # Pick the first matched approver for documentation
                 valid_approvals_per_group[group_name] = GroupApproval(
-                    list(group_approvers)[0], files
+                    sorted(group_approvers)[0], files
                 )
 
         if missing_approvals:
@@ -282,10 +277,20 @@ class PlatformMergeBot:
         log.info("PR #%d is fully approved and ready to merge!", pr.number)
         self.merge_pr(pr, valid_approvals_per_group)
 
+    def _find_bot_comments(self, pr: PullRequest) -> list:
+        """Finds comments posted by this bot on the PR."""
+        bot_comments = []
+        for comment in pr.get_issue_comments():
+            comment_user = getattr(comment.user, "login", None)
+            if comment_user and comment_user.lower() == self.bot_username:
+                if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
+                    bot_comments.append(comment)
+        return bot_comments
+
     def post_eligibility_comment(
         self,
         pr: PullRequest,
-        active_groups: dict[str, list[str]],
+        active_groups: dict[str, set[str]],
         missing_approvals: dict[str, PlatformGroup],
     ) -> None:
         """Posts or updates a comment stating the auto-merge status of the PR."""
@@ -310,82 +315,71 @@ class PlatformMergeBot:
             for glob in group.get_matched_globs(files):
                 comment_body += f"    * `{glob}`\n"
 
-        eligibility_comment_found = False
-        for comment in pr.get_issue_comments():
-            if comment.user and comment.user.login.lower() == self.bot_username:
-                if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
-                    if not eligibility_comment_found:
-                        eligibility_comment_found = True
-                        if comment.body.strip() != comment_body.strip():
-                            if self.dry_run:
-                                log.info(
-                                    "[Dry Run] Would update eligibility comment on PR #%d",
-                                    pr.number,
-                                )
-                            else:
-                                log.info(
-                                    "Updating eligibility comment on PR #%d", pr.number
-                                )
-                                comment.edit(comment_body)
-                        else:
-                            log.debug(
-                                "PR #%d already has an up-to-date eligibility comment.",
-                                pr.number,
-                            )
-                    else:
-                        if self.dry_run:
-                            log.info(
-                                "[Dry Run] Would delete duplicate eligibility comment on PR #%d",
-                                pr.number,
-                            )
-                        else:
-                            log.info(
-                                "Deleting duplicate eligibility comment on PR #%d",
-                                pr.number,
-                            )
-                            try:
-                                comment.delete()
-                            except GithubException as e:
-                                log.error(
-                                    "Failed to delete duplicate comment #%d: %s",
-                                    comment.id,
-                                    e,
-                                )
+        bot_comments = self._find_bot_comments(pr)
+        if bot_comments:
+            main_comment = bot_comments[0]
+            if main_comment.body.strip() != comment_body.strip():
+                if self.dry_run:
+                    log.info(
+                        "[Dry Run] Would update eligibility comment on PR #%d",
+                        pr.number,
+                    )
+                else:
+                    log.info("Updating eligibility comment on PR #%d", pr.number)
+                    main_comment.edit(comment_body)
+            else:
+                log.debug(
+                    "PR #%d already has an up-to-date eligibility comment.",
+                    pr.number,
+                )
 
-        if eligibility_comment_found:
-            return
-
-        if self.dry_run:
-            log.info(
-                "[Dry Run] Would post eligibility comment to PR #%d:\n%s",
-                pr.number,
-                comment_body,
-            )
+            for duplicate in bot_comments[1:]:
+                if self.dry_run:
+                    log.info(
+                        "[Dry Run] Would delete duplicate eligibility comment on PR #%d",
+                        pr.number,
+                    )
+                else:
+                    log.info(
+                        "Deleting duplicate eligibility comment on PR #%d",
+                        pr.number,
+                    )
+                    try:
+                        duplicate.delete()
+                    except GithubException as e:
+                        log.error(
+                            "Failed to delete duplicate comment #%d: %s",
+                            duplicate.id,
+                            e,
+                        )
         else:
-            log.info("Posting eligibility comment to PR #%d", pr.number)
-            pr.create_issue_comment(comment_body)
+            if self.dry_run:
+                log.info(
+                    "[Dry Run] Would post eligibility comment to PR #%d:\n%s",
+                    pr.number,
+                    comment_body,
+                )
+            else:
+                log.info("Posting eligibility comment to PR #%d", pr.number)
+                pr.create_issue_comment(comment_body)
 
     def remove_eligibility_comment(self, pr: PullRequest) -> None:
         """Removes the eligibility comment if it exists on the PR."""
-        for comment in pr.get_issue_comments():
-            if comment.user and comment.user.login.lower() == self.bot_username:
-                if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
-                    if self.dry_run:
-                        log.info(
-                            "[Dry Run] Would delete stale eligibility comment on PR #%d",
-                            pr.number,
-                        )
-                    else:
-                        log.info(
-                            "Deleting stale eligibility comment on PR #%d",
-                            pr.number,
-                        )
-                        try:
-                            comment.delete()
-                        except GithubException as e:
-                            log.error(
-                                "Failed to delete stale comment #%d: %s", comment.id, e
-                            )
+        for comment in self._find_bot_comments(pr):
+            if self.dry_run:
+                log.info(
+                    "[Dry Run] Would delete stale eligibility comment on PR #%d",
+                    pr.number,
+                )
+            else:
+                log.info(
+                    "Deleting stale eligibility comment on PR #%d",
+                    pr.number,
+                )
+                try:
+                    comment.delete()
+                except GithubException as e:
+                    log.error("Failed to delete stale comment #%d: %s", comment.id, e)
 
     def merge_pr(
         self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]
@@ -491,14 +485,11 @@ def main(
         if not gh_token:
             raise click.ClickException(f"Token file {token_file} is empty")
     else:
-        env_var = token_env or "GH_TOKEN"
-        gh_token = os.environ.get(env_var)
-        if not gh_token and env_var == "GH_TOKEN":
-            gh_token = os.environ.get("GITHUB_TOKEN")
+        gh_token = os.environ.get(token_env) or os.environ.get("GITHUB_TOKEN")
 
         if not gh_token:
             raise click.ClickException(
-                f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file"
+                f"Require a token. Set environment variable '{token_env}' (or 'GITHUB_TOKEN') or provide --token-file"
             )
 
     bot = PlatformMergeBot(gh_token, repo, config, dry_run)

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -248,7 +248,7 @@ class PlatformMergeBot:
             try:
                 self.check_and_process_pr(pr)
             except Exception as e:
-                log.error("Error processing PR #%d: %s", pr.number, e, exc_info=True)
+                log.exception("Error processing PR #%d: %s", pr.number, e)
 
 
 @click.command()

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -17,13 +17,12 @@
 
 import logging
 import os
+from typing import NamedTuple
 
 import click
 import coloredlogs
 import pathspec
 import yaml
-from typing import NamedTuple
-
 from github import Github, GithubException
 from github.PullRequest import PullRequest
 

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
+import json
 import logging
 import os
+import urllib.request
 from enum import Enum
 from typing import Iterable, NamedTuple
 
@@ -386,9 +388,6 @@ class PlatformMergeBot:
         """
         variables = {"owner": owner, "name": repo_name, "number": pr.number}
 
-        import json
-        import urllib.request
-
         req = urllib.request.Request(
             "https://api.github.com/graphql",
             data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
@@ -473,6 +472,20 @@ class PlatformMergeBot:
     def _has_ci_passed(self, pr: PullRequest, commit: Commit) -> bool:
         """Checks if all CI checks (combined status and check runs) have passed on the PR's latest commit."""
         combined_status = commit.get_combined_status()
+        check_suites = list(commit.get_check_suites())
+
+        # Guard against empty checks / premature success when commit is fresh.
+        # A normal PR run has at least 10 combined statuses and check suites.
+        total_checks = len(combined_status.statuses) + len(check_suites)
+        if total_checks < 10:
+            log.info(
+                "PR #%d HEAD commit %s has only %d CI checks registered (expected >= 10). Treating as pending.",
+                pr.number,
+                commit.sha[:8],
+                total_checks,
+            )
+            return False
+
         # pullapprove is ignored because it delegates normal PR approvals. Since this
         # bot bypasses standard reviews for platform-restricted changes, PullApprove
         # will remain pending forever.
@@ -491,7 +504,6 @@ class PlatformMergeBot:
                 )
                 return False
 
-        check_suites = commit.get_check_suites()
         for suite in check_suites:
             if suite.status != "completed":
                 log.info(

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -273,9 +273,64 @@ class PlatformMergeBot:
             self.post_eligibility_comment(pr, active_groups, missing_approvals)
             return
 
-        # If we got here, all active groups have at least one approval. We can merge!
-        log.info("PR #%d is fully approved and ready to merge!", pr.number)
+        if not self._has_ci_passed(pr):
+            log.info(
+                "PR #%d is fully approved but CI checks are pending or failed. Skipping merge.",
+                pr.number,
+            )
+            self.post_eligibility_comment(pr, active_groups, missing_approvals)
+            return
+
+        log.info(
+            "PR #%d is fully approved, CI passed, and ready to merge!", pr.number
+        )
         self.merge_pr(pr, valid_approvals_per_group)
+
+    def _has_ci_passed(self, pr: PullRequest) -> bool:
+        """Checks if all CI checks (combined status and check runs) have passed on the PR's latest commit."""
+        commit = self.repo.get_commit(sha=pr.head.sha)
+
+        combined_status = commit.get_combined_status()
+        # pullapprove is ignored because it delegates normal PR approvals. Since this
+        # bot bypasses standard reviews for platform-restricted changes, PullApprove
+        # will remain pending forever.
+        ignored_contexts = {"pullapprove"}
+        for status in combined_status.statuses:
+            if status.context in ignored_contexts:
+                continue
+            if status.state != "success":
+                log.info(
+                    "PR #%d HEAD commit %s status '%s' is '%s' (%s)",
+                    pr.number,
+                    pr.head.sha[:8],
+                    status.context,
+                    status.state,
+                    status.description,
+                )
+                return False
+
+        check_suites = commit.get_check_suites()
+        for suite in check_suites:
+            if suite.status != "completed":
+                log.info(
+                    "PR #%d HEAD commit %s check suite '%s' is not completed (status: '%s')",
+                    pr.number,
+                    pr.head.sha[:8],
+                    suite.id,
+                    suite.status,
+                )
+                return False
+            if suite.conclusion not in ("success", "neutral", "skipped"):
+                log.info(
+                    "PR #%d HEAD commit %s check suite '%s' failed (conclusion: '%s')",
+                    pr.number,
+                    pr.head.sha[:8],
+                    suite.id,
+                    suite.conclusion,
+                )
+                return False
+
+        return True
 
     def _find_bot_comments(self, pr: PullRequest) -> list:
         """Finds comments posted by this bot on the PR."""
@@ -408,6 +463,7 @@ class PlatformMergeBot:
             pr.merge(
                 merge_method="squash",
                 commit_title=f"{pr.title} (Auto-merged by platform-bot)",
+                sha=pr.head.sha,
             )
 
             log.info("Posting merge explanation comment to PR #%d", pr.number)

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import os
+import sys
+from typing import Dict, List, Set, Tuple
+
+import click
+import coloredlogs
+import pathspec
+import yaml
+from github import Github
+from github.PullRequest import PullRequest
+
+log = logging.getLogger(__name__)
+
+__LOG_LEVELS__ = logging.getLevelNamesMapping()
+
+DEFAULT_REPOSITORY = "project-chip/connectedhomeip"
+DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
+
+ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
+
+
+class PlatformGroup:
+    def __init__(self, name: str, maintainers: List[str], paths: List[str]):
+        self.name = name
+        self.maintainers = [m.lower() for m in maintainers]
+        self.paths = paths
+        self.spec = pathspec.PathSpec.from_lines('gitignore', paths)
+
+    def matches_file(self, filepath: str) -> bool:
+        return self.spec.match_file(filepath)
+
+
+class PlatformMergeBot:
+    def __init__(self, token: str, repo_name: str, config_path: str, dry_run: bool):
+        self.api = Github(token)
+        self.repo = self.api.get_repo(repo_name)
+        self.config_path = config_path
+        self.dry_run = dry_run
+        self.groups: Dict[str, PlatformGroup] = {}
+        self.load_config()
+
+    def load_config(self):
+        if not os.path.exists(self.config_path):
+            raise FileNotFoundError(f"Config file not found at {self.config_path}")
+
+        with open(self.config_path, 'r') as f:
+            content = yaml.safe_load(f)
+
+        if not content or not isinstance(content, dict):
+            raise ValueError("Invalid config file format. Expected a YAML dictionary of groups.")
+
+        for group_name, group_data in content.items():
+            if not isinstance(group_data, dict):
+                raise ValueError(f"Invalid data format for group '{group_name}'. Expected a dictionary.")
+            maintainers = group_data.get('maintainers', [])
+            paths = group_data.get('paths', [])
+            if not isinstance(maintainers, list) or not isinstance(paths, list):
+                raise ValueError(f"Group '{group_name}' must contain 'maintainers' and 'paths' lists.")
+            self.groups[group_name] = PlatformGroup(group_name, maintainers, paths)
+
+        log.info("Loaded %d platform groups from config.", len(self.groups))
+
+    def get_pr_approvers(self, pr: PullRequest) -> Set[str]:
+        """Returns the set of users who have currently approved the PR."""
+        approvers = set()
+        change_requesters = set()
+        
+        # get_reviews() returns reviews chronologically
+        for review in pr.get_reviews():
+            user = review.user.login.lower()
+            if review.state == 'APPROVED':
+                approvers.add(user)
+                change_requesters.discard(user)
+            elif review.state == 'CHANGES_REQUESTED':
+                change_requesters.add(user)
+                approvers.discard(user)
+            elif review.state == 'DISMISSED':
+                approvers.discard(user)
+                change_requesters.discard(user)
+                
+        return approvers
+
+    def analyze_pr_files(self, pr: PullRequest) -> Tuple[bool, Dict[str, List[str]], List[str]]:
+        """
+        Analyzes the files changed in the PR.
+        Returns:
+          - is_fully_covered: True if all files match at least one group.
+          - matched_files_per_group: Map of group_name -> list of files matching it.
+          - uncovered_files: List of files that matched no group.
+        """
+        matched_files_per_group: Dict[str, List[str]] = {name: [] for name in self.groups}
+        uncovered_files = []
+        is_fully_covered = True
+
+        # pr.get_files() returns PaginatedList of File objects
+        for pr_file in pr.get_files():
+            filepath = pr_file.filename
+            matched_any = False
+            for group_name, group in self.groups.items():
+                if group.matches_file(filepath):
+                    matched_files_per_group[group_name].append(filepath)
+                    matched_any = True
+            
+            if not matched_any:
+                uncovered_files.append(filepath)
+                is_fully_covered = False
+
+        return is_fully_covered, matched_files_per_group, uncovered_files
+
+    def check_and_process_pr(self, pr: PullRequest):
+        log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr.user.login)
+
+        if pr.draft:
+            log.info("PR #%d is a draft. Skipping.", pr.number)
+            return
+
+        is_fully_covered, matched_files, uncovered_files = self.analyze_pr_files(pr)
+
+        if not is_fully_covered:
+            log.info(
+                "PR #%d contains files outside the platform-maintained scope. Skipping. Uncovered files: %s",
+                pr.number, uncovered_files[:5]
+            )
+            return
+
+        # Determine which groups are active (i.e. have changed files)
+        active_groups = {name: files for name, files in matched_files.items() if files}
+        if not active_groups:
+            log.info("PR #%d has no changed files? Skipping.", pr.number)
+            return
+
+        log.info("PR #%d is fully covered by platform groups: %s", pr.number, list(active_groups.keys()))
+
+        # Get current approvals
+        approvers = self.get_pr_approvers(pr)
+        log.debug("PR #%d current approvers: %s", pr.number, list(approvers))
+
+        # Check approvals for each active group
+        missing_approvals: Dict[str, PlatformGroup] = {}
+        valid_approvals_per_group: Dict[str, Tuple[str, List[str]]] = {} # group_name -> (approver, matched_files)
+
+        for group_name, files in active_groups.items():
+            group = self.groups[group_name]
+            group_approvers = approvers.intersection(group.maintainers)
+            if not group_approvers:
+                missing_approvals[group_name] = group
+            else:
+                # Pick the first matched approver for documentation
+                valid_approvals_per_group[group_name] = (list(group_approvers)[0], files)
+
+        if missing_approvals:
+            log.info(
+                "PR #%d is missing approvals from platform maintainers for groups: %s",
+                pr.number, list(missing_approvals.keys())
+            )
+            self.post_eligibility_comment(pr, active_groups, missing_approvals)
+            return
+
+        # If we got here, all active groups have at least one approval. We can merge!
+        log.info("PR #%d is fully approved and ready to merge!", pr.number)
+        self.merge_pr(pr, valid_approvals_per_group)
+
+    def post_eligibility_comment(self, pr: PullRequest, active_groups: Dict[str, List[str]], missing_approvals: Dict[str, PlatformGroup]):
+        # Check if eligibility comment already exists
+        for comment in pr.get_issue_comments():
+            if ELIGIBILITY_COMMENT_MARKER in comment.body:
+                log.debug("PR #%d already has an eligibility comment. Not posting duplicate.", pr.number)
+                return
+
+        # Generate comment body
+        comment_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
+        comment_body += "### Platform Maintainers Auto-Merge Info\n"
+        comment_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
+        comment_body += "To merge, we require at least one approval from each of these groups:\n"
+        
+        for group_name in active_groups:
+            group = self.groups[group_name]
+            maintainer_mentions = ", ".join([f"@{m}" for m in group.maintainers])
+            status = "❌ Needs approval" if group_name in missing_approvals else "✅ Approved"
+            comment_body += f"- **{group_name}**: {maintainer_mentions} ({status})\n"
+            comment_body += "  *Paths matched:*\n"
+            for glob in group.paths:
+                comment_body += f"    * `{glob}`\n"
+
+        if self.dry_run:
+            log.info("[Dry Run] Would post eligibility comment to PR #%d:\n%s", pr.number, comment_body)
+        else:
+            log.info("Posting eligibility comment to PR #%d", pr.number)
+            pr.create_issue_comment(comment_body)
+
+    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: Dict[str, Tuple[str, List[str]]]):
+        # Generate merge comment explaining reasons
+        merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
+        merge_reason_comment += "This PR has been automatically merged. It contains changes restricted to platform-maintained paths and received the required maintainer approvals:\n\n"
+        
+        for group_name, (approver, files) in valid_approvals_per_group.items():
+            group = self.groups[group_name]
+            # Try to find which glob patterns matched the files in this group
+            matched_globs = set()
+            for f in files:
+                for glob in group.paths:
+                    # quick check of which pattern matched this file
+                    spec = pathspec.PathSpec.from_lines('gitignore', [glob])
+                    if spec.match_file(f):
+                        matched_globs.add(glob)
+            
+            globs_str = ", ".join([f"`{g}`" for g in matched_globs])
+            merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approver}\n"
+
+        if self.dry_run:
+            log.info("[Dry Run] Would post merge comment to PR #%d:\n%s", pr.number, merge_reason_comment)
+            log.info("[Dry Run] Would merge PR #%d (method: squash)", pr.number)
+        else:
+            log.info("Posting merge explanation comment to PR #%d", pr.number)
+            pr.create_issue_comment(merge_reason_comment)
+            
+            log.info("Merging PR #%d", pr.number)
+            # Use squash merge
+            pr.merge(merge_method="squash", commit_title=f"{pr.title} (Auto-merged by platform-bot)")
+
+    def run(self):
+        log.info("Scanning open pull requests...")
+        open_prs = self.repo.get_pulls(state='open')
+        for pr in open_prs:
+            try:
+                self.check_and_process_pr(pr)
+            except Exception as e:
+                log.error("Error processing PR #%d: %s", pr.number, e, exc_info=True)
+
+
+@click.command()
+@click.option(
+    "--log-level",
+    default="INFO",
+    type=click.Choice(list(__LOG_LEVELS__.keys()), case_sensitive=False),
+    help="Determines the verbosity of script output.",
+)
+@click.option("--token-env", default="GH_TOKEN", help="Environment variable containing the GitHub token")
+@click.option("--token-file", help="Read github token from the given file")
+@click.option(
+    "--repo",
+    default=DEFAULT_REPOSITORY,
+    help=f"Github repository name (default: {DEFAULT_REPOSITORY})",
+)
+@click.option(
+    "--config",
+    default=DEFAULT_CONFIG_PATH,
+    help=f"Path to the platform maintainers yaml config (default: {DEFAULT_CONFIG_PATH})",
+)
+@click.option("--dry-run", default=False, is_flag=True, help="Simulate merging and commenting without executing")
+def main(
+    log_level,
+    token_env,
+    token_file,
+    repo,
+    config,
+    dry_run,
+):
+    coloredlogs.install(
+        level=__LOG_LEVELS__[log_level], fmt="%(asctime)s %(levelname)-7s %(message)s"
+    )
+
+    gh_token = None
+    if token_file:
+        with open(token_file) as f:
+            gh_token = f.read().strip()
+        if not gh_token:
+            raise Exception(f"Token file {token_file} is empty")
+    else:
+        env_var = token_env or "GH_TOKEN"
+        gh_token = os.environ.get(env_var)
+        if not gh_token and env_var == "GH_TOKEN":
+            gh_token = os.environ.get("GITHUB_TOKEN")
+        
+        if not gh_token:
+            raise Exception(f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file")
+
+    bot = PlatformMergeBot(gh_token, repo, config, dry_run)
+    bot.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -54,13 +54,23 @@ class PlatformMergeBot:
         self.config_path = config_path
         self.dry_run = dry_run
         self.groups: dict[str, PlatformGroup] = {}
+        self._bot_username = None
         self.load_config()
+
+    @property
+    def bot_username(self) -> str:
+        if self._bot_username is None:
+            try:
+                self._bot_username = self.api.get_user().login.lower()
+            except Exception:
+                self._bot_username = "platform-merge-bot"
+        return self._bot_username
 
     def load_config(self):
         if not os.path.exists(self.config_path):
             raise FileNotFoundError(f"Config file not found at {self.config_path}")
 
-        with open(self.config_path) as f:
+        with open(self.config_path, encoding="utf-8") as f:
             content = yaml.safe_load(f)
 
         if not content or not isinstance(content, dict):
@@ -77,27 +87,19 @@ class PlatformMergeBot:
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
 
-    def get_pr_approvers(self, pr: PullRequest) -> set[str]:
-        """Returns the set of users who have currently approved the PR."""
-        approvers = set()
-        change_requesters = set()
-
+    def get_pr_review_states(self, pr: PullRequest) -> tuple[set[str], set[str]]:
+        """Returns the set of users who have currently approved and those who have requested changes."""
+        user_reviews = {}
         # get_reviews() returns reviews chronologically
         for review in pr.get_reviews():
             if not review.user or not review.user.login:
                 continue
             user = review.user.login.lower()
-            if review.state == 'APPROVED':
-                approvers.add(user)
-                change_requesters.discard(user)
-            elif review.state == 'CHANGES_REQUESTED':
-                change_requesters.add(user)
-                approvers.discard(user)
-            elif review.state == 'DISMISSED':
-                approvers.discard(user)
-                change_requesters.discard(user)
+            user_reviews[user] = review.state
 
-        return approvers
+        approvers = {user for user, state in user_reviews.items() if state == 'APPROVED'}
+        change_requesters = {user for user, state in user_reviews.items() if state == 'CHANGES_REQUESTED'}
+        return approvers, change_requesters
 
     def analyze_pr_files(self, pr: PullRequest) -> tuple[bool, dict[str, list[str]], list[str]]:
         """
@@ -155,9 +157,13 @@ class PlatformMergeBot:
 
         log.info("PR #%d is fully covered by platform groups: %s", pr.number, list(active_groups.keys()))
 
-        # Get current approvals
-        approvers = self.get_pr_approvers(pr)
-        log.debug("PR #%d current approvers: %s", pr.number, list(approvers))
+        # Get current approvals and change requests
+        approvers, change_requesters = self.get_pr_review_states(pr)
+        log.debug("PR #%d current approvers: %s, change requesters: %s", pr.number, list(approvers), list(change_requesters))
+
+        if change_requesters:
+            log.info("PR #%d has active changes requested by: %s. Skipping.", pr.number, list(change_requesters))
+            return
 
         # Check approvals for each active group
         missing_approvals: dict[str, PlatformGroup] = {}
@@ -200,18 +206,18 @@ class PlatformMergeBot:
             for glob in group.paths:
                 comment_body += f"    * `{glob}`\n"
 
-        # Check if eligibility comment already exists
         for comment in pr.get_issue_comments():
-            if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
-                if comment.body.strip() != comment_body.strip():
-                    if self.dry_run:
-                        log.info("[Dry Run] Would update eligibility comment on PR #%d", pr.number)
+            if comment.user and comment.user.login.lower() == self.bot_username:
+                if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
+                    if comment.body.strip() != comment_body.strip():
+                        if self.dry_run:
+                            log.info("[Dry Run] Would update eligibility comment on PR #%d", pr.number)
+                        else:
+                            log.info("Updating eligibility comment on PR #%d", pr.number)
+                            comment.edit(comment_body)
                     else:
-                        log.info("Updating eligibility comment on PR #%d", pr.number)
-                        comment.edit(comment_body)
-                else:
-                    log.debug("PR #%d already has an up-to-date eligibility comment.", pr.number)
-                return
+                        log.debug("PR #%d already has an up-to-date eligibility comment.", pr.number)
+                    return
 
         if self.dry_run:
             log.info("[Dry Run] Would post eligibility comment to PR #%d:\n%s", pr.number, comment_body)
@@ -291,7 +297,7 @@ def main(
 
     gh_token = None
     if token_file:
-        with open(token_file) as f:
+        with open(token_file, encoding="utf-8") as f:
             gh_token = f.read().strip()
         if not gh_token:
             raise Exception(f"Token file {token_file} is empty")

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -39,6 +39,7 @@ ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
 
 class GroupApproval(NamedTuple):
     """Represents an approval for a platform group."""
+
     approver: str
     files: list[str]
 
@@ -50,8 +51,10 @@ class PlatformGroup:
         self.name = name
         self.maintainers = [m.lower() for m in maintainers]
         self.paths = paths
-        self.spec = pathspec.PathSpec.from_lines('gitignore', paths)
-        self.path_specs = {glob: pathspec.PathSpec.from_lines('gitignore', [glob]) for glob in paths}
+        self.spec = pathspec.PathSpec.from_lines("gitignore", paths)
+        self.path_specs = {
+            glob: pathspec.PathSpec.from_lines("gitignore", [glob]) for glob in paths
+        }
 
     def matches_file(self, filepath: str) -> bool:
         """Checks if a file path matches this group's configured paths."""
@@ -64,7 +67,7 @@ class PlatformGroup:
             for glob, spec in self.path_specs.items():
                 if spec.match_file(f):
                     matched_globs.add(glob)
-        return sorted(list(matched_globs))
+        return sorted(matched_globs)
 
 
 class PlatformMergeBot:
@@ -79,9 +82,12 @@ class PlatformMergeBot:
 
     @property
     def bot_username(self) -> str:
+        """Retrieves the username of the authenticated bot, falling back to a default on failure."""
         if self._bot_username is None:
             try:
                 self._bot_username = self.api.get_user().login.lower()
+            except GithubException:
+                self._bot_username = "platform-merge-bot"
             except Exception:
                 self._bot_username = "platform-merge-bot"
         return self._bot_username
@@ -94,19 +100,29 @@ class PlatformMergeBot:
             content = yaml.safe_load(f)
 
         if not content or not isinstance(content, dict):
-            raise ValueError("Invalid config file format. Expected a YAML dictionary of groups.")
+            raise ValueError(
+                "Invalid config file format. Expected a YAML dictionary of groups."
+            )
 
         for group_name, group_data in content.items():
             if not isinstance(group_data, dict):
-                raise ValueError(f"Invalid data format for group '{group_name}'. Expected a dictionary.")
-            maintainers = group_data.get('maintainers', [])
-            paths = group_data.get('paths', [])
+                raise ValueError(
+                    f"Invalid data format for group '{group_name}'. Expected a dictionary."
+                )
+            maintainers = group_data.get("maintainers", [])
+            paths = group_data.get("paths", [])
             if not isinstance(maintainers, list) or not isinstance(paths, list):
-                raise ValueError(f"Group '{group_name}' must contain 'maintainers' and 'paths' lists.")
+                raise ValueError(
+                    f"Group '{group_name}' must contain 'maintainers' and 'paths' lists."
+                )
             if not all(isinstance(m, str) for m in maintainers):
-                raise ValueError(f"Group '{group_name}' maintainers must be a list of strings.")
+                raise ValueError(
+                    f"Group '{group_name}' maintainers must be a list of strings."
+                )
             if not all(isinstance(p, str) for p in paths):
-                raise ValueError(f"Group '{group_name}' paths must be a list of strings.")
+                raise ValueError(
+                    f"Group '{group_name}' paths must be a list of strings."
+                )
             self.groups[group_name] = PlatformGroup(group_name, maintainers, paths)
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
@@ -119,24 +135,32 @@ class PlatformMergeBot:
             if not review.user or not review.user.login:
                 continue
             user = review.user.login.lower()
-            if review.state in ('APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'):
+            if review.state in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
                 user_reviews[user] = review.state
 
-        approvers = {user for user, state in user_reviews.items() if state == 'APPROVED'}
+        approvers = {
+            user for user, state in user_reviews.items() if state == "APPROVED"
+        }
         # Exclude author from self-approval
         author = pr.user.login.lower()
         approvers.discard(author)
-        change_requesters = {user for user, state in user_reviews.items() if state == 'CHANGES_REQUESTED'}
+        change_requesters = {
+            user for user, state in user_reviews.items() if state == "CHANGES_REQUESTED"
+        }
         return approvers, change_requesters
 
-    def analyze_pr_files(self, pr: PullRequest) -> tuple[dict[str, list[str]], list[str]]:
+    def analyze_pr_files(
+        self, pr: PullRequest
+    ) -> tuple[dict[str, list[str]], list[str]]:
         """Analyzes the files changed in the PR.
 
         Returns:
           - matched_files_per_group: Map of group_name -> list of files matching it.
           - uncovered_files: List of files that matched no group.
         """
-        matched_files_per_group: dict[str, list[str]] = {name: [] for name in self.groups}
+        matched_files_per_group: dict[str, list[str]] = {
+            name: [] for name in self.groups
+        }
         uncovered_files = []
 
         # pr.get_files() returns PaginatedList of File objects
@@ -160,7 +184,9 @@ class PlatformMergeBot:
 
     def check_and_process_pr(self, pr: PullRequest) -> None:
         """Checks the coverage and approvals for a single PR, and merges if eligible."""
-        log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr.user.login)
+        log.info(
+            "Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr.user.login
+        )
 
         if pr.draft:
             log.info("PR #%d is a draft. Skipping.", pr.number)
@@ -171,7 +197,8 @@ class PlatformMergeBot:
         if uncovered_files:
             log.info(
                 "PR #%d contains files outside the platform-maintained scope. Skipping. Uncovered files: %s",
-                pr.number, uncovered_files[:5]
+                pr.number,
+                uncovered_files[:5],
             )
             return
 
@@ -181,14 +208,27 @@ class PlatformMergeBot:
             log.info("PR #%d has no changed files? Skipping.", pr.number)
             return
 
-        log.info("PR #%d is fully covered by platform groups: %s", pr.number, list(active_groups.keys()))
+        log.info(
+            "PR #%d is fully covered by platform groups: %s",
+            pr.number,
+            list(active_groups.keys()),
+        )
 
         # Get current approvals and change requests
         approvers, change_requesters = self.get_pr_review_states(pr)
-        log.debug("PR #%d current approvers: %s, change requesters: %s", pr.number, list(approvers), list(change_requesters))
+        log.debug(
+            "PR #%d current approvers: %s, change requesters: %s",
+            pr.number,
+            list(approvers),
+            list(change_requesters),
+        )
 
         if change_requesters:
-            log.info("PR #%d has active changes requested by: %s. Skipping.", pr.number, list(change_requesters))
+            log.info(
+                "PR #%d has active changes requested by: %s. Skipping.",
+                pr.number,
+                list(change_requesters),
+            )
             return
 
         # Check approvals for each active group
@@ -202,12 +242,15 @@ class PlatformMergeBot:
                 missing_approvals[group_name] = group
             else:
                 # Pick the first matched approver for documentation
-                valid_approvals_per_group[group_name] = GroupApproval(list(group_approvers)[0], files)
+                valid_approvals_per_group[group_name] = GroupApproval(
+                    list(group_approvers)[0], files
+                )
 
         if missing_approvals:
             log.info(
                 "PR #%d is missing approvals from platform maintainers for groups: %s",
-                pr.number, list(missing_approvals.keys())
+                pr.number,
+                list(missing_approvals.keys()),
             )
             self.post_eligibility_comment(pr, active_groups, missing_approvals)
             return
@@ -220,19 +263,25 @@ class PlatformMergeBot:
         self,
         pr: PullRequest,
         active_groups: dict[str, list[str]],
-        missing_approvals: dict[str, PlatformGroup]
+        missing_approvals: dict[str, PlatformGroup],
     ) -> None:
         """Posts or updates a comment stating the auto-merge status of the PR."""
         # Generate comment body first so we can compare it
         comment_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
         comment_body += "### Platform Maintainers Auto-Merge Info\n"
         comment_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
-        comment_body += "To merge, we require at least one approval from each of these groups:\n"
+        comment_body += (
+            "To merge, we require at least one approval from each of these groups:\n"
+        )
 
         for group_name, files in active_groups.items():
             group = self.groups[group_name]
             maintainer_mentions = ", ".join([f"@{m}" for m in group.maintainers])
-            status = "❌ Needs approval" if group_name in missing_approvals else "✅ Approved"
+            status = (
+                "❌ Needs approval"
+                if group_name in missing_approvals
+                else "✅ Approved"
+            )
             comment_body += f"- **{group_name}**: {maintainer_mentions} ({status})\n"
             comment_body += "  *Paths matched:*\n"
             for glob in group.get_matched_globs(files):
@@ -243,21 +292,35 @@ class PlatformMergeBot:
                 if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
                     if comment.body.strip() != comment_body.strip():
                         if self.dry_run:
-                            log.info("[Dry Run] Would update eligibility comment on PR #%d", pr.number)
+                            log.info(
+                                "[Dry Run] Would update eligibility comment on PR #%d",
+                                pr.number,
+                            )
                         else:
-                            log.info("Updating eligibility comment on PR #%d", pr.number)
+                            log.info(
+                                "Updating eligibility comment on PR #%d", pr.number
+                            )
                             comment.edit(comment_body)
                     else:
-                        log.debug("PR #%d already has an up-to-date eligibility comment.", pr.number)
+                        log.debug(
+                            "PR #%d already has an up-to-date eligibility comment.",
+                            pr.number,
+                        )
                     return
 
         if self.dry_run:
-            log.info("[Dry Run] Would post eligibility comment to PR #%d:\n%s", pr.number, comment_body)
+            log.info(
+                "[Dry Run] Would post eligibility comment to PR #%d:\n%s",
+                pr.number,
+                comment_body,
+            )
         else:
             log.info("Posting eligibility comment to PR #%d", pr.number)
             pr.create_issue_comment(comment_body)
 
-    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]) -> None:
+    def merge_pr(
+        self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]
+    ) -> None:
         """Merges the PR and posts a comment explaining the approvals."""
         # Generate merge comment explaining reasons
         merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
@@ -270,12 +333,19 @@ class PlatformMergeBot:
             merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approval.approver}\n"
 
         if self.dry_run:
-            log.info("[Dry Run] Would post merge comment to PR #%d:\n%s", pr.number, merge_reason_comment)
+            log.info(
+                "[Dry Run] Would post merge comment to PR #%d:\n%s",
+                pr.number,
+                merge_reason_comment,
+            )
             log.info("[Dry Run] Would merge PR #%d (method: squash)", pr.number)
         else:
             log.info("Merging PR #%d", pr.number)
             # Use squash merge
-            pr.merge(merge_method="squash", commit_title=f"{pr.title} (Auto-merged by platform-bot)")
+            pr.merge(
+                merge_method="squash",
+                commit_title=f"{pr.title} (Auto-merged by platform-bot)",
+            )
 
             log.info("Posting merge explanation comment to PR #%d", pr.number)
             pr.create_issue_comment(merge_reason_comment)
@@ -283,7 +353,7 @@ class PlatformMergeBot:
     def run(self) -> None:
         """Scans all open pull requests and processes them."""
         log.info("Scanning open pull requests...")
-        open_prs = self.repo.get_pulls(state='open')
+        open_prs = self.repo.get_pulls(state="open")
         for pr in open_prs:
             try:
                 self.check_and_process_pr(pr)
@@ -298,7 +368,11 @@ class PlatformMergeBot:
     type=click.Choice(list(_LOG_LEVELS.keys()), case_sensitive=False),
     help="Determines the verbosity of script output.",
 )
-@click.option("--token-env", default="GH_TOKEN", help="Environment variable containing the GitHub token")
+@click.option(
+    "--token-env",
+    default="GH_TOKEN",
+    help="Environment variable containing the GitHub token",
+)
 @click.option("--token-file", help="Read github token from the given file")
 @click.option(
     "--repo",
@@ -310,7 +384,12 @@ class PlatformMergeBot:
     default=DEFAULT_CONFIG_PATH,
     help=f"Path to the platform maintainers yaml config (default: {DEFAULT_CONFIG_PATH})",
 )
-@click.option("--dry-run", default=False, is_flag=True, help="Simulate merging and commenting without executing")
+@click.option(
+    "--dry-run",
+    default=False,
+    is_flag=True,
+    help="Simulate merging and commenting without executing",
+)
 def main(
     log_level: str,
     token_env: str,
@@ -321,7 +400,8 @@ def main(
 ) -> None:
     """Platform Merge Bot entry point."""
     coloredlogs.install(
-        level=_LOG_LEVELS[log_level.upper()], fmt="%(asctime)s %(levelname)-7s %(message)s"
+        level=_LOG_LEVELS[log_level.upper()],
+        fmt="%(asctime)s %(levelname)-7s %(message)s",
     )
 
     gh_token = None
@@ -337,7 +417,9 @@ def main(
             gh_token = os.environ.get("GITHUB_TOKEN")
 
         if not gh_token:
-            raise click.ClickException(f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file")
+            raise click.ClickException(
+                f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file"
+            )
 
     bot = PlatformMergeBot(gh_token, repo, config, dry_run)
     bot.run()

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -41,6 +41,7 @@ class PlatformGroup:
         self.maintainers = [m.lower() for m in maintainers]
         self.paths = paths
         self.spec = pathspec.PathSpec.from_lines('gitignore', paths)
+        self.path_specs = {glob: pathspec.PathSpec.from_lines('gitignore', [glob]) for glob in paths}
 
     def matches_file(self, filepath: str) -> bool:
         return self.spec.match_file(filepath)
@@ -184,13 +185,7 @@ class PlatformMergeBot:
         self.merge_pr(pr, valid_approvals_per_group)
 
     def post_eligibility_comment(self, pr: PullRequest, active_groups: dict[str, list[str]], missing_approvals: dict[str, PlatformGroup]):
-        # Check if eligibility comment already exists
-        for comment in pr.get_issue_comments():
-            if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
-                log.debug("PR #%d already has an eligibility comment. Not posting duplicate.", pr.number)
-                return
-
-        # Generate comment body
+        # Generate comment body first so we can compare it
         comment_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
         comment_body += "### Platform Maintainers Auto-Merge Info\n"
         comment_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
@@ -204,6 +199,19 @@ class PlatformMergeBot:
             comment_body += "  *Paths matched:*\n"
             for glob in group.paths:
                 comment_body += f"    * `{glob}`\n"
+
+        # Check if eligibility comment already exists
+        for comment in pr.get_issue_comments():
+            if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
+                if comment.body.strip() != comment_body.strip():
+                    if self.dry_run:
+                        log.info("[Dry Run] Would update eligibility comment on PR #%d", pr.number)
+                    else:
+                        log.info("Updating eligibility comment on PR #%d", pr.number)
+                        comment.edit(comment_body)
+                else:
+                    log.debug("PR #%d already has an up-to-date eligibility comment.", pr.number)
+                return
 
         if self.dry_run:
             log.info("[Dry Run] Would post eligibility comment to PR #%d:\n%s", pr.number, comment_body)
@@ -221,9 +229,7 @@ class PlatformMergeBot:
             # Try to find which glob patterns matched the files in this group
             matched_globs = set()
             for f in files:
-                for glob in group.paths:
-                    # quick check of which pattern matched this file
-                    spec = pathspec.PathSpec.from_lines('gitignore', [glob])
+                for glob, spec in group.path_specs.items():
                     if spec.match_file(f):
                         matched_globs.add(glob)
 
@@ -234,12 +240,12 @@ class PlatformMergeBot:
             log.info("[Dry Run] Would post merge comment to PR #%d:\n%s", pr.number, merge_reason_comment)
             log.info("[Dry Run] Would merge PR #%d (method: squash)", pr.number)
         else:
-            log.info("Posting merge explanation comment to PR #%d", pr.number)
-            pr.create_issue_comment(merge_reason_comment)
-
             log.info("Merging PR #%d", pr.number)
             # Use squash merge
             pr.merge(merge_method="squash", commit_title=f"{pr.title} (Auto-merged by platform-bot)")
+
+            log.info("Posting merge explanation comment to PR #%d", pr.number)
+            pr.create_issue_comment(merge_reason_comment)
 
     def run(self):
         log.info("Scanning open pull requests...")
@@ -280,7 +286,7 @@ def main(
     dry_run,
 ):
     coloredlogs.install(
-        level=__LOG_LEVELS__[log_level], fmt="%(asctime)s %(levelname)-7s %(message)s"
+        level=__LOG_LEVELS__[log_level.upper()], fmt="%(asctime)s %(levelname)-7s %(message)s"
     )
 
     gh_token = None

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -172,8 +172,8 @@ class PlatformMergeBot:
         """Analyzes the files changed in the PR.
 
         Returns:
-          - matched_files_per_group: Map of group_name -> list of files matching it.
-          - uncovered_files: List of files that matched no group.
+          - matched_files_per_group: Map of group_name -> set of files matching it.
+          - uncovered_files: Set of files that matched no group.
         """
         matched_files_per_group: dict[str, set[str]] = {
             name: set() for name in self.groups

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -362,9 +362,11 @@ class PlatformMergeBot:
           repository(owner: $owner, name: $name) {
             pullRequest(number: $number) {
               reviewThreads(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
                 nodes {
                   isResolved
-                  isOutdated
                   comments(first: 1) {
                     nodes {
                       author { login }
@@ -403,9 +405,16 @@ class PlatformMergeBot:
                         f"GraphQL API returned errors: {res_data['errors']}"
                     )
 
-                threads = res_data["data"]["repository"]["pullRequest"][
+                threads_data = res_data["data"]["repository"]["pullRequest"][
                     "reviewThreads"
-                ]["nodes"]
+                ]
+                if threads_data["pageInfo"]["hasNextPage"]:
+                    log.warning(
+                        "PR #%d has more than 100 review threads. Some unresolved threads might be ignored.",
+                        pr.number,
+                    )
+
+                threads = threads_data["nodes"]
                 for thread in threads:
                     if not thread["isResolved"]:
                         first_comment = (

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -410,8 +410,15 @@ class PlatformMergeBot:
                 ]
                 if threads_data["pageInfo"]["hasNextPage"]:
                     log.warning(
-                        "PR #%d has more than 100 review threads. Some unresolved threads might be ignored.",
+                        "PR #%d has more than 100 review threads. Gating merge to be safe.",
                         pr.number,
+                    )
+                    unresolved.append(
+                        {
+                            "author": "system",
+                            "body_preview": "Too many review threads (>100). Please resolve or clean up threads.",
+                            "url": pr.html_url + "/files",
+                        }
                     )
 
                 threads = threads_data["nodes"]

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -71,7 +71,11 @@ class PlatformGroup:
 
 
 class PlatformMergeBot:
-    def __init__(self, token: str, repo_name: str, config_path: str, dry_run: bool):
+    """Orchestrates scanning, checking coverage, and auto-merging PRs that affect platform-maintained paths."""
+
+    def __init__(
+        self, token: str, repo_name: str, config_path: str, dry_run: bool
+    ) -> None:
         self.api = Github(token)
         self.repo = self.api.get_repo(repo_name)
         self.config_path = config_path

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -22,7 +22,9 @@ import click
 import coloredlogs
 import pathspec
 import yaml
-from github import Github
+from typing import NamedTuple
+
+from github import Github, GithubException
 from github.PullRequest import PullRequest
 
 log = logging.getLogger(__name__)
@@ -35,8 +37,16 @@ DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
 ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
 
 
+class GroupApproval(NamedTuple):
+    """Represents an approval for a platform group."""
+    approver: str
+    files: list[str]
+
+
 class PlatformGroup:
-    def __init__(self, name: str, maintainers: list[str], paths: list[str]):
+    """Represents a platform group configuration."""
+
+    def __init__(self, name: str, maintainers: list[str], paths: list[str]) -> None:
         self.name = name
         self.maintainers = [m.lower() for m in maintainers]
         self.paths = paths
@@ -44,7 +54,17 @@ class PlatformGroup:
         self.path_specs = {glob: pathspec.PathSpec.from_lines('gitignore', [glob]) for glob in paths}
 
     def matches_file(self, filepath: str) -> bool:
+        """Checks if a file path matches this group's configured paths."""
         return self.spec.match_file(filepath)
+
+    def get_matched_globs(self, files: list[str]) -> list[str]:
+        """Returns the list of glob patterns in this group that match any of the given files."""
+        matched_globs = set()
+        for f in files:
+            for glob, spec in self.path_specs.items():
+                if spec.match_file(f):
+                    matched_globs.add(glob)
+        return sorted(list(matched_globs))
 
 
 class PlatformMergeBot:
@@ -109,17 +129,15 @@ class PlatformMergeBot:
         change_requesters = {user for user, state in user_reviews.items() if state == 'CHANGES_REQUESTED'}
         return approvers, change_requesters
 
-    def analyze_pr_files(self, pr: PullRequest) -> tuple[bool, dict[str, list[str]], list[str]]:
-        """
-        Analyzes the files changed in the PR.
+    def analyze_pr_files(self, pr: PullRequest) -> tuple[dict[str, list[str]], list[str]]:
+        """Analyzes the files changed in the PR.
+
         Returns:
-          - is_fully_covered: True if all files match at least one group.
           - matched_files_per_group: Map of group_name -> list of files matching it.
           - uncovered_files: List of files that matched no group.
         """
         matched_files_per_group: dict[str, list[str]] = {name: [] for name in self.groups}
         uncovered_files = []
-        is_fully_covered = True
 
         # pr.get_files() returns PaginatedList of File objects
         for pr_file in pr.get_files():
@@ -137,20 +155,20 @@ class PlatformMergeBot:
 
                 if not matched_any:
                     uncovered_files.append(filepath)
-                    is_fully_covered = False
 
-        return is_fully_covered, matched_files_per_group, uncovered_files
+        return matched_files_per_group, uncovered_files
 
-    def check_and_process_pr(self, pr: PullRequest):
+    def check_and_process_pr(self, pr: PullRequest) -> None:
+        """Checks the coverage and approvals for a single PR, and merges if eligible."""
         log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr.user.login)
 
         if pr.draft:
             log.info("PR #%d is a draft. Skipping.", pr.number)
             return
 
-        is_fully_covered, matched_files, uncovered_files = self.analyze_pr_files(pr)
+        matched_files, uncovered_files = self.analyze_pr_files(pr)
 
-        if not is_fully_covered:
+        if uncovered_files:
             log.info(
                 "PR #%d contains files outside the platform-maintained scope. Skipping. Uncovered files: %s",
                 pr.number, uncovered_files[:5]
@@ -175,7 +193,7 @@ class PlatformMergeBot:
 
         # Check approvals for each active group
         missing_approvals: dict[str, PlatformGroup] = {}
-        valid_approvals_per_group: dict[str, tuple[str, list[str]]] = {}  # group_name -> (approver, matched_files)
+        valid_approvals_per_group: dict[str, GroupApproval] = {}
 
         for group_name, files in active_groups.items():
             group = self.groups[group_name]
@@ -184,7 +202,7 @@ class PlatformMergeBot:
                 missing_approvals[group_name] = group
             else:
                 # Pick the first matched approver for documentation
-                valid_approvals_per_group[group_name] = (list(group_approvers)[0], files)
+                valid_approvals_per_group[group_name] = GroupApproval(list(group_approvers)[0], files)
 
         if missing_approvals:
             log.info(
@@ -198,20 +216,26 @@ class PlatformMergeBot:
         log.info("PR #%d is fully approved and ready to merge!", pr.number)
         self.merge_pr(pr, valid_approvals_per_group)
 
-    def post_eligibility_comment(self, pr: PullRequest, active_groups: dict[str, list[str]], missing_approvals: dict[str, PlatformGroup]):
+    def post_eligibility_comment(
+        self,
+        pr: PullRequest,
+        active_groups: dict[str, list[str]],
+        missing_approvals: dict[str, PlatformGroup]
+    ) -> None:
+        """Posts or updates a comment stating the auto-merge status of the PR."""
         # Generate comment body first so we can compare it
         comment_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
         comment_body += "### Platform Maintainers Auto-Merge Info\n"
         comment_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
         comment_body += "To merge, we require at least one approval from each of these groups:\n"
 
-        for group_name in active_groups:
+        for group_name, files in active_groups.items():
             group = self.groups[group_name]
             maintainer_mentions = ", ".join([f"@{m}" for m in group.maintainers])
             status = "❌ Needs approval" if group_name in missing_approvals else "✅ Approved"
             comment_body += f"- **{group_name}**: {maintainer_mentions} ({status})\n"
             comment_body += "  *Paths matched:*\n"
-            for glob in group.paths:
+            for glob in group.get_matched_globs(files):
                 comment_body += f"    * `{glob}`\n"
 
         for comment in pr.get_issue_comments():
@@ -233,22 +257,17 @@ class PlatformMergeBot:
             log.info("Posting eligibility comment to PR #%d", pr.number)
             pr.create_issue_comment(comment_body)
 
-    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: dict[str, tuple[str, list[str]]]):
+    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]) -> None:
+        """Merges the PR and posts a comment explaining the approvals."""
         # Generate merge comment explaining reasons
         merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
         merge_reason_comment += "This PR has been automatically merged. It contains changes restricted to platform-maintained paths and received the required maintainer approvals:\n\n"
 
-        for group_name, (approver, files) in valid_approvals_per_group.items():
+        for group_name, approval in valid_approvals_per_group.items():
             group = self.groups[group_name]
-            # Try to find which glob patterns matched the files in this group
-            matched_globs = set()
-            for f in files:
-                for glob, spec in group.path_specs.items():
-                    if spec.match_file(f):
-                        matched_globs.add(glob)
-
+            matched_globs = group.get_matched_globs(approval.files)
             globs_str = ", ".join([f"`{g}`" for g in matched_globs])
-            merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approver}\n"
+            merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approval.approver}\n"
 
         if self.dry_run:
             log.info("[Dry Run] Would post merge comment to PR #%d:\n%s", pr.number, merge_reason_comment)
@@ -261,7 +280,8 @@ class PlatformMergeBot:
             log.info("Posting merge explanation comment to PR #%d", pr.number)
             pr.create_issue_comment(merge_reason_comment)
 
-    def run(self):
+    def run(self) -> None:
+        """Scans all open pull requests and processes them."""
         log.info("Scanning open pull requests...")
         open_prs = self.repo.get_pulls(state='open')
         for pr in open_prs:
@@ -292,13 +312,14 @@ class PlatformMergeBot:
 )
 @click.option("--dry-run", default=False, is_flag=True, help="Simulate merging and commenting without executing")
 def main(
-    log_level,
-    token_env,
-    token_file,
-    repo,
-    config,
-    dry_run,
-):
+    log_level: str,
+    token_env: str,
+    token_file: str | None,
+    repo: str,
+    config: str,
+    dry_run: bool,
+) -> None:
+    """Platform Merge Bot entry point."""
     coloredlogs.install(
         level=_LOG_LEVELS[log_level.upper()], fmt="%(asctime)s %(levelname)-7s %(message)s"
     )
@@ -308,7 +329,7 @@ def main(
         with open(token_file, encoding="utf-8") as f:
             gh_token = f.read().strip()
         if not gh_token:
-            raise Exception(f"Token file {token_file} is empty")
+            raise click.ClickException(f"Token file {token_file} is empty")
     else:
         env_var = token_env or "GH_TOKEN"
         gh_token = os.environ.get(env_var)
@@ -316,7 +337,7 @@ def main(
             gh_token = os.environ.get("GITHUB_TOKEN")
 
         if not gh_token:
-            raise Exception(f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file")
+            raise click.ClickException(f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file")
 
     bot = PlatformMergeBot(gh_token, repo, config, dry_run)
     bot.run()

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -17,8 +17,6 @@
 
 import logging
 import os
-import sys
-from typing import Dict, List, Set, Tuple
 
 import click
 import coloredlogs
@@ -38,7 +36,7 @@ ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
 
 
 class PlatformGroup:
-    def __init__(self, name: str, maintainers: List[str], paths: List[str]):
+    def __init__(self, name: str, maintainers: list[str], paths: list[str]):
         self.name = name
         self.maintainers = [m.lower() for m in maintainers]
         self.paths = paths
@@ -54,14 +52,14 @@ class PlatformMergeBot:
         self.repo = self.api.get_repo(repo_name)
         self.config_path = config_path
         self.dry_run = dry_run
-        self.groups: Dict[str, PlatformGroup] = {}
+        self.groups: dict[str, PlatformGroup] = {}
         self.load_config()
 
     def load_config(self):
         if not os.path.exists(self.config_path):
             raise FileNotFoundError(f"Config file not found at {self.config_path}")
 
-        with open(self.config_path, 'r') as f:
+        with open(self.config_path) as f:
             content = yaml.safe_load(f)
 
         if not content or not isinstance(content, dict):
@@ -78,11 +76,11 @@ class PlatformMergeBot:
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
 
-    def get_pr_approvers(self, pr: PullRequest) -> Set[str]:
+    def get_pr_approvers(self, pr: PullRequest) -> set[str]:
         """Returns the set of users who have currently approved the PR."""
         approvers = set()
         change_requesters = set()
-        
+
         # get_reviews() returns reviews chronologically
         for review in pr.get_reviews():
             user = review.user.login.lower()
@@ -95,10 +93,10 @@ class PlatformMergeBot:
             elif review.state == 'DISMISSED':
                 approvers.discard(user)
                 change_requesters.discard(user)
-                
+
         return approvers
 
-    def analyze_pr_files(self, pr: PullRequest) -> Tuple[bool, Dict[str, List[str]], List[str]]:
+    def analyze_pr_files(self, pr: PullRequest) -> tuple[bool, dict[str, list[str]], list[str]]:
         """
         Analyzes the files changed in the PR.
         Returns:
@@ -106,7 +104,7 @@ class PlatformMergeBot:
           - matched_files_per_group: Map of group_name -> list of files matching it.
           - uncovered_files: List of files that matched no group.
         """
-        matched_files_per_group: Dict[str, List[str]] = {name: [] for name in self.groups}
+        matched_files_per_group: dict[str, list[str]] = {name: [] for name in self.groups}
         uncovered_files = []
         is_fully_covered = True
 
@@ -118,7 +116,7 @@ class PlatformMergeBot:
                 if group.matches_file(filepath):
                     matched_files_per_group[group_name].append(filepath)
                     matched_any = True
-            
+
             if not matched_any:
                 uncovered_files.append(filepath)
                 is_fully_covered = False
@@ -154,8 +152,8 @@ class PlatformMergeBot:
         log.debug("PR #%d current approvers: %s", pr.number, list(approvers))
 
         # Check approvals for each active group
-        missing_approvals: Dict[str, PlatformGroup] = {}
-        valid_approvals_per_group: Dict[str, Tuple[str, List[str]]] = {} # group_name -> (approver, matched_files)
+        missing_approvals: dict[str, PlatformGroup] = {}
+        valid_approvals_per_group: dict[str, tuple[str, list[str]]] = {}  # group_name -> (approver, matched_files)
 
         for group_name, files in active_groups.items():
             group = self.groups[group_name]
@@ -178,7 +176,7 @@ class PlatformMergeBot:
         log.info("PR #%d is fully approved and ready to merge!", pr.number)
         self.merge_pr(pr, valid_approvals_per_group)
 
-    def post_eligibility_comment(self, pr: PullRequest, active_groups: Dict[str, List[str]], missing_approvals: Dict[str, PlatformGroup]):
+    def post_eligibility_comment(self, pr: PullRequest, active_groups: dict[str, list[str]], missing_approvals: dict[str, PlatformGroup]):
         # Check if eligibility comment already exists
         for comment in pr.get_issue_comments():
             if ELIGIBILITY_COMMENT_MARKER in comment.body:
@@ -190,7 +188,7 @@ class PlatformMergeBot:
         comment_body += "### Platform Maintainers Auto-Merge Info\n"
         comment_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
         comment_body += "To merge, we require at least one approval from each of these groups:\n"
-        
+
         for group_name in active_groups:
             group = self.groups[group_name]
             maintainer_mentions = ", ".join([f"@{m}" for m in group.maintainers])
@@ -206,11 +204,11 @@ class PlatformMergeBot:
             log.info("Posting eligibility comment to PR #%d", pr.number)
             pr.create_issue_comment(comment_body)
 
-    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: Dict[str, Tuple[str, List[str]]]):
+    def merge_pr(self, pr: PullRequest, valid_approvals_per_group: dict[str, tuple[str, list[str]]]):
         # Generate merge comment explaining reasons
         merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
         merge_reason_comment += "This PR has been automatically merged. It contains changes restricted to platform-maintained paths and received the required maintainer approvals:\n\n"
-        
+
         for group_name, (approver, files) in valid_approvals_per_group.items():
             group = self.groups[group_name]
             # Try to find which glob patterns matched the files in this group
@@ -221,7 +219,7 @@ class PlatformMergeBot:
                     spec = pathspec.PathSpec.from_lines('gitignore', [glob])
                     if spec.match_file(f):
                         matched_globs.add(glob)
-            
+
             globs_str = ", ".join([f"`{g}`" for g in matched_globs])
             merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approver}\n"
 
@@ -231,7 +229,7 @@ class PlatformMergeBot:
         else:
             log.info("Posting merge explanation comment to PR #%d", pr.number)
             pr.create_issue_comment(merge_reason_comment)
-            
+
             log.info("Merging PR #%d", pr.number)
             # Use squash merge
             pr.merge(merge_method="squash", commit_title=f"{pr.title} (Auto-merged by platform-bot)")
@@ -289,7 +287,7 @@ def main(
         gh_token = os.environ.get(env_var)
         if not gh_token and env_var == "GH_TOKEN":
             gh_token = os.environ.get("GITHUB_TOKEN")
-        
+
         if not gh_token:
             raise Exception(f"Require a token. Set environment variable '{env_var}' (or 'GITHUB_TOKEN') or provide --token-file")
 

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -27,7 +27,7 @@ from github.PullRequest import PullRequest
 
 log = logging.getLogger(__name__)
 
-__LOG_LEVELS__ = logging.getLevelNamesMapping()
+_LOG_LEVELS = logging.getLevelNamesMapping()
 
 DEFAULT_REPOSITORY = "project-chip/connectedhomeip"
 DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
@@ -83,6 +83,10 @@ class PlatformMergeBot:
             paths = group_data.get('paths', [])
             if not isinstance(maintainers, list) or not isinstance(paths, list):
                 raise ValueError(f"Group '{group_name}' must contain 'maintainers' and 'paths' lists.")
+            if not all(isinstance(m, str) for m in maintainers):
+                raise ValueError(f"Group '{group_name}' maintainers must be a list of strings.")
+            if not all(isinstance(p, str) for p in paths):
+                raise ValueError(f"Group '{group_name}' paths must be a list of strings.")
             self.groups[group_name] = PlatformGroup(group_name, maintainers, paths)
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
@@ -95,9 +99,13 @@ class PlatformMergeBot:
             if not review.user or not review.user.login:
                 continue
             user = review.user.login.lower()
-            user_reviews[user] = review.state
+            if review.state in ('APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'):
+                user_reviews[user] = review.state
 
         approvers = {user for user, state in user_reviews.items() if state == 'APPROVED'}
+        # Exclude author from self-approval
+        author = pr.user.login.lower()
+        approvers.discard(author)
         change_requesters = {user for user, state in user_reviews.items() if state == 'CHANGES_REQUESTED'}
         return approvers, change_requesters
 
@@ -267,7 +275,7 @@ class PlatformMergeBot:
 @click.option(
     "--log-level",
     default="INFO",
-    type=click.Choice(list(__LOG_LEVELS__.keys()), case_sensitive=False),
+    type=click.Choice(list(_LOG_LEVELS.keys()), case_sensitive=False),
     help="Determines the verbosity of script output.",
 )
 @click.option("--token-env", default="GH_TOKEN", help="Environment variable containing the GitHub token")
@@ -292,7 +300,7 @@ def main(
     dry_run,
 ):
     coloredlogs.install(
-        level=__LOG_LEVELS__[log_level.upper()], fmt="%(asctime)s %(levelname)-7s %(message)s"
+        level=_LOG_LEVELS[log_level.upper()], fmt="%(asctime)s %(levelname)-7s %(message)s"
     )
 
     gh_token = None

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -49,11 +49,12 @@ class PlatformGroup:
 
     def __init__(self, name: str, maintainers: list[str], paths: list[str]) -> None:
         self.name = name
-        self.maintainers = [m.lower() for m in maintainers]
-        self.paths = paths
-        self.spec = pathspec.PathSpec.from_lines("gitignore", paths)
+        self.maintainers = sorted({m.strip().lower() for m in maintainers})
+        self.paths = sorted({p.strip() for p in paths})
+        self.spec = pathspec.PathSpec.from_lines("gitignore", self.paths)
         self.path_specs = {
-            glob: pathspec.PathSpec.from_lines("gitignore", [glob]) for glob in paths
+            glob: pathspec.PathSpec.from_lines("gitignore", [glob])
+            for glob in self.paths
         }
 
     def matches_file(self, filepath: str) -> bool:
@@ -88,11 +89,10 @@ class PlatformMergeBot:
                 self._bot_username = self.api.get_user().login.lower()
             except GithubException:
                 self._bot_username = "platform-merge-bot"
-            except Exception:
-                self._bot_username = "platform-merge-bot"
         return self._bot_username
 
-    def load_config(self):
+    def load_config(self) -> None:
+        """Loads and validates the platform groups configuration from the YAML file."""
         if not os.path.exists(self.config_path):
             raise FileNotFoundError(f"Config file not found at {self.config_path}")
 
@@ -115,14 +115,23 @@ class PlatformMergeBot:
                 raise ValueError(
                     f"Group '{group_name}' must contain 'maintainers' and 'paths' lists."
                 )
-            if not all(isinstance(m, str) for m in maintainers):
+            if not maintainers:
                 raise ValueError(
-                    f"Group '{group_name}' maintainers must be a list of strings."
+                    f"Group '{group_name}' maintainers list cannot be empty."
                 )
-            if not all(isinstance(p, str) for p in paths):
-                raise ValueError(
-                    f"Group '{group_name}' paths must be a list of strings."
-                )
+            if not paths:
+                raise ValueError(f"Group '{group_name}' paths list cannot be empty.")
+
+            for m in maintainers:
+                if not isinstance(m, str) or not m.strip():
+                    raise ValueError(
+                        f"Group '{group_name}' maintainer '{m}' must be a non-empty string."
+                    )
+            for p in paths:
+                if not isinstance(p, str) or not p.strip():
+                    raise ValueError(
+                        f"Group '{group_name}' path '{p}' must be a non-empty string."
+                    )
             self.groups[group_name] = PlatformGroup(group_name, maintainers, paths)
 
         log.info("Loaded %d platform groups from config.", len(self.groups))
@@ -142,7 +151,7 @@ class PlatformMergeBot:
             user for user, state in user_reviews.items() if state == "APPROVED"
         }
         # Exclude author from self-approval
-        author = pr.user.login.lower()
+        author = pr.user.login.lower() if pr.user and pr.user.login else ""
         approvers.discard(author)
         change_requesters = {
             user for user, state in user_reviews.items() if state == "CHANGES_REQUESTED"
@@ -200,12 +209,14 @@ class PlatformMergeBot:
                 pr.number,
                 uncovered_files[:5],
             )
+            self.remove_eligibility_comment(pr)
             return
 
         # Determine which groups are active (i.e. have changed files)
         active_groups = {name: files for name, files in matched_files.items() if files}
         if not active_groups:
             log.info("PR #%d has no changed files? Skipping.", pr.number)
+            self.remove_eligibility_comment(pr)
             return
 
         log.info(
@@ -318,6 +329,24 @@ class PlatformMergeBot:
             log.info("Posting eligibility comment to PR #%d", pr.number)
             pr.create_issue_comment(comment_body)
 
+    def remove_eligibility_comment(self, pr: PullRequest) -> None:
+        """Removes the eligibility comment if it exists on the PR."""
+        for comment in pr.get_issue_comments():
+            if comment.user and comment.user.login.lower() == self.bot_username:
+                if comment.body and ELIGIBILITY_COMMENT_MARKER in comment.body:
+                    if self.dry_run:
+                        log.info(
+                            "[Dry Run] Would delete stale eligibility comment on PR #%d",
+                            pr.number,
+                        )
+                    else:
+                        log.info(
+                            "Deleting stale eligibility comment on PR #%d",
+                            pr.number,
+                        )
+                        comment.delete()
+                    return
+
     def merge_pr(
         self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]
     ) -> None:
@@ -373,7 +402,11 @@ class PlatformMergeBot:
     default="GH_TOKEN",
     help="Environment variable containing the GitHub token",
 )
-@click.option("--token-file", help="Read github token from the given file")
+@click.option(
+    "--token-file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Read github token from the given file",
+)
 @click.option(
     "--repo",
     default=DEFAULT_REPOSITORY,

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -82,6 +82,8 @@ esp32:
             dry_run=False,
         )
         self.bot._bot_username = "platform-merge-bot"
+        self.bot._get_unresolved_threads = MagicMock(return_value=[])
+        self.bot._is_pullapprove_green = MagicMock(return_value=False)
 
     def create_mock_file(self, filename: str) -> MagicMock:
         """Creates a mock file object with the given filename."""
@@ -113,6 +115,7 @@ esp32:
         mock_pr.title = title
         mock_pr.user.login = author
         mock_pr.draft = draft
+        mock_pr.state = "open"
         mock_pr.get_files.return_value = files
         mock_pr.get_reviews.return_value = reviews
         mock_pr.get_issue_comments.return_value = comments or []
@@ -299,6 +302,11 @@ esp32:
         expected_body += "- **nxp**: @doru91, @nxpdev (❌ Needs approval)\n"
         expected_body += "  *Paths matched:*\n"
         expected_body += "    * `src/platform/nxp/**`\n"
+        expected_body += "\n### Merge Requirements Status\n"
+        expected_body += "⚠️ **PR is not ready to merge yet:**\n"
+        expected_body += "- ❌ Needs platform maintainer approvals (see above).\n"
+        expected_body += "- ✅ All review conversations resolved.\n"
+        expected_body += "- ✅ All CI status and check suites passed.\n"
 
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
@@ -640,6 +648,130 @@ esp32:
 
         self.bot.check_and_process_pr(mock_pr)
 
+        mock_pr.merge.assert_called_once()
+
+    def test_check_and_process_pr_pullapprove_green_skips(self) -> None:
+        """Tests that a PR is skipped (and comments removed) if pullapprove is green."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_comment = MagicMock()
+        mock_comment.user.login = "platform-merge-bot"
+        mock_comment.body = "<!-- platform-merge-bot-eligibility-marker -->"
+        mock_pr = self.create_mock_pr(
+            1, "Test PR", "author", files, reviews, comments=[mock_comment]
+        )
+
+        # Mock pullapprove green
+        self.bot._is_pullapprove_green.return_value = True
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        # Should delete the eligibility comment
+        mock_comment.delete.assert_called_once()
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_unresolved_comments_does_not_merge(self) -> None:
+        """Tests that unresolved review threads block merge and print comment status."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock an unresolved thread
+        self.bot._get_unresolved_threads.return_value = [
+            {
+                "author": "jmartinez-silabs",
+                "body_preview": "Maybe we could check...",
+                "url": "https://github.com/project-chip/connectedhomeip/pull/1#discussion_r1",
+            }
+        ]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+        comment_body = mock_pr.create_issue_comment.call_args[0][0]
+        self.assertIn("Has unresolved review conversations", comment_body)
+        self.assertIn("jmartinez-silabs", comment_body)
+        self.assertIn("Maybe we could check...", comment_body)
+
+    def test_check_and_process_pr_closed_skips(self) -> None:
+        """Tests that a closed PR is skipped."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        mock_pr.state = "closed"
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_single_pr_dry_run_bypasses_closed(self) -> None:
+        """Tests that a closed PR is processed when single_pr_mode and dry_run are active."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        mock_pr.state = "closed"
+
+        # Enable single_pr_mode and dry_run
+        self.bot.single_pr_mode = True
+        self.bot.dry_run = True
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # Should log and say "Would merge" in dry-run (which means checking passed and didn't return early)
+        # Note: merge is not called in dry-run, but mock_pr.merge should not be called either.
+        # We can assert that analyze_pr_files was called, proving it bypassed the state check.
+        mock_pr.get_files.assert_called_once()
+
+    def test_check_and_process_pr_skip_checks_comments(self) -> None:
+        """Tests that COMMENTS skip check skips unresolved comment checking."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Configure skip check
+        from platform_merge_bot import ValidationCheck
+
+        self.bot.skip_checks = {ValidationCheck.COMMENTS}
+
+        # Mock unresolved threads (should be ignored)
+        self.bot._get_unresolved_threads.return_value = [
+            {
+                "author": "jmartinez-silabs",
+                "body_preview": "unresolved",
+                "url": "https://github.com/project-chip/connectedhomeip/pull/1#discussion_r1",
+            }
+        ]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # Should merge because comments check was skipped
+        mock_pr.merge.assert_called_once()
+
+    def test_check_and_process_pr_skip_checks_ci(self) -> None:
+        """Tests that CI skip check bypasses failing combined status."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Configure skip check
+        from platform_merge_bot import ValidationCheck
+
+        self.bot.skip_checks = {ValidationCheck.CI}
+
+        # Mock pending status (should be ignored)
+        mock_status = MagicMock()
+        mock_status.context = "license/cla"
+        mock_status.state = "pending"
+        self.mock_commit.get_combined_status.return_value.statuses = [
+            mock_status
+        ]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # Should merge because CI check was skipped
         mock_pr.merge.assert_called_once()
 
 

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -449,6 +449,43 @@ esp32:
         mock_comment.delete.assert_called_once()
         mock_pr.merge.assert_not_called()
 
+    def test_check_and_process_pr_already_commented_deletes_duplicates(self) -> None:
+        """Tests that duplicate eligibility comments are deleted and only one is kept/updated."""
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        reviews = []
+
+        # We have two eligibility comments
+        mock_comment1 = MagicMock()
+        mock_comment1.user.login = "platform-merge-bot"
+        mock_comment1.body = (
+            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
+        )
+
+        mock_comment2 = MagicMock()
+        mock_comment2.user.login = "platform-merge-bot"
+        mock_comment2.body = (
+            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nDuplicate Info..."
+        )
+
+        mock_pr = self.create_mock_pr(
+            1,
+            "Test PR",
+            "author",
+            files,
+            reviews,
+            comments=[mock_comment1, mock_comment2],
+        )
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # The first comment should be edited (updated)
+        mock_comment1.edit.assert_called_once()
+        # The second comment should be deleted
+        mock_comment2.delete.assert_called_once()
+        mock_pr.merge.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -16,16 +16,16 @@
 #
 
 import os
+# Ensure scripts/tools/ is in path so we can import platform_merge_bot
+import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Ensure scripts/tools/ is in path so we can import platform_merge_bot
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import platform_merge_bot
-from platform_merge_bot import PlatformMergeBot, PlatformGroup
+from platform_merge_bot import PlatformMergeBot
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 class TestPlatformMergeBot(unittest.TestCase):
@@ -96,18 +96,18 @@ esp32:
         self.assertEqual(len(self.bot.groups), 2)
         self.assertIn("nxp", self.bot.groups)
         self.assertIn("esp32", self.bot.groups)
-        
+
         nxp_group = self.bot.groups["nxp"]
         self.assertEqual(nxp_group.maintainers, ["doru91", "nxpdev"])
         self.assertEqual(nxp_group.paths, ["src/platform/nxp/**", "examples/**/nxp/**"])
 
     def test_file_matching(self):
         nxp_group = self.bot.groups["nxp"]
-        
+
         self.assertTrue(nxp_group.matches_file("src/platform/nxp/SystemTimeSupport.cpp"))
         self.assertTrue(nxp_group.matches_file("src/platform/nxp/rt/rt1060/SystemTimeSupport.cpp"))
         self.assertTrue(nxp_group.matches_file("examples/all-clusters-app/nxp/main.cpp"))
-        
+
         self.assertFalse(nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp"))
         self.assertFalse(nxp_group.matches_file("src/app/Command.cpp"))
 
@@ -116,12 +116,12 @@ esp32:
             self.create_mock_review("doru91", "COMMENTED"),
             self.create_mock_review("nxpdev", "APPROVED"),
             self.create_mock_review("doru91", "CHANGES_REQUESTED"),
-            self.create_mock_review("doru91", "APPROVED"), # approved later
-            self.create_mock_review("nxpdev", "CHANGES_REQUESTED"), # requested changes later
+            self.create_mock_review("doru91", "APPROVED"),  # approved later
+            self.create_mock_review("nxpdev", "CHANGES_REQUESTED"),  # requested changes later
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
         approvers = self.bot.get_pr_approvers(mock_pr)
-        
+
         # doru91 should be in approvers (latest was approved)
         # nxpdev should NOT be in approvers (latest was changes requested)
         self.assertIn("doru91", approvers)
@@ -143,7 +143,7 @@ esp32:
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
         is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
-        
+
         self.assertTrue(is_fully_covered)
         self.assertEqual(len(uncovered), 0)
         self.assertEqual(len(matched_files["nxp"]), 2)
@@ -152,11 +152,11 @@ esp32:
     def test_analyze_pr_files_not_fully_covered(self):
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
-            self.create_mock_file("src/app/Command.cpp"), # Uncovered
+            self.create_mock_file("src/app/Command.cpp"),  # Uncovered
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
         is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
-        
+
         self.assertFalse(is_fully_covered)
         self.assertEqual(uncovered, ["src/app/Command.cpp"])
         self.assertEqual(len(matched_files["nxp"]), 1)
@@ -164,7 +164,7 @@ esp32:
     def test_check_and_process_pr_draft(self):
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [], draft=True)
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Verify no files were fetched
         mock_pr.get_files.assert_not_called()
 
@@ -174,7 +174,7 @@ esp32:
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should not merge
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
@@ -189,7 +189,7 @@ esp32:
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should not merge, but should post eligibility comment
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_called_once()
@@ -205,9 +205,9 @@ esp32:
         mock_comment = MagicMock()
         mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nInfo..."
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
-        
+
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should not merge, and should NOT create another comment
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
@@ -220,15 +220,15 @@ esp32:
             self.create_mock_review("doru91", "APPROVED"),
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
-        
-        self.bot.run_command_mock = MagicMock() # just in case
+
+        self.bot.run_command_mock = MagicMock()  # just in case
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should merge and comment
         self.assertEqual(mock_pr.create_issue_comment.call_count, 1)
         self.assertIn("Platform Maintainers Auto-Merge Executed", mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
-        
+
         mock_pr.merge.assert_called_once_with(merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)")
 
     def test_check_and_process_pr_multi_group_approved(self):
@@ -241,9 +241,9 @@ esp32:
             self.create_mock_review("esp32dev", "APPROVED"),
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
-        
+
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should merge because both groups are approved
         mock_pr.merge.assert_called_once()
         self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
@@ -259,9 +259,9 @@ esp32:
             self.create_mock_review("doru91", "APPROVED"),
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
-        
+
         self.bot.check_and_process_pr(mock_pr)
-        
+
         # Should NOT merge, should post eligibility indicating esp32 lacks approval
         mock_pr.merge.assert_not_called()
         self.assertIn("- **esp32**: @esp32dev (❌ Needs approval)", mock_pr.create_issue_comment.call_args[0][0])

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -21,15 +21,20 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-import platform_merge_bot
-from platform_merge_bot import PlatformMergeBot
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-# isort: split
+# Global placeholders for dynamically imported local modules (shields them from formatters)
+platform_merge_bot = None
+PlatformGroup = None
+PlatformMergeBot = None
 
 
 class TestPlatformMergeBot(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+        global platform_merge_bot, PlatformGroup, PlatformMergeBot
+        import platform_merge_bot
+        from platform_merge_bot import PlatformGroup, PlatformMergeBot
+
     def setUp(self):
         # Create a temporary config file for testing
         self.config_content = """
@@ -66,6 +71,7 @@ esp32:
             config_path=self.temp_config_name,
             dry_run=False
         )
+        self.bot._bot_username = "platform-merge-bot"
 
     def tearDown(self):
         self.github_patcher.stop()
@@ -113,7 +119,7 @@ esp32:
         self.assertFalse(nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp"))
         self.assertFalse(nxp_group.matches_file("src/app/Command.cpp"))
 
-    def test_get_pr_approvers(self):
+    def test_get_pr_review_states(self):
         reviews = [
             self.create_mock_review("doru91", "COMMENTED"),
             self.create_mock_review("nxpdev", "APPROVED"),
@@ -122,12 +128,13 @@ esp32:
             self.create_mock_review("nxpdev", "CHANGES_REQUESTED"),  # requested changes later
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
-        approvers = self.bot.get_pr_approvers(mock_pr)
+        approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
 
         # doru91 should be in approvers (latest was approved)
         # nxpdev should NOT be in approvers (latest was changes requested)
         self.assertIn("doru91", approvers)
         self.assertNotIn("nxpdev", approvers)
+        self.assertIn("nxpdev", change_requesters)
 
         # test dismissed
         reviews2 = [
@@ -135,7 +142,7 @@ esp32:
             self.create_mock_review("doru91", "DISMISSED"),
         ]
         mock_pr2 = self.create_mock_pr(2, "Test PR 2", "author", [], reviews2)
-        approvers2 = self.bot.get_pr_approvers(mock_pr2)
+        approvers2, change_requesters2 = self.bot.get_pr_review_states(mock_pr2)
         self.assertNotIn("doru91", approvers2)
 
     def test_analyze_pr_files_fully_covered(self):
@@ -215,6 +222,7 @@ esp32:
         reviews = []
         # Existing eligibility comment with different body
         mock_comment = MagicMock()
+        mock_comment.user.login = "platform-merge-bot"
         mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
 
@@ -242,6 +250,7 @@ esp32:
         expected_body += "    * `examples/**/nxp/**`\n"
 
         mock_comment = MagicMock()
+        mock_comment.user.login = "platform-merge-bot"
         mock_comment.body = expected_body
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
 
@@ -306,6 +315,22 @@ esp32:
         mock_pr.merge.assert_not_called()
         self.assertIn("- **esp32**: @esp32dev (❌ Needs approval)", mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("- **nxp**: @doru91, @nxpdev (✅ Approved)", mock_pr.create_issue_comment.call_args[0][0])
+
+    def test_check_and_process_pr_blocked_by_changes_requested(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        # doru91 approved, but someone else requested changes
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+            self.create_mock_review("other_user", "CHANGES_REQUESTED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # Should NOT merge because of the active changes requested
+        mock_pr.merge.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -17,22 +17,22 @@
 
 import os
 import sys
-import tempfile
-import unittest
-from unittest.mock import MagicMock, patch
-
-import platform_merge_bot
-from platform_merge_bot import PlatformMergeBot
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # isort: split
 
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import platform_merge_bot
+from platform_merge_bot import PlatformGroup, PlatformMergeBot
+
 
 class TestPlatformMergeBot(unittest.TestCase):
     def setUp(self):
         # Create a temporary config file for testing
-        self.temp_config = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml')
         self.config_content = """
 nxp:
   maintainers:
@@ -48,8 +48,9 @@ esp32:
   paths:
     - "src/platform/ESP32/**"
 """
-        self.temp_config.write(self.config_content)
-        self.temp_config.close()
+        with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml') as f:
+            f.write(self.config_content)
+            self.temp_config_name = f.name
 
         # Patch Github initialization so we don't hit the network
         self.github_patcher = patch('platform_merge_bot.Github')
@@ -63,13 +64,13 @@ esp32:
         self.bot = PlatformMergeBot(
             token="dummy_token",
             repo_name="dummy/repo",
-            config_path=self.temp_config.name,
+            config_path=self.temp_config_name,
             dry_run=False
         )
 
     def tearDown(self):
         self.github_patcher.stop()
-        os.unlink(self.temp_config.name)
+        os.unlink(self.temp_config_name)
 
     def create_mock_file(self, filename: str) -> MagicMock:
         mock_file = MagicMock()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -27,10 +27,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from platform_merge_bot import (
-    PlatformMergeBot,
-    ELIGIBILITY_COMMENT_MARKER,
-)  # noqa: E402
+from platform_merge_bot import ELIGIBILITY_COMMENT_MARKER, PlatformMergeBot  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -21,21 +21,19 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Global placeholders for dynamically imported local modules (shields them from formatters)
-platform_merge_bot = None
-PlatformGroup = None
-PlatformMergeBot = None
+# Ensure the parent directory is in the path so we can import platform_merge_bot
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# isort: split
+
+# pylint: disable=wrong-import-position
+import platform_merge_bot  # noqa: E402
+from platform_merge_bot import GroupApproval, PlatformGroup, PlatformMergeBot  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-        global platform_merge_bot, PlatformGroup, PlatformMergeBot
-        import platform_merge_bot
-        from platform_merge_bot import PlatformGroup, PlatformMergeBot
-
-    def setUp(self):
+    def setUp(self) -> None:
+        """Sets up the test case by creating a temporary config file and mocking the Github API."""
         # Create a temporary config file for testing
         self.config_content = """
 nxp:
@@ -77,18 +75,30 @@ esp32:
         self.bot._bot_username = "platform-merge-bot"
 
     def create_mock_file(self, filename: str) -> MagicMock:
+        """Creates a mock file object with the given filename."""
         mock_file = MagicMock()
         mock_file.filename = filename
         mock_file.previous_filename = None
         return mock_file
 
     def create_mock_review(self, username: str, state: str) -> MagicMock:
+        """Creates a mock review object with the given user and state."""
         mock_review = MagicMock()
         mock_review.user.login = username
         mock_review.state = state
         return mock_review
 
-    def create_mock_pr(self, number: int, title: str, author: str, files: list, reviews: list, comments: list = None, draft: bool = False) -> MagicMock:
+    def create_mock_pr(
+        self,
+        number: int,
+        title: str,
+        author: str,
+        files: list[MagicMock],
+        reviews: list[MagicMock],
+        comments: list[MagicMock] | None = None,
+        draft: bool = False
+    ) -> MagicMock:
+        """Creates a mock PullRequest object with the given parameters."""
         mock_pr = MagicMock()
         mock_pr.number = number
         mock_pr.title = title
@@ -99,7 +109,8 @@ esp32:
         mock_pr.get_issue_comments.return_value = comments or []
         return mock_pr
 
-    def test_config_loading(self):
+    def test_config_loading(self) -> None:
+        """Tests that the YAML config is parsed correctly into PlatformGroup objects."""
         self.assertEqual(len(self.bot.groups), 2)
         self.assertIn("nxp", self.bot.groups)
         self.assertIn("esp32", self.bot.groups)
@@ -108,7 +119,8 @@ esp32:
         self.assertEqual(nxp_group.maintainers, ["doru91", "nxpdev"])
         self.assertEqual(nxp_group.paths, ["src/platform/nxp/**", "examples/**/nxp/**"])
 
-    def test_file_matching(self):
+    def test_file_matching(self) -> None:
+        """Tests that file path matching against platform groups functions correctly."""
         nxp_group = self.bot.groups["nxp"]
 
         self.assertTrue(nxp_group.matches_file("src/platform/nxp/SystemTimeSupport.cpp"))
@@ -118,7 +130,8 @@ esp32:
         self.assertFalse(nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp"))
         self.assertFalse(nxp_group.matches_file("src/app/Command.cpp"))
 
-    def test_get_pr_review_states(self):
+    def test_get_pr_review_states(self) -> None:
+        """Tests that the correct active reviewers are identified from the chronological reviews list."""
         reviews = [
             self.create_mock_review("doru91", "COMMENTED"),
             self.create_mock_review("nxpdev", "APPROVED"),
@@ -144,49 +157,51 @@ esp32:
         approvers2, change_requesters2 = self.bot.get_pr_review_states(mock_pr2)
         self.assertNotIn("doru91", approvers2)
 
-    def test_analyze_pr_files_fully_covered(self):
+    def test_analyze_pr_files_fully_covered(self) -> None:
+        """Tests that all changed files are covered by platform groups."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
             self.create_mock_file("examples/all-clusters-app/nxp/main.cpp"),
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
-        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+        matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
 
-        self.assertTrue(is_fully_covered)
         self.assertEqual(len(uncovered), 0)
         self.assertEqual(len(matched_files["nxp"]), 2)
         self.assertEqual(len(matched_files["esp32"]), 0)
 
-    def test_analyze_pr_files_not_fully_covered(self):
+    def test_analyze_pr_files_not_fully_covered(self) -> None:
+        """Tests that uncovered files are correctly identified."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
             self.create_mock_file("src/app/Command.cpp"),  # Uncovered
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
-        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+        matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
 
-        self.assertFalse(is_fully_covered)
         self.assertEqual(uncovered, ["src/app/Command.cpp"])
         self.assertEqual(len(matched_files["nxp"]), 1)
 
-    def test_analyze_pr_files_rename_bypass(self):
+    def test_analyze_pr_files_rename_bypass(self) -> None:
+        """Tests that previous filenames of renamed files are also checked for coverage."""
         mock_file = self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")
         mock_file.previous_filename = "src/app/Command.cpp"
         files = [mock_file]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
-        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+        _, uncovered = self.bot.analyze_pr_files(mock_pr)
 
-        self.assertFalse(is_fully_covered)
         self.assertIn("src/app/Command.cpp", uncovered)
 
-    def test_check_and_process_pr_draft(self):
+    def test_check_and_process_pr_draft(self) -> None:
+        """Tests that drafts are skipped entirely without checking files."""
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [], draft=True)
         self.bot.check_and_process_pr(mock_pr)
 
         # Verify no files were fetched
         mock_pr.get_files.assert_not_called()
 
-    def test_check_and_process_pr_not_eligible(self):
+    def test_check_and_process_pr_not_eligible(self) -> None:
+        """Tests that PR containing uncovered files is skipped and not merged."""
         files = [
             self.create_mock_file("src/app/Command.cpp"),
         ]
@@ -197,7 +212,8 @@ esp32:
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
 
-    def test_check_and_process_pr_needs_approval(self):
+    def test_check_and_process_pr_needs_approval(self) -> None:
+        """Tests that PR lacking platform maintainer approvals does not merge and gets an eligibility comment."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
@@ -214,7 +230,8 @@ esp32:
         self.assertIn(platform_merge_bot.ELIGIBILITY_COMMENT_MARKER, mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("Needs approval", mock_pr.create_issue_comment.call_args[0][0])
 
-    def test_check_and_process_pr_already_commented_updates_if_different(self):
+    def test_check_and_process_pr_already_commented_updates_if_different(self) -> None:
+        """Tests that an existing eligibility comment is edited if the status has changed."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
@@ -232,7 +249,8 @@ esp32:
         mock_pr.create_issue_comment.assert_not_called()
         mock_comment.edit.assert_called_once()
 
-    def test_check_and_process_pr_already_commented_no_op_if_identical(self):
+    def test_check_and_process_pr_already_commented_no_op_if_identical(self) -> None:
+        """Tests that an existing eligibility comment is untouched if the status is identical."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
@@ -246,7 +264,6 @@ esp32:
         expected_body += "- **nxp**: @doru91, @nxpdev (❌ Needs approval)\n"
         expected_body += "  *Paths matched:*\n"
         expected_body += "    * `src/platform/nxp/**`\n"
-        expected_body += "    * `examples/**/nxp/**`\n"
 
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
@@ -260,7 +277,8 @@ esp32:
         mock_pr.create_issue_comment.assert_not_called()
         mock_comment.edit.assert_not_called()
 
-    def test_check_and_process_pr_fully_approved_merge(self):
+    def test_check_and_process_pr_fully_approved_merge(self) -> None:
+        """Tests that PR is merged and commented when fully approved."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
@@ -269,7 +287,6 @@ esp32:
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
 
-        self.bot.run_command_mock = MagicMock()  # just in case
         self.bot.check_and_process_pr(mock_pr)
 
         # Should merge and comment
@@ -279,7 +296,8 @@ esp32:
 
         mock_pr.merge.assert_called_once_with(merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)")
 
-    def test_check_and_process_pr_multi_group_approved(self):
+    def test_check_and_process_pr_multi_group_approved(self) -> None:
+        """Tests that PR is merged when all affected platform groups have approved."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
             self.create_mock_file("src/platform/ESP32/SystemTimeSupport.cpp"),
@@ -297,7 +315,8 @@ esp32:
         self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("approved by @esp32dev", mock_pr.create_issue_comment.call_args[0][0])
 
-    def test_check_and_process_pr_multi_group_missing_one_approval(self):
+    def test_check_and_process_pr_multi_group_missing_one_approval(self) -> None:
+        """Tests that PR is not merged and lists pending groups when only some groups approved."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
             self.create_mock_file("src/platform/ESP32/SystemTimeSupport.cpp"),
@@ -315,7 +334,8 @@ esp32:
         self.assertIn("- **esp32**: @esp32dev (❌ Needs approval)", mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("- **nxp**: @doru91, @nxpdev (✅ Approved)", mock_pr.create_issue_comment.call_args[0][0])
 
-    def test_check_and_process_pr_blocked_by_changes_requested(self):
+    def test_check_and_process_pr_blocked_by_changes_requested(self) -> None:
+        """Tests that any active changes requested review blocks auto-merge."""
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
@@ -331,7 +351,8 @@ esp32:
         # Should NOT merge because of the active changes requested
         mock_pr.merge.assert_not_called()
 
-    def test_get_pr_review_states_comment_does_not_overwrite_approval(self):
+    def test_get_pr_review_states_comment_does_not_overwrite_approval(self) -> None:
+        """Tests that a standard comment review does not overwrite an existing approval review."""
         reviews = [
             self.create_mock_review("doru91", "APPROVED"),
             self.create_mock_review("doru91", "COMMENTED"),
@@ -340,7 +361,8 @@ esp32:
         approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
         self.assertIn("doru91", approvers)
 
-    def test_get_pr_review_states_comment_does_not_overwrite_changes_requested(self):
+    def test_get_pr_review_states_comment_does_not_overwrite_changes_requested(self) -> None:
+        """Tests that a standard comment review does not overwrite an existing changes requested review."""
         reviews = [
             self.create_mock_review("doru91", "CHANGES_REQUESTED"),
             self.create_mock_review("doru91", "COMMENTED"),
@@ -348,6 +370,8 @@ esp32:
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
         approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
         self.assertIn("doru91", change_requesters)
+
+
 
 
 if __name__ == '__main__':

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -32,6 +32,8 @@ from platform_merge_bot import PlatformMergeBot  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
+    """Unit tests for the platform merge bot."""
+
     def setUp(self) -> None:
         """Sets up the test case by creating a temporary config file and mocking the Github API."""
         # Create a temporary config file for testing

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -27,8 +27,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-import platform_merge_bot  # noqa: E402
-from platform_merge_bot import PlatformMergeBot  # noqa: E402
+from platform_merge_bot import (
+    PlatformMergeBot,
+    ELIGIBILITY_COMMENT_MARKER,
+)  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
@@ -178,9 +180,15 @@ esp32:
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
         matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
 
-        self.assertEqual(len(uncovered), 0)
-        self.assertEqual(len(matched_files["nxp"]), 2)
-        self.assertEqual(len(matched_files["esp32"]), 0)
+        self.assertEqual(uncovered, set())
+        self.assertEqual(
+            matched_files["nxp"],
+            {
+                "src/platform/nxp/SystemTimeSupport.cpp",
+                "examples/all-clusters-app/nxp/main.cpp",
+            },
+        )
+        self.assertEqual(matched_files["esp32"], set())
 
     def test_analyze_pr_files_not_fully_covered(self) -> None:
         """Tests that uncovered files are correctly identified."""
@@ -191,8 +199,10 @@ esp32:
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
         matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
 
-        self.assertEqual(uncovered, ["src/app/Command.cpp"])
-        self.assertEqual(len(matched_files["nxp"]), 1)
+        self.assertEqual(uncovered, {"src/app/Command.cpp"})
+        self.assertEqual(
+            matched_files["nxp"], {"src/platform/nxp/SystemTimeSupport.cpp"}
+        )
 
     def test_analyze_pr_files_rename_bypass(self) -> None:
         """Tests that previous filenames of renamed files are also checked for coverage."""
@@ -240,7 +250,7 @@ esp32:
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_called_once()
         self.assertIn(
-            platform_merge_bot.ELIGIBILITY_COMMENT_MARKER,
+            ELIGIBILITY_COMMENT_MARKER,
             mock_pr.create_issue_comment.call_args[0][0],
         )
         self.assertIn("Needs approval", mock_pr.create_issue_comment.call_args[0][0])
@@ -254,9 +264,7 @@ esp32:
         # Existing eligibility comment with different body
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
-        mock_comment.body = (
-            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
-        )
+        mock_comment.body = f"{ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
         mock_pr = self.create_mock_pr(
             1, "Test PR", "author", files, reviews, comments=[mock_comment]
         )
@@ -276,7 +284,7 @@ esp32:
         reviews = []
 
         # Generate the expected body to make it identical
-        expected_body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\n"
+        expected_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
         expected_body += "### Platform Maintainers Auto-Merge Info\n"
         expected_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
         expected_body += (
@@ -422,9 +430,7 @@ esp32:
         ]
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
-        mock_comment.body = (
-            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
-        )
+        mock_comment.body = f"{ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
         mock_pr = self.create_mock_pr(
             1, "Test PR", "author", files, [], comments=[mock_comment]
         )
@@ -439,9 +445,7 @@ esp32:
         files = []  # No changed files
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
-        mock_comment.body = (
-            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
-        )
+        mock_comment.body = f"{ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
         mock_pr = self.create_mock_pr(
             1, "Test PR", "author", files, [], comments=[mock_comment]
         )
@@ -461,15 +465,11 @@ esp32:
         # We have two eligibility comments
         mock_comment1 = MagicMock()
         mock_comment1.user.login = "platform-merge-bot"
-        mock_comment1.body = (
-            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
-        )
+        mock_comment1.body = f"{ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
 
         mock_comment2 = MagicMock()
         mock_comment2.user.login = "platform-merge-bot"
-        mock_comment2.body = (
-            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nDuplicate Info..."
-        )
+        mock_comment2.body = f"{ELIGIBILITY_COMMENT_MARKER}\nDuplicate Info..."
 
         mock_pr = self.create_mock_pr(
             1,
@@ -487,6 +487,48 @@ esp32:
         # The second comment should be deleted
         mock_comment2.delete.assert_called_once()
         mock_pr.merge.assert_not_called()
+
+    def test_config_loading_invalid_format(self) -> None:
+        """Tests that ValueError is raised for various invalid config formats."""
+        invalid_contents = [
+            # Not a dict
+            "[]",
+            # Group name not string (YAML allows int keys)
+            "123:\n  maintainers:\n    - dev\n  paths:\n    - 'path/**'",
+            # Group data not dict
+            "group: 'not a dict'",
+            # Unrecognized keys
+            "group:\n  maintainers:\n    - dev\n  paths:\n    - 'path/**'\n  extra: 1",
+            # Maintainers not list
+            "group:\n  maintainers: dev\n  paths:\n    - 'path/**'",
+            # Paths not list
+            "group:\n  maintainers:\n    - dev\n  paths: 'path/**'",
+            # Empty maintainers
+            "group:\n  maintainers: []\n  paths:\n    - 'path/**'",
+            # Empty paths
+            "group:\n  maintainers:\n    - dev\n  paths: []",
+            # Empty maintainer string
+            "group:\n  maintainers:\n    - ''\n  paths:\n    - 'path/**'",
+            # Empty path string
+            "group:\n  maintainers:\n    - dev\n  paths:\n    - ' '",
+        ]
+
+        for content in invalid_contents:
+            with tempfile.NamedTemporaryFile(
+                delete=False, mode="w", suffix=".yaml"
+            ) as f:
+                f.write(content)
+                temp_name = f.name
+            try:
+                with self.assertRaises(ValueError):
+                    PlatformMergeBot(
+                        token="dummy_token",
+                        repo_name="dummy/repo",
+                        config_path=temp_name,
+                        dry_run=False,
+                    )
+            finally:
+                os.unlink(temp_name)
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure scripts/tools/ is in path so we can import platform_merge_bot
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import platform_merge_bot
+from platform_merge_bot import PlatformMergeBot, PlatformGroup
+
+
+class TestPlatformMergeBot(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary config file for testing
+        self.temp_config = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml')
+        self.config_content = """
+nxp:
+  maintainers:
+    - doru91
+    - nxpdev
+  paths:
+    - "src/platform/nxp/**"
+    - "examples/**/nxp/**"
+
+esp32:
+  maintainers:
+    - esp32dev
+  paths:
+    - "src/platform/ESP32/**"
+"""
+        self.temp_config.write(self.config_content)
+        self.temp_config.close()
+
+        # Patch Github initialization so we don't hit the network
+        self.github_patcher = patch('platform_merge_bot.Github')
+        self.mock_github_class = self.github_patcher.start()
+        self.mock_github_instance = MagicMock()
+        self.mock_github_class.return_value = self.mock_github_instance
+        self.mock_repo = MagicMock()
+        self.mock_github_instance.get_repo.return_value = self.mock_repo
+
+        # Initialize bot under test
+        self.bot = PlatformMergeBot(
+            token="dummy_token",
+            repo_name="dummy/repo",
+            config_path=self.temp_config.name,
+            dry_run=False
+        )
+
+    def tearDown(self):
+        self.github_patcher.stop()
+        os.unlink(self.temp_config.name)
+
+    def create_mock_file(self, filename: str) -> MagicMock:
+        mock_file = MagicMock()
+        mock_file.filename = filename
+        return mock_file
+
+    def create_mock_review(self, username: str, state: str) -> MagicMock:
+        mock_review = MagicMock()
+        mock_review.user.login = username
+        mock_review.state = state
+        return mock_review
+
+    def create_mock_pr(self, number: int, title: str, author: str, files: list, reviews: list, comments: list = None, draft: bool = False) -> MagicMock:
+        mock_pr = MagicMock()
+        mock_pr.number = number
+        mock_pr.title = title
+        mock_pr.user.login = author
+        mock_pr.draft = draft
+        mock_pr.get_files.return_value = files
+        mock_pr.get_reviews.return_value = reviews
+        mock_pr.get_issue_comments.return_value = comments or []
+        return mock_pr
+
+    def test_config_loading(self):
+        self.assertEqual(len(self.bot.groups), 2)
+        self.assertIn("nxp", self.bot.groups)
+        self.assertIn("esp32", self.bot.groups)
+        
+        nxp_group = self.bot.groups["nxp"]
+        self.assertEqual(nxp_group.maintainers, ["doru91", "nxpdev"])
+        self.assertEqual(nxp_group.paths, ["src/platform/nxp/**", "examples/**/nxp/**"])
+
+    def test_file_matching(self):
+        nxp_group = self.bot.groups["nxp"]
+        
+        self.assertTrue(nxp_group.matches_file("src/platform/nxp/SystemTimeSupport.cpp"))
+        self.assertTrue(nxp_group.matches_file("src/platform/nxp/rt/rt1060/SystemTimeSupport.cpp"))
+        self.assertTrue(nxp_group.matches_file("examples/all-clusters-app/nxp/main.cpp"))
+        
+        self.assertFalse(nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp"))
+        self.assertFalse(nxp_group.matches_file("src/app/Command.cpp"))
+
+    def test_get_pr_approvers(self):
+        reviews = [
+            self.create_mock_review("doru91", "COMMENTED"),
+            self.create_mock_review("nxpdev", "APPROVED"),
+            self.create_mock_review("doru91", "CHANGES_REQUESTED"),
+            self.create_mock_review("doru91", "APPROVED"), # approved later
+            self.create_mock_review("nxpdev", "CHANGES_REQUESTED"), # requested changes later
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
+        approvers = self.bot.get_pr_approvers(mock_pr)
+        
+        # doru91 should be in approvers (latest was approved)
+        # nxpdev should NOT be in approvers (latest was changes requested)
+        self.assertIn("doru91", approvers)
+        self.assertNotIn("nxpdev", approvers)
+
+        # test dismissed
+        reviews2 = [
+            self.create_mock_review("doru91", "APPROVED"),
+            self.create_mock_review("doru91", "DISMISSED"),
+        ]
+        mock_pr2 = self.create_mock_pr(2, "Test PR 2", "author", [], reviews2)
+        approvers2 = self.bot.get_pr_approvers(mock_pr2)
+        self.assertNotIn("doru91", approvers2)
+
+    def test_analyze_pr_files_fully_covered(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+            self.create_mock_file("examples/all-clusters-app/nxp/main.cpp"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
+        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+        
+        self.assertTrue(is_fully_covered)
+        self.assertEqual(len(uncovered), 0)
+        self.assertEqual(len(matched_files["nxp"]), 2)
+        self.assertEqual(len(matched_files["esp32"]), 0)
+
+    def test_analyze_pr_files_not_fully_covered(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+            self.create_mock_file("src/app/Command.cpp"), # Uncovered
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
+        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+        
+        self.assertFalse(is_fully_covered)
+        self.assertEqual(uncovered, ["src/app/Command.cpp"])
+        self.assertEqual(len(matched_files["nxp"]), 1)
+
+    def test_check_and_process_pr_draft(self):
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [], draft=True)
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Verify no files were fetched
+        mock_pr.get_files.assert_not_called()
+
+    def test_check_and_process_pr_not_eligible(self):
+        files = [
+            self.create_mock_file("src/app/Command.cpp"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should not merge
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_needs_approval(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        # Approver is 'random_user', not a maintainer
+        reviews = [
+            self.create_mock_review("random_user", "APPROVED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should not merge, but should post eligibility comment
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+        self.assertIn(platform_merge_bot.ELIGIBILITY_COMMENT_MARKER, mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn("Needs approval", mock_pr.create_issue_comment.call_args[0][0])
+
+    def test_check_and_process_pr_already_commented_no_duplicate(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        reviews = []
+        # Existing eligibility comment
+        mock_comment = MagicMock()
+        mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nInfo..."
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
+        
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should not merge, and should NOT create another comment
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_fully_approved_merge(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        
+        self.bot.run_command_mock = MagicMock() # just in case
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should merge and comment
+        self.assertEqual(mock_pr.create_issue_comment.call_count, 1)
+        self.assertIn("Platform Maintainers Auto-Merge Executed", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
+        
+        mock_pr.merge.assert_called_once_with(merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)")
+
+    def test_check_and_process_pr_multi_group_approved(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+            self.create_mock_file("src/platform/ESP32/SystemTimeSupport.cpp"),
+        ]
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+            self.create_mock_review("esp32dev", "APPROVED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should merge because both groups are approved
+        mock_pr.merge.assert_called_once()
+        self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn("approved by @esp32dev", mock_pr.create_issue_comment.call_args[0][0])
+
+    def test_check_and_process_pr_multi_group_missing_one_approval(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+            self.create_mock_file("src/platform/ESP32/SystemTimeSupport.cpp"),
+        ]
+        # Only doru91 approved, esp32dev has not
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        
+        self.bot.check_and_process_pr(mock_pr)
+        
+        # Should NOT merge, should post eligibility indicating esp32 lacks approval
+        mock_pr.merge.assert_not_called()
+        self.assertIn("- **esp32**: @esp32dev (❌ Needs approval)", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn("- **nxp**: @doru91, @nxpdev (✅ Approved)", mock_pr.create_issue_comment.call_args[0][0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -74,6 +74,7 @@ esp32:
     def create_mock_file(self, filename: str) -> MagicMock:
         mock_file = MagicMock()
         mock_file.filename = filename
+        mock_file.previous_filename = None
         return mock_file
 
     def create_mock_review(self, username: str, state: str) -> MagicMock:
@@ -161,6 +162,16 @@ esp32:
         self.assertFalse(is_fully_covered)
         self.assertEqual(uncovered, ["src/app/Command.cpp"])
         self.assertEqual(len(matched_files["nxp"]), 1)
+
+    def test_analyze_pr_files_rename_bypass(self):
+        mock_file = self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")
+        mock_file.previous_filename = "src/app/Command.cpp"
+        files = [mock_file]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, [])
+        is_fully_covered, matched_files, uncovered = self.bot.analyze_pr_files(mock_pr)
+
+        self.assertFalse(is_fully_covered)
+        self.assertIn("src/app/Command.cpp", uncovered)
 
     def test_check_and_process_pr_draft(self):
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [], draft=True)

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -208,21 +208,49 @@ esp32:
         self.assertIn(platform_merge_bot.ELIGIBILITY_COMMENT_MARKER, mock_pr.create_issue_comment.call_args[0][0])
         self.assertIn("Needs approval", mock_pr.create_issue_comment.call_args[0][0])
 
-    def test_check_and_process_pr_already_commented_no_duplicate(self):
+    def test_check_and_process_pr_already_commented_updates_if_different(self):
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
         reviews = []
-        # Existing eligibility comment
+        # Existing eligibility comment with different body
         mock_comment = MagicMock()
-        mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nInfo..."
+        mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
 
         self.bot.check_and_process_pr(mock_pr)
 
-        # Should not merge, and should NOT create another comment
+        # Should not merge, should not create a new comment, but should edit the existing one
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
+        mock_comment.edit.assert_called_once()
+
+    def test_check_and_process_pr_already_commented_no_op_if_identical(self):
+        files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
+        ]
+        reviews = []
+
+        # Generate the expected body to make it identical
+        expected_body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\n"
+        expected_body += "### Platform Maintainers Auto-Merge Info\n"
+        expected_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
+        expected_body += "To merge, we require at least one approval from each of these groups:\n"
+        expected_body += "- **nxp**: @doru91, @nxpdev (❌ Needs approval)\n"
+        expected_body += "  *Paths matched:*\n"
+        expected_body += "    * `src/platform/nxp/**`\n"
+        expected_body += "    * `examples/**/nxp/**`\n"
+
+        mock_comment = MagicMock()
+        mock_comment.body = expected_body
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        # Should not merge, should not create a new comment, and should not edit the existing one
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+        mock_comment.edit.assert_not_called()
 
     def test_check_and_process_pr_fully_approved_merge(self):
         files = [

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -66,6 +66,14 @@ esp32:
         self.mock_repo = MagicMock()
         self.mock_github_instance.get_repo.return_value = self.mock_repo
 
+        # Default mock commit with passing CI
+        self.mock_commit = MagicMock()
+        self.mock_commit.get_combined_status.return_value.state = "success"
+        self.mock_commit.get_combined_status.return_value.total_count = 0
+        self.mock_commit.get_combined_status.return_value.statuses = []
+        self.mock_commit.get_check_suites.return_value = []
+        self.mock_repo.get_commit.return_value = self.mock_commit
+
         # Initialize bot under test
         self.bot = PlatformMergeBot(
             token="dummy_token",
@@ -108,6 +116,7 @@ esp32:
         mock_pr.get_files.return_value = files
         mock_pr.get_reviews.return_value = reviews
         mock_pr.get_issue_comments.return_value = comments or []
+        mock_pr.head.sha = "dummy_sha"
         return mock_pr
 
     def test_config_loading(self) -> None:
@@ -328,7 +337,9 @@ esp32:
         )
 
         mock_pr.merge.assert_called_once_with(
-            merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)"
+            merge_method="squash",
+            commit_title="Test PR (Auto-merged by platform-bot)",
+            sha="dummy_sha",
         )
 
     def test_check_and_process_pr_multi_group_approved(self) -> None:
@@ -526,6 +537,110 @@ esp32:
                     )
             finally:
                 os.unlink(temp_name)
+
+    def test_check_and_process_pr_ci_pending_status_does_not_merge(self) -> None:
+        """Tests that a PR is not merged when combined status is pending."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock a pending CI status check
+        mock_status = MagicMock()
+        mock_status.context = "license/cla"
+        mock_status.state = "pending"
+        mock_status.description = "Checking CLA..."
+        self.mock_commit.get_combined_status.return_value.statuses = [mock_status]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        # Should still post/update eligibility comment
+        mock_pr.create_issue_comment.assert_called_once()
+
+    def test_check_and_process_pr_ci_pullapprove_pending_still_merges(self) -> None:
+        """Tests that pullapprove pending status does not block merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock pending pullapprove status but passing CLA status
+        status_cla = MagicMock()
+        status_cla.context = "license/cla"
+        status_cla.state = "success"
+        status_cla.description = "CLA signed"
+
+        status_pa = MagicMock()
+        status_pa.context = "pullapprove"
+        status_pa.state = "pending"
+        status_pa.description = "Pending approvals"
+
+        self.mock_commit.get_combined_status.return_value.statuses = [
+            status_cla,
+            status_pa,
+        ]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_called_once()
+
+    def test_check_and_process_pr_ci_failing_check_suite_does_not_merge(self) -> None:
+        """Tests that a PR is not merged when check suite fails."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock completed but failed check suite
+        mock_suite = MagicMock()
+        mock_suite.status = "completed"
+        mock_suite.conclusion = "failure"
+        self.mock_commit.get_check_suites.return_value = [mock_suite]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+
+    def test_check_and_process_pr_ci_incomplete_check_suite_does_not_merge(self) -> None:
+        """Tests that a PR is not merged when check suite is still running."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock in_progress check suite
+        mock_suite = MagicMock()
+        mock_suite.status = "in_progress"
+        mock_suite.conclusion = None
+        self.mock_commit.get_check_suites.return_value = [mock_suite]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+
+    def test_check_and_process_pr_ci_passing_non_blocking_check_suite_merges(self) -> None:
+        """Tests that neutral/skipped/success check suites allow merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock successful, neutral, and skipped check suites
+        mock_suite1 = MagicMock()
+        mock_suite1.status = "completed"
+        mock_suite1.conclusion = "success"
+
+        mock_suite2 = MagicMock()
+        mock_suite2.status = "completed"
+        mock_suite2.conclusion = "neutral"
+
+        mock_suite3 = MagicMock()
+        mock_suite3.status = "completed"
+        mock_suite3.conclusion = "skipped"
+
+        self.mock_commit.get_check_suites.return_value = [mock_suite1, mock_suite2, mock_suite3]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -291,33 +291,27 @@ esp32:
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
         reviews = []
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
 
-        # Generate the expected body to make it identical
-        expected_body = f"{ELIGIBILITY_COMMENT_MARKER}\n"
-        expected_body += "### Platform Maintainers Auto-Merge Info\n"
-        expected_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
-        expected_body += (
-            "To merge, we require at least one approval from each of these groups:\n"
-        )
-        expected_body += "- **nxp**: @doru91, @nxpdev (❌ Needs approval)\n"
-        expected_body += "  *Paths matched:*\n"
-        expected_body += "    * `src/platform/nxp/**`\n"
-        expected_body += "\n### Merge Requirements Status\n"
-        expected_body += "⚠️ **PR is not ready to merge yet:**\n"
-        expected_body += "- ❌ Needs platform maintainer approvals (see above).\n"
-        expected_body += "- ✅ All review conversations resolved.\n"
-        expected_body += "- ✅ All CI status and check suites passed.\n"
+        # First run: posts the eligibility comment
+        self.bot.check_and_process_pr(mock_pr)
+        mock_pr.create_issue_comment.assert_called_once()
+        posted_comment_body = mock_pr.create_issue_comment.call_args[0][0]
 
+        # Set up the PR to return the posted comment in subsequent get_issue_comments() calls
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
-        mock_comment.body = expected_body
-        mock_pr = self.create_mock_pr(
-            1, "Test PR", "author", files, reviews, comments=[mock_comment]
-        )
+        mock_comment.body = posted_comment_body
+        mock_pr.get_issue_comments.return_value = [mock_comment]
 
+        # Reset mocks
+        mock_pr.merge.reset_mock()
+        mock_pr.create_issue_comment.reset_mock()
+        mock_comment.edit.reset_mock()
+
+        # Second run: should be a no-op since status is identical
         self.bot.check_and_process_pr(mock_pr)
 
-        # Should not merge, should not create a new comment, and should not edit the existing one
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
         mock_comment.edit.assert_not_called()
@@ -773,6 +767,30 @@ esp32:
 
         # Should merge because CI check was skipped
         mock_pr.merge.assert_called_once()
+
+    def test_get_pr_review_states_disallows_self_approval(self) -> None:
+        """Tests that a PR author cannot approve their own PR."""
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+        ]
+        # PR is authored by "doru91"
+        mock_pr = self.create_mock_pr(1, "Test PR", "doru91", [], reviews)
+        approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
+
+        self.assertNotIn("doru91", approvers)
+
+    def test_check_and_process_pr_deleted_author_skips(self) -> None:
+        """Tests that a PR from a deleted/ghost author is skipped."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "ghost", files, reviews)
+        # Simulate deleted user account where pr.user is None
+        mock_pr.user = None
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -22,13 +22,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # Ensure the parent directory is in the path so we can import platform_merge_bot
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # isort: split
 
 # pylint: disable=wrong-import-position
 import platform_merge_bot  # noqa: E402
-from platform_merge_bot import GroupApproval, PlatformGroup, PlatformMergeBot  # noqa: E402
+from platform_merge_bot import PlatformMergeBot  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
@@ -50,13 +50,13 @@ esp32:
   paths:
     - "src/platform/ESP32/**"
 """
-        with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml') as f:
+        with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".yaml") as f:
             f.write(self.config_content)
             self.temp_config_name = f.name
         self.addCleanup(os.unlink, self.temp_config_name)
 
         # Patch Github initialization so we don't hit the network
-        self.github_patcher = patch('platform_merge_bot.Github')
+        self.github_patcher = patch("platform_merge_bot.Github")
         self.mock_github_class = self.github_patcher.start()
         self.addCleanup(self.github_patcher.stop)
 
@@ -70,7 +70,7 @@ esp32:
             token="dummy_token",
             repo_name="dummy/repo",
             config_path=self.temp_config_name,
-            dry_run=False
+            dry_run=False,
         )
         self.bot._bot_username = "platform-merge-bot"
 
@@ -96,7 +96,7 @@ esp32:
         files: list[MagicMock],
         reviews: list[MagicMock],
         comments: list[MagicMock] | None = None,
-        draft: bool = False
+        draft: bool = False,
     ) -> MagicMock:
         """Creates a mock PullRequest object with the given parameters."""
         mock_pr = MagicMock()
@@ -123,11 +123,19 @@ esp32:
         """Tests that file path matching against platform groups functions correctly."""
         nxp_group = self.bot.groups["nxp"]
 
-        self.assertTrue(nxp_group.matches_file("src/platform/nxp/SystemTimeSupport.cpp"))
-        self.assertTrue(nxp_group.matches_file("src/platform/nxp/rt/rt1060/SystemTimeSupport.cpp"))
-        self.assertTrue(nxp_group.matches_file("examples/all-clusters-app/nxp/main.cpp"))
+        self.assertTrue(
+            nxp_group.matches_file("src/platform/nxp/SystemTimeSupport.cpp")
+        )
+        self.assertTrue(
+            nxp_group.matches_file("src/platform/nxp/rt/rt1060/SystemTimeSupport.cpp")
+        )
+        self.assertTrue(
+            nxp_group.matches_file("examples/all-clusters-app/nxp/main.cpp")
+        )
 
-        self.assertFalse(nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp"))
+        self.assertFalse(
+            nxp_group.matches_file("src/platform/ESP32/SystemTimeSupport.cpp")
+        )
         self.assertFalse(nxp_group.matches_file("src/app/Command.cpp"))
 
     def test_get_pr_review_states(self) -> None:
@@ -137,7 +145,9 @@ esp32:
             self.create_mock_review("nxpdev", "APPROVED"),
             self.create_mock_review("doru91", "CHANGES_REQUESTED"),
             self.create_mock_review("doru91", "APPROVED"),  # approved later
-            self.create_mock_review("nxpdev", "CHANGES_REQUESTED"),  # requested changes later
+            self.create_mock_review(
+                "nxpdev", "CHANGES_REQUESTED"
+            ),  # requested changes later
         ]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
         approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
@@ -227,7 +237,10 @@ esp32:
         # Should not merge, but should post eligibility comment
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_called_once()
-        self.assertIn(platform_merge_bot.ELIGIBILITY_COMMENT_MARKER, mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn(
+            platform_merge_bot.ELIGIBILITY_COMMENT_MARKER,
+            mock_pr.create_issue_comment.call_args[0][0],
+        )
         self.assertIn("Needs approval", mock_pr.create_issue_comment.call_args[0][0])
 
     def test_check_and_process_pr_already_commented_updates_if_different(self) -> None:
@@ -239,8 +252,12 @@ esp32:
         # Existing eligibility comment with different body
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
-        mock_comment.body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
-        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
+        mock_comment.body = (
+            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nOutdated Info..."
+        )
+        mock_pr = self.create_mock_pr(
+            1, "Test PR", "author", files, reviews, comments=[mock_comment]
+        )
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -260,7 +277,9 @@ esp32:
         expected_body = f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\n"
         expected_body += "### Platform Maintainers Auto-Merge Info\n"
         expected_body += "This PR is restricted to platform-maintained paths and is eligible for auto-merging upon approval from the designated maintainers.\n\n"
-        expected_body += "To merge, we require at least one approval from each of these groups:\n"
+        expected_body += (
+            "To merge, we require at least one approval from each of these groups:\n"
+        )
         expected_body += "- **nxp**: @doru91, @nxpdev (❌ Needs approval)\n"
         expected_body += "  *Paths matched:*\n"
         expected_body += "    * `src/platform/nxp/**`\n"
@@ -268,7 +287,9 @@ esp32:
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
         mock_comment.body = expected_body
-        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews, comments=[mock_comment])
+        mock_pr = self.create_mock_pr(
+            1, "Test PR", "author", files, reviews, comments=[mock_comment]
+        )
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -291,10 +312,17 @@ esp32:
 
         # Should merge and comment
         self.assertEqual(mock_pr.create_issue_comment.call_count, 1)
-        self.assertIn("Platform Maintainers Auto-Merge Executed", mock_pr.create_issue_comment.call_args[0][0])
-        self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn(
+            "Platform Maintainers Auto-Merge Executed",
+            mock_pr.create_issue_comment.call_args[0][0],
+        )
+        self.assertIn(
+            "approved by @doru91", mock_pr.create_issue_comment.call_args[0][0]
+        )
 
-        mock_pr.merge.assert_called_once_with(merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)")
+        mock_pr.merge.assert_called_once_with(
+            merge_method="squash", commit_title="Test PR (Auto-merged by platform-bot)"
+        )
 
     def test_check_and_process_pr_multi_group_approved(self) -> None:
         """Tests that PR is merged when all affected platform groups have approved."""
@@ -312,8 +340,12 @@ esp32:
 
         # Should merge because both groups are approved
         mock_pr.merge.assert_called_once()
-        self.assertIn("approved by @doru91", mock_pr.create_issue_comment.call_args[0][0])
-        self.assertIn("approved by @esp32dev", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn(
+            "approved by @doru91", mock_pr.create_issue_comment.call_args[0][0]
+        )
+        self.assertIn(
+            "approved by @esp32dev", mock_pr.create_issue_comment.call_args[0][0]
+        )
 
     def test_check_and_process_pr_multi_group_missing_one_approval(self) -> None:
         """Tests that PR is not merged and lists pending groups when only some groups approved."""
@@ -331,8 +363,14 @@ esp32:
 
         # Should NOT merge, should post eligibility indicating esp32 lacks approval
         mock_pr.merge.assert_not_called()
-        self.assertIn("- **esp32**: @esp32dev (❌ Needs approval)", mock_pr.create_issue_comment.call_args[0][0])
-        self.assertIn("- **nxp**: @doru91, @nxpdev (✅ Approved)", mock_pr.create_issue_comment.call_args[0][0])
+        self.assertIn(
+            "- **esp32**: @esp32dev (❌ Needs approval)",
+            mock_pr.create_issue_comment.call_args[0][0],
+        )
+        self.assertIn(
+            "- **nxp**: @doru91, @nxpdev (✅ Approved)",
+            mock_pr.create_issue_comment.call_args[0][0],
+        )
 
     def test_check_and_process_pr_blocked_by_changes_requested(self) -> None:
         """Tests that any active changes requested review blocks auto-merge."""
@@ -361,7 +399,9 @@ esp32:
         approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
         self.assertIn("doru91", approvers)
 
-    def test_get_pr_review_states_comment_does_not_overwrite_changes_requested(self) -> None:
+    def test_get_pr_review_states_comment_does_not_overwrite_changes_requested(
+        self,
+    ) -> None:
         """Tests that a standard comment review does not overwrite an existing changes requested review."""
         reviews = [
             self.create_mock_review("doru91", "CHANGES_REQUESTED"),
@@ -372,7 +412,5 @@ esp32:
         self.assertIn("doru91", change_requesters)
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -55,10 +55,13 @@ esp32:
         with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml') as f:
             f.write(self.config_content)
             self.temp_config_name = f.name
+        self.addCleanup(os.unlink, self.temp_config_name)
 
         # Patch Github initialization so we don't hit the network
         self.github_patcher = patch('platform_merge_bot.Github')
         self.mock_github_class = self.github_patcher.start()
+        self.addCleanup(self.github_patcher.stop)
+
         self.mock_github_instance = MagicMock()
         self.mock_github_class.return_value = self.mock_github_instance
         self.mock_repo = MagicMock()
@@ -72,10 +75,6 @@ esp32:
             dry_run=False
         )
         self.bot._bot_username = "platform-merge-bot"
-
-    def tearDown(self):
-        self.github_patcher.stop()
-        os.unlink(self.temp_config_name)
 
     def create_mock_file(self, filename: str) -> MagicMock:
         mock_file = MagicMock()
@@ -331,6 +330,24 @@ esp32:
 
         # Should NOT merge because of the active changes requested
         mock_pr.merge.assert_not_called()
+
+    def test_get_pr_review_states_comment_does_not_overwrite_approval(self):
+        reviews = [
+            self.create_mock_review("doru91", "APPROVED"),
+            self.create_mock_review("doru91", "COMMENTED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
+        approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
+        self.assertIn("doru91", approvers)
+
+    def test_get_pr_review_states_comment_does_not_overwrite_changes_requested(self):
+        reviews = [
+            self.create_mock_review("doru91", "CHANGES_REQUESTED"),
+            self.create_mock_review("doru91", "COMMENTED"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
+        approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
+        self.assertIn("doru91", change_requesters)
 
 
 if __name__ == '__main__':

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -117,7 +117,7 @@ esp32:
 
         nxp_group = self.bot.groups["nxp"]
         self.assertEqual(nxp_group.maintainers, ["doru91", "nxpdev"])
-        self.assertEqual(nxp_group.paths, ["src/platform/nxp/**", "examples/**/nxp/**"])
+        self.assertEqual(nxp_group.paths, ["examples/**/nxp/**", "src/platform/nxp/**"])
 
     def test_file_matching(self) -> None:
         """Tests that file path matching against platform groups functions correctly."""
@@ -410,6 +410,44 @@ esp32:
         mock_pr = self.create_mock_pr(1, "Test PR", "author", [], reviews)
         approvers, change_requesters = self.bot.get_pr_review_states(mock_pr)
         self.assertIn("doru91", change_requesters)
+
+    def test_check_and_process_pr_removes_comment_when_ineligible(self) -> None:
+        """Tests that a stale eligibility comment is deleted if the PR is no longer eligible."""
+        files = [
+            self.create_mock_file(
+                "src/app/Command.cpp"
+            ),  # Uncovered file makes it ineligible
+        ]
+        mock_comment = MagicMock()
+        mock_comment.user.login = "platform-merge-bot"
+        mock_comment.body = (
+            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
+        )
+        mock_pr = self.create_mock_pr(
+            1, "Test PR", "author", files, [], comments=[mock_comment]
+        )
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_comment.delete.assert_called_once()
+        mock_pr.merge.assert_not_called()
+
+    def test_check_and_process_pr_removes_comment_when_no_changed_files(self) -> None:
+        """Tests that a stale eligibility comment is deleted if the PR has no changed files."""
+        files = []  # No changed files
+        mock_comment = MagicMock()
+        mock_comment.user.login = "platform-merge-bot"
+        mock_comment.body = (
+            f"{platform_merge_bot.ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
+        )
+        mock_pr = self.create_mock_pr(
+            1, "Test PR", "author", files, [], comments=[mock_comment]
+        )
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_comment.delete.assert_called_once()
+        mock_pr.merge.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -792,6 +792,34 @@ esp32:
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
 
+    @patch("urllib.request.urlopen")
+    def test_get_unresolved_threads_pagination_gating(self, mock_urlopen: MagicMock) -> None:
+        """Tests that _get_unresolved_threads appends a system blocker when hasNextPage is True."""
+        import json
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {
+                                "hasNextPage": True
+                            },
+                            "nodes": []
+                        }
+                    }
+                }
+            }
+        }).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [])
+        unresolved = PlatformMergeBot._get_unresolved_threads(self.bot, mock_pr)
+
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["author"], "system")
+        self.assertIn("Too many review threads", unresolved[0]["body_preview"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -17,17 +17,16 @@
 
 import os
 import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-# isort: split
-
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 import platform_merge_bot
-from platform_merge_bot import PlatformGroup, PlatformMergeBot
+from platform_merge_bot import PlatformMergeBot
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# isort: split
 
 
 class TestPlatformMergeBot(unittest.TestCase):

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -820,6 +820,24 @@ esp32:
         self.assertEqual(unresolved[0]["author"], "system")
         self.assertIn("Too many review threads", unresolved[0]["body_preview"])
 
+    @patch("urllib.request.urlopen")
+    def test_get_unresolved_threads_malformed_graphql_response(self, mock_urlopen: MagicMock) -> None:
+        """Tests that _get_unresolved_threads raises RuntimeError if the JSON payload is missing key data structures."""
+        import json
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "data": {
+                "repository": {}
+            }
+        }).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", [], [])
+        with self.assertRaises(RuntimeError) as ctx:
+            PlatformMergeBot._get_unresolved_threads(self.bot, mock_pr)
+
+        self.assertIn("missing PR repository/pullRequest data", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import json
 import os
 import sys
 import tempfile
@@ -71,7 +72,11 @@ esp32:
         self.mock_commit.get_combined_status.return_value.state = "success"
         self.mock_commit.get_combined_status.return_value.total_count = 0
         self.mock_commit.get_combined_status.return_value.statuses = []
-        self.mock_commit.get_check_suites.return_value = []
+        # Default mock 10 successful check suites to pass the minimum checks count guard
+        mock_suite = MagicMock()
+        mock_suite.status = "completed"
+        mock_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] * 10
         self.mock_repo.get_commit.return_value = self.mock_commit
 
         # Initialize bot under test
@@ -595,7 +600,10 @@ esp32:
         mock_suite = MagicMock()
         mock_suite.status = "completed"
         mock_suite.conclusion = "failure"
-        self.mock_commit.get_check_suites.return_value = [mock_suite]
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -612,7 +620,10 @@ esp32:
         mock_suite = MagicMock()
         mock_suite.status = "in_progress"
         mock_suite.conclusion = None
-        self.mock_commit.get_check_suites.return_value = [mock_suite]
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -638,7 +649,11 @@ esp32:
         mock_suite3.status = "completed"
         mock_suite3.conclusion = "skipped"
 
-        self.mock_commit.get_check_suites.return_value = [mock_suite1, mock_suite2, mock_suite3]
+        self.mock_commit.get_check_suites.return_value = [
+            mock_suite1,
+            mock_suite2,
+            mock_suite3,
+        ] + [mock_suite1] * 7
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -795,7 +810,6 @@ esp32:
     @patch("urllib.request.urlopen")
     def test_get_unresolved_threads_pagination_gating(self, mock_urlopen: MagicMock) -> None:
         """Tests that _get_unresolved_threads appends a system blocker when hasNextPage is True."""
-        import json
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps({
             "data": {
@@ -823,7 +837,6 @@ esp32:
     @patch("urllib.request.urlopen")
     def test_get_unresolved_threads_malformed_graphql_response(self, mock_urlopen: MagicMock) -> None:
         """Tests that _get_unresolved_threads raises RuntimeError if the JSON payload is missing key data structures."""
-        import json
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps({
             "data": {
@@ -837,6 +850,26 @@ esp32:
             PlatformMergeBot._get_unresolved_threads(self.bot, mock_pr)
 
         self.assertIn("missing PR repository/pullRequest data", str(ctx.exception))
+
+    def test_check_and_process_pr_ci_insufficient_checks_does_not_merge(self) -> None:
+        """Tests that a commit with fewer than 10 CI checks is treated as pending and does not merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock only 2 check suites (fewer than the required 10)
+        mock_suite = MagicMock()
+        mock_suite.status = "completed"
+        mock_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] * 2
+        self.mock_commit.get_combined_status.return_value.statuses = []
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+        comment_body = mock_pr.create_issue_comment.call_args[0][0]
+        self.assertIn("CI checks are pending or failed", comment_body)
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -16,16 +16,18 @@
 #
 
 import os
-# Ensure scripts/tools/ is in path so we can import platform_merge_bot
 import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# isort: split
+
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 import platform_merge_bot
-from platform_merge_bot import PlatformMergeBot
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from platform_merge_bot import PlatformGroup, PlatformMergeBot
 
 
 class TestPlatformMergeBot(unittest.TestCase):


### PR DESCRIPTION
#### Summary

Implemented an automated platform maintainers merge bot system that allows designated platform maintainers to merge PRs restricted to platform-specific directories, bypassing the standard two-company review/sdk-maintainer approvals.

This includes:
- **Configuration File (`.github/platform_maintainers.yaml`)**: Maps platform-specific paths (via Git-style wildmatch globs) to lists of designated platform maintainers (GitHub handles). Includes active configurations for NXP and Silicon Labs, and opt-in templates for others.
  * *Update*: Added platform config directories (e.g., `config/nxp/**`, `config/silabs/**`) to the path specifications.
- **Auto-Merge Script (`scripts/tools/platform_merge_bot.py`)**:
  - Scans open PRs.
  - Verifies if *all* modified files in a PR match configured platform paths (strict scope check).
  - Checks if every active platform group has at least one approval from its designated maintainers.
  - **CI Gating**: Verifies all non-PullApprove commit status checks and check suites are successful.
  - **CI Checks Minimum Count**: Assures that the commit must have at least 10 status checks and check suites combined, preventing premature success evaluation on newly pushed commits before CI registers them.
  - **PullApprove Bypass**: If the `pullapprove` status check is successful (green), the bot deletes its eligibility comments and skips processing (leaving standard repo queues to merge it).
  - **Unresolved Comments Blocker**: Blocks auto-merge if there are unresolved review threads, listing them in the status comment. Includes outdated unresolved comments to maintain safety.
  - **Pagination Gating**: Safe-blocks merges by inserting a system-level blocker if a PR has more than 100 review threads total, preventing bypass of unresolved threads in subsequent pages.
  - **SHA Pinning**: Enforces `sha=pr.head.sha` during merge to prevent race conditions if new commits are pushed.
  - **Informative Status Comment**: Posts/updates a detailed `Merge Requirements Status` block on eligible PRs to clarify missing approvals, unresolved threads (with links), and CI status.
  - **Dry-run & CLI Testing Mode**: Added `--pr` and `--skip-check` options, allowing maintainers to test "what-if" scenarios on any PR (including closed/merged ones) without triggering mutations.
  - **Optimizations**:
    - Reordered validation checks to execute file analysis first, allowing immediate early exit for ineligible PRs (majority of PRs in repo) and preventing redundant status queries.
    - Fetches the GitHub commit object once per eligible PR and shares it across helper methods, cutting down active API fetches.
    - Returns early from `remove_eligibility_comment` if the PR comments count is zero.
  - **Robustness**: Implemented fail-closed error handling on GraphQL comments retrieval, request timeouts, GraphQL JSON response structure verification, and exit-code failure propagation.
- **GitHub Actions Workflow (`.github/workflows/platform_merge_bot.yaml`)**: Runs the merge bot script on a cron schedule (every 6 hours) or manual trigger. Pinned all pip dependencies to specific versions.

##### Caveats

- Auto-merged PRs will have their merge commits attributed to the owner of the custom PAT (likely Justin, Andrei, or another SDK maintainer who configured the secret), rather than the bot itself.

#### Testing

- Updated and expanded unit tests in `scripts/tools/tests/test_platform_merge_bot.py` (37 tests total) covering:
  - Config parsing and wildmatch path matching.
  - Approval state tracking and merge eligibility.
  - CI status/check suites gating and PullApprove status bypass.
  - Unresolved comments detection and link generation.
  - GraphQL query pagination gating and response validation.
  - CLI dry-run options and bypasses.
  - Self-approval disallowance and deleted author gating.
  - Minimum checks count guard.
- Verified all unit and pre-commit checks pass successfully.
