### PR TITLE
[fuzz] add BLE/BTP FuzzTest harnesses

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -72,6 +72,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   if (pw_enable_fuzz_test_targets) {
     group("pw_fuzz_tests") {
       deps = [
+        "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/ble/tests:fuzz-ble-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/ble/tests:fuzz-ble-layer-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-chip-cert-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/core/tests:fuzz-tlv-reader-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/dnssd/minimal_mdns/tests:fuzz-minmdns-packet-parsing-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -72,9 +72,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   if (pw_enable_fuzz_test_targets) {
     group("pw_fuzz_tests") {
       deps = [
-        "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/ble/tests:fuzz-ble-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/ble/tests:fuzz-ble-layer-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-chip-cert-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/core/tests:fuzz-tlv-reader-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/dnssd/minimal_mdns/tests:fuzz-minmdns-packet-parsing-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",

--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/fuzz_test.gni")
 
 chip_test_suite("tests") {
   output_name = "libBleLayerTests"
@@ -37,4 +38,31 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/platform",
   ]
+}
+
+if (pw_enable_fuzz_test_targets) {
+  chip_pw_fuzz_target("fuzz-btp-engine-pw") {
+    test_source = [ "FuzzBtpEnginePW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/ble",
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
+  chip_pw_fuzz_target("fuzz-ble-endpoint-pw") {
+    test_source = [ "FuzzBleEndPointPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/ble",
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
+  chip_pw_fuzz_target("fuzz-ble-layer-pw") {
+    test_source = [ "FuzzBleLayerPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/ble",
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
 }

--- a/src/ble/tests/FuzzBleEndPointPW.cpp
+++ b/src/ble/tests/FuzzBleEndPointPW.cpp
@@ -35,11 +35,11 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-#include <ble/Ble.h>
 #include <ble/BLEEndPoint.h>
+#include <ble/Ble.h>
+#include <ble/BleConfig.h>
 #include <ble/BleLayer.h>
 #include <ble/BleLayerDelegate.h>
-#include <ble/BleConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
@@ -74,8 +74,7 @@ public:
     }
     CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT) override { return CHIP_NO_ERROR; }
     uint16_t GetMTU(BLE_CONNECTION_OBJECT) const override { return 23; }
-    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
-                              System::PacketBufferHandle) override
+    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *, System::PacketBufferHandle) override
     {
         return CHIP_NO_ERROR;
     }
@@ -99,12 +98,12 @@ namespace {
 
 using chip::Ble::BLEEndPoint;
 using chip::Ble::BleLayer;
+using chip::Ble::BleRole;
 using chip::Ble::FuzzBleApplicationDelegate;
 using chip::Ble::FuzzBleLayerDelegate;
 using chip::Ble::FuzzBlePlatformDelegate;
 using chip::Ble::kBleRole_Central;
 using chip::Ble::kBleRole_Peripheral;
-using chip::Ble::BleRole;
 using chip::System::PacketBufferHandle;
 using namespace fuzztest;
 
@@ -122,19 +121,19 @@ void EnsureInitialized()
 [[maybe_unused]] PacketBufferHandle BuildCapabilitiesRequest(uint8_t windowSize, uint16_t mtu)
 {
     constexpr size_t kReqLen = 9;
-    auto buf = PacketBufferHandle::New(kReqLen);
+    auto buf                 = PacketBufferHandle::New(kReqLen);
     if (buf.IsNull())
         return buf;
     uint8_t * p = buf->Start();
-    p[0] = 0x65; // CHECK_BYTE_1
-    p[1] = 0x6C; // CHECK_BYTE_2
-    p[2] = 0x04; // version
-    p[3] = 0x00;
-    p[4] = 0x00;
-    p[5] = static_cast<uint8_t>(mtu);
-    p[6] = static_cast<uint8_t>(mtu >> 8);
-    p[7] = windowSize;
-    p[8] = 0x00;
+    p[0]        = 0x65; // CHECK_BYTE_1
+    p[1]        = 0x6C; // CHECK_BYTE_2
+    p[2]        = 0x04; // version
+    p[3]        = 0x00;
+    p[4]        = 0x00;
+    p[5]        = static_cast<uint8_t>(mtu);
+    p[6]        = static_cast<uint8_t>(mtu >> 8);
+    p[7]        = windowSize;
+    p[8]        = 0x00;
     buf->SetDataLength(kReqLen);
     return buf;
 }
@@ -142,16 +141,16 @@ void EnsureInitialized()
 [[maybe_unused]] PacketBufferHandle BuildCapabilitiesResponse(uint8_t windowSize, uint16_t fragmentSize)
 {
     constexpr size_t kRespLen = 6;
-    auto buf = PacketBufferHandle::New(kRespLen);
+    auto buf                  = PacketBufferHandle::New(kRespLen);
     if (buf.IsNull())
         return buf;
     uint8_t * p = buf->Start();
-    p[0] = 0x65;
-    p[1] = 0x6C;
-    p[2] = 0x04;
-    p[3] = static_cast<uint8_t>(fragmentSize);
-    p[4] = static_cast<uint8_t>(fragmentSize >> 8);
-    p[5] = windowSize;
+    p[0]        = 0x65;
+    p[1]        = 0x6C;
+    p[2]        = 0x04;
+    p[3]        = static_cast<uint8_t>(fragmentSize);
+    p[4]        = static_cast<uint8_t>(fragmentSize >> 8);
+    p[5]        = windowSize;
     buf->SetDataLength(kRespLen);
     return buf;
 }
@@ -191,10 +190,10 @@ auto AnyMtu()
         3,
         4,
         20,
-        23,    // BLE 4.0 ATT_MTU floor
+        23, // BLE 4.0 ATT_MTU floor
         100,
-        185,   // BLE 4.2 default
-        247,   // BLE 5.x extended
+        185, // BLE 4.2 default
+        247, // BLE 5.x extended
         512,
         1024,
         0xFFFE,
@@ -218,8 +217,7 @@ std::vector<std::vector<EpFrag>> EpFragSeeds()
     };
 }
 
-void BleEndpointReceiveDoesNotCrash(uint8_t windowSize, uint16_t fragmentSize, bool seqBaseOne,
-                                    const std::vector<EpFrag> & frags)
+void BleEndpointReceiveDoesNotCrash(uint8_t windowSize, uint16_t fragmentSize, bool seqBaseOne, const std::vector<EpFrag> & frags)
 {
     EnsureInitialized();
 
@@ -255,8 +253,8 @@ void BleEndpointReceiveDoesNotCrash(uint8_t windowSize, uint16_t fragmentSize, b
 
         chip::Ble::BleTransportCapabilitiesResponseMessage resp;
         resp.mSelectedProtocolVersion = chip::Ble::kBleTransportProtocolVersion_V4; // negotiation OK
-        resp.mFragmentSize            = fragmentSize;                                       // fuzzed field
-        resp.mWindowSize              = windowSize;                                         // fuzzed field
+        resp.mFragmentSize            = fragmentSize;                               // fuzzed field
+        resp.mWindowSize              = windowSize;                                 // fuzzed field
 
         PacketBufferHandle respBuf = PacketBufferHandle::New(chip::Ble::kCapabilitiesResponseLength);
         if (!respBuf.IsNull() && resp.Encode(respBuf) == CHIP_NO_ERROR)
@@ -297,8 +295,8 @@ void BleEndpointReceiveDoesNotCrash(uint8_t windowSize, uint16_t fragmentSize, b
 
 FUZZ_TEST(FuzzBleEndPointPW, BleEndpointReceiveDoesNotCrash)
     .WithDomains(AnyWindowSize(), /* fragmentSize */ AnyMtu(), /* seqBaseOne */ Arbitrary<bool>(),
-                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }),
-                                  Arbitrary<uint16_t>(), Arbitrary<std::vector<uint8_t>>()))
+                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }), Arbitrary<uint16_t>(),
+                                  Arbitrary<std::vector<uint8_t>>()))
                      .WithMaxSize(8)
                      .WithSeeds(EpFragSeeds()));
 

--- a/src/ble/tests/FuzzBleEndPointPW.cpp
+++ b/src/ble/tests/FuzzBleEndPointPW.cpp
@@ -35,11 +35,8 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-#include <ble/BLEEndPoint.h>
 #include <ble/Ble.h>
 #include <ble/BleConfig.h>
-#include <ble/BleLayer.h>
-#include <ble/BleLayerDelegate.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>

--- a/src/ble/tests/FuzzBleEndPointPW.cpp
+++ b/src/ble/tests/FuzzBleEndPointPW.cpp
@@ -29,6 +29,8 @@
  */
 
 #include <cstdint>
+#include <cstdlib>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -95,12 +97,10 @@ namespace {
 
 using chip::Ble::BLEEndPoint;
 using chip::Ble::BleLayer;
-using chip::Ble::BleRole;
 using chip::Ble::FuzzBleApplicationDelegate;
 using chip::Ble::FuzzBleLayerDelegate;
 using chip::Ble::FuzzBlePlatformDelegate;
 using chip::Ble::kBleRole_Central;
-using chip::Ble::kBleRole_Peripheral;
 using chip::System::PacketBufferHandle;
 using namespace fuzztest;
 
@@ -113,48 +113,6 @@ void EnsureInitialized()
         return true;
     }();
     (void) sInitialized;
-}
-
-[[maybe_unused]] PacketBufferHandle BuildCapabilitiesRequest(uint8_t windowSize, uint16_t mtu)
-{
-    constexpr size_t kReqLen = 9;
-    auto buf                 = PacketBufferHandle::New(kReqLen);
-    if (buf.IsNull())
-        return buf;
-    uint8_t * p = buf->Start();
-    p[0]        = 0x65; // CHECK_BYTE_1
-    p[1]        = 0x6C; // CHECK_BYTE_2
-    p[2]        = 0x04; // version
-    p[3]        = 0x00;
-    p[4]        = 0x00;
-    p[5]        = static_cast<uint8_t>(mtu);
-    p[6]        = static_cast<uint8_t>(mtu >> 8);
-    p[7]        = windowSize;
-    p[8]        = 0x00;
-    buf->SetDataLength(kReqLen);
-    return buf;
-}
-
-[[maybe_unused]] PacketBufferHandle BuildCapabilitiesResponse(uint8_t windowSize, uint16_t fragmentSize)
-{
-    constexpr size_t kRespLen = 6;
-    auto buf                  = PacketBufferHandle::New(kRespLen);
-    if (buf.IsNull())
-        return buf;
-    uint8_t * p = buf->Start();
-    p[0]        = 0x65;
-    p[1]        = 0x6C;
-    p[2]        = 0x04;
-    p[3]        = static_cast<uint8_t>(fragmentSize);
-    p[4]        = static_cast<uint8_t>(fragmentSize >> 8);
-    p[5]        = windowSize;
-    buf->SetDataLength(kRespLen);
-    return buf;
-}
-
-[[maybe_unused]] auto AnyRole()
-{
-    return ElementOf<BleRole>({ kBleRole_Central, kBleRole_Peripheral });
 }
 
 // Boundary values for the window-size field — the interesting cases cluster at

--- a/src/ble/tests/FuzzBleEndPointPW.cpp
+++ b/src/ble/tests/FuzzBleEndPointPW.cpp
@@ -1,0 +1,305 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Seeded FuzzTest harness for BLEEndPoint::Receive. Drives the
+ *      capabilities handshake with `ElementOf`-bounded windowSize / MTU values
+ *      that target the field-validation logic, plus seeded BTP fragment slots
+ *      for the post-Connected reorder queue.
+ *
+ *      WindowSize values cover: 0, 1, MIN-1, MIN, MIN+1, MAX, MAX+1, 0xFF.
+ *      MTU values cover: spec floor (23), the underflow boundary (mtu - 3
+ *      arithmetic), MTU = 0, MTU = 1, larger BLE 4.2 / 5.x sizes.
+ */
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <ble/Ble.h>
+#include <ble/BLEEndPoint.h>
+#include <ble/BleLayer.h>
+#include <ble/BleLayerDelegate.h>
+#include <ble/BleConfig.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemLayer.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace Ble {
+
+class FuzzBleLayerDelegate : public BleLayerDelegate
+{
+public:
+    void OnBleConnectionComplete(BLEEndPoint *) override {}
+    void OnBleConnectionError(CHIP_ERROR) override {}
+    void OnEndPointConnectComplete(BLEEndPoint *, CHIP_ERROR) override {}
+    void OnEndPointMessageReceived(BLEEndPoint *, System::PacketBufferHandle &&) override {}
+    void OnEndPointConnectionClosed(BLEEndPoint *, CHIP_ERROR) override {}
+    CHIP_ERROR SetEndPoint(BLEEndPoint *) override { return CHIP_NO_ERROR; }
+};
+
+class FuzzBlePlatformDelegate : public BlePlatformDelegate
+{
+public:
+    CHIP_ERROR SubscribeCharacteristic(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT) override { return CHIP_NO_ERROR; }
+    uint16_t GetMTU(BLE_CONNECTION_OBJECT) const override { return 23; }
+    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
+                              System::PacketBufferHandle) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR SendWriteRequest(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
+                                System::PacketBufferHandle) override
+    {
+        return CHIP_NO_ERROR;
+    }
+};
+
+class FuzzBleApplicationDelegate : public BleApplicationDelegate
+{
+public:
+    void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT) override {}
+};
+
+} // namespace Ble
+} // namespace chip
+
+namespace {
+
+using chip::Ble::BLEEndPoint;
+using chip::Ble::BleLayer;
+using chip::Ble::FuzzBleApplicationDelegate;
+using chip::Ble::FuzzBleLayerDelegate;
+using chip::Ble::FuzzBlePlatformDelegate;
+using chip::Ble::kBleRole_Central;
+using chip::Ble::kBleRole_Peripheral;
+using chip::Ble::BleRole;
+using chip::System::PacketBufferHandle;
+using namespace fuzztest;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        VerifyOrDie(chip::DeviceLayer::SystemLayer().Init() == CHIP_NO_ERROR);
+        std::atexit([] { chip::DeviceLayer::SystemLayer().Shutdown(); });
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+[[maybe_unused]] PacketBufferHandle BuildCapabilitiesRequest(uint8_t windowSize, uint16_t mtu)
+{
+    constexpr size_t kReqLen = 9;
+    auto buf = PacketBufferHandle::New(kReqLen);
+    if (buf.IsNull())
+        return buf;
+    uint8_t * p = buf->Start();
+    p[0] = 0x65; // CHECK_BYTE_1
+    p[1] = 0x6C; // CHECK_BYTE_2
+    p[2] = 0x04; // version
+    p[3] = 0x00;
+    p[4] = 0x00;
+    p[5] = static_cast<uint8_t>(mtu);
+    p[6] = static_cast<uint8_t>(mtu >> 8);
+    p[7] = windowSize;
+    p[8] = 0x00;
+    buf->SetDataLength(kReqLen);
+    return buf;
+}
+
+[[maybe_unused]] PacketBufferHandle BuildCapabilitiesResponse(uint8_t windowSize, uint16_t fragmentSize)
+{
+    constexpr size_t kRespLen = 6;
+    auto buf = PacketBufferHandle::New(kRespLen);
+    if (buf.IsNull())
+        return buf;
+    uint8_t * p = buf->Start();
+    p[0] = 0x65;
+    p[1] = 0x6C;
+    p[2] = 0x04;
+    p[3] = static_cast<uint8_t>(fragmentSize);
+    p[4] = static_cast<uint8_t>(fragmentSize >> 8);
+    p[5] = windowSize;
+    buf->SetDataLength(kRespLen);
+    return buf;
+}
+
+[[maybe_unused]] auto AnyRole()
+{
+    return ElementOf<BleRole>({ kBleRole_Central, kBleRole_Peripheral });
+}
+
+// Boundary values for the window-size field — the interesting cases cluster at
+// 0..effective-min and around MAX. Per BleConfig.h the effective minimum for
+// stability is 3 (BLE_MAX_RECEIVE_WINDOW_SIZE must be > 2), so cover 0/1/2 plus
+// the boundary around MAX.
+auto AnyWindowSize()
+{
+    return ElementOf<uint8_t>({
+        static_cast<uint8_t>(0),
+        static_cast<uint8_t>(1),
+        static_cast<uint8_t>(2),
+        static_cast<uint8_t>(3),
+        static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE - 1),
+        static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE),
+        static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE + 1),
+        static_cast<uint8_t>(0xFE),
+        static_cast<uint8_t>(0xFF),
+    });
+}
+
+// MTU values that target the `mtu - 3` underflow path in the BTP fragment-
+// length calculation.
+auto AnyMtu()
+{
+    return ElementOf<uint16_t>({
+        0,
+        1,
+        2,
+        3,
+        4,
+        20,
+        23,    // BLE 4.0 ATT_MTU floor
+        100,
+        185,   // BLE 4.2 default
+        247,   // BLE 5.x extended
+        512,
+        1024,
+        0xFFFE,
+        0xFFFF,
+    });
+}
+
+// Structure-aware BTP data-phase fragments. Like the BtpEngine harness, the
+// harness stamps the running sequence number (the BtpEngine inside the endpoint
+// gates on seq == expected, so raw bytes bounce at the 2nd fragment). The ack
+// bit is excluded (no TX window). The post-handshake seq base (0 or 1) depends
+// on role / handshake direction, so it is a fuzzed bit (seqBaseOne) that
+// coverage feedback resolves per role.
+using EpFrag = std::tuple<uint8_t, uint16_t, std::vector<uint8_t>>; // (flags, declaredLen, payload)
+
+std::vector<std::vector<EpFrag>> EpFragSeeds()
+{
+    return {
+        { EpFrag{ 0x05, 2, { 0xDE, 0xAD } } },
+        { EpFrag{ 0x01, 4, { 0x01, 0x02 } }, EpFrag{ 0x04, 0, { 0x03, 0x04 } } },
+    };
+}
+
+void BleEndpointReceiveDoesNotCrash(uint8_t windowSize, uint16_t fragmentSize, bool seqBaseOne,
+                                    const std::vector<EpFrag> & frags)
+{
+    EnsureInitialized();
+
+    BleLayer layer;
+    FuzzBlePlatformDelegate platformDelegate;
+    FuzzBleApplicationDelegate appDelegate;
+    FuzzBleLayerDelegate layerDelegate;
+
+    if (layer.Init(&platformDelegate, &appDelegate, &chip::DeviceLayer::SystemLayer()) != CHIP_NO_ERROR)
+    {
+        return;
+    }
+    layer.mBleTransport = &layerDelegate;
+
+    // Single fixed non-null connObj for this central endpoint.
+    BLE_CONNECTION_OBJECT connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(static_cast<uintptr_t>(0x1));
+
+    BLEEndPoint * ep = nullptr;
+    if (layer.NewBleEndPoint(&ep, connObj, kBleRole_Central, /* autoClose */ true) != CHIP_NO_ERROR || ep == nullptr)
+    {
+        layer.Shutdown();
+        return;
+    }
+
+    // Drive the central all the way to Connected, mirroring
+    // TestBleEndPoint::CompleteCentralHandshake. ONLY in the Connected state does
+    // BLEEndPoint::Receive forward fragments to the BTP reassembler — without this
+    // the data path is dead code (the bottleneck that capped this harness before).
+    if (ep->StartConnect() == CHIP_NO_ERROR)
+    {
+        (void) layer.HandleWriteConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_1_UUID);
+        (void) layer.HandleSubscribeComplete(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID);
+
+        chip::Ble::BleTransportCapabilitiesResponseMessage resp;
+        resp.mSelectedProtocolVersion = chip::Ble::kBleTransportProtocolVersion_V4; // negotiation OK
+        resp.mFragmentSize            = fragmentSize;                                       // fuzzed field
+        resp.mWindowSize              = windowSize;                                         // fuzzed field
+
+        PacketBufferHandle respBuf = PacketBufferHandle::New(chip::Ble::kCapabilitiesResponseLength);
+        if (!respBuf.IsNull() && resp.Encode(respBuf) == CHIP_NO_ERROR)
+        {
+            RETURN_SAFELY_IGNORED ep->Receive(std::move(respBuf));
+        }
+    }
+
+    // BTP data phase: stamp the running sequence number so fragments get past
+    // the BtpEngine seq gate and exercise reassembly. The base is fuzzed.
+    uint8_t seq = seqBaseOne ? 1 : 0; // chip::Ble::SequenceNumber_t is uint8_t
+    for (const auto & f : frags)
+    {
+        const uint8_t flags                  = std::get<0>(f);
+        const uint16_t declaredLen           = std::get<1>(f);
+        const std::vector<uint8_t> & payload = std::get<2>(f);
+
+        std::vector<uint8_t> frame;
+        frame.push_back(flags);
+        frame.push_back(seq);
+        if (flags & 0x01) // kStartMessage carries a 16-bit total length
+        {
+            frame.push_back(static_cast<uint8_t>(declaredLen));
+            frame.push_back(static_cast<uint8_t>(declaredLen >> 8));
+        }
+        frame.insert(frame.end(), payload.begin(), payload.end());
+
+        auto buf = PacketBufferHandle::NewWithData(frame.data(), frame.size());
+        if (buf.IsNull())
+            continue;
+        RETURN_SAFELY_IGNORED ep->Receive(std::move(buf));
+        seq = static_cast<uint8_t>(seq + 1);
+    }
+
+    ep->Close();
+    layer.Shutdown();
+}
+
+FUZZ_TEST(FuzzBleEndPointPW, BleEndpointReceiveDoesNotCrash)
+    .WithDomains(AnyWindowSize(), /* fragmentSize */ AnyMtu(), /* seqBaseOne */ Arbitrary<bool>(),
+                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }),
+                                  Arbitrary<uint16_t>(), Arbitrary<std::vector<uint8_t>>()))
+                     .WithMaxSize(8)
+                     .WithSeeds(EpFragSeeds()));
+
+} // namespace

--- a/src/ble/tests/FuzzBleLayerPW.cpp
+++ b/src/ble/tests/FuzzBleLayerPW.cpp
@@ -1,0 +1,483 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Seeded FuzzTest harness for the BleLayer multi-endpoint inbound-dispatch
+ *      seam — the un-fuzzed territory that FuzzBleEndPointPW never reaches
+ *      (it calls NewBleEndPoint(nullptr, ...) which BleLayer rejects, so no
+ *      BLEEndPoint::Receive, no capabilities handshake, and no teardown ever
+ *      runs there).
+ *
+ *      This harness drives external pre-auth inbound upcalls through the real
+ *      entry points BleLayer::HandleWriteReceived / HandleIndicationReceived /
+ *      HandleSubscribeReceived / HandleUnsubscribeReceived /
+ *      HandleWriteConfirmation / HandleIndicationConfirmation /
+ *      HandleConnectionError with NON-NULL connObj values, so that the pool
+ *      Find/GetFree/NewBleEndPoint allocation path, BLEEndPoint::Receive, the
+ *      capabilities handshake field validation, BtpEngine reassembly, and the
+ *      DoClose/FinalizeClose/Free/Release teardown lifecycle all light up.
+ *
+ *      Faithfulness: ONE persistent BleLayer is built and Init'd ONCE behind a
+ *      call_once singleton, together with the SystemLayer and all delegates. The
+ *      endpoint pool storage is a process-global function-local static; a
+ *      per-iteration BleLayer would leave pooled endpoints whose mBle dangles to
+ *      a destroyed layer and produce a false cross-iteration ASan finding. The
+ *      ONLY per-iteration teardown is CloseAllBleConnections(), the real
+ *      production teardown path that Abort()/Free()s every live endpoint and
+ *      restores every slot to mBle==nullptr.
+ */
+
+#include <cstdint>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <ble/Ble.h>
+#include <ble/BLEEndPoint.h>
+#include <ble/BleConfig.h>
+#include <ble/BleError.h>
+#include <ble/BleLayer.h>
+#include <ble/BleLayerDelegate.h>
+#include <ble/BleUUID.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemLayer.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace Ble {
+
+// Sink delegates: swallow everything, never re-enter the layer. (Class A — no
+// trust-boundary validation; the completed-message sink is downstream/out of
+// scope, GetMTU returns a faithful >= 23 value, the handshake's own field
+// validation runs unmodified.) Copied verbatim from FuzzBleEndPointPW.cpp.
+class FuzzBleLayerDelegate : public BleLayerDelegate
+{
+public:
+    void OnBleConnectionComplete(BLEEndPoint *) override {}
+    void OnBleConnectionError(CHIP_ERROR) override {}
+    void OnEndPointConnectComplete(BLEEndPoint *, CHIP_ERROR) override {}
+    void OnEndPointMessageReceived(BLEEndPoint *, System::PacketBufferHandle &&) override {}
+    void OnEndPointConnectionClosed(BLEEndPoint *, CHIP_ERROR) override {}
+    CHIP_ERROR SetEndPoint(BLEEndPoint *) override { return CHIP_NO_ERROR; }
+};
+
+class FuzzBlePlatformDelegate : public BlePlatformDelegate
+{
+public:
+    CHIP_ERROR SubscribeCharacteristic(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT) override { return CHIP_NO_ERROR; }
+    uint16_t GetMTU(BLE_CONNECTION_OBJECT) const override { return 247; }
+    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
+                              System::PacketBufferHandle) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR SendWriteRequest(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
+                                System::PacketBufferHandle) override
+    {
+        return CHIP_NO_ERROR;
+    }
+};
+
+class FuzzBleApplicationDelegate : public BleApplicationDelegate
+{
+public:
+    void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT) override {}
+};
+
+} // namespace Ble
+} // namespace chip
+
+namespace {
+
+using chip::Ble::BLEEndPoint;
+using chip::Ble::BleLayer;
+using chip::Ble::ChipBleUUID;
+using chip::Ble::FuzzBleApplicationDelegate;
+using chip::Ble::FuzzBleLayerDelegate;
+using chip::Ble::FuzzBlePlatformDelegate;
+using chip::System::PacketBufferHandle;
+using namespace fuzztest;
+
+// ---------------------------------------------------------------------------
+// Process-lifetime singletons (see the persistent-layer note in the file header).
+//
+// The BleLayer, its delegates and the SystemLayer are constructed and Init'd
+// EXACTLY ONCE for the whole process. Never per-iteration. The endpoint pool
+// is a process-global function-local static; tearing the layer down per
+// iteration would dangle pooled endpoints' mBle to a freed layer and produce a
+// FALSE cross-iteration UAF.
+// ---------------------------------------------------------------------------
+BleLayer & PersistentLayer()
+{
+    static FuzzBlePlatformDelegate sPlatformDelegate;
+    static FuzzBleApplicationDelegate sAppDelegate;
+    static FuzzBleLayerDelegate sLayerDelegate;
+    static BleLayer * const sLayer = [&]() -> BleLayer * {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        VerifyOrDie(chip::DeviceLayer::SystemLayer().Init() == CHIP_NO_ERROR);
+        std::atexit([] { chip::DeviceLayer::SystemLayer().Shutdown(); });
+        // Intentionally never deleted: a single long-lived BleLayer, exactly as
+        // production has. The pool storage outlives any per-iteration state.
+        auto * layer = new BleLayer();
+        VerifyOrDie(layer->Init(&sPlatformDelegate, &sAppDelegate, &chip::DeviceLayer::SystemLayer()) == CHIP_NO_ERROR);
+        layer->mBleTransport = &sLayerDelegate;
+        return layer;
+    }();
+    return *sLayer;
+}
+
+// ---------------------------------------------------------------------------
+// Frame builders (copied verbatim from FuzzBleEndPointPW.cpp).
+// ---------------------------------------------------------------------------
+[[maybe_unused]] PacketBufferHandle BuildCapabilitiesRequest(uint8_t windowSize, uint16_t mtu)
+{
+    constexpr size_t kReqLen = 9;
+    auto buf                 = PacketBufferHandle::New(kReqLen);
+    if (buf.IsNull())
+        return buf;
+    uint8_t * p = buf->Start();
+    p[0]        = 0x65; // CHECK_BYTE_1
+    p[1]        = 0x6C; // CHECK_BYTE_2
+    p[2]        = 0x04; // version
+    p[3]        = 0x00;
+    p[4]        = 0x00;
+    p[5]        = static_cast<uint8_t>(mtu);
+    p[6]        = static_cast<uint8_t>(mtu >> 8);
+    p[7]        = windowSize;
+    p[8]        = 0x00;
+    buf->SetDataLength(kReqLen);
+    return buf;
+}
+
+[[maybe_unused]] PacketBufferHandle BuildCapabilitiesResponse(uint8_t windowSize, uint16_t fragmentSize)
+{
+    constexpr size_t kRespLen = 6;
+    auto buf                  = PacketBufferHandle::New(kRespLen);
+    if (buf.IsNull())
+        return buf;
+    uint8_t * p = buf->Start();
+    p[0]        = 0x65;
+    p[1]        = 0x6C;
+    p[2]        = 0x04;
+    p[3]        = static_cast<uint8_t>(fragmentSize);
+    p[4]        = static_cast<uint8_t>(fragmentSize >> 8);
+    p[5]        = windowSize;
+    buf->SetDataLength(kRespLen);
+    return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch axes.
+// ---------------------------------------------------------------------------
+enum OpType : uint8_t
+{
+    kWriteReceived          = 0, // CHAR_1 — new-connection / data path
+    kIndicationReceived     = 1, // CHAR_2 — central handshake / data path
+    kSubscribeReceived      = 2, // CHAR_2
+    kUnsubscribeReceived    = 3, // CHAR_2
+    kWriteConfirmation      = 4, // CHAR_1 — ack path (faithful, public upcall)
+    kIndicationConfirmation = 5, // CHAR_2 — ack path (faithful, public upcall)
+    kConnectionError        = 6, // teardown
+    kNumOps                 = 7,
+};
+
+// A single fuzzer-chosen operation: (opType, connId, payload).
+using Op  = std::tuple<uint8_t, uint8_t, std::vector<uint8_t>>;
+using Ops = std::vector<Op>;
+
+// connId -> distinct non-null BLE_CONNECTION_OBJECT. Find/GetFree only compare
+// pointer identity and test mBle!=nullptr; they never dereference connObj. The
+// +1 guarantees non-null (BLE_CONNECTION_UNINITIALIZED == nullptr is rejected).
+BLE_CONNECTION_OBJECT ConnObj(uint8_t connId)
+{
+    return reinterpret_cast<BLE_CONNECTION_OBJECT>(static_cast<uintptr_t>(connId % 4) + 1);
+}
+
+// Small set of teardown error codes to drive.
+CHIP_ERROR PickError(const std::vector<uint8_t> & payload)
+{
+    const CHIP_ERROR errs[] = {
+        BLE_ERROR_REMOTE_DEVICE_DISCONNECTED,
+        BLE_ERROR_APP_CLOSED_CONNECTION,
+        CHIP_ERROR_TIMEOUT,
+    };
+    const uint8_t sel = payload.empty() ? 0 : static_cast<uint8_t>(payload[0] % 3);
+    return errs[sel];
+}
+
+PacketBufferHandle MakeBuf(const std::vector<uint8_t> & payload)
+{
+    return PacketBufferHandle::NewWithData(payload.data(), payload.size());
+}
+
+void DispatchOne(BleLayer & layer, const Op & op)
+{
+    const uint8_t opType                 = static_cast<uint8_t>(std::get<0>(op) % kNumOps);
+    BLE_CONNECTION_OBJECT connObj        = ConnObj(std::get<1>(op));
+    const std::vector<uint8_t> & payload = std::get<2>(op);
+
+    switch (opType)
+    {
+    case kWriteReceived: {
+        auto buf = MakeBuf(payload);
+        if (!buf.IsNull())
+        {
+            (void) layer.HandleWriteReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_1_UUID,
+                                             std::move(buf));
+        }
+        break;
+    }
+    case kIndicationReceived: {
+        auto buf = MakeBuf(payload);
+        if (!buf.IsNull())
+        {
+            (void) layer.HandleIndicationReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID,
+                                                  std::move(buf));
+        }
+        break;
+    }
+    case kSubscribeReceived:
+        (void) layer.HandleSubscribeReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID);
+        break;
+    case kUnsubscribeReceived:
+        (void) layer.HandleUnsubscribeReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID);
+        break;
+    case kWriteConfirmation:
+        // Faithful ack path: BleLayer::HandleWriteConfirmation -> HandleAckReceived.
+        (void) layer.HandleWriteConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_1_UUID);
+        break;
+    case kIndicationConfirmation:
+        // Faithful ack path: BleLayer::HandleIndicationConfirmation -> HandleAckReceived.
+        (void) layer.HandleIndicationConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID);
+        break;
+    case kConnectionError:
+        layer.HandleConnectionError(connObj, PickError(payload));
+        break;
+    default:
+        break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The property: dispatch a bounded sequence of inbound upcalls, then reset the
+// pool via the real teardown path. No crash / no sanitizer error must occur.
+// ---------------------------------------------------------------------------
+// Establish a Connected central endpoint via the proven CompleteCentralHandshake
+// recipe (see TestBleEndPoint.cpp / FuzzBleEndPointPW): StartConnect ->
+// WriteConfirmation -> SubscribeComplete -> Receive(Encode'd V4 response). Without
+// this the dispatch only ever sees freshly-allocated / Connecting endpoints; with
+// it the fuzzed ops exercise Connected-state data delivery and teardown.
+void PreconnectCentral(BleLayer & layer, BLE_CONNECTION_OBJECT connObj)
+{
+    BLEEndPoint * ep = nullptr;
+    if (layer.NewBleEndPoint(&ep, connObj, chip::Ble::kBleRole_Central, /* autoClose */ true) != CHIP_NO_ERROR ||
+        ep == nullptr)
+        return;
+    if (ep->StartConnect() != CHIP_NO_ERROR)
+        return;
+    (void) layer.HandleWriteConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_1_UUID);
+    (void) layer.HandleSubscribeComplete(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &chip::Ble::CHIP_BLE_CHAR_2_UUID);
+
+    chip::Ble::BleTransportCapabilitiesResponseMessage resp;
+    resp.mSelectedProtocolVersion = chip::Ble::kBleTransportProtocolVersion_V4;
+    resp.mFragmentSize            = 247;
+    resp.mWindowSize              = 4;
+    PacketBufferHandle buf = PacketBufferHandle::New(chip::Ble::kCapabilitiesResponseLength);
+    if (!buf.IsNull() && resp.Encode(buf) == CHIP_NO_ERROR)
+        (void) ep->Receive(std::move(buf));
+}
+
+void BleLayerDispatchDoesNotCrash(const Ops & ops)
+{
+    BleLayer & layer = PersistentLayer();
+
+    // Pre-establish Connected central endpoints for the connObjs the ops address,
+    // so the fuzzed dispatch exercises Connected-state paths (data delivery,
+    // connected-state teardown, multi-endpoint interaction), not just allocation.
+    //
+    // NOTE: the default BLE_LAYER_NUM_BLE_ENDPOINTS is 1, so only one of these
+    // connects and the rest hit CHIP_ERROR_ENDPOINT_POOL_FULL. To exercise the
+    // multi-endpoint pool/dispatch/teardown paths, build with the pool raised,
+    // e.g. -DBLE_LAYER_NUM_BLE_ENDPOINTS=4.
+    for (uint8_t cid = 0; cid < 4; ++cid)
+    {
+        PreconnectCentral(layer, ConnObj(cid));
+    }
+
+    for (const auto & op : ops)
+    {
+        DispatchOne(layer, op);
+    }
+
+    // Faithful per-iteration reset: Abort()/Free() every live endpoint through
+    // the production teardown path so every pool slot returns to mBle==nullptr.
+    // This is NOT a layer teardown (the layer is persistent — see the file header).
+    layer.CloseAllBleConnections();
+}
+
+// ---------------------------------------------------------------------------
+// Seed corpus — one representative per dispatch arm, plus lifetime/teardown
+// interleavings, so the mutator can build from each (must pass UUID/null gates).
+// ---------------------------------------------------------------------------
+std::vector<uint8_t> CapReq(uint8_t windowSize, uint16_t mtu)
+{
+    // Wire bytes of a BTP capabilities request (mirrors BuildCapabilitiesRequest).
+    // Built directly so seed construction (which runs at static-init time via
+    // .WithSeeds(SeedSequences())) never calls chip::Platform::MemoryAlloc before
+    // Platform::MemoryInit() — that ordering aborts in VerifyInitialized().
+    //
+    // Wire layout (kCapabilitiesRequestLength=9): magic(2) + supportedVersions(4)
+    // + mtu(2 LE) + windowSize(1). The 4 version bytes encode V4 in the low nibble
+    // of byte 0. (Earlier 3-version layout misaligned mtu/windowSize -> window 0.)
+    return { 0x65, 0x6C, 0x04, 0x00, 0x00, 0x00, static_cast<uint8_t>(mtu), static_cast<uint8_t>(mtu >> 8), windowSize };
+}
+std::vector<uint8_t> CapResp(uint8_t windowSize, uint16_t fragmentSize)
+{
+    // Wire bytes of a BTP capabilities response (mirrors BuildCapabilitiesResponse).
+    return { 0x65, 0x6C, 0x04, static_cast<uint8_t>(fragmentSize), static_cast<uint8_t>(fragmentSize >> 8), windowSize };
+}
+
+Op MkOp(uint8_t opType, uint8_t connId, std::vector<uint8_t> payload)
+{
+    return std::make_tuple(opType, connId, std::move(payload));
+}
+
+std::vector<Ops> SeedSequences()
+{
+    // BTP data fragment shapes (from FuzzBleEndPointPW BtpDataFragmentSeeds).
+    const std::vector<uint8_t> startEnd  = { 0x05, 0x01, 0x01, 0x00, 0x00 };
+    const std::vector<uint8_t> startOnly = { 0x01, 0x00, 0x01, 0x00, 0x00 };
+    const std::vector<uint8_t> endOnly   = { 0x04, 0x01, 0x02, 0x00 };
+    const std::vector<uint8_t> pureAck   = { 0x08 };
+
+    std::vector<Ops> seeds;
+
+    // Peripheral handshake -> Connected -> BTP data path (conn0).
+    seeds.push_back({
+        MkOp(kWriteReceived, 0, CapReq(6, 247)),
+        MkOp(kSubscribeReceived, 0, {}),
+        MkOp(kWriteReceived, 0, startEnd),
+    });
+
+    // Central handshake (conn0) via indication + capabilities response.
+    seeds.push_back({
+        MkOp(kIndicationReceived, 0, CapResp(6, 200)),
+        MkOp(kIndicationReceived, 0, startEnd),
+    });
+
+    // Handshake field-validation boundaries (windowSize / mtu sweeps).
+    const uint8_t windowSizes[]  = { 0, 1, 2, 3, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE - 1),
+                                    static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE),
+                                    static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE + 1), 0xFE, 0xFF };
+    const uint16_t mtus[]        = { 0, 1, 2, 3, 4, 20, 23, 100, 185, 247, 512, 1024, 0xFFFE, 0xFFFF };
+    for (uint8_t ws : windowSizes)
+    {
+        for (uint16_t mtu : mtus)
+        {
+            seeds.push_back({ MkOp(kWriteReceived, 0, CapReq(ws, mtu)), MkOp(kSubscribeReceived, 0, {}) });
+            seeds.push_back({ MkOp(kIndicationReceived, 0, CapResp(ws, mtu)) });
+        }
+    }
+
+    // Disconnect during an in-progress reassembly.
+    seeds.push_back({
+        MkOp(kWriteReceived, 0, CapReq(6, 247)),
+        MkOp(kSubscribeReceived, 0, {}),
+        MkOp(kWriteReceived, 0, startOnly),
+        MkOp(kConnectionError, 0, { 0 }), // BLE_ERROR_REMOTE_DEVICE_DISCONNECTED
+    });
+
+    // Unsubscribe followed by connection-error on the same slot.
+    seeds.push_back({
+        MkOp(kWriteReceived, 0, CapReq(6, 247)),
+        MkOp(kSubscribeReceived, 0, {}),
+        MkOp(kUnsubscribeReceived, 0, {}),
+        MkOp(kConnectionError, 0, { 1 }),
+    });
+
+    // Multiple connections contending for the endpoint pool (pool-full path at NUM==1).
+    seeds.push_back({
+        MkOp(kWriteReceived, 0, CapReq(6, 247)),
+        MkOp(kWriteReceived, 1, CapReq(6, 247)),
+        MkOp(kSubscribeReceived, 0, {}),
+        MkOp(kSubscribeReceived, 1, {}),
+        MkOp(kConnectionError, 0, { 0 }),
+        MkOp(kWriteReceived, 2, CapReq(6, 247)),
+    });
+
+    // Stray confirmations / data against never-opened or freed connObjs.
+    seeds.push_back({
+        MkOp(kWriteConfirmation, 3, {}),
+        MkOp(kIndicationConfirmation, 3, {}),
+        MkOp(kWriteReceived, 3, endOnly),
+        MkOp(kIndicationReceived, 3, pureAck),
+    });
+
+    return seeds;
+}
+
+// Payload domain biased toward valid BTP capabilities-handshake frames so
+// endpoints reach Connected (exercising the multi-endpoint pool's connected-
+// state + teardown paths), while still covering arbitrary/malformed bytes. The
+// capabilities handshake is not sequence-gated, so a single valid frame connects
+// an endpoint without per-endpoint seq tracking (the BTP data path's seq gate is
+// covered deeply by the dedicated FuzzBtpEnginePW / FuzzBleEndPointPW harnesses).
+auto AnyBlePayload()
+{
+    return OneOf(
+        // Capabilities REQUEST (peripheral, CHAR_1 write): magic(2) versions(4) mtu(2 LE) ws(1)
+        Map([](uint16_t mtu, uint8_t ws) {
+            return std::vector<uint8_t>{ 0x65, 0x6C, 0x04, 0x00, 0x00, 0x00, static_cast<uint8_t>(mtu),
+                                         static_cast<uint8_t>(mtu >> 8), ws };
+        },
+            Arbitrary<uint16_t>(), Arbitrary<uint8_t>()),
+        // Capabilities RESPONSE (central, CHAR_2 indication): 65 6C 04 fragLo fragHi ws
+        Map([](uint16_t frag, uint8_t ws) {
+            return std::vector<uint8_t>{ 0x65, 0x6C, 0x04, static_cast<uint8_t>(frag), static_cast<uint8_t>(frag >> 8),
+                                         ws };
+        },
+            Arbitrary<uint16_t>(), Arbitrary<uint8_t>()),
+        // Arbitrary / malformed bytes.
+        Arbitrary<std::vector<uint8_t>>());
+}
+
+} // namespace
+
+FUZZ_TEST(FuzzBleLayerPW, BleLayerDispatchDoesNotCrash)
+    .WithDomains(VectorOf(TupleOf(/* opType  */ ElementOf<uint8_t>({ kWriteReceived, kIndicationReceived, kSubscribeReceived,
+                                                                     kUnsubscribeReceived, kWriteConfirmation,
+                                                                     kIndicationConfirmation, kConnectionError }),
+                                  /* connId   */ ElementOf<uint8_t>({ 0, 1, 2, 3 }),
+                                  /* payload  */ AnyBlePayload()))
+                     .WithMaxSize(24)
+                     .WithSeeds(SeedSequences()));

--- a/src/ble/tests/FuzzBleLayerPW.cpp
+++ b/src/ble/tests/FuzzBleLayerPW.cpp
@@ -51,8 +51,8 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-#include <ble/Ble.h>
 #include <ble/BLEEndPoint.h>
+#include <ble/Ble.h>
 #include <ble/BleConfig.h>
 #include <ble/BleError.h>
 #include <ble/BleLayer.h>
@@ -96,8 +96,7 @@ public:
     }
     CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT) override { return CHIP_NO_ERROR; }
     uint16_t GetMTU(BLE_CONNECTION_OBJECT) const override { return 247; }
-    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *,
-                              System::PacketBufferHandle) override
+    CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *, System::PacketBufferHandle) override
     {
         return CHIP_NO_ERROR;
     }
@@ -300,8 +299,7 @@ void DispatchOne(BleLayer & layer, const Op & op)
 void PreconnectCentral(BleLayer & layer, BLE_CONNECTION_OBJECT connObj)
 {
     BLEEndPoint * ep = nullptr;
-    if (layer.NewBleEndPoint(&ep, connObj, chip::Ble::kBleRole_Central, /* autoClose */ true) != CHIP_NO_ERROR ||
-        ep == nullptr)
+    if (layer.NewBleEndPoint(&ep, connObj, chip::Ble::kBleRole_Central, /* autoClose */ true) != CHIP_NO_ERROR || ep == nullptr)
         return;
     if (ep->StartConnect() != CHIP_NO_ERROR)
         return;
@@ -312,7 +310,7 @@ void PreconnectCentral(BleLayer & layer, BLE_CONNECTION_OBJECT connObj)
     resp.mSelectedProtocolVersion = chip::Ble::kBleTransportProtocolVersion_V4;
     resp.mFragmentSize            = 247;
     resp.mWindowSize              = 4;
-    PacketBufferHandle buf = PacketBufferHandle::New(chip::Ble::kCapabilitiesResponseLength);
+    PacketBufferHandle buf        = PacketBufferHandle::New(chip::Ble::kCapabilitiesResponseLength);
     if (!buf.IsNull() && resp.Encode(buf) == CHIP_NO_ERROR)
         (void) ep->Receive(std::move(buf));
 }
@@ -396,10 +394,16 @@ std::vector<Ops> SeedSequences()
     });
 
     // Handshake field-validation boundaries (windowSize / mtu sweeps).
-    const uint8_t windowSizes[]  = { 0, 1, 2, 3, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE - 1),
+    const uint8_t windowSizes[] = { 0,
+                                    1,
+                                    2,
+                                    3,
+                                    static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE - 1),
                                     static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE),
-                                    static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE + 1), 0xFE, 0xFF };
-    const uint16_t mtus[]        = { 0, 1, 2, 3, 4, 20, 23, 100, 185, 247, 512, 1024, 0xFFFE, 0xFFFF };
+                                    static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE + 1),
+                                    0xFE,
+                                    0xFF };
+    const uint16_t mtus[]       = { 0, 1, 2, 3, 4, 20, 23, 100, 185, 247, 512, 1024, 0xFFFE, 0xFFFF };
     for (uint8_t ws : windowSizes)
     {
         for (uint16_t mtu : mtus)
@@ -411,9 +415,7 @@ std::vector<Ops> SeedSequences()
 
     // Disconnect during an in-progress reassembly.
     seeds.push_back({
-        MkOp(kWriteReceived, 0, CapReq(6, 247)),
-        MkOp(kSubscribeReceived, 0, {}),
-        MkOp(kWriteReceived, 0, startOnly),
+        MkOp(kWriteReceived, 0, CapReq(6, 247)), MkOp(kSubscribeReceived, 0, {}), MkOp(kWriteReceived, 0, startOnly),
         MkOp(kConnectionError, 0, { 0 }), // BLE_ERROR_REMOTE_DEVICE_DISCONNECTED
     });
 
@@ -456,16 +458,18 @@ auto AnyBlePayload()
 {
     return OneOf(
         // Capabilities REQUEST (peripheral, CHAR_1 write): magic(2) versions(4) mtu(2 LE) ws(1)
-        Map([](uint16_t mtu, uint8_t ws) {
-            return std::vector<uint8_t>{ 0x65, 0x6C, 0x04, 0x00, 0x00, 0x00, static_cast<uint8_t>(mtu),
-                                         static_cast<uint8_t>(mtu >> 8), ws };
-        },
+        Map(
+            [](uint16_t mtu, uint8_t ws) {
+                return std::vector<uint8_t>{
+                    0x65, 0x6C, 0x04, 0x00, 0x00, 0x00, static_cast<uint8_t>(mtu), static_cast<uint8_t>(mtu >> 8), ws
+                };
+            },
             Arbitrary<uint16_t>(), Arbitrary<uint8_t>()),
         // Capabilities RESPONSE (central, CHAR_2 indication): 65 6C 04 fragLo fragHi ws
-        Map([](uint16_t frag, uint8_t ws) {
-            return std::vector<uint8_t>{ 0x65, 0x6C, 0x04, static_cast<uint8_t>(frag), static_cast<uint8_t>(frag >> 8),
-                                         ws };
-        },
+        Map(
+            [](uint16_t frag, uint8_t ws) {
+                return std::vector<uint8_t>{ 0x65, 0x6C, 0x04, static_cast<uint8_t>(frag), static_cast<uint8_t>(frag >> 8), ws };
+            },
             Arbitrary<uint16_t>(), Arbitrary<uint8_t>()),
         // Arbitrary / malformed bytes.
         Arbitrary<std::vector<uint8_t>>());

--- a/src/ble/tests/FuzzBleLayerPW.cpp
+++ b/src/ble/tests/FuzzBleLayerPW.cpp
@@ -44,6 +44,7 @@
  */
 
 #include <cstdint>
+#include <cstdlib>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -148,46 +149,6 @@ BleLayer & PersistentLayer()
         return layer;
     }();
     return *sLayer;
-}
-
-// ---------------------------------------------------------------------------
-// Frame builders (copied verbatim from FuzzBleEndPointPW.cpp).
-// ---------------------------------------------------------------------------
-[[maybe_unused]] PacketBufferHandle BuildCapabilitiesRequest(uint8_t windowSize, uint16_t mtu)
-{
-    constexpr size_t kReqLen = 9;
-    auto buf                 = PacketBufferHandle::New(kReqLen);
-    if (buf.IsNull())
-        return buf;
-    uint8_t * p = buf->Start();
-    p[0]        = 0x65; // CHECK_BYTE_1
-    p[1]        = 0x6C; // CHECK_BYTE_2
-    p[2]        = 0x04; // version
-    p[3]        = 0x00;
-    p[4]        = 0x00;
-    p[5]        = static_cast<uint8_t>(mtu);
-    p[6]        = static_cast<uint8_t>(mtu >> 8);
-    p[7]        = windowSize;
-    p[8]        = 0x00;
-    buf->SetDataLength(kReqLen);
-    return buf;
-}
-
-[[maybe_unused]] PacketBufferHandle BuildCapabilitiesResponse(uint8_t windowSize, uint16_t fragmentSize)
-{
-    constexpr size_t kRespLen = 6;
-    auto buf                  = PacketBufferHandle::New(kRespLen);
-    if (buf.IsNull())
-        return buf;
-    uint8_t * p = buf->Start();
-    p[0]        = 0x65;
-    p[1]        = 0x6C;
-    p[2]        = 0x04;
-    p[3]        = static_cast<uint8_t>(fragmentSize);
-    p[4]        = static_cast<uint8_t>(fragmentSize >> 8);
-    p[5]        = windowSize;
-    buf->SetDataLength(kRespLen);
-    return buf;
 }
 
 // ---------------------------------------------------------------------------
@@ -344,7 +305,7 @@ void BleLayerDispatchDoesNotCrash(const Ops & ops)
 // ---------------------------------------------------------------------------
 std::vector<uint8_t> CapReq(uint8_t windowSize, uint16_t mtu)
 {
-    // Wire bytes of a BTP capabilities request (mirrors BuildCapabilitiesRequest).
+    // Wire bytes of a BTP capabilities request.
     // Built directly so seed construction (which runs at static-init time via
     // .WithSeeds(SeedSequences())) never calls chip::Platform::MemoryAlloc before
     // Platform::MemoryInit() — that ordering aborts in VerifyInitialized().
@@ -356,7 +317,7 @@ std::vector<uint8_t> CapReq(uint8_t windowSize, uint16_t mtu)
 }
 std::vector<uint8_t> CapResp(uint8_t windowSize, uint16_t fragmentSize)
 {
-    // Wire bytes of a BTP capabilities response (mirrors BuildCapabilitiesResponse).
+    // Wire bytes of a BTP capabilities response.
     return { 0x65, 0x6C, 0x04, static_cast<uint8_t>(fragmentSize), static_cast<uint8_t>(fragmentSize >> 8), windowSize };
 }
 

--- a/src/ble/tests/FuzzBleLayerPW.cpp
+++ b/src/ble/tests/FuzzBleLayerPW.cpp
@@ -51,13 +51,8 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-#include <ble/BLEEndPoint.h>
 #include <ble/Ble.h>
 #include <ble/BleConfig.h>
-#include <ble/BleError.h>
-#include <ble/BleLayer.h>
-#include <ble/BleLayerDelegate.h>
-#include <ble/BleUUID.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>

--- a/src/ble/tests/FuzzBtpEnginePW.cpp
+++ b/src/ble/tests/FuzzBtpEnginePW.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cstdint>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -94,10 +95,11 @@ void BtpEngineDoesNotCrash(bool expectFirstAck, const std::vector<FragSpec> & fr
         return;
     }
 
-    // Mirror the engine's expected-rx counter (uint8 wrap); matches BtpEngine::Init
-    // (0 normally, 1 when expect_first_ack). Every fragment we build carries the
-    // header+seq bytes, so the engine consumes the seq and increments in lockstep.
-    SequenceNumber_t seq = expectFirstAck ? 1 : 0;
+    // Mirror the engine's expected-rx counter (uint8 wrap); matches BtpEngine::Init,
+    // which sets mRxNextSeqNum = 0 when expect_first_ack, else 1. Every fragment we
+    // build carries the header+seq bytes, so the engine consumes the seq and
+    // increments in lockstep.
+    SequenceNumber_t seq = expectFirstAck ? 0 : 1;
 
     for (const auto & f : frags)
     {

--- a/src/ble/tests/FuzzBtpEnginePW.cpp
+++ b/src/ble/tests/FuzzBtpEnginePW.cpp
@@ -134,8 +134,8 @@ void BtpEngineDoesNotCrash(bool expectFirstAck, const std::vector<FragSpec> & fr
 FUZZ_TEST(FuzzBtpEnginePW, BtpEngineDoesNotCrash)
     .WithDomains(Arbitrary<bool>(),
                  // Per-fragment: (headerFlags from the data-fragment set, declaredLen, payload).
-                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }),
-                                  Arbitrary<uint16_t>(), Arbitrary<std::vector<uint8_t>>()))
+                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }), Arbitrary<uint16_t>(),
+                                  Arbitrary<std::vector<uint8_t>>()))
                      .WithMaxSize(10)
                      .WithSeeds(BtpSeedSequences()));
 

--- a/src/ble/tests/FuzzBtpEnginePW.cpp
+++ b/src/ble/tests/FuzzBtpEnginePW.cpp
@@ -1,0 +1,142 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Seeded FuzzTest harness for the BtpEngine transport-level reassembler.
+ *      Uses real BTP fragment shapes as seeds so the mutator starts from valid
+ *      header-flag combinations and explores the reorder-queue / ack-handling
+ *      branches instead of bouncing off the header-validation gate.
+ */
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <ble/Ble.h>
+#include <ble/BtpEngine.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace {
+
+using chip::Ble::BtpEngine;
+using chip::Ble::SequenceNumber_t;
+using chip::System::PacketBufferHandle;
+using namespace fuzztest;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+// Structure-aware BTP fragment generation.
+//
+// HandleCharacteristicReceived gates every fragment on `seq == mRxNextSeqNum`
+// (a running counter starting at 0, or 1 when expect_first_ack). A raw-byte
+// mutator essentially never reproduces the correct sequence number, so it
+// bounces off the seq gate at the second fragment and the reassembly state
+// machine is never reached. Instead the fuzzer picks per-fragment header flags
+// / declared length / payload, and the harness stamps the CORRECT running
+// sequence number, so the mutator explores the reassembler (Idle->InProgress->
+// End, AddToEnd/CompactHead, length trim) rather than the seq-reject path.
+//
+// The ack bit (kFragmentAck=0x08) is intentionally excluded: the harness never
+// transmits, so the TX window is empty and any ack-bearing fragment is rejected
+// by HandleAckReceived before the sequence number is consumed (which would also
+// desync this harness's seq mirror). Ack/TX-path fuzzing needs a separate
+// harness that drives sends first.
+
+// Per-fragment fuzzed fields: (headerFlags, declaredMsgLen, payload).
+using FragSpec = std::tuple<uint8_t, uint16_t, std::vector<uint8_t>>;
+
+// Seeds: valid multi-fragment messages to bootstrap the corpus.
+std::vector<std::vector<FragSpec>> BtpSeedSequences()
+{
+    return {
+        { FragSpec{ 0x05, 2, { 0xDE, 0xAD } } },
+        { FragSpec{ 0x01, 6, { 0x01, 0x02 } }, FragSpec{ 0x02, 0, { 0x03, 0x04 } }, FragSpec{ 0x04, 0, { 0x05, 0x06 } } },
+        { FragSpec{ 0x01, 4, { 0xAA, 0xBB } }, FragSpec{ 0x04, 0, { 0xCC, 0xDD } } },
+    };
+}
+
+// Property: feeding a sequence of correctly-sequenced BTP data fragments must
+// never crash the reassembler.
+void BtpEngineDoesNotCrash(bool expectFirstAck, const std::vector<FragSpec> & frags)
+{
+    EnsureInitialized();
+
+    BtpEngine engine;
+    if (engine.Init(nullptr, expectFirstAck) != CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    // Mirror the engine's expected-rx counter (uint8 wrap); matches BtpEngine::Init
+    // (0 normally, 1 when expect_first_ack). Every fragment we build carries the
+    // header+seq bytes, so the engine consumes the seq and increments in lockstep.
+    SequenceNumber_t seq = expectFirstAck ? 1 : 0;
+
+    for (const auto & f : frags)
+    {
+        const uint8_t flags                  = std::get<0>(f);
+        const uint16_t declaredLen           = std::get<1>(f);
+        const std::vector<uint8_t> & payload = std::get<2>(f);
+
+        std::vector<uint8_t> frame;
+        frame.push_back(flags);
+        frame.push_back(seq); // correct running sequence number
+        if (flags & 0x01)     // kStartMessage carries a 16-bit total length
+        {
+            frame.push_back(static_cast<uint8_t>(declaredLen));
+            frame.push_back(static_cast<uint8_t>(declaredLen >> 8));
+        }
+        frame.insert(frame.end(), payload.begin(), payload.end());
+
+        auto buf = PacketBufferHandle::NewWithData(frame.data(), frame.size());
+        if (buf.IsNull())
+            continue;
+
+        SequenceNumber_t receivedAck = 0;
+        bool didReceiveAck           = false;
+        RETURN_SAFELY_IGNORED engine.HandleCharacteristicReceived(std::move(buf), receivedAck, didReceiveAck);
+
+        seq = static_cast<SequenceNumber_t>(seq + 1);
+
+        if (engine.RxState() == BtpEngine::kState_Error)
+            break;
+    }
+}
+
+FUZZ_TEST(FuzzBtpEnginePW, BtpEngineDoesNotCrash)
+    .WithDomains(Arbitrary<bool>(),
+                 // Per-fragment: (headerFlags from the data-fragment set, declaredLen, payload).
+                 VectorOf(TupleOf(ElementOf<uint8_t>({ 0x01, 0x02, 0x04, 0x05, 0x06, 0x03, 0x07, 0x00 }),
+                                  Arbitrary<uint16_t>(), Arbitrary<std::vector<uint8_t>>()))
+                     .WithMaxSize(10)
+                     .WithSeeds(BtpSeedSequences()));
+
+} // namespace

--- a/src/ble/tests/FuzzBtpEnginePW.cpp
+++ b/src/ble/tests/FuzzBtpEnginePW.cpp
@@ -32,7 +32,6 @@
 #include <pw_unit_test/framework.h>
 
 #include <ble/Ble.h>
-#include <ble/BtpEngine.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <system/SystemPacketBuffer.h>


### PR DESCRIPTION


### Summary

Coverage-guided FuzzTest harnesses for the BLE/BTP pre-auth inbound path reachable by a peer during commissioning:

- fuzz-btp-engine-pw (FuzzBtpEnginePW): drive BtpEngine::HandleCharacteristicReceived with structurally-valid fragments carrying correct running sequence numbers (the engine gates every fragment on seq == mRxNextSeqNum, so raw bytes bounce at the 2nd fragment), fuzzing header flags / declared length / payload so the reassembler is exercised.

- fuzz-ble-endpoint-pw (FuzzBleEndPointPW): drive a central BLEEndPoint to Connected via the CompleteCentralHandshake sequence (StartConnect -> HandleWriteConfirmation -> HandleSubscribeComplete -> Receive of an encoded capabilities response), then feed seq-correct BTP data fragments — exercising the receive FSM, capabilities handshake field validation, and BTP data path.

- fuzz-ble-layer-pw (FuzzBleLayerPW): fuzz BleLayer multi-endpoint dispatch (write/indication/subscribe/unsubscribe/confirmation/connection-error) over pre-connected endpoints. With the default BLE_LAYER_NUM_BLE_ENDPOINTS=1 only one endpoint connects; build with the pool raised (e.g. -DBLE_LAYER_NUM_BLE_ENDPOINTS=4) to exercise the multi-endpoint paths.



### Testing

All three run clean under coverage-guided ASan FuzzTest campaigns (no crashes).
