### PR TITLE
[Controller] Clean up obsolete subscriptions on keepSubscriptions=False

### DIFF
--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -2321,9 +2321,24 @@ class ChipDeviceControllerBase:
             eventPaths = [self._parseEventPathTuple(
                 v) for v in events] if events else None
 
+            # keepSubscriptions=False -> Server purges existing subscriptions.
+            # Proactively shut down corresponding client-side objects here to:
+            # - Prevent client-side liveness timeouts from marking the secure session defunct.
+            # - Free C++ ReadClient/Exchange context resources early.
+            if reportInterval is not None and not keepSubscriptions:
+                for subscription in list(builtins.chipStack._subscriptions.values()):
+                    if getattr(subscription, 'nodeId', None) == nodeId and subscription._devCtrl == self:
+                        LOGGER.info("Auto-cancelling previous subscription 0x%08x to node %d due to keepSubscriptions=False",
+                                    subscription.subscriptionId, nodeId)
+                        try:
+                            subscription.Shutdown()
+                        except Exception as e:
+                            # Benign: the obsolete subscription might already be terminated by the C++ stack or server.
+                            LOGGER.info("Failed to shut down obsolete subscription: %s", e)
+
             allowLargePayload = payloadCapability in (TransportPayloadCapability.LARGE_PAYLOAD,
                                                       TransportPayloadCapability.MRP_OR_TCP_PAYLOAD)
-            transaction = ClusterAttribute.AsyncReadTransaction(future, eventLoop, self, returnClusterObject)
+            transaction = ClusterAttribute.AsyncReadTransaction(future, eventLoop, self, returnClusterObject, nodeId=nodeId)
             ClusterAttribute.Read(transaction, device=device.deviceProxy,
                                   attributes=attributePaths, dataVersionFilters=clusterDataVersionFilters, events=eventPaths,
                                   eventNumberFilter=eventNumberFilter,

--- a/src/controller/python/matter/clusters/Attribute.py
+++ b/src/controller/python/matter/clusters/Attribute.py
@@ -450,6 +450,7 @@ class SubscriptionTransaction:
             SubscriptionTransaction], None]] = None
         self._onResubscriptionSucceededCb_isAsync = False
         self._onResubscriptionAttemptedCb_isAsync = False
+        self._nodeId = transaction._nodeId
         builtins.chipStack.RegisterSubscription(self)
 
     def GetAttributes(self):
@@ -617,6 +618,10 @@ class SubscriptionTransaction:
     def subscriptionId(self) -> int:
         return self._subscriptionId
 
+    @property
+    def nodeId(self) -> int | None:
+        return self._nodeId
+
     def Shutdown(self):
         if self._isDone:
             LOGGER.warning(
@@ -699,7 +704,7 @@ class AsyncReadTransaction:
         events: list[ClusterEvent]
         tlvAttributes: dict[int, Any]
 
-    def __init__(self, future: Future, eventLoop, devCtrl, returnClusterObject: bool):
+    def __init__(self, future: Future, eventLoop, devCtrl, returnClusterObject: bool, nodeId: Optional[int] = None):
         self._event_loop = eventLoop
         self._future = future
         self._subscription_handler = None
@@ -710,6 +715,7 @@ class AsyncReadTransaction:
         self._pReadClient = None
         self._resultError: Optional[PyChipError] = None
         self._notify_subscription_still_active_callback = None
+        self._nodeId = nodeId
 
     def SetClientObjPointers(self, pReadClient):
         self._pReadClient = pReadClient


### PR DESCRIPTION
#### Summary

##### Problem

- When a new subscription is established with **`keepSubscriptions=False`**, the server purges all previous subscriptions on the secure session.
- The Python test runner (client-side) did not proactively clean up the corresponding client-side subscription objects. This led to:
  - **Liveness Timeout Failures**: Obsolete client-side subscriptions remained active and their background liveness check timers eventually expired.
  - **Session Invalidation**: When a liveness timeout occurred, it marked the secure session as **`defunct`**, breaking subsequent read/write communication on the same session (e.g. in Step 10 of `TC_IDM_4_3.py` when it missed 37 out of 50 reports).
  - **Resource Leakage**: C++ `ReadClient` and Exchange context resources were not freed early.

Example failure: https://github.com/project-chip/connectedhomeip/actions/runs/28873325487

##### Changes

- Intercept subscription requests in `ChipDeviceCtrl.py` and if **`keepSubscriptions=False`** is specified:
  - Proactively shut down all existing client-side subscription objects targeting that node on that controller.
- Passed the `nodeId` down to the `AsyncReadTransaction` and `SubscriptionTransaction` objects to allow identifying which subscriptions to target.

#### Testing

- Verified that `TC_IDM_4_3.py` passes successfully locally:
  ```bash
  ./scripts/tests/local.py python-tests --test-filter TC_IDM_4_3 --override-binary-path ALL_CLUSTERS_APP out/linux-x64-all-clusters-clang/chip-all-clusters-app
  ```
- Confirmed from logs that the auto-cancellation logic triggers and cancels obsolete subscriptions:
  ```
  INFO Auto-cancelling previous subscription 0x3e2452df to node 305414945 due to keepSubscriptions=False
  ```
