### PR TITLE
Recover Linux Avahi lookups after client failure

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -869,10 +869,10 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
         MdnsAvahi * instance = context->mInstance;
         instance->mAllocatedBrowses.remove(context);
 
-        DnssdBrowseCallback callback   = context->mCallback;
-        void * callbackContext         = context->mContext;
-        uint64_t clientGeneration      = instance->mClientGeneration;
-        uint64_t shutdownGeneration    = instance->mShutdownGeneration;
+        DnssdBrowseCallback callback = context->mCallback;
+        void * callbackContext       = context->mContext;
+        uint64_t clientGeneration    = instance->mClientGeneration;
+        uint64_t shutdownGeneration  = instance->mShutdownGeneration;
         std::vector<DnssdService> services;
         services.swap(context->mServices);
 

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -760,7 +760,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     AvahiServiceBrowser * browser;
     BrowseContext * browseContext = chip::Platform::New<BrowseContext>();
     VerifyOrReturnError(browseContext != nullptr, CHIP_ERROR_NO_MEMORY);
-    AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
+    AvahiIfIndex avahiInterface = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
 
     browseContext->mInstance    = this;
     browseContext->mContext     = context;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -347,6 +347,9 @@ exit:
 
 void MdnsAvahi::Shutdown()
 {
+    ++mClientGeneration;
+    ++mShutdownGeneration;
+
     TEMPORARY_RETURN_IGNORED StopPublish();
 
     // Release child objects before their client. Avahi would otherwise destroy the
@@ -389,6 +392,7 @@ CHIP_ERROR MdnsAvahi::RebuildClient()
     VerifyOrReturnError(mInitCallback != nullptr && mErrorCallback != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogError(DeviceLayer, "Avahi client failed; rebuilding it and cancelling outstanding lookups");
+    ++mClientGeneration;
 
     // Detach the contexts first because their callbacks may start new DNS-SD operations.
     std::list<ResolveContext *> staleResolves;
@@ -860,15 +864,48 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
     // If we were already asked to stop, no need to send a callback - no one is listening.
     if (!context->mStopped.load())
     {
-        // The callback may start a lookup that rebuilds the Avahi client and deletes
-        // this context. Move everything needed by the callback to local storage first.
-        DnssdBrowseCallback callback = context->mCallback;
-        void * callbackContext       = context->mContext;
+        // The callback may rebuild or shut down the Avahi client. Detach this context
+        // so those operations cannot recursively notify or delete it.
+        MdnsAvahi * instance = context->mInstance;
+        instance->mAllocatedBrowses.remove(context);
+
+        DnssdBrowseCallback callback   = context->mCallback;
+        void * callbackContext         = context->mContext;
+        uint64_t clientGeneration      = instance->mClientGeneration;
+        uint64_t shutdownGeneration    = instance->mShutdownGeneration;
         std::vector<DnssdService> services;
         services.swap(context->mServices);
 
         // since this is continuous browse, finalBrowse will always be false.
         callback(callbackContext, services.data(), services.size(), false, CHIP_NO_ERROR);
+
+        if (instance->mShutdownGeneration != shutdownGeneration)
+        {
+            // Client destruction released the browser while this context was detached.
+            context->mBrowser = nullptr;
+            chip::Platform::Delete(context);
+        }
+        else if (instance->mClientGeneration != clientGeneration)
+        {
+            // A rebuild released the old browser. Complete this detached lookup
+            // sequentially rather than recursively from RebuildClient().
+            context->mBrowser = nullptr;
+            if (!context->mStopped.load())
+            {
+                callback(callbackContext, nullptr, 0, true, CHIP_ERROR_FORCED_RESET);
+            }
+            chip::Platform::Delete(context);
+        }
+        else if (context->mStopped.load())
+        {
+            avahi_service_browser_free(browser);
+            context->mBrowser = nullptr;
+            chip::Platform::Delete(context);
+        }
+        else
+        {
+            instance->mAllocatedBrowses.push_back(context);
+        }
     }
     else
     {

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -355,6 +355,68 @@ void MdnsAvahi::Shutdown()
     }
 }
 
+bool MdnsAvahi::ClientHasFailed() const
+{
+    return mClient == nullptr || avahi_client_get_state(mClient) == AVAHI_CLIENT_FAILURE;
+}
+
+CHIP_ERROR MdnsAvahi::RebuildClient()
+{
+    ChipLogError(DeviceLayer, "Avahi client is in a failed state; rebuilding it and cancelling stale operations");
+
+    // Detach contexts before freeing the Avahi client. Freeing the client also frees
+    // its browsers/resolvers, but the CHIP contexts still need to notify their callers.
+    std::list<ResolveContext *> staleResolves;
+    staleResolves.swap(mAllocatedResolves);
+    std::list<BrowseContext *> staleBrowses;
+    staleBrowses.swap(mAllocatedBrowses);
+
+    // ResolveContext owns mResolver in its destructor. Free and null the resolver now
+    // so the later Avahi client teardown cannot leave the context with a stale pointer.
+    for (auto * resolve : staleResolves)
+    {
+        if (resolve->mResolver != nullptr)
+        {
+            avahi_service_resolver_free(resolve->mResolver);
+            resolve->mResolver = nullptr;
+        }
+    }
+
+    TEMPORARY_RETURN_IGNORED StopPublish();
+    if (mClient != nullptr)
+    {
+        avahi_client_free(mClient);
+        mClient = nullptr;
+    }
+
+    int avahiError   = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    mClient          = avahi_client_new(mPoller.GetAvahiPoll(), AVAHI_CLIENT_NO_FAIL, HandleClientState, this, &avahiError);
+    if (mClient == nullptr)
+    {
+        ChipLogError(DeviceLayer, "Failed to rebuild Avahi client: %s", avahi_strerror(avahiError));
+        error = CHIP_ERROR_OPEN_FAILED;
+    }
+
+    // Callbacks may start new DNS-SD operations. Invoke them only after the new client
+    // has been created or the failed rebuild has left mClient in a consistent state.
+    for (auto * resolve : staleResolves)
+    {
+        resolve->mCallback(resolve->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_FORCED_RESET);
+        chip::Platform::Delete(resolve);
+    }
+    for (auto * browse : staleBrowses)
+    {
+        if (!browse->mStopped.load())
+        {
+            browse->mCallback(browse->mContext, nullptr, 0, true, CHIP_ERROR_FORCED_RESET);
+        }
+        chip::Platform::Delete(browse);
+    }
+
+    return error;
+}
+
 CHIP_ERROR MdnsAvahi::SetHostname(const char * hostname)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -658,16 +720,42 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     browseContext->mReceivedAllCached = false;
     browseContext->mStopped.store(false);
 
+    if (mClient == nullptr)
+    {
+        CHIP_ERROR error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
+        {
+            chip::Platform::Delete(browseContext);
+            *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
+            return error;
+        }
+    }
+
     browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
                                         static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
+    if (browser == nullptr && ClientHasFailed())
+    {
+        CHIP_ERROR error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
+        {
+            chip::Platform::Delete(browseContext);
+            *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
+            return error;
+        }
+        browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
+                                            static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
+    }
     // Otherwise the browser will be freed in the callback
     if (browser == nullptr)
     {
+        ChipLogError(DeviceLayer, "Avahi browse setup failed: %s",
+                     mClient ? avahi_strerror(avahi_client_errno(mClient)) : "no mClient");
         chip::Platform::Delete(browseContext);
         *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
     }
     else
     {
+        mAllocatedBrowses.push_back(browseContext);
         *browseIdentifier = reinterpret_cast<intptr_t>(browseContext);
     }
 
@@ -743,6 +831,7 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
     else
     {
         // browse is stopped, so free browse handle and context
+        context->mInstance->mAllocatedBrowses.remove(context);
         avahi_service_browser_free(browser);
         chip::Platform::Delete(context);
     }
@@ -757,8 +846,9 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
     switch (event)
     {
     case AVAHI_BROWSER_FAILURE:
-        context->mCallback(context->mContext, nullptr, 0, true, CHIP_ERROR_INTERNAL);
+        context->mInstance->mAllocatedBrowses.remove(context);
         avahi_service_browser_free(browser);
+        context->mCallback(context->mContext, nullptr, 0, true, CHIP_ERROR_INTERNAL);
         chip::Platform::Delete(context);
         break;
     case AVAHI_BROWSER_NEW:
@@ -766,6 +856,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         if (context->mStopped.load())
         {
             // browse is stopped, so free browse handle and context
+            context->mInstance->mAllocatedBrowses.remove(context);
             avahi_service_browser_free(browser);
             chip::Platform::Delete(context);
             break;
@@ -929,13 +1020,42 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     resolveContext->mAddressType = ToAvahiProtocol(addressType);
     resolveContext->mFullType    = GetFullType(type, protocol);
 
+    if (mClient == nullptr)
+    {
+        mAllocatedResolves.remove(resolveContext);
+        error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
+        {
+            chip::Platform::Delete(resolveContext);
+            return error;
+        }
+        mAllocatedResolves.push_back(resolveContext);
+    }
+
     resolveContext->mResolver =
         avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
                                    nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
                                    reinterpret_cast<void *>(resolveContext->mNumber));
+    if (resolveContext->mResolver == nullptr && ClientHasFailed())
+    {
+        mAllocatedResolves.remove(resolveContext);
+        error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
+        {
+            chip::Platform::Delete(resolveContext);
+            return error;
+        }
+        mAllocatedResolves.push_back(resolveContext);
+        resolveContext->mResolver =
+            avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
+                                       nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
+                                       reinterpret_cast<void *>(resolveContext->mNumber));
+    }
     // Otherwise the resolver will be freed in the callback
     if (resolveContext->mResolver == nullptr)
     {
+        ChipLogError(DeviceLayer, "Avahi resolve setup failed: %s",
+                     mClient ? avahi_strerror(avahi_client_errno(mClient)) : "no mClient");
         error = CHIP_ERROR_INTERNAL;
         FreeResolveContext(resolveContext->mNumber);
     }

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -745,6 +745,14 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
                              chip::Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context,
                              intptr_t * browseIdentifier)
 {
+    *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
+
+    // Recover a failed client before allocating state so a rebuild failure needs no cleanup.
+    if (ClientHasFailed())
+    {
+        ReturnErrorOnFailure(RebuildClient());
+    }
+
     AvahiServiceBrowser * browser;
     BrowseContext * browseContext = chip::Platform::New<BrowseContext>();
     AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
@@ -761,17 +769,6 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     browseContext->mProtocol          = GetFullType(type, protocol);
     browseContext->mReceivedAllCached = false;
     browseContext->mStopped.store(false);
-
-    if (ClientHasFailed())
-    {
-        CHIP_ERROR error = RebuildClient();
-        if (error != CHIP_NO_ERROR)
-        {
-            chip::Platform::Delete(browseContext);
-            *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
-            return error;
-        }
-    }
 
     browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
                                         static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
@@ -1052,6 +1049,23 @@ void MdnsAvahi::FreeResolveContext(size_t handle)
     }
 }
 
+void MdnsAvahi::FinalizeResolve(ResolveContext * context, DnssdService * result, const Span<Inet::IPAddress> & addresses,
+                                CHIP_ERROR error)
+{
+    // A resolve is terminal, so detach the context and release its resolver before invoking the
+    // callback. The callback may start a new lookup that re-enters RebuildClient() or Shutdown();
+    // detaching keeps those from freeing this resolver a second time or invoking the callback again.
+    mAllocatedResolves.remove(context);
+    if (context->mResolver != nullptr)
+    {
+        avahi_service_resolver_free(context->mResolver);
+        context->mResolver = nullptr;
+    }
+
+    context->mCallback(context->mContext, result, addresses, error);
+    chip::Platform::Delete(context);
+}
+
 void MdnsAvahi::StopResolve(const char * name)
 {
     // Cancel and delete any pending resolves for this instance name.
@@ -1070,8 +1084,7 @@ void MdnsAvahi::StopResolve(const char * name)
 
     for (auto * context : contexts)
     {
-        context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
-        chip::Platform::Delete(context);
+        FinalizeResolve(context, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
     }
 }
 
@@ -1166,14 +1179,13 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
             if (context->mResolver == nullptr)
             {
                 ChipLogError(DeviceLayer, "Avahi resolve failed on retry");
-                context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
-                sInstance.FreeResolveContext(handle);
+                sInstance.FinalizeResolve(context, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
             }
             return;
         }
         ChipLogError(DeviceLayer, "Avahi resolve failed");
-        context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
-        break;
+        sInstance.FinalizeResolve(context, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
+        return;
     case AVAHI_RESOLVER_FOUND:
         DnssdService result = {};
 
@@ -1250,16 +1262,14 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
 
         if (result_err == CHIP_NO_ERROR)
         {
-            context->mCallback(context->mContext, &result, Span<Inet::IPAddress>(&ipAddress, 1), CHIP_NO_ERROR);
+            sInstance.FinalizeResolve(context, &result, Span<Inet::IPAddress>(&ipAddress, 1), CHIP_NO_ERROR);
         }
         else
         {
-            context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), result_err);
+            sInstance.FinalizeResolve(context, nullptr, Span<Inet::IPAddress>(), result_err);
         }
-        break;
+        return;
     }
-
-    sInstance.FreeResolveContext(handle);
 }
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -426,7 +426,8 @@ CHIP_ERROR MdnsAvahi::RebuildClient()
     mClient          = avahi_client_new(mPoller.GetAvahiPoll(), AVAHI_CLIENT_NO_FAIL, HandleClientState, this, &avahiError);
     if (mClient == nullptr || avahiError != 0)
     {
-        ChipLogError(DeviceLayer, "Failed to rebuild Avahi client: %s", avahi_strerror(avahiError));
+        ChipLogError(DeviceLayer, "Failed to rebuild Avahi client: %d: %s", avahiError,
+                     avahiError == AVAHI_OK ? "no error reported" : avahi_strerror(avahiError));
         if (mClient != nullptr)
         {
             avahi_client_free(mClient);
@@ -757,7 +758,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     browseContext->mReceivedAllCached = false;
     browseContext->mStopped.store(false);
 
-    if (mClient == nullptr)
+    if (ClientHasFailed())
     {
         CHIP_ERROR error = RebuildClient();
         if (error != CHIP_NO_ERROR)
@@ -859,12 +860,15 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
     // If we were already asked to stop, no need to send a callback - no one is listening.
     if (!context->mStopped.load())
     {
-        // since this is continuous browse, finalBrowse will always be false.
-        context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), false, CHIP_NO_ERROR);
+        // The callback may start a lookup that rebuilds the Avahi client and deletes
+        // this context. Move everything needed by the callback to local storage first.
+        DnssdBrowseCallback callback = context->mCallback;
+        void * callbackContext       = context->mContext;
+        std::vector<DnssdService> services;
+        services.swap(context->mServices);
 
-        // Clearing records/services already passed to application through delegate. Keeping it may cause
-        // duplicates in next query / retry attempt as currently found will also come again from cache.
-        context->mServices.clear();
+        // since this is continuous browse, finalBrowse will always be false.
+        callback(callbackContext, services.data(), services.size(), false, CHIP_NO_ERROR);
     }
     else
     {
@@ -1038,6 +1042,11 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
                               Inet::IPAddressType transportType, Inet::InterfaceId interface, DnssdResolveCallback callback,
                               void * context)
 {
+    if (ClientHasFailed())
+    {
+        ReturnErrorOnFailure(RebuildClient());
+    }
+
     AvahiIfIndex avahiInterface     = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
     ResolveContext * resolveContext = AllocateResolveContext();
     if (resolveContext == nullptr)
@@ -1060,18 +1069,6 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     resolveContext->mTransport   = ToAvahiProtocol(transportType);
     resolveContext->mAddressType = ToAvahiProtocol(addressType);
     resolveContext->mFullType    = GetFullType(type, protocol);
-
-    if (mClient == nullptr)
-    {
-        mAllocatedResolves.remove(resolveContext);
-        error = RebuildClient();
-        if (error != CHIP_NO_ERROR)
-        {
-            chip::Platform::Delete(resolveContext);
-            return error;
-        }
-        mAllocatedResolves.push_back(resolveContext);
-    }
 
     resolveContext->mResolver =
         avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -360,29 +360,12 @@ bool MdnsAvahi::ClientHasFailed() const
     return mClient == nullptr || avahi_client_get_state(mClient) == AVAHI_CLIENT_FAILURE;
 }
 
-CHIP_ERROR MdnsAvahi::RebuildClient()
+CHIP_ERROR MdnsAvahi::ResetClientForLookup()
 {
-    ChipLogError(DeviceLayer, "Avahi client is in a failed state; rebuilding it and cancelling stale operations");
+    VerifyOrReturnError(mPublishedGroups.empty(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mAllocatedResolves.empty() && mBrowseCount == 0, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mInitCallback != nullptr && mErrorCallback != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    // Detach contexts before freeing the Avahi client. Freeing the client also frees
-    // its browsers/resolvers, but the CHIP contexts still need to notify their callers.
-    std::list<ResolveContext *> staleResolves;
-    staleResolves.swap(mAllocatedResolves);
-    std::list<BrowseContext *> staleBrowses;
-    staleBrowses.swap(mAllocatedBrowses);
-
-    // ResolveContext owns mResolver in its destructor. Free and null the resolver now
-    // so the later Avahi client teardown cannot leave the context with a stale pointer.
-    for (auto * resolve : staleResolves)
-    {
-        if (resolve->mResolver != nullptr)
-        {
-            avahi_service_resolver_free(resolve->mResolver);
-            resolve->mResolver = nullptr;
-        }
-    }
-
-    TEMPORARY_RETURN_IGNORED StopPublish();
     if (mClient != nullptr)
     {
         avahi_client_free(mClient);
@@ -392,26 +375,15 @@ CHIP_ERROR MdnsAvahi::RebuildClient()
     int avahiError   = 0;
     CHIP_ERROR error = CHIP_NO_ERROR;
     mClient          = avahi_client_new(mPoller.GetAvahiPoll(), AVAHI_CLIENT_NO_FAIL, HandleClientState, this, &avahiError);
-    if (mClient == nullptr)
+    if (mClient == nullptr || avahiError != 0)
     {
-        ChipLogError(DeviceLayer, "Failed to rebuild Avahi client: %s", avahi_strerror(avahiError));
-        error = CHIP_ERROR_OPEN_FAILED;
-    }
-
-    // Callbacks may start new DNS-SD operations. Invoke them only after the new client
-    // has been created or the failed rebuild has left mClient in a consistent state.
-    for (auto * resolve : staleResolves)
-    {
-        resolve->mCallback(resolve->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_FORCED_RESET);
-        chip::Platform::Delete(resolve);
-    }
-    for (auto * browse : staleBrowses)
-    {
-        if (!browse->mStopped.load())
+        ChipLogError(DeviceLayer, "Failed to reset Avahi client: %s", avahi_strerror(avahiError));
+        if (mClient != nullptr)
         {
-            browse->mCallback(browse->mContext, nullptr, 0, true, CHIP_ERROR_FORCED_RESET);
+            avahi_client_free(mClient);
+            mClient = nullptr;
         }
-        chip::Platform::Delete(browse);
+        error = CHIP_ERROR_OPEN_FAILED;
     }
 
     return error;
@@ -722,7 +694,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
 
     if (mClient == nullptr)
     {
-        CHIP_ERROR error = RebuildClient();
+        CHIP_ERROR error = ResetClientForLookup();
         if (error != CHIP_NO_ERROR)
         {
             chip::Platform::Delete(browseContext);
@@ -735,15 +707,11 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
                                         static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
     if (browser == nullptr && ClientHasFailed())
     {
-        CHIP_ERROR error = RebuildClient();
-        if (error != CHIP_NO_ERROR)
+        if (ResetClientForLookup() == CHIP_NO_ERROR)
         {
-            chip::Platform::Delete(browseContext);
-            *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
-            return error;
+            browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(),
+                                                nullptr, static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
         }
-        browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
-                                            static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
     }
     // Otherwise the browser will be freed in the callback
     if (browser == nullptr)
@@ -755,7 +723,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     }
     else
     {
-        mAllocatedBrowses.push_back(browseContext);
+        mBrowseCount++;
         *browseIdentifier = reinterpret_cast<intptr_t>(browseContext);
     }
 
@@ -831,7 +799,7 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
     else
     {
         // browse is stopped, so free browse handle and context
-        context->mInstance->mAllocatedBrowses.remove(context);
+        context->mInstance->mBrowseCount--;
         avahi_service_browser_free(browser);
         chip::Platform::Delete(context);
     }
@@ -846,7 +814,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
     switch (event)
     {
     case AVAHI_BROWSER_FAILURE:
-        context->mInstance->mAllocatedBrowses.remove(context);
+        context->mInstance->mBrowseCount--;
         avahi_service_browser_free(browser);
         context->mCallback(context->mContext, nullptr, 0, true, CHIP_ERROR_INTERNAL);
         chip::Platform::Delete(context);
@@ -856,7 +824,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         if (context->mStopped.load())
         {
             // browse is stopped, so free browse handle and context
-            context->mInstance->mAllocatedBrowses.remove(context);
+            context->mInstance->mBrowseCount--;
             avahi_service_browser_free(browser);
             chip::Platform::Delete(context);
             break;
@@ -1023,7 +991,7 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     if (mClient == nullptr)
     {
         mAllocatedResolves.remove(resolveContext);
-        error = RebuildClient();
+        error = ResetClientForLookup();
         if (error != CHIP_NO_ERROR)
         {
             chip::Platform::Delete(resolveContext);
@@ -1039,17 +1007,15 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     if (resolveContext->mResolver == nullptr && ClientHasFailed())
     {
         mAllocatedResolves.remove(resolveContext);
-        error = RebuildClient();
-        if (error != CHIP_NO_ERROR)
-        {
-            chip::Platform::Delete(resolveContext);
-            return error;
-        }
+        error = ResetClientForLookup();
         mAllocatedResolves.push_back(resolveContext);
-        resolveContext->mResolver =
-            avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
-                                       nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
-                                       reinterpret_cast<void *>(resolveContext->mNumber));
+        if (error == CHIP_NO_ERROR)
+        {
+            resolveContext->mResolver = avahi_service_resolver_new(
+                mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(), nullptr,
+                resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
+                reinterpret_cast<void *>(resolveContext->mNumber));
+        }
     }
     // Otherwise the resolver will be freed in the callback
     if (resolveContext->mResolver == nullptr)

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -393,6 +393,7 @@ CHIP_ERROR MdnsAvahi::RebuildClient()
 
     ChipLogError(DeviceLayer, "Avahi client failed; rebuilding it and cancelling outstanding lookups");
     ++mClientGeneration;
+    const uint64_t shutdownGeneration = mShutdownGeneration;
 
     // Detach the contexts first because their callbacks may start new DNS-SD operations.
     std::list<ResolveContext *> staleResolves;
@@ -444,12 +445,15 @@ CHIP_ERROR MdnsAvahi::RebuildClient()
     // failed rebuild has left mClient in a consistent state.
     for (auto * resolve : staleResolves)
     {
-        resolve->mCallback(resolve->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_FORCED_RESET);
+        if (mShutdownGeneration == shutdownGeneration)
+        {
+            resolve->mCallback(resolve->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_FORCED_RESET);
+        }
         chip::Platform::Delete(resolve);
     }
     for (auto * browse : staleBrowses)
     {
-        if (!browse->mStopped.load())
+        if (mShutdownGeneration == shutdownGeneration && !browse->mStopped.load())
         {
             browse->mCallback(browse->mContext, nullptr, 0, true, CHIP_ERROR_FORCED_RESET);
         }
@@ -755,6 +759,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
 
     AvahiServiceBrowser * browser;
     BrowseContext * browseContext = chip::Platform::New<BrowseContext>();
+    VerifyOrReturnError(browseContext != nullptr, CHIP_ERROR_NO_MEMORY);
     AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
 
     browseContext->mInstance    = this;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -348,11 +348,34 @@ exit:
 void MdnsAvahi::Shutdown()
 {
     TEMPORARY_RETURN_IGNORED StopPublish();
+
+    // Release child objects before their client. Avahi would otherwise destroy the
+    // child objects while leaving the Matter lookup contexts with stale pointers.
+    for (auto * resolve : mAllocatedResolves)
+    {
+        chip::Platform::Delete(resolve);
+    }
+    mAllocatedResolves.clear();
+    for (auto * browse : mAllocatedBrowses)
+    {
+        if (browse->mBrowser != nullptr)
+        {
+            avahi_service_browser_free(browse->mBrowser);
+            browse->mBrowser = nullptr;
+        }
+        chip::Platform::Delete(browse);
+    }
+    mAllocatedBrowses.clear();
+
     if (mClient)
     {
         avahi_client_free(mClient);
         mClient = nullptr;
     }
+
+    mInitCallback       = nullptr;
+    mErrorCallback      = nullptr;
+    mAsyncReturnContext = nullptr;
 }
 
 bool MdnsAvahi::ClientHasFailed() const
@@ -360,11 +383,37 @@ bool MdnsAvahi::ClientHasFailed() const
     return mClient == nullptr || avahi_client_get_state(mClient) == AVAHI_CLIENT_FAILURE;
 }
 
-CHIP_ERROR MdnsAvahi::ResetClientForLookup()
+CHIP_ERROR MdnsAvahi::RebuildClient()
 {
     VerifyOrReturnError(mPublishedGroups.empty(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(mAllocatedResolves.empty() && mBrowseCount == 0, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mInitCallback != nullptr && mErrorCallback != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    ChipLogError(DeviceLayer, "Avahi client failed; rebuilding it and cancelling outstanding lookups");
+
+    // Detach the contexts first because their callbacks may start new DNS-SD operations.
+    std::list<ResolveContext *> staleResolves;
+    staleResolves.swap(mAllocatedResolves);
+    std::list<BrowseContext *> staleBrowses;
+    staleBrowses.swap(mAllocatedBrowses);
+
+    // Avahi client destruction also destroys its child objects. Release the tracked
+    // objects now and clear their pointers so deleting the contexts cannot free them twice.
+    for (auto * resolve : staleResolves)
+    {
+        if (resolve->mResolver != nullptr)
+        {
+            avahi_service_resolver_free(resolve->mResolver);
+            resolve->mResolver = nullptr;
+        }
+    }
+    for (auto * browse : staleBrowses)
+    {
+        if (browse->mBrowser != nullptr)
+        {
+            avahi_service_browser_free(browse->mBrowser);
+            browse->mBrowser = nullptr;
+        }
+    }
 
     if (mClient != nullptr)
     {
@@ -377,13 +426,29 @@ CHIP_ERROR MdnsAvahi::ResetClientForLookup()
     mClient          = avahi_client_new(mPoller.GetAvahiPoll(), AVAHI_CLIENT_NO_FAIL, HandleClientState, this, &avahiError);
     if (mClient == nullptr || avahiError != 0)
     {
-        ChipLogError(DeviceLayer, "Failed to reset Avahi client: %s", avahi_strerror(avahiError));
+        ChipLogError(DeviceLayer, "Failed to rebuild Avahi client: %s", avahi_strerror(avahiError));
         if (mClient != nullptr)
         {
             avahi_client_free(mClient);
             mClient = nullptr;
         }
         error = CHIP_ERROR_OPEN_FAILED;
+    }
+
+    // Notify callers only after the replacement client has been created, or after a
+    // failed rebuild has left mClient in a consistent state.
+    for (auto * resolve : staleResolves)
+    {
+        resolve->mCallback(resolve->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_FORCED_RESET);
+        chip::Platform::Delete(resolve);
+    }
+    for (auto * browse : staleBrowses)
+    {
+        if (!browse->mStopped.load())
+        {
+            browse->mCallback(browse->mContext, nullptr, 0, true, CHIP_ERROR_FORCED_RESET);
+        }
+        chip::Platform::Delete(browse);
     }
 
     return error;
@@ -694,7 +759,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
 
     if (mClient == nullptr)
     {
-        CHIP_ERROR error = ResetClientForLookup();
+        CHIP_ERROR error = RebuildClient();
         if (error != CHIP_NO_ERROR)
         {
             chip::Platform::Delete(browseContext);
@@ -707,11 +772,15 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
                                         static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
     if (browser == nullptr && ClientHasFailed())
     {
-        if (ResetClientForLookup() == CHIP_NO_ERROR)
+        CHIP_ERROR error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
         {
-            browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(),
-                                                nullptr, static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
+            chip::Platform::Delete(browseContext);
+            *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
+            return error;
         }
+        browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
+                                            static_cast<AvahiLookupFlags>(0), HandleBrowse, browseContext);
     }
     // Otherwise the browser will be freed in the callback
     if (browser == nullptr)
@@ -723,7 +792,8 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     }
     else
     {
-        mBrowseCount++;
+        browseContext->mBrowser = browser;
+        mAllocatedBrowses.push_back(browseContext);
         *browseIdentifier = reinterpret_cast<intptr_t>(browseContext);
     }
 
@@ -799,8 +869,9 @@ void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBro
     else
     {
         // browse is stopped, so free browse handle and context
-        context->mInstance->mBrowseCount--;
+        context->mInstance->mAllocatedBrowses.remove(context);
         avahi_service_browser_free(browser);
+        context->mBrowser = nullptr;
         chip::Platform::Delete(context);
     }
 }
@@ -814,8 +885,9 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
     switch (event)
     {
     case AVAHI_BROWSER_FAILURE:
-        context->mInstance->mBrowseCount--;
+        context->mInstance->mAllocatedBrowses.remove(context);
         avahi_service_browser_free(browser);
+        context->mBrowser = nullptr;
         context->mCallback(context->mContext, nullptr, 0, true, CHIP_ERROR_INTERNAL);
         chip::Platform::Delete(context);
         break;
@@ -824,8 +896,9 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         if (context->mStopped.load())
         {
             // browse is stopped, so free browse handle and context
-            context->mInstance->mBrowseCount--;
+            context->mInstance->mAllocatedBrowses.remove(context);
             avahi_service_browser_free(browser);
+            context->mBrowser = nullptr;
             chip::Platform::Delete(context);
             break;
         }
@@ -991,7 +1064,7 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     if (mClient == nullptr)
     {
         mAllocatedResolves.remove(resolveContext);
-        error = ResetClientForLookup();
+        error = RebuildClient();
         if (error != CHIP_NO_ERROR)
         {
             chip::Platform::Delete(resolveContext);
@@ -1007,15 +1080,17 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     if (resolveContext->mResolver == nullptr && ClientHasFailed())
     {
         mAllocatedResolves.remove(resolveContext);
-        error = ResetClientForLookup();
-        mAllocatedResolves.push_back(resolveContext);
-        if (error == CHIP_NO_ERROR)
+        error = RebuildClient();
+        if (error != CHIP_NO_ERROR)
         {
-            resolveContext->mResolver = avahi_service_resolver_new(
-                mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(), nullptr,
-                resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
-                reinterpret_cast<void *>(resolveContext->mNumber));
+            chip::Platform::Delete(resolveContext);
+            return error;
         }
+        mAllocatedResolves.push_back(resolveContext);
+        resolveContext->mResolver =
+            avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
+                                       nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
+                                       reinterpret_cast<void *>(resolveContext->mNumber));
     }
     // Otherwise the resolver will be freed in the callback
     if (resolveContext->mResolver == nullptr)

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -135,7 +135,7 @@ private:
         AvahiIfIndex mInterface;
         std::string mProtocol;
         std::atomic_bool mStopped{ false };
-        AvahiServiceBrowser * mBrowser;
+        AvahiServiceBrowser * mBrowser = nullptr;
     };
 
     struct ResolveContext
@@ -162,12 +162,12 @@ private:
         }
     };
 
-    MdnsAvahi() : mClient(nullptr) {}
+    MdnsAvahi() = default;
     static MdnsAvahi sInstance;
 
     bool ClientHasFailed() const;
 
-    CHIP_ERROR ResetClientForLookup();
+    CHIP_ERROR RebuildClient();
 
     /// Allocates a new resolve context with a unique `mNumber`
     ResolveContext * AllocateResolveContext();
@@ -191,11 +191,11 @@ private:
                               const char * host_name, const AvahiAddress * address, uint16_t port, AvahiStringList * txt,
                               AvahiLookupResultFlags flags, void * userdata);
 
-    DnssdAsyncReturnCallback mInitCallback;
-    DnssdAsyncReturnCallback mErrorCallback;
-    void * mAsyncReturnContext;
+    DnssdAsyncReturnCallback mInitCallback  = nullptr;
+    DnssdAsyncReturnCallback mErrorCallback = nullptr;
+    void * mAsyncReturnContext              = nullptr;
 
-    AvahiClient * mClient;
+    AvahiClient * mClient = nullptr;
     std::map<std::string, AvahiEntryGroup *> mPublishedGroups;
     Poller mPoller;
     static constexpr size_t kMaxBrowseRetries = 4;
@@ -204,7 +204,7 @@ private:
     size_t mResolveCount = 0;
     std::list<ResolveContext *> mAllocatedResolves;
 
-    size_t mBrowseCount = 0;
+    std::list<BrowseContext *> mAllocatedBrowses;
 };
 
 } // namespace Dnssd

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -167,7 +167,7 @@ private:
 
     bool ClientHasFailed() const;
 
-    CHIP_ERROR RebuildClient();
+    CHIP_ERROR ResetClientForLookup();
 
     /// Allocates a new resolve context with a unique `mNumber`
     ResolveContext * AllocateResolveContext();
@@ -204,7 +204,7 @@ private:
     size_t mResolveCount = 0;
     std::list<ResolveContext *> mAllocatedResolves;
 
-    std::list<BrowseContext *> mAllocatedBrowses;
+    size_t mBrowseCount = 0;
 };
 
 } // namespace Dnssd

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
@@ -199,6 +200,11 @@ private:
     std::map<std::string, AvahiEntryGroup *> mPublishedGroups;
     Poller mPoller;
     static constexpr size_t kMaxBrowseRetries = 4;
+
+    // Incremented whenever the client lifecycle is invalidated. Shutdown has a
+    // separate generation so an active callback can distinguish it from rebuild.
+    std::atomic<uint64_t> mClientGeneration{ 0 };
+    std::atomic<uint64_t> mShutdownGeneration{ 0 };
 
     // Handling of allocated resolves
     size_t mResolveCount = 0;

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -165,6 +165,10 @@ private:
     MdnsAvahi() : mClient(nullptr) {}
     static MdnsAvahi sInstance;
 
+    bool ClientHasFailed() const;
+
+    CHIP_ERROR RebuildClient();
+
     /// Allocates a new resolve context with a unique `mNumber`
     ResolveContext * AllocateResolveContext();
 
@@ -199,6 +203,8 @@ private:
     // Handling of allocated resolves
     size_t mResolveCount = 0;
     std::list<ResolveContext *> mAllocatedResolves;
+
+    std::list<BrowseContext *> mAllocatedBrowses;
 };
 
 } // namespace Dnssd

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -177,6 +177,12 @@ private:
     void FreeResolveContext(size_t handle);
     void FreeResolveContext(const char * name);
 
+    // Completes a resolve: detaches the context and releases its resolver before invoking the
+    // terminal callback, so a re-entrant RebuildClient()/Shutdown() started from that callback
+    // cannot free the resolver twice or invoke the callback again. Deletes the context after.
+    void FinalizeResolve(ResolveContext * context, DnssdService * result, const Span<Inet::IPAddress> & addresses,
+                         CHIP_ERROR error);
+
     static void HandleClientState(AvahiClient * client, AvahiClientState state, void * context);
     void HandleClientState(AvahiClient * client, AvahiClientState state);
 


### PR DESCRIPTION
### The problem

In stress testing, commissioning can fail after the Linux controller’s network connection drops and reconnects. The device may already have joined the network, but the controller’s Avahi/mDNS client can remain in a bad state and fail to create new browse or resolve operations. That causes operational discovery to fail during commissioning.

### The fix

Add a Linux Avahi recovery path for lookup setup failures. If Avahi browse/resolve creation fails and the client is either missing or in a failed state (`AVAHI_CLIENT_FAILURE`), rebuild the Avahi client and retry the lookup once.

During rebuild, the DNS-SD implementation detaches any outstanding browse and resolve contexts that were tied to the failed Avahi client, prevents stale Avahi resolver pointers from being freed twice, recreates the client, and notifies stale callers with `CHIP_ERROR_FORCED_RESET`. This avoids waiting for failure callbacks that may never arrive from the failed Avahi client.

The rebuild still avoids resetting while Matter services are being published, so the recovery path does not silently drop active advertisements.

### Why this belongs in Matter

Matter uses the system `libavahi-client`, which communicates with `avahi-daemon` over D-Bus; connectedhomeip does not vendor either component. Avahi documents `AVAHI_CLIENT_FAILURE` as terminal and requires consumers to free and recreate the client and its associated objects, so this implements the required client lifecycle rather than compensating for an upstream defect. OS updates may reduce the triggering disconnects, but do not remove that responsibility.

### Testing

Built the Linux Avahi platform target:

```
ninja -C out/linux-x64-all-clusters-avahi-check \
  obj/third_party/connectedhomeip/src/platform/Linux/Linux.DnssdImpl.cpp.o \
  third_party/connectedhomeip/src/platform/Linux:Linux
```

No unit tests were added. This path does not lend itself well to existing unit tests because it depends on Avahi C API behavior, Linux DNS-SD client state, and callback/lifecycle behavior around failed Avahi browse/resolve objects. Unit testing would likely require adding an abstraction layer around Avahi client/browser/resolver creation or introducing a fake Avahi backend, which would be more infrastructure than this targeted Linux recovery fix warrants.

### Related issues

Fixes: #39482