### PR TITLE
[TC-SC-3.1] Remove initiator Sigma1/Sigma3 field list from step descriptions

### DIFF
--- a/src/python_testing/TC_SC_3_1.py
+++ b/src/python_testing/TC_SC_3_1.py
@@ -82,8 +82,8 @@ class TC_SC_3_1(MatterBaseTest):
 
         self.step("1d",
                   "Initiator constructs and sends a TLV-encoded Sigma1 to the Responder. "
-                  "Verify I=1, S=0, DSIZ=0, sigma-1-struct TLV, Session Type=0 (Unicast), Protocol ID=0x0000 (SECURE_CHANNEL), Opcode=0x30 (CASE Sigma1). "
-                  "NOTE: This step is done automatically and verified by successful completion of the read in step 1c.")
+                  "Sending Sigma1 is performed automatically as part of the CASE handshake and is not "
+                  "independently captured; its success is confirmed by the successful completion of the read in step 1c.")
 
         self.step(2,
                   "Upon receiving Sigma1, the Responder generates Sigma2.",
@@ -121,9 +121,8 @@ class TC_SC_3_1(MatterBaseTest):
 
         self.step(5,
                   "Initiator constructs and sends a TLV-encoded Sigma3 message. "
-                  "Verify I=1, S=0, DSIZ=0, sigma-3-struct TLV, Session Type=0 (Unicast), "
-                  "Protocol ID=0x0000 (SECURE_CHANNEL), Opcode=0x32 (CASE Sigma3). "
-                  " NOTE: This step is done automatically and verified by successful completion of the read in step 1c.")
+                  "Sending Sigma3 is performed automatically as part of the CASE handshake and is not "
+                  "independently captured; its success is confirmed by the successful completion of the read in step 1c.")
 
         self.step(6,
                   "Session establishment completes.",


### PR DESCRIPTION
#### Summary

The step descriptions in `TC_SC_3_1.py` listed specific header-field values for the initiator's outbound Sigma1 and Sigma3 messages, even though the test does not capture or assert those messages. This removes that detail so the descriptions reflect only what the test actually checks.

##### Problem

-   Step 1d (Sigma1) and step 5 (Sigma3) descriptions enumerated per-field expectations (`I=1, S=0, DSIZ=0, Session Type, Protocol ID, Opcode`) alongside the note that the step is performed automatically and verified by the read in step 1c.
-   The `case_capture` module only snapshots **inbound** (responder to initiator) messages — Sigma2, Sigma2_Resume, and the final StatusReport. There is no capture slot for the initiator's own Sigma1/Sigma3, so those fields are never individually asserted. Listing per-field values the test does not check adds misleading detail.
-   One of the listed values was also **incorrect**: it stated `S=0`, but per the Secure Channel spec (CASE, "Message format") initiator messages SHALL set `S Flag = 1` (the CHIP initiator sends `S=1`, using an ephemeral random source node ID on the unauthenticated session).

##### Solution

-   Remove the field enumeration in steps 1d and 5, keeping the note that success is confirmed by the read in step 1c.
-   No assertions change: the captured Sigma2 header checks (`S=0`, `DSIZ=1`, opcode, protocol ID) are untouched and remain spec-correct. The step count is unchanged.

#### Related issues

The corresponding test-plan update is in chip-test-plans PR [CHIP-Specifications/chip-test-plans#6193](https://github.com/CHIP-Specifications/chip-test-plans/pull/6193).

#### Testing

-   N/A. Description-only change to `self.step(...)` strings; no assertions or control flow modified, so the behavior of `TC_SC_3_1.py` is unchanged. `python3 -m py_compile` passes.