### PR TITLE
[Chef] Fix contentapp failing test due to missing attribute reports 

### DIFF
--- a/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
+++ b/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
@@ -132,7 +132,8 @@ void PlatformDelegate::HandleHideApp(CommandResponseHelper<LauncherResponseType>
     {
         auto status = app->GetApplicationStatus();
         if (status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleFocus ||
-            status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleNotFocus)
+            status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleNotFocus ||
+            status == ApplicationBasic::ApplicationStatusEnum::kActiveHidden)
         {
             app->SetApplicationStatus(ApplicationBasic::ApplicationStatusEnum::kActiveHidden);
             MatterReportingAttributeChangeCallback(app->GetEndpointId(), ApplicationBasic::Id,

--- a/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
+++ b/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
@@ -96,15 +96,9 @@ void PlatformDelegate::HandleStopApp(CommandResponseHelper<LauncherResponseType>
     else
     {
         auto status = app->GetApplicationStatus();
-        if (status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleFocus ||
-            status == ApplicationBasic::ApplicationStatusEnum::kActiveHidden ||
-            status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleNotFocus ||
-            status == ApplicationBasic::ApplicationStatusEnum::kStopped)
-        {
-            app->SetApplicationStatus(ApplicationBasic::ApplicationStatusEnum::kStopped);
-            MatterReportingAttributeChangeCallback(app->GetEndpointId(), ApplicationBasic::Id,
-                                                   ApplicationBasic::Attributes::Status::Id);
-        }
+        app->SetApplicationStatus(ApplicationBasic::ApplicationStatusEnum::kStopped);
+        MatterReportingAttributeChangeCallback(app->GetEndpointId(), ApplicationBasic::Id,
+                                               ApplicationBasic::Attributes::Status::Id);
         if (app == mCurrentApp)
         {
             mCurrentApp = nullptr;

--- a/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
+++ b/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
@@ -95,7 +95,6 @@ void PlatformDelegate::HandleStopApp(CommandResponseHelper<LauncherResponseType>
     }
     else
     {
-        auto status = app->GetApplicationStatus();
         app->SetApplicationStatus(ApplicationBasic::ApplicationStatusEnum::kStopped);
         MatterReportingAttributeChangeCallback(app->GetEndpointId(), ApplicationBasic::Id,
                                                ApplicationBasic::Attributes::Status::Id);

--- a/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
+++ b/examples/chef/common/clusters/application-launch/chef-application-launch-delegate.cpp
@@ -98,7 +98,8 @@ void PlatformDelegate::HandleStopApp(CommandResponseHelper<LauncherResponseType>
         auto status = app->GetApplicationStatus();
         if (status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleFocus ||
             status == ApplicationBasic::ApplicationStatusEnum::kActiveHidden ||
-            status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleNotFocus)
+            status == ApplicationBasic::ApplicationStatusEnum::kActiveVisibleNotFocus ||
+            status == ApplicationBasic::ApplicationStatusEnum::kStopped)
         {
             app->SetApplicationStatus(ApplicationBasic::ApplicationStatusEnum::kStopped);
             MatterReportingAttributeChangeCallback(app->GetEndpointId(), ApplicationBasic::Id,

--- a/examples/chef/common/clusters/audio-output/AudioOutputManager.cpp
+++ b/examples/chef/common/clusters/audio-output/AudioOutputManager.cpp
@@ -70,7 +70,8 @@ bool AudioOutputManager::HandleRenameOutput(const uint8_t & index, const chip::C
         if (outputData.index == index)
         {
             outputData.Rename(newName);
-            MatterReportingAttributeChangeCallback(mEndpoint, AudioOutput::Id, AudioOutput::Attributes::OutputList::Id);
+            MatterReportingAttributeChangeCallback(mEndpoint, chip::app::Clusters::AudioOutput::Id,
+                                                   chip::app::Clusters::AudioOutput::Attributes::OutputList::Id);
             return true;
         }
     }

--- a/examples/chef/common/clusters/audio-output/AudioOutputManager.cpp
+++ b/examples/chef/common/clusters/audio-output/AudioOutputManager.cpp
@@ -18,6 +18,7 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeValueEncoder.h>
+#include <app/reporting/reporting.h>
 #include <app/util/config.h>
 #include <map>
 
@@ -69,6 +70,7 @@ bool AudioOutputManager::HandleRenameOutput(const uint8_t & index, const chip::C
         if (outputData.index == index)
         {
             outputData.Rename(newName);
+            MatterReportingAttributeChangeCallback(mEndpoint, AudioOutput::Id, AudioOutput::Attributes::OutputList::Id);
             return true;
         }
     }

--- a/examples/chef/common/clusters/media-input/MediaInputManager.cpp
+++ b/examples/chef/common/clusters/media-input/MediaInputManager.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/reporting/reporting.h>
 #include <app/util/config.h>
 #include <map>
 
@@ -108,6 +109,7 @@ bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharS
         if (inputData.index == index)
         {
             inputData.Rename(newName);
+            MatterReportingAttributeChangeCallback(mEndpoint, MediaInput::Id, MediaInput::Attributes::InputList::Id);
             return true;
         }
     }

--- a/examples/chef/common/clusters/media-input/MediaInputManager.cpp
+++ b/examples/chef/common/clusters/media-input/MediaInputManager.cpp
@@ -109,7 +109,8 @@ bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharS
         if (inputData.index == index)
         {
             inputData.Rename(newName);
-            MatterReportingAttributeChangeCallback(mEndpoint, MediaInput::Id, MediaInput::Attributes::InputList::Id);
+            MatterReportingAttributeChangeCallback(mEndpoint, chip::app::Clusters::MediaInput::Id,
+                                                   chip::app::Clusters::MediaInput::Attributes::InputList::Id);
             return true;
         }
     }

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -76,7 +76,8 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     mCurrentTarget     = static_cast<uint8_t>(target);
     if (targetChanged && mEndpoint != chip::kInvalidEndpointId)
     {
-        MatterReportingAttributeChangeCallback(mEndpoint, TargetNavigator::Id, TargetNavigator::Attributes::CurrentTarget::Id);
+        MatterReportingAttributeChangeCallback(mEndpoint, chip::app::Clusters::TargetNavigator::Id,
+                                               chip::app::Clusters::TargetNavigator::Attributes::CurrentTarget::Id);
     }
 
     response.data   = chip::MakeOptional("data response"_span);

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -19,6 +19,7 @@
 #ifdef MATTER_DM_PLUGIN_TARGET_NAVIGATOR_SERVER
 #include "TargetNavigatorManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/reporting/reporting.h>
 #include <lib/support/Span.h>
 
 #include <list>
@@ -71,7 +72,12 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
         TEMPORARY_RETURN_IGNORED helper.Success(response);
         return;
     }
-    mCurrentTarget = static_cast<uint8_t>(target);
+    bool targetChanged = (mCurrentTarget != static_cast<uint8_t>(target));
+    mCurrentTarget     = static_cast<uint8_t>(target);
+    if (targetChanged && mEndpoint != chip::kInvalidEndpointId)
+    {
+        MatterReportingAttributeChangeCallback(mEndpoint, TargetNavigator::Id, TargetNavigator::Attributes::CurrentTarget::Id);
+    }
 
     response.data   = chip::MakeOptional("data response"_span);
     response.status = StatusEnum::kSuccess;

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.h
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.h
@@ -36,10 +36,12 @@ public:
     void HandleNavigateTarget(chip::app::CommandResponseHelper<NavigateTargetResponseType> & responser, const uint64_t & target,
                               const chip::CharSpan & data) override;
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
+    void SetEndpointId(chip::EndpointId endpoint) { mEndpoint = endpoint; }
 
 protected:
     // NOTE: the ids for each target start at 1 so that we can reserve 0 as "no current target"
     static const uint8_t kNoCurrentTarget = 0;
+    chip::EndpointId mEndpoint            = chip::kInvalidEndpointId;
     std::list<std::string> mTargets;
     uint8_t mCurrentTarget;
 

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -493,7 +493,11 @@ void emberAfTargetNavigatorClusterInitCallback(EndpointId endpoint)
     ChipLogProgress(Zcl, "TV Linux App: TargetNavigator::SetDefaultDelegate");
     uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, TargetNavigator::Id,
                                                        MATTER_DM_TARGET_NAVIGATOR_CLUSTER_SERVER_ENDPOINT_COUNT);
-    TargetNavigator::SetDefaultDelegate(endpoint, &targetNavigatorManager[ep]);
+    if (ep < MATTER_DM_TARGET_NAVIGATOR_CLUSTER_SERVER_ENDPOINT_COUNT)
+    {
+        targetNavigatorManager[ep].SetEndpointId(endpoint);
+        TargetNavigator::SetDefaultDelegate(endpoint, &targetNavigatorManager[ep]);
+    }
 }
 #endif
 


### PR DESCRIPTION
### Summary

Fix casting video player chef app: Add missing attribute reports.
Python Tests now automatically check for attribute reports after pull/43274 which exposed missing attr reports in casting video player chef app.



### Testing

```
scripts/run_in_python_env.sh out/python_env './scripts/tests/run_python_test.py --app examples/chef/linux/out/rootnode_castingvideoplayer_contentapp_34699714e7 --factory-reset --script ./examples/chef/tests/castingvideoplayer_contentapp_test.py --script-args "--commissioning-method on-network --discriminator 3840 --passcode 20202021" --app-stdin-pipe /tmp/chef_stdin.txt'
```