### PR TITLE
[dependabot] Group github/codeql-action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
       - "/.github/actions/**"
     schedule:
       interval: "weekly"
+    groups:
+      # github/codeql-action/{init,analyze,upload-sarif} are distinct Dependabot
+      # dependencies, so ungrouped bumps land in separate PRs and diverge the pinned
+      # SHAs, which trips the "CodeQL action pins are consistent" check in lint.yml.
+      # Group them (across both directory scopes) so every ref moves in one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
#### Summary

Dependabot treats `github/codeql-action/init`, `/analyze`, and `/upload-sarif` as three distinct dependencies, so it opens a separate PR per sub-action — and, because the `github-actions` config covers two directory scopes (`/` and `/.github/actions/**`), per scope as well. Each of those PRs bumps only its own pin to the new release SHA and leaves the siblings behind, which diverges the pinned SHAs and trips the "CodeQL action pins are consistent" guard in `lint.yml` (all `github/codeql-action/*` pins must share one SHA to avoid a CLI/config version skew). The fragments are also mutually blocking — none can pass the guard on its own, and collectively they still miss any sub-action Dependabot did not happen to open a PR for.

Contrast with e.g. #72688 (`actions/checkout` 6.0.3 → 7.0.0), which updated ~60 workflow files in a single PR with no group: that works because every occurrence shares one dependency name, and Dependabot bumps all instances of the same dependency name in one PR. The codeql-action pins differ only in sub-path, which Dependabot counts as separate dependencies — hence the fragmentation.

This adds a Dependabot `group` spanning both directory scopes so every `github/codeql-action` ref bumps together in one PR, keeping the pins consistent by construction.

Supersedes the piecemeal bump PRs #72885, #72886, #72890.

#### Testing

After the PR is merged, will retrigger dependabot to make sure it works