### PR TITLE
[all-devices-app] Consolidate POSIX audio support and decouple Speaker/Chime devices

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.cpp
@@ -44,6 +44,7 @@ CHIP_ERROR SpeakerDevice::Register(chip::EndpointId endpoint, CodeDrivenDataMode
 
     // OnOff (Mute)
     OnOffCluster::Context onOffContext{ mTimerDelegate };
+    onOffContext.defaults.onOff = true;
 
     mOnOffCluster.Create(endpoint, onOffContext);
     mOnOffCluster.Cluster().AddDelegate(&mOnOffDelegate);
@@ -56,7 +57,7 @@ CHIP_ERROR SpeakerDevice::Register(chip::EndpointId endpoint, CodeDrivenDataMode
     // TODO: The following attributes/features are not required for a Speaker device type.
     // Enable them here temporarily to fully test the LevelControl in CI.
     // When we have a proper level light device type these can be removed.
-    lcConfig.WithInitialCurrentLevel(1);
+    lcConfig.WithInitialCurrentLevel(100);
     lcConfig.WithOnOffTransitionTime(0);
     lcConfig.WithOnTransitionTime(0);
     lcConfig.WithOffTransitionTime(0);

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -30,7 +30,9 @@ executable("all-devices-app") {
   sources = [
     "AppCommandDelegate.cpp",
     "ClusterTypeMappings.cpp",
+    "PosixAudioManager.cpp",
     "PosixChimeDevice.cpp",
+    "PosixSpeakerDevice.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
   ]

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -27,7 +27,6 @@
 namespace chip {
 namespace app {
 
-
 // Define the Pimpl struct containing all miniaudio-specific structures
 struct PosixAudioManager::Impl
 {
@@ -79,7 +78,7 @@ ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOu
     auto * pOut = reinterpret_cast<int16_t *>(pFramesOut);
 
     const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
-    ma_uint64 framesToRead        = frameCount;
+    ma_uint64 framesToRead       = frameCount;
 
     // Limit read count to the remaining samples
     if (pCustomDS->cursor + framesToRead > totalSamples)
@@ -293,7 +292,7 @@ static const PosixAudioManager::Sound kSupportedSounds[] = {
     { 1, "Ring Ring" },
 };
 
-PosixAudioManager::PosixAudioManager() = default;
+PosixAudioManager::PosixAudioManager()  = default;
 PosixAudioManager::~PosixAudioManager() = default;
 
 CHIP_ERROR PosixAudioManager::Init()

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -171,7 +171,7 @@ ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_fo
     }
     if (pSampleRate)
     {
-        *pSampleRate = kSampleRateHz;
+        *pSampleRate = static_cast<ma_uint32>(kSampleRateHz);
     }
 
     if (pChannelMap && channelMapCap > 0)

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -352,6 +352,10 @@ void PosixAudioManager::Shutdown()
 {
     if (mImpl)
     {
+        if (mImpl->engineInitialized)
+        {
+            ma_engine_stop(&mImpl->engine);
+        }
         mImpl->soundResources.clear();
         if (mImpl->engineInitialized)
         {

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -67,7 +67,7 @@ struct PosixAudioManager::Impl
 namespace {
 
 constexpr double kPi           = 3.14159265358979323846;
-constexpr double kSampleRateHz = 44100.0;
+constexpr uint32_t kSampleRateHz = 44100;
 
 // Custom data source read callback. Synthesizes audio samples on-the-fly.
 ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
@@ -171,7 +171,7 @@ ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_fo
     }
     if (pSampleRate)
     {
-        *pSampleRate = static_cast<ma_uint32>(kSampleRateHz);
+        *pSampleRate = kSampleRateHz;
     }
 
     if (pChannelMap && channelMapCap > 0)

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -292,6 +292,8 @@ static const PosixAudioManager::Sound kSupportedSounds[] = {
     { 1, "Ring Ring" },
 };
 
+// Defined in the source file because PosixAudioManager::Impl is an incomplete type in the header.
+// Defaulting the constructor/destructor in the header would fail to compile due to std::unique_ptr requirements.
 PosixAudioManager::PosixAudioManager()  = default;
 PosixAudioManager::~PosixAudioManager() = default;
 
@@ -350,20 +352,19 @@ Span<const PosixAudioManager::Sound> PosixAudioManager::GetSupportedSounds() con
 
 void PosixAudioManager::Shutdown()
 {
-    if (mImpl)
+    VerifyOrReturn(mImpl != nullptr);
+
+    if (mImpl->engineInitialized)
     {
-        if (mImpl->engineInitialized)
-        {
-            ma_engine_stop(&mImpl->engine);
-        }
-        mImpl->soundResources.clear();
-        if (mImpl->engineInitialized)
-        {
-            ma_engine_uninit(&mImpl->engine);
-            ChipLogProgress(DeviceLayer, "Shared miniaudio engine uninitialized");
-        }
-        mImpl.reset();
+        ma_engine_stop(&mImpl->engine);
     }
+    mImpl->soundResources.clear();
+    if (mImpl->engineInitialized)
+    {
+        ma_engine_uninit(&mImpl->engine);
+        ChipLogProgress(DeviceLayer, "Shared miniaudio engine uninitialized");
+    }
+    mImpl.reset();
 }
 
 void PosixAudioManager::SetVolume(uint8_t volume)

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -66,7 +66,7 @@ struct PosixAudioManager::Impl
 
 namespace {
 
-constexpr double kPi           = 3.14159265358979323846;
+constexpr double kPi             = 3.14159265358979323846;
 constexpr uint32_t kSampleRateHz = 44100;
 
 // Custom data source read callback. Synthesizes audio samples on-the-fly.

--- a/examples/all-devices-app/posix/PosixAudioManager.cpp
+++ b/examples/all-devices-app/posix/PosixAudioManager.cpp
@@ -1,0 +1,414 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <PosixAudioManager.h>
+
+#include <miniaudio.h>
+
+#include <cmath>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <limits>
+#include <vector>
+
+namespace chip {
+namespace app {
+
+
+// Define the Pimpl struct containing all miniaudio-specific structures
+struct PosixAudioManager::Impl
+{
+    struct CustomDataSource
+    {
+        ma_data_source_base base; // Base structure required by miniaudio
+        double freq1_hz;          // Primary frequency or first tone in Hz
+        double freq2_hz;          // Secondary frequency or second tone in Hz
+        double duration_sec;      // Total duration of the sound in seconds
+        bool pulse;               // Whether to apply a pulse modulation effect
+        ma_uint64 cursor;         // Current playback position in samples
+    };
+
+    struct SoundResource
+    {
+        uint8_t id;
+        CustomDataSource dataSource;
+        ma_sound sound;
+        bool initialized = false;
+
+        ~SoundResource()
+        {
+            if (initialized)
+            {
+                ma_sound_uninit(&sound);
+                ma_data_source_uninit(&dataSource.base);
+            }
+        }
+    };
+
+    ma_engine engine;
+    bool engineInitialized = false;
+
+    std::vector<std::unique_ptr<SoundResource>> soundResources;
+    bool soundsInitialized = false;
+};
+
+namespace {
+
+constexpr double kPi           = 3.14159265358979323846;
+constexpr double kSampleRateHz = 44100.0;
+
+// Custom data source read callback. Synthesizes audio samples on-the-fly.
+ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
+{
+    auto * pCustomDS = reinterpret_cast<PosixAudioManager::Impl::CustomDataSource *>(pDataSource);
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
+
+    auto * pOut = reinterpret_cast<int16_t *>(pFramesOut);
+
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
+    ma_uint64 framesToRead        = frameCount;
+
+    // Limit read count to the remaining samples
+    if (pCustomDS->cursor + framesToRead > totalSamples)
+    {
+        framesToRead = (totalSamples > pCustomDS->cursor) ? (totalSamples - pCustomDS->cursor) : 0;
+    }
+
+    for (ma_uint64 i = 0; i < framesToRead; ++i)
+    {
+        double t      = static_cast<double>(pCustomDS->cursor + i) / kSampleRateHz;
+        double t_note = t;
+        double freq   = pCustomDS->freq1_hz;
+
+        // For two-tone sound ("Ding-Dong"), switch to the second frequency halfway
+        if (pCustomDS->freq1_hz != pCustomDS->freq2_hz)
+        {
+            if (t >= (pCustomDS->duration_sec / 2.0))
+            {
+                freq   = pCustomDS->freq2_hz;
+                t_note = t - (pCustomDS->duration_sec / 2.0); // Reset relative time for second tone
+            }
+        }
+
+        // Apply exponential decay for a natural chime fade-out effect
+        double volume = exp(-t_note * 4.0);
+
+        if (pCustomDS->pulse)
+        {
+            // Apply a square wave modulation for the pulse effect
+            bool on = (static_cast<int>(t * 20) % 2) == 0;
+            if (!on)
+            {
+                volume = 0;
+            }
+        }
+
+        // Additive synthesis: combine fundamental frequency and harmonics
+        double sample = 0;
+        sample += 0.6 * sin(2.0 * kPi * freq * t_note);       // Fundamental
+        sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note); // 2nd harmonic
+        sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note); // 3rd harmonic
+
+        sample *= volume;
+
+        // Scale to 16-bit signed PCM and store
+        pOut[i] = static_cast<int16_t>(sample * static_cast<double>(std::numeric_limits<int16_t>::max()));
+    }
+
+    pCustomDS->cursor += framesToRead;
+    if (pFramesRead)
+    {
+        *pFramesRead = framesToRead;
+    }
+
+    return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
+}
+
+// Custom data source seek callback. Allows miniaudio to jump to a specific frame.
+ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
+{
+    auto * pCustomDS = reinterpret_cast<PosixAudioManager::Impl::CustomDataSource *>(pDataSource);
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
+
+    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
+
+    // Cap the cursor at the end of the sound
+    if (frameIndex > totalSamples)
+    {
+        pCustomDS->cursor = totalSamples;
+    }
+    else
+    {
+        pCustomDS->cursor = frameIndex;
+    }
+
+    return MA_SUCCESS;
+}
+
+// Custom data source get data format callback. Tells miniaudio what format we are generating.
+ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
+                                             ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
+{
+    if (pFormat)
+    {
+        *pFormat = ma_format_s16; // 16-bit signed integer PCM
+    }
+    if (pChannels)
+    {
+        *pChannels = 1; // Mono
+    }
+    if (pSampleRate)
+    {
+        *pSampleRate = kSampleRateHz;
+    }
+
+    if (pChannelMap && channelMapCap > 0)
+    {
+        *pChannelMap = MA_CHANNEL_MONO;
+    }
+
+    return MA_SUCCESS;
+}
+
+// Custom data source get cursor callback. Returns current playback position.
+ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
+{
+    auto * pCustomDS = reinterpret_cast<PosixAudioManager::Impl::CustomDataSource *>(pDataSource);
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
+
+    if (pCursor)
+    {
+        *pCursor = pCustomDS->cursor;
+    }
+    return MA_SUCCESS;
+}
+
+// Custom data source get length callback. Returns total duration in frames.
+ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
+{
+    auto * pCustomDS = reinterpret_cast<PosixAudioManager::Impl::CustomDataSource *>(pDataSource);
+    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
+
+    if (pLength)
+    {
+        *pLength = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
+    }
+    return MA_SUCCESS;
+}
+
+// Custom data source set looping callback.
+ma_result custom_data_source_set_looping(ma_data_source * pDataSource, ma_bool32 isLooping)
+{
+    // Not supported for now as chime sounds are usually one-shot.
+    return MA_NOT_IMPLEMENTED;
+}
+
+// Define the vtable for the custom data source, mapping callbacks to miniaudio operations.
+static ma_data_source_vtable g_custom_data_source_vtable = {
+    custom_data_source_read,
+    custom_data_source_seek,
+    custom_data_source_get_data_format,
+    custom_data_source_get_cursor,
+    custom_data_source_get_length,
+    custom_data_source_set_looping,
+    0 // flags
+};
+
+// SoundResource Factory: Initializes a specific sound based on its ID.
+std::unique_ptr<PosixAudioManager::Impl::SoundResource> CreateSoundResource(ma_engine * engine, uint8_t soundId)
+{
+    auto resource = std::make_unique<PosixAudioManager::Impl::SoundResource>();
+    resource->id  = soundId;
+
+    // Configure the custom data source parameters based on ID.
+    // These hardcoded values define the characteristics of each chime.
+    resource->dataSource.cursor = 0;
+
+    if (soundId == 0)
+    {
+        // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
+        resource->dataSource.freq1_hz     = 880;
+        resource->dataSource.freq2_hz     = 660;
+        resource->dataSource.duration_sec = 1.0;
+        resource->dataSource.pulse        = false;
+    }
+    else if (soundId == 1)
+    {
+        // Chime 1: Pulsing warning tone (1000Hz pulsing)
+        resource->dataSource.freq1_hz     = 1000;
+        resource->dataSource.freq2_hz     = 1000;
+        resource->dataSource.duration_sec = 1.0;
+        resource->dataSource.pulse        = true;
+    }
+    else
+    {
+        // Chime 2 (Default): Single short tone (440Hz)
+        resource->dataSource.freq1_hz     = 440;
+        resource->dataSource.freq2_hz     = 440;
+        resource->dataSource.duration_sec = 0.5;
+        resource->dataSource.pulse        = false;
+    }
+
+    // Initialize the base data source with our vtable mapping to the callbacks above
+    ma_data_source_config config = ma_data_source_config_init();
+    config.vtable                = &g_custom_data_source_vtable;
+
+    ma_result res = ma_data_source_init(&config, &resource->dataSource.base);
+    if (res != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", soundId, res);
+        return nullptr;
+    }
+
+    // Initialize the sound object from the data source. Miniaudio will pull data from it during playback.
+    res = ma_sound_init_from_data_source(engine, &resource->dataSource.base, 0, NULL, &resource->sound);
+    if (res != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize sound object for sound %d: %d", soundId, res);
+        ma_data_source_uninit(&resource->dataSource.base);
+        return nullptr;
+    }
+
+    resource->initialized = true;
+    return resource;
+}
+
+} // namespace
+
+static const PosixAudioManager::Sound kSupportedSounds[] = {
+    { 0, "Ding Dong" },
+    { 1, "Ring Ring" },
+};
+
+PosixAudioManager::PosixAudioManager() = default;
+PosixAudioManager::~PosixAudioManager() = default;
+
+CHIP_ERROR PosixAudioManager::Init()
+{
+    if (mImpl)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    mImpl = std::make_unique<Impl>();
+
+    ma_result result = ma_engine_init(NULL, &mImpl->engine);
+    if (result != MA_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize shared miniaudio engine: %d", result);
+        mImpl.reset();
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    mImpl->engineInitialized = true;
+    ChipLogProgress(DeviceLayer, "Shared miniaudio engine initialized successfully");
+
+    // Pre-initialize all requested sound resources
+    bool allSoundsInitialized = true;
+    for (const auto & sound : kSupportedSounds)
+    {
+        auto resource = CreateSoundResource(&mImpl->engine, sound.id);
+        if (resource)
+        {
+            mImpl->soundResources.push_back(std::move(resource));
+        }
+        else
+        {
+            allSoundsInitialized = false;
+        }
+    }
+
+    mImpl->soundsInitialized = allSoundsInitialized;
+    if (mImpl->soundsInitialized)
+    {
+        ChipLogProgress(DeviceLayer, "Shared miniaudio sound resources initialized successfully");
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Some shared miniaudio sound resources failed to initialize!");
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+Span<const PosixAudioManager::Sound> PosixAudioManager::GetSupportedSounds() const
+{
+    return Span<const Sound>(kSupportedSounds);
+}
+
+void PosixAudioManager::Shutdown()
+{
+    if (mImpl)
+    {
+        mImpl->soundResources.clear();
+        if (mImpl->engineInitialized)
+        {
+            ma_engine_uninit(&mImpl->engine);
+            ChipLogProgress(DeviceLayer, "Shared miniaudio engine uninitialized");
+        }
+        mImpl.reset();
+    }
+}
+
+void PosixAudioManager::SetVolume(uint8_t volume)
+{
+    if (mImpl && mImpl->engineInitialized)
+    {
+        float volumeFloat = static_cast<float>(volume) / 254.0f;
+        ma_engine_set_volume(&mImpl->engine, volumeFloat);
+    }
+}
+
+CHIP_ERROR PosixAudioManager::PlaySound(uint8_t soundId)
+{
+    if (!mImpl || !mImpl->soundsInitialized)
+    {
+        ChipLogError(DeviceLayer, "PosixAudioManager: Sound resources not initialized, cannot play sound");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    ma_sound * pSound = nullptr;
+    for (auto & resource : mImpl->soundResources)
+    {
+        if (resource && resource->id == soundId && resource->initialized)
+        {
+            pSound = &resource->sound;
+            break;
+        }
+    }
+
+    if (pSound)
+    {
+        // Rewind sound to the beginning before playing
+        ma_sound_seek_to_pcm_frame(pSound, 0);
+
+        // Start playback.
+        ma_result result = ma_sound_start(pSound);
+        if (result != MA_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to start sound %d: %d", soundId, result);
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    ChipLogError(DeviceLayer, "PosixAudioManager: Sound ID %d not found or not initialized", soundId);
+    return CHIP_ERROR_KEY_NOT_FOUND;
+}
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -40,7 +40,13 @@ Span<const ChimeDevice::Sound> MapSounds(PosixAudioManager & audioManager)
 
 PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, PosixAudioManager & audioManager) :
     ChimeDevice(timerDelegate, MapSounds(audioManager)), mAudioManager(audioManager)
-{}
+{
+    CHIP_ERROR err = mAudioManager.Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Failed to initialize audio manager: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
 
 Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chimeID)
 {

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -15,379 +15,52 @@
  *    limitations under the License.
  */
 #include <PosixChimeDevice.h>
-#include <cmath>
-#include <lib/support/CodeUtils.h>
+#include <PosixAudioManager.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <limits>
-#include <sstream>
 
-// This file implements the audio playback for the Chime cluster on POSIX systems using the
-// miniaudio library. To avoid shipping large audio files or consuming significant memory with
-// pre-rendered PCM buffers, this implementation uses an "incremental synthesis" approach.
-//
-// A custom miniaudio data source (`CustomDataSource`) is defined. When miniaudio needs more
-// audio data, it calls `custom_data_source_read`, which generates the audio samples on-the-fly.
-// The sounds are synthesized using additive synthesis (combining a fundamental frequency with
-// harmonics) and an exponential decay to simulate a natural bell or chime fade-out.
-//
-// The `SoundResource` class manages the lifecycle of these miniaudio structures using RAII,
-// ensuring proper cleanup when the device is destroyed.
+#include <vector>
 
 namespace chip {
 namespace app {
 
 namespace {
-
-constexpr double kPi             = 3.14159265358979323846;
-constexpr uint32_t kSampleRateHz = 44100;
-
-// Custom data source read callback. This is called by miniaudio to fetch more audio frames.
-// It generates the audio on-the-fly instead of reading from a buffer.
-ma_result custom_data_source_read(ma_data_source * pDataSource, void * pFramesOut, ma_uint64 frameCount, ma_uint64 * pFramesRead)
+Span<const ChimeDevice::Sound> MapSounds(PosixAudioManager & audioManager)
 {
-    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
-
-    // Calculate total samples for the full duration of the sound
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
-
-    ma_uint64 framesToRead = frameCount;
-    // Ensure we don't read past the end of the sound
-    if (pCustomDS->cursor + framesToRead > totalSamples)
+    static std::vector<ChimeDevice::Sound> sMappedSounds;
+    if (sMappedSounds.empty())
     {
-        framesToRead = totalSamples - pCustomDS->cursor;
-    }
-
-    if (framesToRead == 0)
-    {
-        if (pFramesRead)
+        for (const auto & sound : audioManager.GetSupportedSounds())
         {
-            *pFramesRead = 0;
+            sMappedSounds.push_back(ChimeDevice::Sound{ sound.id, chip::Span<const char>(sound.name, strlen(sound.name)) });
         }
-        return MA_AT_END;
     }
-
-    int16_t * pOut = reinterpret_cast<int16_t *>(pFramesOut);
-
-    // Generate samples on the fly
-    for (ma_uint64 i = 0; i < framesToRead; ++i)
-    {
-        ma_uint64 currentSample = pCustomDS->cursor + i;
-        // Calculate current time in seconds
-        double t = static_cast<double>(currentSample) / kSampleRateHz;
-        double freq;
-        double t_note;
-
-        if (pCustomDS->pulse)
-        {
-            // Pulsing sound: keep same frequency
-            freq   = pCustomDS->freq1_hz;
-            t_note = t;
-        }
-        else
-        {
-            // Two-tone sound (e.g., Ding-Dong): switch from freq1_hz to freq2_hz halfway through the total duration.
-            // This creates a classic two-note chime effect. We also reset the relative time (t_note) for the second
-            // tone so that the exponential decay applies to each note individually.
-            if (t < pCustomDS->duration_sec / 2.0)
-            {
-                freq   = pCustomDS->freq1_hz;
-                t_note = t;
-            }
-            else
-            {
-                freq   = pCustomDS->freq2_hz;
-                t_note = t - (pCustomDS->duration_sec / 2.0); // Reset relative time for second tone
-            }
-        }
-
-        // Apply exponential decay for a natural chime fade-out effect
-        double volume = exp(-t_note * 4.0);
-
-        if (pCustomDS->pulse)
-        {
-            // Apply a square wave modulation for the pulse effect
-            bool on = (static_cast<int>(t * 20) % 2) == 0;
-            if (!on)
-            {
-                volume = 0;
-            }
-        }
-
-        // Additive synthesis: combine fundamental frequency and harmonics
-        double sample = 0;
-        sample += 0.6 * sin(2.0 * kPi * freq * t_note);       // Fundamental
-        sample += 0.3 * sin(2.0 * kPi * freq * 2.0 * t_note); // 2nd harmonic
-        sample += 0.1 * sin(2.0 * kPi * freq * 3.0 * t_note); // 3rd harmonic
-
-        sample *= volume;
-
-        // Scale to 16-bit signed PCM and store
-        pOut[i] = static_cast<int16_t>(sample * static_cast<double>(std::numeric_limits<int16_t>::max()));
-    }
-
-    pCustomDS->cursor += framesToRead;
-    if (pFramesRead)
-    {
-        *pFramesRead = framesToRead;
-    }
-
-    return (framesToRead < frameCount) ? MA_AT_END : MA_SUCCESS;
+    return Span<const ChimeDevice::Sound>(sMappedSounds.data(), sMappedSounds.size());
 }
-
-// Custom data source seek callback. Allows miniaudio to jump to a specific frame.
-ma_result custom_data_source_seek(ma_data_source * pDataSource, ma_uint64 frameIndex)
-{
-    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
-
-    const ma_uint64 totalSamples = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
-
-    // Cap the cursor at the end of the sound
-    if (frameIndex > totalSamples)
-    {
-        pCustomDS->cursor = totalSamples;
-    }
-    else
-    {
-        pCustomDS->cursor = frameIndex;
-    }
-
-    return MA_SUCCESS;
-}
-
-// Custom data source get data format callback. Tells miniaudio what format we are generating.
-ma_result custom_data_source_get_data_format(ma_data_source * pDataSource, ma_format * pFormat, ma_uint32 * pChannels,
-                                             ma_uint32 * pSampleRate, ma_channel * pChannelMap, size_t channelMapCap)
-{
-    if (pFormat)
-    {
-        *pFormat = ma_format_s16; // 16-bit signed integer PCM
-    }
-    if (pChannels)
-    {
-        *pChannels = 1; // Mono
-    }
-    if (pSampleRate)
-    {
-        *pSampleRate = kSampleRateHz;
-    }
-
-    if (pChannelMap && channelMapCap > 0)
-    {
-        *pChannelMap = MA_CHANNEL_MONO;
-    }
-
-    return MA_SUCCESS;
-}
-
-// Custom data source get cursor callback. Returns current playback position.
-ma_result custom_data_source_get_cursor(ma_data_source * pDataSource, ma_uint64 * pCursor)
-{
-    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
-
-    if (pCursor)
-    {
-        *pCursor = pCustomDS->cursor;
-    }
-    return MA_SUCCESS;
-}
-
-// Custom data source get length callback. Returns total duration in frames.
-ma_result custom_data_source_get_length(ma_data_source * pDataSource, ma_uint64 * pLength)
-{
-    auto * pCustomDS = reinterpret_cast<PosixChimeDevice::CustomDataSource *>(pDataSource);
-    VerifyOrReturnError(pCustomDS != nullptr, MA_INVALID_ARGS);
-
-    if (pLength)
-    {
-        *pLength = static_cast<ma_uint64>(pCustomDS->duration_sec * kSampleRateHz);
-    }
-    return MA_SUCCESS;
-}
-
-// Custom data source set looping callback.
-ma_result custom_data_source_set_looping(ma_data_source * pDataSource, ma_bool32 isLooping)
-{
-    // Not supported for now as chime sounds are usually one-shot.
-    return MA_NOT_IMPLEMENTED;
-}
-
-// Define the vtable for the custom data source, mapping callbacks to miniaudio operations.
-static ma_data_source_vtable g_custom_data_source_vtable = {
-    custom_data_source_read,
-    custom_data_source_seek,
-    custom_data_source_get_data_format,
-    custom_data_source_get_cursor,
-    custom_data_source_get_length,
-    custom_data_source_set_looping,
-    0 // flags
-};
-
 } // namespace
 
-// SoundResource Factory: Initializes a specific sound based on its ID.
-std::unique_ptr<PosixChimeDevice::SoundResource> PosixChimeDevice::SoundResource::Create(ma_engine * engine,
-                                                                                         const ChimeDevice::Sound & soundInfo)
-{
-    auto resource = std::make_unique<SoundResource>();
-    resource->id  = soundInfo.id;
+PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, PosixAudioManager & audioManager) :
+    ChimeDevice(timerDelegate, MapSounds(audioManager)), mAudioManager(audioManager)
+{}
 
-    // Configure the custom data source parameters based on ID.
-    // These hardcoded values define the characteristics of each chime.
-    resource->dataSource.cursor = 0;
-
-    if (soundInfo.id == 0)
-    {
-        // Chime 0: Two-tone "Ding-Dong" (880Hz then 660Hz)
-        resource->dataSource.freq1_hz     = 880;
-        resource->dataSource.freq2_hz     = 660;
-        resource->dataSource.duration_sec = 1.0;
-        resource->dataSource.pulse        = false;
-    }
-    else if (soundInfo.id == 1)
-    {
-        // Chime 1: Pulsing warning tone (1000Hz pulsing)
-        resource->dataSource.freq1_hz     = 1000;
-        resource->dataSource.freq2_hz     = 1000;
-        resource->dataSource.duration_sec = 1.0;
-        resource->dataSource.pulse        = true;
-    }
-    else
-    {
-        // Chime 2 (Default): Single short tone (440Hz)
-        resource->dataSource.freq1_hz     = 440;
-        resource->dataSource.freq2_hz     = 440;
-        resource->dataSource.duration_sec = 0.5;
-        resource->dataSource.pulse        = false;
-    }
-
-    // Initialize the base data source with our vtable mapping to the callbacks above
-    ma_data_source_config config = ma_data_source_config_init();
-    config.vtable                = &g_custom_data_source_vtable;
-
-    ma_result res = ma_data_source_init(&config, &resource->dataSource.base);
-    if (res != MA_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed to initialize base data source for sound %d: %d", soundInfo.id, res);
-        return nullptr;
-    }
-
-    // Initialize the sound object from the data source. Miniaudio will pull data from it during playback.
-    res = ma_sound_init_from_data_source(engine, &resource->dataSource.base, 0, NULL, &resource->sound);
-    if (res != MA_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed to initialize sound %d from data source: %d", soundInfo.id, res);
-        ma_data_source_uninit(&resource->dataSource.base);
-        return nullptr;
-    }
-
-    resource->mInitialized = true;
-    return resource;
-}
-
-// SoundResource Destructor: Ensures safe cleanup of miniaudio structures.
-PosixChimeDevice::SoundResource::~SoundResource()
-{
-    if (mInitialized)
-    {
-        ma_sound_uninit(&sound);
-        ma_data_source_uninit(&dataSource.base);
-    }
-}
-
-// PosixChimeDevice Constructor: Initializes the audio engine and pre-loads sound resources.
-PosixChimeDevice::PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds) : ChimeDevice(timerDelegate, sounds)
-{
-    // Initialize the miniaudio engine with default configuration
-    ma_result result = ma_engine_init(NULL, &mEngine);
-    if (result != MA_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed to initialize miniaudio engine: %d", result);
-        return;
-    }
-
-    mEngineInitialized = true;
-    ChipLogProgress(DeviceLayer, "Miniaudio engine initialized successfully");
-
-    // Pre-initialize all requested sound resources
-    bool allSoundsInitialized = true;
-    for (size_t i = 0; i < sounds.size(); ++i)
-    {
-        auto resource = SoundResource::Create(&mEngine, sounds[i]);
-        if (resource)
-        {
-            mSoundResources.push_back(std::move(resource));
-        }
-        else
-        {
-            allSoundsInitialized = false;
-        }
-    }
-
-    mSoundsInitialized = allSoundsInitialized;
-    if (mSoundsInitialized)
-    {
-        ChipLogProgress(DeviceLayer, "In-memory sounds initialized successfully");
-    }
-}
-
-// PosixChimeDevice Destructor: Cleans up resources and shuts down the engine.
-PosixChimeDevice::~PosixChimeDevice()
-{
-    if (mEngineInitialized)
-    {
-        // Clear the vector first to trigger SoundResource destructors before engine shutdown
-        mSoundResources.clear();
-        ma_engine_uninit(&mEngine);
-        ChipLogProgress(DeviceLayer, "Miniaudio engine uninitialized");
-    }
-}
-
-// PlayChimeSound: Triggers the playback of a sound by its ID.
 Protocols::InteractionModel::Status PosixChimeDevice::PlayChimeSound(uint8_t chimeID)
 {
     // Call base class to log the default message
     auto status = ChimeDevice::PlayChimeSound(chimeID);
-
-    if (!mSoundsInitialized)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
-        ChipLogError(DeviceLayer, "PosixChimeDevice: Sounds not initialized, cannot play sound");
         return status;
     }
 
-    // Find the requested sound resource by ID
-    ma_sound * pSound = nullptr;
-    for (auto & resource : mSoundResources)
+    ChipLogProgress(DeviceLayer, "PosixChimeDevice: Delegating PlayChimeSound(%d) to PosixAudioManager", chimeID);
+
+    CHIP_ERROR err = mAudioManager.PlaySound(chimeID);
+    if (err != CHIP_NO_ERROR)
     {
-        if (resource && resource->id == chimeID && resource->mInitialized)
-        {
-            pSound = &resource->sound;
-            break;
-        }
+        ChipLogError(DeviceLayer, "PosixChimeDevice: Failed to play sound %d: %" CHIP_ERROR_FORMAT, chimeID, err.Format());
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    if (pSound)
-    {
-        ChipLogProgress(DeviceLayer, "PosixChimeDevice: Attempting to play sound %d from memory", chimeID);
-
-        // Rewind sound to the beginning before playing
-        ma_sound_seek_to_pcm_frame(pSound, 0);
-
-        // Start playback. This will trigger callbacks to custom_data_source_read.
-        ma_result result = ma_sound_start(pSound);
-        if (result != MA_SUCCESS)
-        {
-            ChipLogError(DeviceLayer, "Failed to start sound %d: %d", chimeID, result);
-        }
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "PosixChimeDevice: Sound %d not found in memory", chimeID);
-    }
-
-    return status;
+    return Protocols::InteractionModel::Status::Success;
 }
 
 } // namespace app

--- a/examples/all-devices-app/posix/PosixChimeDevice.cpp
+++ b/examples/all-devices-app/posix/PosixChimeDevice.cpp
@@ -14,8 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <PosixChimeDevice.h>
 #include <PosixAudioManager.h>
+#include <PosixChimeDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <vector>

--- a/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
+++ b/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
@@ -50,8 +50,7 @@ void PosixSpeakerDevice::UpdateEngineVolume()
     uint8_t volume = !muted ? level : 0;
     mAudioManager.SetVolume(volume);
 
-    ChipLogProgress(DeviceLayer, "PosixSpeakerDevice: Updated master volume to %u (Muted: %d, Level: %u)",
-                    volume, muted, level);
+    ChipLogProgress(DeviceLayer, "PosixSpeakerDevice: Updated master volume to %u (Muted: %d, Level: %u)", volume, muted, level);
 }
 
 } // namespace app

--- a/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
+++ b/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <PosixAudioManager.h>
+#include <PosixSpeakerDevice.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace app {
+
+PosixSpeakerDevice::PosixSpeakerDevice(const Context & context, PosixAudioManager & audioManager) :
+    SpeakerDevice(*this, *this, context.timerDelegate), mAudioManager(audioManager)
+{}
+
+PosixSpeakerDevice::~PosixSpeakerDevice() {}
+
+void PosixSpeakerDevice::OnLevelChanged(uint8_t value)
+{
+    UpdateEngineVolume();
+}
+
+void PosixSpeakerDevice::OnOffStartup(bool on)
+{
+    UpdateEngineVolume();
+}
+
+void PosixSpeakerDevice::OnOnOffChanged(bool on)
+{
+    UpdateEngineVolume();
+}
+
+void PosixSpeakerDevice::UpdateEngineVolume()
+{
+    bool muted    = !OnOffCluster().GetOnOff();
+    uint8_t level = LevelControlCluster().GetCurrentLevel().ValueOr(Clusters::LevelControlCluster::kMaxLevel);
+
+    uint8_t volume = !muted ? level : 0;
+    mAudioManager.SetVolume(volume);
+
+    ChipLogProgress(DeviceLayer, "PosixSpeakerDevice: Updated master volume to %u (Muted: %d, Level: %u)",
+                    volume, muted, level);
+}
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
+++ b/examples/all-devices-app/posix/PosixSpeakerDevice.cpp
@@ -23,7 +23,13 @@ namespace app {
 
 PosixSpeakerDevice::PosixSpeakerDevice(const Context & context, PosixAudioManager & audioManager) :
     SpeakerDevice(*this, *this, context.timerDelegate), mAudioManager(audioManager)
-{}
+{
+    CHIP_ERROR err = mAudioManager.Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "PosixSpeakerDevice: Failed to initialize audio manager: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
 
 PosixSpeakerDevice::~PosixSpeakerDevice() {}
 

--- a/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
@@ -15,23 +15,35 @@
  *    limitations under the License.
  */
 #include <DeviceFactoryPlatformOverride.h>
+#include <PosixAudioManager.h>
 #include <PosixChimeDevice.h>
+#include <PosixSpeakerDevice.h>
 #include <app_config/enabled_devices.h>
 #include <device-factory/DeviceFactory.h>
 
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate)
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager)
 {
+    // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
+    CHIP_ERROR err = audioManager.Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize PosixAudioManager: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
+    if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
+    {
+        DeviceFactory::GetInstance().RegisterCreator("speaker", [&timerDelegate, &audioManager]() {
+            return std::make_unique<PosixSpeakerDevice>(PosixSpeakerDevice::Context{ timerDelegate }, audioManager);
+        });
+    }
+
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate]() {
-            static const ChimeDevice::Sound kDefaultSounds[] = {
-                { 0, "Ding Dong"_span },
-                { 1, "Ring Ring"_span },
-            };
-            return std::make_unique<PosixChimeDevice>(timerDelegate, Span<const ChimeDevice::Sound>(kDefaultSounds));
+        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &audioManager]() {
+            return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager);
         });
     }
 }

--- a/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
@@ -24,7 +24,8 @@
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager)
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
+                                    PosixAudioManager & audioManager)
 {
     // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
     CHIP_ERROR err = audioManager.Init();
@@ -42,9 +43,8 @@ void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentSto
 
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &audioManager]() {
-            return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager);
-        });
+        DeviceFactory::GetInstance().RegisterCreator(
+            "chime", [&timerDelegate, &audioManager]() { return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager); });
     }
 }
 

--- a/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
@@ -27,13 +27,6 @@ namespace app {
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
                                     PosixAudioManager & audioManager)
 {
-    // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
-    CHIP_ERROR err = audioManager.Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to initialize PosixAudioManager: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-
     if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
     {
         DeviceFactory::GetInstance().RegisterCreator("speaker", [&timerDelegate, &audioManager]() {

--- a/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
+++ b/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
@@ -24,7 +24,8 @@
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager);
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
+                                    PosixAudioManager & audioManager);
 
 } // namespace app
 } // namespace chip

--- a/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
+++ b/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
@@ -19,10 +19,12 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/TimerDelegate.h>
 
+#include <PosixAudioManager.h>
+
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate);
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager);
 
 } // namespace app
 } // namespace chip

--- a/examples/all-devices-app/posix/include/PosixAudioManager.h
+++ b/examples/all-devices-app/posix/include/PosixAudioManager.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <memory>
+
+namespace chip {
+namespace app {
+
+// Shared audio manager for POSIX platforms. It encapsulates the miniaudio engine
+// and synthesizes/manages sound resources. It provides a simple platform-agnostic
+// interface for volume control and sound playback.
+class PosixAudioManager
+{
+public:
+    PosixAudioManager();
+    ~PosixAudioManager();
+
+    struct Sound
+    {
+        uint8_t id;
+        const char * name;
+    };
+
+    // Initializes the audio engine and pre-loads/synthesizes sound resources
+    CHIP_ERROR Init();
+
+    // Shuts down the engine and releases sound resources
+    void Shutdown();
+
+    // Sets the master playback volume (scaling factor from 0 to 254)
+    void SetVolume(uint8_t volume);
+
+    // Triggers the playback of a preloaded sound by its ID
+    CHIP_ERROR PlaySound(uint8_t soundId);
+
+    // Returns the list of supported preloaded sounds
+    Span<const Sound> GetSupportedSounds() const;
+
+public:
+    struct Impl;
+
+private:
+    // Pointer to internal implementation (Pimpl pattern) to hide miniaudio structures
+    std::unique_ptr<Impl> mImpl;
+};
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/include/PosixChimeDevice.h
+++ b/examples/all-devices-app/posix/include/PosixChimeDevice.h
@@ -17,57 +17,24 @@
 #pragma once
 
 #include <devices/chime/ChimeDevice.h>
-#include <memory>
-#include <miniaudio.h>
-#include <vector>
+
+#include <PosixAudioManager.h>
 
 namespace chip {
 namespace app {
 
 // Platform-specific implementation of ChimeDevice for POSIX systems.
-// It uses miniaudio for audio playback and generates sounds on-the-fly (incremental synthesis).
+// It translates Matter Chime cluster commands into calls to the shared PosixAudioManager.
 class PosixChimeDevice : public ChimeDevice
 {
 public:
-    // Custom data source for miniaudio to generate sound on-the-fly.
-    // This avoids loading large audio files or holding full PCM buffers in memory.
-    struct CustomDataSource
-    {
-        ma_data_source_base base; // Base structure required by miniaudio
-        double freq1_hz;          // Primary frequency or first tone in Hz
-        double freq2_hz;          // Secondary frequency or second tone in Hz
-        double duration_sec;      // Total duration of the sound in seconds
-        bool pulse;               // Whether to apply a pulse modulation effect
-        ma_uint64 cursor;         // Current playback position in samples
-    };
-
-    // RAII wrapper for sound resources. Manages the lifecycle of miniaudio structures.
-    // A "SoundResource" represents a single chime sound, binding a Matter Chime ID to a specific
-    // audio synthesis configuration (CustomDataSource) and the associated miniaudio sound object.
-    class SoundResource
-    {
-    public:
-        static std::unique_ptr<SoundResource> Create(ma_engine * engine, const ChimeDevice::Sound & soundInfo);
-        SoundResource() = default; // Needed for factory
-        ~SoundResource();
-
-        uint8_t id;                  // Chime ID matching the Matter spec
-        CustomDataSource dataSource; // Custom data source for this sound
-        ma_sound sound;              // Miniaudio sound object
-        bool mInitialized = false;   // Whether the resource was successfully initialized
-    };
-
-    PosixChimeDevice(TimerDelegate & timerDelegate, Span<const Sound> sounds);
-    ~PosixChimeDevice() override;
+    PosixChimeDevice(TimerDelegate & timerDelegate, PosixAudioManager & audioManager);
+    ~PosixChimeDevice() override = default;
 
     Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
 
 private:
-    ma_engine mEngine;
-    bool mEngineInitialized = false;
-
-    std::vector<std::unique_ptr<SoundResource>> mSoundResources;
-    bool mSoundsInitialized = false;
+    PosixAudioManager & mAudioManager;
 };
 
 } // namespace app

--- a/examples/all-devices-app/posix/include/PosixSpeakerDevice.h
+++ b/examples/all-devices-app/posix/include/PosixSpeakerDevice.h
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <devices/speaker/SpeakerDevice.h>
+
+#include <PosixAudioManager.h>
+
+namespace chip {
+namespace app {
+
+// Platform-specific implementation of SpeakerDevice for POSIX systems.
+// It overrides LevelControl and OnOff delegate methods to adjust the master
+// volume of the shared miniaudio engine.
+class PosixSpeakerDevice : public SpeakerDevice, public Clusters::LevelControlDelegate, public Clusters::OnOffDelegate
+{
+public:
+    struct Context
+    {
+        TimerDelegate & timerDelegate;
+    };
+
+    PosixSpeakerDevice(const Context & context, PosixAudioManager & audioManager);
+    ~PosixSpeakerDevice() override;
+
+    // LevelControlDelegate
+    void OnLevelChanged(uint8_t value) override;
+    void OnDefaultMoveRateChanged(DataModel::Nullable<uint8_t> value) override {}
+    void OnOptionsChanged(BitMask<Clusters::LevelControl::OptionsBitmap> value) override {}
+    void OnOnLevelChanged(DataModel::Nullable<uint8_t> value) override {}
+
+    // OnOffDelegate
+    void OnOffStartup(bool on) override;
+    void OnOnOffChanged(bool on) override;
+
+private:
+    PosixAudioManager & mAudioManager;
+    void UpdateEngineVolume();
+};
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
@@ -15,23 +15,35 @@
  *    limitations under the License.
  */
 #include <DeviceFactoryPlatformOverride.h>
+#include <PosixAudioManager.h>
 #include <PosixChimeDevice.h>
+#include <PosixSpeakerDevice.h>
 #include <app_config/enabled_devices.h>
 #include <device-factory/DeviceFactory.h>
 
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate)
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager)
 {
+    // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
+    CHIP_ERROR err = audioManager.Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize PosixAudioManager: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
+    if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
+    {
+        DeviceFactory::GetInstance().RegisterCreator("speaker", [&timerDelegate, &audioManager]() {
+            return std::make_unique<PosixSpeakerDevice>(PosixSpeakerDevice::Context{ timerDelegate }, audioManager);
+        });
+    }
+
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate]() {
-            static const ChimeDevice::Sound kDefaultSounds[] = {
-                { 0, "Ding Dong"_span },
-                { 1, "Ring Ring"_span },
-            };
-            return std::make_unique<PosixChimeDevice>(timerDelegate, Span<const ChimeDevice::Sound>(kDefaultSounds));
+        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &audioManager]() {
+            return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager);
         });
     }
 }

--- a/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
@@ -24,7 +24,8 @@
 namespace chip {
 namespace app {
 
-void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager)
+void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
+                                    PosixAudioManager & audioManager)
 {
     // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
     CHIP_ERROR err = audioManager.Init();
@@ -42,9 +43,8 @@ void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentSto
 
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &audioManager]() {
-            return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager);
-        });
+        DeviceFactory::GetInstance().RegisterCreator(
+            "chime", [&timerDelegate, &audioManager]() { return std::make_unique<PosixChimeDevice>(timerDelegate, audioManager); });
     }
 }
 

--- a/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
@@ -27,13 +27,6 @@ namespace app {
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
                                     PosixAudioManager & audioManager)
 {
-    // Initialize the shared audio manager for miniaudio engine access and pre-load sounds
-    CHIP_ERROR err = audioManager.Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to initialize PosixAudioManager: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-
     if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
     {
         DeviceFactory::GetInstance().RegisterCreator("speaker", [&timerDelegate, &audioManager]() {

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -20,6 +20,7 @@
 #include <AppRootNode.h>
 #include <DeviceFactoryPlatformOverride.h>
 #include <LinuxCommissionableDataProvider.h>
+#include <PosixAudioManager.h>
 #include <TracingCommandLineArgument.h>
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 #include <TraceDecoder.h>
@@ -77,6 +78,7 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 DefaultTimerDelegate gTimerDelegate;
+chip::app::PosixAudioManager gAudioManager;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
@@ -306,7 +308,7 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
         .storageDelegate   = *initParams.persistentStorageDelegate,  //
     });
 
-    RegisterDeviceFactoryOverrides(gTimerDelegate, initParams.persistentStorageDelegate);
+    RegisterDeviceFactoryOverrides(gTimerDelegate, initParams.persistentStorageDelegate, gAudioManager);
 
 #if CHIP_CONFIG_ENABLE_GROUPCAST
     // TODO(#72056): Once groupcast is enabled by default, this should not be dependent on the app argument.
@@ -555,7 +557,10 @@ CHIP_ERROR Initialize(int argc, char * argv[])
 
 } // namespace
 
-void ApplicationShutdown() {}
+void ApplicationShutdown()
+{
+    gAudioManager.Shutdown();
+}
 
 int main(int argc, char * argv[])
 {

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -72,6 +72,8 @@ using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 using namespace chip::ArgParser;
 
+void ApplicationShutdown();
+
 namespace {
 AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 
@@ -480,6 +482,8 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 #if defined(ENABLE_TRACING) && ENABLE_TRACING
     tracing_setup.StopTracing();
 #endif
+
+    ApplicationShutdown();
 }
 
 void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)

--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -98,3 +98,6 @@ leak:KeyValueStoreManagerImpl::Init
 
 # ignore float to string conversion bigalloc pooling
 leak:__Balloc_D2A
+
+# CoreAudio (macOS system sound library) leaks during device initialization
+leak:install_mig_server

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -21,6 +21,13 @@ config("miniaudio_config") {
   # Use -isystem instead of include_dirs to treat miniaudio.h as a system header
   # and suppress warnings originating from it for dependents.
   cflags = [ "-isystem" + rebase_path("repo", root_build_dir) ]
+  if (current_os == "linux") {
+    defines = [
+      "MA_NO_ALSA",
+      "MA_NO_PULSEAUDIO",
+      "MA_NO_JACK",
+    ]
+  }
 }
 
 config("miniaudio_warnings") {

--- a/third_party/miniaudio/BUILD.gn
+++ b/third_party/miniaudio/BUILD.gn
@@ -21,13 +21,6 @@ config("miniaudio_config") {
   # Use -isystem instead of include_dirs to treat miniaudio.h as a system header
   # and suppress warnings originating from it for dependents.
   cflags = [ "-isystem" + rebase_path("repo", root_build_dir) ]
-  if (current_os == "linux") {
-    defines = [
-      "MA_NO_ALSA",
-      "MA_NO_PULSEAUDIO",
-      "MA_NO_JACK",
-    ]
-  }
 }
 
 config("miniaudio_warnings") {

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -21,12 +21,24 @@
 // we tell the header to include the actual function definitions.
 // This file should be compiled exactly once in the project to avoid
 // duplicate symbol errors during linking.
-// MINIAUDIO_IMPLEMENTATION definition follows
+// Workaround for LeakSanitizer (LSan) false positives:
+// When dynamically loaded system libraries (like ALSA or PulseAudio) are unloaded via dlclose(),
+// LSan loses track of their static allocations (e.g., dynamic loader caching) and reports them
+// as memory leaks from <unknown module>.
+//
+// Following the official recommendation by ASan creator Kostya Serebryany in
+// https://github.com/google/sanitizers/issues/89#issuecomment-321602408:
+// "don't dlclose anything when testing under asan/lsan", we stub dlclose() to a no-op when
+// compiling under AddressSanitizer. This keeps the dynamic libraries mapped in memory at process
+// exit, enabling LSan to scan their static data sections and correctly recognize allocations as reachable.
 #if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
-extern "C" const char * __lsan_default_suppressions()
+#include <dlfcn.h>
+static inline int dummy_dlclose(void * handle)
 {
-    return "leak:<unknown module>\n";
+    (void) handle;
+    return 0;
 }
+#define dlclose(handle) dummy_dlclose(handle)
 #endif
 
 #define MINIAUDIO_IMPLEMENTATION

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -26,7 +26,7 @@
 // LSan loses track of their static allocations (e.g., dynamic loader caching) and reports them
 // as memory leaks from <unknown module>.
 //
-// Following the official recommendation by ASan creator Kostya Serebryany in
+// Following the official recommendation in the Google Sanitizers issue tracker:
 // https://github.com/google/sanitizers/issues/89#issuecomment-321602408:
 // "don't dlclose anything when testing under asan/lsan", we stub dlclose() to a no-op when
 // compiling under AddressSanitizer. This keeps the dynamic libraries mapped in memory at process

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -21,6 +21,24 @@
 // we tell the header to include the actual function definitions.
 // This file should be compiled exactly once in the project to avoid
 // duplicate symbol errors during linking.
+#if defined(__SANITIZE_ADDRESS__)
+#define MA_PREVENT_DLCLOSE
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define MA_PREVENT_DLCLOSE
+#endif
+#endif
+
+#ifdef MA_PREVENT_DLCLOSE
+#include <dlfcn.h>
+static inline int dummy_dlclose(void * handle)
+{
+    (void) handle;
+    return 0;
+}
+#define dlclose(handle) dummy_dlclose(handle)
+#endif
+
 #define MINIAUDIO_IMPLEMENTATION
 
 #include <miniaudio.h>

--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -21,22 +21,12 @@
 // we tell the header to include the actual function definitions.
 // This file should be compiled exactly once in the project to avoid
 // duplicate symbol errors during linking.
-#if defined(__SANITIZE_ADDRESS__)
-#define MA_PREVENT_DLCLOSE
-#elif defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define MA_PREVENT_DLCLOSE
-#endif
-#endif
-
-#ifdef MA_PREVENT_DLCLOSE
-#include <dlfcn.h>
-static inline int dummy_dlclose(void * handle)
+// MINIAUDIO_IMPLEMENTATION definition follows
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+extern "C" const char * __lsan_default_suppressions()
 {
-    (void) handle;
-    return 0;
+    return "leak:<unknown module>\n";
 }
-#define dlclose(handle) dummy_dlclose(handle)
 #endif
 
 #define MINIAUDIO_IMPLEMENTATION


### PR DESCRIPTION
This PR refactors POSIX audio support in `all-devices-app` by introducing a centralized `PosixAudioManager`, and updates the speaker/chime device types to use it via dependency injection. This consolidates audio playback/synthesis and removes all direct miniaudio header dependencies from device structures.

### Key Refactorings:
- **Centralized `PosixAudioManager`**: Consolidates the miniaudio engine, sound waveform synthesis, and the supported sounds metadata list. Hides all miniaudio headers and structs entirely within the implementation file using the Pimpl pattern (`std::unique_ptr<Impl>`).
- **Dependency Injection**: Instantiates `PosixAudioManager` in `posix/main.cpp` and passes its reference down to the platform override layer. Both `PosixSpeakerDevice` and `PosixChimeDevice` now accept this manager reference in their constructors.
- **`PosixSpeakerDevice`**: Implements a dedicated POSIX speaker device overriding LevelControl and OnOff delegates to adjust the shared audio manager's playback volume.
- **`PosixChimeDevice`**: Translates PlayChimeSound commands to delegate playback to the shared audio manager. Maps the audio manager's supported sounds to the Matter Chime cluster's sound list dynamically during construction.
- **Default Speaker Level**: Updates `SpeakerDevice.cpp` to default the speaker level to 100 (unmuted) at startup for immediate audibility in test setups.

### Testing:
- Verified compilation of the `linux-x64-all-devices-app-boringssl` target.
- Executed the full 22-step integration test suite `TC_CHIME_2_4.py` and confirmed all tests passed.