### PR TITLE
[Time synchronization] Fix compilation when ReadClient is disabled

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -48,7 +48,7 @@ declare_args() {
   # enable time sync client for use in `time-synchronization-server` (if linked)
   # TODO: this should probably be migrated to be time-synchronization-server specific
   #       if the cluster build targets are decoupled as stand-alone units.
-  time_sync_enable_tsc_feature = 1
+  time_sync_enable_tsc_feature = chip_enable_read_client
 
   # Systems that can spare a bit of RAM for InteractionModelEngine/delegate
   # pointers should do so (allows InteractionModelEngine decoupling and less usage
@@ -61,6 +61,10 @@ declare_args() {
   # for files that chip_data_model requires.
   chip_app_data_model_target = "${chip_root}/examples/*"
 }
+
+assert(
+    !time_sync_enable_tsc_feature || chip_enable_read_client,
+    "Time Synchronization TSC feature requires chip_enable_read_client to be enabled.")
 
 buildconfig_header("app_buildconfig") {
   header = "AppBuildConfig.h"

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -22,7 +22,7 @@
 
 #include <system/SystemClock.h>
 
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
 #include <app/InteractionModelEngine.h>
 #endif
 
@@ -39,7 +39,7 @@ namespace chip::app::Clusters {
 
 namespace {
 
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     TimeSynchronizationCluster * timeSynchronization = reinterpret_cast<TimeSynchronizationCluster *>(context);
@@ -174,7 +174,7 @@ TimeSynchronizationCluster::TimeSynchronizationCluster(EndpointId endpoint, cons
     mFeatures(features), mOptionalAttributeSet(optionalAttributeSet), mSupportsDNSResolve(config.supportsDNSResolve),
     mNTPServerAvailable(config.ntpServerAvailable), mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource),
     mDelegate(config.delegate), mTimeSyncContext(context),
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
     mOnDeviceConnectedCallback(OnDeviceConnectedWrapper, this),
     mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureWrapper, this),
 #endif
@@ -397,7 +397,7 @@ void TimeSynchronizationCluster::AttemptToGetFallbackNTPTimeFromDelegate()
     }
 }
 
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
 void TimeSynchronizationCluster::OnDeviceConnectedFn(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     // Connected to our trusted time source, let's read the time.
@@ -524,7 +524,7 @@ void TimeSynchronizationCluster::OnFallbackNTPCompletionFn(bool timeSyncSuccessf
 
 CHIP_ERROR TimeSynchronizationCluster::AttemptToGetTimeFromTrustedNode()
 {
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
     if (!mTrustedTimeSource.IsNull())
     {
         ScopedNodeId nodeId(mTrustedTimeSource.Value().nodeID, mTrustedTimeSource.Value().fabricIndex);

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -22,7 +22,7 @@
 
 #include <system/SystemClock.h>
 
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
 #include <app/InteractionModelEngine.h>
 #endif
 
@@ -39,7 +39,7 @@ namespace chip::app::Clusters {
 
 namespace {
 
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     TimeSynchronizationCluster * timeSynchronization = reinterpret_cast<TimeSynchronizationCluster *>(context);
@@ -174,7 +174,7 @@ TimeSynchronizationCluster::TimeSynchronizationCluster(EndpointId endpoint, cons
     mFeatures(features), mOptionalAttributeSet(optionalAttributeSet), mSupportsDNSResolve(config.supportsDNSResolve),
     mNTPServerAvailable(config.ntpServerAvailable), mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource),
     mDelegate(config.delegate), mTimeSyncContext(context),
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
     mOnDeviceConnectedCallback(OnDeviceConnectedWrapper, this),
     mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureWrapper, this),
 #endif
@@ -397,7 +397,7 @@ void TimeSynchronizationCluster::AttemptToGetFallbackNTPTimeFromDelegate()
     }
 }
 
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
 void TimeSynchronizationCluster::OnDeviceConnectedFn(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     // Connected to our trusted time source, let's read the time.
@@ -524,7 +524,7 @@ void TimeSynchronizationCluster::OnFallbackNTPCompletionFn(bool timeSyncSuccessf
 
 CHIP_ERROR TimeSynchronizationCluster::AttemptToGetTimeFromTrustedNode()
 {
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
     if (!mTrustedTimeSource.IsNull())
     {
         ScopedNodeId nodeId(mTrustedTimeSource.Value().nodeID, mTrustedTimeSource.Value().fabricIndex);

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <app/AppConfig.h>
 #include <app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.h>
 #include <app/clusters/time-synchronization-server/TimeSyncDataProvider.h>
 #include <app/clusters/time-synchronization-server/time-synchronization-delegate.h>
@@ -31,9 +32,14 @@
 
 #include <app/server/Server.h>
 
-// NOTE: this is part of AppConfig, so this has to be checked for AFTER the inclusion
-//       of that header
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+// The Time Synchronization Client (TSC) feature requires a Read Client to query time from a
+// trusted time source. On resource-constrained devices, the Read Client may be disabled
+// (CHIP_CONFIG_ENABLE_READ_CLIENT = 0) to save space. We must only enable the TSC feature
+// if the Read Client is available, otherwise compilation will fail due to inheriting from
+// the incomplete ReadClient::Callback type.
+#define TIME_SYNC_TSC_FEATURE_ENABLED (TIME_SYNC_ENABLE_TSC_FEATURE && CHIP_CONFIG_ENABLE_READ_CLIENT)
+
+#if TIME_SYNC_TSC_FEATURE_ENABLED
 #include <app/ReadClient.h>
 #endif
 
@@ -69,7 +75,7 @@ enum class TimeSyncEventFlag : uint8_t
 
 class TimeSynchronizationCluster : public DefaultServerCluster,
                                    public FabricTable::Delegate
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
     ,
                                    public ReadClient::Callback
 #endif
@@ -112,7 +118,7 @@ public:
     // Fabric Table delegate functions
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
 
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
     // CASE connection functions
     void OnDeviceConnectedFn(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
     void OnDeviceConnectionFailureFn();
@@ -200,7 +206,7 @@ private:
 
     CHIP_ERROR AttemptToGetTimeFromTrustedNode();
 
-#if TIME_SYNC_ENABLE_TSC_FEATURE
+#if TIME_SYNC_TSC_FEATURE_ENABLED
     chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
     struct TimeReadInfo

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.h
@@ -32,14 +32,7 @@
 
 #include <app/server/Server.h>
 
-// The Time Synchronization Client (TSC) feature requires a Read Client to query time from a
-// trusted time source. On resource-constrained devices, the Read Client may be disabled
-// (CHIP_CONFIG_ENABLE_READ_CLIENT = 0) to save space. We must only enable the TSC feature
-// if the Read Client is available, otherwise compilation will fail due to inheriting from
-// the incomplete ReadClient::Callback type.
-#define TIME_SYNC_TSC_FEATURE_ENABLED (TIME_SYNC_ENABLE_TSC_FEATURE && CHIP_CONFIG_ENABLE_READ_CLIENT)
-
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
 #include <app/ReadClient.h>
 #endif
 
@@ -75,7 +68,7 @@ enum class TimeSyncEventFlag : uint8_t
 
 class TimeSynchronizationCluster : public DefaultServerCluster,
                                    public FabricTable::Delegate
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
     ,
                                    public ReadClient::Callback
 #endif
@@ -118,7 +111,7 @@ public:
     // Fabric Table delegate functions
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
 
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
     // CASE connection functions
     void OnDeviceConnectedFn(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
     void OnDeviceConnectionFailureFn();
@@ -206,7 +199,7 @@ private:
 
     CHIP_ERROR AttemptToGetTimeFromTrustedNode();
 
-#if TIME_SYNC_TSC_FEATURE_ENABLED
+#if TIME_SYNC_ENABLE_TSC_FEATURE
     chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
     struct TimeReadInfo


### PR DESCRIPTION
#### Summary

- **Problem**: On resource-constrained platforms (such as Silicon Labs EFR32 lighting-app), the Interaction Model Read Client is disabled (`CHIP_CONFIG_ENABLE_READ_CLIENT = 0`) to optimize flash/RAM footprints. However, the Time Synchronization Client (TSC) feature was unconditionally set to `1` by default and tried to inherit from the `ReadClient::Callback` type, which is undefined when Read Client is disabled. This resulted in compilation failures (`invalid use of incomplete type`).
- **Impact**: Compilation fails on any platform that enables `time-synchronization-server` but disables `ReadClient`.
- **Solution**: 
  - Gated the `time_sync_enable_tsc_feature` GN build argument to default to `chip_enable_read_client`, and added a compile-time assertion in `src/app/BUILD.gn` to catch incompatible configurations early.
  - Sourced `<app/AppConfig.h>` inside the time synchronization server header to ensure the preprocessor flag `TIME_SYNC_ENABLE_TSC_FEATURE` is correctly imported during header compilation.

#### Testing

- Successfully compiled the `efr32-brd4187c-light` application (which disables `ReadClient` by default).
- Successfully compiled the `linux-x64-all-clusters-clang` example application and ran all unit tests.
