### PR TITLE
fetch_paa_certs_in_dcl.py: include SubjectKeyId in cert filename in order to avoid collisions

### DIFF
--- a/credentials/fetch_paa_certs_from_dcl.py
+++ b/credentials/fetch_paa_certs_from_dcl.py
@@ -82,9 +82,11 @@ def parse_paa_root_certs(cmdpipe, paa_list):
                 paa_list.append(copy.deepcopy(result))
 
 
-def write_cert(certificate, subject):
-    filename = 'dcld_mirror_' + \
-        re.sub('[^a-zA-Z0-9_-]', '', re.sub('[=, ]', '_', subject))
+def write_cert(certificate, subject, subject_key_id):
+    # Include subject_key_id in filename to handle multiple certs with same subject
+    sanitized_subject = re.sub('[^a-zA-Z0-9_-]', '', re.sub('[=, ]', '_', subject))
+    sanitized_skid = re.sub('[^a-zA-Z0-9_-]', '', re.sub('[: ]', '_', subject_key_id))
+    filename = f'dcld_mirror_{sanitized_subject}_{sanitized_skid}'
     with open(filename + '.pem', 'w+') as outfile:
         outfile.write(certificate)
     # convert pem file to der
@@ -166,7 +168,7 @@ def fetch_cd_signing_certs(store_path):
         certificate, subject = get_cert_from_rest(rest_node_url, subject, subject_key_id)
 
         print(f"Downloaded CD signing cert with subject: {subject}")
-        write_cert(certificate, subject)
+        write_cert(certificate, subject, subject_key_id)
 
     os.chdir(original_dir)
 
@@ -220,7 +222,7 @@ def fetch_paa_certs(use_main_net_dcld, use_test_net_dcld, use_main_net_http, use
         certificate = certificate.rstrip('\n')
 
         print(f"Downloaded PAA certificate with subject: {subject}")
-        write_cert(certificate, subject)
+        write_cert(certificate, subject, paa['subjectKeyId'])
 
     os.chdir(original_dir)
 

--- a/src/python_testing/TC_DA_1_7.py
+++ b/src/python_testing/TC_DA_1_7.py
@@ -61,11 +61,11 @@ FORBIDDEN_AKID = [
     bytes_from_hex("6A:FD:22:77:1F:51:1F:EC:BF:16:41:97:67:10:DC:DC:31:A1:71:7E")
 ]
 
-# List of certificate names that are known to have some issues, but not yet
+# List of certificate filename prefixes that are known to have some issues, but not yet
 # updated in DCL. They will fail the test at runtime if seen, but not in CI.
-ALLOWED_SKIPPED_FILENAMES = [
-    "dcld_mirror_SERIALNUMBER_63709380400001_CN_NXP_Matter_Test_PAA_O_NXP_Semiconductors_NV_C_NL.der",
-    "dcld_mirror_SERIALNUMBER_63709330400001_CN_NXP_Matter_PAA_O_NXP_Semiconductors_NV_C_NL.der"
+ALLOWED_SKIPPED_FILENAME_PREFIXES = [
+    "dcld_mirror_SERIALNUMBER_63709380400001_CN_NXP_Matter_Test_PAA_O_NXP_Semiconductors_NV_C_NL",
+    "dcld_mirror_SERIALNUMBER_63709330400001_CN_NXP_Matter_PAA_O_NXP_Semiconductors_NV_C_NL"
 ]
 
 
@@ -88,7 +88,9 @@ def load_all_paa(paa_path: Path) -> dict:
                         paa_by_skid[skid] = (Path(filename).name, paa_cert)
             except (OSError, ValueError) as e:
                 log.error("Failed to load %s: %s", filename, e)
-                if Path(filename).name not in ALLOWED_SKIPPED_FILENAMES:
+                # Check if filename starts with any allowed prefix
+                filename_base = Path(filename).name
+                if not any(filename_base.startswith(prefix) for prefix in ALLOWED_SKIPPED_FILENAME_PREFIXES):
                     log.error("Re-raising error and failing: found new invalid PAA: %s", filename)
                     raise
 


### PR DESCRIPTION
### Summary

Include `SubjectKeyId` into PAA certificate filename in order to avoid collisions for certificates with the same `SubjectId`

### Testing
To be tested against the real device in IDT.
