### PR TITLE
[NXP][SE05x] SE05x Crypto Host fallback updated to use PSA APIs for NXP MCUs

### DIFF
--- a/examples/platform/nxp/se05x/linux/AppMain.cpp
+++ b/examples/platform/nxp/se05x/linux/AppMain.cpp
@@ -59,6 +59,10 @@
 #include <ControllerShellCommands.h>
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+#ifndef CHIP_LINUX_APP_START_COMMISSIONER_AT_BOOT
+#define CHIP_LINUX_APP_START_COMMISSIONER_AT_BOOT 1
+#endif
+
 #if defined(ENABLE_CHIP_SHELL)
 #include <CommissioneeShellCommands.h>
 #include <lib/shell/Engine.h> // nogncheck
@@ -155,8 +159,6 @@
 #include "DeviceAttestationSe05xCredsExample.h"
 #endif
 #include <third_party/simw-top-mini/repo/demos/se05x_host_gpio/se05x_host_gpio.h>
-
-#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 
 using namespace chip;
 using namespace chip::ArgParser;
@@ -1050,11 +1052,13 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+#if CHIP_LINUX_APP_START_COMMISSIONER_AT_BOOT
     ChipLogProgress(AppServer, "Starting commissioner");
     VerifyOrReturn(InitCommissioner(LinuxDeviceOptions::GetInstance().securedCommissionerPort,
                                     LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort,
                                     LinuxDeviceOptions::GetInstance().commissionerFabricId) == CHIP_NO_ERROR);
     ChipLogProgress(AppServer, "Started commissioner");
+#endif // CHIP_LINUX_APP_START_COMMISSIONER_AT_BOOT
 #if defined(ENABLE_CHIP_SHELL)
     Shell::RegisterControllerCommands();
 #endif // defined(ENABLE_CHIP_SHELL)
@@ -1104,11 +1108,10 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     Server::GetInstance().Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    // Commissioner shutdown call shuts down entire stack, including the platform manager.
     ShutdownCommissioner();
-#else
-    DeviceLayer::PlatformMgr().Shutdown();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+
+    DeviceLayer::PlatformMgr().Shutdown();
 
 #if ENABLE_TRACING
     tracing_setup.StopTracing();

--- a/examples/platform/nxp/se05x/linux/BUILD.gn
+++ b/examples/platform/nxp/se05x/linux/BUILD.gn
@@ -49,6 +49,7 @@ config("app-main-config") {
     "../",
     "../../../linux",
     "${chip_root}/src/platform/nxp/crypto/se05x",
+    "${chip_root}/examples/platform/nxp/common/app_se05x/include",
   ]
 }
 
@@ -179,6 +180,35 @@ source_set("app-options") {
   public_configs = [ ":app-main-config" ]
 }
 
+source_set("named-pipes") {
+  sources = [
+    "../../../linux/NamedPipeCommands.cpp",
+    "../../../linux/NamedPipeCommands.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib",
+    "${chip_root}/src/platform/logging:default",
+  ]
+
+  public_configs = [ ":app-main-config" ]
+}
+
+source_set("commissionable-init") {
+  sources = [
+    "../../../linux/CommissionableInit.cpp",
+    "../../../linux/CommissionableInit.h",
+  ]
+
+  public_deps = [
+    ":app-options",
+    ":linux-commissionable-data-provider",
+    "${chip_root}/src/lib",
+  ]
+
+  public_configs = [ ":app-main-config" ]
+}
+
 source_set("app-main") {
   defines = [
     "ENABLE_TRACING=${matter_enable_tracing_support}",
@@ -201,12 +231,10 @@ source_set("app-main") {
     "SE05X_SPAKE_VERIFIER_TP_ITER_CNT=$chip_se05x_spake_verifier_tp_iter_cnt",
   ]
 
+  defines += [ "CONFIG_CHIP_SE05X=1" ]
+
   sources = [
     "../../../linux/AppMain.h",
-    "../../../linux/CommissionableInit.cpp",
-    "../../../linux/CommissionableInit.h",
-    "../../../linux/NamedPipeCommands.cpp",
-    "../../../linux/NamedPipeCommands.h",
     "../DeviceAttestationSe05xCredsExample.cpp",
     "AppMain.cpp",
   ]
@@ -215,6 +243,7 @@ source_set("app-main") {
     ":app-main-loop",
     ":app-options",
     ":boolean-state-configuration-test-event-trigger",
+    ":commissionable-init",
     ":commissioner-main",
     ":commodity-metering-test-event-trigger",
     ":commodity-price-test-event-trigger",
@@ -225,6 +254,7 @@ source_set("app-main") {
     ":energy-reporting-test-event-trigger",
     ":linux-commissionable-data-provider",
     ":meter-identification-test-event-trigger",
+    ":named-pipes",
     ":smco-test-event-trigger",
     ":software-diagnostics-test-event-trigger",
     ":water-heater-management-test-event-trigger",
@@ -237,6 +267,7 @@ source_set("app-main") {
     ":ota-test-event-trigger",
     "${chip_root}/examples/providers:all_clusters_device_info_provider",
     "${chip_root}/examples/providers:device_info_provider_please_do_not_reuse_as_is",
+    "${chip_root}/src/access",
     "${chip_root}/src/app/server",
     "${chip_root}/src/setup_payload:onboarding-codes-utils",
   ]

--- a/src/platform/nxp/crypto/se05x/BUILD.gn
+++ b/src/platform/nxp/crypto/se05x/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("//build_overrides/nlassert.gni")
 import("//build_overrides/nxp_sdk.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")
@@ -37,9 +38,14 @@ static_library("nxp_crypto_lib") {
     "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_rng.cpp",
     "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp",
     "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.cpp",
-    "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp",
     "${chip_root}/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp",
   ]
+
+  if (chip_device_platform != "linux") {
+    sources += [ "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp" ]
+  } else {
+    sources += [ "${chip_root}/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack_MbedTLS.cpp" ]
+  }
 
   if (chip_crypto != "psa") {
     if (chip_device_platform == "linux" || nxp_platform == "rt/rw61x" ||

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
 {
     CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
     uint32_t keyid         = kKeyId_hkdf_sha256_hmac_keyid;
-    sss_object_t keyObject = { 0 };
+    se_sss_object_t keyObject = { 0 };
     smStatus_t smstatus    = SM_NOT_OK;
     sss_status_t status    = kStatus_SSS_Fail;
 
@@ -58,17 +58,17 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
     VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrExit(gex_sss_chip_ctx.session.subsystem != kType_SSS_SubSystem_NONE, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.session.subsystem != kType_SE_SSS_SubSystem_NONE, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, secret_length,
+    status = se_sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, secret_length,
                                             kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, secret, secret_length, secret_length * 8, NULL, 0);
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, secret, secret_length, secret_length * 8, NULL, 0);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     smstatus = Se05x_API_HKDF_Extended(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyObject.keyId,
@@ -79,9 +79,9 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
     error = CHIP_NO_ERROR;
 exit:
 
-    if (keyObject.keyStore->session != NULL)
+    if (keyObject.keyStore != nullptr && keyObject.keyStore->session != NULL)
     {
-        sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
+        se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
@@ -32,11 +32,11 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
                                        const size_t salt_length, const uint8_t * info, const size_t info_length,
                                        uint8_t * out_buffer, size_t out_length)
 {
-    CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
-    uint32_t keyid         = kKeyId_hkdf_sha256_hmac_keyid;
+    CHIP_ERROR error          = CHIP_ERROR_INTERNAL;
+    uint32_t keyid            = kKeyId_hkdf_sha256_hmac_keyid;
     se_sss_object_t keyObject = { 0 };
-    smStatus_t smstatus    = SM_NOT_OK;
-    sss_status_t status    = kStatus_SSS_Fail;
+    smStatus_t smstatus       = SM_NOT_OK;
+    sss_status_t status       = kStatus_SSS_Fail;
 
     if (salt_length > 64 || info_length > 80 || secret_length > 256 || out_length > 768)
     {
@@ -65,7 +65,7 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, secret_length,
-                                            kKeyObject_Mode_Transient);
+                                               kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, secret, secret_length, secret_length * 8, NULL, 0);

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
@@ -34,11 +34,11 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
                                        uint8_t * out_buffer, size_t out_length)
 
 {
-    CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
-    uint32_t keyid         = kKeyId_hmac_sha256_keyid;
+    CHIP_ERROR error          = CHIP_ERROR_INTERNAL;
+    uint32_t keyid            = kKeyId_hmac_sha256_keyid;
     se_sss_mac_t ctx_mac      = { 0 };
     se_sss_object_t keyObject = { 0 };
-    sss_status_t status    = kStatus_SSS_Fail;
+    sss_status_t status       = kStatus_SSS_Fail;
 
     ChipLogDetail(Crypto, "HMAC_SHA256 : Using se05x for HMAC");
 
@@ -63,7 +63,7 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, key_length,
-                                            kKeyObject_Mode_Transient);
+                                               kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, key, key_length, key_length * 8, NULL, 0);
@@ -106,7 +106,7 @@ exit:
         se_sss_mac_context_free(&ctx_mac);
     }
 
-    if (keyObject.keyStore != nullptr  && keyObject.keyStore->session != NULL)
+    if (keyObject.keyStore != nullptr && keyObject.keyStore->session != NULL)
     {
         se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
@@ -36,8 +36,8 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
 {
     CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
     uint32_t keyid         = kKeyId_hmac_sha256_keyid;
-    sss_mac_t ctx_mac      = { 0 };
-    sss_object_t keyObject = { 0 };
+    se_sss_mac_t ctx_mac      = { 0 };
+    se_sss_object_t keyObject = { 0 };
     sss_status_t status    = kStatus_SSS_Fail;
 
     ChipLogDetail(Crypto, "HMAC_SHA256 : Using se05x for HMAC");
@@ -59,22 +59,22 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, key_length,
+    status = se_sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, key_length,
                                             kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, key, key_length, key_length * 8, NULL, 0);
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, key, key_length, key_length * 8, NULL, 0);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_mac_context_init(&ctx_mac, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_HMAC_SHA256, kMode_SSS_Mac);
+    status = se_sss_mac_context_init(&ctx_mac, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_HMAC_SHA256, kMode_SSS_Mac);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     if (message_length <= MAX_MAC_ONE_SHOT_DATA_LEN)
     {
-        status = sss_mac_one_go(&ctx_mac, message, message_length, out_buffer, &out_length);
+        status = se_sss_mac_one_go(&ctx_mac, message, message_length, out_buffer, &out_length);
         VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
     }
     else
@@ -83,18 +83,18 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
         size_t datalenTemp = 0;
         size_t rem_len     = message_length;
 
-        status = sss_mac_init(&ctx_mac);
+        status = se_sss_mac_init(&ctx_mac);
         VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
         while (rem_len > 0)
         {
             datalenTemp = (rem_len > MAX_MAC_ONE_SHOT_DATA_LEN) ? MAX_MAC_ONE_SHOT_DATA_LEN : rem_len;
-            status      = sss_mac_update(&ctx_mac, (message + (message_length - rem_len)), datalenTemp);
+            status      = se_sss_mac_update(&ctx_mac, (message + (message_length - rem_len)), datalenTemp);
             VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
             rem_len = rem_len - datalenTemp;
         }
 
-        status = sss_mac_finish(&ctx_mac, out_buffer, &out_length);
+        status = se_sss_mac_finish(&ctx_mac, out_buffer, &out_length);
         VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
     }
 
@@ -103,12 +103,12 @@ exit:
 
     if (ctx_mac.session != NULL)
     {
-        sss_mac_context_free(&ctx_mac);
+        se_sss_mac_context_free(&ctx_mac);
     }
 
-    if (keyObject.keyStore->session != NULL)
+    if (keyObject.keyStore != nullptr  && keyObject.keyStore->session != NULL)
     {
-        sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
+        se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
@@ -98,9 +98,9 @@ P256KeypairSE05x::~P256KeypairSE05x()
 
 CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 {
-    sss_status_t status    = kStatus_SSS_Fail;
+    sss_status_t status       = kStatus_SSS_Fail;
     se_sss_object_t keyObject = { 0 };
-    uint8_t pubkey[128]    = {
+    uint8_t pubkey[128]       = {
         0,
     };
     size_t pubKeyLen   = sizeof(pubkey);
@@ -197,13 +197,13 @@ CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_leng
 
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     uint32_t keyid                    = 0;
-    se_sss_asymmetric_t asymm_ctx        = { 0 };
+    se_sss_asymmetric_t asymm_ctx     = { 0 };
     uint8_t hash[kSHA256_Hash_Length] = {
         0,
     };
     size_t hashLen                                           = sizeof(hash);
     sss_status_t status                                      = kStatus_SSS_Success;
-    se_sss_object_t keyObject                                   = { 0 };
+    se_sss_object_t keyObject                                = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_raw_sig_span(out_signature.Bytes(), out_signature.Capacity());
@@ -231,7 +231,8 @@ CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_leng
     status = se_sss_key_object_get_handle(&keyObject, keyid);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
+    status =
+        se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_asymmetric_sign_digest(&asymm_ctx, hash, hashLen, signature_se05x, &signature_se05x_len);
@@ -383,8 +384,8 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(se_sss_object_t * keyObject, const uint8_t
     status = se_sss_key_object_init(keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = se_sss_key_object_allocate_handle(keyObject, kKeyId_sha256_ecc_pub_keyid, kSSS_KeyPart_Public, kSE_SSS_CipherType_EC_NIST_P,
-                                            256, kKeyObject_Mode_Transient);
+    status = se_sss_key_object_allocate_handle(keyObject, kKeyId_sha256_ecc_pub_keyid, kSSS_KeyPart_Public,
+                                               kSE_SSS_CipherType_EC_NIST_P, 256, kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit((sizeof(nist256_header) + keylen) <= sizeof(public_key), error = CHIP_ERROR_INTERNAL);
@@ -409,14 +410,14 @@ exit:
 CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg, size_t msg_length,
                                                             const P256ECDSASignature & signature) const
 {
-    CHIP_ERROR error           = CHIP_ERROR_INTERNAL;
-    sss_status_t status        = kStatus_SSS_Success;
+    CHIP_ERROR error              = CHIP_ERROR_INTERNAL;
+    sss_status_t status           = kStatus_SSS_Success;
     se_sss_asymmetric_t asymm_ctx = { 0 };
-    uint8_t hash[32]           = {
+    uint8_t hash[32]              = {
         0,
     };
     size_t hash_length                                       = sizeof(hash);
-    se_sss_object_t keyObject                                   = { 0 };
+    se_sss_object_t keyObject                                = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_der_sig_span(signature_se05x, signature_se05x_len);
@@ -472,8 +473,8 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
 {
     CHIP_ERROR error                                         = CHIP_ERROR_INTERNAL;
     sss_status_t status                                      = kStatus_SSS_Success;
-    se_sss_asymmetric_t asymm_ctx                               = { 0 };
-    se_sss_object_t keyObject                                   = { 0 };
+    se_sss_asymmetric_t asymm_ctx                            = { 0 };
+    se_sss_object_t keyObject                                = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_der_sig_span(signature_se05x, signature_se05x_len);
@@ -501,7 +502,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
     signature_se05x_len = out_der_sig_span.size();
 
     status = se_sss_asymmetric_verify_digest(&asymm_ctx, const_cast<uint8_t *>(hash), hash_length, (uint8_t *) signature_se05x,
-                                          signature_se05x_len);
+                                             signature_se05x_len);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INVALID_SIGNATURE);
 
     error = CHIP_NO_ERROR;
@@ -575,12 +576,12 @@ static int add_tlv(uint8_t * buf, size_t buf_index, uint8_t tag, size_t len, uin
 
 CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) const
 {
-    CHIP_ERROR error           = CHIP_ERROR_INTERNAL;
-    sss_status_t status        = kStatus_SSS_Success;
+    CHIP_ERROR error              = CHIP_ERROR_INTERNAL;
+    sss_status_t status           = kStatus_SSS_Success;
     se_sss_asymmetric_t asymm_ctx = { 0 };
     se_sss_object_t keyObject     = { 0 };
-    uint32_t keyid             = 0;
-    int ret                    = -1;
+    uint32_t keyid                = 0;
+    int ret                       = -1;
 
     uint8_t data_to_hash[128] = { 0 };
     size_t data_to_hash_len   = sizeof(data_to_hash);
@@ -694,7 +695,8 @@ CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t 
     status = se_sss_key_object_get_handle(&keyObject, keyid);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
+    status =
+        se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_asymmetric_sign_digest(&asymm_ctx, hash, hash_length, Uint8::to_uchar(signature), &signature_len);

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
@@ -99,7 +99,7 @@ P256KeypairSE05x::~P256KeypairSE05x()
 CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 {
     sss_status_t status    = kStatus_SSS_Fail;
-    sss_object_t keyObject = { 0 };
+    se_sss_object_t keyObject = { 0 };
     uint8_t pubkey[128]    = {
         0,
     };
@@ -139,13 +139,13 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 
     ChipLogDetail(Crypto, "se05x::Generate nist256 key using se05x (at id = 0x%" PRIx32 ")", keyid);
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Pair, kSSS_CipherType_EC_NIST_P, 256, options);
+    status = se_sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Pair, kSE_SSS_CipherType_EC_NIST_P, 256, options);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_generate_key(&gex_sss_chip_ctx.ks, &keyObject, 256, 0);
+    status = se_sss_key_store_generate_key(&gex_sss_chip_ctx.ks, &keyObject, 256, 0);
     if (status != kStatus_SSS_Success)
     {
 #ifdef ENABLE_GENERATE_EC_KEY_HOST_ON_FAILURE
@@ -163,7 +163,7 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 #endif
     }
 
-    status = sss_key_store_get_key(&gex_sss_chip_ctx.ks, &keyObject, pubkey, &pubKeyLen, &pbKeyBitLen);
+    status = se_sss_key_store_get_key(&gex_sss_chip_ctx.ks, &keyObject, pubkey, &pubKeyLen, &pbKeyBitLen);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     {
@@ -197,13 +197,13 @@ CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_leng
 
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     uint32_t keyid                    = 0;
-    sss_asymmetric_t asymm_ctx        = { 0 };
+    se_sss_asymmetric_t asymm_ctx        = { 0 };
     uint8_t hash[kSHA256_Hash_Length] = {
         0,
     };
     size_t hashLen                                           = sizeof(hash);
     sss_status_t status                                      = kStatus_SSS_Success;
-    sss_object_t keyObject                                   = { 0 };
+    se_sss_object_t keyObject                                   = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_raw_sig_span(out_signature.Bytes(), out_signature.Capacity());
@@ -225,16 +225,16 @@ CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_leng
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_get_handle(&keyObject, keyid);
+    status = se_sss_key_object_get_handle(&keyObject, keyid);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
+    status = se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_asymmetric_sign_digest(&asymm_ctx, hash, hashLen, signature_se05x, &signature_se05x_len);
+    status = se_sss_asymmetric_sign_digest(&asymm_ctx, hash, hashLen, signature_se05x, &signature_se05x_len);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     error = EcdsaAsn1SignatureToRaw(kP256_FE_Length, ByteSpan{ signature_se05x, signature_se05x_len }, out_raw_sig_span);
@@ -247,7 +247,7 @@ CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_leng
 exit:
     if (asymm_ctx.session != nullptr)
     {
-        sss_asymmetric_context_free(&asymm_ctx);
+        se_sss_asymmetric_context_free(&asymm_ctx);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {
@@ -343,7 +343,7 @@ CHIP_ERROR P256KeypairSE05x::ECDH_derive_secret(const P256PublicKey & remote_pub
     const uint8_t * const rem_pubKey = Uint8::to_const_uchar(remote_public_key);
     const size_t rem_pubKeyLen       = remote_public_key.Length();
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != nullptr, error = CHIP_ERROR_INTERNAL);
 
     smstatus = Se05x_API_ECGenSharedSecret(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, rem_pubKey,
                                            rem_pubKeyLen, out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, &secret_length);
@@ -363,7 +363,7 @@ exit:
 
 /* EC Public key HSM implementation */
 
-CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * key, size_t keylen)
+CHIP_ERROR SE05X_Set_ECDSA_Public_Key(se_sss_object_t * keyObject, const uint8_t * key, size_t keylen)
 {
     uint8_t public_key[128] = {
         0,
@@ -380,10 +380,10 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * 
     VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     /* Set public key */
-    status = sss_key_object_init(keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(keyObject, kKeyId_sha256_ecc_pub_keyid, kSSS_KeyPart_Public, kSSS_CipherType_EC_NIST_P,
+    status = se_sss_key_object_allocate_handle(keyObject, kKeyId_sha256_ecc_pub_keyid, kSSS_KeyPart_Public, kSE_SSS_CipherType_EC_NIST_P,
                                             256, kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
@@ -394,7 +394,7 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * 
     memcpy(public_key + public_key_len, key, keylen);
     public_key_len = public_key_len + keylen;
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, keyObject, public_key, public_key_len, 256, NULL, 0);
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, keyObject, public_key, public_key_len, 256, NULL, 0);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -411,12 +411,12 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg,
 {
     CHIP_ERROR error           = CHIP_ERROR_INTERNAL;
     sss_status_t status        = kStatus_SSS_Success;
-    sss_asymmetric_t asymm_ctx = { 0 };
+    se_sss_asymmetric_t asymm_ctx = { 0 };
     uint8_t hash[32]           = {
         0,
     };
     size_t hash_length                                       = sizeof(hash);
-    sss_object_t keyObject                                   = { 0 };
+    se_sss_object_t keyObject                                   = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_der_sig_span(signature_se05x, signature_se05x_len);
@@ -437,7 +437,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg,
 
     /* ECC Verify */
     status =
-        sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Verify);
+        se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Verify);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     error = EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
@@ -446,19 +446,19 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg,
 
     signature_se05x_len = out_der_sig_span.size();
 
-    status = sss_asymmetric_verify_digest(&asymm_ctx, hash, hash_length, (uint8_t *) signature_se05x, signature_se05x_len);
+    status = se_sss_asymmetric_verify_digest(&asymm_ctx, hash, hash_length, (uint8_t *) signature_se05x, signature_se05x_len);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INVALID_SIGNATURE);
 
     error = CHIP_NO_ERROR;
 exit:
     if (asymm_ctx.session != NULL)
     {
-        sss_asymmetric_context_free(&asymm_ctx);
+        se_sss_asymmetric_context_free(&asymm_ctx);
     }
 
-    if (keyObject.keyStore->session != NULL)
+    if (keyObject.keyStore != nullptr && keyObject.keyStore->session != NULL)
     {
-        sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
+        se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {
@@ -472,8 +472,8 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
 {
     CHIP_ERROR error                                         = CHIP_ERROR_INTERNAL;
     sss_status_t status                                      = kStatus_SSS_Success;
-    sss_asymmetric_t asymm_ctx                               = { 0 };
-    sss_object_t keyObject                                   = { 0 };
+    se_sss_asymmetric_t asymm_ctx                               = { 0 };
+    se_sss_object_t keyObject                                   = { 0 };
     uint8_t signature_se05x[kMax_ECDSA_Signature_Length_Der] = { 0 };
     size_t signature_se05x_len                               = sizeof(signature_se05x);
     MutableByteSpan out_der_sig_span(signature_se05x, signature_se05x_len);
@@ -491,7 +491,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
 
     /* ECC Verify */
     status =
-        sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Verify);
+        se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Verify);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     error = EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan{ Uint8::to_const_uchar(signature.ConstBytes()), signature.Length() },
@@ -500,7 +500,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
 
     signature_se05x_len = out_der_sig_span.size();
 
-    status = sss_asymmetric_verify_digest(&asymm_ctx, const_cast<uint8_t *>(hash), hash_length, (uint8_t *) signature_se05x,
+    status = se_sss_asymmetric_verify_digest(&asymm_ctx, const_cast<uint8_t *>(hash), hash_length, (uint8_t *) signature_se05x,
                                           signature_se05x_len);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INVALID_SIGNATURE);
 
@@ -508,12 +508,12 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
 exit:
     if (asymm_ctx.session != NULL)
     {
-        sss_asymmetric_context_free(&asymm_ctx);
+        se_sss_asymmetric_context_free(&asymm_ctx);
     }
 
-    if (keyObject.keyStore->session != NULL)
+    if (keyObject.keyStore != nullptr && keyObject.keyStore->session != NULL)
     {
-        sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
+        se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {
@@ -577,8 +577,8 @@ CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t 
 {
     CHIP_ERROR error           = CHIP_ERROR_INTERNAL;
     sss_status_t status        = kStatus_SSS_Success;
-    sss_asymmetric_t asymm_ctx = { 0 };
-    sss_object_t keyObject     = { 0 };
+    se_sss_asymmetric_t asymm_ctx = { 0 };
+    se_sss_object_t keyObject     = { 0 };
     uint32_t keyid             = 0;
     int ret                    = -1;
 
@@ -688,16 +688,16 @@ CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t 
     SuccessOrExit(error);
 
     // Sign on hash
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_get_handle(&keyObject, keyid);
+    status = se_sss_key_object_get_handle(&keyObject, keyid);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
+    status = se_sss_asymmetric_context_init(&asymm_ctx, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_SHA256, kMode_SSS_Sign);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_asymmetric_sign_digest(&asymm_ctx, hash, hash_length, Uint8::to_uchar(signature), &signature_len);
+    status = se_sss_asymmetric_sign_digest(&asymm_ctx, hash, hash_length, Uint8::to_uchar(signature), &signature_len);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit((csr_index + 3) <= csr_length, error = CHIP_ERROR_INTERNAL);
@@ -751,7 +751,7 @@ CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t 
 exit:
     if (asymm_ctx.session != NULL)
     {
-        sss_asymmetric_context_free(&asymm_ctx);
+        se_sss_asymmetric_context_free(&asymm_ctx);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR PBKDF2_sha256_SE05x::pbkdf2_sha256(const uint8_t * password, size_t p
     policy_for_hmac_key.policies[0] = &hmac_withPol;
     policy_for_hmac_key.policies[1] = &commonPol;
 
-    sss_object_t hmacKeyObj = {
+    se_sss_object_t hmacKeyObj = {
         0,
     };
 
@@ -74,14 +74,14 @@ CHIP_ERROR PBKDF2_sha256_SE05x::pbkdf2_sha256(const uint8_t * password, size_t p
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&hmacKeyObj, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, sizeof(password),
+    status = se_sss_key_object_allocate_handle(&hmacKeyObj, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, sizeof(password),
                                             kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &hmacKeyObj, password, plen, plen * 8, &policy_for_hmac_key,
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &hmacKeyObj, password, plen, plen * 8, &policy_for_hmac_key,
                                    sizeof(policy_for_hmac_key));
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
@@ -93,9 +93,9 @@ CHIP_ERROR PBKDF2_sha256_SE05x::pbkdf2_sha256(const uint8_t * password, size_t p
 
     error = CHIP_NO_ERROR;
 exit:
-    if (hmacKeyObj.keyStore->session != NULL)
+    if (hmacKeyObj.keyStore != nullptr && hmacKeyObj.keyStore->session != NULL)
     {
-        sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &hmacKeyObj);
+        se_sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &hmacKeyObj);
     }
     if (se05x_close_session() != CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
@@ -78,11 +78,11 @@ CHIP_ERROR PBKDF2_sha256_SE05x::pbkdf2_sha256(const uint8_t * password, size_t p
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_object_allocate_handle(&hmacKeyObj, keyid, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC, sizeof(password),
-                                            kKeyObject_Mode_Transient);
+                                               kKeyObject_Mode_Transient);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &hmacKeyObj, password, plen, plen * 8, &policy_for_hmac_key,
-                                   sizeof(policy_for_hmac_key));
+                                      sizeof(policy_for_hmac_key));
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     smStatus = Se05x_API_PBKDF2_extended(

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_rng.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_rng.cpp
@@ -24,10 +24,13 @@
 
 #include "CHIPCryptoPALHsm_se05x_utils.h"
 #include <lib/core/CHIPEncoding.h>
+#include <mbedtls/version.h>
 
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
 #if ENABLE_SE05X_RND_GEN
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
+#endif
 #endif
 
 namespace chip {
@@ -38,7 +41,7 @@ namespace Crypto {
 CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 {
     sss_status_t status;
-    sss_rng_context_t ctx_rng = { 0 };
+    se_sss_rng_context_t ctx_rng = { 0 };
 
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
@@ -47,13 +50,13 @@ CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    status = sss_rng_context_init(&ctx_rng, &gex_sss_chip_ctx.session /* Session */);
+    status = se_sss_rng_context_init(&ctx_rng, &gex_sss_chip_ctx.session /* Session */);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_rng_get_random(&ctx_rng, out_buffer, out_length);
+    status = se_sss_rng_get_random(&ctx_rng, out_buffer, out_length);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    sss_rng_context_free(&ctx_rng);
+    se_sss_rng_context_free(&ctx_rng);
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
@@ -194,7 +194,7 @@ CHIP_ERROR create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE role, hsm_pake
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
-    subtype.pakeMode = kSE05x_SPAKE2PLUS_P256_SHA256_HKDF_HMAC;
+    subtype.pakeMode = kSE05x_SPAKE2PLUS_P256_SHA256_HKDF_HMAC_v02;
 
 #if ENABLE_REENTRANCY
     VerifyOrReturnError(spake_objects_created < LIMIT_CRYPTO_OBJECTS, CHIP_ERROR_INTERNAL);
@@ -388,8 +388,8 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR(chip::ChipError::Range::kPlatform, smstatus));
 
 #if !ENABLE_SE05X_SPAKE_VERIFIER_USE_TP_VALUES
-    ReturnErrorOnFailure(se05x_set_key_for_spake(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_HMAC));
-    ReturnErrorOnFailure(se05x_set_key_for_spake(Lin_id_v, Lin, Lin_len, kSSS_KeyPart_Default, kSSS_CipherType_HMAC));
+    ReturnErrorOnFailure(se05x_set_key_for_spake(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC));
+    ReturnErrorOnFailure(se05x_set_key_for_spake(Lin_id_v, Lin, Lin_len, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC));
 #endif
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
@@ -468,8 +468,8 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
                                           SE05x_SPAKE2PLUS_DEVICE_TYPE_A);
     VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR(chip::ChipError::Range::kPlatform, smstatus));
 
-    ReturnErrorOnFailure(se05x_set_key_for_spake(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_HMAC));
-    ReturnErrorOnFailure(se05x_set_key_for_spake(w1in_id_p, w1in_mod, w1in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_HMAC));
+    ReturnErrorOnFailure(se05x_set_key_for_spake(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC));
+    ReturnErrorOnFailure(se05x_set_key_for_spake(w1in_id_p, w1in_mod, w1in_mod_len, kSSS_KeyPart_Default, kSE_SSS_CipherType_HMAC));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
                                         static_cast<SE05x_CryptoObjectID_t>(hsm_pake_context.spake_objId),

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.cpp
@@ -131,13 +131,13 @@ CHIP_ERROR se05x_close_session(void)
         ex_sss_session_close(&gex_sss_chip_ctx);
         memset(&gex_sss_chip_ctx, 0, sizeof(gex_sss_chip_ctx));
         is_session_open = 0;
-    }
 
-    ChipLogDetail(Crypto, "Turn OFF SE05x secure element after session close");
-    if (se05x_host_gpio_power_set(0) != 0)
-    {
-        ChipLogError(NotSpecified, "SE05x - Error in se05x_host_gpio_power_set(0) function");
-        return CHIP_ERROR_INTERNAL;
+        ChipLogDetail(Crypto, "Turn OFF SE05x secure element after session close");
+        if (se05x_host_gpio_power_set(0) != 0)
+        {
+            ChipLogError(NotSpecified, "SE05x - Error in se05x_host_gpio_power_set(0) function");
+            return CHIP_ERROR_INTERNAL;
+        }
     }
 
     return CHIP_NO_ERROR;
@@ -170,6 +170,52 @@ CHIP_ERROR se05x_check_object_exists(uint32_t keyid, bool * key_exists)
             return CHIP_NO_ERROR;
         }
         *key_exists = true;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+
+/* Read object size from se05x */
+CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t *psize)
+{
+    smStatus_t smstatus   = SM_NOT_OK;
+    SE05x_Result_t exists = kSE05x_Result_NA;
+
+    VerifyOrReturnError(psize != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (se05x_session_open() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x error: Error in session open");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if (gex_sss_chip_ctx.ks.session == NULL)
+    {
+        ChipLogError(Crypto, "se05x error: Session is NULL");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    // First check if object exists
+    smstatus = Se05x_API_CheckObjectExists(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, objid, &exists);
+    if (smstatus != SM_OK)
+    {
+        ChipLogError(Crypto, "se05x error: Error in Se05x_API_CheckObjectExists for objid 0x%" PRIx32, objid);
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if (exists == kSE05x_Result_FAILURE)
+    {
+        ChipLogDetail(Crypto, "se05x info: Object does not exist for objid 0x%" PRIx32, objid);
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    // Read the object size
+    smstatus = Se05x_API_ReadSize(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, objid, psize);
+    if (smstatus != SM_OK)
+    {
+        ChipLogError(Crypto, "se05x error: Error in Se05x_API_ReadSize for objid 0x%" PRIx32, objid);
+        return CHIP_ERROR_INTERNAL;
     }
 
     return CHIP_NO_ERROR;
@@ -216,10 +262,10 @@ void se05x_delete_key(uint32_t keyid)
 
 /* Set key in se05x */
 CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t keylen, sss_key_part_t keyPart,
-                                   sss_cipher_type_t cipherType)
+                                   se_sss_cipher_type_t cipherType)
 {
     sss_status_t status       = kStatus_SSS_Success;
-    sss_object_t keyObject    = { 0 };
+    se_sss_object_t keyObject    = { 0 };
     const uint8_t keyBuf[128] = {
         0,
     };
@@ -247,7 +293,7 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
     policy_for_hmac_key.policies[0] = &hmac_withPol;
     policy_for_hmac_key.policies[1] = &commonPol;
 
-    if (cipherType == kSSS_CipherType_EC_NIST_P)
+    if (cipherType == kSE_SSS_CipherType_EC_NIST_P)
     {
         VerifyOrReturnError(keylen < (sizeof(keyBuf) - sizeof(header1)), CHIP_ERROR_INTERNAL);
 
@@ -268,13 +314,13 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
         bitlen    = (size_t) keylen * 8;
     }
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyid, keyPart, cipherType, keyBufLen, kKeyObject_Mode_Persistent);
+    status = se_sss_key_object_allocate_handle(&keyObject, keyid, keyPart, cipherType, keyBufLen, kKeyObject_Mode_Persistent);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, keyBuf, keyBufLen, bitlen, &policy_for_hmac_key,
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, keyBuf, keyBufLen, bitlen, &policy_for_hmac_key,
                                    sizeof(policy_for_hmac_key));
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
@@ -284,7 +330,7 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
 /* Get certificate from se05x */
 CHIP_ERROR se05x_get_certificate(uint32_t keyId, uint8_t * buf, size_t * buflen)
 {
-    sss_object_t keyObject = { 0 };
+    se_sss_object_t keyObject = { 0 };
     sss_status_t status    = kStatus_SSS_Fail;
     size_t certBitLen      = 0;
 
@@ -296,13 +342,13 @@ CHIP_ERROR se05x_get_certificate(uint32_t keyId, uint8_t * buf, size_t * buflen)
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_get_handle(&keyObject, keyId);
+    status = se_sss_key_object_get_handle(&keyObject, keyId);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_get_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, &certBitLen);
+    status = se_sss_key_store_get_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, &certBitLen);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -311,17 +357,20 @@ CHIP_ERROR se05x_get_certificate(uint32_t keyId, uint8_t * buf, size_t * buflen)
 /* Set certificate in se05x */
 CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buflen)
 {
-    sss_object_t keyObject = { 0 };
+    se_sss_object_t keyObject = { 0 };
     sss_status_t status    = kStatus_SSS_Fail;
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError((SIZE_MAX / 8) >= (buflen), CHIP_ERROR_INTERNAL);
+
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSSS_CipherType_Certificate, buflen,
+    status = se_sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSE_SSS_CipherType_Certificate, buflen,
                                             kKeyObject_Mode_Transient);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -330,36 +379,20 @@ CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buf
 /* Set Binary data in se05x */
 CHIP_ERROR se05x_set_binary_data(uint32_t keyId, const uint8_t * buf, size_t buflen)
 {
-    sss_object_t keyObject = { 0 };
+    se_sss_object_t keyObject = { 0 };
     sss_status_t status    = kStatus_SSS_Fail;
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError((SIZE_MAX / 8) >= (buflen), CHIP_ERROR_INTERNAL);
+
+    status = se_sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSSS_CipherType_Binary, buflen,
-                                            kKeyObject_Mode_Transient);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
-
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
-
-    return CHIP_NO_ERROR;
-}
-
-/* Set EC key in se05x */
-CHIP_ERROR se05x_set_ec_key(uint32_t keyId, const uint8_t * buf, size_t buflen)
-{
-    sss_object_t keyObject = { 0 };
-    sss_status_t status    = kStatus_SSS_Fail;
-
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
-
-    status = sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Pair, kSSS_CipherType_EC_NIST_P, buflen,
+    status = se_sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSE_SSS_CipherType_Binary, buflen,
                                             kKeyObject_Mode_Persistent);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, 256, NULL, 0);
+    status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.cpp
@@ -175,9 +175,8 @@ CHIP_ERROR se05x_check_object_exists(uint32_t keyid, bool * key_exists)
     return CHIP_NO_ERROR;
 }
 
-
 /* Read object size from se05x */
-CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t *psize)
+CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t * psize)
 {
     smStatus_t smstatus   = SM_NOT_OK;
     SE05x_Result_t exists = kSE05x_Result_NA;
@@ -265,7 +264,7 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
                                    se_sss_cipher_type_t cipherType)
 {
     sss_status_t status       = kStatus_SSS_Success;
-    se_sss_object_t keyObject    = { 0 };
+    se_sss_object_t keyObject = { 0 };
     const uint8_t keyBuf[128] = {
         0,
     };
@@ -321,7 +320,7 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, keyBuf, keyBufLen, bitlen, &policy_for_hmac_key,
-                                   sizeof(policy_for_hmac_key));
+                                      sizeof(policy_for_hmac_key));
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -331,8 +330,8 @@ CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t k
 CHIP_ERROR se05x_get_certificate(uint32_t keyId, uint8_t * buf, size_t * buflen)
 {
     se_sss_object_t keyObject = { 0 };
-    sss_status_t status    = kStatus_SSS_Fail;
-    size_t certBitLen      = 0;
+    sss_status_t status       = kStatus_SSS_Fail;
+    size_t certBitLen         = 0;
 
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(buflen != nullptr, CHIP_ERROR_INTERNAL);
@@ -358,7 +357,7 @@ CHIP_ERROR se05x_get_certificate(uint32_t keyId, uint8_t * buf, size_t * buflen)
 CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buflen)
 {
     se_sss_object_t keyObject = { 0 };
-    sss_status_t status    = kStatus_SSS_Fail;
+    sss_status_t status       = kStatus_SSS_Fail;
 
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError((SIZE_MAX / 8) >= (buflen), CHIP_ERROR_INTERNAL);
@@ -367,7 +366,7 @@ CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buf
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSE_SSS_CipherType_Certificate, buflen,
-                                            kKeyObject_Mode_Transient);
+                                               kKeyObject_Mode_Transient);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);
@@ -380,7 +379,7 @@ CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buf
 CHIP_ERROR se05x_set_binary_data(uint32_t keyId, const uint8_t * buf, size_t buflen)
 {
     se_sss_object_t keyObject = { 0 };
-    sss_status_t status    = kStatus_SSS_Fail;
+    sss_status_t status       = kStatus_SSS_Fail;
 
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError((SIZE_MAX / 8) >= (buflen), CHIP_ERROR_INTERNAL);
@@ -389,7 +388,7 @@ CHIP_ERROR se05x_set_binary_data(uint32_t keyId, const uint8_t * buf, size_t buf
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_object_allocate_handle(&keyObject, keyId, kSSS_KeyPart_Default, kSE_SSS_CipherType_Binary, buflen,
-                                            kKeyObject_Mode_Persistent);
+                                               kKeyObject_Mode_Persistent);
     VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = se_sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, buf, buflen, buflen * 8, NULL, 0);

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.h
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.h
@@ -34,7 +34,7 @@
 #include "ex_sss_boot.h"
 #include "se051h_nfc_comm_prov.h"
 #include "se05x_host_gpio.h"
-#include "sss/inc/fsl_sss_api.h"
+#include "inc/fsl_sss_api.h"
 #include <fsl_sss_se05x_apis.h>
 #include <se05x_APDU.h>
 
@@ -106,11 +106,11 @@ void se05x_delete_key(uint32_t keyid);
  * @param[in] key - Buffer with AES / EC key key.
  * @param[in] keylen - Key length.
  * @param[in] keyPart - Type of key.
- * @param[in] cipherType - kSSS_CipherType_EC_NIST_P for ecc and kSSS_CipherType_HMAC for AES key.
+ * @param[in] cipherType - kSE_SSS_CipherType_EC_NIST_P for ecc and kSE_SSS_CipherType_HMAC for AES key.
  * @return CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
  */
 CHIP_ERROR se05x_set_key_for_spake(uint32_t keyid, const uint8_t * key, size_t keylen, sss_key_part_t keyPart,
-                                   sss_cipher_type_t cipherType);
+                                   se_sss_cipher_type_t cipherType);
 /**
  * @brief Get certificate in se05x.
  * The certificate is stored with transient option. The contents are lost on session close.
@@ -133,23 +133,13 @@ CHIP_ERROR se05x_set_certificate(uint32_t keyId, const uint8_t * buf, size_t buf
 
 /**
  * @brief Set binary data in se05x.
- * The certificate is stored with transient option. The contents are lost on session close.
+ * The certificate is stored with Persistent option. The contents are lost on session close.
  * @param[in] keyid - Key id of the object.
  * @param[in] buf - Buffer containing binary data.
  * @param[in] buflen - Buffer length.
  * @return CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
  */
 CHIP_ERROR se05x_set_binary_data(uint32_t keyId, const uint8_t * buf, size_t buflen);
-
-/**
- * @brief Set EC key in se05x.
- * The Key is stored with Persistent option.
- * @param[in] keyid - Key id of the object.
- * @param[in] buf - Buffer containing Key data.
- * @param[in] buflen - Buffer length.
- * @return CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
- */
-CHIP_ERROR se05x_set_ec_key(uint32_t keyId, const uint8_t * buf, size_t buflen);
 
 /**
  * @brief Perform internal sign in se05x (only on SE051H).
@@ -181,6 +171,13 @@ void se05x_setCryptoObjID(SE05x_CryptoObjectID_t objId, uint8_t status);
 
 #endif // #if ENABLE_REENTRANCY
 
+/**
+ * @brief Read the size of a secure object in SE05x.
+ * @param[in] objid - Object identifier
+ * @param[out] psize - Pointer to store the object size
+ * @return CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
+ */
+CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t *psize);
 #ifdef __cplusplus
 }
 #endif

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.h
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_utils.h
@@ -32,9 +32,9 @@
 
 /* se05x includes */
 #include "ex_sss_boot.h"
+#include "inc/fsl_sss_api.h"
 #include "se051h_nfc_comm_prov.h"
 #include "se05x_host_gpio.h"
-#include "inc/fsl_sss_api.h"
 #include <fsl_sss_se05x_apis.h>
 #include <se05x_APDU.h>
 
@@ -177,7 +177,7 @@ void se05x_setCryptoObjID(SE05x_CryptoObjectID_t objId, uint8_t status);
  * @param[out] psize - Pointer to store the object size
  * @return CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
  */
-CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t *psize);
+CHIP_ERROR se05x_read_object_size(uint32_t objid, uint16_t * psize);
 #ifdef __cplusplus
 }
 #endif

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp
@@ -17,34 +17,28 @@
 
 /**
  *    @file
- *      mbedTLS based implementation of CHIP crypto primitives
+ *    PSA Crypto based implementation of CHIP crypto primitives (host fallback)
  */
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/CHIPCryptoPALmbedTLS.h>
 
 #include <type_traits>
+#include <psa/crypto.h>
 
-#include <mbedtls/bignum.h>
-#include <mbedtls/ccm.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/ecdh.h>
-#include <mbedtls/ecdsa.h>
-#include <mbedtls/ecp.h>
-#include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
-#include <mbedtls/hkdf.h>
 #include <mbedtls/md.h>
 #include <mbedtls/pkcs5.h>
-#include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-#include <mbedtls/x509_crt.h>
-#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
 #include <mbedtls/oid.h>
+#include <mbedtls/pk.h>
 #include <mbedtls/version.h>
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_csr.h>
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#include <mbedtls/x509_crt.h>
+#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+
 
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BufferWriter.h>
@@ -59,54 +53,88 @@
 namespace chip {
 namespace Crypto {
 
-static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
+// Structure to hold PSA key ID inside P256KeypairContext
+struct PsaP256KeyContext
 {
-    return (chip::Crypto::DRBG_get_bytes(out_buffer, out_length) == CHIP_NO_ERROR) ? 0 : 1;
+    psa_key_id_t key_id;
+};
+
+static_assert(sizeof(PsaP256KeyContext) <= sizeof(P256KeypairContext),
+              "PsaP256KeyContext must fit in P256KeypairContext");
+
+static inline PsaP256KeyContext * to_psa_context(P256KeypairContext * context)
+{
+    return SafePointerCast<PsaP256KeyContext *>(context);
 }
 
-static inline mbedtls_ecp_keypair * to_keypair(P256KeypairContext * context)
-{
-    return SafePointerCast<mbedtls_ecp_keypair *>(context);
-}
-
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
 static inline const mbedtls_ecp_keypair * to_const_keypair(const P256KeypairContext * context)
 {
     return SafePointerCast<const mbedtls_ecp_keypair *>(context);
 }
+#endif
+
+static inline const PsaP256KeyContext * to_const_psa_context(const P256KeypairContext * context)
+{
+    return SafePointerCast<const PsaP256KeyContext *>(context);
+}
+
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
+{
+    return (chip::Crypto::DRBG_get_bytes(out_buffer, out_length) == CHIP_NO_ERROR) ? 0 : 1;
+}
+#endif
 
 CHIP_ERROR Initialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256KeypairContext * mKeypair)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    CHIP_ERROR error     = CHIP_NO_ERROR;
+    psa_status_t result  = PSA_SUCCESS;
+    size_t pubkey_size   = 0;
+    psa_key_id_t key_id  = PSA_KEY_ID_NULL;
 
-    size_t pubkey_size = 0;
 
     pk->Clear();
 
-    mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey->Type());
+    // Initialize the context
+    PsaP256KeyContext * ctx = to_psa_context(mKeypair);
+    memset(ctx, 0, sizeof(PsaP256KeyContext));
 
-    mbedtls_ecp_keypair * keypair = to_keypair(mKeypair);
-    mbedtls_ecp_keypair_init(keypair);
+    // Set up PSA key attributes for P-256
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+    psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
+    psa_set_key_usage_flags(&attributes,
+                            PSA_KEY_USAGE_SIGN_HASH |
+                            PSA_KEY_USAGE_VERIFY_HASH |
+                            PSA_KEY_USAGE_DERIVE |
+                            PSA_KEY_USAGE_EXPORT);
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+    psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDH);
+    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
 
-    result = mbedtls_ecp_gen_key(group, keypair, CryptoRNG, nullptr);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    // Generate the key pair
+    result = psa_generate_key(&attributes, &key_id);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_write_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), &keypair->CHIP_CRYPTO_PAL_PRIVATE(Q),
-                                            MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size, Uint8::to_uchar(mPublicKey->Bytes()),
-                                            mPublicKey->Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    // Export the public key
+    result = psa_export_public_key(key_id,
+                                    Uint8::to_uchar(mPublicKey->Bytes()),
+                                    mPublicKey->Length(),
+                                    &pubkey_size);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == mPublicKey->Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    keypair = nullptr;
-    // mInitialized to be set in caller function
-    // pk.mInitialized = true;
+    // Store the key ID in the context
+    ctx->key_id = key_id;
+    key_id = PSA_KEY_ID_NULL;
 
 exit:
-    if (keypair != nullptr)
+    if (key_id != PSA_KEY_ID_NULL)
     {
-        mbedtls_ecp_keypair_free(keypair);
-        keypair = nullptr;
+        psa_destroy_key(key_id);
     }
+    psa_reset_key_attributes(&attributes);
 
     _log_mbedTLS_error(result);
     return error;
@@ -115,107 +143,59 @@ exit:
 CHIP_ERROR ECDSA_sign_msg_H(P256KeypairContext * mKeypair, const uint8_t * msg, const size_t msg_length,
                             P256ECDSASignature & out_signature)
 {
-    // To be checked by the caller
-    // VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
 
     uint8_t digest[kSHA256_Hash_Length];
     memset(&digest[0], 0, sizeof(digest));
     ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
 
-#if defined(MBEDTLS_ECDSA_C)
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
-    mbedtls_mpi r, s;
-    mbedtls_mpi_init(&r);
-    mbedtls_mpi_init(&s);
+    CHIP_ERROR error       = CHIP_NO_ERROR;
+    psa_status_t result    = PSA_SUCCESS;
+    size_t signature_length = 0;
 
-    const mbedtls_ecp_keypair * keypair = to_const_keypair(mKeypair);
+    const PsaP256KeyContext * ctx = to_const_psa_context(mKeypair);
 
-    mbedtls_ecdsa_context ecdsa_ctxt;
-    mbedtls_ecdsa_init(&ecdsa_ctxt);
+    // PSA sign hash - directly produces signature in r||s format
+    result = psa_sign_hash(ctx->key_id,
+                           PSA_ALG_ECDSA(PSA_ALG_SHA_256),
+                           digest,
+                           sizeof(digest),
+                           out_signature.Bytes(),
+                           out_signature.Capacity(),
+                           &signature_length);
 
-    result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, keypair);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_ecdsa_sign(&ecdsa_ctxt.CHIP_CRYPTO_PAL_PRIVATE(grp), &r, &s, &ecdsa_ctxt.CHIP_CRYPTO_PAL_PRIVATE(d),
-                                Uint8::to_const_uchar(digest), sizeof(digest), CryptoRNG, nullptr);
-
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit((mbedtls_mpi_size(&r) <= kP256_FE_Length) && (mbedtls_mpi_size(&s) <= kP256_FE_Length),
-                 error = CHIP_ERROR_INTERNAL);
-
-    // Concatenate r and s to output. Sizes were checked above.
-    result = mbedtls_mpi_write_binary(&r, out_signature.Bytes() + 0u, kP256_FE_Length);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_mpi_write_binary(&s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(signature_length == kP256_ECDSA_Signature_Length_Raw, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(out_signature.SetLength(signature_length) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    keypair = nullptr;
-    mbedtls_ecdsa_free(&ecdsa_ctxt);
-    mbedtls_mpi_free(&s);
-    mbedtls_mpi_free(&r);
     _log_mbedTLS_error(result);
     return error;
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
 
 CHIP_ERROR ECDH_derive_secret_H(P256KeypairContext * mKeypair, const P256PublicKey & remote_public_key,
                                 P256ECDHDerivedSecret & out_secret)
 {
-#if defined(MBEDTLS_ECDH_C)
-
     CHIP_ERROR error     = CHIP_NO_ERROR;
-    int result           = 0;
-    size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
+    psa_status_t result  = PSA_SUCCESS;
+    size_t secret_length = 0;
+    const PsaP256KeyContext * ctx = to_const_psa_context(mKeypair);
 
-    mbedtls_ecp_group ecp_grp;
-    mbedtls_ecp_group_init(&ecp_grp);
-
-    mbedtls_mpi mpi_secret;
-    mbedtls_mpi_init(&mpi_secret);
-
-    mbedtls_ecp_point ecp_pubkey;
-    mbedtls_ecp_point_init(&ecp_pubkey);
-
-    const mbedtls_ecp_keypair * keypair = to_const_keypair(mKeypair);
-
-    // To be checked by the caller
-    // VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
-
-    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(remote_public_key.Type()));
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result =
-        mbedtls_ecp_point_read_binary(&ecp_grp, &ecp_pubkey, Uint8::to_const_uchar(remote_public_key), remote_public_key.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result =
-        mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &keypair->CHIP_CRYPTO_PAL_PRIVATE(d), CryptoRNG, nullptr);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_mpi_write_binary(&mpi_secret, out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, secret_length);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    // Perform ECDH key agreement directly with peer public key bytes
+    result = psa_raw_key_agreement(PSA_ALG_ECDH,
+                                   ctx->key_id,
+                                   Uint8::to_const_uchar(remote_public_key),
+                                   remote_public_key.Length(),
+                                   out_secret.Bytes(),
+                                   out_secret.Capacity(),
+                                   &secret_length);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
     TEMPORARY_RETURN_IGNORED out_secret.SetLength(secret_length);
 
 exit:
-    keypair = nullptr;
-    mbedtls_ecp_group_free(&ecp_grp);
-    mbedtls_mpi_free(&mpi_secret);
-    mbedtls_ecp_point_free(&ecp_pubkey);
     _log_mbedTLS_error(result);
     return error;
-
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
 
 CHIP_ERROR NewCertificateSigningRequest_H(P256KeypairContext * mKeypair, uint8_t * out_csr, size_t & csr_length)
@@ -225,28 +205,33 @@ CHIP_ERROR NewCertificateSigningRequest_H(P256KeypairContext * mKeypair, uint8_t
     int result       = 0;
     size_t out_length;
 
+    const PsaP256KeyContext * ctx = to_const_psa_context(mKeypair);
+
     mbedtls_x509write_csr csr;
     mbedtls_x509write_csr_init(&csr);
 
+    // Wrap PSA key ID in an mbedtls_pk_context using opaque key setup
     mbedtls_pk_context pk;
-    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
-    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx)  = to_keypair(mKeypair);
-    VerifyOrExit(pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) != nullptr, error = CHIP_ERROR_INTERNAL);
+    mbedtls_pk_init(&pk);
 
-    // To be checked by the caller
-    // VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+    // In Mbed TLS 4, we use mbedtls_pk_wrap_psa to wrap PSA key
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+    result = mbedtls_pk_setup_opaque(&pk, ctx->key_id);
+#else
+    result = mbedtls_pk_wrap_psa(&pk, ctx->key_id);
+#endif
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     mbedtls_x509write_csr_set_key(&csr, &pk);
-
     mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);
-
-    // TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
-    //       CHIP Spec doesn't specify the subject name that can be used.
-    //       Figure out the correct value and update this code.
     result = mbedtls_x509write_csr_set_subject_name(&csr, "O=CSR");
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
     result = mbedtls_x509write_csr_der(&csr, out_csr, csr_length, CryptoRNG, nullptr);
+#else
+    result = mbedtls_x509write_csr_der(&csr, out_csr, csr_length);
+#endif
     VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(CanCastTo<size_t>(result), error = CHIP_ERROR_INTERNAL);
 
@@ -257,7 +242,6 @@ CHIP_ERROR NewCertificateSigningRequest_H(P256KeypairContext * mKeypair, uint8_t
     if (csr_length != out_length)
     {
         // mbedTLS API writes the CSR at the end of the provided buffer.
-        // Let's move it to the start of the buffer.
         size_t offset = csr_length - out_length;
         memmove(out_csr, &out_csr[offset], out_length);
     }
@@ -265,39 +249,43 @@ CHIP_ERROR NewCertificateSigningRequest_H(P256KeypairContext * mKeypair, uint8_t
     csr_length = out_length;
 
 exit:
+    mbedtls_pk_free(&pk);
     mbedtls_x509write_csr_free(&csr);
 
     _log_mbedTLS_error(result);
     return error;
 #else
-    ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
+    ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created...");
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
 }
 
 CHIP_ERROR Serialize_H(const P256KeypairContext mKeypair, const P256PublicKey mPublicKey, P256SerializedKeypair & output)
 {
-    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
-    size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
+    const PsaP256KeyContext * ctx = to_const_psa_context(&mKeypair);
+
+    size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
     Encoding::BufferWriter bbuf(output.Bytes(), len);
     uint8_t privkey[kP256_PrivateKey_Length];
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    CHIP_ERROR error    = CHIP_NO_ERROR;
+    psa_status_t result = PSA_SUCCESS;
+    size_t privkey_size = 0;
 
+    // Write the public key to the output buffer
     bbuf.Put(mPublicKey, mPublicKey.Length());
-
     VerifyOrExit(bbuf.Available() == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(mbedtls_mpi_size(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d)) <= bbuf.Available(), error = CHIP_ERROR_INTERNAL);
-    result = mbedtls_mpi_write_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d), Uint8::to_uchar(privkey), sizeof(privkey));
-
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    // Export private key from PSA key storage
+    result = psa_export_key(ctx->key_id,
+                            Uint8::to_uchar(privkey),
+                            sizeof(privkey),
+                            &privkey_size);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(privkey_size == kP256_PrivateKey_Length, error = CHIP_ERROR_INTERNAL);
 
     bbuf.Put(privkey, sizeof(privkey));
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_BUFFER_TOO_SMALL);
-
     TEMPORARY_RETURN_IGNORED output.SetLength(bbuf.Needed());
-
 exit:
     ClearSecretData(privkey, sizeof(privkey));
     _log_mbedTLS_error(result);
@@ -308,41 +296,59 @@ CHIP_ERROR Deserialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypa
 {
     Encoding::BufferWriter bbuf(*mPublicKey, mPublicKey->Length());
 
-    int result       = 0;
-    CHIP_ERROR error = CHIP_NO_ERROR;
+    psa_status_t result = PSA_SUCCESS;
+    CHIP_ERROR error    = CHIP_NO_ERROR;
+    psa_key_id_t key_id = PSA_KEY_ID_NULL;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    PsaP256KeyContext * ctx = NULL;
+    const uint8_t * privkey = NULL;
+
+    VerifyOrExit(input.Length() == mPublicKey->Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Extract private key bytes
+    privkey = input.ConstBytes() + mPublicKey->Length();
 
     pk->Clear();
 
-    mbedtls_ecp_keypair * keypair = to_keypair(mKeypair);
-    mbedtls_ecp_keypair_init(keypair);
+    // Initialize the context
+    ctx = to_psa_context(mKeypair);
+    memset(ctx, 0, sizeof(PsaP256KeyContext));
 
-    result = mbedtls_ecp_group_load(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), MapECPGroupId(mPublicKey->Type()));
+    // Set up PSA key attributes for importing the private key
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+    // psa_set_key_bits(&attributes, 256);
+    psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
+    psa_set_key_usage_flags(&attributes,
+                            PSA_KEY_USAGE_SIGN_HASH |
+                            PSA_KEY_USAGE_VERIFY_HASH |
+                            PSA_KEY_USAGE_DERIVE |
+                            PSA_KEY_USAGE_EXPORT);
 
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+    // psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDH);
+    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
 
-    VerifyOrExit(input.Length() == mPublicKey->Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    // Import the raw private key scalar into PSA
+    result = psa_import_key(&attributes,
+                            privkey,
+                            kP256_PrivateKey_Length,
+                            &key_id);
+    psa_reset_key_attributes(&attributes);
+    VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Extract public key from serialized input
     bbuf.Put(input.ConstBytes(), mPublicKey->Length());
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
 
-    printf("\n");
-    for (size_t i = 0; i < mPublicKey->Length(); i++)
-    {
-        printf("0x%02X ", Uint8::to_const_uchar(*mPublicKey)[i]);
-    }
-    printf("\n");
-
-    result = mbedtls_ecp_point_read_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), &keypair->CHIP_CRYPTO_PAL_PRIVATE(Q),
-                                           Uint8::to_const_uchar(*mPublicKey), mPublicKey->Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    {
-        const uint8_t * privkey = input.ConstBytes() /*Uint8::to_const_uchar(input)*/ + mPublicKey->Length();
-
-        result = mbedtls_mpi_read_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d), privkey, kP256_PrivateKey_Length);
-        VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    }
+    // Store key ID in context - ownership transferred
+    ctx->key_id = key_id;
+    key_id = PSA_KEY_ID_NULL;
 
 exit:
+    if (key_id != PSA_KEY_ID_NULL)
+    {
+        psa_destroy_key(key_id);
+    }
     _log_mbedTLS_error(result);
     return error;
 }

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack.cpp
@@ -23,22 +23,21 @@
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/CHIPCryptoPALmbedTLS.h>
 
-#include <type_traits>
 #include <psa/crypto.h>
+#include <type_traits>
 
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
-#include <mbedtls/pkcs5.h>
-#include <mbedtls/sha256.h>
 #include <mbedtls/oid.h>
 #include <mbedtls/pk.h>
+#include <mbedtls/pkcs5.h>
+#include <mbedtls/sha256.h>
 #include <mbedtls/version.h>
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_csr.h>
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 #include <mbedtls/x509_crt.h>
 #endif // defined(MBEDTLS_X509_CRT_PARSE_C)
-
 
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BufferWriter.h>
@@ -59,8 +58,7 @@ struct PsaP256KeyContext
     psa_key_id_t key_id;
 };
 
-static_assert(sizeof(PsaP256KeyContext) <= sizeof(P256KeypairContext),
-              "PsaP256KeyContext must fit in P256KeypairContext");
+static_assert(sizeof(PsaP256KeyContext) <= sizeof(P256KeypairContext), "PsaP256KeyContext must fit in P256KeypairContext");
 
 static inline PsaP256KeyContext * to_psa_context(P256KeypairContext * context)
 {
@@ -88,11 +86,10 @@ static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
 
 CHIP_ERROR Initialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256KeypairContext * mKeypair)
 {
-    CHIP_ERROR error     = CHIP_NO_ERROR;
-    psa_status_t result  = PSA_SUCCESS;
-    size_t pubkey_size   = 0;
-    psa_key_id_t key_id  = PSA_KEY_ID_NULL;
-
+    CHIP_ERROR error    = CHIP_NO_ERROR;
+    psa_status_t result = PSA_SUCCESS;
+    size_t pubkey_size  = 0;
+    psa_key_id_t key_id = PSA_KEY_ID_NULL;
 
     pk->Clear();
 
@@ -105,10 +102,7 @@ CHIP_ERROR Initialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypai
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
     psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
     psa_set_key_usage_flags(&attributes,
-                            PSA_KEY_USAGE_SIGN_HASH |
-                            PSA_KEY_USAGE_VERIFY_HASH |
-                            PSA_KEY_USAGE_DERIVE |
-                            PSA_KEY_USAGE_EXPORT);
+                            PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH | PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT);
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
     psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDH);
     psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
@@ -118,16 +112,13 @@ CHIP_ERROR Initialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypai
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     // Export the public key
-    result = psa_export_public_key(key_id,
-                                    Uint8::to_uchar(mPublicKey->Bytes()),
-                                    mPublicKey->Length(),
-                                    &pubkey_size);
+    result = psa_export_public_key(key_id, Uint8::to_uchar(mPublicKey->Bytes()), mPublicKey->Length(), &pubkey_size);
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == mPublicKey->Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Store the key ID in the context
     ctx->key_id = key_id;
-    key_id = PSA_KEY_ID_NULL;
+    key_id      = PSA_KEY_ID_NULL;
 
 exit:
     if (key_id != PSA_KEY_ID_NULL)
@@ -145,25 +136,19 @@ CHIP_ERROR ECDSA_sign_msg_H(P256KeypairContext * mKeypair, const uint8_t * msg, 
 {
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
 
-
     uint8_t digest[kSHA256_Hash_Length];
     memset(&digest[0], 0, sizeof(digest));
     ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
 
-    CHIP_ERROR error       = CHIP_NO_ERROR;
-    psa_status_t result    = PSA_SUCCESS;
+    CHIP_ERROR error        = CHIP_NO_ERROR;
+    psa_status_t result     = PSA_SUCCESS;
     size_t signature_length = 0;
 
     const PsaP256KeyContext * ctx = to_const_psa_context(mKeypair);
 
     // PSA sign hash - directly produces signature in r||s format
-    result = psa_sign_hash(ctx->key_id,
-                           PSA_ALG_ECDSA(PSA_ALG_SHA_256),
-                           digest,
-                           sizeof(digest),
-                           out_signature.Bytes(),
-                           out_signature.Capacity(),
-                           &signature_length);
+    result = psa_sign_hash(ctx->key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest, sizeof(digest), out_signature.Bytes(),
+                           out_signature.Capacity(), &signature_length);
 
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(signature_length == kP256_ECDSA_Signature_Length_Raw, error = CHIP_ERROR_INTERNAL);
@@ -177,19 +162,14 @@ exit:
 CHIP_ERROR ECDH_derive_secret_H(P256KeypairContext * mKeypair, const P256PublicKey & remote_public_key,
                                 P256ECDHDerivedSecret & out_secret)
 {
-    CHIP_ERROR error     = CHIP_NO_ERROR;
-    psa_status_t result  = PSA_SUCCESS;
-    size_t secret_length = 0;
+    CHIP_ERROR error              = CHIP_NO_ERROR;
+    psa_status_t result           = PSA_SUCCESS;
+    size_t secret_length          = 0;
     const PsaP256KeyContext * ctx = to_const_psa_context(mKeypair);
 
     // Perform ECDH key agreement directly with peer public key bytes
-    result = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                   ctx->key_id,
-                                   Uint8::to_const_uchar(remote_public_key),
-                                   remote_public_key.Length(),
-                                   out_secret.Bytes(),
-                                   out_secret.Capacity(),
-                                   &secret_length);
+    result = psa_raw_key_agreement(PSA_ALG_ECDH, ctx->key_id, Uint8::to_const_uchar(remote_public_key), remote_public_key.Length(),
+                                   out_secret.Bytes(), out_secret.Capacity(), &secret_length);
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
     TEMPORARY_RETURN_IGNORED out_secret.SetLength(secret_length);
 
@@ -276,10 +256,7 @@ CHIP_ERROR Serialize_H(const P256KeypairContext mKeypair, const P256PublicKey mP
     VerifyOrExit(bbuf.Available() == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
 
     // Export private key from PSA key storage
-    result = psa_export_key(ctx->key_id,
-                            Uint8::to_uchar(privkey),
-                            sizeof(privkey),
-                            &privkey_size);
+    result = psa_export_key(ctx->key_id, Uint8::to_uchar(privkey), sizeof(privkey), &privkey_size);
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(privkey_size == kP256_PrivateKey_Length, error = CHIP_ERROR_INTERNAL);
 
@@ -296,12 +273,12 @@ CHIP_ERROR Deserialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypa
 {
     Encoding::BufferWriter bbuf(*mPublicKey, mPublicKey->Length());
 
-    psa_status_t result = PSA_SUCCESS;
-    CHIP_ERROR error    = CHIP_NO_ERROR;
-    psa_key_id_t key_id = PSA_KEY_ID_NULL;
+    psa_status_t result             = PSA_SUCCESS;
+    CHIP_ERROR error                = CHIP_NO_ERROR;
+    psa_key_id_t key_id             = PSA_KEY_ID_NULL;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    PsaP256KeyContext * ctx = NULL;
-    const uint8_t * privkey = NULL;
+    PsaP256KeyContext * ctx         = NULL;
+    const uint8_t * privkey         = NULL;
 
     VerifyOrExit(input.Length() == mPublicKey->Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -319,20 +296,14 @@ CHIP_ERROR Deserialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypa
     // psa_set_key_bits(&attributes, 256);
     psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
     psa_set_key_usage_flags(&attributes,
-                            PSA_KEY_USAGE_SIGN_HASH |
-                            PSA_KEY_USAGE_VERIFY_HASH |
-                            PSA_KEY_USAGE_DERIVE |
-                            PSA_KEY_USAGE_EXPORT);
+                            PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH | PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT);
 
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
     // psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDH);
     psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
 
     // Import the raw private key scalar into PSA
-    result = psa_import_key(&attributes,
-                            privkey,
-                            kP256_PrivateKey_Length,
-                            &key_id);
+    result = psa_import_key(&attributes, privkey, kP256_PrivateKey_Length, &key_id);
     psa_reset_key_attributes(&attributes);
     VerifyOrExit(result == PSA_SUCCESS, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -342,7 +313,7 @@ CHIP_ERROR Deserialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256Keypa
 
     // Store key ID in context - ownership transferred
     ctx->key_id = key_id;
-    key_id = PSA_KEY_ID_NULL;
+    key_id      = PSA_KEY_ID_NULL;
 
 exit:
     if (key_id != PSA_KEY_ID_NULL)

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack_MbedTLS.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_HostFallBack_MbedTLS.cpp
@@ -1,0 +1,344 @@
+/*
+ *
+ *    Copyright (c) 2020-2022, 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      mbedTLS based implementation of CHIP crypto primitives
+ */
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <crypto/CHIPCryptoPALmbedTLS.h>
+
+#include <type_traits>
+
+#include <mbedtls/bignum.h>
+#include <mbedtls/ccm.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/ecdsa.h>
+#include <mbedtls/ecp.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/hkdf.h>
+#include <mbedtls/md.h>
+#include <mbedtls/pkcs5.h>
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#include <mbedtls/x509_crt.h>
+#endif // defined(MBEDTLS_X509_CRT_PARSE_C)
+#include <mbedtls/oid.h>
+#include <mbedtls/version.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/x509_csr.h>
+
+#include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/BufferWriter.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/SafePointerCast.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <string.h>
+
+namespace chip {
+namespace Crypto {
+
+static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
+{
+    return (chip::Crypto::DRBG_get_bytes(out_buffer, out_length) == CHIP_NO_ERROR) ? 0 : 1;
+}
+
+static inline mbedtls_ecp_keypair * to_keypair(P256KeypairContext * context)
+{
+    return SafePointerCast<mbedtls_ecp_keypair *>(context);
+}
+
+static inline const mbedtls_ecp_keypair * to_const_keypair(const P256KeypairContext * context)
+{
+    return SafePointerCast<const mbedtls_ecp_keypair *>(context);
+}
+
+CHIP_ERROR Initialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256KeypairContext * mKeypair)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+
+    size_t pubkey_size = 0;
+
+    pk->Clear();
+
+    mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey->Type());
+
+    mbedtls_ecp_keypair * keypair = to_keypair(mKeypair);
+    mbedtls_ecp_keypair_init(keypair);
+
+    result = mbedtls_ecp_gen_key(group, keypair, CryptoRNG, nullptr);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_ecp_point_write_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), &keypair->CHIP_CRYPTO_PAL_PRIVATE(Q),
+                                            MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size, Uint8::to_uchar(mPublicKey->Bytes()),
+                                            mPublicKey->Length());
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pubkey_size == mPublicKey->Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    keypair = nullptr;
+    // mInitialized to be set in caller function
+    // pk.mInitialized = true;
+
+exit:
+    if (keypair != nullptr)
+    {
+        mbedtls_ecp_keypair_free(keypair);
+        keypair = nullptr;
+    }
+
+    _log_mbedTLS_error(result);
+    return error;
+}
+
+CHIP_ERROR ECDSA_sign_msg_H(P256KeypairContext * mKeypair, const uint8_t * msg, const size_t msg_length,
+                            P256ECDSASignature & out_signature)
+{
+    // To be checked by the caller
+    // VerifyOrReturnError(mInitialized, CHIP_ERROR_UNINITIALIZED);
+    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t digest[kSHA256_Hash_Length];
+    memset(&digest[0], 0, sizeof(digest));
+    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
+
+#if defined(MBEDTLS_ECDSA_C)
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    mbedtls_mpi r, s;
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(mKeypair);
+
+    mbedtls_ecdsa_context ecdsa_ctxt;
+    mbedtls_ecdsa_init(&ecdsa_ctxt);
+
+    result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, keypair);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_ecdsa_sign(&ecdsa_ctxt.CHIP_CRYPTO_PAL_PRIVATE(grp), &r, &s, &ecdsa_ctxt.CHIP_CRYPTO_PAL_PRIVATE(d),
+                                Uint8::to_const_uchar(digest), sizeof(digest), CryptoRNG, nullptr);
+
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit((mbedtls_mpi_size(&r) <= kP256_FE_Length) && (mbedtls_mpi_size(&s) <= kP256_FE_Length),
+                 error = CHIP_ERROR_INTERNAL);
+
+    // Concatenate r and s to output. Sizes were checked above.
+    result = mbedtls_mpi_write_binary(&r, out_signature.Bytes() + 0u, kP256_FE_Length);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_mpi_write_binary(&s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    keypair = nullptr;
+    mbedtls_ecdsa_free(&ecdsa_ctxt);
+    mbedtls_mpi_free(&s);
+    mbedtls_mpi_free(&r);
+    _log_mbedTLS_error(result);
+    return error;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+CHIP_ERROR ECDH_derive_secret_H(P256KeypairContext * mKeypair, const P256PublicKey & remote_public_key,
+                                P256ECDHDerivedSecret & out_secret)
+{
+#if defined(MBEDTLS_ECDH_C)
+
+    CHIP_ERROR error     = CHIP_NO_ERROR;
+    int result           = 0;
+    size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
+
+    mbedtls_ecp_group ecp_grp;
+    mbedtls_ecp_group_init(&ecp_grp);
+
+    mbedtls_mpi mpi_secret;
+    mbedtls_mpi_init(&mpi_secret);
+
+    mbedtls_ecp_point ecp_pubkey;
+    mbedtls_ecp_point_init(&ecp_pubkey);
+
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(mKeypair);
+
+    // To be checked by the caller
+    // VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(remote_public_key.Type()));
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result =
+        mbedtls_ecp_point_read_binary(&ecp_grp, &ecp_pubkey, Uint8::to_const_uchar(remote_public_key), remote_public_key.Length());
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    result =
+        mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &keypair->CHIP_CRYPTO_PAL_PRIVATE(d), CryptoRNG, nullptr);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_mpi_write_binary(&mpi_secret, out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, secret_length);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    TEMPORARY_RETURN_IGNORED out_secret.SetLength(secret_length);
+
+exit:
+    keypair = nullptr;
+    mbedtls_ecp_group_free(&ecp_grp);
+    mbedtls_mpi_free(&mpi_secret);
+    mbedtls_ecp_point_free(&ecp_pubkey);
+    _log_mbedTLS_error(result);
+    return error;
+
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+CHIP_ERROR NewCertificateSigningRequest_H(P256KeypairContext * mKeypair, uint8_t * out_csr, size_t & csr_length)
+{
+#if defined(MBEDTLS_X509_CSR_WRITE_C)
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    size_t out_length;
+
+    mbedtls_x509write_csr csr;
+    mbedtls_x509write_csr_init(&csr);
+
+    mbedtls_pk_context pk;
+    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
+    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx)  = to_keypair(mKeypair);
+    VerifyOrExit(pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    // To be checked by the caller
+    // VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    mbedtls_x509write_csr_set_key(&csr, &pk);
+
+    mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);
+
+    // TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
+    //       CHIP Spec doesn't specify the subject name that can be used.
+    //       Figure out the correct value and update this code.
+    result = mbedtls_x509write_csr_set_subject_name(&csr, "O=CSR");
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_x509write_csr_der(&csr, out_csr, csr_length, CryptoRNG, nullptr);
+    VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<size_t>(result), error = CHIP_ERROR_INTERNAL);
+
+    out_length = static_cast<size_t>(result);
+    result     = 0;
+    VerifyOrExit(out_length <= csr_length, error = CHIP_ERROR_INTERNAL);
+
+    if (csr_length != out_length)
+    {
+        // mbedTLS API writes the CSR at the end of the provided buffer.
+        // Let's move it to the start of the buffer.
+        size_t offset = csr_length - out_length;
+        memmove(out_csr, &out_csr[offset], out_length);
+    }
+
+    csr_length = out_length;
+
+exit:
+    mbedtls_x509write_csr_free(&csr);
+
+    _log_mbedTLS_error(result);
+    return error;
+#else
+    ChipLogError(Crypto, "MBEDTLS_X509_CSR_WRITE_C is not enabled. CSR cannot be created");
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
+}
+
+CHIP_ERROR Serialize_H(const P256KeypairContext mKeypair, const P256PublicKey mPublicKey, P256SerializedKeypair & output)
+{
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
+    size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
+    Encoding::BufferWriter bbuf(output.Bytes(), len);
+    uint8_t privkey[kP256_PrivateKey_Length];
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+
+    bbuf.Put(mPublicKey, mPublicKey.Length());
+
+    VerifyOrExit(bbuf.Available() == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(mbedtls_mpi_size(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d)) <= bbuf.Available(), error = CHIP_ERROR_INTERNAL);
+    result = mbedtls_mpi_write_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d), Uint8::to_uchar(privkey), sizeof(privkey));
+
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    bbuf.Put(privkey, sizeof(privkey));
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    TEMPORARY_RETURN_IGNORED output.SetLength(bbuf.Needed());
+
+exit:
+    ClearSecretData(privkey, sizeof(privkey));
+    _log_mbedTLS_error(result);
+    return error;
+}
+
+CHIP_ERROR Deserialize_H(P256Keypair * pk, P256PublicKey * mPublicKey, P256KeypairContext * mKeypair, P256SerializedKeypair & input)
+{
+    Encoding::BufferWriter bbuf(*mPublicKey, mPublicKey->Length());
+
+    int result       = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    pk->Clear();
+
+    mbedtls_ecp_keypair * keypair = to_keypair(mKeypair);
+    mbedtls_ecp_keypair_init(keypair);
+
+    result = mbedtls_ecp_group_load(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), MapECPGroupId(mPublicKey->Type()));
+
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(input.Length() == mPublicKey->Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    bbuf.Put(input.ConstBytes(), mPublicKey->Length());
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+
+    result = mbedtls_ecp_point_read_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(grp), &keypair->CHIP_CRYPTO_PAL_PRIVATE(Q),
+                                           Uint8::to_const_uchar(*mPublicKey), mPublicKey->Length());
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    {
+        const uint8_t * privkey = input.ConstBytes() /*Uint8::to_const_uchar(input)*/ + mPublicKey->Length();
+
+        result = mbedtls_mpi_read_binary(&keypair->CHIP_CRYPTO_PAL_PRIVATE(d), privkey, kP256_PrivateKey_Length);
+        VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+exit:
+    _log_mbedTLS_error(result);
+    return error;
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_se05x.h
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPAL_se05x.h
@@ -31,7 +31,7 @@ typedef struct hsm_pake_context_s
 {
     uint8_t spake_context[32];
     size_t spake_context_len;
-    uint8_t spake_objId;
+    uint16_t spake_objId;
 } hsm_pake_context_t;
 #endif // #if ((ENABLE_SE05X_SPAKE_VERIFIER) || (ENABLE_SE05X_SPAKE_PROVER))
 

--- a/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
+++ b/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
@@ -73,7 +73,10 @@ PersistentStorageOpKeystorese05x::ExtractKeyIdFromSerializedKeypair(const Crypto
     // Verify magic number
     if (memcmp(privKeyRef, se05x_magic_no, sizeof(se05x_magic_no)) != 0)
     {
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        /** Check only for Magic Number. Return Success when key not present in SE05x.  */
+        ChipLogDetail(Crypto, "Not a ref key, Key not present in SE05x.");
+        outKeyId = 0;
+        return CHIP_NO_ERROR;
     }
 
     // Extract KeyID (big-endian, 4 bytes)
@@ -313,6 +316,7 @@ CHIP_ERROR PersistentStorageOpKeystorese05x::CommitOpKeypairForFabric(FabricInde
     }
 
     // Verify the new key exists in SE05x
+    if (pendingKeyId != 0)
     {
         bool pendingKeyExists = false;
         err                   = se05x_check_object_exists(pendingKeyId, &pendingKeyExists);


### PR DESCRIPTION
#### Summary

- SE05x Crypto Host fallback updated to use PSA APIs for NXP MCUs
- Mbed TLS APIs are still used for Linux platform
- Name changes in SE05x middleware are adapted (conflic due to secure enclave code) 

#### Testing
- Tested using chip tool and all cluster app on RW612 MCU for successful commissioning
- Tested using chip tool and Thermostat app on Linux for successful commissioning
