### PR TITLE
Arrange build dependencies for TimeFormatLocalization cluster

### DIFF
--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -71,6 +71,7 @@ source_set("clusters") {
     "thread-border-router-management-server",
     "thread-network-diagnostics-server",
     "thread-network-directory-server",
+    "time-format-localization-server",
     "tls-certificate-management-server",
     "tls-client-management-server",
     "valve-configuration-and-control-server",

--- a/src/app/clusters/time-format-localization-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/time-format-localization-server/app_config_dependent_sources.cmake
@@ -18,11 +18,3 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
 )
-
-# These are the things that BUILD.gn dependencies would pull
-TARGET_SOURCES(
-  ${APP_TARGET}
-  PRIVATE
-    "${CLUSTER_DIR}/TimeFormatLocalizationCluster.cpp"
-    "${CLUSTER_DIR}/TimeFormatLocalizationCluster.h"
-)


### PR DESCRIPTION
### Summary

Move build dependencies to match the latest approach for CodeDriven clusters.

Keeping the .gni and .cmake files consistent.

### Related issues

NA

### Testing

No code change, the CI should validate that the targets still compile.
