### PR TITLE
Add Media File Management cluster server implementation delegates, updates to ContentLauncher and MediaPlayback

### DIFF
--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -3853,6 +3853,98 @@ cluster ContentAppObserver = 1296 {
   command ContentAppMessage(ContentAppMessageRequest): ContentAppMessageResponse = 0;
 }
 
+/** This cluster provides an interface for managing and sharing media files on devices such as Streaming Speakers, Smart TVs, or other media playback devices. */
+provisional cluster MediaFileManagement = 1297 {
+  revision 1;
+
+  enum FileStatusEnum : enum8 {
+    kSuccess = 0;
+    kInsufficientStorage = 1;
+    kInvalidFileID = 2;
+    kAuthenticationFailed = 3;
+    kFileNotAvailable = 4;
+    kInvalidRequest = 5;
+    kUnsupportedMimeType = 6;
+  }
+
+  bitmap Feature : bitmap32 {
+    kMediaSharing = 0x1;
+  }
+
+  struct FileDescriptionStruct {
+    int64u fileID = 0;
+    char_string<128> name = 1;
+    int64u size = 2;
+    long_char_string<256> mimeType = 3;
+    long_char_string<256> imageUri = 4;
+  }
+
+  provisional info event SharedFilesAdded = 0 {
+    int16u requestID = 0;
+    int16u responseID = 1;
+  }
+
+  provisional readonly attribute access(read: manage) int64u totalStorage = 0;
+  provisional readonly attribute access(read: manage) int64u availableStorage = 1;
+  provisional readonly attribute access(read: manage) FileDescriptionStruct availableFiles[] = 2;
+  provisional readonly attribute access(read: manage) char_string supportedMimeTypes[] = 3;
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+
+  request struct AddFileRequest {
+    char_string<128> name = 0;
+    int64u size = 1;
+    long_char_string<256> mimeType = 2;
+    long_char_string<256> imageUri = 3;
+  }
+
+  response struct AddFileResponse = 1 {
+    FileStatusEnum status = 0;
+    nullable int64u fileID = 1;
+  }
+
+  request struct DeleteFileRequest {
+    int64u fileID = 0;
+  }
+
+  request struct RequestSharedFilesRequest {
+    char_string<128> clientName = 0;
+    int16u requestID = 1;
+    optional nullable char_string supportedMimeTypes[] = 2;
+  }
+
+  request struct GetSharedFileRequest {
+    int16u responseID = 0;
+  }
+
+  response struct GetSharedFileResponse = 5 {
+    FileStatusEnum status = 0;
+    optional nullable FileDescriptionStruct fileDescription = 1;
+  }
+
+  request struct OfferFileRequest {
+    char_string<128> clientName = 0;
+    char_string<128> name = 1;
+    int64u size = 2;
+    long_char_string<256> mimeType = 3;
+    long_char_string<256> imageUri = 4;
+  }
+
+  /** Upon receipt, this command SHALL initiate the process of adding a new media file to the device's storage. */
+  command access(invoke: manage) AddFile(AddFileRequest): AddFileResponse = 0;
+  /** Upon receipt, this command SHALL delete the specified media file from the device's storage. */
+  command access(invoke: manage) DeleteFile(DeleteFileRequest): DefaultSuccess = 2;
+  /** Upon receipt, this command SHALL initiate a request for the server to share files with the requesting client. */
+  command RequestSharedFiles(RequestSharedFilesRequest): DefaultSuccess = 3;
+  /** Upon receipt, this command SHALL retrieve information about a file that was previously shared with the requesting client. */
+  command GetSharedFile(GetSharedFileRequest): GetSharedFileResponse = 4;
+  /** Upon receipt, this command SHALL indicate that the requesting client wishes to share a file with the server. */
+  command OfferFile(OfferFileRequest): DefaultSuccess = 6;
+}
+
 endpoint 0 {
   device type ma_rootdevice = 22, version 5;
 
@@ -4269,10 +4361,12 @@ endpoint 1 {
     callback attribute availableAudioTracks;
     callback attribute activeTextTrack;
     callback attribute availableTextTracks;
+    callback attribute availableCommands;
+    callback attribute contentInfo;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 0x003;
+    ram      attribute featureMap default = 0x001F;
     ram      attribute clusterRevision default = 2;
 
     handle command Play;
@@ -4318,13 +4412,18 @@ endpoint 1 {
   }
 
   server cluster ContentLauncher {
+    emits event ContentReplication;
     callback attribute acceptHeader;
     ram      attribute supportedStreamingProtocols;
-    ram      attribute featureMap default = 0x0003;
+    ram      attribute movable default = 0;
+    callback attribute presets;
+    ram      attribute featureMap default = 0x00FF;
     ram      attribute clusterRevision default = 2;
 
     handle command LaunchContent;
     handle command LaunchURL;
+    handle command ContentReplicationRequest;
+    handle command PlayPreset;
   }
 
   server cluster AudioOutput {
@@ -4377,6 +4476,22 @@ endpoint 1 {
     handle command UnblockUnratedContent;
     handle command SetOnDemandRatingThreshold;
     handle command SetScheduledContentRatingThreshold;
+  }
+
+  server cluster MediaFileManagement {
+    emits event SharedFilesAdded;
+    callback attribute totalStorage default = 0;
+    callback attribute availableStorage default = 0;
+    callback attribute availableFiles;
+    callback attribute supportedMimeTypes;
+    ram      attribute featureMap default = 0x0001;
+    ram      attribute clusterRevision default = 1;
+
+    handle command AddFile;
+    handle command DeleteFile;
+    handle command RequestSharedFiles;
+    handle command GetSharedFile;
+    handle command OfferFile;
   }
 }
 endpoint 2 {
@@ -4495,7 +4610,9 @@ endpoint 3 {
     callback attribute availableAudioTracks;
     callback attribute activeTextTrack;
     callback attribute availableTextTracks;
-    ram      attribute featureMap default = 0x0003;
+    callback attribute availableCommands;
+    callback attribute contentInfo;
+    ram      attribute featureMap default = 0x001F;
     ram      attribute clusterRevision default = 1;
 
     handle command Play;
@@ -4525,13 +4642,18 @@ endpoint 3 {
   }
 
   server cluster ContentLauncher {
+    emits event ContentReplication;
     callback attribute acceptHeader;
     ram      attribute supportedStreamingProtocols;
-    ram      attribute featureMap default = 0x0003;
+    ram      attribute movable default = 0;
+    callback attribute presets;
+    ram      attribute featureMap default = 0x00FF;
     ram      attribute clusterRevision default = 1;
 
     handle command LaunchContent;
     handle command LaunchURL;
+    handle command ContentReplicationRequest;
+    handle command PlayPreset;
   }
 
   server cluster ApplicationLauncher {

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -5646,7 +5646,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x003",
+              "defaultValue": "0x001F",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -5663,6 +5663,38 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "2",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AvailableCommands",
+              "code": 11,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ContentInfo",
+              "code": 12,
+              "mfgCode": null,
+              "side": "server",
+              "type": "ContentInfoStruct",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -5922,6 +5954,30 @@
               "source": "server",
               "isIncoming": 0,
               "isEnabled": 1
+            },
+            {
+              "name": "ContentReplicationRequest",
+              "code": 3,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "ContentReplicationResponse",
+              "code": 4,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "PlayPreset",
+              "code": 5,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
             }
           ],
           "attributes": [
@@ -5967,7 +6023,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0003",
+              "defaultValue": "0x00FF",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -5988,6 +6044,47 @@
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0
+            },
+            {
+              "name": "Movable",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "boolean",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "Presets",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ],
+          "events": [
+            {
+              "name": "ContentReplication",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
             }
           ]
         },
@@ -6550,6 +6647,180 @@
           "events": [
             {
               "name": "RemainingScreenTimeExpired",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            }
+          ]
+        },
+        {
+          "name": "Media File Management",
+          "code": 1297,
+          "mfgCode": null,
+          "define": "MEDIA_FILE_MANAGEMENT_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "apiMaturity": "provisional",
+          "commands": [
+            {
+              "name": "AddFile",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "AddFileResponse",
+              "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "DeleteFile",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "RequestSharedFiles",
+              "code": 3,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "GetSharedFile",
+              "code": 4,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "GetSharedFileResponse",
+              "code": 5,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "OfferFile",
+              "code": 6,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "TotalStorage",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int64u",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AvailableStorage",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int64u",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AvailableFiles",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "SupportedMimeTypes",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0x0001",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ],
+          "events": [
+            {
+              "name": "SharedFilesAdded",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -7997,7 +8268,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0003",
+              "defaultValue": "0x001F",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -8017,6 +8288,38 @@
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "AvailableCommands",
+              "code": 11,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ContentInfo",
+              "code": 12,
+              "mfgCode": null,
+              "side": "server",
+              "type": "ContentInfoStruct",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
               "reportableChange": 0
             }
           ],
@@ -8169,6 +8472,30 @@
               "source": "server",
               "isIncoming": 0,
               "isEnabled": 1
+            },
+            {
+              "name": "ContentReplicationRequest",
+              "code": 3,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "ContentReplicationResponse",
+              "code": 4,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "PlayPreset",
+              "code": 5,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
             }
           ],
           "attributes": [
@@ -8214,7 +8541,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0003",
+              "defaultValue": "0x00FF",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -8235,6 +8562,47 @@
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0
+            },
+            {
+              "name": "Movable",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "boolean",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "Presets",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ],
+          "events": [
+            {
+              "name": "ContentReplication",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
             }
           ]
         },

--- a/src/app/clusters/content-launch-server/content-launch-delegate.h
+++ b/src/app/clusters/content-launch-server/content-launch-delegate.h
@@ -46,9 +46,25 @@ public:
     virtual void HandleLaunchUrl(CommandResponseHelper<Commands::LauncherResponse::Type> & helper, const CharSpan & contentUrl,
                                  const CharSpan & displayString, const BrandingInformation & brandingInformation) = 0;
 
+    virtual void HandleContentReplicationRequest(CommandResponseHelper<Commands::ContentReplicationResponse::Type> & helper)
+    {
+        Commands::ContentReplicationResponse::Type response;
+        (void) helper.Success(response);
+    }
+
+    virtual void HandlePlayPreset(CommandResponseHelper<Commands::LauncherResponse::Type> & helper, uint16_t presetID)
+    {
+        Commands::LauncherResponse::Type response;
+        response.status = StatusEnum::kURLNotAvailable;
+        (void) helper.Success(response);
+    }
+
     virtual CHIP_ERROR HandleGetAcceptHeaderList(app::AttributeValueEncoder & aEncoder) = 0;
 
     virtual uint32_t HandleGetSupportedStreamingProtocols() = 0;
+
+    virtual bool HandleGetMovable() { return false; }
+    virtual CHIP_ERROR HandleGetPresets(app::AttributeValueEncoder & aEncoder) { return aEncoder.EncodeEmptyList(); }
 
     bool HasFeature(chip::EndpointId endpoint, Feature feature);
     virtual uint32_t GetFeatureMap(chip::EndpointId endpoint)      = 0;

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -282,6 +282,21 @@ exit:
     return true;
 }
 
+bool emberAfContentLauncherClusterContentReplicationRequestCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const ContentLauncher::Commands::ContentReplicationRequest::DecodableType & commandData)
+{
+    commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+    return true;
+}
+
+bool emberAfContentLauncherClusterPlayPresetCallback(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+                                                     const ContentLauncher::Commands::PlayPreset::DecodableType & commandData)
+{
+    commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+    return true;
+}
+
 // -----------------------------------------------------------------------------
 // Plugin initialization
 

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -159,6 +159,20 @@ CHIP_ERROR ContentLauncherAttrAccess::Read(const app::ConcreteReadAttributePath 
 
         return ReadSupportedStreamingProtocolsAttribute(aEncoder, delegate);
     }
+    case app::Clusters::ContentLauncher::Attributes::Movable::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.Encode(false);
+        }
+        return aEncoder.Encode(delegate->HandleGetMovable());
+    }
+    case app::Clusters::ContentLauncher::Attributes::Presets::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.EncodeEmptyList();
+        }
+        return delegate->HandleGetPresets(aEncoder);
+    }
     case app::Clusters::ContentLauncher::Attributes::FeatureMap::Id: {
         if (isDelegateNull(delegate, endpoint))
         {
@@ -286,14 +300,48 @@ bool emberAfContentLauncherClusterContentReplicationRequestCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
     const ContentLauncher::Commands::ContentReplicationRequest::DecodableType & commandData)
 {
-    commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    app::CommandResponseHelper<Commands::ContentReplicationResponse::Type> responder(commandObj, commandPath);
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint) || !delegate->HasFeature(endpoint, Feature::kContentReplication))
+    {
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+        return true;
+    }
+
+    delegate->HandleContentReplicationRequest(responder);
+
+    if (!responder.HasSentResponse())
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+    }
+
     return true;
 }
 
 bool emberAfContentLauncherClusterPlayPresetCallback(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                                      const ContentLauncher::Commands::PlayPreset::DecodableType & commandData)
 {
-    commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    app::CommandResponseHelper<Commands::LauncherResponse::Type> responder(commandObj, commandPath);
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint) || !delegate->HasFeature(endpoint, Feature::kPresets))
+    {
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
+        return true;
+    }
+
+    delegate->HandlePlayPreset(responder, commandData.presetID);
+
+    if (!responder.HasSentResponse())
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+    }
+
     return true;
 }
 

--- a/src/app/clusters/media-file-management-server/BUILD.gn
+++ b/src/app/clusters/media-file-management-server/BUILD.gn
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+group("media-file-management-server") {
+}

--- a/src/app/clusters/media-file-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/media-file-management-server/app_config_dependent_sources.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the equivalent to app_config_dependent_sources.gni
+TARGET_SOURCES(
+  ${APP_TARGET}
+  PRIVATE
+    "${CLUSTER_DIR}/media-file-management-delegate.h"
+    "${CLUSTER_DIR}/media-file-management-server.cpp"
+    "${CLUSTER_DIR}/media-file-management-server.h"
+)

--- a/src/app/clusters/media-file-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/media-file-management-server/app_config_dependent_sources.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+app_config_dependent_sources = [
+  "media-file-management-delegate.h",
+  "media-file-management-server.cpp",
+  "media-file-management-server.h",
+]

--- a/src/app/clusters/media-file-management-server/media-file-management-delegate.h
+++ b/src/app/clusters/media-file-management-server/media-file-management-delegate.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeValueEncoder.h>
+#include <app/CommandResponseHelper.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace MediaFileManagement {
+
+using FileDescriptionStruct = Structs::FileDescriptionStruct::Type;
+using AddFileResponseType   = Commands::AddFileResponse::Type;
+using GetSharedFileResponseType = Commands::GetSharedFileResponse::Type;
+
+class Delegate
+{
+public:
+    virtual void HandleAddFile(CommandResponseHelper<AddFileResponseType> & helper, const CharSpan & name, uint64_t size,
+                               const CharSpan & mimeType, const CharSpan & imageUri) = 0;
+
+    virtual void HandleDeleteFile(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, uint64_t fileID) = 0;
+
+    virtual void HandleRequestSharedFiles(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+                                          const CharSpan & clientName, uint16_t requestID,
+                                          const Optional<DataModel::DecodableList<CharSpan>> & supportedMimeTypes) = 0;
+
+    virtual void HandleGetSharedFile(CommandResponseHelper<GetSharedFileResponseType> & helper, uint16_t responseID) = 0;
+
+    virtual void HandleOfferFile(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, const CharSpan & clientName,
+                                 const CharSpan & name, uint64_t size, const CharSpan & mimeType, const CharSpan & imageUri) = 0;
+
+    virtual CHIP_ERROR HandleGetAvailableFiles(app::AttributeValueEncoder & aEncoder) = 0;
+    virtual CHIP_ERROR HandleGetSupportedMimeTypes(app::AttributeValueEncoder & aEncoder) = 0;
+    virtual uint64_t HandleGetTotalStorage() = 0;
+    virtual uint64_t HandleGetAvailableStorage() = 0;
+
+    virtual uint32_t GetFeatureMap(chip::EndpointId endpoint)      = 0;
+    virtual uint16_t GetClusterRevision(chip::EndpointId endpoint) = 0;
+
+    virtual ~Delegate() = default;
+};
+
+} // namespace MediaFileManagement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/media-file-management-server/media-file-management-delegate.h
+++ b/src/app/clusters/media-file-management-server/media-file-management-delegate.h
@@ -41,7 +41,7 @@ public:
 
     virtual void HandleRequestSharedFiles(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                           const CharSpan & clientName, uint16_t requestID,
-                                          const Optional<DataModel::DecodableList<CharSpan>> & supportedMimeTypes) = 0;
+                                          const Optional<DataModel::Nullable<DataModel::DecodableList<CharSpan>>> & supportedMimeTypes) = 0;
 
     virtual void HandleGetSharedFile(CommandResponseHelper<GetSharedFileResponseType> & helper, uint16_t responseID) = 0;
 

--- a/src/app/clusters/media-file-management-server/media-file-management-delegate.h
+++ b/src/app/clusters/media-file-management-server/media-file-management-delegate.h
@@ -27,8 +27,8 @@ namespace app {
 namespace Clusters {
 namespace MediaFileManagement {
 
-using FileDescriptionStruct = Structs::FileDescriptionStruct::Type;
-using AddFileResponseType   = Commands::AddFileResponse::Type;
+using FileDescriptionStruct     = Structs::FileDescriptionStruct::Type;
+using AddFileResponseType       = Commands::AddFileResponse::Type;
 using GetSharedFileResponseType = Commands::GetSharedFileResponse::Type;
 
 class Delegate
@@ -39,19 +39,20 @@ public:
 
     virtual void HandleDeleteFile(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, uint64_t fileID) = 0;
 
-    virtual void HandleRequestSharedFiles(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-                                          const CharSpan & clientName, uint16_t requestID,
-                                          const Optional<DataModel::Nullable<DataModel::DecodableList<CharSpan>>> & supportedMimeTypes) = 0;
+    virtual void
+    HandleRequestSharedFiles(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, const CharSpan & clientName,
+                             uint16_t requestID,
+                             const Optional<DataModel::Nullable<DataModel::DecodableList<CharSpan>>> & supportedMimeTypes) = 0;
 
     virtual void HandleGetSharedFile(CommandResponseHelper<GetSharedFileResponseType> & helper, uint16_t responseID) = 0;
 
     virtual void HandleOfferFile(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, const CharSpan & clientName,
                                  const CharSpan & name, uint64_t size, const CharSpan & mimeType, const CharSpan & imageUri) = 0;
 
-    virtual CHIP_ERROR HandleGetAvailableFiles(app::AttributeValueEncoder & aEncoder) = 0;
+    virtual CHIP_ERROR HandleGetAvailableFiles(app::AttributeValueEncoder & aEncoder)     = 0;
     virtual CHIP_ERROR HandleGetSupportedMimeTypes(app::AttributeValueEncoder & aEncoder) = 0;
-    virtual uint64_t HandleGetTotalStorage() = 0;
-    virtual uint64_t HandleGetAvailableStorage() = 0;
+    virtual uint64_t HandleGetTotalStorage()                                              = 0;
+    virtual uint64_t HandleGetAvailableStorage()                                          = 0;
 
     virtual uint32_t GetFeatureMap(chip::EndpointId endpoint)      = 0;
     virtual uint16_t GetClusterRevision(chip::EndpointId endpoint) = 0;

--- a/src/app/clusters/media-file-management-server/media-file-management-server.cpp
+++ b/src/app/clusters/media-file-management-server/media-file-management-server.cpp
@@ -1,0 +1,266 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "media-file-management-server.h"
+#include "media-file-management-delegate.h"
+
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/CommandHandler.h>
+#include <app/CommandResponseHelper.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/data-model/Encode.h>
+#include <app/util/attribute-storage.h>
+#include <app/util/config.h>
+#include <platform/CHIPDeviceConfig.h>
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::MediaFileManagement;
+using Protocols::InteractionModel::Status;
+
+static constexpr size_t kMediaFileManagementDelegateTableSize =
+    MATTER_DM_MEDIA_FILE_MANAGEMENT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
+static_assert(kMediaFileManagementDelegateTableSize <= kEmberInvalidEndpointIndex,
+              "MediaFileManagement Delegate table size error");
+
+// -----------------------------------------------------------------------------
+// Delegate Implementation
+
+using chip::app::Clusters::MediaFileManagement::Delegate;
+
+namespace {
+
+Delegate * gDelegateTable[kMediaFileManagementDelegateTableSize] = { nullptr };
+
+Delegate * GetDelegate(EndpointId endpoint)
+{
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, MediaFileManagement::Id,
+                                                       MATTER_DM_MEDIA_FILE_MANAGEMENT_CLUSTER_SERVER_ENDPOINT_COUNT);
+    return (ep >= kMediaFileManagementDelegateTableSize ? nullptr : gDelegateTable[ep]);
+}
+
+bool isDelegateNull(Delegate * delegate, EndpointId endpoint)
+{
+    if (delegate == nullptr)
+    {
+        ChipLogProgress(Zcl, "Media File Management has no delegate set for endpoint:%u", endpoint);
+        return true;
+    }
+    return false;
+}
+} // namespace
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace MediaFileManagement {
+
+void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate)
+{
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, MediaFileManagement::Id,
+                                                       MATTER_DM_MEDIA_FILE_MANAGEMENT_CLUSTER_SERVER_ENDPOINT_COUNT);
+    if (ep < kMediaFileManagementDelegateTableSize)
+    {
+        gDelegateTable[ep] = delegate;
+    }
+}
+
+} // namespace MediaFileManagement
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
+// -----------------------------------------------------------------------------
+// Attribute Accessor Implementation
+
+namespace {
+
+class MediaFileManagementAttrAccess : public app::AttributeAccessInterface
+{
+public:
+    MediaFileManagementAttrAccess() :
+        app::AttributeAccessInterface(Optional<EndpointId>::Missing(), chip::app::Clusters::MediaFileManagement::Id)
+    {}
+
+    CHIP_ERROR Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder) override;
+};
+
+MediaFileManagementAttrAccess gMediaFileManagementAttrAccess;
+
+CHIP_ERROR MediaFileManagementAttrAccess::Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder)
+{
+    EndpointId endpoint = aPath.mEndpointId;
+    Delegate * delegate = GetDelegate(endpoint);
+
+    switch (aPath.mAttributeId)
+    {
+    case Attributes::TotalStorage::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.Encode(static_cast<uint64_t>(0));
+        }
+        return aEncoder.Encode(delegate->HandleGetTotalStorage());
+    }
+    case Attributes::AvailableStorage::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.Encode(static_cast<uint64_t>(0));
+        }
+        return aEncoder.Encode(delegate->HandleGetAvailableStorage());
+    }
+    case Attributes::AvailableFiles::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.EncodeEmptyList();
+        }
+        return delegate->HandleGetAvailableFiles(aEncoder);
+    }
+    case Attributes::SupportedMimeTypes::Id: {
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.EncodeEmptyList();
+        }
+        return delegate->HandleGetSupportedMimeTypes(aEncoder);
+    }
+    default: {
+        break;
+    }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+} // anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Matter Framework Callbacks Implementation
+
+bool emberAfMediaFileManagementClusterAddFileCallback(app::CommandHandler * commandObj,
+                                                      const app::ConcreteCommandPath & commandPath,
+                                                      const Commands::AddFile::DecodableType & commandData)
+{
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    app::CommandResponseHelper<Commands::AddFileResponse::Type> responder(commandObj, commandPath);
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint))
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+
+    delegate->HandleAddFile(responder, commandData.name, commandData.size, commandData.mimeType, commandData.imageUri);
+
+    if (!responder.HasSentResponse())
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+    }
+
+    return true;
+}
+
+bool emberAfMediaFileManagementClusterDeleteFileCallback(app::CommandHandler * commandObj,
+                                                         const app::ConcreteCommandPath & commandPath,
+                                                         const Commands::DeleteFile::DecodableType & commandData)
+{
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint))
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+
+    delegate->HandleDeleteFile(commandObj, commandPath, commandData.fileID);
+
+    return true;
+}
+
+bool emberAfMediaFileManagementClusterRequestSharedFilesCallback(app::CommandHandler * commandObj,
+                                                                 const app::ConcreteCommandPath & commandPath,
+                                                                 const Commands::RequestSharedFiles::DecodableType & commandData)
+{
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint))
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+
+    delegate->HandleRequestSharedFiles(commandObj, commandPath, commandData.clientName, commandData.requestID,
+                                       commandData.supportedMimeTypes);
+
+    return true;
+}
+
+bool emberAfMediaFileManagementClusterGetSharedFileCallback(app::CommandHandler * commandObj,
+                                                            const app::ConcreteCommandPath & commandPath,
+                                                            const Commands::GetSharedFile::DecodableType & commandData)
+{
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    app::CommandResponseHelper<Commands::GetSharedFileResponse::Type> responder(commandObj, commandPath);
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint))
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+
+    delegate->HandleGetSharedFile(responder, commandData.responseID);
+
+    if (!responder.HasSentResponse())
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+    }
+
+    return true;
+}
+
+bool emberAfMediaFileManagementClusterOfferFileCallback(app::CommandHandler * commandObj,
+                                                        const app::ConcreteCommandPath & commandPath,
+                                                        const Commands::OfferFile::DecodableType & commandData)
+{
+    EndpointId endpoint = commandPath.mEndpointId;
+
+    Delegate * delegate = GetDelegate(endpoint);
+    if (isDelegateNull(delegate, endpoint))
+    {
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+
+    delegate->HandleOfferFile(commandObj, commandPath, commandData.clientName, commandData.name, commandData.size,
+                              commandData.mimeType, commandData.imageUri);
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// Plugin initialization
+
+void MatterMediaFileManagementPluginServerInitCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Register(&gMediaFileManagementAttrAccess);
+}

--- a/src/app/clusters/media-file-management-server/media-file-management-server.cpp
+++ b/src/app/clusters/media-file-management-server/media-file-management-server.cpp
@@ -36,8 +36,7 @@ using Protocols::InteractionModel::Status;
 
 static constexpr size_t kMediaFileManagementDelegateTableSize =
     MATTER_DM_MEDIA_FILE_MANAGEMENT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
-static_assert(kMediaFileManagementDelegateTableSize <= kEmberInvalidEndpointIndex,
-              "MediaFileManagement Delegate table size error");
+static_assert(kMediaFileManagementDelegateTableSize <= kEmberInvalidEndpointIndex, "MediaFileManagement Delegate table size error");
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation

--- a/src/app/clusters/media-file-management-server/media-file-management-server.h
+++ b/src/app/clusters/media-file-management-server/media-file-management-server.h
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "media-file-management-delegate.h"
+#include <app-common/zap-generated/cluster-objects.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace MediaFileManagement {
+
+void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate);
+
+} // namespace MediaFileManagement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/media-playback-server/media-playback-delegate.h
+++ b/src/app/clusters/media-playback-server/media-playback-delegate.h
@@ -47,6 +47,8 @@ public:
     virtual CHIP_ERROR HandleGetAvailableAudioTracks(app::AttributeValueEncoder & aEncoder) = 0;
     virtual CHIP_ERROR HandleGetActiveTextTrack(app::AttributeValueEncoder & aEncoder)      = 0;
     virtual CHIP_ERROR HandleGetAvailableTextTracks(app::AttributeValueEncoder & aEncoder)  = 0;
+    virtual CHIP_ERROR HandleGetAvailableCommands(app::AttributeValueEncoder & aEncoder) { return aEncoder.EncodeEmptyList(); }
+    virtual CHIP_ERROR HandleGetContentInfo(app::AttributeValueEncoder & aEncoder) { return CHIP_NO_ERROR; }
 
     virtual void HandlePlay(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)               = 0;
     virtual void HandlePause(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)              = 0;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -163,6 +163,9 @@ CHIP_ERROR MediaPlaybackAttrAccess::Read(const app::ConcreteReadAttributePath & 
         case app::Clusters::MediaPlayback::Attributes::AvailableTextTracks::Id: {
             return aEncoder.EncodeEmptyList();
         }
+        case app::Clusters::MediaPlayback::Attributes::AvailableCommands::Id: {
+            return aEncoder.EncodeEmptyList();
+        }
         default: {
             return CHIP_NO_ERROR;
             break;
@@ -194,6 +197,10 @@ CHIP_ERROR MediaPlaybackAttrAccess::Read(const app::ConcreteReadAttributePath & 
         return ReadActiveTextTrackAttribute(aEncoder, delegate);
     case app::Clusters::MediaPlayback::Attributes::AvailableTextTracks::Id:
         return ReadAvailableTextTracksAttribute(aEncoder, delegate);
+    case app::Clusters::MediaPlayback::Attributes::AvailableCommands::Id:
+        return delegate->HandleGetAvailableCommands(aEncoder);
+    case app::Clusters::MediaPlayback::Attributes::ContentInfo::Id:
+        return delegate->HandleGetContentInfo(aEncoder);
     case app::Clusters::ContentLauncher::Attributes::FeatureMap::Id:
         return ReadFeatureFlagAttribute(endpoint, aEncoder, delegate);
     case app::Clusters::AccountLogin::Attributes::ClusterRevision::Id:

--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -237,7 +237,7 @@
         "ELECTRICAL_PROTECTION_ALARM_CLUSTER": [],
         "GROUPCAST_CLUSTER": ["groupcast"],
         "HUMIDISTAT_CLUSTER": ["humidistat-server"],
-        "MEDIA_FILE_MANAGEMENT_CLUSTER": [],
+        "MEDIA_FILE_MANAGEMENT_CLUSTER": ["media-file-management-server"],
         "METER_IDENTIFICATION_CLUSTER": ["meter-identification-server"],
         "MICROWAVE_OVEN_MODE_CLUSTER": ["mode-base-server"],
         "DOOR_LOCK_CLUSTER": ["door-lock-server"],


### PR DESCRIPTION
### Summary
- Add Media File Management cluster (0x0511) server implementation at `src/app/clusters/media-file-management-server/` with delegate interface, server, and build files
- Add Media File Management cluster to tv-app endpoint 1 with all commands, attributes, SharedFilesAdded event, and MediaSharing feature
- Update Content Launcher in tv-app to enable all features (0x00FF) including ContentReplication, ContentQueueing, and Presets
- Add Content Launcher Movable and Presets attributes, ContentReplication event, and new commands (ContentReplicationRequest, PlayPreset)
- Update zap_cluster_list.json to map Media File Management to its server directory

Next step will be to update tv-app implementation of these new features

### Testing
- [x] CI passes (build, lint)
- [x] tv-app builds with new cluster enabled
- [x] Verify chip-tool can discover new cluster attributes and commands