### PR TITLE
Retry operational CASE setup after responder BUSY

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -515,6 +515,18 @@ void OperationalSessionSetup::OnResponderBusy(System::Clock::Milliseconds16 requ
     // retry or communicate it to our API consumer.
     mRequestedBusyDelay = requestedDelay;
 #endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+    if (!mGrantedBusyRetryAfterAttemptExhaustion && mRemainingAttempts == 0)
+    {
+        mRemainingAttempts = 1;
+        if (mResolveAttemptsAllowed == 0)
+        {
+            mResolveAttemptsAllowed = 1;
+        }
+        mGrantedBusyRetryAfterAttemptExhaustion = true;
+    }
+#endif
 }
 
 void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session)
@@ -820,10 +832,6 @@ CHIP_ERROR OperationalSessionSetup::ScheduleSessionSetupReattempt(System::Clock:
     timerDelay = std::chrono::duration_cast<System::Clock::Seconds16>(actualTimerDelay);
 
     CHIP_ERROR err = mInitParams.exchangeMgr->GetSessionManager()->SystemLayer()->StartTimer(actualTimerDelay, TrySetupAgain, this);
-
-    // TODO: If responseWasBusy, should we increment, mRemainingAttempts and
-    // mResolveAttemptsAllowed, since we were explicitly told to retry?  Hard to
-    // tell what consumers expect out of a capped retry count here.
 
     // The cast on count() is needed because the type count() returns might not
     // actually be uint16_t; on some platforms it's int.

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -293,6 +293,10 @@ public:
 #endif // CHIP_CONFIG_ENABLE_ADDRESS_RESOLVE_FALLBACK
 
 private:
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+    friend class TestOperationalSessionSetupBusy;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
     enum class State : uint8_t
     {
         Uninitialized,    // Error state: OperationalSessionSetup is useless
@@ -349,6 +353,8 @@ private:
     uint8_t mAttemptsDone      = 0;
 
     uint8_t mResolveAttemptsAllowed = 0;
+
+    bool mGrantedBusyRetryAfterAttemptExhaustion = false;
 
     Callback::CallbackDeque mConnectionRetry;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -187,6 +187,7 @@ chip_test_suite("tests") {
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
     "TestNumericAttributeTraits.cpp",
+    "TestOperationalSessionSetupBusy.cpp",
     "TestOperationalSessionSetupFallback.cpp",
     "TestOperationalStateClusterObjects.cpp",
     "TestPendingResponseTrackerImpl.cpp",

--- a/src/app/tests/TestOperationalSessionSetupBusy.cpp
+++ b/src/app/tests/TestOperationalSessionSetupBusy.cpp
@@ -27,8 +27,8 @@
 namespace chip {
 namespace {
 
-constexpr NodeId kTestNodeId       = 0x123456789abcdefULL;
-constexpr FabricIndex kFabricIndex = 1;
+constexpr NodeId kTestNodeId              = 0x123456789abcdefULL;
+constexpr FabricIndex kFabricIndex        = 1;
 constexpr uint16_t kMaxGroupsPerFabric    = 5;
 constexpr uint16_t kMaxGroupKeysPerFabric = 8;
 

--- a/src/app/tests/TestOperationalSessionSetupBusy.cpp
+++ b/src/app/tests/TestOperationalSessionSetupBusy.cpp
@@ -1,0 +1,161 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <app/CASEClientPool.h>
+#include <app/OperationalSessionSetup.h>
+#include <app/tests/AppTestContext.h>
+#include <credentials/GroupDataProviderImpl.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
+
+namespace chip {
+namespace {
+
+constexpr NodeId kTestNodeId       = 0x123456789abcdefULL;
+constexpr FabricIndex kFabricIndex = 1;
+constexpr uint16_t kMaxGroupsPerFabric    = 5;
+constexpr uint16_t kMaxGroupKeysPerFabric = 8;
+
+class MockCASEClientPool : public CASEClientPoolDelegate
+{
+public:
+    CASEClient * Allocate() override { return nullptr; }
+    void Release(CASEClient * client) override {}
+};
+
+class MockOperationalSessionReleaseDelegate : public OperationalSessionReleaseDelegate
+{
+public:
+    void ReleaseSession(OperationalSessionSetup * sessionSetup) override {}
+};
+
+} // namespace
+
+class TestOperationalSessionSetupBusy : public chip::Testing::AppContext
+{
+public:
+    void BusyResponseAfterAttemptExhaustionGrantsOneRetry();
+    void BusyResponseKeepsExistingResolveRetryBudget();
+    void BusyResponseWithRemainingBudgetDoesNotGrantExtra();
+    void BusyResponseGrantsExtraRetryOnlyOnce();
+
+    void SetUp() override
+    {
+        AppContext::SetUp();
+        Credentials::SetGroupDataProvider(&mGroupDataProvider);
+    }
+
+    void TearDown() override
+    {
+        Credentials::SetGroupDataProvider(nullptr);
+        AppContext::TearDown();
+    }
+
+protected:
+    CASEClientInitParams CreateInitParams()
+    {
+        CASEClientInitParams params;
+        params.sessionManager    = &GetSecureSessionManager();
+        params.exchangeMgr       = &GetExchangeManager();
+        params.fabricTable       = &GetFabricTable();
+        params.groupDataProvider = &mGroupDataProvider;
+        return params;
+    }
+
+    OperationalSessionSetup CreateSessionSetup()
+    {
+        return OperationalSessionSetup(CreateInitParams(), &mClientPool, ScopedNodeId(kTestNodeId, kFabricIndex),
+                                       &mReleaseDelegate);
+    }
+
+    Credentials::GroupDataProviderImpl mGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
+    MockCASEClientPool mClientPool;
+    MockOperationalSessionReleaseDelegate mReleaseDelegate;
+};
+
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
+TEST_F_FROM_FIXTURE(TestOperationalSessionSetupBusy, BusyResponseAfterAttemptExhaustionGrantsOneRetry)
+{
+    OperationalSessionSetup sessionSetup = CreateSessionSetup();
+
+    sessionSetup.mRemainingAttempts                      = 0;
+    sessionSetup.mResolveAttemptsAllowed                 = 0;
+    sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion = false;
+
+    sessionSetup.OnResponderBusy(System::Clock::Milliseconds16(5000));
+
+    EXPECT_EQ(sessionSetup.mRemainingAttempts, 1u);
+    EXPECT_EQ(sessionSetup.mResolveAttemptsAllowed, 1u);
+    EXPECT_TRUE(sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion);
+}
+
+TEST_F_FROM_FIXTURE(TestOperationalSessionSetupBusy, BusyResponseKeepsExistingResolveRetryBudget)
+{
+    OperationalSessionSetup sessionSetup = CreateSessionSetup();
+
+    sessionSetup.mRemainingAttempts                      = 0;
+    sessionSetup.mResolveAttemptsAllowed                 = 3;
+    sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion = false;
+
+    sessionSetup.OnResponderBusy(System::Clock::Milliseconds16(5000));
+
+    EXPECT_EQ(sessionSetup.mRemainingAttempts, 1u);
+    EXPECT_EQ(sessionSetup.mResolveAttemptsAllowed, 3u);
+    EXPECT_TRUE(sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion);
+}
+
+TEST_F_FROM_FIXTURE(TestOperationalSessionSetupBusy, BusyResponseWithRemainingBudgetDoesNotGrantExtra)
+{
+    OperationalSessionSetup sessionSetup = CreateSessionSetup();
+
+    sessionSetup.mRemainingAttempts                      = 2;
+    sessionSetup.mResolveAttemptsAllowed                 = 0;
+    sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion = false;
+
+    sessionSetup.OnResponderBusy(System::Clock::Milliseconds16(5000));
+
+    EXPECT_EQ(sessionSetup.mRemainingAttempts, 2u);
+    EXPECT_EQ(sessionSetup.mResolveAttemptsAllowed, 0u);
+    EXPECT_FALSE(sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion);
+}
+
+TEST_F_FROM_FIXTURE(TestOperationalSessionSetupBusy, BusyResponseGrantsExtraRetryOnlyOnce)
+{
+    OperationalSessionSetup sessionSetup = CreateSessionSetup();
+
+    sessionSetup.mRemainingAttempts                      = 0;
+    sessionSetup.mResolveAttemptsAllowed                 = 0;
+    sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion = false;
+
+    sessionSetup.OnResponderBusy(System::Clock::Milliseconds16(5000));
+
+    sessionSetup.mRemainingAttempts      = 0;
+    sessionSetup.mResolveAttemptsAllowed = 0;
+
+    sessionSetup.OnResponderBusy(System::Clock::Milliseconds16(5000));
+
+    EXPECT_EQ(sessionSetup.mRemainingAttempts, 0u);
+    EXPECT_EQ(sessionSetup.mResolveAttemptsAllowed, 0u);
+    EXPECT_TRUE(sessionSetup.mGrantedBusyRetryAfterAttemptExhaustion);
+}
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
+} // namespace chip


### PR DESCRIPTION
### The problem

A Python `ReadAttribute()` first calls `GetConnectedDevice()` before sending the Interaction Model read. The normal controller path requests only a small operational CASE setup attempt budget, and that budget is decremented as soon as operational discovery/setup begins.

If the responder then sends a Secure Channel `BUSY` status with a requested wait time, `OperationalSessionSetup::OnResponderBusy()` records the delay, but `OnSessionEstablishmentError()` only schedules a retry when `mRemainingAttempts > 0`. With the attempt budget already exhausted, the stack surfaces `CHIP_ERROR_BUSY` back to the caller instead of honoring the peer's "wait, then retry" response.

This appears as an intermittent read failure under stress: session/subscription recovery or other operational traffic creates timing pressure, the device responds `BUSY`, and a plain one-shot read fails while trying to reacquire a CASE session. The next attempt typically succeeds once the device is no longer contended.

There was a TODO comment in `ScheduleSessionSetupReattempt()` about whether `BUSY` should restore retry budget, so this issue was clearly contemplated by the original author.

### The fix

Update `OperationalSessionSetup::OnResponderBusy()` so that when a responder `BUSY` arrives after the normal attempt budget is exhausted, the setup object grants one bounded retry. Because `OnResponderBusy()` runs before `OnSessionEstablishmentError()` for the same `BUSY`, the restored budget allows the existing retry path to schedule the peer-requested wait instead of failing.

The retry is intentionally limited to one extra grant per setup object, tracked by a new `mGrantedBusyRetryAfterAttemptExhaustion` flag, so this honors the responder's explicit retry request without creating an unbounded retry loop. Larger existing retry budgets are left untouched, and the normal busy-delay handling continues to use the responder-requested delay when scheduling the retry.

### Testing

Added `TestOperationalSessionSetupBusy.cpp` and wired it into `src/app/tests/BUILD.gn`.

The new unit tests cover:
- granting one retry when `BUSY` arrives after the attempt budget is exhausted
- preserving an existing (larger) resolve retry budget
- not granting an extra retry when normal retry budget remains
- granting the `BUSY` retry only once per setup object, even across multiple `BUSY` responses

### Related issues

Fixes #33830