### PR TITLE
[Tests] Fix option name translation and type casting in chiptool YAML runner

### DIFF
--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -30,11 +30,12 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     kwargs = {'test_name': test_name, 'show_adapter_logs': show_adapter_logs, 'specifications_paths': specifications_paths, 'pics': pics,
               'additional_pseudo_clusters_directory': additional_pseudo_clusters_directory}
 
-    # Naming translation map from command-line options (e.g. --PICS or --value-wait-extra-duration-ms)
-    # to the exact click option parameter variable names expected by runner_base (e.g. pics, valueWaitExtraDurationMs).
-    # Since command line parsing collects unknown options manually as strings inside the commands list,
-    # we bypass click's automatic option name mapping and type conversion. This map restores the naming
-    # translation.
+    # Translate command-line to invoke variable names for unknown parameters
+    #   - need option to variable name translation (i.e. underscores: --stop_on_error is stop_on_error in python)
+    #   - need type conversion (click would convert things to ints, bools and such instead of strings)
+    #
+    # These are known mappings between one argument and the corresponding known name. Everything else
+    # would just replace '-' with '_':
     option_mapping = {
         'PICS': 'pics',
         'value-wait-extra-duration-ms': 'valueWaitExtraDurationMs',
@@ -43,11 +44,11 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     index = 0
     while len(commands) - index > 1:
         key = commands[index].replace('--', '')
+        # Map things like `--stop-on-error` to `stop_on_error` since we ctx.invoke directly (need python names)
         mapped_key = option_mapping.get(key, key.replace('-', '_'))
         val = commands[index+1]
-        # Because options are manually parsed as strings from the argv commands list,
-        # we must perform manual type casting to match the types expected by runner_base.
-        # Otherwise, passing them as strings would lead to TypeErrors or unexpected truthiness (e.g. bool("False")).
+
+        # convert known typed values
         if mapped_key == 'valueWaitExtraDurationMs':
             val = int(val)
         elif mapped_key == 'stop_on_error':

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -34,6 +34,9 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     #   - need option to variable name translation (i.e. underscores: --stop_on_error is stop_on_error in python)
     #   - need type conversion (click would convert things to ints, bools and such instead of strings)
     #
+    # Example: --value-wait-extra-duration-ms must map to valueWaitExtraDurationMs (int)
+    # as defined by the option and signature of runner_base in scripts/tests/chipyaml/runner.py.
+    #
     # These are known mappings between one argument and the corresponding known name. Everything else
     # would just replace '-' with '_':
     option_mapping = {

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -43,7 +43,7 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     index = 0
     while len(commands) - index > 1:
         key = commands[index].replace('--', '')
-        mapped_key = option_mapping.get(key, key)
+        mapped_key = option_mapping.get(key, key.replace('-', '_'))
         val = commands[index+1]
         # Because options are manually parsed as strings from the argv commands list,
         # we must perform manual type casting to match the types expected by runner_base.

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -41,6 +41,14 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
         'value-wait-extra-duration-ms': 'valueWaitExtraDurationMs',
     }
 
+    str_to_bool = lambda val: val.lower() in ('true', '1', 'yes')
+
+    type_conversions = {
+        'valueWaitExtraDurationMs': int,
+        'stop_on_error': str_to_bool,
+        'use_default_pseudo_clusters': str_to_bool,
+    }
+
     index = 0
     while len(commands) - index > 1:
         key = commands[index].replace('--', '')
@@ -49,12 +57,9 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
         val = commands[index+1]
 
         # convert known typed values
-        if mapped_key == 'valueWaitExtraDurationMs':
-            val = int(val)
-        elif mapped_key == 'stop_on_error':
-            val = val.lower() in ('true', '1', 'yes')
-        elif mapped_key == 'use_default_pseudo_clusters':
-            val = val.lower() in ('true', '1', 'yes')
+        if mapped_key in type_conversions:
+            val = type_conversions[mapped_key](val)
+
         kwargs[mapped_key] = val
         index += 2
     ctx.invoke(runner_base, **kwargs)

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -37,6 +37,8 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     #   - manual type conversion (since options are parsed manually as strings, we must cast
     #     to expected types like int or bool to match the function signature)
     #
+    # See runner_base definition in scripts/tests/chipyaml/runner.py for the full parameter list and target types.
+    #
     # These are known mappings between one argument and the corresponding known name. Everything else
     # would just replace '-' with '_':
     option_mapping = {

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -30,9 +30,31 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     kwargs = {'test_name': test_name, 'show_adapter_logs': show_adapter_logs, 'specifications_paths': specifications_paths, 'pics': pics,
               'additional_pseudo_clusters_directory': additional_pseudo_clusters_directory}
 
+    # Naming translation map from command-line options (e.g. --PICS or --value-wait-extra-duration-ms)
+    # to the exact click option parameter variable names expected by runner_base (e.g. pics, valueWaitExtraDurationMs).
+    # Since command line parsing collects unknown options manually as strings inside the commands list,
+    # we bypass click's automatic option name mapping and type conversion. This map restores the naming
+    # translation.
+    option_mapping = {
+        'PICS': 'pics',
+        'value-wait-extra-duration-ms': 'valueWaitExtraDurationMs',
+    }
+
     index = 0
     while len(commands) - index > 1:
-        kwargs[commands[index].replace('--', '')] = commands[index+1]
+        key = commands[index].replace('--', '')
+        mapped_key = option_mapping.get(key, key)
+        val = commands[index+1]
+        # Because options are manually parsed as strings from the argv commands list,
+        # we must perform manual type casting to match the types expected by runner_base.
+        # Otherwise, passing them as strings would lead to TypeErrors or unexpected truthiness (e.g. bool("False")).
+        if mapped_key == 'valueWaitExtraDurationMs':
+            val = int(val)
+        elif mapped_key == 'stop_on_error':
+            val = val.lower() in ('true', '1', 'yes')
+        elif mapped_key == 'use_default_pseudo_clusters':
+            val = val.lower() in ('true', '1', 'yes')
+        kwargs[mapped_key] = val
         index += 2
     ctx.invoke(runner_base, **kwargs)
 

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -30,12 +30,12 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
     kwargs = {'test_name': test_name, 'show_adapter_logs': show_adapter_logs, 'specifications_paths': specifications_paths, 'pics': pics,
               'additional_pseudo_clusters_directory': additional_pseudo_clusters_directory}
 
-    # Translate command-line to invoke variable names for unknown parameters
-    #   - need option to variable name translation (i.e. underscores: --stop_on_error is stop_on_error in python)
-    #   - need type conversion (click would convert things to ints, bools and such instead of strings)
-    #
-    # Example: --value-wait-extra-duration-ms must map to valueWaitExtraDurationMs (int)
-    # as defined by the option and signature of runner_base in scripts/tests/chipyaml/runner.py.
+    # Translate command-line arguments to Click/Python parameter names:
+    #   - option to variable name translation (e.g. `--stop-on-error` translates to `stop_on_error`)
+    #   - custom mapping for option destination variables (e.g. `--PICS` maps to `pics`,
+    #     `--value-wait-extra-duration-ms` maps to `valueWaitExtraDurationMs`)
+    #   - manual type conversion (since options are parsed manually as strings, we must cast
+    #     to expected types like int or bool to match the function signature)
     #
     # These are known mappings between one argument and the corresponding known name. Everything else
     # would just replace '-' with '_':

--- a/scripts/tests/chipyaml/tests_tool.py
+++ b/scripts/tests/chipyaml/tests_tool.py
@@ -41,7 +41,7 @@ def send_yaml_command(ctx, test_tool, test_name: str, server_path: str, server_a
         'value-wait-extra-duration-ms': 'valueWaitExtraDurationMs',
     }
 
-    str_to_bool = lambda val: val.lower() in ('true', '1', 'yes')
+    def str_to_bool(val): return val.lower() in ('true', '1', 'yes')
 
     type_conversions = {
         'valueWaitExtraDurationMs': int,


### PR DESCRIPTION
#### Summary

**Problem:**
When running test commands (like `chiptool.py` or `darwinframeworktool.py`) with custom options, unrecognized arguments (e.g. `--value-wait-extra-duration-ms 5000`) are manually parsed as string pairs inside `send_yaml_command`. 

This manual forwarding had two major issues:
* **Option Key Mismatch:** Options were passed to Click's `runner_base` using option keys directly (e.g., `value-wait-extra-duration-ms`) rather than Click's internal parameter variable names (e.g., `valueWaitExtraDurationMs`).
* **Missing Type Conversion:** Arguments were forwarded as raw strings, bypassing Click's built-in conversion to expected types (such as `int` or `bool`).

**Impact:**
Because of the key name mismatch, the custom options fell back to their default values (e.g. `valueWaitExtraDurationMs` defaulted to 250ms). 
On slow environments (like the Darwin macOS ASAN runner), this caused premature timeouts when waiting for slower transitions.
* **Example Failure:** In [CI Job Failure 85641737634](https://github.com/project-chip/connectedhomeip/actions/runs/28873355838/job/85641737634), `Test_WaitForAttributeValue` timed out waiting for level 100 after just `1.25s` (transition time 1.0s + 250ms default extra wait), whereas the actual transition on that run took `~1.7s` to complete.

**Changes:**
1. Added `option_mapping` to translate dashed command-line option keys (e.g. `--value-wait-extra-duration-ms`) to the click destination variable names (e.g. `valueWaitExtraDurationMs`).
2. Normalized other unmapped options by automatically replacing hyphens with underscores (e.g. `--stop-on-error` maps to `stop_on_error`).
3. Implemented an extensible `type_conversions` mapping to perform type conversions from raw CLI string parameters to their expected python parameter types (e.g., `int` and `bool`).

#### Testing
Ran python test suite unit tests:
`python3 -m unittest discover -s scripts/py_matter_yamltests/`
All tests passed.
