### PR TITLE
[controller] Do not complete the commissioning stage from mismatched ICD management responses

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1570,7 +1570,7 @@ void DeviceCommissioner::OnICDManagementStayActiveResponse(
 
 exit:
     CommissioningDelegate::CommissioningReport report;
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
+    commissioner->CommissioningStageComplete(err, report);
 }
 
 bool DeviceCommissioner::ExtendArmFailSafeInternal(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1534,11 +1534,16 @@ void DeviceCommissioner::OnFailedToExtendedArmFailSafeDeviceAttestation(void * c
 void DeviceCommissioner::OnICDManagementRegisterClientResponse(
     void * context, const app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType & data)
 {
-    CHIP_ERROR err                    = CHIP_NO_ERROR;
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    VerifyOrExit(commissioner != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(commissioner->mCommissioningStage == CommissioningStage::kICDRegistration, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(commissioner->mDeviceBeingCommissioned != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // On any failed check below, do NOT call CommissioningStageComplete: this response tells us
+    // nothing about whatever stage is actually in progress, and completing it here would report
+    // that unrelated stage as finished (or die on a null mDeviceBeingCommissioned).
+    VerifyOrReturn(commissioner != nullptr, ChipLogError(Controller, "RegisterClientResponse received with null context"));
+    VerifyOrReturn(commissioner->mCommissioningStage == CommissioningStage::kICDRegistration,
+                   ChipLogError(Controller, "RegisterClientResponse received in incorrect stage '%s'",
+                                StageToString(commissioner->mCommissioningStage)));
+    VerifyOrReturn(commissioner->mDeviceBeingCommissioned != nullptr,
+                   ChipLogError(Controller, "RegisterClientResponse received while no device is being commissioned"));
 
     if (commissioner->mPairingDelegate != nullptr)
     {
@@ -1546,31 +1551,35 @@ void DeviceCommissioner::OnICDManagementRegisterClientResponse(
             ScopedNodeId(commissioner->mDeviceBeingCommissioned->GetDeviceId(), commissioner->GetFabricIndex()), data.ICDCounter);
     }
 
-exit:
+    // All checks passed: a successful RegisterClientResponse means the kICDRegistration stage is complete.
     CommissioningDelegate::CommissioningReport report;
-    commissioner->CommissioningStageComplete(err, report);
+    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
 
 void DeviceCommissioner::OnICDManagementStayActiveResponse(
     void * context, const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data)
 {
-    CHIP_ERROR err                    = CHIP_NO_ERROR;
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    VerifyOrExit(commissioner != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(commissioner->mCommissioningStage == CommissioningStage::kICDSendStayActive, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(commissioner->mDeviceBeingCommissioned != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // On any failed check below, do NOT call CommissioningStageComplete: this response tells us
+    // nothing about whatever stage is actually in progress, and completing it here would report
+    // that unrelated stage as finished (or die on a null mDeviceBeingCommissioned).
+    VerifyOrReturn(commissioner != nullptr, ChipLogError(Controller, "StayActiveResponse received with null context"));
+    VerifyOrReturn(commissioner->mCommissioningStage == CommissioningStage::kICDSendStayActive,
+                   ChipLogError(Controller, "StayActiveResponse received in incorrect stage '%s'",
+                                StageToString(commissioner->mCommissioningStage)));
+    VerifyOrReturn(commissioner->mDeviceBeingCommissioned != nullptr,
+                   ChipLogError(Controller, "StayActiveResponse received while no device is being commissioned"));
 
     if (commissioner->mPairingDelegate != nullptr)
     {
         commissioner->mPairingDelegate->OnICDStayActiveComplete(
-
             ScopedNodeId(commissioner->mDeviceBeingCommissioned->GetDeviceId(), commissioner->GetFabricIndex()),
             data.promisedActiveDuration);
     }
 
-exit:
+    // All checks passed: a successful StayActiveResponse means the kICDSendStayActive stage is complete.
     CommissioningDelegate::CommissioningReport report;
-    commissioner->CommissioningStageComplete(err, report);
+    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
 
 bool DeviceCommissioner::ExtendArmFailSafeInternal(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1535,9 +1535,7 @@ void DeviceCommissioner::OnICDManagementRegisterClientResponse(
     void * context, const app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType & data)
 {
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    // On any failed check below, do NOT call CommissioningStageComplete: this response tells us
-    // nothing about whatever stage is actually in progress, and completing it here would report
-    // that unrelated stage as finished (or die on a null mDeviceBeingCommissioned).
+    // On any failed check, log and return: this response says nothing about the stage actually in progress.
     VerifyOrReturn(commissioner != nullptr, ChipLogError(Controller, "RegisterClientResponse received with null context"));
     VerifyOrReturn(commissioner->mCommissioningStage == CommissioningStage::kICDRegistration,
                    ChipLogError(Controller, "RegisterClientResponse received in incorrect stage '%s'",
@@ -1551,7 +1549,7 @@ void DeviceCommissioner::OnICDManagementRegisterClientResponse(
             ScopedNodeId(commissioner->mDeviceBeingCommissioned->GetDeviceId(), commissioner->GetFabricIndex()), data.ICDCounter);
     }
 
-    // All checks passed: a successful RegisterClientResponse means the kICDRegistration stage is complete.
+    // All checks passed: the kICDRegistration stage is complete.
     CommissioningDelegate::CommissioningReport report;
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
@@ -1560,9 +1558,7 @@ void DeviceCommissioner::OnICDManagementStayActiveResponse(
     void * context, const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data)
 {
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    // On any failed check below, do NOT call CommissioningStageComplete: this response tells us
-    // nothing about whatever stage is actually in progress, and completing it here would report
-    // that unrelated stage as finished (or die on a null mDeviceBeingCommissioned).
+    // On any failed check, log and return: this response says nothing about the stage actually in progress.
     VerifyOrReturn(commissioner != nullptr, ChipLogError(Controller, "StayActiveResponse received with null context"));
     VerifyOrReturn(commissioner->mCommissioningStage == CommissioningStage::kICDSendStayActive,
                    ChipLogError(Controller, "StayActiveResponse received in incorrect stage '%s'",
@@ -1577,7 +1573,7 @@ void DeviceCommissioner::OnICDManagementStayActiveResponse(
             data.promisedActiveDuration);
     }
 
-    // All checks passed: a successful StayActiveResponse means the kICDSendStayActive stage is complete.
+    // All checks passed: the kICDSendStayActive stage is complete.
     CommissioningDelegate::CommissioningReport report;
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -53,6 +53,7 @@ chip_test_suite("tests") {
   if (chip_support_commissioning_in_controller && chip_build_controller) {
     test_sources += [
       "TestAutoCommissioner.cpp",
+      "TestICDManagementResponses.cpp",
       "TestParseICDInfo.cpp",
     ]
   }

--- a/src/controller/tests/DeviceCommissionerTestAccess.h
+++ b/src/controller/tests/DeviceCommissionerTestAccess.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include <app/DeviceProxy.h>
+#include <clusters/IcdManagement/Commands.h>
 #include <controller/CHIPDeviceController.h>
 
 namespace chip {
@@ -32,6 +34,24 @@ public:
     CHIP_ERROR ParseICDInfo(Controller::ReadCommissioningInfo & info) { return mCommissioner->ParseICDInfo(info); }
 
     void SetAttributeCache(Platform::UniquePtr<app::ClusterStateCache> cache) { mCommissioner->mAttributeCache = std::move(cache); }
+
+    void SetCommissioningStage(Controller::CommissioningStage stage) { mCommissioner->mCommissioningStage = stage; }
+
+    void SetDeviceBeingCommissioned(DeviceProxy * device) { mCommissioner->mDeviceBeingCommissioned = device; }
+
+    static void OnICDManagementRegisterClientResponse(
+        Controller::DeviceCommissioner * commissioner,
+        const app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType & data)
+    {
+        Controller::DeviceCommissioner::OnICDManagementRegisterClientResponse(commissioner, data);
+    }
+
+    static void
+    OnICDManagementStayActiveResponse(Controller::DeviceCommissioner * commissioner,
+                                      const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data)
+    {
+        Controller::DeviceCommissioner::OnICDManagementStayActiveResponse(commissioner, data);
+    }
 
 private:
     Controller::DeviceCommissioner * mCommissioner = nullptr;

--- a/src/controller/tests/TestICDManagementResponses.cpp
+++ b/src/controller/tests/TestICDManagementResponses.cpp
@@ -1,0 +1,207 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <app/DeviceProxy.h>
+#include <controller/CHIPDeviceController.h>
+#include <controller/CommissioningDelegate.h>
+#include <controller/DevicePairingDelegate.h>
+#include <controller/tests/DeviceCommissionerTestAccess.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <clusters/IcdManagement/Commands.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::Controller;
+using namespace chip::Testing;
+
+namespace {
+
+constexpr NodeId kTestNodeId = 0x12344321;
+
+class FakeDeviceProxy : public DeviceProxy
+{
+public:
+    void Disconnect() override {}
+    NodeId GetDeviceId() const override { return kTestNodeId; }
+    Messaging::ExchangeManager * GetExchangeManager() const override { return nullptr; }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return NullOptional; }
+
+protected:
+    bool IsSecureConnected() const override { return false; }
+};
+
+class MockPairingDelegate : public DevicePairingDelegate
+{
+public:
+    void OnCommissioningStatusUpdate(PeerId peerId, CommissioningStage stageCompleted, CHIP_ERROR error) override
+    {
+        mStatusUpdateCount++;
+        mLastStageCompleted = stageCompleted;
+        mLastError          = error;
+    }
+
+    void OnICDRegistrationComplete(ScopedNodeId icdNodeId, uint32_t icdCounter) override
+    {
+        mRegistrationCompleteCount++;
+        mLastICDCounter = icdCounter;
+    }
+
+    void OnICDStayActiveComplete(ScopedNodeId icdNodeId, uint32_t promisedActiveDurationMsec) override
+    {
+        mStayActiveCompleteCount++;
+        mLastPromisedActiveDuration = promisedActiveDurationMsec;
+    }
+
+    int mStatusUpdateCount                 = 0;
+    CommissioningStage mLastStageCompleted = CommissioningStage::kError;
+    CHIP_ERROR mLastError                  = CHIP_NO_ERROR;
+    int mRegistrationCompleteCount         = 0;
+    uint32_t mLastICDCounter               = 0;
+    int mStayActiveCompleteCount           = 0;
+    uint32_t mLastPromisedActiveDuration   = 0;
+};
+
+class TestICDManagementResponses : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+protected:
+    FakeDeviceProxy mDevice;
+    MockPairingDelegate mDelegate;
+    DeviceCommissioner mCommissioner{};
+};
+
+// A response landing in a stage it does not belong to must be ignored: it says nothing about
+// the stage actually in progress, so completing that stage (with any error) would be wrong.
+TEST_F(TestICDManagementResponses, StayActiveResponseInWrongStageIsIgnored)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDRegistration);
+    access.SetDeviceBeingCommissioned(&mDevice);
+
+    IcdManagement::Commands::StayActiveResponse::DecodableType data;
+    data.promisedActiveDuration = 1000u;
+    DeviceCommissionerTestAccess::OnICDManagementStayActiveResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mStayActiveCompleteCount, 0);
+    EXPECT_EQ(mDelegate.mStatusUpdateCount, 0);
+}
+
+TEST_F(TestICDManagementResponses, RegisterClientResponseInWrongStageIsIgnored)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDSendStayActive);
+    access.SetDeviceBeingCommissioned(&mDevice);
+
+    IcdManagement::Commands::RegisterClientResponse::DecodableType data;
+    data.ICDCounter = 77u;
+    DeviceCommissionerTestAccess::OnICDManagementRegisterClientResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mRegistrationCompleteCount, 0);
+    EXPECT_EQ(mDelegate.mStatusUpdateCount, 0);
+}
+
+TEST_F(TestICDManagementResponses, StayActiveResponseInCorrectStageCompletesStage)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDSendStayActive);
+    access.SetDeviceBeingCommissioned(&mDevice);
+
+    IcdManagement::Commands::StayActiveResponse::DecodableType data;
+    data.promisedActiveDuration = 1234u;
+    DeviceCommissionerTestAccess::OnICDManagementStayActiveResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mStayActiveCompleteCount, 1);
+    EXPECT_EQ(mDelegate.mLastPromisedActiveDuration, 1234u);
+    ASSERT_EQ(mDelegate.mStatusUpdateCount, 1);
+    EXPECT_EQ(mDelegate.mLastStageCompleted, CommissioningStage::kICDSendStayActive);
+    EXPECT_EQ(mDelegate.mLastError, CHIP_NO_ERROR);
+}
+
+TEST_F(TestICDManagementResponses, RegisterClientResponseInCorrectStageCompletesStage)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDRegistration);
+    access.SetDeviceBeingCommissioned(&mDevice);
+
+    IcdManagement::Commands::RegisterClientResponse::DecodableType data;
+    data.ICDCounter = 77u;
+    DeviceCommissionerTestAccess::OnICDManagementRegisterClientResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mRegistrationCompleteCount, 1);
+    EXPECT_EQ(mDelegate.mLastICDCounter, 77u);
+    ASSERT_EQ(mDelegate.mStatusUpdateCount, 1);
+    EXPECT_EQ(mDelegate.mLastStageCompleted, CommissioningStage::kICDRegistration);
+    EXPECT_EQ(mDelegate.mLastError, CHIP_NO_ERROR);
+}
+
+// Before the handlers checked-then-returned, the paths below crashed: the shared exit still
+// called CommissioningStageComplete, which dies on a null mDeviceBeingCommissioned (and the
+// null-context case dereferenced the null commissioner outright).
+TEST_F(TestICDManagementResponses, StayActiveResponseWithNoDeviceIsIgnored)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDSendStayActive);
+    access.SetDeviceBeingCommissioned(nullptr);
+
+    IcdManagement::Commands::StayActiveResponse::DecodableType data;
+    DeviceCommissionerTestAccess::OnICDManagementStayActiveResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mStayActiveCompleteCount, 0);
+    EXPECT_EQ(mDelegate.mStatusUpdateCount, 0);
+}
+
+TEST_F(TestICDManagementResponses, RegisterClientResponseWithNoDeviceIsIgnored)
+{
+    DeviceCommissionerTestAccess access(&mCommissioner);
+    mCommissioner.RegisterPairingDelegate(&mDelegate);
+    access.SetCommissioningStage(CommissioningStage::kICDRegistration);
+    access.SetDeviceBeingCommissioned(nullptr);
+
+    IcdManagement::Commands::RegisterClientResponse::DecodableType data;
+    DeviceCommissionerTestAccess::OnICDManagementRegisterClientResponse(&mCommissioner, data);
+
+    EXPECT_EQ(mDelegate.mRegistrationCompleteCount, 0);
+    EXPECT_EQ(mDelegate.mStatusUpdateCount, 0);
+}
+
+TEST_F(TestICDManagementResponses, StayActiveResponseWithNullContextIsIgnored)
+{
+    IcdManagement::Commands::StayActiveResponse::DecodableType data;
+    DeviceCommissionerTestAccess::OnICDManagementStayActiveResponse(nullptr, data);
+}
+
+TEST_F(TestICDManagementResponses, RegisterClientResponseWithNullContextIsIgnored)
+{
+    IcdManagement::Commands::RegisterClientResponse::DecodableType data;
+    DeviceCommissionerTestAccess::OnICDManagementRegisterClientResponse(nullptr, data);
+}
+
+} // namespace


### PR DESCRIPTION
#### Summary

`DeviceCommissioner::OnICDManagementRegisterClientResponse` and `OnICDManagementStayActiveResponse` used a `VerifyOrExit` pattern whose shared `exit:` label always called `CommissioningStageComplete`, so a response that failed its preconditions still completed whatever stage was in progress.

##### Problem

- **Wrong commissioning stage**: the response says nothing about the stage actually in progress, yet that unrelated stage was reported complete (`RegisterClientResponse` delivered `CHIP_ERROR_INCORRECT_STATE` for it, `StayActiveResponse` even reported it as success).
- **No device being commissioned**: the `exit:` path still called `CommissioningStageComplete`, which dies on `VerifyOrDie(mDeviceBeingCommissioned)`.
- **Null context**: the `exit:` path dereferenced the null commissioner.
- None of these paths are reachable through the normal single-threaded sequential commissioning flow (`StopPairing` cancels the in-flight command sender), so this is consistency/defense-in-depth hardening rather than a field-reachable bug.

##### Solution

- Convert each precondition in both handlers to `VerifyOrReturn` with an error log: a mismatched response is now ignored, leaving the stage actually in progress undisturbed.
- `CommissioningStageComplete(CHIP_NO_ERROR)` is reached only when all checks passed, at which point the response legitimately completes the ICD stage.
- This supersedes the first revision of this PR, which only propagated `err` at the `exit:` label; review pointed out the error paths crash before or inside `CommissioningStageComplete`, making that propagation unreachable.

#### Related issues

Fixes #72801

#### Testing

- Added `src/controller/tests/TestICDManagementResponses.cpp` covering both handlers: wrong-stage responses are ignored (no `OnCommissioningStatusUpdate`, no ICD delegate callback), no-device and null-context paths return without crashing, and correct-stage responses still complete the stage with `CHIP_NO_ERROR`.
- Verified red to green: against the previous handlers, the wrong-stage tests fail (spurious stage completion observed) and the no-device test aborts via `VerifyOrDie` in `CommissioningStageComplete`; with this change, all 8 tests pass (ASan build).
- Extended `DeviceCommissionerTestAccess` with stage/device setters and static invokers for the private handlers.
