### PR TITLE
[NXP][Zephyr] Switch NXP Zephyr examples to Zephyr 4.4

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -147,7 +147,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:200
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:203
 
         steps:
             - name: Checkout

--- a/config/nxp/app/bootloader.conf
+++ b/config/nxp/app/bootloader.conf
@@ -23,3 +23,6 @@
 #CONFIG_BOOT_SIGNATURE_KEY_FILE="root-rsa-2048.pem"
 
 CONFIG_BOOT_MAX_IMG_SECTORS=2048
+# The default upgrade mode of MCUboot has changed to swap using offset,
+# so we need to explicitly select swap using move to enable it.
+CONFIG_BOOT_SWAP_USING_MOVE=y

--- a/config/nxp/chip-module/Kconfig
+++ b/config/nxp/chip-module/Kconfig
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-if SOC_FAMILY_NXP_RW
+if SOC_FAMILY_NXP_RW || SOC_FAMILY_MCXW
 
 rsource "../cmake/Kconfig.matter.nxp"
 
@@ -53,4 +53,4 @@ if CHIP_APP_OPERATIONAL_KEYSTORE
 	endchoice # CHIP_APP_OPERATIONAL_KEYSTORE_SELECTION
 endif # CHIP_APP_OPERATIONAL_KEYSTORE
 
-endif # SOC_FAMILY_NXP_RW
+endif # SOC_FAMILY_NXP_RW || SOC_FAMILY_MCXW

--- a/config/nxp/chip-module/Kconfig
+++ b/config/nxp/chip-module/Kconfig
@@ -18,6 +18,22 @@ if SOC_FAMILY_NXP_RW
 
 rsource "../cmake/Kconfig.matter.nxp"
 
+# These options should be moved to a common application layer Kconfig file, which does not exist yet.
+# For now, they are added here to avoid dupplication in the different application Kconfig files.
+config CHIP_APP_IDENTIFY
+    bool "App Identify"
+    default y
+    help
+      Enable application common clusters implementation for the Identify cluster.
+      Registers the Identify Clusters only for CHIP_APP_IDENTIFY_ENDPOINT.
+      If needed, specific application code must register the cluster for the other endpoints.
+
+config CHIP_APP_IDENTIFY_ENDPOINT
+	int "Endpoint ID for Identify cluster"
+	default 1
+	help
+      Set the endpoint ID for the Identify cluster implementation.
+
 config CHIP_APP_OPERATIONAL_KEYSTORE
 	bool "Use custom implementation of operational keystore"
 	default y if CHIP_SE05X

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -118,6 +118,9 @@ config LOG_BACKEND_UART
 config SHELL_LOG_BACKEND
 	default n
 
+config LOG_RUNTIME_DEFAULT_LEVEL
+	default 4 #debug
+
 endif # LOG_MODE_DEFERRED
 
 config LOG_BUFFER_SIZE
@@ -544,7 +547,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2048 if CHIP_WIFI
 
 choice LIBC_IMPLEMENTATION
-	default NEWLIB_LIBC
+	default PICOLIBC
 endchoice
 
 if CHIP_ETHERNET
@@ -567,9 +570,6 @@ config MBEDTLS_USER_CONFIG_ENABLE
 config MBEDTLS_ENTROPY_C
 	default y
 
-config MBEDTLS_ENTROPY_POLL_ZEPHYR
-	default y
-
 config MBEDTLS_SSL_MAX_CONTENT_LEN
 	default 8192
 
@@ -579,26 +579,11 @@ config MBEDTLS_ENABLE_HEAP
 config MBEDTLS_HEAP_SIZE
 	default 15360
 
-config MBEDTLS_CIPHER_AES_ENABLED
-	default y
-
-config MBEDTLS_CIPHER_CCM_ENABLED
-	default y
-
 config MBEDTLS_CTR_DRBG_C
 	default y
 
-config MBEDTLS_CIPHER_MODE_CBC_ENABLED
+config MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 	default y
-
-config MBEDTLS_ECP_C
-	default y
-
-config MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	default y
-
-config MBEDTLS_HKDF_C
-    default y
 
 choice CHIP_CRYPTO
     default CHIP_CRYPTO_PSA

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -235,6 +235,9 @@ config NET_TC_TX_SKIP_FOR_HIGH_PRIO
 config NET_CONTEXT_PRIORITY
 	default y
 
+config NET_CONTEXT_RECV_PKTINFO
+	default y
+
 # Network buffers
 config NET_PKT_RX_COUNT
 	default 14

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -638,6 +638,16 @@ choice CHIP_CRYPTO
 
 endchoice
 
+if CHIP_CRYPTO_PSA
+
+config MBEDTLS_PSA_CRYPTO_STORAGE_C
+	default y
+
+config SECURE_STORAGE
+	default y
+
+endif # CHIP_CRYPTO_PSA
+
 config WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
 	default y if WIFI_NM_WPA_SUPPLICANT && CHIP_CRYPTO_PSA
 

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -47,6 +47,7 @@ config CHIP_TASK_PRIORITY
 	default 5
 
 config CHIP_TASK_STACK_SIZE
+	default 13312 if CHIP_SE05X  # Increase is due to the additional middle-ware APDU buffers and Zephyr
 	default 10240
 
 config MAX_EVENT_QUEUE_SIZE
@@ -178,13 +179,6 @@ config MAIN_STACK_SIZE
 	default 16384 if CHIP_SE05X  # Increase is due to the additional middle-ware APDU buffers and Zephyr
 	default 6144 if NET_L2_OPENTHREAD
 	default 3072
-
-config CHIP_TASK_STACK_SIZE
-	int "Matter task stack size"
-	default 13312 if CHIP_SE05X  # Increase is due to the additional middle-ware APDU buffers and Zephyr
-	default 8192
-	help
-	  Set the stack size (in bytes) for the chip task (CHIP event loop).
 	  
 # AEAD ITS transform module encryption key provider
 choice SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER
@@ -704,17 +698,9 @@ choice POSIX_AEP_CHOICE
 endchoice
 
 config CHIP_SE05X
-	bool "Enable SE05X secure element support"
 	select SE05X_LIB
 	select I2C
 	select PINCTRL
-	help
-		Enable support for NXP SE05X secure element.
-		The SE05X provides hardware-based cryptographic operations,
-		secure key storage, and device attestation capabilities.
-		When enabled, cryptographic operations (ECDSA, ECDH, etc.)
-		will be offloaded to the SE05X hardware instead of using
-		software implementations.
 
 endif # CHIP
 

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -18,7 +18,7 @@
 # This file only changes defaults and thus all symbols here must be promptless
 # and safeguarded so that they only are applied when building Matter.
 
-if SOC_FAMILY_NXP_RW
+if SOC_FAMILY_NXP_RW || SOC_FAMILY_MCXW
 
 if CHIP
 
@@ -142,7 +142,7 @@ config LOG_DEFAULT_LEVEL
 config CHIP_LOG_SIZE_OPTIMIZATION
 	default y
 
-endif
+endif # LOG
 
 config PRINTK_SYNC
 	default y
@@ -185,6 +185,11 @@ config CHIP_TASK_STACK_SIZE
 	default 8192
 	help
 	  Set the stack size (in bytes) for the chip task (CHIP event loop).
+	  
+# AEAD ITS transform module encryption key provider
+choice SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER
+	default SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_ENTRY_UID_HASH if SOC_SERIES_MCXW7XX
+endchoice
 
 config INIT_STACKS
 	default y
@@ -274,13 +279,46 @@ config OPENTHREAD_PING_SENDER
 config OPENTHREAD_SLAAC
 	default y
 
-# Increase number of message buffers in the buffer pool
+# Number of message buffers in the buffer pool
 config OPENTHREAD_NUM_MESSAGE_BUFFERS
+	default 30 if SOC_SERIES_MCXW7XX
 	default 256
 
 # Enable IPv6 fragmentation support
 config OPENTHREAD_IP6_FRAGM
 	default y
+
+# Enable CSL Receiver support
+config OPENTHREAD_CSL_RECEIVER
+	default y if SOC_SERIES_MCXW7XX
+
+# CSL receiver wake up margin in microseconds
+config OPENTHREAD_CSL_RECEIVE_TIME_AHEAD
+	default 2500 if SOC_SERIES_MCXW7XX
+
+# CSL transmitter request time ahead
+config OPENTHREAD_CSL_REQUEST_TIME_AHEAD
+	default 2500 if SOC_SERIES_MCXW7XX
+
+# Minimum receiving time before start of MHR
+config OPENTHREAD_MIN_RECEIVE_ON_AHEAD
+	default 320 if SOC_SERIES_MCXW7XX
+
+# Minimum receiving time after start of MHR
+config OPENTHREAD_MIN_RECEIVE_ON_AFTER
+	default 64 if SOC_SERIES_MCXW7XX
+
+# Software transmission security logic
+config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
+	default n if SOC_SERIES_MCXW7XX
+
+# Enable Domain Unicast Address feature
+config OPENTHREAD_DUA
+	default y if SOC_SERIES_MCXW7XX
+
+# Enable Multicast Listener Registration support
+config OPENTHREAD_MLR
+	default y if SOC_SERIES_MCXW7XX
 
 if OPENTHREAD_DEBUG
 
@@ -543,9 +581,11 @@ config LOG_PROCESS_THREAD_STACK_SIZE
 	default 1536
 
 config HEAP_MEM_POOL_SIZE
+	default 25600 if SOC_SERIES_MCXW7XX
 	default 122880
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
+	default 8192 if SOC_SERIES_MCXW7XX # 8 kB
 	default 28672 # 28 kB
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
@@ -577,12 +617,14 @@ config MBEDTLS_ENTROPY_C
 	default y
 
 config MBEDTLS_SSL_MAX_CONTENT_LEN
+	default 768 if SOC_SERIES_MCXW7XX
 	default 8192
 
 config MBEDTLS_ENABLE_HEAP
 	default y
 
 config MBEDTLS_HEAP_SIZE
+	default 8192 if SOC_SERIES_MCXW7XX
 	default 15360
 
 config MBEDTLS_CTR_DRBG_C
@@ -666,4 +708,4 @@ config CHIP_SE05X
 
 endif # CHIP
 
-endif # SOC_FAMILY_NXP_RW
+endif # SOC_FAMILY_NXP_RW || SOC_FAMILY_MCXW

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -46,6 +46,9 @@ config CHIP_SYSTEM_USE_ZEPHYR_SOCKET_EXTENSIONS
 config CHIP_TASK_PRIORITY
 	default 5
 
+config CHIP_TASK_STACK_SIZE
+	default 10240
+
 config MAX_EVENT_QUEUE_SIZE
 	default 64
 

--- a/config/nxp/cmake/Kconfig.matter.nxp
+++ b/config/nxp/cmake/Kconfig.matter.nxp
@@ -188,6 +188,12 @@ config CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 		The application can provide its own singleton, for example by creating
 		a class that inherits from FactoryDataProviderImpl and overrides only the methods that need customization.
 
+config NXP_FACTORY_DAC_BLOB_GENERATION
+	bool "Enable factory DAC private key blob generation"
+	help
+		Enable factory DAC private key blob generation for secure storage.
+		To be used only during factory process.
+
 endif
 
 if CHIP_FACTORY_DATA_BUILD

--- a/docs/platforms/nxp/nxp_zephyr_guide.md
+++ b/docs/platforms/nxp/nxp_zephyr_guide.md
@@ -65,8 +65,8 @@ $ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp
 > not upstream yet. While you can decide to use nxp-zsdk top of tree, we
 > recommend using a proper release tag delivered by NXP. This will ensure a
 > certain level of quality of the nxp-zsdk in use. Currently, we highly
-> recommend using the `nxp-v4.4.1.1` tag, based on Zephyr 4.4.1 release. Reach to
-> your NXP contact for more details.
+> recommend using the `nxp-v4.4.1.1` tag, based on Zephyr 4.4.1 release. Reach
+> to your NXP contact for more details.
 
 Steps to build the example:
 

--- a/docs/platforms/nxp/nxp_zephyr_guide.md
+++ b/docs/platforms/nxp/nxp_zephyr_guide.md
@@ -57,7 +57,7 @@ Prerequisites:
     follows:
 
 ```shell
-$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.3.0
+$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.4.1.1
 ```
 
 > **Note**: While some of NXP platforms are supported in Zephyr upstream, we
@@ -65,7 +65,7 @@ $ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp
 > not upstream yet. While you can decide to use nxp-zsdk top of tree, we
 > recommend using a proper release tag delivered by NXP. This will ensure a
 > certain level of quality of the nxp-zsdk in use. Currently, we highly
-> recommend using the `nxp-v4.3.0` tag, based on Zephyr 4.3 release. Reach to
+> recommend using the `nxp-v4.4.1.1` tag, based on Zephyr 4.4.1 release. Reach to
 > your NXP contact for more details.
 
 Steps to build the example:

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -21,6 +21,7 @@ get_filename_component(ALL_CLUSTERS_COMMON_DIR ${CHIP_ROOT}/examples/all-cluster
 get_filename_component(ALL_CLUSTERS_NXP_COMMON_DIR ${CHIP_ROOT}/examples/all-clusters-app/nxp/common REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_COMMON_DIR ${CHIP_ROOT}/examples/platform/nxp/common REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_ZEPHYR_DIR ${CHIP_ROOT}/examples/platform/nxp/zephyr REALPATH)
+get_filename_component(NXP_MATTER_SUPPORT_DIR ${CHIP_ROOT}/third_party/nxp/nxp_matter_support REALPATH)
 
 # Perform common operations like detecting extra overlays in the platform folder for the target board
 # This must be called before find_package(Zephyr)
@@ -107,6 +108,14 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
+    if (CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION)
+        target_sources(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc/ELSFactoryData.c
+        )
+        target_include_directories(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc
+        )
+    endif()
 endif()
 
 chip_configure_data_model(app

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -73,6 +73,15 @@ target_sources(app
     ${EXAMPLE_PLATFORM_NXP_ZEPHYR_DIR}/factory_data/source/AppFactoryDataExample.cpp
 )
 
+if(CONFIG_CHIP_APP_IDENTIFY)
+    target_include_directories(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/include
+    )
+    target_sources(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/source/Identify.cpp
+    )
+endif()
+
 if(CONFIG_CHIP_CUSTOM_BLE_ADV_DATA)
     target_sources(app PRIVATE
                     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_ble/source/BleZephyrManagerApp.cpp

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -83,36 +83,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	w25q512jvfiq: w25q512jvfiq@0 {
-		status = "okay";
+&w25q512jvfiq {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -58,36 +58,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	mx25u51245g: mx25u51245g@0 {
-		status = "okay";
+&mx25u51245g {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -21,6 +21,7 @@ get_filename_component(ALL_CLUSTERS_COMMON_DIR ${CHIP_ROOT}/examples/all-cluster
 get_filename_component(LAUNDRY_WASHER_NXP_COMMON_DIR ${CHIP_ROOT}/examples/laundry-washer-app/nxp/common REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_COMMON_DIR ${CHIP_ROOT}/examples/platform/nxp/common REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_ZEPHYR_DIR ${CHIP_ROOT}/examples/platform/nxp/zephyr REALPATH)
+get_filename_component(NXP_MATTER_SUPPORT_DIR ${CHIP_ROOT}/third_party/nxp/nxp_matter_support REALPATH)
 
 # Perform common operations like detecting extra overlays in the platform folder for the target board
 # This must be called before find_package(Zephyr)
@@ -104,6 +105,14 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
+    if (CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION)
+        target_sources(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc/ELSFactoryData.c
+        )
+        target_include_directories(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc
+        )
+    endif()
 endif()
 
 chip_configure_data_model(app

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -70,6 +70,15 @@ target_sources(app
     ${EXAMPLE_PLATFORM_NXP_ZEPHYR_DIR}/factory_data/source/AppFactoryDataExample.cpp
 )
 
+if(CONFIG_CHIP_APP_IDENTIFY)
+    target_include_directories(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/include
+    )
+    target_sources(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/source/Identify.cpp
+    )
+endif()
+
 if(CONFIG_CHIP_CUSTOM_BLE_ADV_DATA)
     target_sources(app PRIVATE
                     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_ble/source/BleZephyrManagerApp.cpp

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -57,36 +57,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	w25q512jvfiq: w25q512jvfiq@0 {
-		status = "okay";
+&w25q512jvfiq {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -58,36 +58,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	mx25u51245g: mx25u51245g@0 {
-		status = "okay";
+&mx25u51245g {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
@@ -63,6 +63,12 @@ public:
      */
     virtual CHIP_ERROR AppMatter_Register(void) override;
 
+    /**
+     * \brief This function is called at the begging of the InitServer function.
+     *
+     */
+    virtual void PreInitMatterServerInstance(void) override;
+
 private:
     void DispatchEvent(const AppEvent & event);
 };

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -113,8 +113,8 @@
 #if CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED
 #include <app/reporting/SynchronizedReportSchedulerImpl.h>
 #endif
-
-#if CONFIG_CHIP_CRYPTO_PSA && CONFIG_APP_FREERTOS_OS
+ 
+#if CONFIG_CHIP_CRYPTO_PSA
 #include <crypto/PSAOperationalKeystore.h>
 #endif
 
@@ -154,7 +154,7 @@ app::Clusters::NetworkCommissioning::Instance
     sNetworkCommissioningInstance(0, chip::NXP::App::GetAppTask().GetEthernetDriverInstance());
 #endif
 
-#if CONFIG_CHIP_CRYPTO_PSA && CONFIG_APP_FREERTOS_OS
+#if CONFIG_CHIP_CRYPTO_PSA
 chip::Crypto::PSAOperationalKeystore sPSAOperationalKeystore{};
 #endif
 
@@ -218,7 +218,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 #if CONFIG_CHIP_APP_OPERATIONAL_KEYSTORE
     initParams.operationalKeystore = chip::NXP::App::OperationalKeystore::GetInstance();
 
-#elif CONFIG_CHIP_CRYPTO_PSA && CONFIG_APP_FREERTOS_OS
+#elif CONFIG_CHIP_CRYPTO_PSA
     initParams.operationalKeystore = &sPSAOperationalKeystore;
 #endif
     (void) initParams.InitializeStaticResourcesBeforeServerInit();

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -113,7 +113,7 @@
 #if CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED
 #include <app/reporting/SynchronizedReportSchedulerImpl.h>
 #endif
- 
+
 #if CONFIG_CHIP_CRYPTO_PSA
 #include <crypto/PSAOperationalKeystore.h>
 #endif

--- a/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
@@ -46,6 +46,13 @@
 #include <platform/Zephyr/DeviceInstanceInfoProviderImpl.h>
 #endif
 
+#if CONFIG_CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#if CONFIG_SOC_FAMILY_NXP_RW
+#include <platform/nxp/common/crypto/S50/S50KeyAllocator.h>
+#endif // CONFIG_SOC_FAMILY_NXP_RW
+#endif // CONFIG_CHIP_CRYPTO_PSA
+
 #include "AppFactoryData.h"
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
@@ -80,6 +87,16 @@ chip::DeviceLayer::NetworkCommissioning::EthernetDriver * chip::NXP::App::AppTas
         &(NetworkCommissioning::NxpEthDriver::Instance()));
 }
 #endif
+
+void chip::NXP::App::AppTaskZephyr::PreInitMatterServerInstance()
+{
+#if CONFIG_CHIP_CRYPTO_PSA && CONFIG_SOC_FAMILY_NXP_RW
+    // Configure the PSA crypto subsystem to use the S50 secure element
+    // for hardware-backed key storage.
+    static chip::DeviceLayer::S50KeyAllocator s50KeyAllocator;
+    chip::Crypto::SetPSAKeyAllocator(&s50KeyAllocator);
+#endif
+}
 
 CHIP_ERROR chip::NXP::App::AppTaskZephyr::AppMatter_Register()
 {

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -22,6 +22,7 @@ get_filename_component(THERMOSTAT_NXP_COMMON_DIR ${CHIP_ROOT}/examples/thermosta
 get_filename_component(THERMOSTAT_NXP_ZAP_DIR ${CHIP_ROOT}/examples/thermostat/nxp/zap REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_COMMON_DIR ${CHIP_ROOT}/examples/platform/nxp/common REALPATH)
 get_filename_component(EXAMPLE_PLATFORM_NXP_ZEPHYR_DIR ${CHIP_ROOT}/examples/platform/nxp/zephyr REALPATH)
+get_filename_component(NXP_MATTER_SUPPORT_DIR ${CHIP_ROOT}/third_party/nxp/nxp_matter_support REALPATH)
 
 # Perform common operations like detecting extra overlays in the platform folder for the target board
 # This must be called before find_package(Zephyr)
@@ -110,6 +111,14 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
+    if (CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION)
+        target_sources(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc/ELSFactoryData.c
+        )
+        target_include_directories(app PRIVATE
+            ${NXP_MATTER_SUPPORT_DIR}/gn_build/rt_sdk/sdk_hook/els_pkc
+        )
+    endif()
 endif()
 
 if(CONFIG_CHIP_WIFI)

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -76,6 +76,15 @@ target_sources(app
     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/icd/source/ICDUtil.cpp
 )
 
+if(CONFIG_CHIP_APP_IDENTIFY)
+    target_include_directories(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/include
+    )
+    target_sources(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/clusters/source/Identify.cpp
+    )
+endif()
+
 if(CONFIG_CHIP_CUSTOM_BLE_ADV_DATA)
     target_sources(app PRIVATE
                     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_ble/source/BleZephyrManagerApp.cpp

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
@@ -83,36 +83,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	w25q512jvfiq: w25q512jvfiq@0 {
-		status = "okay";
+&w25q512jvfiq {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -57,36 +57,36 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	mx25u51245g: mx25u51245g@0 {
-		status = "okay";
+&mx25u51245g {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
-
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
-
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
-
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
-
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
+
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
+
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
+
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
+		};
+
 	};
 };

--- a/src/platform/nxp/common/crypto/S50/S50KeyAllocator.h
+++ b/src/platform/nxp/common/crypto/S50/S50KeyAllocator.h
@@ -26,7 +26,6 @@ public:
     void UpdateKeyAttributes(psa_key_attributes_t & attrs) override
     {
         using namespace chip::Crypto;
-        psa_key_id_t keyId          = psa_get_key_id(&attrs);
         psa_key_lifetime_t lifetime = psa_get_key_lifetime(&attrs);
         psa_key_type_t keyType      = psa_get_key_type(&attrs);
 

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
@@ -52,7 +52,7 @@ static constexpr size_t kSpake2pSalt_MaxBase64Len = BASE64_ENCODED_LEN(chip::Cry
 #ifdef CONFIG_CHIP_NXP_PLATFORM_MCXW72
 static constexpr size_t kDacKeyBlobSize =
     PSA_S200_NON_EL2GO_BLOB_EXPORT_SIZE(PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1), 256);
-#elif defined(CONFIG_CHIP_NXP_PLATFORM_RW61X)
+#elif defined(CONFIG_CHIP_NXP_PLATFORM_RW61X) || defined(CONFIG_SOC_SERIES_RW6XX)
 static constexpr size_t kDacKeyBlobSize = 48;
 #else
 #define kDacKeyBlobSize Crypto::kP256_PrivateKey_Length

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -30,11 +30,22 @@
 #endif // MBEDTLS_VERSION_NUMBER >= 0x04000000
 #include "mbedtls/sha256.h"
 
+#if defined(CONFIG_SOC_SERIES_RW6XX)
+#include "els_pkc_driver.h"
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION)
+#include "ELSFactoryData.h"
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) */
+#endif /* defined(CONFIG_SOC_SERIES_RW6XX) */
+
 /* -------------------------------------------------------------------------- */
 /*                               Private macros                               */
 /* -------------------------------------------------------------------------- */
 
 #define HASH_ID 0xCE47BA5E
+
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+#define DAC_KEY_BLOB_SIZE 48
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
 
 /* -------------------------------------------------------------------------- */
 /*                            Class implementation                            */
@@ -99,52 +110,30 @@ CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * 
     return err;
 }
 
-CHIP_ERROR FactoryDataProviderImpl::SignWithDacKey(const ByteSpan & digestToSign, MutableByteSpan & outSignBuffer)
+void FactoryDataProviderImpl::UpdateKeyAttributes(psa_key_attributes_t & attrs)
 {
-    Crypto::P256ECDSASignature signature;
-    Crypto::P256Keypair keypair;
-
-    VerifyOrReturnError(!outSignBuffer.empty(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(!digestToSign.empty(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(outSignBuffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
-
-    // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
-    // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
-    Crypto::P256PublicKey dacPublicKey;
-    uint16_t certificateSize = 0;
-    uint32_t certificateAddr;
-    ReturnErrorOnFailure(SearchForId(FactoryDataId::kDacCertificateId, NULL, 0, certificateSize, &certificateAddr));
-    MutableByteSpan dacCertSpan((uint8_t *) certificateAddr, certificateSize);
-
-    /* Extract Public Key of DAC certificate from itself */
-    ReturnErrorOnFailure(Crypto::ExtractPubkeyFromX509Cert(dacCertSpan, dacPublicKey));
-
-    /* Get private key of DAC certificate from reserved section */
-    uint16_t keySize = 0;
-    uint32_t keyAddr;
-    ReturnErrorOnFailure(SearchForId(FactoryDataId::kDacPrivateKeyId, NULL, 0, keySize, &keyAddr));
-    MutableByteSpan dacPrivateKeySpan((uint8_t *) keyAddr, keySize);
-
-    ReturnErrorOnFailure(keypair.HazardousOperationLoadKeypairFromRaw(ByteSpan(dacPrivateKeySpan.data(), dacPrivateKeySpan.size()),
-                                                                      ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length())));
-
-    ReturnErrorOnFailure(keypair.ECDSA_sign_msg(digestToSign.data(), digestToSign.size(), signature));
-
-    return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);
+#ifdef CONFIG_SOC_SERIES_RW6XX
+    if (psa_get_key_lifetime(&attrs) == PSA_KEY_LIFETIME_VOLATILE)
+    {
+        psa_set_key_lifetime(&attrs,
+                             PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_LIFETIME_VOLATILE,
+                                                                            PSA_CRYPTO_ELS_PKC_LOCATION_S50_RFC3394_STORAGE));
+    }
+#endif /* CONFIG_SOC_SERIES_RW6XX */
 }
 
 CHIP_ERROR FactoryDataProviderImpl::Init(void)
 {
     int ret;
     CHIP_ERROR res;
-    const struct device * flashDevice;
     uint8_t currentBlock[16];
+    uint8_t calculatedHash[Crypto::kSHA256_Hash_Length];
     off_t factoryDataOffset = PARTITION_OFFSET(factory_partition);
 
-    flashDevice = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+    mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 
     /* Read the factory data header from flash */
-    ret = flash_read(flashDevice, factoryDataOffset, (void *) &mFactoryData, sizeof(FactoryDataProviderImpl::Header));
+    ret = flash_read(mFlashDevice, factoryDataOffset, (void *) &mFactoryData.header, sizeof(Header));
     if (ret != 0)
     {
         return CHIP_ERROR_READ_FAILED;
@@ -156,34 +145,87 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
         return CHIP_ERROR_NOT_FOUND;
     }
 
-    // TODO: add HASH compute + check
+    factoryDataOffset += sizeof(Header);
 
-    factoryDataOffset += sizeof(FactoryDataProviderImpl::Header);
-
-    /* Load the buffer into RAM by reading each 16 bytes blocks */
+    /* First, read data as plaintext */
     for (int i = 0; (uint32_t) i < (mFactoryData.header.size / 16U); i++)
     {
-        ret = flash_read(flashDevice, factoryDataOffset + i * 16, (void *) &currentBlock[0], sizeof(currentBlock));
+        ret = flash_read(mFlashDevice, factoryDataOffset + i * 16, (void *) &mFactoryData.factoryDataBuffer[i * 16], 16);
         if (ret != 0)
         {
             return CHIP_ERROR_READ_FAILED;
         }
+    }
 
+    /* Calculate hash and verify */
+    ReturnErrorOnFailure(Crypto::Hash_SHA256(mFactoryData.factoryDataBuffer, mFactoryData.header.size, calculatedHash));
+    
+    if (memcmp(calculatedHash, mFactoryData.header.hash, kHashLen) != 0)
+    {
+        /* Hash didn't match - data might be encrypted, try to decrypt */
         if (pAesKey != NULL)
         {
-            /* Decrypt data if a key has been set */
-            res = ReadEncryptedData(&mFactoryData.factoryDataBuffer[i * 16], &currentBlock[0]);
-            if (res != CHIP_NO_ERROR)
+            ChipLogProgress(DeviceLayer, "Hash mismatch, attempting decryption...");
+            
+            /* Re-read and decrypt */
+            for (int i = 0; (uint32_t) i < (mFactoryData.header.size / 16U); i++)
             {
-                return res;
+                ret = flash_read(mFlashDevice, factoryDataOffset + i * 16, (void *) &currentBlock[0], 16);
+                if (ret != 0)
+                {
+                    return CHIP_ERROR_READ_FAILED;
+                }
+                
+                res = ReadEncryptedData(&mFactoryData.factoryDataBuffer[i * 16], &currentBlock[0]);
+                if (res != CHIP_NO_ERROR)
+                {
+                    return res;
+                }
             }
+            
+            /* Verify hash after decryption */
+            ReturnErrorOnFailure(Crypto::Hash_SHA256(mFactoryData.factoryDataBuffer, mFactoryData.header.size, calculatedHash));
+            
+            if (memcmp(calculatedHash, mFactoryData.header.hash, kHashLen) != 0)
+            {
+                ChipLogError(DeviceLayer, "Hash verification failed after decryption");
+                return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
+            }
+            
+            ChipLogProgress(DeviceLayer, "Decryption successful, hash verified");
         }
         else
         {
-            /* No key was set, copy the data as is */
-            memcpy(&mFactoryData.factoryDataBuffer[i * 16], &currentBlock[0], sizeof(currentBlock));
+            ChipLogError(DeviceLayer, "Hash verification failed, no encryption key set");
+            return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
         }
     }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Factory data hash verified successfully");
+    }
+
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+    uint16_t keySize = 0;
+
+    ChipLogProgress(DeviceLayer, "Init: only protect DAC private key");
+
+    /* Check whether the kDacPrivateKeyId data is converted or not */
+    ReturnErrorOnFailure(SearchForId(FactoryDataId::kDacPrivateKeyId, NULL, 0, keySize));
+    if (keySize == DAC_KEY_BLOB_SIZE)
+    {
+        /* The kDacPrivateKeyId data is converted already, do nothing */
+        ChipLogProgress(DeviceLayer, "SSS: DAC private key already converted to blob");
+    }
+    else
+    {
+        /* Provision the DAC private key into S50 and the returned wrapped key is stored
+         * in the previous area of factory data, update the hash and re-write the factory data in Flash */
+        ChipLogProgress(DeviceLayer, "SSS: convert DAC private key to blob");
+        els_enable();
+        ReturnLogErrorOnFailure(ELS_ConvertDacKey());
+    }
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
 
     return CHIP_NO_ERROR;
 }
@@ -224,6 +266,131 @@ CHIP_ERROR FactoryDataProviderImpl::ReadEncryptedData(uint8_t * dest, uint8_t * 
 
     return CHIP_NO_ERROR;
 }
+
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+
+CHIP_ERROR FactoryDataProviderImpl::ELS_ConvertDacKey()
+{
+    CHIP_ERROR error                = CHIP_NO_ERROR;
+    size_t blobSize                 = DAC_KEY_BLOB_SIZE;
+    size_t newSize                  = sizeof(Header) + mFactoryData.header.size + (ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD);
+    uint8_t blob[DAC_KEY_BLOB_SIZE] = { 0 };
+    uint32_t keyAddr;
+    off_t factoryDataOffset   = PARTITION_OFFSET(factory_partition);
+    size_t factoryDataSize    = PARTITION_SIZE(factory_partition);
+    int ret;
+
+    uint8_t * data = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(newSize));
+    VerifyOrExit(data != nullptr, error = CHIP_ERROR_NO_MEMORY);
+
+    /* Import plain DAC key and generate the blob */
+    SuccessOrExit(error = ELS_ExportBlob(blob, &blobSize, keyAddr));
+
+    ChipLogProgress(DeviceLayer, "SSS: extracted blob from DAC private key");
+    VerifyOrExit(blobSize == DAC_KEY_BLOB_SIZE, error = CHIP_ERROR_INTERNAL);
+
+    /* Read header from flash */
+    ret = flash_read(mFlashDevice, factoryDataOffset, data, sizeof(Header));
+    VerifyOrExit(ret == 0, error = CHIP_ERROR_READ_FAILED);
+
+    /* Copy factory data buffer after header */
+    memcpy(data + sizeof(Header), mFactoryData.factoryDataBuffer, mFactoryData.header.size);
+    ChipLogProgress(DeviceLayer, "SSS: cached factory data in RAM");
+
+    /* Replace private plain DAC key by the blob into factory data RAM buffer */
+    SuccessOrExit(error = ReplaceWithBlob(data, blob, blobSize, keyAddr));
+    ChipLogProgress(DeviceLayer, "SSS: replaced DAC private key with secured blob");
+
+    /* Erase flash factory data partition */
+    ret = flash_erase(mFlashDevice, factoryDataOffset, factoryDataSize);
+    VerifyOrExit(ret == 0, error = CHIP_ERROR_WRITE_FAILED);
+
+    /* Write new factory data into flash */
+    ret = flash_write(mFlashDevice, factoryDataOffset, data, newSize);
+    VerifyOrExit(ret == 0, error = CHIP_ERROR_WRITE_FAILED);
+    ChipLogProgress(DeviceLayer, "SSS: updated factory data");
+
+    /* Update RAM buffer with new data (remove header section) */
+    memmove(&data[0], &data[sizeof(Header)], newSize - sizeof(Header));
+    memset(mFactoryData.factoryDataBuffer, 0, sizeof(mFactoryData.factoryDataBuffer));
+    memcpy(mFactoryData.factoryDataBuffer, data, newSize - sizeof(Header));
+
+    /* Update factory data payload size */
+    mFactoryData.header.size = newSize - sizeof(Header);
+
+exit:
+    if (data != nullptr)
+    {
+        chip::Platform::MemoryFree(data);
+    }
+    return error;
+}
+
+CHIP_ERROR FactoryDataProviderImpl::ELS_ExportBlob(uint8_t * data, size_t * dataLen, uint32_t & addr)
+{
+    status_t status = STATUS_SUCCESS;
+    uint8_t keyBuf[Crypto::kP256_PrivateKey_Length];
+    uint16_t keySize = 0;
+    MutableByteSpan keySpan(keyBuf);
+
+    /* Search key ID FactoryDataId::kDacPrivateKeyId */
+    ReturnErrorOnFailure(SearchForId(FactoryDataId::kDacPrivateKeyId, keySpan.data(), keySpan.size(), keySize, &addr));
+    keySpan.reduce_size(keySize);
+
+    mcuxClEls_KeyProp_t plain_key_properties = {
+        .word = { .value = MCUXCLELS_KEYPROPERTY_VALUE_SECURE | MCUXCLELS_KEYPROPERTY_VALUE_PRIVILEGED |
+                      MCUXCLELS_KEYPROPERTY_VALUE_KEY_SIZE_256 | MCUXCLELS_KEYPROPERTY_VALUE_KGSRC }
+    };
+
+    mcuxClEls_KeyIndex_t key_index = MCUXCLELS_KEY_SLOTS;
+
+    /* Import plain DAC key into S50 */
+    status = import_plain_key_into_els(keySpan.data(), keySpan.size(), plain_key_properties, &key_index);
+    VerifyOrReturnError(status == STATUS_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "import_plain_key_into_els failed: 0x%08x", status));
+
+    /* ELS generate key blob. The blob created here is one that can be directly imported into ELS again. */
+    status = export_key_from_els(key_index, data, dataLen);
+    VerifyOrReturnError(status == STATUS_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "export_key_from_els failed: 0x%08x", status));
+
+    status = els_delete_key(key_index);
+    VerifyOrReturnError(status == STATUS_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "els_delete_key failed: 0x%08x", status));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FactoryDataProviderImpl::ReplaceWithBlob(uint8_t * data, uint8_t * blob, size_t blobLen, uint32_t KeyAddr)
+{
+    size_t newSize                           = mFactoryData.header.size + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD;
+    FactoryDataProviderImpl::Header * header = reinterpret_cast<FactoryDataProviderImpl::Header *>(data);
+    uint8_t * payload                        = data + sizeof(FactoryDataProviderImpl::Header);
+    uint8_t offset                           = (uint8_t *) (KeyAddr - kValueOffset) - (uint8_t *) &mFactoryData.factoryDataBuffer[0];
+    size_t subsequentDataOffset              = offset + kValueOffset + Crypto::kP256_PrivateKey_Length;
+
+    /* Move subsequent data to make room for the larger blob */
+    memmove(payload + subsequentDataOffset + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD,
+            payload + subsequentDataOffset,
+            mFactoryData.header.size - subsequentDataOffset);
+
+    header->size = newSize;
+
+    /* Update associated TLV length */
+    memcpy(payload + offset + kLengthOffset, (uint16_t *) &blobLen, sizeof(uint16_t));
+
+    /* Replace private plain DAC key by the blob */
+    memcpy(payload + offset + kValueOffset, blob, blobLen);
+
+    /* Update Header with new hash value */
+    uint8_t hash[Crypto::kSHA256_Hash_Length] = { 0 };
+    ReturnErrorOnFailure(Crypto::Hash_SHA256(payload, header->size, hash));
+    memcpy(header->hash, hash, sizeof(header->hash));
+
+    return CHIP_NO_ERROR;
+}
+
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
 
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -276,8 +276,8 @@ CHIP_ERROR FactoryDataProviderImpl::ELS_ConvertDacKey()
     size_t newSize                  = sizeof(Header) + mFactoryData.header.size + (ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD);
     uint8_t blob[DAC_KEY_BLOB_SIZE] = { 0 };
     uint32_t keyAddr;
-    off_t factoryDataOffset   = PARTITION_OFFSET(factory_partition);
-    size_t factoryDataSize    = PARTITION_SIZE(factory_partition);
+    off_t factoryDataOffset = PARTITION_OFFSET(factory_partition);
+    size_t factoryDataSize  = PARTITION_SIZE(factory_partition);
     int ret;
 
     uint8_t * data = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(newSize));
@@ -366,12 +366,11 @@ CHIP_ERROR FactoryDataProviderImpl::ReplaceWithBlob(uint8_t * data, uint8_t * bl
     size_t newSize                           = mFactoryData.header.size + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD;
     FactoryDataProviderImpl::Header * header = reinterpret_cast<FactoryDataProviderImpl::Header *>(data);
     uint8_t * payload                        = data + sizeof(FactoryDataProviderImpl::Header);
-    uint8_t offset                           = (uint8_t *) (KeyAddr - kValueOffset) - (uint8_t *) &mFactoryData.factoryDataBuffer[0];
-    size_t subsequentDataOffset              = offset + kValueOffset + Crypto::kP256_PrivateKey_Length;
+    uint8_t offset              = (uint8_t *) (KeyAddr - kValueOffset) - (uint8_t *) &mFactoryData.factoryDataBuffer[0];
+    size_t subsequentDataOffset = offset + kValueOffset + Crypto::kP256_PrivateKey_Length;
 
     /* Move subsequent data to make room for the larger blob */
-    memmove(payload + subsequentDataOffset + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD,
-            payload + subsequentDataOffset,
+    memmove(payload + subsequentDataOffset + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD, payload + subsequentDataOffset,
             mFactoryData.header.size - subsequentDataOffset);
 
     header->size = newSize;

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -159,14 +159,14 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
 
     /* Calculate hash and verify */
     ReturnErrorOnFailure(Crypto::Hash_SHA256(mFactoryData.factoryDataBuffer, mFactoryData.header.size, calculatedHash));
-    
+
     if (memcmp(calculatedHash, mFactoryData.header.hash, kHashLen) != 0)
     {
         /* Hash didn't match - data might be encrypted, try to decrypt */
         if (pAesKey != NULL)
         {
             ChipLogProgress(DeviceLayer, "Hash mismatch, attempting decryption...");
-            
+
             /* Re-read and decrypt */
             for (int i = 0; (uint32_t) i < (mFactoryData.header.size / 16U); i++)
             {
@@ -175,23 +175,23 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
                 {
                     return CHIP_ERROR_READ_FAILED;
                 }
-                
+
                 res = ReadEncryptedData(&mFactoryData.factoryDataBuffer[i * 16], &currentBlock[0]);
                 if (res != CHIP_NO_ERROR)
                 {
                     return res;
                 }
             }
-            
+
             /* Verify hash after decryption */
             ReturnErrorOnFailure(Crypto::Hash_SHA256(mFactoryData.factoryDataBuffer, mFactoryData.header.size, calculatedHash));
-            
+
             if (memcmp(calculatedHash, mFactoryData.header.hash, kHashLen) != 0)
             {
                 ChipLogError(DeviceLayer, "Hash verification failed after decryption");
                 return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
             }
-            
+
             ChipLogProgress(DeviceLayer, "Decryption successful, hash verified");
         }
         else

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -22,7 +22,12 @@
 #include <platform/nxp/zephyr/FactoryDataProviderImpl.h>
 
 /* mbedtls */
+#include <mbedtls/version.h>
+#if (MBEDTLS_VERSION_NUMBER >= 0x04000000)
+#include "mbedtls/private/aes.h"
+#else
 #include "mbedtls/aes.h"
+#endif // MBEDTLS_VERSION_NUMBER >= 0x04000000
 #include "mbedtls/sha256.h"
 
 /* -------------------------------------------------------------------------- */
@@ -134,7 +139,7 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
     CHIP_ERROR res;
     const struct device * flashDevice;
     uint8_t currentBlock[16];
-    off_t factoryDataOffset = FIXED_PARTITION_OFFSET(factory_partition);
+    off_t factoryDataOffset = PARTITION_OFFSET(factory_partition);
 
     flashDevice = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
@@ -46,7 +46,7 @@ private:
     struct FactoryData
     {
         struct Header header;
-        uint8_t factoryDataBuffer[FIXED_PARTITION_SIZE(factory_partition) - sizeof(struct Header)];
+        uint8_t factoryDataBuffer[PARTITION_SIZE(factory_partition) - sizeof(struct Header)];
     };
 
     FactoryData mFactoryData;

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
@@ -39,8 +39,9 @@ public:
     CHIP_ERROR Init(void);
     CHIP_ERROR SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                            uint32_t * contentAddr = NULL);
-    CHIP_ERROR SignWithDacKey(const ByteSpan & digestToSign, MutableByteSpan & outSignBuffer);
     CHIP_ERROR SetEncryptionMode(EncryptionMode mode);
+
+    void UpdateKeyAttributes(psa_key_attributes_t & attrs) override;
 
 private:
     struct FactoryData
@@ -50,8 +51,15 @@ private:
     };
 
     FactoryData mFactoryData;
+    const struct device * mFlashDevice = nullptr;
 
     CHIP_ERROR ReadEncryptedData(uint8_t * dest, uint8_t * source);
+
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+    CHIP_ERROR ReplaceWithBlob(uint8_t * data, uint8_t * blob, size_t blobLen, uint32_t KeyAddr);
+    CHIP_ERROR ELS_ExportBlob(uint8_t * data, size_t * dataLen, uint32_t & addr);
+    CHIP_ERROR ELS_ConvertDacKey();
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
 };
 
 FactoryDataProvider & FactoryDataPrvdImpl();

--- a/src/test_driver/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/src/test_driver/nxp/zephyr/boards/frdm_rw612.overlay
@@ -48,36 +48,35 @@
 
 &flexspi {
 	status = "okay";
+};
 
-	w25q512jvfiq: w25q512jvfiq@0 {
-		status = "okay";
+&w25q512jvfiq {
+	status = "okay";
 
-		partitions {
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
+		};
 
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 0x440000>;
-			};
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x440000>;
+		};
 
-			slot1_partition: partition@460000 {
-				label = "image-1";
-				reg = <0x00460000 0x440000>;
-			};
+		slot1_partition: partition@460000 {
+			label = "image-1";
+			reg = <0x00460000 0x440000>;
+		};
 
-			storage_partition: partition@3FEF000 {
-				label = "storage";
-				reg = <0x03FEF000 DT_SIZE_K(64)>;
-			};
+		storage_partition: partition@3FEF000 {
+			label = "storage";
+			reg = <0x03FEF000 DT_SIZE_K(64)>;
+		};
 
-			factory_partition: partition@3FFF000 {
-				label = "factory-data";
-				reg = <0x03FFF000 DT_SIZE_K(4)>;
-			};
-
+		factory_partition: partition@3FFF000 {
+			label = "factory-data";
+			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/src/test_driver/nxp/zephyr/main/main.cpp
+++ b/src/test_driver/nxp/zephyr/main/main.cpp
@@ -18,8 +18,8 @@
 #include <lib/support/UnitTest.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <pw_unit_test/framework.h>
-#include <zephyr/settings/settings.h>
 #include <unistd.h>
+#include <zephyr/settings/settings.h>
 
 #include <zephyr/logging/log.h>
 

--- a/src/test_driver/nxp/zephyr/main/main.cpp
+++ b/src/test_driver/nxp/zephyr/main/main.cpp
@@ -19,6 +19,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <pw_unit_test/framework.h>
 #include <zephyr/settings/settings.h>
+#include <unistd.h>
 
 #include <zephyr/logging/log.h>
 

--- a/src/test_driver/nxp/zephyr/prj.conf
+++ b/src/test_driver/nxp/zephyr/prj.conf
@@ -52,3 +52,9 @@ CONFIG_MAIN_STACK_SIZE=8704
 CONFIG_CHIP_ZEPHYR_USE_POSIX_DEFAULT_SOURCE=y
 
 CONFIG_SHELL=n
+
+# The app selects its pw_log backend in CMakeLists.txt (pw_log_basic). Leaving the
+# Kconfig default (PIGWEED_LOG_ZEPHYR) injects pw_log_zephyr into zephyr_interface,
+# which creates a build-graph cycle with the generated heap_constants.h. Forcing
+# PIGWEED_LOG_NONE here breaks that cycle at its source.
+CONFIG_PIGWEED_LOG_NONE=y


### PR DESCRIPTION
### Summary

This PR migrates NXP Zephyr-based examples to Zephyr 4.4 (nxp-v4.4.1.1).

All changes in this PR are required together and cannot be split further due to
inter-dependencies introduced by the Zephyr 4.4 migration.

### Changes

#### Zephyr 4.4 migration
- Remove deprecated mbedTLS Kconfig options
- Switch from NEWLIB to PICOLIBC (NEWLIB removed from Zephyr SDK 1.0)
- Enable `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS` required for legacy ECP crypto support
- Update deprecated entropy Kconfig to `CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY`
- Fix deferred log mode runtime level
- Update factory data files to use `PARTITION_SIZE`
- Remove type declaration in `KCONFIG.defaults`

#### Fixes required by the Zephyr 4.4 migration
- **Stack overflow**: Increase CHIP task stack size to prevent stack overflow during
  commissioning when factory data is enabled
- **OTA**: Enable `CONFIG_BOOT_SWAP_USING_MOVE` in `bootloader.conf` — MCUBoot changed
  its default upgrade mode to `CONFIG_BOOT_PREFER_SWAP_OFFSET` in Zephyr 4.4, which is
  incompatible with the current flash partitioning
- **IPv6**: Enable `NET_CONTEXT_RECV_PKTINFO` to fix `IPV6_PKTINFO failed: 109` error

#### Security enhancements (RW612)
- Add DAC key protection with S50 secure enclave:
  - DAC key blob generation with ELS
  - `SignWithDacKey` with PSA using common implementation
  - Hash check of factory data during Init
- Support operational key storage with S50 secure enclave

#### CI
- Update `chip-build-nxp-zephyr` docker image to version 203 (Zephyr SDK 1.0.1, nxp-v4.4.1.1)

### Testing
- Tested on NXP RW612 Zephyr platform. To reproduce build: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr -DEXTRA_CONF_FILE=prj_ota.conf"
- OTA update validated with `CONFIG_BOOT_SWAP_USING_MOVE`
- Commissioning with factory data validated