### PR TITLE
bound ble scan record parsing in WbsDeviceScanner::ReportDevice

### DIFF
--- a/src/platform/webos/wbs/WbsDeviceScanner.cpp
+++ b/src/platform/webos/wbs/WbsDeviceScanner.cpp
@@ -278,7 +278,14 @@ void WbsDeviceScanner::ReportDevice(const pbnjson::JValue & device)
         0,
     };
     uint8_t * payload = &aScanRecord[0];
-    ssize_t total_len = scanRecordDataJObj.arraySize();
+
+    // scanRecord comes from a remote device and may be larger than aScanRecord
+    // (e.g. BLE 5 extended advertising), so clamp it to the buffer before copying.
+    if (scanRecordDataJSize > static_cast<ssize_t>(sizeof(aScanRecord)))
+    {
+        scanRecordDataJSize = static_cast<ssize_t>(sizeof(aScanRecord));
+    }
+    ssize_t total_len = scanRecordDataJSize;
 
     for (ssize_t j = 0; j < scanRecordDataJSize; j++)
     {
@@ -286,19 +293,27 @@ void WbsDeviceScanner::ReportDevice(const pbnjson::JValue & device)
         if (chip::CanCastTo<uint8_t>(v))
             aScanRecord[j] = static_cast<uint8_t>(v);
     }
-    uint8_t adv_length   = 0;
-    uint8_t adv_type     = 0;
-    uint8_t sizeConsumed = 0;
-    bool finished        = false;
+    const uint8_t * const end = aScanRecord + total_len;
+    uint8_t adv_length        = 0;
+    uint8_t adv_type          = 0;
+    size_t sizeConsumed       = 0;
+    bool finished             = false;
 
     while (!finished)
     {
+        if (payload >= end)
+            break;
+
         adv_length = *payload;
         payload++;
-        sizeConsumed += 1 + adv_length;
+        sizeConsumed += 1u + adv_length;
 
         if (adv_length != 0)
         {
+            // The AD structure spans adv_length bytes from adv_type; don't read past the record.
+            if (payload + adv_length > end)
+                break;
+
             adv_type = *payload;
             payload++;
             adv_length--;
@@ -367,7 +382,7 @@ void WbsDeviceScanner::ReportDevice(const pbnjson::JValue & device)
             payload += adv_length;
         }
 
-        if (sizeConsumed >= total_len)
+        if (sizeConsumed >= static_cast<size_t>(total_len))
             finished = true;
     }
 


### PR DESCRIPTION
### Summary

`WbsDeviceScanner::ReportDevice` copies a nearby device's `scanRecord` into a fixed 256-byte stack buffer `aScanRecord`, but the copy loop is bounded only by the advertised element count (`scanRecordDataJObj.arraySize()`), and the following AD-structure walk never checks the `payload` pointer against the end of the record. A scan record larger than the buffer (BLE 5 extended advertising carries far more than 256 bytes) overflows the stack in the copy loop; the walk also reads past the buffer, and `sizeConsumed` is a `uint8_t` that wraps, so the `sizeConsumed >= total_len` termination is unreliable for records over 255 bytes. The bytes come from a remote broadcaster and reach this code pre-commissioning through the bluetooth2 LE scan subscription (`OnLeDeviceScanned` -> `ReportDevice`).

Fix clamps the record length to the buffer before copying, widens `sizeConsumed` to `size_t`, and bounds each AD structure against the record end so both the copy and the walk stay in range.

### Related issues

None.

### Testing

Behavior for well-formed advertisements is unchanged; over-length or truncated records now stop at the buffer/record boundary instead of running past it. This platform target does not build in the standard host CI, so I validated the copy-and-walk logic with a standalone extraction compiled under `-fsanitize=address,undefined`: a 400-byte record triggers a stack-buffer-overflow write before the change and runs clean after it.