### PR TITLE
[Fix] Update Basic Information Clusters DataModelRevision to 21 to match spec for 1.6 and update BINFO_2_1 test module to validate

### DIFF
--- a/src/app/SpecificationDefinedRevisions.h
+++ b/src/app/SpecificationDefinedRevisions.h
@@ -41,7 +41,7 @@ inline constexpr uint8_t kInteractionModelRevisionTag               = 0xFF;
  * See section 7.1.1. "Revision History" in the "Data Model Specification"
  * chapter of the core Matter specification.
  */
-inline constexpr uint16_t kDataModelRevision = 19;
+inline constexpr uint16_t kDataModelRevision = 21;
 
 /*
  * A number identifying the specification version against which the

--- a/src/python_testing/support_modules/binfo_attributes_verification.py
+++ b/src/python_testing/support_modules/binfo_attributes_verification.py
@@ -124,7 +124,8 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
                                      f"DataModelRevision should be {expected_data_model_revision} for SpecificationVersion 0x{specification_version:08X}")
             else:
                 # Pre-1.3 devices do not expose SpecificationVersion; DataModelRevision is 1, 16, or 17.
-                asserts.assert_in(ret1, (1, 16, 17), "DataModelRevision should be 1, 16, or 17 for devices without SpecificationVersion")
+                asserts.assert_in(ret1, (1, 16, 17),
+                                  "DataModelRevision should be 1, 16, or 17 for devices without SpecificationVersion")
         elif not hasattr(cluster.Attributes, 'DataModelRevision'):
             self.mark_current_step_skipped()
         exit()

--- a/src/python_testing/support_modules/binfo_attributes_verification.py
+++ b/src/python_testing/support_modules/binfo_attributes_verification.py
@@ -25,15 +25,37 @@ from matter.clusters.ClusterObjects import Cluster
 from matter.testing.conformance import ConformanceException
 from matter.testing.decorators import _has_attribute
 from matter.testing.matter_testing import MatterBaseTest, TestStep
-from matter.testing.spec_parsing import dm_from_spec_version
+from matter.testing.spec_parsing import PrebuiltDataModelDirectory, dm_from_spec_version
+
+# Expected Basic Information DataModelRevision for each Matter specification version.
+# the DataModelRevision value maps to Matter versions as follows:
+#   1 or 16 -> Matter 1.0 / 1.1
+#   17      -> Matter 1.2 / 1.3
+#   18      -> Matter 1.4 / 1.4.1
+#   19      -> Matter 1.4.2 / 1.5
+#   20      -> Matter 1.5.1
+#   21      -> Matter 1.6 / 1.6.1
+# SpecificationVersion (added in Matter 1.3) is used to select the expected value.
+_DATA_MODEL_REVISION_BY_SPEC = {
+    PrebuiltDataModelDirectory.k1_3: 17,    # Matter 1.3 (Technically also 1.2, but it has no SpecificationVersion attribute)
+    PrebuiltDataModelDirectory.k1_4: 18,    # Matter 1.4
+    PrebuiltDataModelDirectory.k1_4_1: 18,  # Matter 1.4.1
+    PrebuiltDataModelDirectory.k1_4_2: 19,  # Matter 1.4.2
+    PrebuiltDataModelDirectory.k1_5: 19,    # Matter 1.5
+    PrebuiltDataModelDirectory.k1_5_1: 20,  # Matter 1.5.1
+    PrebuiltDataModelDirectory.k1_6: 21,    # Matter 1.6
+    PrebuiltDataModelDirectory.k1_6_1: 21,  # Matter 1.6.1
+}
 
 
 class BasicInformationAttributesVerificationBase(MatterBaseTest):
     def steps(self) -> list[TestStep]:
         return [
             TestStep(0, "DUT commissioned if not already done", is_commissioning=True),
-            TestStep(1, "TH reads DataModelRevision from the DUT.",
-                     "Verify that the value is DataModelRevision of current matter version 1.6 which is value 21"),
+            TestStep(1, "TH reads DataModelRevision (and, when supported, SpecificationVersion) from the DUT.",
+                     "Verify that DataModelRevision matches the value expected for the DUT's Matter specification version "
+                     "(17 for 1.2/1.3, 18 for 1.4/1.4.1, 19 for 1.4.2/1.5, 20 for 1.5.1, 21 for 1.6/1.6.1). "
+                     "If SpecificationVersion is not supported (pre-1.3 devices), verify the value is 1, 16, or 17."),
             TestStep(2, "TH reads VendorName from the DUT.", "Verify that the VendorName returns a string with max 32 bytes"),
             TestStep(3, "TH reads VendorID from the DUT.", "Verify value is in the range of 0x0001 to 0xFFF4"),
             TestStep(4, "TH reads ProductName from the DUT.", "Verify it is a string with max length of 32 bytes."),
@@ -91,9 +113,21 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
         self.step(1)
         if hasattr(cluster.Attributes, 'DataModelRevision') and await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.DataModelRevision):
             ret1 = await self.read_single_attribute_check_success(cluster=cluster, attribute=cluster.Attributes.DataModelRevision)
-            asserts.assert_equal(ret1, 21, "DataModelRevision should be 21")
+            if hasattr(cluster.Attributes, 'SpecificationVersion') and await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.SpecificationVersion):
+                specification_version = await self.read_single_attribute_check_success(cluster=cluster, attribute=cluster.Attributes.SpecificationVersion)
+                try:
+                    data_model = dm_from_spec_version(specification_version)
+                except ConformanceException:
+                    asserts.fail(f'Unknown SpecificationVersion 0x{specification_version:08X}')
+                expected_data_model_revision = _DATA_MODEL_REVISION_BY_SPEC[data_model]
+                asserts.assert_equal(ret1, expected_data_model_revision,
+                                     f"DataModelRevision should be {expected_data_model_revision} for SpecificationVersion 0x{specification_version:08X}")
+            else:
+                # Pre-1.3 devices do not expose SpecificationVersion; DataModelRevision is 1, 16, or 17.
+                asserts.assert_in(ret1, (1, 16, 17), "DataModelRevision should be 1, 16, or 17 for devices without SpecificationVersion")
         elif not hasattr(cluster.Attributes, 'DataModelRevision'):
             self.mark_current_step_skipped()
+        exit()
 
         # Step 2: VendorName
         self.step(2)

--- a/src/python_testing/support_modules/binfo_attributes_verification.py
+++ b/src/python_testing/support_modules/binfo_attributes_verification.py
@@ -33,7 +33,7 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
         return [
             TestStep(0, "DUT commissioned if not already done", is_commissioning=True),
             TestStep(1, "TH reads DataModelRevision from the DUT.",
-                     "Verify that the value is DataModelRevision of current matter version 1.5 which is value 19"),
+                     "Verify that the value is DataModelRevision of current matter version 1.6 which is value 21"),
             TestStep(2, "TH reads VendorName from the DUT.", "Verify that the VendorName returns a string with max 32 bytes"),
             TestStep(3, "TH reads VendorID from the DUT.", "Verify value is in the range of 0x0001 to 0xFFF4"),
             TestStep(4, "TH reads ProductName from the DUT.", "Verify it is a string with max length of 32 bytes."),
@@ -87,10 +87,11 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
         self.endpoint = self.get_endpoint()
         self.step(0)  # commissioning already done
 
+        # Step 1: DataModelRevision
         self.step(1)
         if hasattr(cluster.Attributes, 'DataModelRevision') and await self.attribute_guard(endpoint=self.endpoint, attribute=cluster.Attributes.DataModelRevision):
             ret1 = await self.read_single_attribute_check_success(cluster=cluster, attribute=cluster.Attributes.DataModelRevision)
-            asserts.assert_equal(ret1, 19, "DataModelRevision should be 19")
+            asserts.assert_equal(ret1, 21, "DataModelRevision should be 21")
         elif not hasattr(cluster.Attributes, 'DataModelRevision'):
             self.mark_current_step_skipped()
 

--- a/src/python_testing/support_modules/binfo_attributes_verification.py
+++ b/src/python_testing/support_modules/binfo_attributes_verification.py
@@ -128,7 +128,6 @@ class BasicInformationAttributesVerificationBase(MatterBaseTest):
                                   "DataModelRevision should be 1, 16, or 17 for devices without SpecificationVersion")
         elif not hasattr(cluster.Attributes, 'DataModelRevision'):
             self.mark_current_step_skipped()
-        exit()
 
         # Step 2: VendorName
         self.step(2)


### PR DESCRIPTION
### Summary

- Updates value for kDataModelRevision in SpecificationDefinedRevisions.h to 21 to align with spec for Matter Version 1.6 as noticed here: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Data-Model.adoc#ref_DataModelRevisionHistory 
- Updates binfo_attributes_verification test step 1 for BINFO_2_1 test module to validate change made.

### Related issues

Fixes: #72863  
Test Plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6244

### Testing

```
scripts/tests/run_python_test.py --factory-reset --app out/linux-x64-all-clusters/chip-all-clusters-app --app-args "--discriminator 1234 --passcode 20202021 --KVS kvs1" --script-args "--storage-path admin_storage.json --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 0 --commissioning-method on-network" --script src/python_testing/TC_BINFO_2_1.py
```