### PR TITLE
[NXP] Update chip-build-nxp-zephyr Docker image to Zephyr 4.4

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-202 : [Silabs] Update Silabs Zephyr Docker image (86c6d6a)
+203 : [NXP] Update NXP Zephyr Docker image to Zephyr 4.4 (nxp-v4.4.1.1)

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -10,8 +10,8 @@ RUN set -x \
 
 WORKDIR /opt/nxp-zephyr
 RUN set -x \
-    && ZEPHYR_SDK_VERSION=0.17.4 \
-    && NXP_ZSDK_VERSION=nxp-v4.3.0 \
+    && ZEPHYR_SDK_VERSION=1.0.1 \
+    && NXP_ZSDK_VERSION=nxp-v4.4.1.1 \
     && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz | tar -xJ \
     && zephyr-sdk-${ZEPHYR_SDK_VERSION}/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
@@ -23,10 +23,10 @@ RUN set -x \
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
-COPY --from=build /opt/nxp-zephyr/zephyr-sdk-0.17.4/ /opt/nxp-zephyr/zephyr-sdk-0.17.4/
+COPY --from=build /opt/nxp-zephyr/zephyr-sdk-1.0.1/ /opt/nxp-zephyr/zephyr-sdk-1.0.1/
 COPY --from=build /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
 
 WORKDIR /opt/nxp-zephyr
 
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
-ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.17.4
+ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-1.0.1


### PR DESCRIPTION
#### Summary

Updates the `chip-build-nxp-zephyr` Docker image to Zephyr 4.4, so NXP Matter
Zephyr examples can be built in CI against the newer Zephyr baseline.

#### Changes

- `integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile`
  - Bump the NXP ZSDK manifest from `nxp-v4.3.0` to `nxp-v4.4.1.1`
    (Zephyr 4.4.1).
  - Bump the Zephyr SDK from `0.17.4` to `1.0.1`, which is the toolchain
    version required by Zephyr 4.4 (`zephyr/SDK_VERSION`).
  - Update the `COPY` paths and `ZEPHYR_NXP_SDK_INSTALL_DIR` accordingly.
- `integrations/docker/images/base/chip-build/version`
  - Bump `202` -> `203` so the updated image is rebuilt and published.

#### Notes

- The `.github/workflows/examples-nxp.yaml` reference is intentionally left on
  its current tag in this PR. Repointing the Zephyr CI job to the new image
  will be done in a follow-up, once the NXP platform-layer changes required to
  support Zephyr 4.4 are in place. This PR only produces/publishes the new
  build image.

#### Testing

- Zephyr 4.4.1 has been tested with the NXP Zephyr examples separately. Those
  examples require additional platform-layer changes that will be submitted
  shortly after this PR, at which point the CI workflow will be repointed to
  the new image.
