### PR TITLE
[NXP][Zephyr] Add OTA build target for RW61x Zephyr thermostat in NXP CI

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -183,14 +183,14 @@ jobs:
             - name: clean build
               run: rm -rf ./out
 
-            - name: Build NXP Zephyr thermostat Wi-Fi example
+            - name: Build NXP Zephyr thermostat Wi-Fi OTA example
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp
                   == 'true' || steps.changed_paths.outputs.pigweed == 'true'
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-thermostat \
+                      --target nxp-rw61x-zephyr-thermostat-ota \
                       build \
                   "
 


### PR DESCRIPTION

### Summary

Replace nxp-rw61x-zephyr-thermostat with nxp-rw61x-zephyr-thermostat-ota in the 'Build NXP Zephyr thermostat Wi-Fi example' step of the Zephyr CI job in .github/workflows/examples-nxp.yaml.

This ensures OTA-related breaking changes on Zephyr files are caught by the GitHub CI without adding extra CI time.

### Testing

CI build run will validate this OTA build.
