### PR TITLE
[WebRTC] Initialize iceServers Optional in Requestor HandleOffer

### DIFF
--- a/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.cpp
@@ -159,6 +159,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorCluster::HandleOffer(const
     // Convert ICE servers list from DecodableList to vector.
     if (req.ICEServers.HasValue())
     {
+        // Engage the Optional with an empty vector before populating it below.
+        args.iceServers.Emplace();
         auto iterator = req.ICEServers.Value().begin();
         while (iterator.Next())
         {

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -24,6 +24,7 @@
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <app/data-model-provider/tests/TestConstants.h>
 #include <clusters/WebRTCTransportRequestor/Attributes.h>
 #include <clusters/WebRTCTransportRequestor/Commands.h>
 #include <clusters/WebRTCTransportRequestor/Enums.h>
@@ -221,6 +222,44 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestReadUnsupportedAttribute)
     auto status = tester.ReadAttribute(0xFFFF /* Invalid attribute ID */, dummyValue);
     EXPECT_FALSE(status.IsSuccess());
     EXPECT_EQ(status.GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::UnsupportedAttribute);
+
+    server.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// HandleOffer converts the wire ICEServers list into OfferArgs::iceServers
+// (an Optional<std::vector>). Exercises an Offer carrying a non-empty
+// ICEServers list and verifies it is handled successfully.
+TEST_F(TestWebRTCTransportRequestorCluster, TestHandleOfferWithICEServers)
+{
+    TestServerClusterContext context;
+    MockWebRTCTransportRequestorDelegate mockDelegate;
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
+    ASSERT_EQ(server.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // Seed a session matching the ClusterTester's default subject so
+    // FindSession() succeeds and HandleOffer reaches the ICEServers conversion.
+    static constexpr uint16_t kSessionId = 42;
+    WebRTCSessionStruct session;
+    session.id          = kSessionId;
+    session.peerNodeID  = Testing::kTestNodeId;
+    session.fabricIndex = Testing::kTestFabricIndex;
+    session.streamUsage = StreamUsageEnum::kLiveView;
+    ASSERT_EQ(server.UpsertSession(session), WebRTCTransportRequestorCluster::UpsertResultEnum::kInserted);
+
+    ClusterTester tester(server);
+
+    // A single ICEServers entry exercises the conversion loop; its fields are
+    // not inspected by the cluster.
+    Globals::Structs::ICEServerStruct::Type iceServer;
+    Commands::Offer::Type request;
+    request.webRTCSessionID = kSessionId;
+    request.sdp             = chip::CharSpan::fromCharString("v=0");
+    request.ICEServers.SetValue(
+        DataModel::List<const Globals::Structs::ICEServerStruct::Type>(&iceServer, 1));
+
+    auto result = tester.Invoke(request);
+    ASSERT_TRUE(result.status.has_value());
+    EXPECT_TRUE(result.status->IsSuccess());
 
     server.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -257,8 +257,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestHandleOfferWithICEServers)
     request.ICEServers.SetValue(DataModel::List<const Globals::Structs::ICEServerStruct::Type>(&iceServer, 1));
 
     auto result = tester.Invoke(request);
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_TRUE(result.status->IsSuccess());
+    EXPECT_TRUE(result.IsSuccess());
 
     server.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -18,13 +18,13 @@
 #include <app/CommandHandler.h>
 #include <app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/data-model-provider/tests/TestConstants.h>
 #include <app/data-model/Decode.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
-#include <app/data-model-provider/tests/TestConstants.h>
 #include <clusters/WebRTCTransportRequestor/Attributes.h>
 #include <clusters/WebRTCTransportRequestor/Commands.h>
 #include <clusters/WebRTCTransportRequestor/Enums.h>
@@ -254,8 +254,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestHandleOfferWithICEServers)
     Commands::Offer::Type request;
     request.webRTCSessionID = kSessionId;
     request.sdp             = chip::CharSpan::fromCharString("v=0");
-    request.ICEServers.SetValue(
-        DataModel::List<const Globals::Structs::ICEServerStruct::Type>(&iceServer, 1));
+    request.ICEServers.SetValue(DataModel::List<const Globals::Structs::ICEServerStruct::Type>(&iceServer, 1));
 
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.status.has_value());


### PR DESCRIPTION
#### Problem

`WebRTCTransportRequestorCluster::HandleOffer` converts the request's `ICEServers` list into `OfferArgs::iceServers`, an `Optional<std::vector<ICEServerDecodableStruct>>`. It pushed entries into the vector via `args.iceServers.Value().push_back(...)` without first engaging the `Optional`, so the conversion path was only correct when the `ICEServers` field was absent.

#### Change

Call `args.iceServers.Emplace()` to engage the `Optional` with an empty vector before the populate loop, matching how the sibling `iceTransportPolicy` value is set. Behavior is unchanged when the request omits `ICEServers`.

#### Testing

Adds a regression test (`TestHandleOfferWithICEServers`) that invokes `Offer` with a non-empty `ICEServers` list against a seeded session and asserts the command is handled successfully.