### PR TITLE
[Tools] Add jepenven-silabs and lpbeliveau-silabs to the silabs platform maintainer pool

### DIFF
--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -24,13 +24,13 @@ nxp:
 silabs:
   maintainers:
     - jmartinez-silabs
+    - jepenven-silabs
+    - lpbeliveau-silabs
     # Proposed maintainers (uncomment to activate):
-    # - mkardous-silabs
     # - chirag-silabs
     # - arun-silabs
     # - rosahay-silabs
-    # - jepenven-silabs
-    # - lpbeliveau-silabs
+
   paths:
     - "src/platform/silabs/**"
     - "examples/platform/silabs/**"


### PR DESCRIPTION
### Summary
Adding two Silabs reviewers and contributors on the project as Silabs platform maintainers.
Their approvals will be enough to merge Silabs platform only PR.
- `jepenven-silabs`
- `lpbeliveau-silabs`

misc: remove `mkardous-silabs` he is not longer part of the organisations. (Silabs and CSA)

### Related issues
n/a

### Testing
n/a
