### PR TITLE
[NXP][config][zephyr] Enlarge IPv6 ND tables for dense-network robustness

### DIFF
--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -496,9 +496,27 @@ config NET_IPV6_FRAGMENT_TIMEOUT
 	default 3
 
 # options managed by IP4/IP6 simultaneous support
-# aligned here to match OpenThread config
+
+# IPv6 Neighbor Discovery table sizing for dense networks. Where many routers
+# advertise continuously (an "RA storm"), each is pinned in the neighbor cache
+# as a non-evictable router entry; size the tables above the expected router
+# count so peers are never evicted under churn.
+
+# Neighbor cache: must hold all routers plus active peers without eviction.
+config NET_IPV6_MAX_NEIGHBORS
+	default 32
+
+# Route table: must hold all advertised routes plus the in-use route.
+config NET_MAX_ROUTES
+	default 16
+
+# Default-router list: track all advertising routers.
 config NET_MAX_ROUTERS
-	default 1
+	default 16
+
+# On-link prefixes (SLAAC): headroom for more than one advertised prefix.
+config NET_IF_IPV6_PREFIX_COUNT
+	default 4
 
 config NET_MAX_CONN
 	default 10


### PR DESCRIPTION

### Summary

In dense IPv6 environments where many routers advertise continuously ("RA storm"), the Zephyr IPv6 stack pins every RA source in the neighbor cache as a **non-evictable** `is_router=true` entry. The cache eviction path deliberately skips router entries, so once the cache fills with routers, no new neighbor can be admitted.

With the previous defaults (`NET_IPV6_MAX_NEIGHBORS 8`, `NET_MAX_ROUTERS 1`), a Wi-Fi device could complete commissioning but then become **unreachable for post-commissioning operational sessions** because peers were evicted or could not be inserted under churn.


### Root Cause

`NET_IPV6_MAX_NEIGHBORS` was set to 8 (Zephyr default). In a captured RA-storm environment, 16 distinct routers advertised simultaneously, filling the cache entirely with non-evictable router entries. Any subsequent neighbor solicitation (e.g. address resolution for the commissioner) failed silently.

### Fix

Increase the four Zephyr IPv6 ND Kconfig defaults in `config/nxp/chip-module/Kconfig.defaults` for Wi-Fi targets:

| Config | Old | New | Rationale |
|---|---|---|---|
| `NET_IPV6_MAX_NEIGHBORS` | 8 | 32 | Primary fix — must hold all routers + active peers without eviction |
| `NET_MAX_ROUTES` | 8 | 16 | Secondary headroom; route table is LRU but must not thrash under storm |
| `NET_MAX_ROUTERS` | 1 | 16 | Matches measured worst-case (16 distinct routers in captured environment) |
| `NET_IF_IPV6_PREFIX_COUNT` | 2 | 4 | Headroom for multiple advertised SLAAC prefixes; minimal RAM cost |


### Testing

- Verified fix: with the enlarged tables, the device remains reachable post-commissioning under the same RA-storm conditions.
- To reproduce: build NXP Zephyr thermostat example on RW612 the commission the device with ble-wifi
- build command used: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr"
