### PR TITLE
[Telink] Fix commissioning with tl3218x_retention board.

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -249,10 +249,10 @@ jobs:
               # Run test for master and all PRs
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-factory-data' build"
+                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    telink tl3218x_retention light-switch-app-ota-factory-data \
-                    out/telink-tl3218x_retention-light-switch-ota-factory-data/zephyr/zephyr.elf \
+                    telink tl3218x_retention light-switch-app-ota \
+                    out/telink-tl3218x_retention-light-switch-ota/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
 
             - name: clean out build output (keep tools)
@@ -568,7 +568,7 @@ jobs:
               # Run test for master and all PRs
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-factory-data' build"
+                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota' build"
 
             - name: clean out build output (keep tools)
               run: rm -rf ./out/telink*

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -523,6 +523,7 @@ config MBEDTLS_PSA_CRYPTO_C
 
 config TELINK_TLX_SHA_HW_SLOTS
     int
+    default 2 if BOARD_TL3218X_RETENTION
     default 8 if SOC_RISCV_TELINK_TLX
 
 endif # !ZEPHYR_VERSION_3_3


### PR DESCRIPTION
### Summary

HW SHA increases RAM usage which is critical for some SOCs with limited RAM amount.
Since additional RAM amount is per CONFIG_TELINK_TLX_SHA_HW_SLOTS reduce these slots.
Changes are relative only to Telink platform: TL3218X retention config.

### Related issues

N/A

### Testing

Manually proceeding commissioning with chip-tool. Used SOC TL3218X in retention configuration under _examples/light-switch-app/telink_
