### PR TITLE
[UDC] Fix off-by-one string copy in ReadPayload (#72604)

### DIFF
--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -219,20 +219,20 @@ public:
 
 private:
     PeerAddress mPeerAddress;
-    char mInstanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
-    char mDeviceName[Dnssd::kMaxDeviceNameLen + 1];
-    uint16_t mLongDiscriminator = 0;
-    uint16_t mVendorId          = 0;
-    uint16_t mProductId         = 0;
-    uint16_t mCdPort            = 0;
-    uint8_t mRotatingId[chip::Dnssd::kMaxRotatingIdLen];
-    size_t mRotatingIdLen                                         = 0;
-    char mPairingInst[chip::Dnssd::kMaxPairingInstructionLen + 1] = {};
-    uint16_t mPairingHint                                         = 0;
+    char mInstanceName[Dnssd::Commission::kInstanceNameMaxLength + 1] = {};
+    char mDeviceName[Dnssd::kMaxDeviceNameLen + 1]                    = {};
+    uint16_t mLongDiscriminator                                       = 0;
+    uint16_t mVendorId                                                = 0;
+    uint16_t mProductId                                               = 0;
+    uint16_t mCdPort                                                  = 0;
+    uint8_t mRotatingId[chip::Dnssd::kMaxRotatingIdLen]               = {};
+    size_t mRotatingIdLen                                             = 0;
+    char mPairingInst[chip::Dnssd::kMaxPairingInstructionLen + 1]     = {};
+    uint16_t mPairingHint                                             = 0;
 
-    constexpr static size_t kMaxTargetAppInfos = CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS;
-    uint8_t mNumTargetAppInfos                 = 0; // number of vendor Ids
-    TargetAppInfo mTargetAppInfos[kMaxTargetAppInfos];
+    constexpr static size_t kMaxTargetAppInfos        = CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS;
+    uint8_t mNumTargetAppInfos                        = 0; // number of vendor Ids
+    TargetAppInfo mTargetAppInfos[kMaxTargetAppInfos] = {};
 
     bool mNoPasscode                = false;
     bool mCdUponPasscodeDialog      = false;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -288,14 +288,14 @@ private:
     char mDeviceName[Dnssd::kMaxDeviceNameLen + 1]                    = {};
     uint16_t mCdPort                                                  = 0;
 
-    uint16_t mVendorId  = 0;
-    uint16_t mProductId = 0;
-    uint8_t mRotatingId[chip::Dnssd::kMaxRotatingIdLen];
-    size_t mRotatingIdLen = 0;
+    uint16_t mVendorId                                  = 0;
+    uint16_t mProductId                                 = 0;
+    uint8_t mRotatingId[chip::Dnssd::kMaxRotatingIdLen] = {};
+    size_t mRotatingIdLen                               = 0;
 
-    constexpr static size_t kMaxTargetAppInfos = 10;
-    uint8_t mNumTargetAppInfos                 = 0; // number of vendor Ids
-    TargetAppInfo mTargetAppInfos[kMaxTargetAppInfos];
+    constexpr static size_t kMaxTargetAppInfos        = 10;
+    uint8_t mNumTargetAppInfos                        = 0; // number of vendor Ids
+    TargetAppInfo mTargetAppInfos[kMaxTargetAppInfos] = {};
 
     char mPairingInst[chip::Dnssd::kMaxPairingInstructionLen + 1] = {};
     uint16_t mPairingHint                                         = 0;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -269,12 +269,12 @@ void UserDirectedCommissioningClient::OnMessageReceived(const Transport::PeerAdd
                     "UserDirectedCommissioningClient::OnMessageReceived() CommissionerDeclaration DataLength() = %" PRIu32,
                     static_cast<uint32_t>(msg->DataLength()));
 
-    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes];
-    size_t udcPayloadLength = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
-    msg->Read(udcPayload, udcPayloadLength);
+    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes] = {};
+    size_t udcPayloadLength                                            = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
+    ReturnOnFailure(msg->Read(udcPayload, udcPayloadLength));
 
     CommissionerDeclaration cd;
-    cd.ReadPayload(udcPayload, sizeof(udcPayload));
+    ReturnOnFailure(cd.ReadPayload(udcPayload, udcPayloadLength));
     cd.DebugLog();
 
     // Call the registered mCommissionerDeclarationHandler, if any.

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -57,12 +57,12 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
 
     ChipLogProgress(AppServer, "IdentityDeclaration DataLength()=%" PRIu32, static_cast<uint32_t>(msg->DataLength()));
 
-    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes];
-    size_t udcPayloadLength = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
-    msg->Read(udcPayload, udcPayloadLength);
+    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes] = {};
+    size_t udcPayloadLength                                            = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
+    ReturnOnFailure(msg->Read(udcPayload, udcPayloadLength));
 
     IdentificationDeclaration id;
-    id.ReadPayload(udcPayload, sizeof(udcPayload));
+    ReturnOnFailure(id.ReadPayload(udcPayload, udcPayloadLength));
 
     if (id.GetCancelPasscode())
     {
@@ -248,7 +248,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
     size_t instanceNameLen = strnlen(reinterpret_cast<const char *>(udcPayload), sizeof(mInstanceName) - 1);
     Platform::CopyString(mInstanceName, ByteSpan(udcPayload, instanceNameLen));
 
-    if (payloadBufferSize <= sizeof(mInstanceName))
+    if (payloadBufferSize == sizeof(mInstanceName))
     {
         ChipLogProgress(AppServer, "UDC - No TLV information in Identification Declaration");
         return CHIP_NO_ERROR;
@@ -305,8 +305,16 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
             break;
         case kRotatingIdTag:
             // rotatingId
-            mRotatingIdLen = reader.GetLength();
-            err            = reader.GetBytes(mRotatingId, sizeof(mRotatingId));
+            if (reader.GetLength() <= sizeof(mRotatingId))
+            {
+                mRotatingIdLen = reader.GetLength();
+                err            = reader.GetBytes(mRotatingId, sizeof(mRotatingId));
+            }
+            else
+            {
+                mRotatingIdLen = 0;
+                err            = CHIP_ERROR_BUFFER_TOO_SMALL;
+            }
             break;
         case kTargetAppListTag:
             // app vendor list
@@ -395,6 +403,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "IdentificationDeclaration::ReadPayload read error %" CHIP_ERROR_FORMAT, err.Format());
+            return err;
         }
     }
 
@@ -406,6 +415,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
     else
     {
         ChipLogError(AppServer, "IdentificationDeclaration::ReadPayload exiting early error %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
     }
 
     ChipLogProgress(AppServer, "UDC TLV parse complete");

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -25,6 +25,7 @@
 
 #include "UserDirectedCommissioning.h"
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/CHIPMemString.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/raw/Base.h>
 
@@ -238,13 +239,14 @@ CHIP_ERROR UserDirectedCommissioningServer::EncodeUDCMessage(const System::Packe
 
 CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t payloadBufferSize)
 {
-    size_t i = 0;
-    while (i < std::min<size_t>(sizeof(mInstanceName), payloadBufferSize) && udcPayload[i] != '\0')
+    if (payloadBufferSize < sizeof(mInstanceName))
     {
-        mInstanceName[i] = (char) udcPayload[i];
-        i++;
+        ChipLogError(AppServer, "UDC payload too short for instance name");
+        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
     }
-    mInstanceName[i] = '\0';
+
+    size_t instanceNameLen = strnlen(reinterpret_cast<const char *>(udcPayload), sizeof(mInstanceName) - 1);
+    Platform::CopyString(mInstanceName, ByteSpan(udcPayload, instanceNameLen));
 
     if (payloadBufferSize <= sizeof(mInstanceName))
     {
@@ -252,7 +254,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
         return CHIP_NO_ERROR;
     }
     // advance i to the end of the fixed length block containing instance name
-    i = sizeof(mInstanceName);
+    size_t i = sizeof(mInstanceName);
 
     CHIP_ERROR err;
 

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -3,6 +3,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/core/TLV.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/support/BufferWriter.h>
@@ -482,6 +483,73 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
 
     // TODO: remove following "force-fail" debug line
     // NL_TEST_ASSERT(inSuite, rotatingIdLen != id.GetRotatingIdLength());
+}
+
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOversizedRotatingId)
+{
+    IdentificationDeclaration idOut;
+    const char * instanceName = "servertest1";
+
+    uint8_t idBuffer[500] = {};
+    Platform::CopyString(reinterpret_cast<char *>(idBuffer), Dnssd::Commission::kInstanceNameMaxLength + 1, instanceName);
+
+    size_t offset = Dnssd::Commission::kInstanceNameMaxLength + 1;
+    TLV::TLVWriter writer;
+    writer.Init(idBuffer + offset, sizeof(idBuffer) - offset);
+
+    TLV::TLVType outerContainerType = TLV::kTLVType_Structure;
+    EXPECT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
+
+    uint8_t oversizedId[60] = {};
+    memset(oversizedId, 0xAB, sizeof(oversizedId));
+    EXPECT_EQ(writer.PutBytes(TLV::ContextTag(7), oversizedId, sizeof(oversizedId)), CHIP_NO_ERROR);
+
+    EXPECT_EQ(writer.EndContainer(outerContainerType), CHIP_NO_ERROR);
+    EXPECT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+
+    size_t totalLen = offset + writer.GetLengthWritten();
+
+    EXPECT_NE(idOut.ReadPayload(idBuffer, totalLen), CHIP_NO_ERROR);
+    EXPECT_EQ(idOut.GetRotatingIdLength(), 0u);
+}
+
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTruncatedPayload)
+{
+    IdentificationDeclaration idOut;
+    uint8_t idBuffer[5] = { 't', 'e', 's', 't', '\0' };
+
+    EXPECT_EQ(idOut.ReadPayload(idBuffer, sizeof(idBuffer)), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+}
+
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationPureHeader)
+{
+    IdentificationDeclaration idOut;
+    const char * instanceName                                       = "servertest1";
+    uint8_t idBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1] = {};
+    Platform::CopyString(reinterpret_cast<char *>(idBuffer), sizeof(idBuffer), instanceName);
+
+    EXPECT_EQ(idOut.ReadPayload(idBuffer, sizeof(idBuffer)), CHIP_NO_ERROR);
+    EXPECT_STREQ(idOut.GetInstanceName(), instanceName);
+}
+
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOob)
+{
+    IdentificationDeclaration idOut;
+    uint8_t idBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(idBuffer, 'A', sizeof(idBuffer));
+
+    const char * deviceName = "test-device";
+    idOut.SetDeviceName(deviceName);
+    EXPECT_STREQ(idOut.GetDeviceName(), deviceName);
+
+    EXPECT_EQ(idOut.ReadPayload(idBuffer, sizeof(idBuffer)), CHIP_NO_ERROR);
+
+    EXPECT_STREQ(idOut.GetDeviceName(), deviceName);
+
+    char expectedInstanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    memset(expectedInstanceName, 'A', Dnssd::Commission::kInstanceNameMaxLength);
+    expectedInstanceName[Dnssd::Commission::kInstanceNameMaxLength] = '\0';
+    EXPECT_STREQ(idOut.GetInstanceName(), expectedInstanceName);
 }
 
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -3,8 +3,8 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPSafeCasts.h>
-#include <lib/core/TLV.h>
 #include <lib/core/StringBuilderAdapters.h>
+#include <lib/core/TLV.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -552,6 +552,7 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOob)
     EXPECT_STREQ(idOut.GetInstanceName(), expectedInstanceName);
 }
 
+
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -552,7 +552,6 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationOob)
     EXPECT_STREQ(idOut.GetInstanceName(), expectedInstanceName);
 }
 
-
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;


### PR DESCRIPTION
### Summary

* fix(udc): Prevent off-by-one OOB write in IdentificationDeclaration::ReadPayload

In UDC server parsing, the loop copying the instance name from the payload did not account for the array bounds correctly, allowing it to write a null terminator past the end of the `mInstanceName` array.

Replaced the character-by-character copy loop with `strnlen` and `Platform::CopyString` to safely bounds-check and copy the string.

Added regression test TestUDCIdentificationDeclarationOob.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------


(cherry picked from commit 01db7c7be7bbb0c6db907e58fb6079736a7958f0)


### Testing

build, linux and android