### PR TITLE
Darwin: For Thread devices, reuse active session if present

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -146,6 +146,10 @@ typedef void (^CommissionDeviceBlock)(MTRCommissioningParameters *);
     // Keep track of dns-sd resolution objects for shutdown-time cleanup.
     os_unfair_lock _deviceConnectivityMonitorLock;
     NSHashTable<MTRDeviceConnectivityMonitor *> * _weakSetOfDeviceConnectivityMonitors;
+
+#ifdef DEBUG
+    BOOL _unitTestSuppressGetSessionConnectivityMonitorFire;
+#endif
 }
 
 // TODO: Figure out whether the work queue storage lives here or in the superclass
@@ -1501,6 +1505,16 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 }
 
 #ifdef DEBUG
+- (void)setUnitTestSuppressGetSessionConnectivityMonitorFire:(BOOL)suppress
+{
+    _unitTestSuppressGetSessionConnectivityMonitorFire = suppress;
+}
+
+- (BOOL)unitTestSuppressGetSessionConnectivityMonitorFire
+{
+    return _unitTestSuppressGetSessionConnectivityMonitorFire;
+}
+
 - (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts
 {
     std::lock_guard lock(*self.deviceMapLock);
@@ -1751,6 +1765,19 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     // In the case that this device is known to use thread, queue this with subscription attempts as well, to
     // help with throttling Thread traffic.
     if ([self definitelyUsesThreadForDevice:nodeID]) {
+        // If we already have a live operational CASE session to this node, reuse it directly.
+        // Reusing an existing session generates no new session-establishment Thread traffic.
+        __block BOOL haveExistingCASESession = NO;
+        dispatch_sync(_chipWorkQueue, ^{
+            VerifyOrReturn([self checkIsRunning]);
+            auto scopedNodeID = self->_cppCommissioner->GetPeerScopedId(nodeID);
+            haveExistingCASESession = self->_cppCommissioner->SessionMgr()->FindSecureSessionForNode(scopedNodeID).HasValue();
+        });
+        if (haveExistingCASESession) {
+            [self directlyGetSessionForNode:nodeID parameters:parameters completion:completion];
+            return;
+        }
+
         __block MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull workItemCompletion) {
             MTRInternalDeviceConnectionCallback completionWrapper = ^(chip::Messaging::ExchangeManager * _Nullable exchangeManager,
@@ -1765,14 +1792,28 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         // handler block retains the monitor object itself, forming a retain cycle. The cycle is
         // broken when stopMonitoring is called.
         MTRDeviceConnectivityMonitor * deviceConnectivityMonitor = [[MTRDeviceConnectivityMonitor alloc] initWithCompressedFabricID:self.compressedFabricID nodeID:@(nodeID)];
-        BOOL monitorStarted = [deviceConnectivityMonitor startMonitoringWithHandler:^{
-            // Ensure the work item is queued only once, since this handler could be called multiple times in a row
-            if (workItem) {
-                [self->_concurrentSubscriptionPool enqueueWorkItem:workItem descriptionWithFormat:@"device controller getSessionForNode nodeID: 0x%016llX", nodeID];
-                workItem = nil;
-                [deviceConnectivityMonitor stopMonitoring];
-            }
-        } queue:_chipWorkQueue];
+        // suppressMonitor is a DEBUG-only unit-test hook: when set, simulate a connectivity monitor
+        // that starts but whose nw path never becomes satisfied/viable, so the handler never fires
+        // and the work item is never enqueued. This has been observed in the field with idle Thread
+        // sleepy end devices, for example. It is always NO in release builds.
+        BOOL suppressMonitor = NO;
+#ifdef DEBUG
+        suppressMonitor = _unitTestSuppressGetSessionConnectivityMonitorFire;
+#endif
+
+        BOOL monitorStarted;
+        if (suppressMonitor) {
+            monitorStarted = YES;
+        } else {
+            monitorStarted = [deviceConnectivityMonitor startMonitoringWithHandler:^{
+                // Ensure the work item is queued only once, since this handler could be called multiple times in a row
+                if (workItem) {
+                    [self->_concurrentSubscriptionPool enqueueWorkItem:workItem descriptionWithFormat:@"device controller getSessionForNode nodeID: 0x%016llX", nodeID];
+                    workItem = nil;
+                    [deviceConnectivityMonitor stopMonitoring];
+                }
+            } queue:_chipWorkQueue];
+        }
 
         if (monitorStarted) {
             // Add the monitor object to the weak set, so that the above retain cycle can be broken

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1765,14 +1765,12 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     // In the case that this device is known to use thread, queue this with subscription attempts as well, to
     // help with throttling Thread traffic.
     if ([self definitelyUsesThreadForDevice:nodeID]) {
-        // If we already have a live operational CASE session to this node, reuse it directly.
-        // Reusing an existing session generates no new session-establishment Thread traffic.
+        // Reuse an existing CASE session directly; it generates no new Thread traffic.
         __block BOOL haveExistingCASESession = NO;
-        dispatch_sync(_chipWorkQueue, ^{
-            VerifyOrReturn([self checkIsRunning]);
+        [self syncRunOnWorkQueue:^{
             auto scopedNodeID = self->_cppCommissioner->GetPeerScopedId(nodeID);
             haveExistingCASESession = self->_cppCommissioner->SessionMgr()->FindSecureSessionForNode(scopedNodeID).HasValue();
-        });
+        } error:nil];
         if (haveExistingCASESession) {
             [self directlyGetSessionForNode:nodeID parameters:parameters completion:completion];
             return;

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2971,6 +2971,94 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     XCTAssertFalse([controller isRunning]);
 }
 
+#ifdef DEBUG
+// A one-shot MTRBaseDevice read to a Thread device must not hang forever when the
+// getSessionForNode connectivity monitor does not signal connectivity (as is expected when the
+// device cannot currently be reached, e.g. an idle Thread SED). If an operational CASE session
+// already exists, the read must reuse it instead of being gated behind that monitor.
+- (void)testGetSessionForThreadDeviceReusesActiveSessionWhenConnectivityMonitorNeverFires
+{
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type queue = dispatch_get_main_queue();
+
+    __auto_type * rootKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(rootKeys);
+    __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(operationalKeys);
+    __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
+
+    NSNumber * fabricID = @(456);
+    NSNumber * nodeID = @(123);
+
+    NSError * error;
+    MTRPerControllerStorageTestsCertificateIssuer * certificateIssuer;
+    MTRDeviceController * controller = [self startControllerWithRootKeys:rootKeys
+                                                         operationalKeys:operationalKeys
+                                                                fabricID:fabricID
+                                                                  nodeID:nodeID
+                                                                 storage:storageDelegate
+                                                                   error:&error
+                                                       certificateIssuer:&certificateIssuer];
+    XCTAssertNil(error);
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    NSNumber * deviceID = @(17);
+    certificateIssuer.nextNodeID = deviceID;
+    [self commissionWithController:controller newNodeID:deviceID];
+
+    // Register cleanup as a teardown block so it runs even if an assertion below aborts the test
+    // (this class sets continueAfterFailure=NO). Without this, a failure here would leave the
+    // shared commissionee paired and the controller running, poisoning subsequent tests. The
+    // suppression flag is cleared first so the reset/shutdown path can acquire a session normally.
+    __weak __auto_type weakSelf = self;
+    [self addTeardownBlock:^{
+        __auto_type self = weakSelf; // re-bind strongly for the block's duration without retaining the test case
+        if (self == nil) {
+            return;
+        }
+        controller.unitTestSuppressGetSessionConnectivityMonitorFire = NO;
+        __auto_type * resetBaseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+        ResetCommissioneeWithNodeID(resetBaseDevice, queue, self, kTimeoutInSeconds, deviceID);
+        [controller shutdown];
+        XCTAssertFalse([controller isRunning]);
+    }];
+
+    // Bring up an MTRDevice and wait for its subscription to establish, so that an operational
+    // CASE session to the device exists. pretendThreadEnabled forces the Thread getSessionForNode path.
+    __auto_type * subscriptionExpectation = [self expectationWithDescription:@"Subscription established"];
+    subscriptionExpectation.assertForOverFulfill = NO;
+    __auto_type * device = [MTRDevice deviceWithNodeID:deviceID controller:controller];
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+    delegate.pretendThreadEnabled = YES;
+    delegate.onReportEnd = ^{
+        [subscriptionExpectation fulfill];
+    };
+    [device setDelegate:delegate queue:queue];
+    [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
+
+    // Simulate the condition where the getSessionForNode connectivity monitor does not signal
+    // connectivity -- as expected when the device cannot currently be reached (e.g. an idle Thread
+    // sleepy end device that already has an active CASE session). The monitor's handler never runs,
+    // so the queued work item is never enqueued and a read would otherwise hang here.
+    controller.unitTestSuppressGetSessionConnectivityMonitorFire = YES;
+
+    // A one-shot MTRBaseDevice read must still complete (by reusing the already-active session),
+    // rather than hanging behind the never-firing connectivity monitor.
+    __auto_type * readExpectation = [self expectationWithDescription:@"BaseDevice read completes"];
+    __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+    __auto_type * onOffCluster = [[MTRBaseClusterOnOff alloc] initWithDevice:baseDevice endpointID:@(1) queue:queue];
+    [onOffCluster readAttributeOnOffWithCompletion:^(NSNumber * value, NSError * _Nullable readError) {
+        XCTAssertNil(readError);
+        [readExpectation fulfill];
+    }];
+    // Generous, but far short of an indefinite hang: pre-fix this times out, post-fix it is near-instant.
+    [self waitForExpectations:@[ readExpectation ] timeout:30];
+}
+#endif // DEBUG
+
 - (void)testSubscriptionPool
 {
     // QRCodes generated for discriminators 1111~1115 and passcodes 1001~1005

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -3057,6 +3057,84 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     // Generous, but far short of an indefinite hang: pre-fix this times out, post-fix it is near-instant.
     [self waitForExpectations:@[ readExpectation ] timeout:30];
 }
+
+// Complement to the reuse test above: when no active CASE session exists, a Thread
+// getSessionForNode must NOT take the reuse shortcut. It falls through to the connectivity-monitor
+// throttle path, which (with the monitor allowed to fire) re-establishes a session and completes.
+- (void)testGetSessionForThreadDeviceReestablishesViaConnectivityMonitorWhenNoActiveSession
+{
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type queue = dispatch_get_main_queue();
+
+    __auto_type * rootKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(rootKeys);
+    __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(operationalKeys);
+    __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
+
+    NSNumber * fabricID = @(456);
+    NSNumber * nodeID = @(123);
+
+    NSError * error;
+    MTRPerControllerStorageTestsCertificateIssuer * certificateIssuer;
+    MTRDeviceController * controller = [self startControllerWithRootKeys:rootKeys
+                                                         operationalKeys:operationalKeys
+                                                                fabricID:fabricID
+                                                                  nodeID:nodeID
+                                                                 storage:storageDelegate
+                                                                   error:&error
+                                                       certificateIssuer:&certificateIssuer];
+    XCTAssertNil(error);
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    NSNumber * deviceID = @(17);
+    certificateIssuer.nextNodeID = deviceID;
+    [self commissionWithController:controller newNodeID:deviceID];
+
+    __weak __auto_type weakSelf = self;
+    [self addTeardownBlock:^{
+        __auto_type self = weakSelf;
+        if (self == nil) {
+            return;
+        }
+        __auto_type * resetBaseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+        ResetCommissioneeWithNodeID(resetBaseDevice, queue, self, kTimeoutInSeconds, deviceID);
+        [controller shutdown];
+        XCTAssertFalse([controller isRunning]);
+    }];
+
+    // Establish a subscription so the device is Thread-classified and reachable.
+    __auto_type * subscriptionExpectation = [self expectationWithDescription:@"Subscription established"];
+    subscriptionExpectation.assertForOverFulfill = NO;
+    __auto_type * device = [MTRDevice deviceWithNodeID:deviceID controller:controller];
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+    delegate.pretendThreadEnabled = YES;
+    delegate.onReportEnd = ^{
+        [subscriptionExpectation fulfill];
+    };
+    [device setDelegate:delegate queue:queue];
+    [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
+
+    // Leave the monitor free to fire (opposite of the reuse test) and drop the active CASE session,
+    // so getSessionForNode cannot reuse and must go through the connectivity-monitor throttle path.
+    controller.unitTestSuppressGetSessionConnectivityMonitorFire = NO;
+    __auto_type * invalidateDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+    [invalidateDevice invalidateCASESession];
+
+    // The read must still complete: the monitor signals connectivity, the work item is enqueued, and
+    // a session is (re)established -- proving the throttle path is intact for the no-session case.
+    __auto_type * readExpectation = [self expectationWithDescription:@"BaseDevice read completes"];
+    __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+    __auto_type * onOffCluster = [[MTRBaseClusterOnOff alloc] initWithDevice:baseDevice endpointID:@(1) queue:queue];
+    [onOffCluster readAttributeOnOffWithCompletion:^(NSNumber * value, NSError * _Nullable readError) {
+        XCTAssertNil(readError);
+        [readExpectation fulfill];
+    }];
+    [self waitForExpectations:@[ readExpectation ] timeout:60];
+}
 #endif // DEBUG
 
 - (void)testSubscriptionPool

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -72,6 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #ifdef DEBUG
 @interface MTRDeviceController (TestDebug)
+@property (nonatomic, assign) BOOL unitTestSuppressGetSessionConnectivityMonitorFire;
 - (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts;
 - (NSUInteger)unitTestDelegateCount;
 @end

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -80,6 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRBaseDevice (TestDebug)
 // Test function for whitebox testing
 + (id)CHIPEncodeAndDecodeNSObject:(id)object;
+- (void)invalidateCASESession;
 @end
 
 @interface MTRDevice (TestDebug)


### PR DESCRIPTION
We can skip the connectivity check / throttle if a session is already established for the node.

### Summary

The logic to throttle connections to Thread devices can skip the connectivity check step if a session was previously established.

This prevents waiting / timeouts for idle sleepy end devices.

### Testing

- Added unit tests for the specific scenario.
