### PR TITLE
Add support to input vendor_reserved fields in NOCSR elements

### DIFF
--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -272,11 +272,11 @@ CHIP_ERROR ReadRootCertificates(AttributeValueEncoder & aEncoder, FabricTable & 
     });
 }
 
-std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-                                                              TLV::TLVReader & input_arguments, FabricTable & fabricTable,
-                                                              FailSafeContext & failSafeContext,
-                                                              Credentials::DeviceAttestationCredentialsProvider & dacProvider,
-                                                              const ByteSpan (&vendorReserved)[3])
+std::optional<DataModel::ActionReturnStatus>
+HandleCSRRequest(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, TLV::TLVReader & input_arguments,
+                 FabricTable & fabricTable, FailSafeContext & failSafeContext,
+                 Credentials::DeviceAttestationCredentialsProvider & dacProvider,
+                 const ByteSpan (&vendorReserved)[OperationalCredentialsCluster::kMaxCSRVendorReservedFields])
 {
     MATTER_TRACE_SCOPE("CSRRequest", "OperationalCredentials");
     Commands::CSRRequest::DecodableType commandData;

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
@@ -275,7 +275,8 @@ CHIP_ERROR ReadRootCertificates(AttributeValueEncoder & aEncoder, FabricTable & 
 std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                                               TLV::TLVReader & input_arguments, FabricTable & fabricTable,
                                                               FailSafeContext & failSafeContext,
-                                                              Credentials::DeviceAttestationCredentialsProvider & dacProvider)
+                                                              Credentials::DeviceAttestationCredentialsProvider & dacProvider,
+                                                              const ByteSpan (&vendorReserved)[3])
 {
     MATTER_TRACE_SCOPE("CSRRequest", "OperationalCredentials");
     Commands::CSRRequest::DecodableType commandData;
@@ -312,7 +313,6 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
     {
         constexpr size_t csrLength = Crypto::kMIN_CSR_Buffer_Size;
         size_t nocsrLengthEstimate = 0;
-        ByteSpan kNoVendorReserved;
         Platform::ScopedMemoryBuffer<uint8_t> csr;
         MutableByteSpan csrSpan;
 
@@ -346,10 +346,11 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
         ChipLogProgress(Zcl, "OpCreds: AllocatePendingOperationalKey succeeded");
 
         // Encode the NOCSR elements with the CSR and Nonce
-        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),  // CSR buffer
-                                                          CSRNonce.size(), // CSR Nonce
-                                                          0u               // no vendor reserved data
-        );
+        nocsrLengthEstimate = TLV::EstimateStructOverhead(csrSpan.size(),            // CSR buffer
+                                                          CSRNonce.size(),           // CSR Nonce
+                                                          vendorReserved[0].size(),  // vendor_reserved1
+                                                          vendorReserved[1].size(),  // vendor_reserved2
+                                                          vendorReserved[2].size()); // vendor_reserved3
 
         if (!nocsrElements.Alloc(nocsrLengthEstimate + attestationChallenge.size()))
         {
@@ -361,8 +362,8 @@ std::optional<DataModel::ActionReturnStatus> HandleCSRRequest(CommandHandler * c
 
         VerifyOrExit(nocsrElementsSpan.size() >= nocsrLengthEstimate, errorStatus = Status::ConstraintError);
 
-        err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, kNoVendorReserved,
-                                                  kNoVendorReserved, kNoVendorReserved, nocsrElementsSpan);
+        err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, vendorReserved[0],
+                                                  vendorReserved[1], vendorReserved[2], nocsrElementsSpan);
         VerifyOrExit(err == CHIP_NO_ERROR, errorStatus = Status::Failure);
 
         // Append attestation challenge in the back of the reserved space for the signature
@@ -1037,6 +1038,18 @@ void OnPlatformEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, in
 }
 } // anonymous namespace
 
+CHIP_ERROR OperationalCredentialsCluster::SetCSRVendorReserved(CSRVendorReservedField field, ByteSpan data)
+{
+    auto index = static_cast<size_t>(field);
+    VerifyOrReturnError(index < kMaxCSRVendorReservedFields, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mCsrVendorReserved[index] = data;
+
+    ChipLogProgress(Zcl, "OpCreds: CSR vendor_reserved%u set (%u bytes)", static_cast<unsigned>(index + 1),
+                    static_cast<unsigned>(data.size()));
+    return CHIP_NO_ERROR;
+}
+
 void OperationalCredentialsCluster::FailSafeCleanup(const DeviceLayer::ChipDeviceEvent * event,
                                                     OperationalCredentialsCluster * cluster)
 {
@@ -1184,7 +1197,7 @@ std::optional<DataModel::ActionReturnStatus> OperationalCredentialsCluster::Invo
         return HandleCertificateChainRequest(handler, request.path, input_arguments, mOpCredsContext.dacProvider);
     case OperationalCredentials::Commands::CSRRequest::Id:
         return HandleCSRRequest(handler, request.path, input_arguments, mOpCredsContext.fabricTable,
-                                mOpCredsContext.failSafeContext, mOpCredsContext.dacProvider);
+                                mOpCredsContext.failSafeContext, mOpCredsContext.dacProvider, mCsrVendorReserved);
     case OperationalCredentials::Commands::AddNOC::Id: {
         bool reportChange = false;
         std::optional<DataModel::ActionReturnStatus> returnStatus =

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
@@ -59,7 +59,7 @@ public:
     };
 
     OperationalCredentialsCluster(EndpointId endpoint, const Context context) :
-        DefaultServerCluster({ endpoint, OperationalCredentials::Id }), mOpCredsContext(context) {};
+        DefaultServerCluster({ endpoint, OperationalCredentials::Id }), mOpCredsContext(context){};
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown(ClusterShutdownType type) override;

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
@@ -59,7 +59,7 @@ public:
     };
 
     OperationalCredentialsCluster(EndpointId endpoint, const Context context) :
-        DefaultServerCluster({ endpoint, OperationalCredentials::Id }), mOpCredsContext(context){};
+        DefaultServerCluster({ endpoint, OperationalCredentials::Id }), mOpCredsContext(context) {};
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown(ClusterShutdownType type) override;
@@ -101,7 +101,7 @@ public:
 
 private:
     const OperationalCredentialsCluster::Context mOpCredsContext;
-    ByteSpan mCsrVendorReserved[kMaxCSRVendorReservedFields];
+    ByteSpan mCsrVendorReserved[kMaxCSRVendorReservedFields] = {};
 };
 
 } // namespace Clusters

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
@@ -33,6 +33,17 @@ namespace Clusters {
 class OperationalCredentialsCluster : public DefaultServerCluster, chip::FabricTable::Delegate
 {
 public:
+    /// Number of vendor_reserved fields supported in CSRResponse NOCSRElements (context tags 3, 4, 5).
+    static constexpr size_t kMaxCSRVendorReservedFields = 3;
+
+    /// Identifies which vendor_reserved field to set in the CSRResponse NOCSRElements.
+    enum class CSRVendorReservedField : uint8_t
+    {
+        kVendorReserved1 = 0, // context tag 3
+        kVendorReserved2 = 1, // context tag 4
+        kVendorReserved3 = 2, // context tag 5
+    };
+
     struct Context
     {
         FabricTable & fabricTable;
@@ -52,6 +63,22 @@ public:
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown(ClusterShutdownType type) override;
+
+    /**
+     * @brief Set vendor-specific data to be included in CSRResponse NOCSRElements.
+     *
+     * The caller retains ownership of the underlying memory, which must remain valid for as
+     * long as it may be used to answer a CSRRequest. Pass an empty ByteSpan to clear a field.
+     *
+     * Note: the resulting nocsr_elements_message (CSR + nonce + all vendor_reserved fields)
+     * SHALL be no more than RESP_MAX (900) bytes per the Matter spec. Oversized data causes
+     * CSRRequest to fail with CHIP_ERROR_MESSAGE_TOO_LONG at construction time.
+     *
+     * @param field  Which vendor_reserved field to set.
+     * @param data   Vendor-specific data; empty span clears the field.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_ARGUMENT if field is out of range.
+     */
+    CHIP_ERROR SetCSRVendorReserved(CSRVendorReservedField field, ByteSpan data);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -74,6 +101,7 @@ public:
 
 private:
     const OperationalCredentialsCluster::Context mOpCredsContext;
+    ByteSpan mCsrVendorReserved[kMaxCSRVendorReservedFields];
 };
 
 } // namespace Clusters

--- a/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
+++ b/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.h
@@ -67,8 +67,8 @@ public:
     /**
      * @brief Set vendor-specific data to be included in CSRResponse NOCSRElements.
      *
-     * The caller retains ownership of the underlying memory, which must remain valid for as
-     * long as it may be used to answer a CSRRequest. Pass an empty ByteSpan to clear a field.
+     * The caller retains ownership of the underlying memory, which must remain valid for the
+     * lifetime of this cluster instance. Pass an empty ByteSpan to clear a field.
      *
      * Note: the resulting nocsr_elements_message (CSR + nonce + all vendor_reserved fields)
      * SHALL be no more than RESP_MAX (900) bytes per the Matter spec. Oversized data causes

--- a/src/app/clusters/operational-credentials-server/tests/TestOperationalCredentials.cpp
+++ b/src/app/clusters/operational-credentials-server/tests/TestOperationalCredentials.cpp
@@ -102,4 +102,35 @@ TEST_F(TestOperationalCredentials, TestCommands)
                                               }));
 }
 
+TEST_F(TestOperationalCredentials, TestSetCSRVendorReserved)
+{
+    OperationalCredentialsCluster::Context context = {
+        .fabricTable                = Server::GetInstance().GetFabricTable(),
+        .failSafeContext            = Server::GetInstance().GetFailSafeContext(),
+        .sessionManager             = Server::GetInstance().GetSecureSessionManager(),
+        .dnssdServer                = app::DnssdServer::Instance(),
+        .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(),
+        .dacProvider                = *Credentials::GetDeviceAttestationCredentialsProvider(),
+        .groupDataProvider          = *Server::GetInstance().GetGroupDataProvider(),
+        .accessControl              = Access::GetAccessControl(),
+        .platformManager            = DeviceLayer::PlatformMgr(),
+        .eventManagement            = EventManagement::GetInstance(),
+    };
+    OperationalCredentialsCluster cluster(kRootEndpointId, context);
+
+    using Field = OperationalCredentialsCluster::CSRVendorReservedField;
+    const uint8_t payload[]{ 0xAA, 0xBB, 0xCC };
+
+    // Each of the three valid fields can be set, and a field can be cleared with an empty span.
+    EXPECT_EQ(cluster.SetCSRVendorReserved(Field::kVendorReserved1, ByteSpan(payload)), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetCSRVendorReserved(Field::kVendorReserved2, ByteSpan(payload)), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetCSRVendorReserved(Field::kVendorReserved3, ByteSpan(payload)), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetCSRVendorReserved(Field::kVendorReserved1, ByteSpan()), CHIP_NO_ERROR);
+
+    // An out-of-range field index is rejected.
+    EXPECT_EQ(cluster.SetCSRVendorReserved(static_cast<Field>(OperationalCredentialsCluster::kMaxCSRVendorReservedFields),
+                                           ByteSpan(payload)),
+              CHIP_ERROR_INVALID_ARGUMENT);
+}
+
 } // namespace


### PR DESCRIPTION
### Summary

- Adds `OperationalCredentialsCluster::SetCSRVendorReserved()` to let applications include vendor-specific data in the CSRResponse NOCSRElements (context tags 3, 4, 5).

### Related issues

- Fixes #43758

### Testing

- New unit test.
- Verified vendor_reserved data present in CSRResponse NOCSRElements in chip-tool logs.
