### PR TITLE
fix out-of-bounds guard in IdentificationDeclaration::AddTargetAppInfo

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -115,7 +115,7 @@ public:
 
     bool AddTargetAppInfo(TargetAppInfo vid)
     {
-        if (mNumTargetAppInfos >= sizeof(mTargetAppInfos))
+        if (mNumTargetAppInfos >= MATTER_ARRAY_SIZE(mTargetAppInfos))
         {
             // already at max
             return false;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -549,6 +549,36 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOob)
     EXPECT_STREQ(idOut.GetInstanceName(), expectedInstanceName);
 }
 
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppInfoOverflow)
+{
+    IdentificationDeclaration id;
+
+    // Add far more target app infos than the fixed array can hold. AddTargetAppInfo must
+    // reject the extras instead of writing past the end of mTargetAppInfos.
+    uint8_t accepted = 0;
+    for (uint16_t i = 0; i < 64; i++)
+    {
+        TargetAppInfo appInfo;
+        appInfo.vendorId  = static_cast<uint16_t>(i + 1);
+        appInfo.productId = static_cast<uint16_t>(i + 100);
+        if (id.AddTargetAppInfo(appInfo))
+        {
+            accepted++;
+        }
+    }
+
+    // The count must be capped and every stored entry must be retrievable.
+    EXPECT_EQ(id.GetNumTargetAppInfos(), accepted);
+    EXPECT_LT(id.GetNumTargetAppInfos(), 64);
+    for (uint8_t i = 0; i < id.GetNumTargetAppInfos(); i++)
+    {
+        TargetAppInfo appInfo;
+        EXPECT_TRUE(id.GetTargetAppInfo(i, appInfo));
+        EXPECT_EQ(appInfo.vendorId, static_cast<uint16_t>(i + 1));
+        EXPECT_EQ(appInfo.productId, static_cast<uint16_t>(i + 100));
+    }
+}
+
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;


### PR DESCRIPTION
### Summary

`IdentificationDeclaration::AddTargetAppInfo` bounds its write into the fixed `mTargetAppInfos` array with `mNumTargetAppInfos >= sizeof(mTargetAppInfos)`. That array is `TargetAppInfo[kMaxTargetAppInfos]`, with `kMaxTargetAppInfos == 10` and `sizeof(TargetAppInfo) == 16`, so `sizeof(mTargetAppInfos)` is 160 rather than 10. The guard lets the count grow to 160 and writes vendorId/productId past the end of the array once more than 10 target app infos are added.

Switched the check to `MATTER_ARRAY_SIZE(mTargetAppInfos)`, the element-count idiom already used for `mRotatingId` a few lines above and matching the correct guard in `UDCClientState::AddTargetAppInfo`.

### Related issues

None.

### Testing

Added `TestUDCIdentificationDeclarationTargetAppInfoOverflow` in `TestUdcMessages.cpp`. It adds well beyond the cap and checks the stored count stays bounded and every entry is retrievable. Before the fix the extra writes run off the array (AddressSanitizer flags a stack-buffer-overflow write on the 11th add); after it the count caps at 10.