### PR TITLE
Fix CASE client double free during session callbacks

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -63,12 +63,12 @@ void OperationalSessionSetup::MoveToState(State aTargetState)
         }
 #endif
 
-        mState = aTargetState;
-
         if (aTargetState != State::Connecting)
         {
             CleanupCASEClient();
         }
+
+        mState = aTargetState;
     }
 }
 
@@ -504,6 +504,7 @@ void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error, Sess
     MATTER_LOG_METRIC_END(kMetricDeviceOperationalDiscovery, error);
     MATTER_LOG_METRIC_END(kMetricDeviceCASESession, error);
 
+    CleanupCASEClient();
     DequeueConnectionCallbacks(error, stage);
     // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
 }
@@ -531,6 +532,7 @@ void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session
     {
         // Got an invalid session, just dispatch an error.  We have to do this
         // so we don't leak.
+        CleanupCASEClient();
         DequeueConnectionCallbacks(CHIP_ERROR_INCORRECT_STATE);
 
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
@@ -544,10 +546,35 @@ void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session
 
 void OperationalSessionSetup::CleanupCASEClient()
 {
-    if (mCASEClient)
+    CASEClient * caseClient = mCASEClient;
+    if (caseClient == nullptr)
     {
-        mClientPool->Release(mCASEClient);
-        mCASEClient = nullptr;
+        return;
+    }
+
+    CASEClientPoolDelegate * clientPool = mClientPool;
+    mCASEClient                       = nullptr;
+
+    VerifyOrReturn(clientPool != nullptr, ChipLogError(Discovery, "Cannot release CASEClient without a client pool"));
+
+    auto releaseClient = [clientPool, caseClient]() { clientPool->Release(caseClient); };
+
+    if (mState != State::Connecting)
+    {
+        releaseClient();
+        return;
+    }
+
+    auto * systemLayer = mInitParams.sessionManager == nullptr ? nullptr : mInitParams.sessionManager->SystemLayer();
+    VerifyOrReturn(systemLayer != nullptr,
+                   ChipLogError(Discovery, "Cannot schedule deferred CASEClient release without a SystemLayer"));
+
+    CHIP_ERROR err = systemLayer->ScheduleLambda(releaseClient);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Discovery, "Failed to schedule deferred CASEClient release: %" CHIP_ERROR_FORMAT
+                                "; leaking client to avoid re-entrant destruction",
+                     err.Format());
     }
 }
 
@@ -571,8 +598,10 @@ OperationalSessionSetup::~OperationalSessionSetup()
 
     if (mCASEClient)
     {
-        // Make sure we don't leak it.
+        // Make sure we don't leak it. CASESession delegate callbacks detach
+        // mCASEClient before releasing this object.
         mClientPool->Release(mCASEClient);
+        mCASEClient = nullptr;
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -553,7 +553,7 @@ void OperationalSessionSetup::CleanupCASEClient()
     }
 
     CASEClientPoolDelegate * clientPool = mClientPool;
-    mCASEClient                       = nullptr;
+    mCASEClient                         = nullptr;
 
     VerifyOrReturn(clientPool != nullptr, ChipLogError(Discovery, "Cannot release CASEClient without a client pool"));
 
@@ -572,8 +572,9 @@ void OperationalSessionSetup::CleanupCASEClient()
     CHIP_ERROR err = systemLayer->ScheduleLambda(releaseClient);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to schedule deferred CASEClient release: %" CHIP_ERROR_FORMAT
-                                "; leaking client to avoid re-entrant destruction",
+        ChipLogError(Discovery,
+                     "Failed to schedule deferred CASEClient release: %" CHIP_ERROR_FORMAT
+                     "; leaking client to avoid re-entrant destruction",
                      err.Format());
     }
 }

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -555,8 +555,6 @@ void OperationalSessionSetup::CleanupCASEClient()
     CASEClientPoolDelegate * clientPool = mClientPool;
     mCASEClient                         = nullptr;
 
-    VerifyOrReturn(clientPool != nullptr, ChipLogError(Discovery, "Cannot release CASEClient without a client pool"));
-
     auto releaseClient = [clientPool, caseClient]() { clientPool->Release(caseClient); };
 
     if (mState != State::Connecting)
@@ -565,9 +563,11 @@ void OperationalSessionSetup::CleanupCASEClient()
         return;
     }
 
-    auto * systemLayer = mInitParams.sessionManager == nullptr ? nullptr : mInitParams.sessionManager->SystemLayer();
+    auto * systemLayer = GetSystemLayer();
     VerifyOrReturn(systemLayer != nullptr,
-                   ChipLogError(Discovery, "Cannot schedule deferred CASEClient release without a SystemLayer"));
+                   ChipLogError(Discovery,
+                                "Cannot schedule deferred CASEClient release without a SystemLayer; leaking client to avoid "
+                                "re-entrant destruction"));
 
     CHIP_ERROR err = systemLayer->ScheduleLambda(releaseClient);
     if (err != CHIP_NO_ERROR)
@@ -796,7 +796,8 @@ CHIP_ERROR OperationalSessionSetup::ScheduleSessionSetupReattempt(System::Clock:
     VerifyOrDie(mRemainingAttempts > 0);
     // Try again, but not if things are in shutdown such that we can't get
     // to a system layer, and not if we've run out of attempts.
-    if (!mInitParams.exchangeMgr->GetSessionManager() || !mInitParams.exchangeMgr->GetSessionManager()->SystemLayer())
+    auto * systemLayer = GetSystemLayer();
+    if (systemLayer == nullptr)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
@@ -849,7 +850,7 @@ CHIP_ERROR OperationalSessionSetup::ScheduleSessionSetupReattempt(System::Clock:
     }
     timerDelay = std::chrono::duration_cast<System::Clock::Seconds16>(actualTimerDelay);
 
-    CHIP_ERROR err = mInitParams.exchangeMgr->GetSessionManager()->SystemLayer()->StartTimer(actualTimerDelay, TrySetupAgain, this);
+    CHIP_ERROR err = systemLayer->StartTimer(actualTimerDelay, TrySetupAgain, this);
 
     // TODO: If responseWasBusy, should we increment, mRemainingAttempts and
     // mResolveAttemptsAllowed, since we were explicitly told to retry?  Hard to
@@ -868,10 +869,7 @@ void OperationalSessionSetup::CancelSessionSetupReattempt()
     // If we can't get a system layer, there is no way for us to cancel things
     // at this point, but hopefully that's because everything is torn down
     // anyway and hence the timer will not fire.
-    auto * sessionManager = mInitParams.exchangeMgr->GetSessionManager();
-    VerifyOrReturn(sessionManager != nullptr);
-
-    auto * systemLayer = sessionManager->SystemLayer();
+    auto * systemLayer = GetSystemLayer();
     VerifyOrReturn(systemLayer != nullptr);
 
     systemLayer->CancelTimer(TrySetupAgain, this);
@@ -953,14 +951,6 @@ void OperationalSessionSetup::NotifyRetryHandlers(CHIP_ERROR error, System::Cloc
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
-#if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
-void OperationalSessionSetup::SetFallbackResolveResult(const AddressResolve::ResolveResult & result)
-{
-    ChipLogProgress(Discovery, "OperationalSessionSetup[" ChipLogFormatScopedNodeId "]: Setting fallback resolve result",
-                    ChipLogValueScopedNodeId(mPeerId));
-    mFallbackResolveResult.SetValue(result);
-}
-
 System::Layer * OperationalSessionSetup::GetSystemLayer()
 {
     auto * sessionManager = mInitParams.exchangeMgr->GetSessionManager();
@@ -969,6 +959,14 @@ System::Layer * OperationalSessionSetup::GetSystemLayer()
         return nullptr;
     }
     return sessionManager->SystemLayer();
+}
+
+#if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
+void OperationalSessionSetup::SetFallbackResolveResult(const AddressResolve::ResolveResult & result)
+{
+    ChipLogProgress(Discovery, "OperationalSessionSetup[" ChipLogFormatScopedNodeId "]: Setting fallback resolve result",
+                    ChipLogValueScopedNodeId(mPeerId));
+    mFallbackResolveResult.SetValue(result);
 }
 
 CHIP_ERROR OperationalSessionSetup::StartFallbackTimer()

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -65,7 +65,11 @@ void OperationalSessionSetup::MoveToState(State aTargetState)
 
         if (aTargetState != State::Connecting)
         {
-            CleanupCASEClient();
+            // Cleanup must observe the old state. Defer destruction when
+            // leaving Connecting unsuccessfully from a CASESession delegate
+            // callback. On successful CASE completion, release immediately
+            // to make the client slot available to another establishment.
+            CleanupCASEClient(/* deferRelease = */ mState == State::Connecting && aTargetState != State::SecureConnected);
         }
 
         mState = aTargetState;
@@ -339,7 +343,7 @@ CHIP_ERROR OperationalSessionSetup::EstablishConnection(const ResolveResult & re
     if (err != CHIP_NO_ERROR)
     {
         MATTER_LOG_METRIC_END(kMetricDeviceCASESession, err);
-        CleanupCASEClient();
+        CleanupCASEClient(/* deferRelease = */ false);
         return err;
     }
 
@@ -504,7 +508,7 @@ void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error, Sess
     MATTER_LOG_METRIC_END(kMetricDeviceOperationalDiscovery, error);
     MATTER_LOG_METRIC_END(kMetricDeviceCASESession, error);
 
-    CleanupCASEClient();
+    CleanupCASEClient(/* deferRelease = */ true);
     DequeueConnectionCallbacks(error, stage);
     // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
 }
@@ -532,7 +536,7 @@ void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session
     {
         // Got an invalid session, just dispatch an error.  We have to do this
         // so we don't leak.
-        CleanupCASEClient();
+        CleanupCASEClient(/* deferRelease = */ true);
         DequeueConnectionCallbacks(CHIP_ERROR_INCORRECT_STATE);
 
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
@@ -544,7 +548,7 @@ void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session
     DequeueConnectionCallbacks(CHIP_NO_ERROR);
 }
 
-void OperationalSessionSetup::CleanupCASEClient()
+void OperationalSessionSetup::CleanupCASEClient(bool deferRelease)
 {
     CASEClient * caseClient = mCASEClient;
     if (caseClient == nullptr)
@@ -557,7 +561,7 @@ void OperationalSessionSetup::CleanupCASEClient()
 
     auto releaseClient = [clientPool, caseClient]() { clientPool->Release(caseClient); };
 
-    if (mState != State::Connecting)
+    if (!deferRelease)
     {
         releaseClient();
         return;

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -65,13 +65,14 @@ void OperationalSessionSetup::MoveToState(State aTargetState)
 
         if (aTargetState != State::Connecting)
         {
-            // Cleanup must observe the old state. Defer destruction when
-            // leaving Connecting unsuccessfully from a CASESession delegate
-            // callback. On successful CASE completion, release immediately
-            // to make the client slot available to another establishment.
+            // Defer destruction when leaving Connecting unsuccessfully from a
+            // CASESession delegate callback. On successful CASE completion,
+            // release immediately to make the client slot available to another
+            // establishment.
             CleanupCASEClient(/* deferRelease = */ mState == State::Connecting && aTargetState != State::SecureConnected);
         }
 
+        // Cleanup must observe the old state before this assignment.
         mState = aTargetState;
     }
 }

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -380,6 +380,12 @@ private:
 
     void CleanupCASEClient();
 
+    /**
+     * Helper to get the System::Layer from the session manager.
+     * Returns nullptr if not available.
+     */
+    System::Layer * GetSystemLayer();
+
     void Connect(Callback::Callback<OnDeviceConnected> * onConnection, Callback::Callback<OnDeviceConnectionFailure> * onFailure,
                  Callback::Callback<OnSetupFailure> * onSetupFailure,
                  TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
@@ -494,12 +500,6 @@ private:
      * Start the fallback timeout timer.
      */
     CHIP_ERROR StartFallbackTimer();
-
-    /**
-     * Helper to get the System::Layer from the session manager.
-     * Returns nullptr if not available.
-     */
-    System::Layer * GetSystemLayer();
 
 #endif // CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
 };

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -52,6 +52,10 @@ namespace chip {
 
 class OperationalSessionSetup;
 
+namespace Testing {
+class OperationalSessionSetupTestAccess;
+} // namespace Testing
+
 /**
  * @brief Delegate provided when creating OperationalSessionSetup.
  *
@@ -156,6 +160,8 @@ typedef void (*OnDeviceConnectionRetry)(void * context, const ScopedNodeId & pee
  */
 class DLL_EXPORT OperationalSessionSetup : public SessionEstablishmentDelegate, public AddressResolve::NodeListener
 {
+    friend class Testing::OperationalSessionSetupTestAccess;
+
 public:
     struct ConnectionFailureInfo
     {
@@ -494,6 +500,7 @@ private:
      * Returns nullptr if not available.
      */
     System::Layer * GetSystemLayer();
+
 #endif // CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
 };
 

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -378,7 +378,7 @@ private:
      */
     bool AttachToExistingSecureSession();
 
-    void CleanupCASEClient();
+    void CleanupCASEClient(bool deferRelease);
 
     /**
      * Helper to get the System::Layer from the session manager.

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -168,10 +168,7 @@ protected:
     void DrainSystemLayer()
     {
         EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void {
-                          EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR);
-                      },
-                      0),
+                      [](intptr_t) -> void { EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, 0),
                   CHIP_NO_ERROR);
         chip::DeviceLayer::PlatformMgr().RunEventLoop();
     }

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -166,10 +166,7 @@ protected:
         return params;
     }
 
-    static void StopEventLoop(intptr_t)
-    {
-        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR);
-    }
+    static void StopEventLoop(intptr_t) { EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }
 
     void DrainSystemLayer()
     {

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -228,7 +228,7 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSy
 {
     ExchangeManager uninitializedExchangeManager;
     CASEClientInitParams params = CreateCASEClientInitParams();
-    params.exchangeMgr           = &uninitializedExchangeManager;
+    params.exchangeMgr          = &uninitializedExchangeManager;
 
     OperationalSessionSetup sessionSetup(params, &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
     chip::Testing::OperationalSessionSetupTestAccess access(&sessionSetup);

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -168,7 +168,10 @@ protected:
     void DrainSystemLayer()
     {
         EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, 0),
+                      [](intptr_t) -> void {
+                          EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR);
+                      },
+                      0),
                   CHIP_NO_ERROR);
         chip::DeviceLayer::PlatformMgr().RunEventLoop();
     }

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -168,7 +168,7 @@ protected:
     void DrainSystemLayer()
     {
         EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void { RETURN_SAFELY_IGNORED chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); }, 0),
+                      [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, 0),
                   CHIP_NO_ERROR);
         chip::DeviceLayer::PlatformMgr().RunEventLoop();
     }
@@ -222,6 +222,27 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseS
     DrainSystemLayer();
 
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+}
+
+TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSystemLayerUnavailable)
+{
+    ExchangeManager uninitializedExchangeManager;
+    CASEClientInitParams params = CreateCASEClientInitParams();
+    params.exchangeMgr           = &uninitializedExchangeManager;
+
+    OperationalSessionSetup sessionSetup(params, &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
+    chip::Testing::OperationalSessionSetupTestAccess access(&sessionSetup);
+    CASEClient * caseClient = mCASEClientPool.Allocate();
+    ASSERT_NE(caseClient, nullptr);
+
+    access.SetCASEClient(caseClient);
+    access.SetStateConnecting();
+    access.CleanupCASEClient();
+
+    EXPECT_EQ(access.GetCASEClient(), nullptr);
+    EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
+
+    mCASEClientPool.Release(caseClient);
 }
 
 #if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -27,10 +27,14 @@
 #include <app/CASESessionManager.h>
 #include <app/OperationalSessionSetup.h>
 #include <app/tests/AppTestContext.h>
+#include <credentials/GroupDataProviderImpl.h>
 #include <lib/address_resolve/AddressResolve.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/Pool.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
 
@@ -40,9 +44,48 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
 
+namespace chip {
+namespace Testing {
+
+class OperationalSessionSetupTestAccess
+{
+public:
+    explicit OperationalSessionSetupTestAccess(OperationalSessionSetup * sessionSetup) : mSessionSetup(sessionSetup) {}
+
+    void SetCASEClient(CASEClient * client) { mSessionSetup->mCASEClient = client; }
+    CASEClient * GetCASEClient() const { return mSessionSetup->mCASEClient; }
+    void SetStateConnecting() { mSessionSetup->mState = OperationalSessionSetup::State::Connecting; }
+    void CleanupCASEClient() { mSessionSetup->CleanupCASEClient(); }
+
+private:
+    OperationalSessionSetup * mSessionSetup = nullptr;
+};
+
+} // namespace Testing
+} // namespace chip
+
 namespace {
 
 constexpr uint16_t kTestPort = 5540;
+constexpr NodeId kTestNodeId = 0x123456789abcdefULL;
+constexpr FabricIndex kFabricIndex = 1;
+
+class MockCASEClientPool : public CASEClientPoolDelegate
+{
+public:
+    CASEClient * Allocate() override { return mClientPool.CreateObject(); }
+
+    void Release(CASEClient * client) override
+    {
+        mReleaseCount++;
+        mClientPool.ReleaseObject(client);
+    }
+
+    int mReleaseCount = 0;
+
+private:
+    ObjectPool<CASEClient, 1> mClientPool;
+};
 
 class MockOperationalSessionReleaseDelegate : public OperationalSessionReleaseDelegate
 {
@@ -101,6 +144,7 @@ public:
         AppContext::SetUp();
         mReleaseDelegate.Reset();
         mSessionDelegate.Reset();
+        mCASEClientPool.mReleaseCount = 0;
     }
 
     void TearDown() override { AppContext::TearDown(); }
@@ -108,6 +152,26 @@ public:
 protected:
     MockOperationalSessionReleaseDelegate mReleaseDelegate;
     MockSessionEstablishmentDelegate mSessionDelegate;
+    MockCASEClientPool mCASEClientPool;
+    Credentials::GroupDataProviderImpl mGroupDataProvider;
+
+    CASEClientInitParams CreateCASEClientInitParams()
+    {
+        CASEClientInitParams params;
+        params.sessionManager     = &GetSecureSessionManager();
+        params.exchangeMgr        = &GetExchangeManager();
+        params.fabricTable        = &GetFabricTable();
+        params.groupDataProvider  = &mGroupDataProvider;
+        return params;
+    }
+
+    void DrainSystemLayer()
+    {
+        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                      [](intptr_t) -> void { RETURN_SAFELY_IGNORED chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); }, 0),
+                  CHIP_NO_ERROR);
+        chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    }
 
     AddressResolve::ResolveResult CreateTestResolveResult()
     {
@@ -122,10 +186,45 @@ protected:
     }
 };
 
-#if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
+TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesInline)
+{
+    OperationalSessionSetup sessionSetup(CreateCASEClientInitParams(), &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex),
+                                         &mReleaseDelegate);
+    chip::Testing::OperationalSessionSetupTestAccess access(&sessionSetup);
+    CASEClient * caseClient = mCASEClientPool.Allocate();
+    ASSERT_NE(caseClient, nullptr);
 
-constexpr NodeId kTestNodeId       = 0x123456789abcdefULL;
-constexpr FabricIndex kFabricIndex = 1;
+    access.SetCASEClient(caseClient);
+    access.CleanupCASEClient();
+
+    EXPECT_EQ(access.GetCASEClient(), nullptr);
+    EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+}
+
+TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseSessionSetupAfterReturn)
+{
+    CASEClient * caseClient = mCASEClientPool.Allocate();
+    ASSERT_NE(caseClient, nullptr);
+
+    auto * sessionSetup = chip::Platform::New<OperationalSessionSetup>(
+        CreateCASEClientInitParams(), &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
+    ASSERT_NE(sessionSetup, nullptr);
+
+    chip::Testing::OperationalSessionSetupTestAccess access(sessionSetup);
+    access.SetCASEClient(caseClient);
+    access.SetStateConnecting();
+    access.CleanupCASEClient();
+
+    EXPECT_EQ(access.GetCASEClient(), nullptr);
+    EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
+
+    chip::Platform::Delete(sessionSetup);
+    DrainSystemLayer();
+
+    EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+}
+
+#if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
 
 TEST_F(TestOperationalSessionSetupFallback, TestSetFallbackResolveResult)
 {

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -32,7 +32,6 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Pool.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -189,7 +188,6 @@ protected:
 
 TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesInline)
 {
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: immediate release start");
     OperationalSessionSetup sessionSetup(CreateCASEClientInitParams(), &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex),
                                          &mReleaseDelegate);
     chip::Testing::OperationalSessionSetupTestAccess access(&sessionSetup);
@@ -201,12 +199,10 @@ TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesIn
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: immediate release complete");
 }
 
 TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseSessionSetupAfterReturn)
 {
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release start");
     CASEClient * caseClient = mCASEClientPool.Allocate();
     ASSERT_NE(caseClient, nullptr);
 
@@ -221,20 +217,15 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseS
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release scheduled");
 
     chip::Platform::Delete(sessionSetup);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: setup deleted");
     DrainSystemLayer();
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: system layer drained");
 
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release complete");
 }
 
 TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSystemLayerUnavailable)
 {
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer start");
     ExchangeManager uninitializedExchangeManager;
     CASEClientInitParams params = CreateCASEClientInitParams();
     params.exchangeMgr          = &uninitializedExchangeManager;
@@ -250,10 +241,8 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSy
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer retention confirmed");
 
     mCASEClientPool.Release(caseClient);
-    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer cleanup complete");
 }
 
 #if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -32,6 +32,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Pool.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -165,11 +166,14 @@ protected:
         return params;
     }
 
+    static void StopEventLoop(intptr_t)
+    {
+        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR);
+    }
+
     void DrainSystemLayer()
     {
-        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-                      [](intptr_t) -> void { EXPECT_EQ(chip::DeviceLayer::PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR); }, 0),
-                  CHIP_NO_ERROR);
+        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop, 0), CHIP_NO_ERROR);
         chip::DeviceLayer::PlatformMgr().RunEventLoop();
     }
 
@@ -188,6 +192,7 @@ protected:
 
 TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesInline)
 {
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: immediate release start");
     OperationalSessionSetup sessionSetup(CreateCASEClientInitParams(), &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex),
                                          &mReleaseDelegate);
     chip::Testing::OperationalSessionSetupTestAccess access(&sessionSetup);
@@ -199,10 +204,12 @@ TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesIn
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: immediate release complete");
 }
 
 TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseSessionSetupAfterReturn)
 {
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release start");
     CASEClient * caseClient = mCASEClientPool.Allocate();
     ASSERT_NE(caseClient, nullptr);
 
@@ -217,15 +224,20 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseS
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release scheduled");
 
     chip::Platform::Delete(sessionSetup);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: setup deleted");
     DrainSystemLayer();
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: system layer drained");
 
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: deferred release complete");
 }
 
 TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSystemLayerUnavailable)
 {
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer start");
     ExchangeManager uninitializedExchangeManager;
     CASEClientInitParams params = CreateCASEClientInitParams();
     params.exchangeMgr          = &uninitializedExchangeManager;
@@ -241,8 +253,10 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSy
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer retention confirmed");
 
     mCASEClientPool.Release(caseClient);
+    ChipLogProgress(AppServer, "OperationalSessionSetup cleanup test: no SystemLayer cleanup complete");
 }
 
 #if CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -66,8 +66,8 @@ private:
 
 namespace {
 
-constexpr uint16_t kTestPort = 5540;
-constexpr NodeId kTestNodeId = 0x123456789abcdefULL;
+constexpr uint16_t kTestPort       = 5540;
+constexpr NodeId kTestNodeId       = 0x123456789abcdefULL;
 constexpr FabricIndex kFabricIndex = 1;
 
 class MockCASEClientPool : public CASEClientPoolDelegate
@@ -158,10 +158,10 @@ protected:
     CASEClientInitParams CreateCASEClientInitParams()
     {
         CASEClientInitParams params;
-        params.sessionManager     = &GetSecureSessionManager();
-        params.exchangeMgr        = &GetExchangeManager();
-        params.fabricTable        = &GetFabricTable();
-        params.groupDataProvider  = &mGroupDataProvider;
+        params.sessionManager    = &GetSecureSessionManager();
+        params.exchangeMgr       = &GetExchangeManager();
+        params.fabricTable       = &GetFabricTable();
+        params.groupDataProvider = &mGroupDataProvider;
         return params;
     }
 
@@ -206,8 +206,8 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseS
     CASEClient * caseClient = mCASEClientPool.Allocate();
     ASSERT_NE(caseClient, nullptr);
 
-    auto * sessionSetup = chip::Platform::New<OperationalSessionSetup>(
-        CreateCASEClientInitParams(), &mCASEClientPool, ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
+    auto * sessionSetup = chip::Platform::New<OperationalSessionSetup>(CreateCASEClientInitParams(), &mCASEClientPool,
+                                                                       ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
     ASSERT_NE(sessionSetup, nullptr);
 
     chip::Testing::OperationalSessionSetupTestAccess access(sessionSetup);

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -55,14 +55,8 @@ public:
     void SetCASEClient(CASEClient * client) { mSessionSetup->mCASEClient = client; }
     CASEClient * GetCASEClient() const { return mSessionSetup->mCASEClient; }
     void SetStateConnecting() { mSessionSetup->mState = OperationalSessionSetup::State::Connecting; }
-    void CleanupCASEClientImmediately()
-    {
-        mSessionSetup->CleanupCASEClient(/* deferRelease = */ false);
-    }
-    void CleanupCASEClientAfterCallback()
-    {
-        mSessionSetup->CleanupCASEClient(/* deferRelease = */ true);
-    }
+    void CleanupCASEClientImmediately() { mSessionSetup->CleanupCASEClient(/* deferRelease = */ false); }
+    void CleanupCASEClientAfterCallback() { mSessionSetup->CleanupCASEClient(/* deferRelease = */ true); }
     void MoveToSecureConnected() { mSessionSetup->MoveToState(OperationalSessionSetup::State::SecureConnected); }
     void MoveToNeedsAddress() { mSessionSetup->MoveToState(OperationalSessionSetup::State::NeedsAddress); }
 

--- a/src/app/tests/TestOperationalSessionSetupFallback.cpp
+++ b/src/app/tests/TestOperationalSessionSetupFallback.cpp
@@ -55,7 +55,16 @@ public:
     void SetCASEClient(CASEClient * client) { mSessionSetup->mCASEClient = client; }
     CASEClient * GetCASEClient() const { return mSessionSetup->mCASEClient; }
     void SetStateConnecting() { mSessionSetup->mState = OperationalSessionSetup::State::Connecting; }
-    void CleanupCASEClient() { mSessionSetup->CleanupCASEClient(); }
+    void CleanupCASEClientImmediately()
+    {
+        mSessionSetup->CleanupCASEClient(/* deferRelease = */ false);
+    }
+    void CleanupCASEClientAfterCallback()
+    {
+        mSessionSetup->CleanupCASEClient(/* deferRelease = */ true);
+    }
+    void MoveToSecureConnected() { mSessionSetup->MoveToState(OperationalSessionSetup::State::SecureConnected); }
+    void MoveToNeedsAddress() { mSessionSetup->MoveToState(OperationalSessionSetup::State::NeedsAddress); }
 
 private:
     OperationalSessionSetup * mSessionSetup = nullptr;
@@ -195,10 +204,30 @@ TEST_F(TestOperationalSessionSetupFallback, ImmediateCASEClientCleanupReleasesIn
     ASSERT_NE(caseClient, nullptr);
 
     access.SetCASEClient(caseClient);
-    access.CleanupCASEClient();
+    access.CleanupCASEClientImmediately();
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+}
+
+TEST_F(TestOperationalSessionSetupFallback, SuccessfulCASEClientCleanupReleasesInline)
+{
+    CASEClient * caseClient = mCASEClientPool.Allocate();
+    ASSERT_NE(caseClient, nullptr);
+
+    auto * sessionSetup = chip::Platform::New<OperationalSessionSetup>(CreateCASEClientInitParams(), &mCASEClientPool,
+                                                                       ScopedNodeId(kTestNodeId, kFabricIndex), &mReleaseDelegate);
+    ASSERT_NE(sessionSetup, nullptr);
+
+    chip::Testing::OperationalSessionSetupTestAccess access(sessionSetup);
+    access.SetCASEClient(caseClient);
+    access.SetStateConnecting();
+    access.MoveToSecureConnected();
+
+    EXPECT_EQ(access.GetCASEClient(), nullptr);
+    EXPECT_EQ(mCASEClientPool.mReleaseCount, 1);
+
+    chip::Platform::Delete(sessionSetup);
 }
 
 TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseSessionSetupAfterReturn)
@@ -213,11 +242,13 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupDoesNotUseS
     chip::Testing::OperationalSessionSetupTestAccess access(sessionSetup);
     access.SetCASEClient(caseClient);
     access.SetStateConnecting();
-    access.CleanupCASEClient();
+    access.MoveToNeedsAddress();
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);
 
+    // The session setup can be released before the queued cleanup executes;
+    // the client pool must remain alive until the System Layer drains it.
     chip::Platform::Delete(sessionSetup);
     DrainSystemLayer();
 
@@ -236,8 +267,7 @@ TEST_F(TestOperationalSessionSetupFallback, DeferredCASEClientCleanupLeaksWhenSy
     ASSERT_NE(caseClient, nullptr);
 
     access.SetCASEClient(caseClient);
-    access.SetStateConnecting();
-    access.CleanupCASEClient();
+    access.CleanupCASEClientAfterCallback();
 
     EXPECT_EQ(access.GetCASEClient(), nullptr);
     EXPECT_EQ(mCASEClientPool.mReleaseCount, 0);

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -252,7 +252,7 @@ private:
 
     ObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> mContextPool;
 
-    SessionManager * mSessionManager;
+    SessionManager * mSessionManager = nullptr;
     ReliableMessageMgr mReliableMessageMgr;
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST


### PR DESCRIPTION
### The problem

OperationalSessionSetup could release its CASEClient while still unwinding from a CASESession success or error callback. Since CASEClient owns the live CASESession, that could destroy the session object during its own callback path and lead to heap corruption or a later double-free crash.

### The fix

CASEClient cleanup now detaches the client from OperationalSessionSetup first. If cleanup happens while the setup is still in the Connecting state, the actual pool release is deferred onto the system layer so the CASESession callback stack can finish unwinding. Normal cleanup paths still release immediately.

### Testing

Added unit coverage for immediate CASEClient cleanup and deferred cleanup from the Connecting state. The deferred cleanup test verifies that the client is not released inline and can still be released after the OperationalSessionSetup object has been destroyed.

### Related issues

Fixes #42947