### PR TITLE
[Chef] Fix missing declarations of src files in ESP and NRF CMake

### DIFF
--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -67,7 +67,7 @@ set(SRC_DIRS_LIST
                       "${CHEF}/common/clusters/temperature-control/"
                       "${CHEF}/common/clusters/wake-on-lan/"
                       "${CHEF}/common/clusters/water-heater-management/"
-                      "${CHEF}/common/clusters/water-heater-mode"
+                      "${CHEF}/common/clusters/water-heater-mode/"
                       "${CHEF}/common/clusters/window-covering/"
                       "${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/attributes"
 )

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRC_DIRS_LIST
                       "${CHEF}/common/clusters/temperature-control/"
                       "${CHEF}/common/clusters/wake-on-lan/"
                       "${CHEF}/common/clusters/water-heater-management/"
+                      "${CHEF}/common/clusters/water-heater-mode"
                       "${CHEF}/common/clusters/window-covering/"
                       "${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/attributes"
 )

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC_DIRS_LIST
                       "${CHEF}/common/clusters/channel/"
                       "${CHEF}/common/clusters/chime/"
                       "${CHEF}/common/clusters/content-launch/"
+                      "${CHEF}/common/clusters/device-energy-management-mode/"
                       "${CHEF}/common/clusters/door-lock/"
                       "${CHEF}/common/clusters/keypad-input/"
                       "${CHEF}/common/clusters/laundry-dryer-controls/"

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -122,6 +122,7 @@ target_sources(app PRIVATE
     ${CHEF}/common/clusters/target-navigator/TargetNavigatorManager.cpp
     ${CHEF}/common/clusters/wake-on-lan/WakeOnLanManager.cpp
     ${CHEF}/common/clusters/water-heater-management/chef-water-heater-management.cpp
+    ${CHEF}/common/clusters/water-heater-mode/chef-water-heater-mode.cpp
     ${CHEF}/common/clusters/window-covering/chef-window-covering.cpp
     ${CHEF}/common/stubs.cpp
     ${CHEF}/nrfconnect/AppTask.cpp

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(app PRIVATE
     ${CHEF}/common/clusters/channel/ChannelManager.cpp
     ${CHEF}/common/clusters/chime/chef-chime-delegate.cpp
     ${CHEF}/common/clusters/content-launch/chef-content-launch-delegate.cpp
+    ${CHEF}/common/clusters/device-energy-management-mode/chef-device-energy-management-mode.cpp
     ${CHEF}/common/clusters/door-lock/chef-doorlock-stubs.cpp
     ${CHEF}/common/clusters/door-lock/chef-lock-endpoint.cpp
     ${CHEF}/common/clusters/door-lock/chef-lock-manager.cpp


### PR DESCRIPTION
### Summary

https://github.com/project-chip/connectedhomeip/pull/72058 added new src files in chef. These need to be added to the CMake for nrf and esp32.

### Testing

Built affected chef apps

```
./chef.py -br -d rootnode_waterheater_21bd13d651 -t esp32 -a && ./chef.py -br -d rootnode_waterheater_21bd13d651 -t nrfconnect -a

./chef.py -br -d rootnode_heatpump_87ivjRAECh -t esp32 && ./chef.py -br -d rootnode_heatpump_87ivjRAECh -t nrfconnect
```