### PR TITLE
[TC-SC-3.5] Show manual pairing code in commissioning prompts

### DIFF
--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -178,11 +178,10 @@ class TC_SC_3_5(MatterBaseTest):
         # Instructing TH Server to accept a new Commissioner, which is the DUT
         params = await self.th_client.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.th_server_discriminator, option=1)
-        new_random_passcode = params.setupPinCode
         await asyncio.sleep(1)
         log.info("OpenCommissioningWindow complete")
 
-        return new_random_passcode
+        return params.setupManualCode, params.setupPinCode
 
     async def revoke_and_open_commissioning_window(self):
         ''' Before reopening Commissioning Window, we need to instruct TH_SERVER to revoke any active OpenCommissioningWindows.'''
@@ -260,12 +259,12 @@ class TC_SC_3_5(MatterBaseTest):
 
         else:
             self.step("1a")
-            th_server_passcode = await self.open_commissioning_window()
+            th_server_manual_code, th_server_passcode = await self.open_commissioning_window()
 
             self.step("1b")
             prompt_msg = (
-                "\nPlease commission the TH_SERVER app from DUT:\n"
-                f"  pairing onnetwork 1 {th_server_passcode}\n"
+                "\nPlease commission the TH_SERVER app from DUT using the Manual Pairing Code below:\n"
+                f"  Manual Pairing Code: {th_server_manual_code}  (chip-tool: pairing onnetwork 1 {th_server_passcode})\n"
                 "Input 'Y' if commissioner DUT commissions TH server app successfully \n"
                 "Input 'N' if commissioner DUT fails commissioning \n "
             )
@@ -318,15 +317,15 @@ class TC_SC_3_5(MatterBaseTest):
 
         # ------------------------------------------- Inject Fault into Sigma2 TBEData2Encrypted---------------------------------------------
         self.step("2a")
-        th_server_passcode = await self.open_commissioning_window()
+        th_server_manual_code, th_server_passcode = await self.open_commissioning_window()
 
         self.step("2b")
         await self.send_fault_injection_command(CHIPFaultId.CASECorruptTBEData2Encrypted)
 
         self.step("2c")
         prompt_msg = (
-            "\nPlease commission the TH_SERVER app from DUT:\n"
-            f"  pairing onnetwork 1 {th_server_passcode}\n"
+            "\nPlease commission the TH_SERVER app from DUT using the Manual Pairing Code below:\n"
+            f"  Manual Pairing Code: {th_server_manual_code}  (chip-tool: pairing onnetwork 1 {th_server_passcode})\n"
             "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
             "Input 'N' if commissioner DUT commissions successfully \n "
             "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
@@ -351,16 +350,16 @@ class TC_SC_3_5(MatterBaseTest):
         # ------------------------------------------- Inject Fault into Sigma2 responderNOC---------------------------------------------
 
         self.step("3a")
-        th_server_passcode = await self.revoke_and_open_commissioning_window()
+        th_server_manual_code, th_server_passcode = await self.revoke_and_open_commissioning_window()
 
         self.step("3b")
         await self.send_fault_injection_command(CHIPFaultId.CASECorruptSigma2NOC)
 
         self.step("3c")
         prompt_msg = (
-            "\nPlease commission the TH_SERVER app from DUT:\n"
+            "\nPlease commission the TH_SERVER app from DUT using the Manual Pairing Code below:\n"
             "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
-            f"  pairing onnetwork 2 {th_server_passcode}\n"
+            f"  Manual Pairing Code: {th_server_manual_code}  (chip-tool: pairing onnetwork 2 {th_server_passcode})\n"
             "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
             "Input 'N' if commissioner DUT commissions successfully \n "
             "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
@@ -391,16 +390,16 @@ class TC_SC_3_5(MatterBaseTest):
             self.skip_step("4c")
         else:
             self.step("4a")
-            th_server_passcode = await self.revoke_and_open_commissioning_window()
+            th_server_manual_code, th_server_passcode = await self.revoke_and_open_commissioning_window()
 
             self.step("4b")
             await self.send_fault_injection_command(CHIPFaultId.CASECorruptSigma2ICAC)
 
             self.step("4c")
             prompt_msg = (
-                "\nPlease commission the TH_SERVER app from DUT:\n"
+                "\nPlease commission the TH_SERVER app from DUT using the Manual Pairing Code below:\n"
                 "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
-                f"  pairing onnetwork 3 {th_server_passcode}\n"
+                f"  Manual Pairing Code: {th_server_manual_code}  (chip-tool: pairing onnetwork 3 {th_server_passcode})\n"
                 "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
                 "Input 'N' if commissioner DUT commissions successfully \n "
                 "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
@@ -425,16 +424,16 @@ class TC_SC_3_5(MatterBaseTest):
         # ------------------------------------------- Inject Fault into Sigma2 Signature---------------------------------------------
 
         self.step("5a")
-        th_server_passcode = await self.revoke_and_open_commissioning_window()
+        th_server_manual_code, th_server_passcode = await self.revoke_and_open_commissioning_window()
 
         self.step("5b")
         await self.send_fault_injection_command(CHIPFaultId.CASECorruptSigma2Signature)
 
         self.step("5c")
         prompt_msg = (
-            "\nPlease commission the TH_SERVER app from DUT:\n"
+            "\nPlease commission the TH_SERVER app from DUT using the Manual Pairing Code below:\n"
             "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
-            f"  pairing onnetwork 4 {th_server_passcode}\n"
+            f"  Manual Pairing Code: {th_server_manual_code}  (chip-tool: pairing onnetwork 4 {th_server_passcode})\n"
             "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
             "Input 'N' if commissioner DUT commissions successfully \n "
             "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"


### PR DESCRIPTION
### Summary

The user prompts in `TC_SC_3_5` previously printed only the chip-tool `pairing onnetwork <node> <passcode>` line containing the raw setup PIN. Real commissioners pair using a manual pairing code, not a raw PIN, so a tester driving an actual DUT commissioner (rather than chip-tool) cannot act on the prompt. This was reported during Test Harness runs of TC-SC-3.5.

This change makes `open_commissioning_window()` return the manual pairing code (`params.setupManualCode`) alongside the passcode, and every commissioning prompt now leads with the Manual Pairing Code. The existing `pairing onnetwork` line is kept as a parenthetical hint so SDK testers using chip-tool are unaffected.

Only the prompt-facing text and the value threaded into it change; the test steps, assertions, and CI (`PICS_SDK_CI_ONLY`) path are unchanged.

### Related issues

Reported in project-chip/certification-tool#973

### Testing

Ran the test locally in CI mode against a freshly built all-clusters app with fault injection (`linux-x64-all-clusters-nlfaultinject-clang`):

```
python3 src/python_testing/TC_SC_3_5.py \
  --storage-path admin_storage.json \
  --string-arg th_server_app_path:out/linux-x64-all-clusters-nlfaultinject-clang/chip-all-clusters-app-nlfaultinject \
  --PICS src/app/tests/suites/certification/ci-pics-values
```

Result: `Error 0, Executed 1, Failed 0, Passed 1, Requested 1, Skipped 0`. This exercises `open_commissioning_window()` returning `setupManualCode` and the prompt strings being built with it across all steps. The manual-code display in the interactive prompts was additionally confirmed by a Test Harness run in project-chip/certification-tool#973.