### PR TITLE
Fix Thread Commissioning error for normal commissioning process in python controller

### DIFF
--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1489,7 +1489,7 @@ class ChipDeviceControllerBase:
 
         return self._Cluster
 
-    async def FindOrEstablishPASESession(self, setupCode: str, nodeId: int, timeoutMs: typing.Optional[int] = None, baHost: typing.Optional[str] = None, baPort: typing.Optional[int] = None) -> typing.Optional[DeviceProxyWrapper]:
+    async def FindOrEstablishPASESession(self, setupCode: str, nodeId: int, timeoutMs: typing.Optional[int] = None, threadMeshCoPConfig: tuple[str, int] | None = None) -> typing.Optional[DeviceProxyWrapper]:
         '''
         Find or establish a PASE session.
 
@@ -1497,6 +1497,7 @@ class ChipDeviceControllerBase:
             setUpCode (str): The setup code of the device.
             nodeId (int): The node ID of the device.
             timeoutMs (Optional[int]): Optional timeout in milliseconds.
+            threadMeshCoPConfig (Optional[tuple[str, int]]): Optional Border Agent host and port for Thread MeshCoP PASE.
 
         Returns:
             DeviceProxyWrapper on success, if not is None.
@@ -1508,14 +1509,11 @@ class ChipDeviceControllerBase:
         if res.is_success:
             return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.COMMISSIONEE, self._dmLib)
 
-        if baHost is None:
-            if baPort is not None:
-                raise ValueError("Both baHost and baPort must be provided, or both must be None")
+        if threadMeshCoPConfig is None:
             await self.EstablishPASESession(setupCode, nodeId)
         else:
-            if baPort is None:
-                raise ValueError("Both baHost and baPort must be provided, or both must be None")
-            await self.EstablishPASESessionThreadMeshcop(baHost, setupCode, nodeId, baPort)
+            threadBorderAgentHost, threadBorderAgentPort = threadMeshCoPConfig
+            await self.EstablishPASESessionThreadMeshcop(threadBorderAgentHost, setupCode, nodeId, threadBorderAgentPort)
 
         res = await self._ChipStack.CallAsyncWithResult(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
             self.devCtrl, nodeId, byref(returnDevice)), timeoutMs)

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1489,7 +1489,7 @@ class ChipDeviceControllerBase:
 
         return self._Cluster
 
-    async def FindOrEstablishPASESession(self, setupCode: str, nodeId: int, timeoutMs: typing.Optional[int] = None) -> typing.Optional[DeviceProxyWrapper]:
+    async def FindOrEstablishPASESession(self, setupCode: str, nodeId: int, timeoutMs: typing.Optional[int] = None, baHost: typing.Optional[str] = None, baPort: typing.Optional[int] = None) -> typing.Optional[DeviceProxyWrapper]:
         '''
         Find or establish a PASE session.
 
@@ -1508,7 +1508,10 @@ class ChipDeviceControllerBase:
         if res.is_success:
             return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.COMMISSIONEE, self._dmLib)
 
-        await self.EstablishPASESession(setupCode, nodeId)
+        if baHost is None or baPort is None:
+            await self.EstablishPASESession(setupCode, nodeId)
+        else:
+            await self.EstablishPASESessionThreadMeshcop(baHost, setupCode, nodeId, baPort)
 
         res = await self._ChipStack.CallAsyncWithResult(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
             self.devCtrl, nodeId, byref(returnDevice)), timeoutMs)

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1508,12 +1508,13 @@ class ChipDeviceControllerBase:
         if res.is_success:
             return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.COMMISSIONEE, self._dmLib)
 
-        if (baHost is None) != (baPort is None):
-            raise ValueError("Both baHost and baPort must be provided, or both must be None")
-
-        if baHost is None and baPort is None:
+        if baHost is None:
+            if baPort is not None:
+                raise ValueError("Both baHost and baPort must be provided, or both must be None")
             await self.EstablishPASESession(setupCode, nodeId)
         else:
+            if baPort is None:
+                raise ValueError("Both baHost and baPort must be provided, or both must be None")
             await self.EstablishPASESessionThreadMeshcop(baHost, setupCode, nodeId, baPort)
 
         res = await self._ChipStack.CallAsyncWithResult(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1508,7 +1508,10 @@ class ChipDeviceControllerBase:
         if res.is_success:
             return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.COMMISSIONEE, self._dmLib)
 
-        if baHost is None or baPort is None:
+        if (baHost is None) != (baPort is None):
+            raise ValueError("Both baHost and baPort must be provided, or both must be None")
+
+        if baHost is None and baPort is None:
             await self.EstablishPASESession(setupCode, nodeId)
         else:
             await self.EstablishPASESessionThreadMeshcop(baHost, setupCode, nodeId, baPort)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -183,10 +183,25 @@ class Commission:
                 self.info.passcode
             )
 
-        commissionee = await self.dev_ctrl.FindOrEstablishPASESession(
-            setupCode=setup_code,
-            nodeId=self.node_id
-        )
+        if self.commissioning_info.commissioning_method == "thread-meshcop":
+            if self.commissioning_info.thread_ba_host is None:
+                raise ValueError("Thread MeshCoP PASE requires a border agent host")
+
+            if self.commissioning_info.thread_ba_port is None:
+                raise ValueError("Thread MeshCoP PASE requires a border agent port")
+
+            commissionee = await self.dev_ctrl.FindOrEstablishPASESession(
+                setupCode=setup_code,
+                nodeId=self.node_id,
+                baHost=self.commissioning_info.thread_ba_host,
+                baPort=self.commissioning_info.thread_ba_port,
+            )
+        else:
+            commissionee = await self.dev_ctrl.FindOrEstablishPASESession(
+                setupCode=setup_code,
+                nodeId=self.node_id
+            )
+
         if commissionee is None:
             raise RuntimeError("Failed to find or establish PASE session")
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -184,17 +184,16 @@ class Commission:
             )
 
         if self.commissioning_info.commissioning_method == "thread-meshcop":
-            if self.commissioning_info.thread_ba_host is None:
-                raise ValueError("Thread MeshCoP PASE requires a border agent host")
+            thread_ba_host = self.commissioning_info.thread_ba_host
+            thread_ba_port = self.commissioning_info.thread_ba_port
 
-            if self.commissioning_info.thread_ba_port is None:
-                raise ValueError("Thread MeshCoP PASE requires a border agent port")
+            if thread_ba_host is None or thread_ba_port is None:
+                raise ValueError("Thread MeshCoP PASE requires both border agent host and port")
 
             commissionee = await self.dev_ctrl.FindOrEstablishPASESession(
                 setupCode=setup_code,
                 nodeId=self.node_id,
-                baHost=self.commissioning_info.thread_ba_host,
-                baPort=self.commissioning_info.thread_ba_port,
+                threadMeshCoPConfig=(thread_ba_host, thread_ba_port),
             )
         else:
             commissionee = await self.dev_ctrl.FindOrEstablishPASESession(


### PR DESCRIPTION
### Summary

normal commissioning process in python fails for Thread Commissioning devices as the controller is trying to establish PASE session without border agent port and host. Change it to use EstablishPASESessionThreadMeshcop()

### Related issues

NA

### Testing

Tested with the TC_ACE_1_2.py script
```
python3 src/python_testing/TC_ACE_1_2.py \
  --storage-path admin_storage.json \
  --commissioning-method thread-meshcop \
  --discriminator 3840 \
  --passcode 20202021 \
  --thread-ba-host 192.168.3.2 \
  --thread-ba-port 49154 \
  --thread-dataset-hex 0e08000000000001000000030000134a0300001535060004001fffe00208f8607c0f40e7b6e50708fd73cb1ff2bf3bd20510077f0d82a19158b1ee6181c626f542e6030f4f70656e5468726561642d3563366301025c6c0410a64c65c738d20d5e25492e6238dc58c90c0402a0f7f8 \
  --timeout 900
```