### PR TITLE
[Fix] Apply Thermostat preset setpoints when activating a preset (SetActivePresetRequest)

### DIFF
--- a/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
@@ -329,9 +329,9 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
 
         // Write the heating setpoint first when both setpoints are moving down to avoid
         // transiently violating the deadband (cooling - heating >= MinSetpointDeadBand).
-        int16_t currentHeating  = 0;
-        bool hasCurrentHeating  = (OccupiedHeatingSetpoint::Get(endpoint, &currentHeating) == Status::Success);
-        bool writeHeatingFirst  = heatingSetpointValue.HasValue() && coolingSetpointValue.HasValue() && hasCurrentHeating &&
+        int16_t currentHeating = 0;
+        bool hasCurrentHeating = (OccupiedHeatingSetpoint::Get(endpoint, &currentHeating) == Status::Success);
+        bool writeHeatingFirst = heatingSetpointValue.HasValue() && coolingSetpointValue.HasValue() && hasCurrentHeating &&
             EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint) < currentHeating;
 
         if (writeHeatingFirst)

--- a/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
@@ -18,6 +18,7 @@
 #include "ThermostatClusterPresets.h"
 #include "ThermostatCluster.h"
 
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 using namespace chip;
@@ -116,18 +117,22 @@ bool MatchingPendingPresetExists(Delegate * delegate, const PresetStructWithOwne
 
 /**
  * @brief Finds and returns an entry in the Presets attribute list that matches
- *        a preset, if such an entry exists. The presetToMatch must have a preset handle.
+ *        the given preset handle, if such an entry exists.
  *
  * @param[in] delegate The delegate to use.
- * @param[in] presetToMatch The preset to match with.
- * @param[out] matchingPreset The preset in the Presets attribute list that has the same PresetHandle as the presetToMatch.
+ * @param[in] presetHandle The preset handle to match against entries in the Presets attribute list.
+ * @param[out] matchingPreset The preset in the Presets attribute list that has the same PresetHandle as @p presetHandle.
+ *                            Only valid if @p found is set to true.
+ * @param[out] found Set to true if a matching preset was found; set to false if no matching preset exists.
  *
- * @return true if a matching entry was found in the  presets attribute list, false otherwise.
+ * @return CHIP_NO_ERROR if the lookup completed (regardless of whether a matching preset was found);
+ *         otherwise an appropriate error code.
  */
-bool GetMatchingPresetInPresets(Delegate * delegate, const DataModel::Nullable<ByteSpan> & presetHandle,
-                                PresetStructWithOwnedMembers & matchingPreset)
+CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & presetHandle,
+                                      PresetStructWithOwnedMembers & matchingPreset, bool & found)
 {
-    VerifyOrReturnValue(delegate != nullptr, false);
+    found = false;
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     for (uint8_t i = 0; true; i++)
     {
@@ -140,16 +145,18 @@ bool GetMatchingPresetInPresets(Delegate * delegate, const DataModel::Nullable<B
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "GetMatchingPresetInPresets: GetPresetAtIndex failed with error %" CHIP_ERROR_FORMAT, err.Format());
-            return false;
+            return err;
         }
 
-        // Note: presets coming from our delegate always have a handle.
-        if (presetHandle.Value().data_equal(matchingPreset.GetPresetHandle().Value()))
+        // Treat presets with a null handle as non-matching.
+        auto presetHandleFromPreset = matchingPreset.GetPresetHandle();
+        if (!presetHandleFromPreset.IsNull() && presetHandle.data_equal(presetHandleFromPreset.Value()))
         {
-            return true;
+            found = true;
+            return CHIP_NO_ERROR;
         }
     }
-    return false;
+    return CHIP_NO_ERROR;
 }
 
 /**
@@ -302,10 +309,44 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         return Status::InvalidInState;
     }
 
-    // If the preset handle passed in the command is not present in the Presets attribute, return INVALID_COMMAND.
-    if (!presetHandle.IsNull() && !IsPresetHandlePresentInPresets(delegate, presetHandle.Value()))
+    if (!presetHandle.IsNull())
     {
-        return Status::InvalidCommand;
+        PresetStructWithOwnedMembers matchingPreset;
+        bool found           = false;
+        CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, presetHandle.Value(), matchingPreset, found);
+        if (lookupErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Failed to lookup preset with error %" CHIP_ERROR_FORMAT, lookupErr.Format());
+            return StatusIB(lookupErr).mStatus;
+        }
+        if (!found)
+        {
+            return Status::InvalidCommand;
+        }
+
+        Optional<int16_t> coolingSetpointValue = matchingPreset.GetCoolingSetpoint();
+        if (coolingSetpointValue.HasValue())
+        {
+            int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
+            Status status                      = OccupiedCoolingSetpoint::Set(endpoint, constrainedCoolingSetpoint);
+            if (status != Status::Success)
+            {
+                ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
+                return status;
+            }
+        }
+
+        Optional<int16_t> heatingSetpointValue = matchingPreset.GetHeatingSetpoint();
+        if (heatingSetpointValue.HasValue())
+        {
+            int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
+            Status status                      = OccupiedHeatingSetpoint::Set(endpoint, constrainedHeatingSetpoint);
+            if (status != Status::Success)
+            {
+                ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));
+                return status;
+            }
+        }
     }
 
     CHIP_ERROR err = delegate->SetActivePresetHandle(presetHandle);
@@ -341,7 +382,13 @@ CHIP_ERROR ThermostatAttrAccess::AppendPendingPreset(Thermostat::Delegate * dele
         // Per spec we need to check that:
         // (a) There is an existing non-pending preset with this handle.
         PresetStructWithOwnedMembers matchingPreset;
-        if (!GetMatchingPresetInPresets(delegate, preset.GetPresetHandle().Value(), matchingPreset))
+        bool found           = false;
+        CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, preset.GetPresetHandle().Value(), matchingPreset, found);
+        if (lookupErr != CHIP_NO_ERROR)
+        {
+            return CHIP_IM_GLOBAL_STATUS(InvalidInState);
+        }
+        if (!found)
         {
             return CHIP_IM_GLOBAL_STATUS(NotFound);
         }

--- a/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterPresets.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & pres
     {
         CHIP_ERROR err = delegate->GetPresetAtIndex(i, matchingPreset);
 
-        if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
+        if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED || err == CHIP_ERROR_NOT_FOUND)
         {
             break;
         }
@@ -325,19 +325,16 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         }
 
         Optional<int16_t> coolingSetpointValue = matchingPreset.GetCoolingSetpoint();
-        if (coolingSetpointValue.HasValue())
-        {
-            int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
-            Status status                      = OccupiedCoolingSetpoint::Set(endpoint, constrainedCoolingSetpoint);
-            if (status != Status::Success)
-            {
-                ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
-                return status;
-            }
-        }
-
         Optional<int16_t> heatingSetpointValue = matchingPreset.GetHeatingSetpoint();
-        if (heatingSetpointValue.HasValue())
+
+        // Write the heating setpoint first when both setpoints are moving down to avoid
+        // transiently violating the deadband (cooling - heating >= MinSetpointDeadBand).
+        int16_t currentHeating  = 0;
+        bool hasCurrentHeating  = (OccupiedHeatingSetpoint::Get(endpoint, &currentHeating) == Status::Success);
+        bool writeHeatingFirst  = heatingSetpointValue.HasValue() && coolingSetpointValue.HasValue() && hasCurrentHeating &&
+            EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint) < currentHeating;
+
+        if (writeHeatingFirst)
         {
             int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
             Status status                      = OccupiedHeatingSetpoint::Set(endpoint, constrainedHeatingSetpoint);
@@ -345,6 +342,37 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
             {
                 ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));
                 return status;
+            }
+            int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
+            status                             = OccupiedCoolingSetpoint::Set(endpoint, constrainedCoolingSetpoint);
+            if (status != Status::Success)
+            {
+                ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
+                return status;
+            }
+        }
+        else
+        {
+            if (coolingSetpointValue.HasValue())
+            {
+                int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
+                Status status                      = OccupiedCoolingSetpoint::Set(endpoint, constrainedCoolingSetpoint);
+                if (status != Status::Success)
+                {
+                    ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
+                    return status;
+                }
+            }
+
+            if (heatingSetpointValue.HasValue())
+            {
+                int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
+                Status status                      = OccupiedHeatingSetpoint::Set(endpoint, constrainedHeatingSetpoint);
+                if (status != Status::Success)
+                {
+                    ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));
+                    return status;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary

Fixes `SetActivePreset` so that activating a preset correctly applies the preset's setpoints to the runtime attributes before updating `ActivePresetHandle`.

##### Problem

- `SetActivePreset` only validated that the requested preset handle existed in the `Presets` list, then called `SetActivePresetHandle` directly.
- The preset's `OccupiedCoolingSetpoint` and `OccupiedHeatingSetpoint` values were **never applied** to the corresponding runtime attributes, so the thermostat's operating setpoints remained unchanged after a `SetActivePresetRequest` command.

##### Solution

- `SetActivePreset` now resolves the target preset once via `GetMatchingPresetInPresets`, applies the preset's cooling and heating setpoints (with existing limit enforcement via `EnforceCoolingSetpointLimits` / `EnforceHeatingSetpointLimits`) before calling `SetActivePresetHandle`.
- `GetMatchingPresetInPresets` is refactored from returning `bool` to returning `CHIP_ERROR` with a separate `bool & found` output parameter, allowing lookup failures to be distinguished from "preset not found" and propagated as accurate IM status values.
- Presets with a null handle are now explicitly treated as non-matching, removing a latent null-dereference risk in the loop.
- Logging added on all failure paths for easier debugging.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/72791

#### Testing

Tested with thermostat/linux example:
https://github.com/project-chip/connectedhomeip/tree/master/examples/thermostat/linux

I am not a member of the CSA, so I do not have permission to update the Python test file. I don't know what step number to assign to a new test.

- Built and validated with the `thermostat/linux` example.
- Manually exercised `SetActivePresetRequest` and confirmed that `OccupiedCoolingSetpoint` and `OccupiedHeatingSetpoint` are updated to the preset values after activation.

```
[1782761982.942] [145428:145428] [EM] >>> [E:43479r S:42004 M:81306921] (S) Msg RX from 1:000000000001B669 [269A] to 0000000000000089 --- Type 0001:08 (IM:InvokeCommandRequest) (B:80)
[1782761982.943] [145428:145428] [EM] Handling via exchange: 43479r, Delegate: 0x5758ddbcdb88
[1782761982.943] [145428:145428] [DMG] InvokeRequestMessage =
[1782761982.943] [145428:145428] [DMG] {
[1782761982.943] [145428:145428] [DMG]  suppressResponse = false, 
[1782761982.943] [145428:145428] [DMG]  timedRequest = false, 
[1782761982.943] [145428:145428] [DMG]  InvokeRequests =
[1782761982.943] [145428:145428] [DMG]  [
[1782761982.943] [145428:145428] [DMG]          CommandDataIB =
[1782761982.943] [145428:145428] [DMG]          {
[1782761982.943] [145428:145428] [DMG]                  CommandPathIB =
[1782761982.943] [145428:145428] [DMG]                  {
[1782761982.943] [145428:145428] [DMG]                          EndpointId = 0x1,
[1782761982.943] [145428:145428] [DMG]                          ClusterId = 0x201,
[1782761982.943] [145428:145428] [DMG]                          CommandId = 0x6,
[1782761982.943] [145428:145428] [DMG]                  },
[1782761982.943] [145428:145428] [DMG] 
[1782761982.943] [145428:145428] [DMG]                  CommandFields = 
[1782761982.943] [145428:145428] [DMG]                  {
[1782761982.943] [145428:145428] [DMG]                          0x0 = [
[1782761982.943] [145428:145428] [DMG]                                          0x01, 
[1782761982.943] [145428:145428] [DMG]                          ] (1 bytes)
[1782761982.943] [145428:145428] [DMG]                  },
[1782761982.943] [145428:145428] [DMG]          },
[1782761982.943] [145428:145428] [DMG] 
[1782761982.943] [145428:145428] [DMG]  ],
[1782761982.943] [145428:145428] [DMG] 
[1782761982.943] [145428:145428] [DMG]  InteractionModelRevision = 11
[1782761982.943] [145428:145428] [DMG] },
[1782761982.943] [145428:145428] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=o r=i
[1782761982.943] [145428:145428] [DMG] AccessControl: allowed
[1782761982.943] [145428:145428] [DMG] Received command for Endpoint=1 Cluster=0x0000_0201 Command=0x0000_0006
[1782761982.943] [145428:145428] [-] Set ActivePresetHandle to 
[1782761982.943] [145428:145428] [-] 0x01, 
[1782761982.943] [145428:145428] [DMG] Cannot merge the new path into any existing path, create one.
[1782761982.943] [145428:145428] [DMG] Command handler moving to [NewRespons]
[1782761982.943] [145428:145428] [DMG] Command handler moving to [ Preparing]
[1782761982.943] [145428:145428] [DMG] Command handler moving to [AddingComm]
[1782761982.943] [145428:145428] [DMG] Command handler moving to [AddedComma]
[1782761982.943] [145428:145428] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 1
[1782761982.943] [145428:145428] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 0
[1782761982.943] [145428:145428] [DMG] Command handler moving to [AwaitingDe]
[1782761982.943] [145428:145428] [EM] <<< [E:43479r S:42004 M:119002304 (Ack:81306921)] (S) Msg TX from 0000000000000089 to 1:000000000001B669 [269A] [UDP:[fe80::ec28:db1f:6506:3c00%ens33]:47370] --- Type 0001:09 (IM:InvokeCommandResponse) (B:68)
[1782761982.944] [145428:145428] [EM] ??1 [E:43479r S:42004 M:119002304] (S) Msg Retransmission to 1:000000000001B669 scheduled for 390ms from now [State:Active II:500 AI:300 AT:4000]
[1782761982.944] [145428:145428] [DMG] Command response sender moving to [AllInvokeR]
[1782761982.944] [145428:145428] [DMG] Building Reports for ReadHandler with LastReportGeneration = 0x0000002D DirtyGeneration = 0x0000002E
[1782761982.945] [145428:145428] [DMG] <RE:Run> Cluster 201, Attribute 4e is dirty
[1782761982.945] [145428:145428] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1782761982.945] [145428:145428] [DMG] AccessControl: allowed
[1782761982.945] [145428:145428] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1782761982.945] [145428:145428] [DMG] AccessControl: allowed
[1782761982.945] [145428:145428] [DMG] Reading attribute: Cluster=0x0000_0201 Endpoint=0x1 AttributeId=0x0000_004E (expanded=1)
[1782761982.945] [145428:145428] [DMG] Fetched 0 events
[1782761982.945] [145428:145428] [DMG] <RE> Sending report (payload has 42 bytes)...
[1782761982.945] [145428:145428] [EM] <<< [E:4001i S:42004 M:119002305] (S) Msg TX from 0000000000000089 to 1:000000000001B669 [269A] [UDP:[fe80::ec28:db1f:6506:3c00%ens33]:47370] --- Type 0001:05 (IM:ReportData) (B:72)
[1782761982.946] [145428:145428] [EM] ??1 [E:4001i S:42004 M:119002305] (S) Msg Retransmission to 1:000000000001B669 scheduled for 387ms from now [State:Active II:500 AI:300 AT:4000]
[1782761982.946] [145428:145428] [DMG] IM RH moving to [AwaitingReportResponse]
[1782761982.946] [145428:145428] [DMG] <RE> ReportsInFlight = 1 with readHandler 0, RE has no more messages
[1782761982.946] [145428:145428] [DMG] All ReadHandler-s are clean, clear GlobalDirtySet
[1782761982.952] [145428:145428] [EM] >>> [E:43479r S:42004 M:81306922 (Ack:119002304)] (S) Msg RX from 1:000000000001B669 [269A] to 0000000000000089 --- Type 0000:10 (SecureChannel:StandaloneAck) (B:50)
[1782761982.952] [145428:145428] [EM] Found matching exchange: 43479r, Delegate: (nil)
[1782761982.952] [145428:145428] [EM] Rxd Ack; Removing MessageCounter:119002304 from Retrans Table on exchange 43479r
[1782761982.974] [145428:145428] [EM] >>> [E:4001i S:42004 M:81306923 (Ack:119002305)] (S) Msg RX from 1:000000000001B669 [269A] to 0000000000000089 --- Type 0001:01 (IM:StatusResponse) (B:42)
[1782761982.974] [145428:145428] [EM] Found matching exchange: 4001i, Delegate: 0x5758dec3d0c8
[1782761982.974] [145428:145428] [EM] Rxd Ack; Removing MessageCounter:119002305 from Retrans Table on exchange 4001i
[1782761982.974] [145428:145428] [DMG] StatusResponseMessage =
[1782761982.974] [145428:145428] [DMG] {
[1782761982.974] [145428:145428] [DMG]  Status = 0x00 (SUCCESS),
[1782761982.974] [145428:145428] [DMG]  InteractionModelRevision = 12
[1782761982.974] [145428:145428] [DMG] }
[1782761982.974] [145428:145428] [IM] Received status response, status is 0x00 (SUCCESS)
[1782761982.974] [145428:145428] [DMG] <RE> OnReportConfirm: NumReports = 0
[1782761982.974] [145428:145428] [DMG] IM RH moving to [CanStartReporting]
[1782761982.975] [145428:145428] [EM] <<< [E:4001i S:42004 M:119002306 (Ack:81306923)] (S) Msg TX from 0000000000000089 to 1:000000000001B669 [269A] [UDP:[fe80::ec28:db1f:6506:3c00%ens33]:47370] --- Type 0000:10 (SecureChannel:StandaloneAck) (B:34)
[1782761982.975] [145428:145428] [EM] Flushed pending ack for MessageCounter:81306923 on exchange 4001i
```
