### PR TITLE
feat(casting): Add deviceName support to iOS MCDeviceInstanceInfoProvider (#72089)

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -27,9 +27,37 @@
 #import "core/Types.h"
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <lib/support/CHIPMemString.h>
+#include <platform/Darwin/ConfigurationManagerImpl.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #import <Foundation/Foundation.h>
+
+namespace {
+__weak id<MCDeviceInstanceInfoProvider> sDeviceInstanceInfoDelegate = nil;
+
+CHIP_ERROR ConfigValueProviderCallback(const char * configNamespace, const char * name,
+    char * buf, size_t bufSize, size_t & outLen)
+{
+    id<MCDeviceInstanceInfoProvider> delegate = sDeviceInstanceInfoDelegate;
+    if (delegate == nil) {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+
+    NSString * value = nil;
+    if (strcmp(name, "device-name") == 0 && [delegate respondsToSelector:@selector(deviceName)]) {
+        value = [delegate deviceName];
+    }
+
+    if (value == nil) {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+
+    chip::Platform::CopyString(buf, bufSize, [value UTF8String]);
+    outLen = strlen(buf);
+    return CHIP_NO_ERROR;
+}
+} // namespace
 
 @interface MCCastingApp ()
 
@@ -99,8 +127,9 @@
     _serverInitParamsProvider = new MCCommonCaseDeviceServerInitParamsProvider();
 
     // Initialize MCDeviceInstanceInfoProviderBridge if the dataSource provides a delegate
+    id<MCDeviceInstanceInfoProvider> infoProvider = nil;
     if ([dataSource respondsToSelector:@selector(castingAppDidReceiveRequestForDeviceInstanceInfoProvider:)]) {
-        id<MCDeviceInstanceInfoProvider> infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
+        infoProvider = [dataSource castingAppDidReceiveRequestForDeviceInstanceInfoProvider:self];
         if (infoProvider != nil) {
             ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting up pull-based MCDeviceInstanceInfoProviderBridge");
             delete _deviceInstanceInfoProvider;
@@ -126,6 +155,11 @@
     if (_deviceInstanceInfoProvider != nullptr) {
         ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() setting custom DeviceInstanceInfoProvider");
         chip::DeviceLayer::SetDeviceInstanceInfoProvider(_deviceInstanceInfoProvider);
+
+        // Register the general-purpose config value provider so platform queries
+        // (e.g. GetCommissionableDeviceName) call through to the delegate at runtime.
+        sDeviceInstanceInfoDelegate = infoProvider;
+        chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ConfigValueProviderCallback);
     }
 
     // Get and store the CHIP Work queue

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCDeviceInstanceInfo.h
@@ -41,6 +41,15 @@
 - (NSNumber * _Nullable)hardwareVersion;
 - (NSString * _Nullable)hardwareVersionString;
 
+/**
+ * @brief The commissionable device name shown on the casting target's commissioning prompt.
+ *
+ * On Android, this corresponds to kConfigKey_DeviceName in PreferencesConfigurationManager.
+ * The value is written into the platform ConfigurationManager at init time so it is used
+ * by UDC and mDNS advertisements.
+ */
+- (NSString * _Nullable)deviceName;
+
 @end
 
 #endif /* MCDeviceInstanceInfo_h */

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCInitializationExample.swift
@@ -135,6 +135,10 @@ class SampleDeviceInstanceInfoProvider: NSObject, MCDeviceInstanceInfoProvider {
     func productName() -> String? {
         return "Test Casting App"
     }
+
+    func deviceName() -> String? {
+        return "My Casting App"
+    }
 }
 
 // This class is a singleton

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -256,6 +256,32 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 #endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
+{
+    if (mConfigValueProvider != nullptr)
+    {
+        size_t outLen  = 0;
+        CHIP_ERROR err = mConfigValueProvider(PosixConfig::kConfigKey_DeviceName.Namespace, PosixConfig::kConfigKey_DeviceName.Name,
+                                              buf, bufSize, outLen);
+        if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+        {
+            return err;
+        }
+    }
+
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
+    size_t outLen  = 0;
+    CHIP_ERROR err = ReadConfigValueStr(PosixConfig::kConfigKey_DeviceName, buf, bufSize, outLen);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        return GenericConfigurationManagerImpl<PosixConfig>::GetCommissionableDeviceName(buf, bufSize);
+    }
+    return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
+}
+
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
 #if CHIP_DISABLE_PLATFORM_KVS

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -42,8 +42,31 @@ inline constexpr int kCountryCodeLength = 2;
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
+    /**
+     * General-purpose callback for providing configuration values at runtime.
+     * Mirrors Android's ConfigurationManager.readConfigValueStr(namespace, name).
+     *
+     * @param configNamespace  The config namespace (e.g. "chip-factory")
+     * @param name             The config key name (e.g. "device-name")
+     * @param buf              Buffer to write the null-terminated value into
+     * @param bufSize          Size of the buffer
+     * @param outLen           Set to the length of the value written (excluding null terminator)
+     * @return CHIP_NO_ERROR if a value was provided,
+     *         CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND to fall through to the next source
+     */
+    using ConfigValueProvider = CHIP_ERROR (*)(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                               size_t & outLen);
+
     CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR StoreProductId(uint16_t productId);
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
+
+    /**
+     * Set a general-purpose config value provider that is consulted at runtime
+     * before PosixConfig or compile-time defaults. Analogous to Android's
+     * PreferencesConfigurationManager.readConfigValueStr().
+     */
+    void SetConfigValueProvider(ConfigValueProvider provider) { mConfigValueProvider = provider; }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetWiFiNetworkInformations(WiFiNetworkInfos & infos);
@@ -78,6 +101,8 @@ private:
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
+
+    ConfigValueProvider mConfigValueProvider = nullptr;
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -55,6 +55,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_Spake2pSalt           = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
 const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfigNamespace_ChipFactory, "vendor-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_DeviceName            = { kConfigNamespace_ChipFactory, "device-name" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed        = { kConfigNamespace_ChipConfig, "fail-safe-armed" };

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -68,6 +68,7 @@ public:
     static const Key kConfigKey_ConfigurationVersion;
     static const Key kConfigKey_VendorId;
     static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_DeviceName;
 
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_RebootCount;

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -34,8 +34,14 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/BuildTime.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
+
+#ifdef __APPLE__
+#include <platform/Darwin/ConfigurationManagerImpl.h>
+#include <platform/Darwin/PosixConfig.h>
+#endif
 
 using namespace chip;
 using namespace chip::Logging;
@@ -472,5 +478,161 @@ TEST_F(TestConfigurationMgr, GetProductId)
     EXPECT_GE(productId, 1u);
     EXPECT_LE(productId, 0xffff);
 }
+
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceName)
+{
+    char buf[64];
+
+    if (!ConfigurationMgr().IsCommissionableDeviceNameEnabled())
+    {
+        // If device name is not enabled, skip this test
+        GTEST_SKIP();
+    }
+
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GT(strlen(buf), 0u);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+
+#ifdef __APPLE__
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromConfig)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char buf[64];
+    const char * testName = "My Test Device";
+
+    // Write a device name to PosixConfig
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, testName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Verify ConfigurationMgr returns the stored value
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, testName);
+
+    // Clear the config key and verify fallback to compile-time default
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+
+static CHIP_ERROR TestConfigValueProvider(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                          size_t & outLen)
+{
+    if (strcmp(name, "device-name") == 0)
+    {
+        const char * value = "Dynamic Device Name";
+        if (bufSize <= strlen(value))
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        strcpy(buf, value);
+        outLen = strlen(value);
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+TEST_F(TestConfigurationMgr, GetCommissionableDeviceNameFromProvider)
+{
+    char buf[64];
+
+    // Set a dynamic provider
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(TestConfigValueProvider);
+
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, "Dynamic Device Name");
+
+    // Clear provider, verify fallback to compile-time default
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+}
+
+static CHIP_ERROR ProviderThatReturnsNotFound(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                              size_t & outLen)
+{
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+static CHIP_ERROR ProviderWithSmallBuffer(const char * configNamespace, const char * name, char * buf, size_t bufSize,
+                                          size_t & outLen)
+{
+    if (strcmp(name, "device-name") == 0)
+    {
+        const char * value = "This name is longer than a tiny buffer";
+        if (bufSize <= strlen(value))
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        strcpy(buf, value);
+        outLen = strlen(value);
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+TEST_F(TestConfigurationMgr, ConfigValueProviderTakesPriorityOverConfig)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char buf[64];
+    const char * configName = "Config Name";
+
+    // Write a value to PosixConfig
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, configName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Set a provider — it should take priority over the config value
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(TestConfigValueProvider);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, "Dynamic Device Name");
+
+    // Provider returns NOT_FOUND — should fall through to PosixConfig
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ProviderThatReturnsNotFound);
+    err = ConfigurationMgr().GetCommissionableDeviceName(buf, sizeof(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(buf, configName);
+
+    // Clean up
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+}
+
+TEST_F(TestConfigurationMgr, ConfigValueProviderBufferTooSmall)
+{
+    char smallBuf[5];
+
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(ProviderWithSmallBuffer);
+    CHIP_ERROR err = ConfigurationMgr().GetCommissionableDeviceName(smallBuf, sizeof(smallBuf));
+    EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // Clean up
+    ConfigurationManagerImpl::GetDefaultInstance().SetConfigValueProvider(nullptr);
+}
+
+TEST_F(TestConfigurationMgr, DeviceNameConfigBufferTooSmall)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    char smallBuf[5];
+    const char * longName = "A name that exceeds the buffer";
+
+    CHIP_ERROR err = PosixConfig::WriteConfigValueStr(PosixConfig::kConfigKey_DeviceName, longName);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetCommissionableDeviceName(smallBuf, sizeof(smallBuf));
+    EXPECT_NE(err, CHIP_NO_ERROR);
+
+    // Clean up
+    PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_DeviceName);
+}
+#endif // __APPLE__
 
 } // namespace


### PR DESCRIPTION

### Summary


* feat(casting): Add deviceName support to iOS MCDeviceInstanceInfoProvider

Add a deviceName optional method to the MCDeviceInstanceInfoProvider protocol, allowing iOS casting apps to override the commissionable device name shown on casting targets during commissioning.

The implementation:
- Adds kConfigKey_DeviceName to Darwin PosixConfig
- Overrides GetCommissionableDeviceName in Darwin ConfigurationManagerImpl to read from PosixConfig (falling back to compile-time default)
- Writes the delegate's deviceName into PosixConfig at init time

This mirrors Android's PreferencesConfigurationManager.readConfigValueStr() pattern for kConfigKey_DeviceName.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* test(platform): Add unit tests for GetCommissionableDeviceName

- Generic test verifies the default compile-time value is returned
- Darwin-specific test verifies PosixConfig override works and fallback to default after clearing the config key

* fix: Address PR review and CI build failure

- Remove #include <lib/dnssd/TxtFields.h> from test (not in GN deps)
- Use plain buffer size instead of Dnssd constant
- Cache infoProvider to avoid redundant delegate call
- Clear PosixConfig key when deviceName is nil (proper fallback)
- Add error handling and logging for PosixConfig writes

* fix: Address bzbarsky-apple review feedback

- Return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE when KVS is disabled instead of calling uninitialized base class
- Use instance method ReadConfigValueStr instead of fully-qualified static PosixConfig::ReadConfigValueStr
- Simplify namespace qualification in base class call

* refactor(casting): Make deviceName truly pull-based via runtime callback

Replace the init-time PosixConfig write with a DeviceNameProvider callback on ConfigurationManagerImpl. GetCommissionableDeviceName() now calls through to the registered provider on every query, enabling the app to return dynamic values at commissioning time.

This matches Android's PreferencesConfigurationManager pattern where readConfigValueStr(kConfigKey_DeviceName) is called at runtime.

Priority order: provider callback > PosixConfig key > compile-time default.

* test(platform): Add more Darwin GetCommissionableDeviceName tests

- Provider takes priority over PosixConfig value
- Provider returning NOT_FOUND falls through to PosixConfig
- Buffer-too-small handling from provider callback
- Buffer-too-small handling from PosixConfig read

* refactor(platform): Replace DeviceNameProvider with general-purpose ConfigValueProvider

Replace the single-purpose DeviceNameProvider callback with a general-purpose ConfigValueProvider(namespace, name, buf, bufSize, outLen) that mirrors Android's readConfigValueStr(namespace, name) pattern.

This avoids per-field callback proliferation — future config fields (e.g. productName, vendorName) can be served by the same provider without API changes. The casting app's ObjC bridge dispatches based on the key name, matching Android's switch-on-key pattern.

Priority: ConfigValueProvider > PosixConfig KVS > compile-time default.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* fix(platform): Address PR review feedback for device name provider

- Rename example device name to clarify it's the casting source
- Hoist mConfigValueProvider block above #if to eliminate duplication
- Clarify null-termination contract in ConfigValueProvider doc

---------


(cherry picked from commit bbe462b6e001a61d7c77dd0d8de012db7a60f757)


### Testing

build and iOS