### PR TITLE
[NXP] Allow user to overide diagnostic impl

### DIFF
--- a/config/nxp/cmake/Kconfig.matter.nxp
+++ b/config/nxp/cmake/Kconfig.matter.nxp
@@ -267,4 +267,14 @@ config CHIP_DEVICE_GENERATE_ROTATING_DEVICE_UID
 
 endif #CHIP_FACTORY_DATA_BUILD
 
+config CHIP_DIAGNOSTIC_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
+	bool "Custom diagnostic data provider singleton implementation"
+	help
+		Allows to use a custom diagnostic data provider singleton implementation.
+		If enabled, the user must define GetDiagnosticDataProviderImpl() returning
+		a DiagnosticDataProvider reference. The platform default singleton wrapper
+		is not compiled, but DiagnosticDataProviderImpl remains available as a base class.
+		This is useful when an application needs to customize the diagnostic
+		data provider behavior, for example to override GetActiveHardwareFaults().
+
 endif # CHIP

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -57,11 +57,6 @@ inline size_t GetMinimumEverFreeHeapSize()
 namespace chip {
 namespace DeviceLayer {
 
-DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
-{
-    static DiagnosticDataProviderImpl sInstance;
-    return sInstance;
-}
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
@@ -566,10 +561,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 }
 #endif
 
+#ifndef CONFIG_CHIP_DIAGNOSTIC_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
 {
-    return DiagnosticDataProviderImpl::GetDefaultInstance();
+    static DiagnosticDataProviderImpl sInstance;
+    return sInstance;
 }
+#endif /* CONFIG_CHIP_DIAGNOSTIC_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL */
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -57,7 +57,6 @@ inline size_t GetMinimumEverFreeHeapSize()
 namespace chip {
 namespace DeviceLayer {
 
-
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
     size_t freeHeapSize;

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.h
@@ -36,8 +36,6 @@ namespace DeviceLayer {
 class DiagnosticDataProviderImpl : public DiagnosticDataProvider
 {
 public:
-    static DiagnosticDataProviderImpl & GetDefaultInstance();
-
     // ===== Methods that implement the PlatformManager abstract interface.
 
     bool SupportsWatermarks() override { return true; }

--- a/src/platform/nxp/mcxw72/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/mcxw72/PlatformManagerImpl.cpp
@@ -151,7 +151,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDiagnosticDataProvider(&GetDiagnosticDataProviderImpl());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     /* Initialize platform services */

--- a/src/platform/nxp/rt/rt1060/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rt1060/PlatformManagerImpl.cpp
@@ -357,7 +357,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDiagnosticDataProvider(&GetDiagnosticDataProviderImpl());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     /* Initialize LwIP via Wi-Fi layer. */

--- a/src/platform/nxp/rt/rt1170/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rt1170/PlatformManagerImpl.cpp
@@ -299,7 +299,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDiagnosticDataProvider(&GetDiagnosticDataProviderImpl());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     /* Initialize LwIP via Wi-Fi layer. */

--- a/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
@@ -187,7 +187,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDiagnosticDataProvider(&GetDiagnosticDataProviderImpl());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     /* Initialize LwIP via Wi-Fi layer. */


### PR DESCRIPTION
### Summary

Allow the application to override the diagnostic implementation in order add custom feature like for hardware fault (sensors, GUI ...)

### Testing

Build matter NXP thermostat application with enabling the new CONFIG_CHIP_DIAGNOSTIC_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL kconfig and check that the chip-tool command use the application diagnostic implementation to read hardware fault attributes
