### PR TITLE
[Silabs] Add an API to check the Initialize state of AppTask

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -290,7 +290,7 @@ CHIP_ERROR BaseApplication::Init()
         return err;
     }
 
-    mIsApplicationInitialized = (err == CHIP_NO_ERROR);
+    mIsApplicationInitialized = true;
     return err;
 }
 

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -289,6 +289,8 @@ CHIP_ERROR BaseApplication::Init()
         appError(err);
         return err;
     }
+
+    mIsApplicationInitialized = (err == CHIP_NO_ERROR);
     return err;
 }
 
@@ -1043,6 +1045,8 @@ bool BaseApplication::GetProvisionStatus()
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
+    // Verify that the App layer is initialized before propagating attribute changes callback to it.
+    VerifyOrReturn(CustomerAppTask::GetAppTask().IsApplicationInitialized());
     // Route through CustomerAppTask / AppTaskImpl (CRTP) so overrides use DMPostAttributeChangeCallbackImpl.
     CustomerAppTask::GetAppTask().DMPostAttributeChangeCallback(attributePath, type, size, value);
 }

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -122,7 +122,7 @@ public:
      *
      * @return Set to true when Init() was called successfully
      */
-    bool IsApplicationInitialized() { return mIsApplicationInitialized; }
+    bool IsApplicationInitialized() const { return mIsApplicationInitialized; }
 
     /**
      * @brief PostEvent function that add event to AppTask queue for processing

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -118,6 +118,13 @@ public:
     void UnlinkAppLed() { sAppActionLed = nullptr; }
 
     /**
+     * @brief Check if the application is initialized
+     *
+     * @return Set to true when Init() was called successfully
+     */
+    bool IsApplicationInitialized() { return mIsApplicationInitialized; }
+
+    /**
      * @brief PostEvent function that add event to AppTask queue for processing
      *
      * @param event AppEvent to post
@@ -291,5 +298,6 @@ protected:
     bool mSyncClusterToButtonAction;
 
 private:
+    bool mIsApplicationInitialized = false;
     static void InitOTARequestorHandler(chip::System::Layer * systemLayer, void * appState);
 };


### PR DESCRIPTION
### Summary
Slight change in some refactor app lead cases where MatterPostChangeAttributeCallback was propagated in the AppTask before it is initialized leading to a crash.

For example setting StartUpOnOff attribute to any value could,(would in the case of Toggle) trigger a early OnOff state change.

Fix:
- Add a Boolean/Api to our BaseApplication, usable by the inheriting AppTaskImpl, to indicate that the AppTask is fully initialized.
- Set the bool, mIsApplicationInitialized, at the end of BaseApplication::Init() once BaseInit() and AppInit() are successfully called.
- Check IsApplicationInitialized() before propagating the MatterPostChangeAttributeCallback to te AppTaskImpl


### Related issues
SL internal issues : https://jira.silabs.com/browse/MATTER-6412 and https://jira.silabs.com/browse/MATTER-6361

### Testing
Commission the lighting-app.
Set StartUpOnOff attribute to Toggle(2) : ./chip-tool onoff write start-up-on-off 2 $NODE_ID 1
Reboot the device, Led state Toggles every reboot, app doesn't crash anymore.
run Test_TC_OO_2_4.yaml