### PR TITLE
platform/Linux: Spell GLib Strings as 'gchar' and Add GStrvPtr/GBorrowedStrvPtr/GCharPtr Aliases

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -275,7 +275,7 @@ struct GAutoPtrDeleter
  *    Deleter trait for a single, caller-owned C string.
  *
 
- *  `GAutoPtr<char>` manages a `char *` pointing at one
+ *  `GAutoPtr<gchar>` manages a `gchar *` pointing at one
  *  null-terminated string from the GLib allocator (for example, @c
  *  g_strdup(), `g_strdup_printf()`, or a generated `*_dup_*()`
  *  accessor). Released with a single `g_free()`.
@@ -285,14 +285,14 @@ struct GAutoPtrDeleter
  *  @note
  *    Scalar case only. Do not conflate with the string-*array* cases
  *    @ref GAutoPtrDeleter<gchar *> (owned vector, `g_strfreev()`) and
- *    @ref GAutoPtrDeleter<const char *> (borrowed vector,
+ *    @ref GAutoPtrDeleter<const gchar *> (borrowed vector,
  *    container-only `g_free()`).
  *
  *  @sa GFree
  *
  */
 template <>
-struct GAutoPtrDeleter<char>
+struct GAutoPtrDeleter<gchar>
 {
     using deleter = GFree;
 };
@@ -302,14 +302,14 @@ struct GAutoPtrDeleter<char>
  *    Deleter trait for a *borrowed* null-terminated string array: the
  *    container is caller-owned, the elements are not.
  *
- *  `GAutoPtr<const char *>` manages a `const char **` from APIs that
+ *  `GAutoPtr<const gchar *>` manages a `const gchar **` from APIs that
  *  return a shallow copy of a string array while retaining ownership
  *  of the strings. Canonical producer: `g_variant_get_strv()`, whose
  *  array must be released with `g_free()` while its strings stay
  *  owned by the `GVariant` and must **not** be freed.
  *
- *  Stored pointer: `const char **` (== `const gchar **`). Released
- *  with: `g_free()` on the array only.
+ *  Stored pointer: `const gchar **`. Released with: `g_free()` on the
+ *  array only.
  *
  *  @warning
  *    Do **not** change this to `g_strfreev()` and do **not** drop the
@@ -323,7 +323,7 @@ struct GAutoPtrDeleter<char>
  *
  *  @note
  *    `gchar` is `ypedef`'d to `char`, so `GAutoPtr<const gchar *>`
- *    and `GAutoPtr<const char *>` name the same instantiation and
+ *    and `GAutoPtr<const gchar *>` name the same instantiation and
  *    select this specialization; the call-site spelling difference is
  *    cosmetic.
  *
@@ -332,7 +332,7 @@ struct GAutoPtrDeleter<char>
  *
  */
 template <>
-struct GAutoPtrDeleter<const char *>
+struct GAutoPtrDeleter<const gchar *>
 {
     using deleter = GFree;
 };
@@ -383,18 +383,17 @@ struct GAutoPtrDeleter<GError>
  *  g_strsplit(), `g_strdupv()`, `g_variant_dup_strv()`. The whole
  *  vector is released with `g_strfreev()`.
  *
- *  Stored pointer: `gchar **` (== `char **`). Released with:
- *  `g_strfreev()`.
+ *  Stored pointer: `gchar **`. Released with: `g_strfreev()`.
  *
  *  @note
- *    Choose between this and @ref GAutoPtrDeleter<const char *> by
+ *    Choose between this and @ref GAutoPtrDeleter<const gchar *> by
  *    the const-ness of the GLib return type: `gchar **` (for example,
  *    `g_variant_dup_strv`) selects this trait; `const gchar **` (for
  *    example, `g_variant_get_strv`) selects the const one. The
  *    pointer conversion rules enforce that choice at compile time.
  *
  *  @sa GStrvDeleter
- *  @sa GAutoPtrDeleter<const char *>
+ *  @sa GAutoPtrDeleter<const gchar *>
  *
  */
 template <>
@@ -455,9 +454,9 @@ struct GAutoPtrDeleter<GVariantIter>
  *    string-array specializations the angle-bracket type is the
  *    element while the owned object is the array:
  *
- *      - `GAutoPtr<char>`         owns `char *`        (one string; `g_free`)
- *      - `GAutoPtr<gchar *>`      owns `gchar **`      (owned strv; `g_strfreev`)
- *      - `GAutoPtr<const char *>` owns `const char **` (borrowed strv; `g_free` on the container only)
+ *      - `GAutoPtr<gchar>`         owns `gchar *`        (one string; `g_free`)
+ *      - `GAutoPtr<gchar *>`       owns `gchar **`       (owned strv; `g_strfreev`)
+ *      - `GAutoPtr<const gchar *>` owns `const gchar **` (borrowed strv; `g_free` on the container only)
  *
  *  @sa GAutoPtrDeleter
  *  @sa UniquePointerReceiver

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -497,4 +497,74 @@ public:
     UniquePointerReceiver<T, deleter> GetReceiver() { return MakeUniquePointerReceiver(*this); }
 };
 
+/**
+ *  @brief
+ *    Owning smart pointer for a single, caller-owned GLib C string.
+ *
+ *  Alias for `GAutoPtr<gchar>`. Use for one NUL-terminated string from
+ *  the GLib allocator, e.g. `g_strdup()`, `g_strdup_printf()`, or a
+ *  generated `*_dup_*()` accessor. Released with a single `g_free()`.
+ *
+ *  Stored pointer: `gchar *`. Released with: `g_free()`.
+ *
+ *  @note
+ *    Scalar string only; this is **not** a strv. For arrays use
+ *    `GStrvPtr` (owned) or `GBorrowedStrvPtr` (borrowed).
+ *
+ *  @sa GAutoPtrDeleter<gchar>
+ *
+ */
+using GCharPtr = GAutoPtr<gchar>;
+
+/**
+ *  @brief
+ *    Owning smart pointer for a fully caller-owned, null-terminated GLib
+ *    string array (a "strv").
+ *
+ *  Alias for `GAutoPtr<gchar *>`. Use for arrays returned by deep-copy
+ *  APIs that transfer ownership of both the array and every string, e.g.
+ *  `g_strsplit()`, `g_strdupv()`, `g_variant_dup_strv()`. The whole
+ *  vector is released with `g_strfreev()`.
+ *
+ *  Stored pointer: `gchar **`. Released with: `g_strfreev()`.
+ *
+ *  @note
+ *    This is the *owned* strv. Its borrowed twin is `GBorrowedStrvPtr`;
+ *    the two are kept distinct at compile time by the const-qualifier on
+ *    the element type, so an owned array cannot be assigned the borrowed
+ *    deleter or vice versa.
+ *
+ *  @sa GBorrowedStrvPtr
+ *  @sa GAutoPtrDeleter<gchar *>
+ *
+ */
+using GStrvPtr = GAutoPtr<gchar *>;
+
+/**
+ *  @brief
+ *    Owning smart pointer for a *borrowed* null-terminated GLib string
+ *    array: the container is caller-owned, the strings are not.
+ *
+ *  Alias for `GAutoPtr<const gchar *>`. Use for arrays returned by
+ *  shallow-copy APIs that hand back the vector but retain ownership of
+ *  the strings, canonically `g_variant_get_strv()`. Only the array is
+ *  released, with `g_free()`; the strings stay owned by their source
+ *  (e.g. the `GVariant`) and must **not** be freed.
+ *
+ *  Stored pointer: `const gchar **`. Released with: `g_free()` on the
+ *  array only.
+ *
+ *  @warning
+ *    The `const` is load-bearing, not cosmetic: because `const gchar **`
+ *    does not convert to `gchar **` (or vice versa), it is what makes
+ *    routing a borrowed array into the owning `GStrvPtr` deleter, or an
+ *    owned array into this one, a compile error. Do not strip it to
+ *    "simplify" the type.
+ *
+ *  @sa GStrvPtr
+ *  @sa GAutoPtrDeleter<const gchar *>
+ *
+ */
+using GBorrowedStrvPtr = GAutoPtr<const gchar *>;
+
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -120,7 +120,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     VerifyOrReturnValue(mWpaSupplicant.iface, false);
-    GAutoPtr<gchar> state(wpa_supplicant_1_interface_dup_state(mWpaSupplicant.iface.get()));
+    GCharPtr state(wpa_supplicant_1_interface_dup_state(mWpaSupplicant.iface.get()));
     // The "completed" state indicates that we are associated with the access point.
     return g_strcmp0(state.get(), "completed") == 0;
 }
@@ -936,7 +936,7 @@ static CHIP_ERROR AddOrReplaceBlob(WpaSupplicant1Interface * iface, const char *
     GAutoPtr<GError> err;
     if (!wpa_supplicant_1_interface_call_remove_blob_sync(iface, name, nullptr, &err.GetReceiver()))
     {
-        GAutoPtr<gchar> remoteError(g_dbus_error_get_remote_error(err.get()));
+        GCharPtr remoteError(g_dbus_error_get_remote_error(err.get()));
         if (!(remoteError && strcmp(remoteError.get(), kWpaSupplicantBlobUnknown) == 0))
         {
             ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to remove blob: %s",
@@ -1429,7 +1429,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetBssInfo(const char * bssPath, NetworkCom
         {
             return res;
         }
-        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
@@ -1460,7 +1460,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetBssInfo(const char * bssPath, NetworkCom
         {
             return res;
         }
-        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -120,7 +120,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     VerifyOrReturnValue(mWpaSupplicant.iface, false);
-    GAutoPtr<char> state(wpa_supplicant_1_interface_dup_state(mWpaSupplicant.iface.get()));
+    GAutoPtr<gchar> state(wpa_supplicant_1_interface_dup_state(mWpaSupplicant.iface.get()));
     // The "completed" state indicates that we are associated with the access point.
     return g_strcmp0(state.get(), "completed") == 0;
 }
@@ -936,7 +936,7 @@ static CHIP_ERROR AddOrReplaceBlob(WpaSupplicant1Interface * iface, const char *
     GAutoPtr<GError> err;
     if (!wpa_supplicant_1_interface_call_remove_blob_sync(iface, name, nullptr, &err.GetReceiver()))
     {
-        GAutoPtr<char> remoteError(g_dbus_error_get_remote_error(err.get()));
+        GAutoPtr<gchar> remoteError(g_dbus_error_get_remote_error(err.get()));
         if (!(remoteError && strcmp(remoteError.get(), kWpaSupplicantBlobUnknown) == 0))
         {
             ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to remove blob: %s",
@@ -1429,7 +1429,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetBssInfo(const char * bssPath, NetworkCom
         {
             return res;
         }
-        GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
@@ -1460,7 +1460,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetBssInfo(const char * bssPath, NetworkCom
         {
             return res;
         }
-        GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     // If get property is called inside dbus thread (we are going to make it so), XXX_get_XXX can be used instead of XXX_dup_XXX
     // which is a little bit faster and the returned object doesn't need to be freed. Same for all following get properties.
-    GAutoPtr<char> role(openthread_border_router_dup_device_role(mProxy.get()));
+    GAutoPtr<gchar> role(openthread_border_router_dup_device_role(mProxy.get()));
     if (role)
     {
         ThreadDeviceRoleChangedHandler(role.get());
@@ -440,7 +440,7 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     }
 
-    GAutoPtr<char> role(openthread_border_router_dup_device_role(mProxy.get()));
+    GAutoPtr<gchar> role(openthread_border_router_dup_device_role(mProxy.get()));
     if (!role)
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     if (strcmp(role.get(), kOpenthreadDeviceRoleDetached) == 0 || strcmp(role.get(), kOpenthreadDeviceRoleDisabled) == 0)

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     // If get property is called inside dbus thread (we are going to make it so), XXX_get_XXX can be used instead of XXX_dup_XXX
     // which is a little bit faster and the returned object doesn't need to be freed. Same for all following get properties.
-    GAutoPtr<gchar> role(openthread_border_router_dup_device_role(mProxy.get()));
+    GCharPtr role(openthread_border_router_dup_device_role(mProxy.get()));
     if (role)
     {
         ThreadDeviceRoleChangedHandler(role.get());
@@ -440,7 +440,7 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     }
 
-    GAutoPtr<gchar> role(openthread_border_router_dup_device_role(mProxy.get()));
+    GCharPtr role(openthread_border_router_dup_device_role(mProxy.get()));
     if (!role)
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     if (strcmp(role.get(), kOpenthreadDeviceRoleDetached) == 0 || strcmp(role.get(), kOpenthreadDeviceRoleDisabled) == 0)

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -286,7 +286,7 @@ bool WpaSupplicantClient::GetBssInfo(const gchar * inBssPath,
         {
             return res;
         }
-        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
@@ -317,7 +317,7 @@ bool WpaSupplicantClient::GetBssInfo(const gchar * inBssPath,
         {
             return res;
         }
-        GAutoPtr<const gchar *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHandle = keyMgmts.get();
 
         VerifyOrReturnError(keyMgmtsHandle != nullptr, res);

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -256,8 +256,8 @@ protected:
     {
         GAutoPtr<WpaSupplicant1> proxy;
         GAutoPtr<WpaSupplicant1Interface> iface;
-        GAutoPtr<gchar> interfacePath;
-        GAutoPtr<gchar> networkPath;
+        GCharPtr interfacePath;
+        GCharPtr networkPath;
 
         // Must be called synchronously on the GLib thread while the
         // GLib main loop is still running.

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -256,8 +256,8 @@ protected:
     {
         GAutoPtr<WpaSupplicant1> proxy;
         GAutoPtr<WpaSupplicant1Interface> iface;
-        GAutoPtr<char> interfacePath;
-        GAutoPtr<char> networkPath;
+        GAutoPtr<gchar> interfacePath;
+        GAutoPtr<gchar> networkPath;
 
         // Must be called synchronously on the GLib thread while the
         // GLib main loop is still running.

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -117,7 +117,7 @@ CHIP_ERROR BluezAdvertisement::Init(BluezAdapter1 * apAdapter, const char * aAdv
 
     mAdapter.reset(reinterpret_cast<BluezAdapter1 *>(g_object_ref(apAdapter)));
 
-    GAutoPtr<char> rootPath;
+    GAutoPtr<gchar> rootPath;
     g_object_get(G_OBJECT(mEndpoint.GetGattApplicationObjectManager()), "object-path", &rootPath.GetReceiver(), nullptr);
     g_snprintf(mAdvPath, sizeof(mAdvPath), "%s/advertising", rootPath.get());
     chip::Platform::CopyString(mAdvUUID, aAdvUUID);
@@ -180,7 +180,7 @@ CHIP_ERROR BluezAdvertisement::SetupServiceData(ServiceDataFlags aFlags)
 
     GVariant * serviceData = g_variant_builder_end(&serviceDataBuilder);
 
-    GAutoPtr<char> debugStr(g_variant_print(serviceData, TRUE));
+    GAutoPtr<gchar> debugStr(g_variant_print(serviceData, TRUE));
     ChipLogDetail(DeviceLayer, "SET service data to %s", StringOrNullMarker(debugStr.get()));
 
     bluez_leadvertisement1_set_service_data(mAdv.get(), serviceData);

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -117,7 +117,7 @@ CHIP_ERROR BluezAdvertisement::Init(BluezAdapter1 * apAdapter, const char * aAdv
 
     mAdapter.reset(reinterpret_cast<BluezAdapter1 *>(g_object_ref(apAdapter)));
 
-    GAutoPtr<gchar> rootPath;
+    GCharPtr rootPath;
     g_object_get(G_OBJECT(mEndpoint.GetGattApplicationObjectManager()), "object-path", &rootPath.GetReceiver(), nullptr);
     g_snprintf(mAdvPath, sizeof(mAdvPath), "%s/advertising", rootPath.get());
     chip::Platform::CopyString(mAdvUUID, aAdvUUID);
@@ -180,7 +180,7 @@ CHIP_ERROR BluezAdvertisement::SetupServiceData(ServiceDataFlags aFlags)
 
     GVariant * serviceData = g_variant_builder_end(&serviceDataBuilder);
 
-    GAutoPtr<gchar> debugStr(g_variant_print(serviceData, TRUE));
+    GCharPtr debugStr(g_variant_print(serviceData, TRUE));
     ChipLogDetail(DeviceLayer, "SET service data to %s", StringOrNullMarker(debugStr.get()));
 
     bluez_leadvertisement1_set_service_data(mAdv.get(), serviceData);

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -226,7 +226,7 @@ BluezGattCharacteristic1 * BluezEndpoint::CreateGattCharacteristic(BluezGattServ
                                                                    const char * aUUID, const char * const * aFlags)
 {
     const char * servicePath = g_dbus_object_get_object_path(g_dbus_interface_get_object(G_DBUS_INTERFACE(aService)));
-    GAutoPtr<gchar> charPath(g_strdup_printf("%s/%s", servicePath, aCharName));
+    GCharPtr charPath(g_strdup_printf("%s/%s", servicePath, aCharName));
     BluezObjectSkeleton * object;
     BluezGattCharacteristic1 * characteristic;
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -226,7 +226,7 @@ BluezGattCharacteristic1 * BluezEndpoint::CreateGattCharacteristic(BluezGattServ
                                                                    const char * aUUID, const char * const * aFlags)
 {
     const char * servicePath = g_dbus_object_get_object_path(g_dbus_interface_get_object(G_DBUS_INTERFACE(aService)));
-    GAutoPtr<char> charPath(g_strdup_printf("%s/%s", servicePath, aCharName));
+    GAutoPtr<gchar> charPath(g_strdup_printf("%s/%s", servicePath, aCharName));
     BluezObjectSkeleton * object;
     BluezGattCharacteristic1 * characteristic;
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -119,8 +119,8 @@ private:
     bool mIsInitialized = false;
 
     // Paths for objects published by this service
-    GAutoPtr<char> mRootPath;
-    GAutoPtr<char> mServicePath;
+    GAutoPtr<gchar> mRootPath;
+    GAutoPtr<gchar> mServicePath;
 
     // Objects (interfaces) published by this service
     GAutoPtr<GDBusObjectManagerServer> mRoot;
@@ -134,7 +134,7 @@ private:
 
     std::unordered_map<std::string, BluezConnection *> mConnMap;
     GAutoPtr<GCancellable> mConnectCancellable;
-    GAutoPtr<char> mPeerDevicePath;
+    GAutoPtr<gchar> mPeerDevicePath;
 
     // Allow BluezConnection to access our private members
     friend class BluezConnection;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -119,8 +119,8 @@ private:
     bool mIsInitialized = false;
 
     // Paths for objects published by this service
-    GAutoPtr<gchar> mRootPath;
-    GAutoPtr<gchar> mServicePath;
+    GCharPtr mRootPath;
+    GCharPtr mServicePath;
 
     // Objects (interfaces) published by this service
     GAutoPtr<GDBusObjectManagerServer> mRoot;
@@ -134,7 +134,7 @@ private:
 
     std::unordered_map<std::string, BluezConnection *> mConnMap;
     GAutoPtr<GCancellable> mConnectCancellable;
-    GAutoPtr<gchar> mPeerDevicePath;
+    GCharPtr mPeerDevicePath;
 
     // Allow BluezConnection to access our private members
     friend class BluezConnection;


### PR DESCRIPTION
### Summary

Makes `GAutoPtr` string ownership self-documenting at the call site. Resolves #72787. Builds on the GLibTypeDeleter.h documentation pass (#72771). Two commits:

1. _Spell GLib character strings as `gchar` (no functional change)_:
    * `char` -> `gchar` at call sites and member declarations where the pointee is a GLib allocation, so it is textually clear these are _GLib_ strings, **not** `std`/C `char` buffers.
   * `gchar` is `typedef char`; genuine C `char` uses are left alone.
2. _Add and adopt aliases_:
   * Three `GAutoPtr` aliases that put the ownership contract into the type name, with all call sites converted:

```c++
       using GStrvPtr         = GAutoPtr<gchar *>;        // owned strv,    g_strfreev
       using GBorrowedStrvPtr = GAutoPtr<const gchar *>;  // borrowed strv, g_free container
       using GCharPtr         = GAutoPtr<gchar>;          // one string,    g_free
```

**No functional change:** Each alias is an exact synonym for the instantiation it replaces; deleters are unmodified.

#### Why

The owned/borrowed strv distinction is carried entirely by a `const` that is easy to miss, and the borrowed form was spelled two ways in-tree (`const char *` versus `const gchar *`). The clearest example is the g_variant_get_strv() key-management loops:

##### Before

```c++
    GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
    const gchar ** keyMgmtsHandle = keyMgmts.get();
    // ... walk, freeing nothing ...
```

##### After

```c++
    GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
    const gchar ** keyMgmtsHandle = keyMgmts.get();
    // type now states the strings must not be freed
```

The `.get()` return type is unchanged (`const gchar **`), so the raw iteration that follows is untouched; only the declaration line changes.

#### Scope

- GLib char-string sites/members -> `gchar`
- All owned-strv sites           -> `GStrvPtr`
- All borrowed-strv sites (both prior spellings) -> `GBorrowedStrvPtr`
- All single-string sites        -> `GCharPtr`

After this change these spellings are the only sanctioned ones for their respective concepts; raw `GAutoPtr<gchar *>` / `GAutoPtr<const gchar *>` / `GAutoPtr<gchar>` at a call site should be flagged in future review.

### Related issues

Fixes #72787.

### Testing

- `char` -> `gchar` is a typedef-equivalent spelling change; alias adoption is a   type-name substitution with identical semantics.
- Builds on Linux (aarch64/armv7l) unchanged.
- `chip-tool` Wi-Fi path exercised (the keyMgmt loops): network-scan key management parsing behaves as before.