### PR TITLE
[Tools] platform-bot followups: gate merges on "merge conflicts"

### DIFF
--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -334,7 +334,13 @@ class PlatformMergeBot:
         if ValidationCheck.CI not in self.skip_checks:
             ci_passed = self._has_ci_passed(pr, commit)
 
-        is_ready = not missing_approvals and not unresolved_threads and ci_passed
+        is_mergeable = pr.mergeable
+        is_ready = (
+            not missing_approvals
+            and not unresolved_threads
+            and ci_passed
+            and is_mergeable is True
+        )
 
         if not is_ready:
             log.info(
@@ -342,7 +348,12 @@ class PlatformMergeBot:
                 pr.number,
             )
             self.post_eligibility_comment(
-                pr, active_groups, missing_approvals, unresolved_threads, ci_passed
+                pr,
+                active_groups,
+                missing_approvals,
+                unresolved_threads,
+                ci_passed,
+                is_mergeable,
             )
             return
 
@@ -543,6 +554,7 @@ class PlatformMergeBot:
         missing_approvals: dict[str, PlatformGroup],
         unresolved_threads: list[dict],
         ci_passed: bool,
+        mergeable: bool | None,
     ) -> None:
         """Posts or updates a comment stating the auto-merge status of the PR."""
         # Generate comment body first so we can compare it
@@ -567,7 +579,7 @@ class PlatformMergeBot:
                 comment_body += f"    * `{glob}`\n"
 
         comment_body += "\n### Merge Requirements Status\n"
-        if not missing_approvals and not unresolved_threads and ci_passed:
+        if not missing_approvals and not unresolved_threads and ci_passed and mergeable is True:
             comment_body += "✅ **All checks passed. PR is ready for merge.**\n"
         else:
             comment_body += "⚠️ **PR is not ready to merge yet:**\n"
@@ -589,6 +601,13 @@ class PlatformMergeBot:
                 comment_body += "- ✅ All CI status and check suites passed.\n"
             else:
                 comment_body += "- ❌ CI checks are pending or failed.\n"
+
+            if mergeable is True:
+                comment_body += "- ✅ No merge conflicts.\n"
+            elif mergeable is False:
+                comment_body += "- ❌ PR has merge conflicts (resolve conflicts before merge).\n"
+            else:
+                comment_body += "- ⚠️ Mergeability state is computing on GitHub.\n"
 
         bot_comments = self._find_bot_comments(pr)
         if bot_comments:

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -121,6 +121,7 @@ esp32:
         mock_pr.user.login = author
         mock_pr.draft = draft
         mock_pr.state = "open"
+        mock_pr.mergeable = True
         mock_pr.get_files.return_value = files
         mock_pr.get_reviews.return_value = reviews
         mock_pr.get_issue_comments.return_value = comments or []
@@ -870,6 +871,34 @@ esp32:
         mock_pr.create_issue_comment.assert_called_once()
         comment_body = mock_pr.create_issue_comment.call_args[0][0]
         self.assertIn("CI checks are pending or failed", comment_body)
+
+    def test_check_and_process_pr_merge_conflicts_does_not_merge(self) -> None:
+        """Tests that a PR with merge conflicts is blocked from auto-merging."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        mock_pr.mergeable = False
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+        comment_body = mock_pr.create_issue_comment.call_args[0][0]
+        self.assertIn("PR has merge conflicts", comment_body)
+
+    def test_check_and_process_pr_merge_conflicts_computing(self) -> None:
+        """Tests that a PR whose mergeability state is still computing is blocked."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+        mock_pr.mergeable = None
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_called_once()
+        comment_body = mock_pr.create_issue_comment.call_args[0][0]
+        self.assertIn("Mergeability state is computing", comment_body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Follow-up improvement to gate auto-merges on the Pull Request's mergeability status (conflicts):

- **Gated Merges on PR Mergeability (Conflicts)**: Evaluates `pr.mergeable` status. If the PR has merge conflicts (`False`), the bot blocks the auto-merge and formats a clear conflict blocker state (`❌ PR has merge conflicts (resolve conflicts before merge)`) in the status comment. If it's still computing (`None`), it waits.
- **Improved Status Comment Requirements Checklist**: Displays a clear status for the mergeability check in the comment.

#### Testing

- Added 2 new unit tests in `scripts/tools/tests/test_platform_merge_bot.py` (totaling 39 tests) covering:
  - Merge conflicts gating (`mergeable = False`).
  - Mergeability computing state block (`mergeable = None`).
- Verified all unit and pre-commit checks pass successfully.
