### PR TITLE
Fix use-after-free segfault on BluezConnection pointer

### DIFF
--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -438,6 +438,14 @@ CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_O
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR BleLayer::CloseUnclaimedConnection(BLE_CONNECTION_OBJECT connObj)
+{
+    VerifyOrReturnError(mState == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mPlatformDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mPlatformDelegate->CloseConnection(connObj);
+}
+
 // Handle remote central's initiation of CHIP over BLE protocol handshake.
 CHIP_ERROR BleLayer::HandleBleTransportConnectionInitiated(BLE_CONNECTION_OBJECT connObj, PacketBufferHandle && pBuf)
 {

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -283,6 +283,9 @@ public:
 
     CHIP_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
 
+    /// Close a connection that is not associated with a BLE endpoint.
+    CHIP_ERROR CloseUnclaimedConnection(BLE_CONNECTION_OBJECT connObj);
+
     void CloseAllBleConnections();
     void CloseBleConnection(BLE_CONNECTION_OBJECT connObj);
 

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -62,9 +62,9 @@ class TestBleLayer : public BleLayer,
 public:
     // Add mOnBleConnectionCompleteCalls and mOnBleConnectionErrorCalls
     // to check if the callbacks are invoked correctly.
-    int mOnBleConnectionCompleteCalls = 0;
-    int mOnBleConnectionErrorCalls    = 0;
-    int mCloseConnectionCalls         = 0;
+    int mOnBleConnectionCompleteCalls           = 0;
+    int mOnBleConnectionErrorCalls              = 0;
+    int mCloseConnectionCalls                   = 0;
     BLE_CONNECTION_OBJECT mLastClosedConnection = BLE_CONNECTION_UNINITIALIZED;
 
     static void SetUpTestSuite()

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -64,6 +64,8 @@ public:
     // to check if the callbacks are invoked correctly.
     int mOnBleConnectionCompleteCalls = 0;
     int mOnBleConnectionErrorCalls    = 0;
+    int mCloseConnectionCalls         = 0;
+    BLE_CONNECTION_OBJECT mLastClosedConnection = BLE_CONNECTION_UNINITIALIZED;
 
     static void SetUpTestSuite()
     {
@@ -82,6 +84,8 @@ public:
         // Reset the connection flags before each test.
         mOnBleConnectionCompleteCalls = 0;
         mOnBleConnectionErrorCalls    = 0;
+        mCloseConnectionCalls         = 0;
+        mLastClosedConnection         = BLE_CONNECTION_UNINITIALIZED;
         ASSERT_EQ(Init(this, this, this, &DeviceLayer::SystemLayer()), CHIP_NO_ERROR);
         mBleTransport = this;
     }
@@ -170,7 +174,12 @@ public:
     {
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR CloseConnection(BLE_CONNECTION_OBJECT connObj) override
+    {
+        mCloseConnectionCalls++;
+        mLastClosedConnection = connObj;
+        return CHIP_NO_ERROR;
+    }
     uint16_t GetMTU(BLE_CONNECTION_OBJECT) const override { return 0; }
     CHIP_ERROR SendIndication(BLE_CONNECTION_OBJECT, const ChipBleUUID *, const ChipBleUUID *, PacketBufferHandle) override
     {
@@ -400,6 +409,15 @@ TEST_F(TestBleLayer, CloseBleConnection)
     ASSERT_TRUE(HandleWriteReceivedCapabilitiesRequest(connObj));
 
     CloseBleConnection(connObj);
+}
+
+TEST_F(TestBleLayer, CloseUnclaimedConnection)
+{
+    const auto connObj = GetConnectionObject();
+
+    EXPECT_EQ(BleLayer::CloseUnclaimedConnection(connObj), CHIP_NO_ERROR);
+    EXPECT_EQ(mCloseConnectionCalls, 1);
+    EXPECT_EQ(mLastClosedConnection, connObj);
 }
 
 TEST_F(TestBleLayer, ExceedBleConnectionEndPointLimit)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -33,6 +33,7 @@
 #include <platform/internal/NFCCommissioningManager.h>
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>
+#include <utility>
 #include <vector>
 
 constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS * chip::kMillisecondsPerSecond;
@@ -590,7 +591,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, s
         SetUpCodePairerParameters params;
         params.SetPeerAddress(Transport::PeerAddress::BLE());
         params.mLongDiscriminator = matchedLongDiscriminator;
-        mDiscoveredParameters.emplace_front(params);
+        mDiscoveredParameters.emplace_front(std::move(params));
     }
     else
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -580,7 +580,18 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, s
     // results in setup payload order.  If we do this, we might want to restrict it to
     // cases when the different payloads have different vendor/product IDs, since if
     // they are all the same product presumably ordering really does not matter.
-    mDiscoveredParameters.emplace_front(connObj, matchedLongDiscriminator);
+    if (mWaitingForPASE)
+    {
+        SetUpCodePairerParameters params;
+        params.SetPeerAddress(Transport::PeerAddress::BLE());
+        params.mLongDiscriminator = matchedLongDiscriminator;
+        mDiscoveredParameters.emplace_front(params);
+    }
+    else
+    {
+        mDiscoveredParameters.emplace_front(connObj, matchedLongDiscriminator);
+    }
+
     ConnectToDiscoveredDevice();
 }
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -578,7 +578,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, s
     // the connection object. If the DUT disconnects before this queued entry is
     // retried, that object may be invalidated by the platform. Queue
     // reconnectable BLE parameters instead so the later retry starts a fresh BLE
-    // connection.
+    // connection, then close the unused connection object.
     //
     // TODO: Consider implementing the SHOULD the spec has about commissioning things
     // in QR code order by waiting for a second or something before actually starting
@@ -592,6 +592,10 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, s
         params.SetPeerAddress(Transport::PeerAddress::BLE());
         params.mLongDiscriminator = matchedLongDiscriminator;
         mDiscoveredParameters.emplace_front(std::move(params));
+        if (mBleLayer != nullptr)
+        {
+            LogErrorOnFailure(mBleLayer->CloseUnclaimedConnection(connObj));
+        }
     }
     else
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -568,11 +568,16 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, s
     mWaitingForDiscovery[kBLETransport] = false;
 
     // In order to not wait for all the possible addresses discovered over mdns to
-    // be tried before trying to connect over BLE, the discovered connection object is
-    // inserted at the beginning of the list.
+    // be tried before trying to connect over BLE, the discovered BLE option is
+    // inserted at the beginning of the list. It makes it the 'next' thing to try
+    // to connect to if there are already some discovered parameters in the list.
     //
-    // It makes it the 'next' thing to try to connect to if there are already some
-    // discovered parameters in the list.
+    // If a PASE attempt is already in progress, do not queue connObj for later.
+    // No BLEEndPoint has been created for it yet, and the BLE platform still owns
+    // the connection object. If the DUT disconnects before this queued entry is
+    // retried, that object may be invalidated by the platform. Queue
+    // reconnectable BLE parameters instead so the later retry starts a fresh BLE
+    // connection.
     //
     // TODO: Consider implementing the SHOULD the spec has about commissioning things
     // in QR code order by waiting for a second or something before actually starting

--- a/src/controller/tests/SetUpCodePairerTestAccess.h
+++ b/src/controller/tests/SetUpCodePairerTestAccess.h
@@ -45,6 +45,9 @@ public:
 
     CHIP_ERROR GetLastPASEError() const { return mPairer->mLastPASEError; }
 
+    size_t GetDiscoveredParametersCount() const { return mPairer->mDiscoveredParameters.size(); }
+    const Controller::SetUpCodePairerParameters & FrontDiscoveredParameters() const { return mPairer->mDiscoveredParameters.front(); }
+
     bool HasCurrentPASEParameters() const { return mPairer->mCurrentPASEParameters.HasValue(); }
     void SetCurrentPASEParameters(const Controller::SetUpCodePairerParameters & params)
     {
@@ -52,6 +55,13 @@ public:
     }
 
     void ExpectPASEEstablishment() { mPairer->ExpectPASEEstablishment(); }
+
+#if CONFIG_NETWORK_LAYER_BLE
+    void CallOnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, std::optional<uint16_t> longDiscriminator)
+    {
+        mPairer->OnDiscoveredDeviceOverBle(connObj, longDiscriminator);
+    }
+#endif
 
     void CallOnPairingComplete(CHIP_ERROR error) { mPairer->OnPairingComplete(error, std::nullopt, std::nullopt); }
 

--- a/src/controller/tests/SetUpCodePairerTestAccess.h
+++ b/src/controller/tests/SetUpCodePairerTestAccess.h
@@ -46,7 +46,10 @@ public:
     CHIP_ERROR GetLastPASEError() const { return mPairer->mLastPASEError; }
 
     size_t GetDiscoveredParametersCount() const { return mPairer->mDiscoveredParameters.size(); }
-    const Controller::SetUpCodePairerParameters & FrontDiscoveredParameters() const { return mPairer->mDiscoveredParameters.front(); }
+    const Controller::SetUpCodePairerParameters & FrontDiscoveredParameters() const
+    {
+        return mPairer->mDiscoveredParameters.front();
+    }
 
     bool HasCurrentPASEParameters() const { return mPairer->mCurrentPASEParameters.HasValue(); }
     void SetCurrentPASEParameters(const Controller::SetUpCodePairerParameters & params)

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -26,6 +26,7 @@
 #include <transport/raw/PeerAddress.h>
 
 #include <memory>
+#include <optional>
 
 using namespace chip;
 using namespace chip::Controller;
@@ -168,7 +169,7 @@ TEST_F(TestSetUpCodePairer, DeferredBleDiscoveryQueuesReconnectableParams)
     Access().SetWaitingForPASE(true);
 
     auto * connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(0x1234);
-    Access().CallOnDiscoveredDeviceOverBle(connObj, std::make_optional<uint16_t>(3840));
+    Access().CallOnDiscoveredDeviceOverBle(connObj, std::optional<uint16_t>{ 3840 });
 
     ASSERT_EQ(Access().GetDiscoveredParametersCount(), 1u);
 
@@ -177,7 +178,7 @@ TEST_F(TestSetUpCodePairer, DeferredBleDiscoveryQueuesReconnectableParams)
     EXPECT_FALSE(params.HasConnectionObject());
     EXPECT_FALSE(params.HasDiscoveredObject());
     ASSERT_TRUE(params.mLongDiscriminator.has_value());
-    EXPECT_EQ(params.mLongDiscriminator.value(), 3840);
+    EXPECT_EQ(params.mLongDiscriminator, std::optional<uint16_t>{ 3840 });
 }
 #endif
 

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -162,4 +162,23 @@ TEST_F(TestSetUpCodePairer, SyncPASEFailure_ClearsCurrentPASEParameters)
     EXPECT_FALSE(Access().HasCurrentPASEParameters());
 }
 
+#if CONFIG_NETWORK_LAYER_BLE
+TEST_F(TestSetUpCodePairer, DeferredBleDiscoveryQueuesReconnectableParams)
+{
+    Access().SetWaitingForPASE(true);
+
+    auto * connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(0x1234);
+    Access().CallOnDiscoveredDeviceOverBle(connObj, std::make_optional<uint16_t>(3840));
+
+    ASSERT_EQ(Access().GetDiscoveredParametersCount(), 1u);
+
+    const auto & params = Access().FrontDiscoveredParameters();
+    EXPECT_EQ(params.GetPeerAddress().GetTransportType(), Transport::Type::kBle);
+    EXPECT_FALSE(params.HasConnectionObject());
+    EXPECT_FALSE(params.HasDiscoveredObject());
+    ASSERT_TRUE(params.mLongDiscriminator.has_value());
+    EXPECT_EQ(params.mLongDiscriminator.value(), 3840);
+}
+#endif
+
 } // namespace

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -37,15 +37,15 @@ using PairerAccess = chip::Testing::SetUpCodePairerTestAccess;
 namespace {
 
 template <typename T>
-static typename std::enable_if<std::is_integral<T>::value, T>::type MakeTestConnectionObject(unsigned int value)
+static typename std::enable_if<std::is_integral<T>::value, T>::type MakeTestConnectionObject(uint8_t *)
 {
-    return static_cast<T>(value);
+    return static_cast<T>(1);
 }
 
 template <typename T>
-static typename std::enable_if<std::is_pointer<T>::value, T>::type MakeTestConnectionObject(unsigned int value)
+static typename std::enable_if<std::is_pointer<T>::value, T>::type MakeTestConnectionObject(uint8_t * storage)
 {
-    return reinterpret_cast<T>(static_cast<uintptr_t>(value));
+    return reinterpret_cast<T>(storage);
 }
 
 // DeviceCommissioner is too large to embed in a test fixture (it exceeds
@@ -182,7 +182,8 @@ TEST_F(TestSetUpCodePairer, DeferredBleDiscoveryQueuesReconnectableParams)
 {
     Access().SetWaitingForPASE(true);
 
-    BLE_CONNECTION_OBJECT connObj = MakeTestConnectionObject<BLE_CONNECTION_OBJECT>(0x1234);
+    uint8_t connectionObjectStorage;
+    BLE_CONNECTION_OBJECT connObj = MakeTestConnectionObject<BLE_CONNECTION_OBJECT>(&connectionObjectStorage);
     Access().CallOnDiscoveredDeviceOverBle(connObj, std::optional<uint16_t>{ 3840 });
 
     ASSERT_EQ(Access().GetDiscoveredParametersCount(), 1u);

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -25,14 +25,28 @@
 #include <lib/core/CHIPError.h>
 #include <transport/raw/PeerAddress.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
+#include <type_traits>
 
 using namespace chip;
 using namespace chip::Controller;
 using PairerAccess = chip::Testing::SetUpCodePairerTestAccess;
 
 namespace {
+
+template <typename T>
+static typename std::enable_if<std::is_integral<T>::value, T>::type MakeTestConnectionObject(unsigned int value)
+{
+    return static_cast<T>(value);
+}
+
+template <typename T>
+static typename std::enable_if<std::is_pointer<T>::value, T>::type MakeTestConnectionObject(unsigned int value)
+{
+    return reinterpret_cast<T>(static_cast<uintptr_t>(value));
+}
 
 // DeviceCommissioner is too large to embed in a test fixture (it exceeds
 // the pw_unit_test light backend's static memory pool).  Heap-allocate it
@@ -168,7 +182,7 @@ TEST_F(TestSetUpCodePairer, DeferredBleDiscoveryQueuesReconnectableParams)
 {
     Access().SetWaitingForPASE(true);
 
-    auto * connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(0x1234);
+    BLE_CONNECTION_OBJECT connObj = MakeTestConnectionObject<BLE_CONNECTION_OBJECT>(0x1234);
     Access().CallOnDiscoveredDeviceOverBle(connObj, std::optional<uint16_t>{ 3840 });
 
     ASSERT_EQ(Access().GetDiscoveredParametersCount(), 1u);


### PR DESCRIPTION
### What is wrong

`SetUpCodePairer` can discover the same commissionee over BLE and UDP/DNS-SD concurrently. If a UDP PASE attempt is already in progress (`mWaitingForPASE == true`) when BLE discovery succeeds, the old code queued the live `BluezConnection *` in `mDiscoveredParameters` for a later retry. At that point no `BLEEndPoint` had been created for the connection, so the BLE layer had no endpoint associated with that pointer.

If the DUT closes the BLE link while the UDP PASE attempt is still in flight, `BluezEndpoint` removes the `BluezConnection` from its map and schedules it for deletion. `BleLayer::HandleConnectionError` logs that there is no endpoint for the connection error and returns, leaving the queued raw pointer untouched. When UDP PASE later fails and the pairer retries the queued BLE entry, it can pass a freed `BluezConnection *` into `BleLayer::NewBleConnectionByObject`. The resulting endpoint wraps a stale connection object, which can fail on the first write because `mC1` is gone and then crash while trying to close the same freed connection.

### How it was fixed

In `SetUpCodePairer::OnDiscoveredDeviceOverBle`, when `mWaitingForPASE == true`, the live connection handle is no longer stored. Instead, the pairer queues a reconnectable BLE entry: a BLE peer address plus the matched long discriminator, when one was reported. When the deferred retry runs, `ConnectToDiscoveredDevice()` resolves the discriminator back to the matching setup payload and fills in the setup PIN/discriminator. `DeviceCommissioner::EstablishPASEConnection()` then uses those parameters to call `BleLayer::NewBleConnectionByDiscriminator`, starting a fresh BLE scan instead of reusing the old connection object.

When `mWaitingForPASE == false`, the existing fast path is preserved: the live connection handle is queued and consumed immediately, creating a `BLEEndPoint` for the active connection instead of leaving the raw pointer dormant.

### Testing

TestSetUpCodePairer.cpp gets a new test, `DeferredBleDiscoveryQueuesReconnectableParams`, which:
- Sets `mWaitingForPASE = true` to simulate an in-flight PASE attempt
- Calls `OnDiscoveredDeviceOverBle` with a representative connection object and long discriminator
- Asserts that the enqueued entry has a BLE peer address but **no** `ConnectionObject` and **no** `DiscoveredObject` — confirming the raw pointer was not stored
- Asserts that the long discriminator was preserved so the later retry can resolve the correct setup payload

`SetUpCodePairerTestAccess` is extended with `GetDiscoveredParametersCount()`, `FrontDiscoveredParameters()`, and `CallOnDiscoveredDeviceOverBle()` to expose the state needed by the new test without modifying production code visibility.

### Issues affected

Fixes #72252 