### PR TITLE
fix(thermostat-server): notify subscribers when ActivePresetHandle changes

### DIFF
--- a/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
+++ b/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
@@ -150,6 +150,7 @@ private:
 
     uint8_t mActivePresetHandleData[kPresetHandleSize];
     size_t mActivePresetHandleDataSize;
+    bool mActivePresetHandleIsNull = true;
 
     uint8_t mMaxThermostatSuggestions;
     ThermostatSuggestionStructWithOwnedMembers mThermostatSuggestions[kMaxNumberOfThermostatSuggestions];

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -147,6 +147,14 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
+    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
+    ByteSpan newHandle = newActivePresetHandle.IsNull() ? ByteSpan() : newActivePresetHandle.Value();
+
+    if (oldHandle.data_equal(newHandle))
+    {
+        return CHIP_NO_ERROR;
+    }
+
     if (!newActivePresetHandle.IsNull())
     {
         size_t newActivePresetHandleSize = newActivePresetHandle.Value().size();
@@ -168,6 +176,9 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
         mActivePresetHandleDataSize = 0;
         ChipLogDetail(NotSpecified, "Clear ActivePresetHandle");
     }
+
+    MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
+
     return CHIP_NO_ERROR;
 }
 
@@ -449,7 +460,6 @@ CHIP_ERROR ThermostatDelegate::ReEvaluateCurrentSuggestion()
         // ActivePresetHandle. Otherwise set the ActivePresetHandle to the preset handle in the suggestion and set
         // ThermostatSuggestionNotFollowingReason to null.
         TEMPORARY_RETURN_IGNORED SetActivePresetHandle(currentThermostatSuggestion.GetPresetHandle());
-        MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
         TEMPORARY_RETURN_IGNORED SetThermostatSuggestionNotFollowingReason(DataModel::NullNullable);
 
         // Start a timer from the timestamp in currentMatterEpochTimestamp to the timestamp in the expiration time.

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -132,7 +132,7 @@ CHIP_ERROR ThermostatDelegate::GetPresetAtIndex(size_t index, PresetStructWithOw
 
 CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<MutableByteSpan> & activePresetHandle)
 {
-    if (mActivePresetHandleDataSize != 0)
+    if (!mActivePresetHandleIsNull)
     {
         ReturnErrorOnFailure(
             CopySpanToMutableSpan(ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize), activePresetHandle.Value()));
@@ -147,15 +147,16 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
-    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
-    ByteSpan newHandle = newActivePresetHandle.IsNull() ? ByteSpan() : newActivePresetHandle.Value();
+    bool newIsNull = newActivePresetHandle.IsNull();
 
-    if (oldHandle.data_equal(newHandle))
+    if (mActivePresetHandleIsNull == newIsNull &&
+        (newIsNull ||
+         ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize).data_equal(newActivePresetHandle.Value())))
     {
         return CHIP_NO_ERROR;
     }
 
-    if (!newActivePresetHandle.IsNull())
+    if (!newIsNull)
     {
         size_t newActivePresetHandleSize = newActivePresetHandle.Value().size();
         if (newActivePresetHandleSize > sizeof(mActivePresetHandleData))
@@ -177,6 +178,7 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
         ChipLogDetail(NotSpecified, "Clear ActivePresetHandle");
     }
 
+    mActivePresetHandleIsNull = newIsNull;
     MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
 
     return CHIP_NO_ERROR;

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -148,9 +148,9 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
     bool newIsNull = newActivePresetHandle.IsNull();
+    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
 
-    if (mActivePresetHandleIsNull == newIsNull &&
-        (newIsNull || ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize).data_equal(newActivePresetHandle.Value())))
+    if (mActivePresetHandleIsNull == newIsNull && (newIsNull || oldHandle.data_equal(newActivePresetHandle.Value())))
     {
         return CHIP_NO_ERROR;
     }

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -150,8 +150,7 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
     bool newIsNull = newActivePresetHandle.IsNull();
 
     if (mActivePresetHandleIsNull == newIsNull &&
-        (newIsNull ||
-         ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize).data_equal(newActivePresetHandle.Value())))
+        (newIsNull || ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize).data_equal(newActivePresetHandle.Value())))
     {
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
#### Summary

`SetActivePreset()` was updating the `ActivePresetHandle` attribute via the delegate but not calling `MatterReportingAttributeChangeCallback()` afterwards. As a result, active subscriptions never received a Report Data message when the active preset changed via `SetActivePresetRequest` — the new value was silently applied on the device side but never pushed to subscribers.

The suggestion-driven path (`ReEvaluateCurrentSuggestion`) did call the reporting callback, but this was a separate, duplicated call rather than a centralized one.

Additionally, `ActivePresetHandle` is a nullable `octstr` with no `minLength` constraint. The previous implementation used `mActivePresetHandleDataSize == 0` to represent both the null state and a non-null empty octet string, making them indistinguishable.

#### Root Cause

In `thermostat-delegate-impl.cpp`, `SetActivePresetHandle()` updates the stored handle bytes but never notifies the reporting engine:

```cpp
// Before: no subscription report triggered from SetActivePresetRequest path
CHIP_ERROR err = delegate->SetActivePresetHandle(presetHandle);
return Status::Success;
// ← MatterReportingAttributeChangeCallback never called here
```

`GetActivePresetHandle` and `SetActivePresetHandle` also lacked an explicit null flag, conflating null with an empty (size-0) octet string.

#### Fix

- Centralize `MatterReportingAttributeChangeCallback` inside `SetActivePresetHandle` so both the command path (`SetActivePresetRequest`) and the suggestion path (`ReEvaluateCurrentSuggestion`) emit consistent subscription reports.
- Add an explicit `mActivePresetHandleIsNull` boolean flag to correctly distinguish null from a non-null empty `octstr`, as required by the attribute's type definition.
- Only emit a subscription report when the value has actually changed: null-to-null and same-value comparisons both short-circuit without reporting.
- Remove the now-redundant `MatterReportingAttributeChangeCallback` call from `ReEvaluateCurrentSuggestion`.

#### Related issues

Fixes: #43582

#### Testing

Tested with thermostat/linux example. After `SetActivePresetRequest`:

1. `ActivePresetHandle` is updated correctly ✅
2. Attribute `0x4E` is marked dirty, dirty generation incremented ✅
3. A `ReportData` message is sent to the subscriber ✅
4. Subscriber acknowledges with SUCCESS ✅
5. When the same value is set again, no spurious report is emitted ✅

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short
- [x] CI time didn't increase