### PR TITLE
[TC-DGWIFI-3.2] Update cluster name to "Wi-Fi Network Diagnostics" as per spec and test plan

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DGWIFI_3_2_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGWIFI_3_2_Simulated.yaml
@@ -19,7 +19,7 @@ PICS:
 
 config:
     nodeId: 0x12344321
-    cluster: "WiFi Network Diagnostics"
+    cluster: "Wi-Fi Network Diagnostics"
     endpoint: 0
 
 tests:


### PR DESCRIPTION
### Summary
Test case TC-DGWIFI-3.2 (YAML-simulated) was failing due to a cluster name mismatch. The test expectation `"WiFiNetworkDiagnostics == Wi-FiNetworkDiagnostics"` evaluated to `false`, indicating a discrepancy between the cluster name used in the script and the expected value.

### Fix
Updated the cluster name in the script from `WiFi Network Diagnostics` to `Wi-Fi Network Diagnostics`, in accordance with the test plan and specification.

### Related issues
Fix for: https://github.com/project-chip/matter-test-scripts/issues/353

### Testing
Tested in RPI platform.