### PR TITLE
python_test: Fix commissionable subtype discovery fallback

### DIFF
--- a/src/python_testing/mdns_discovery/README.md
+++ b/src/python_testing/mdns_discovery/README.md
@@ -212,9 +212,14 @@ get_commissionable_subtypes()
         ▼
    get_all_service_types()
         │
-        └── discovers all advertised mDNS service types
+        ├── discovers all advertised mDNS service types
+        │
         ▼
-filters for commissionable service subtypes
+   get_commissionable_services()
+        │
+        └── discovers commissionable service PTR and TXT data
+        ▼
+filters and derives commissionable service subtypes
         ▼
 returns List[str]
 ```

--- a/src/python_testing/mdns_discovery/README.md
+++ b/src/python_testing/mdns_discovery/README.md
@@ -217,9 +217,14 @@ get_commissionable_subtypes()
         ▼
    get_commissionable_services()
         │
-        └── discovers commissionable service PTR and TXT data
+        └── discovers commissionable service TXT data
         ▼
-filters and derives commissionable service subtypes
+derives candidate commissionable service subtypes
+        │
+        ▼
+   get_ptr_records()
+        │
+        └── verifies candidate subtypes with direct PTR browses
         ▼
 returns List[str]
 ```

--- a/src/python_testing/mdns_discovery/mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/mdns_discovery.py
@@ -408,17 +408,64 @@ class MdnsDiscovery:
         Returns:
             list[str]: A list of strings representing the discovered commissionable mDNS service subtypes.
         """
-        # Get service types
+        sub_types: list[str] = []
+
+        def add_subtype(subtype: str) -> None:
+            if subtype and subtype not in sub_types:
+                sub_types.append(subtype)
+
+        commissionable_type = MdnsServiceType.COMMISSIONABLE.value
+
+        # Get service types advertised via DNS-SD service type enumeration.
         service_types = await self.get_all_service_types(
             discovery_timeout_sec=discovery_timeout_sec,
             log_output=False
         )
 
-        # Filter for commissionable subtypes
-        sub_types = [
-            st for st in service_types
-            if st.startswith('_') and f'._sub.{MdnsServiceType.COMMISSIONABLE.value}' in st
-        ]
+        # Filter for commissionable subtypes.
+        for service_type in service_types:
+            if service_type.startswith('_') and f'._sub.{commissionable_type}' in service_type:
+                add_subtype(service_type)
+
+        # Subtypes are not required to be returned by DNS-SD service type
+        # enumeration. Browse commissionable services and derive the subtype
+        # browse names from the advertised service type and TXT data.
+        commissionable_services = await self.get_commissionable_services(
+            discovery_timeout_sec=discovery_timeout_sec,
+            log_output=False
+        )
+
+        for service_info in commissionable_services:
+            service_type = service_info.service_type
+            if service_type and service_type.startswith('_') and f'._sub.{commissionable_type}' in service_type:
+                add_subtype(service_type)
+
+            txt = service_info.txt or {}
+
+            discriminator = txt.get('D')
+            if discriminator:
+                add_subtype(f"_L{discriminator}._sub.{commissionable_type}")
+                try:
+                    add_subtype(f"_S{(int(discriminator) >> 8) & 0x0F}._sub.{commissionable_type}")
+                except ValueError:
+                    pass
+
+            cm = txt.get('CM')
+            if cm:
+                try:
+                    if int(cm) != 0:
+                        add_subtype(f"_CM._sub.{commissionable_type}")
+                except ValueError:
+                    pass
+
+            vendor_and_product = txt.get('VP')
+            if vendor_and_product:
+                vendor_id = vendor_and_product.split('+', 1)[0]
+                add_subtype(f"_V{vendor_id}._sub.{commissionable_type}")
+
+            device_type = txt.get('DT')
+            if device_type:
+                add_subtype(f"_T{device_type}._sub.{commissionable_type}")
 
         if log_output:
             log.info(

--- a/src/python_testing/mdns_discovery/mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/mdns_discovery.py
@@ -410,10 +410,15 @@ class MdnsDiscovery:
             list[str]: A list of strings representing the discovered commissionable mDNS service subtypes.
         """
         sub_types: list[str] = []
+        candidate_subtypes: list[str] = []
 
         def add_subtype(subtype: str) -> None:
             if subtype and subtype not in sub_types:
                 sub_types.append(subtype)
+
+        def add_candidate_subtype(subtype: str) -> None:
+            if subtype and subtype not in sub_types and subtype not in candidate_subtypes:
+                candidate_subtypes.append(subtype)
 
         commissionable_type = MdnsServiceType.COMMISSIONABLE.value
 
@@ -429,8 +434,9 @@ class MdnsDiscovery:
                 add_subtype(service_type)
 
         # Subtypes are not required to be returned by DNS-SD service type
-        # enumeration. Browse commissionable services and derive the subtype
-        # browse names from the advertised service type and TXT data.
+        # enumeration. Browse commissionable services and derive candidate
+        # subtype browse names from TXT data, then verify those candidates with
+        # direct PTR browses before returning them.
         commissionable_services = await self.get_commissionable_services(
             discovery_timeout_sec=discovery_timeout_sec,
             log_output=False
@@ -445,24 +451,33 @@ class MdnsDiscovery:
 
             discriminator = txt.get('D')
             if discriminator:
-                add_subtype(f"_L{discriminator}._sub.{commissionable_type}")
+                add_candidate_subtype(f"_L{discriminator}._sub.{commissionable_type}")
                 with suppress(ValueError):
-                    add_subtype(f"_S{(int(discriminator) >> 8) & 0x0F}._sub.{commissionable_type}")
+                    add_candidate_subtype(f"_S{(int(discriminator) >> 8) & 0x0F}._sub.{commissionable_type}")
 
             cm = txt.get('CM')
             if cm:
                 with suppress(ValueError):
                     if int(cm) != 0:
-                        add_subtype(f"_CM._sub.{commissionable_type}")
+                        add_candidate_subtype(f"_CM._sub.{commissionable_type}")
 
             vendor_and_product = txt.get('VP')
             if vendor_and_product:
                 vendor_id = vendor_and_product.split('+', 1)[0]
-                add_subtype(f"_V{vendor_id}._sub.{commissionable_type}")
+                add_candidate_subtype(f"_V{vendor_id}._sub.{commissionable_type}")
 
             device_type = txt.get('DT')
             if device_type:
-                add_subtype(f"_T{device_type}._sub.{commissionable_type}")
+                add_candidate_subtype(f"_T{device_type}._sub.{commissionable_type}")
+
+        if candidate_subtypes:
+            ptr_records = await self.get_ptr_records(
+                service_types=candidate_subtypes,
+                discovery_timeout_sec=discovery_timeout_sec,
+                log_output=False,
+            )
+            for ptr_record in ptr_records:
+                add_subtype(ptr_record.service_type)
 
         if log_output:
             log.info(

--- a/src/python_testing/mdns_discovery/mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/mdns_discovery.py
@@ -19,6 +19,7 @@ import json
 import logging
 import time
 from asyncio import Event, Semaphore, create_task, gather, sleep, wait_for
+from contextlib import suppress
 from typing import Optional
 
 from mdns_discovery.data_classes.aaaa_record import AaaaRecord
@@ -445,18 +446,14 @@ class MdnsDiscovery:
             discriminator = txt.get('D')
             if discriminator:
                 add_subtype(f"_L{discriminator}._sub.{commissionable_type}")
-                try:
+                with suppress(ValueError):
                     add_subtype(f"_S{(int(discriminator) >> 8) & 0x0F}._sub.{commissionable_type}")
-                except ValueError:
-                    pass
 
             cm = txt.get('CM')
             if cm:
-                try:
+                with suppress(ValueError):
                     if int(cm) != 0:
                         add_subtype(f"_CM._sub.{commissionable_type}")
-                except ValueError:
-                    pass
 
             vendor_and_product = txt.get('VP')
             if vendor_and_product:

--- a/src/python_testing/mdns_discovery/tests/test_mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/tests/test_mdns_discovery.py
@@ -22,19 +22,47 @@ from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
 
 
 class FakeMdnsDiscovery(MdnsDiscovery):
-    def __init__(self, service_types: list[str], commissionable_services: list[SimpleNamespace]):
+    def __init__(
+        self,
+        service_types: list[str],
+        commissionable_services: list[SimpleNamespace],
+        advertised_subtypes: list[str],
+    ):
         self.service_types = service_types
         self.commissionable_services = commissionable_services
+        self.advertised_subtypes = advertised_subtypes
+        self.ptr_record_queries: list[list[str]] = []
 
-    async def get_all_service_types(self, log_output: bool = False, discovery_timeout_sec: float = 15) -> list[str]:
+    async def get_all_service_types(
+        self,
+        log_output: bool = False,
+        discovery_timeout_sec: float = 15,
+    ) -> list[str]:
         return self.service_types
 
-    async def get_commissionable_services(self, log_output: bool = False, discovery_timeout_sec: float = 15) -> list[SimpleNamespace]:
+    async def get_commissionable_services(
+        self,
+        log_output: bool = False,
+        discovery_timeout_sec: float = 15,
+    ) -> list[SimpleNamespace]:
         return self.commissionable_services
+
+    async def get_ptr_records(
+        self,
+        service_types: list[str],
+        discovery_timeout_sec: float = 15,
+        log_output: bool = False,
+    ) -> list[SimpleNamespace]:
+        self.ptr_record_queries.append(service_types)
+        return [
+            SimpleNamespace(service_type=service_type)
+            for service_type in service_types
+            if service_type in self.advertised_subtypes
+        ]
 
 
 class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
-    async def test_derives_subtypes_when_service_type_enumeration_omits_them(self):
+    async def test_verifies_txt_derived_subtypes_with_ptr_browse(self):
         commissionable_type = MdnsServiceType.COMMISSIONABLE.value
         service_info = SimpleNamespace(
             service_type=commissionable_type,
@@ -46,10 +74,17 @@ class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
             }
         )
 
-        subtypes = await FakeMdnsDiscovery(
+        discovery = FakeMdnsDiscovery(
             service_types=[commissionable_type],
             commissionable_services=[service_info],
-        ).get_commissionable_subtypes()
+            advertised_subtypes=[
+                f"_L3840._sub.{commissionable_type}",
+                f"_S15._sub.{commissionable_type}",
+                f"_CM._sub.{commissionable_type}",
+            ],
+        )
+
+        subtypes = await discovery.get_commissionable_subtypes()
 
         self.assertEqual(
             subtypes,
@@ -57,9 +92,17 @@ class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
                 f"_L3840._sub.{commissionable_type}",
                 f"_S15._sub.{commissionable_type}",
                 f"_CM._sub.{commissionable_type}",
+            ]
+        )
+        self.assertEqual(
+            discovery.ptr_record_queries,
+            [[
+                f"_L3840._sub.{commissionable_type}",
+                f"_S15._sub.{commissionable_type}",
+                f"_CM._sub.{commissionable_type}",
                 f"_V65521._sub.{commissionable_type}",
                 f"_T10._sub.{commissionable_type}",
-            ]
+            ]]
         )
 
     async def test_merges_enumerated_and_discovered_subtypes_without_duplicates(self):
@@ -69,14 +112,17 @@ class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
             txt={'D': '15', 'CM': '0'}
         )
 
-        subtypes = await FakeMdnsDiscovery(
+        discovery = FakeMdnsDiscovery(
             service_types=[
                 commissionable_type,
                 f"_L15._sub.{commissionable_type}",
                 f"_S0._sub.{commissionable_type}",
             ],
             commissionable_services=[service_info],
-        ).get_commissionable_subtypes()
+            advertised_subtypes=[],
+        )
+
+        subtypes = await discovery.get_commissionable_subtypes()
 
         self.assertEqual(
             subtypes,
@@ -85,6 +131,7 @@ class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
                 f"_S0._sub.{commissionable_type}",
             ]
         )
+        self.assertEqual(discovery.ptr_record_queries, [])
 
 
 if __name__ == '__main__':

--- a/src/python_testing/mdns_discovery/tests/test_mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/tests/test_mdns_discovery.py
@@ -1,0 +1,91 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import unittest
+from types import SimpleNamespace
+
+from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
+
+
+class FakeMdnsDiscovery(MdnsDiscovery):
+    def __init__(self, service_types: list[str], commissionable_services: list[SimpleNamespace]):
+        self.service_types = service_types
+        self.commissionable_services = commissionable_services
+
+    async def get_all_service_types(self, log_output: bool = False, discovery_timeout_sec: float = 15) -> list[str]:
+        return self.service_types
+
+    async def get_commissionable_services(self, log_output: bool = False, discovery_timeout_sec: float = 15) -> list[SimpleNamespace]:
+        return self.commissionable_services
+
+
+class TestGetCommissionableSubtypes(unittest.IsolatedAsyncioTestCase):
+    async def test_derives_subtypes_when_service_type_enumeration_omits_them(self):
+        commissionable_type = MdnsServiceType.COMMISSIONABLE.value
+        service_info = SimpleNamespace(
+            service_type=commissionable_type,
+            txt={
+                'D': '3840',
+                'CM': '2',
+                'VP': '65521+32769',
+                'DT': '10',
+            }
+        )
+
+        subtypes = await FakeMdnsDiscovery(
+            service_types=[commissionable_type],
+            commissionable_services=[service_info],
+        ).get_commissionable_subtypes()
+
+        self.assertEqual(
+            subtypes,
+            [
+                f"_L3840._sub.{commissionable_type}",
+                f"_S15._sub.{commissionable_type}",
+                f"_CM._sub.{commissionable_type}",
+                f"_V65521._sub.{commissionable_type}",
+                f"_T10._sub.{commissionable_type}",
+            ]
+        )
+
+    async def test_merges_enumerated_and_discovered_subtypes_without_duplicates(self):
+        commissionable_type = MdnsServiceType.COMMISSIONABLE.value
+        service_info = SimpleNamespace(
+            service_type=f"_L15._sub.{commissionable_type}",
+            txt={'D': '15', 'CM': '0'}
+        )
+
+        subtypes = await FakeMdnsDiscovery(
+            service_types=[
+                commissionable_type,
+                f"_L15._sub.{commissionable_type}",
+                f"_S0._sub.{commissionable_type}",
+            ],
+            commissionable_services=[service_info],
+        ).get_commissionable_subtypes()
+
+        self.assertEqual(
+            subtypes,
+            [
+                f"_L15._sub.{commissionable_type}",
+                f"_S0._sub.{commissionable_type}",
+            ]
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

Derive commissionable subtype browse names from discovered commissionable service TXT records when DNS-SD service type enumeration does not return subtype browse names.

### Related issues

#72928

### Testing

Add test_mdns_discovery.py
