### PR TITLE
[BDX] Add TCP support for BDX Protocol and adjust max BlockSize

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
@@ -136,7 +136,11 @@ object ChipClient {
   /**
    * Wrapper around [ChipDeviceController.getConnectedDevicePointer] to return the value directly.
    */
-  suspend fun getConnectedDevicePointer(context: Context, nodeId: Long, allowLargePayload: Boolean = false): Long {
+  suspend fun getConnectedDevicePointer(
+    context: Context,
+    nodeId: Long,
+    allowLargePayload: Boolean = false
+  ): Long {
     // TODO (#21539) This is a memory leak because we currently never call
     // releaseConnectedDevicePointer
     // once we are done with the returned device pointer. Memory leak was introduced since the
@@ -147,7 +151,8 @@ object ChipClient {
     return suspendCancellableCoroutine { continuation ->
       getDeviceController(context)
         .getConnectedDevicePointer(
-          nodeId, allowLargePayload,
+          nodeId,
+          allowLargePayload,
           object : GetConnectedDeviceCallback {
             override fun onDeviceConnected(devicePointer: Long) {
               Log.d(TAG, "Got connected device pointer")

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
@@ -136,7 +136,7 @@ object ChipClient {
   /**
    * Wrapper around [ChipDeviceController.getConnectedDevicePointer] to return the value directly.
    */
-  suspend fun getConnectedDevicePointer(context: Context, nodeId: Long): Long {
+  suspend fun getConnectedDevicePointer(context: Context, nodeId: Long, allowLargePayload: Boolean = false): Long {
     // TODO (#21539) This is a memory leak because we currently never call
     // releaseConnectedDevicePointer
     // once we are done with the returned device pointer. Memory leak was introduced since the
@@ -147,7 +147,7 @@ object ChipClient {
     return suspendCancellableCoroutine { continuation ->
       getDeviceController(context)
         .getConnectedDevicePointer(
-          nodeId,
+          nodeId, allowLargePayload,
           object : GetConnectedDeviceCallback {
             override fun onDeviceConnected(devicePointer: Long) {
               Log.d(TAG, "Got connected device pointer")

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
@@ -107,7 +107,7 @@ class OtaProviderClientFragment : Fragment() {
     binding.vendorIdEd.setText(ChipClient.VENDOR_ID.toString())
     binding.delayActionTimeEd.setText("0")
 
-    deviceController.startOTAProvider(otaProviderCallback)
+    deviceController.startOTAProvider(otaProviderCallback, 65535)
     return binding.root
   }
 
@@ -499,9 +499,11 @@ class OtaProviderClientFragment : Fragment() {
   private suspend fun sendAnnounceOTAProviderBtnClick() {
     requireActivity().runOnUiThread { updateOTAStatusBtnClick() }
 
+    val enableLargePayload = binding.enableLargePayload.isChecked
+
     val devicePtr =
       try {
-        ChipClient.getConnectedDevicePointer(requireContext(), addressUpdateFragment.deviceId)
+        ChipClient.getConnectedDevicePointer(requireContext(), addressUpdateFragment.deviceId, enableLargePayload)
       } catch (e: IllegalStateException) {
         Log.d(TAG, "getConnectedDevicePointer exception", e)
         showMessage("Get DevicePointer fail!")

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
@@ -503,7 +503,11 @@ class OtaProviderClientFragment : Fragment() {
 
     val devicePtr =
       try {
-        ChipClient.getConnectedDevicePointer(requireContext(), addressUpdateFragment.deviceId, enableLargePayload)
+        ChipClient.getConnectedDevicePointer(
+          requireContext(),
+          addressUpdateFragment.deviceId,
+          enableLargePayload
+        )
       } catch (e: IllegalStateException) {
         Log.d(TAG, "getConnectedDevicePointer exception", e)
         showMessage("Get DevicePointer fail!")

--- a/examples/android/CHIPTool/app/src/main/res/layout/ota_provider_client_fragment.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/ota_provider_client_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -60,6 +61,18 @@
         android:text="@string/ota_provider_user_consent_needed_text"
         android:textSize="16sp"
         android:layout_below="@id/delayActionTimeTv" />
+
+    <Switch
+        android:id="@+id/enableLargePayload"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="16sp"
+        android:checked="false"
+        android:text="@string/ota_provider_support_large_payload_text"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/delayActionTimeEd"
+        tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <Spinner
         android:id="@+id/titleUserConsentNeededSp"

--- a/examples/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/examples/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -275,13 +275,14 @@
     <string name="ota_provider_query_image_response_status_text">Query Image Response Status</string>
     <string name="ota_provider_delayed_action_time_text">DelayTime</string>
     <string name="ota_provider_user_consent_needed_text">User Consent Needed (bool)</string>
+    <string name="ota_provider_support_large_payload_text">Large Payload</string>
     <string name="ota_provider_read_write_attribute_text">R/W Attribute</string>
     <string name="ota_provider_write_acl_btn_text">Write Acl</string>
     <string name="ota_provider_read_attribute_btn_text">Read</string>
     <string name="ota_provider_write_attribute_btn_text">Write</string>
     <string name="ota_provider_vendorId_text">Vendor ID</string>
     <string name="ota_provider_softwareVersion_text">SW Version</string>
-    <string name="ota_provider_softwareVersion_default_text">1</string>
+    <string name="ota_provider_softwareVersion_default_text">2</string>
     <string name="ota_provider_select_firmware_file_text">Select Firmware</string>
     <string name="ota_provider_update_ota_status_text">Update OTA Status</string>
     <string name="ota_provider_start_firmware_update_text">Start Firmware Update</string>

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -320,9 +320,19 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
         if (mBdxOtaSender.InitializeTransfer(commandObj->GetSubjectDescriptor().fabricIndex,
                                              commandObj->GetSubjectDescriptor().subject) == CHIP_NO_ERROR)
         {
+            uint16_t blockSize = mMaxBDXBlockSize;
+            chip::SessionHandle sessionHandle = commandObj->GetExchangeContext()->GetSessionHandle();
+            if (sessionHandle->AllowsLargePayload())
+            {
+                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+            }
+            else
+            {
+                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+            }
             CHIP_ERROR error =
                 mBdxOtaSender.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender, bdxFlags,
-                                                 mMaxBDXBlockSize, kBdxTimeout, chip::System::Clock::Milliseconds32(mPollInterval));
+                                                 blockSize, kBdxTimeout, chip::System::Clock::Milliseconds32(mPollInterval));
             if (error != CHIP_NO_ERROR)
             {
                 ChipLogError(SoftwareUpdate, "Cannot prepare for transfer: %" CHIP_ERROR_FORMAT, error.Format());

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -320,7 +320,7 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
         if (mBdxOtaSender.InitializeTransfer(commandObj->GetSubjectDescriptor().fabricIndex,
                                              commandObj->GetSubjectDescriptor().subject) == CHIP_NO_ERROR)
         {
-            uint16_t blockSize = mMaxBDXBlockSize;
+            uint16_t blockSize                = mMaxBDXBlockSize;
             chip::SessionHandle sessionHandle = commandObj->GetExchangeContext()->GetSessionHandle();
             if (sessionHandle->AllowsLargePayload())
             {

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -324,11 +324,11 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
             chip::SessionHandle sessionHandle = commandObj->GetExchangeContext()->GetSessionHandle();
             if (sessionHandle->AllowsLargePayload())
             {
-                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - bdx::kDataBlockHeaderSize));
             }
             else
             {
-                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+                blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - bdx::kDataBlockHeaderSize));
             }
             CHIP_ERROR error =
                 mBdxOtaSender.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender, bdxFlags,

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -82,6 +82,7 @@ constexpr uint16_t kOptionPeriodicQueryTimeout = 'p';
 constexpr uint16_t kOptionUserConsentState     = 'u';
 constexpr uint16_t kOptionWatchdogTimeout      = 'w';
 constexpr uint16_t kSkipExecImageFile          = 's';
+constexpr uint16_t kOptionLargePayload         = 'l';
 constexpr size_t kMaxFilePathSize              = 256;
 
 uint32_t gPeriodicQueryTimeoutSec = 0;
@@ -103,6 +104,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "watchdogTimeout", chip::ArgParser::kArgumentRequired, kOptionWatchdogTimeout },
     { "skipExecImageFile", chip::ArgParser::kNoArgument, kSkipExecImageFile },
     { "maxBDXBlockSize", chip::ArgParser::kArgumentRequired, kOptionMaxBDXBlockSize },
+    { "largePayload", chip::ArgParser::kNoArgument, kOptionLargePayload },
     {},
 };
 
@@ -140,6 +142,9 @@ OptionSet cmdLineOptions = {
     "       If none or zero is supplied, the timeout is determined by the driver.\n"
     "  -s, --skipExecImageFile\n"
     "       To only check Notify Update Applied Command, skip the Image File execution.\n"
+    "  -l, --largePayload\n"
+    "       If supplied, enables support for large payloads.\n"
+    "       If a session is not open, it establishes a session using TCP to allow large data transmission.\n"
 };
 
 OptionSet * allOptions[] = { &cmdLineOptions, nullptr };
@@ -310,6 +315,10 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
         {
             gMaxBDXBlockSize = blockSize;
         }
+        break;
+    }
+    case kOptionLargePayload: {
+        gRequestorCore.SetLargePayload(true);
         break;
     }
     default:

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -835,12 +835,12 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager & excha
     if (sessionHandle->AllowsLargePayload())
     {
         initOptions.MaxBlockSize =
-            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     else
     {
         initOptions.MaxBlockSize =
-            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     initOptions.FileDesLength  = static_cast<uint16_t>(mFileDesignator.size());
     initOptions.FileDesignator = reinterpret_cast<const uint8_t *>(mFileDesignator.data());

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -366,7 +366,16 @@ void DefaultOTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
     ChipLogDetail(SoftwareUpdate, "Establishing session to provider node ID 0x" ChipLogFormatX64 " on fabric index %d",
                   ChipLogValueX64(mProviderLocation.Value().providerNodeID), mProviderLocation.Value().fabricIndex);
 
-    mCASESessionManager->FindOrEstablishSession(GetProviderScopedId(), &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    chip::Optional<SessionHandle> sessionHandle = mServer->GetSecureSessionManager().FindSecureSessionForNode(chip::ScopedNodeId(mProviderLocation.Value().providerNodeID, mProviderLocation.Value().fabricIndex));
+    bool supportLargePayload = mSupportLargePayload;
+
+    // If a current session exists and it does not support LargePayload, disable LargePayload support.
+    if (sessionHandle.HasValue() && !sessionHandle.Value()->AllowsLargePayload())
+    {
+        supportLargePayload = false;
+    }
+
+    mCASESessionManager->FindOrEstablishSession(GetProviderScopedId(), &mOnConnectedCallback, &mOnConnectionFailureCallback, supportLargePayload ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload);
 }
 
 void DefaultOTARequestor::DisconnectFromProvider()
@@ -820,7 +829,14 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager & excha
 
     TransferSession::TransferInitData initOptions;
     initOptions.TransferCtlFlags = bdx::TransferControlFlags::kReceiverDrive;
-    initOptions.MaxBlockSize     = mOtaRequestorDriver->GetMaxDownloadBlockSize();
+    if (sessionHandle->AllowsLargePayload())
+    {
+        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+    }
+    else
+    {
+        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+    }
     initOptions.FileDesLength    = static_cast<uint16_t>(mFileDesignator.size());
     initOptions.FileDesignator   = reinterpret_cast<const uint8_t *>(mFileDesignator.data());
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -834,13 +834,13 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager & excha
     initOptions.TransferCtlFlags = bdx::TransferControlFlags::kReceiverDrive;
     if (sessionHandle->AllowsLargePayload())
     {
-        initOptions.MaxBlockSize =
-            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - bdx::kDataBlockHeaderSize));
+        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(),
+                                            static_cast<uint16_t>(kMaxLargeAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     else
     {
-        initOptions.MaxBlockSize =
-            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - bdx::kDataBlockHeaderSize));
+        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(),
+                                            static_cast<uint16_t>(kMaxAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     initOptions.FileDesLength  = static_cast<uint16_t>(mFileDesignator.size());
     initOptions.FileDesignator = reinterpret_cast<const uint8_t *>(mFileDesignator.data());

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -366,7 +366,8 @@ void DefaultOTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
     ChipLogDetail(SoftwareUpdate, "Establishing session to provider node ID 0x" ChipLogFormatX64 " on fabric index %d",
                   ChipLogValueX64(mProviderLocation.Value().providerNodeID), mProviderLocation.Value().fabricIndex);
 
-    chip::Optional<SessionHandle> sessionHandle = mServer->GetSecureSessionManager().FindSecureSessionForNode(chip::ScopedNodeId(mProviderLocation.Value().providerNodeID, mProviderLocation.Value().fabricIndex));
+    chip::Optional<SessionHandle> sessionHandle = mServer->GetSecureSessionManager().FindSecureSessionForNode(
+        chip::ScopedNodeId(mProviderLocation.Value().providerNodeID, mProviderLocation.Value().fabricIndex));
     bool supportLargePayload = mSupportLargePayload;
 
     // If a current session exists and it does not support LargePayload, disable LargePayload support.
@@ -375,7 +376,9 @@ void DefaultOTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
         supportLargePayload = false;
     }
 
-    mCASESessionManager->FindOrEstablishSession(GetProviderScopedId(), &mOnConnectedCallback, &mOnConnectionFailureCallback, supportLargePayload ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload);
+    mCASESessionManager->FindOrEstablishSession(GetProviderScopedId(), &mOnConnectedCallback, &mOnConnectionFailureCallback,
+                                                supportLargePayload ? TransportPayloadCapability::kLargePayload
+                                                                    : TransportPayloadCapability::kMRPPayload);
 }
 
 void DefaultOTARequestor::DisconnectFromProvider()
@@ -831,14 +834,16 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager & excha
     initOptions.TransferCtlFlags = bdx::TransferControlFlags::kReceiverDrive;
     if (sessionHandle->AllowsLargePayload())
     {
-        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+        initOptions.MaxBlockSize =
+            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
     }
     else
     {
-        initOptions.MaxBlockSize = std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+        initOptions.MaxBlockSize =
+            std::min(mOtaRequestorDriver->GetMaxDownloadBlockSize(), static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
     }
-    initOptions.FileDesLength    = static_cast<uint16_t>(mFileDesignator.size());
-    initOptions.FileDesignator   = reinterpret_cast<const uint8_t *>(mFileDesignator.data());
+    initOptions.FileDesLength  = static_cast<uint16_t>(mFileDesignator.size());
+    initOptions.FileDesignator = reinterpret_cast<const uint8_t *>(mFileDesignator.data());
 
     chip::Messaging::ExchangeContext * exchangeCtx = exchangeMgr.NewContext(sessionHandle, &mBdxMessenger);
     VerifyOrReturnError(exchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -119,6 +119,11 @@ public:
         return mAttributes ? mAttributes->GetDefaultOtaProviderListIterator() : ProviderLocationList::Iterator(nullptr, 0);
     }
 
+    void SetLargePayload(bool supportLargePayload)
+    {
+        mSupportLargePayload = supportLargePayload;
+    }
+
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state,
                                 app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason) override;
@@ -356,6 +361,8 @@ private:
     // in the OTARequestorDriver on reboot.
     Optional<ProviderLocationType> mProviderLocation;
     SessionHolder mSessionHolder;
+
+    bool mSupportLargePayload = false;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -119,10 +119,7 @@ public:
         return mAttributes ? mAttributes->GetDefaultOtaProviderListIterator() : ProviderLocationList::Iterator(nullptr, 0);
     }
 
-    void SetLargePayload(bool supportLargePayload)
-    {
-        mSupportLargePayload = supportLargePayload;
-    }
+    void SetLargePayload(bool supportLargePayload) { mSupportLargePayload = supportLargePayload; }
 
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state,

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -700,7 +700,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR AndroidDeviceControllerWrapper::StartOTAProvider(jobject otaProviderDelegate)
+CHIP_ERROR AndroidDeviceControllerWrapper::StartOTAProvider(jobject otaProviderDelegate, uint16_t maxBDXBlockSize)
 {
 #if CHIP_DEVICE_CONFIG_DYNAMIC_SERVER
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -710,7 +710,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::StartOTAProvider(jobject otaProviderD
 
     VerifyOrExit(otaProviderBridge != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    err = otaProviderBridge->Init(systemState->SystemLayer(), systemState->ExchangeMgr(), otaProviderDelegate);
+    err = otaProviderBridge->Init(systemState->SystemLayer(), systemState->ExchangeMgr(), otaProviderDelegate, maxBDXBlockSize);
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(Controller, "OTA Provider Initialize Error : %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -206,7 +206,7 @@ public:
 
     CHIP_ERROR UpdateAttestationTrustStoreBridge(jobject attestationTrustStoreDelegate, jobject cdTrustKeys);
 
-    CHIP_ERROR StartOTAProvider(jobject otaProviderDelegate, uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
+    CHIP_ERROR StartOTAProvider(jobject otaProviderDelegate, uint16_t maxBDXBlockSize = 1024 /* Default BDX Block Size */);
 
     CHIP_ERROR FinishOTAProvider();
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -206,7 +206,7 @@ public:
 
     CHIP_ERROR UpdateAttestationTrustStoreBridge(jobject attestationTrustStoreDelegate, jobject cdTrustKeys);
 
-    CHIP_ERROR StartOTAProvider(jobject otaProviderDelegate);
+    CHIP_ERROR StartOTAProvider(jobject otaProviderDelegate, uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
 
     CHIP_ERROR FinishOTAProvider();
 

--- a/src/controller/java/BdxOTASender.cpp
+++ b/src/controller/java/BdxOTASender.cpp
@@ -48,7 +48,8 @@ CHIP_ERROR BdxOTASender::PrepareForTransfer(FabricIndex fabricIndex, NodeId node
 
     BitFlags<bdx::TransferControlFlags> flags(bdx::TransferControlFlags::kReceiverDrive);
 
-    chip::Optional<SessionHandle> sessionHandle = mExchangeMgr->GetSessionManager()->FindSecureSessionForNode(chip::ScopedNodeId(nodeId, fabricIndex));
+    chip::Optional<SessionHandle> sessionHandle =
+        mExchangeMgr->GetSessionManager()->FindSecureSessionForNode(chip::ScopedNodeId(nodeId, fabricIndex));
     if (!sessionHandle.HasValue())
     {
         return CHIP_ERROR_INCORRECT_STATE;

--- a/src/controller/java/BdxOTASender.cpp
+++ b/src/controller/java/BdxOTASender.cpp
@@ -58,11 +58,11 @@ CHIP_ERROR BdxOTASender::PrepareForTransfer(FabricIndex fabricIndex, NodeId node
     uint16_t blockSize = 0;
     if (sessionHandle.Value()->AllowsLargePayload())
     {
-        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     else
     {
-        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - bdx::kDataBlockHeaderSize));
     }
     return Responder::PrepareForTransfer(mSystemLayer, kBdxRole, flags, blockSize, kBdxTimeout, kBdxPollIntervalMs);
 }

--- a/src/controller/java/BdxOTASender.cpp
+++ b/src/controller/java/BdxOTASender.cpp
@@ -29,9 +29,6 @@ using namespace chip::app;
 using namespace chip::bdx;
 using Protocols::InteractionModel::Status;
 
-// TODO Expose a method onto the delegate to make that configurable.
-constexpr uint32_t kMaxBdxBlockSize = 1024;
-
 // Since the BDX timeout is 5 minutes and we are starting this after query image is available and before the BDX init comes,
 // we just double the timeout to give enough time for the BDX init to come in a reasonable amount of time.
 constexpr System::Clock::Timeout kBdxInitReceivedTimeout = System::Clock::Seconds16(10 * 60);
@@ -50,10 +47,26 @@ CHIP_ERROR BdxOTASender::PrepareForTransfer(FabricIndex fabricIndex, NodeId node
     ReturnErrorOnFailure(ConfigureState(fabricIndex, nodeId));
 
     BitFlags<bdx::TransferControlFlags> flags(bdx::TransferControlFlags::kReceiverDrive);
-    return Responder::PrepareForTransfer(mSystemLayer, kBdxRole, flags, kMaxBdxBlockSize, kBdxTimeout, kBdxPollIntervalMs);
+
+    chip::Optional<SessionHandle> sessionHandle = mExchangeMgr->GetSessionManager()->FindSecureSessionForNode(chip::ScopedNodeId(nodeId, fabricIndex));
+    if (!sessionHandle.HasValue())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    uint16_t blockSize = 0;
+    if (sessionHandle.Value()->AllowsLargePayload())
+    {
+        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxLargeAppMessageLen - kMaxTagLen));
+    }
+    else
+    {
+        blockSize = std::min(mMaxBDXBlockSize, static_cast<uint16_t>(kMaxAppMessageLen - kMaxTagLen));
+    }
+    return Responder::PrepareForTransfer(mSystemLayer, kBdxRole, flags, blockSize, kBdxTimeout, kBdxPollIntervalMs);
 }
 
-CHIP_ERROR BdxOTASender::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeMgr)
+CHIP_ERROR BdxOTASender::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeMgr, uint16_t maxBDXBlockSize)
 {
     assertChipStackLockedByCurrentThread();
 
@@ -66,6 +79,8 @@ CHIP_ERROR BdxOTASender::Init(System::Layer * systemLayer, Messaging::ExchangeMa
 
     mSystemLayer = systemLayer;
     mExchangeMgr = exchangeMgr;
+
+    mMaxBDXBlockSize = maxBDXBlockSize;
 
     return CHIP_NO_ERROR;
 }
@@ -261,8 +276,6 @@ CHIP_ERROR BdxOTASender::OnBlockQuery(TransferSession::OutputEvent & event)
     {
         bytesToSkip = event.bytesToSkip.BytesToSkip;
     }
-
-    // uint64_t transferGeneration = mTransferGeneration;
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 

--- a/src/controller/java/BdxOTASender.h
+++ b/src/controller/java/BdxOTASender.h
@@ -22,7 +22,7 @@
 #include <protocols/bdx/BdxUri.h>
 #include <protocols/bdx/TransferFacilitator.h>
 
-constexpr uint32_t kMaxBDXURILen = 256;
+constexpr uint32_t kMaxBDXURILen        = 256;
 constexpr uint16_t kDefaultBdxBlockSize = 1024;
 
 class BdxOTASender : public chip::bdx::Responder
@@ -34,7 +34,8 @@ public:
 
     CHIP_ERROR PrepareForTransfer(chip::FabricIndex fabricIndex, chip::NodeId nodeId);
 
-    CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeMgr, uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
+    CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeMgr,
+                    uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
 
     CHIP_ERROR Shutdown();
 

--- a/src/controller/java/BdxOTASender.h
+++ b/src/controller/java/BdxOTASender.h
@@ -23,6 +23,7 @@
 #include <protocols/bdx/TransferFacilitator.h>
 
 constexpr uint32_t kMaxBDXURILen = 256;
+constexpr uint16_t kDefaultBdxBlockSize = 1024;
 
 class BdxOTASender : public chip::bdx::Responder
 {
@@ -33,7 +34,7 @@ public:
 
     CHIP_ERROR PrepareForTransfer(chip::FabricIndex fabricIndex, chip::NodeId nodeId);
 
-    CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeMgr);
+    CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeMgr, uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
 
     CHIP_ERROR Shutdown();
 
@@ -73,4 +74,6 @@ private:
     // which transfer we are currently doing, so we can ignore async calls
     // attached to no-longer-running transfers.
     uint64_t mTransferGeneration = 0;
+
+    uint16_t mMaxBDXBlockSize = kDefaultBdxBlockSize;
 };

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -557,7 +557,7 @@ exit:
     }
 }
 
-JNI_METHOD(void, startOTAProvider)(JNIEnv * env, jobject self, jlong handle, jobject otaProviderDelegate)
+JNI_METHOD(void, startOTAProvider)(JNIEnv * env, jobject self, jlong handle, jobject otaProviderDelegate, jint maxBDXBlockSize)
 {
 #if CHIP_DEVICE_CONFIG_DYNAMIC_SERVER
     chip::DeviceLayer::StackLock lock;
@@ -567,7 +567,7 @@ JNI_METHOD(void, startOTAProvider)(JNIEnv * env, jobject self, jlong handle, job
     VerifyOrExit(wrapper != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogProgress(Controller, "startOTAProvider() called");
-    err = wrapper->StartOTAProvider(otaProviderDelegate);
+    err = wrapper->StartOTAProvider(otaProviderDelegate, static_cast<uint16_t>(maxBDXBlockSize));
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -1485,7 +1485,7 @@ JNI_METHOD(jlong, getDeviceBeingCommissionedPointer)(JNIEnv * env, jobject self,
     return reinterpret_cast<jlong>(commissioneeDevice);
 }
 
-JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong handle, jlong nodeId, jlong callbackHandle)
+JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong handle, jlong nodeId, jboolean allowLargePayload, jlong callbackHandle)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -1494,7 +1494,7 @@ JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong ha
     GetConnectedDeviceCallback * connectedDeviceCallback = reinterpret_cast<GetConnectedDeviceCallback *>(callbackHandle);
     VerifyOrExit(connectedDeviceCallback != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     err = wrapper->Controller()->GetConnectedDevice(static_cast<chip::NodeId>(nodeId), &connectedDeviceCallback->mOnSuccess,
-                                                    &connectedDeviceCallback->mOnFailure);
+                                                    &connectedDeviceCallback->mOnFailure, allowLargePayload == JNI_TRUE ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload);
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1485,7 +1485,8 @@ JNI_METHOD(jlong, getDeviceBeingCommissionedPointer)(JNIEnv * env, jobject self,
     return reinterpret_cast<jlong>(commissioneeDevice);
 }
 
-JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong handle, jlong nodeId, jboolean allowLargePayload, jlong callbackHandle)
+JNI_METHOD(void, getConnectedDevicePointer)
+(JNIEnv * env, jobject self, jlong handle, jlong nodeId, jboolean allowLargePayload, jlong callbackHandle)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -1493,8 +1494,9 @@ JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong ha
 
     GetConnectedDeviceCallback * connectedDeviceCallback = reinterpret_cast<GetConnectedDeviceCallback *>(callbackHandle);
     VerifyOrExit(connectedDeviceCallback != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    err = wrapper->Controller()->GetConnectedDevice(static_cast<chip::NodeId>(nodeId), &connectedDeviceCallback->mOnSuccess,
-                                                    &connectedDeviceCallback->mOnFailure, allowLargePayload == JNI_TRUE ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload);
+    err = wrapper->Controller()->GetConnectedDevice(
+        static_cast<chip::NodeId>(nodeId), &connectedDeviceCallback->mOnSuccess, &connectedDeviceCallback->mOnFailure,
+        allowLargePayload == JNI_TRUE ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload);
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -565,6 +565,7 @@ JNI_METHOD(void, startOTAProvider)(JNIEnv * env, jobject self, jlong handle, job
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
     VerifyOrExit(wrapper != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(maxBDXBlockSize >= 1 && maxBDXBlockSize <= 65535, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     ChipLogProgress(Controller, "startOTAProvider() called");
     err = wrapper->StartOTAProvider(otaProviderDelegate, static_cast<uint16_t>(maxBDXBlockSize));

--- a/src/controller/java/OTAProviderDelegateBridge.cpp
+++ b/src/controller/java/OTAProviderDelegateBridge.cpp
@@ -51,13 +51,13 @@ OTAProviderDelegateBridge::~OTAProviderDelegateBridge()
 }
 
 CHIP_ERROR OTAProviderDelegateBridge::Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager,
-                                           jobject otaProviderDelegate)
+                                           jobject otaProviderDelegate, uint16_t maxBDXBlockSize)
 {
     ReturnLogErrorOnFailure(mOtaProviderDelegate.Init(otaProviderDelegate));
 
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this);
     mBdxOTASender = std::make_unique<BdxOTASender>(mOtaProviderDelegate.ObjectRef());
-    return mBdxOTASender->Init(systemLayer, exchangeManager);
+    return mBdxOTASender->Init(systemLayer, exchangeManager, maxBDXBlockSize);
 }
 
 void OTAProviderDelegateBridge::Shutdown()

--- a/src/controller/java/OTAProviderDelegateBridge.h
+++ b/src/controller/java/OTAProviderDelegateBridge.h
@@ -33,7 +33,7 @@ class OTAProviderDelegateBridge : public chip::app::Clusters::OTAProviderDelegat
 public:
     ~OTAProviderDelegateBridge() override;
     CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager,
-                    jobject OTAProviderDelegate);
+                    jobject OTAProviderDelegate, uint16_t maxBDXBlockSize = kDefaultBdxBlockSize);
     void Shutdown();
 
     /**

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -144,7 +144,11 @@ public class ChipDeviceController {
    * @param aOTAProviderDelegate Delegate for OTA Provider
    */
   public void startOTAProvider(OTAProviderDelegate aOTAProviderDelegate) {
-    startOTAProvider(deviceControllerPtr, aOTAProviderDelegate);
+    startOTAProvider(deviceControllerPtr, aOTAProviderDelegate, 1024 /* Default BDX Block Size */);
+  }
+
+  public void startOTAProvider(OTAProviderDelegate aOTAProviderDelegate, int maxBDXBlockSize) {
+    startOTAProvider(deviceControllerPtr, aOTAProviderDelegate, maxBDXBlockSize);
   }
 
   /** Disable OTA Provider server cluster */
@@ -669,7 +673,12 @@ public class ChipDeviceController {
    */
   public void getConnectedDevicePointer(long nodeId, GetConnectedDeviceCallback callback) {
     GetConnectedDeviceCallbackJni jniCallback = new GetConnectedDeviceCallbackJni(callback);
-    getConnectedDevicePointer(deviceControllerPtr, nodeId, jniCallback.getCallbackHandle());
+    getConnectedDevicePointer(deviceControllerPtr, nodeId, false, jniCallback.getCallbackHandle());
+  }
+
+  public void getConnectedDevicePointer(long nodeId, boolean allowLargePayload, GetConnectedDeviceCallback callback) {
+    GetConnectedDeviceCallbackJni jniCallback = new GetConnectedDeviceCallbackJni(callback);
+    getConnectedDevicePointer(deviceControllerPtr, nodeId, allowLargePayload, jniCallback.getCallbackHandle());
   }
 
   public void releaseConnectedDevicePointer(long devicePtr) {
@@ -1655,7 +1664,7 @@ public class ChipDeviceController {
       AttestationTrustStoreDelegate delegate,
       @Nullable List<byte[]> cdTrustKeys);
 
-  private native void startOTAProvider(long deviceControllerPtr, OTAProviderDelegate delegate);
+  private native void startOTAProvider(long deviceControllerPtr, OTAProviderDelegate delegate, int maxBDXBlockSize);
 
   private native void finishOTAProvider(long deviceControllerPtr);
 
@@ -1731,7 +1740,7 @@ public class ChipDeviceController {
   private native long getDeviceBeingCommissionedPointer(long deviceControllerPtr, long nodeId);
 
   private native void getConnectedDevicePointer(
-      long deviceControllerPtr, long deviceId, long callbackHandle);
+      long deviceControllerPtr, long deviceId, boolean allowLargePayload, long callbackHandle);
 
   private native void releaseOperationalDevicePointer(long devicePtr);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -676,9 +676,11 @@ public class ChipDeviceController {
     getConnectedDevicePointer(deviceControllerPtr, nodeId, false, jniCallback.getCallbackHandle());
   }
 
-  public void getConnectedDevicePointer(long nodeId, boolean allowLargePayload, GetConnectedDeviceCallback callback) {
+  public void getConnectedDevicePointer(
+      long nodeId, boolean allowLargePayload, GetConnectedDeviceCallback callback) {
     GetConnectedDeviceCallbackJni jniCallback = new GetConnectedDeviceCallbackJni(callback);
-    getConnectedDevicePointer(deviceControllerPtr, nodeId, allowLargePayload, jniCallback.getCallbackHandle());
+    getConnectedDevicePointer(
+        deviceControllerPtr, nodeId, allowLargePayload, jniCallback.getCallbackHandle());
   }
 
   public void releaseConnectedDevicePointer(long devicePtr) {
@@ -1664,7 +1666,8 @@ public class ChipDeviceController {
       AttestationTrustStoreDelegate delegate,
       @Nullable List<byte[]> cdTrustKeys);
 
-  private native void startOTAProvider(long deviceControllerPtr, OTAProviderDelegate delegate, int maxBDXBlockSize);
+  private native void startOTAProvider(
+      long deviceControllerPtr, OTAProviderDelegate delegate, int maxBDXBlockSize);
 
   private native void finishOTAProvider(long deviceControllerPtr);
 

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -36,6 +36,11 @@ namespace bdx {
 
 inline constexpr uint16_t kMaxFileDesignatorLen = 0xFF;
 
+/**
+ * The overhead size of the BlockCounter in a DataBlock message.
+ */
+inline constexpr uint16_t kDataBlockHeaderSize  = sizeof(uint32_t);
+
 inline constexpr char kProtocolName[] = "BDX";
 
 enum class MessageType : uint8_t

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -39,7 +39,7 @@ inline constexpr uint16_t kMaxFileDesignatorLen = 0xFF;
 /**
  * The overhead size of the BlockCounter in a DataBlock message.
  */
-inline constexpr uint16_t kDataBlockHeaderSize  = sizeof(uint32_t);
+inline constexpr uint16_t kDataBlockHeaderSize = sizeof(uint32_t);
 
 inline constexpr char kProtocolName[] = "BDX";
 

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -29,7 +29,12 @@ constexpr uint8_t kBdxVersion = 0; ///< The version of this implementation of th
 CHIP_ERROR WriteToPacketBuffer(const ::chip::bdx::BdxMessage & msgStruct, ::chip::System::PacketBufferHandle & msgBuf)
 {
     size_t msgDataSize = msgStruct.MessageSize();
-    ::chip::Encoding::LittleEndian::PacketBufferWriter bbuf(chip::MessagePacketBuffer::New(msgDataSize), msgDataSize);
+    chip::System::PacketBufferHandle packetBufHandle = chip::MessagePacketBuffer::New(msgDataSize);
+    if (packetBufHandle.IsNull())
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    ::chip::Encoding::LittleEndian::PacketBufferWriter bbuf(std::move(packetBufHandle), msgDataSize);
     if (bbuf.IsNull())
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -28,7 +28,7 @@ constexpr uint8_t kBdxVersion = 0; ///< The version of this implementation of th
  */
 CHIP_ERROR WriteToPacketBuffer(const ::chip::bdx::BdxMessage & msgStruct, ::chip::System::PacketBufferHandle & msgBuf)
 {
-    size_t msgDataSize = msgStruct.MessageSize();
+    size_t msgDataSize                               = msgStruct.MessageSize();
     chip::System::PacketBufferHandle packetBufHandle = chip::MessagePacketBuffer::New(msgDataSize);
     if (packetBufHandle.IsNull())
     {

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -154,8 +154,10 @@ public:
      */
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     static constexpr size_t kMaxAllocSize = kLargeBufMaxSizeWithoutReserve;
+    static constexpr size_t kBufMaxSize   = kLargeBufMaxSize;
 #else
     static constexpr size_t kMaxAllocSize          = kMaxSizeWithoutReserve;
+    static constexpr size_t kBufMaxSize            = kMaxSize;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -149,8 +149,9 @@ public:
     static constexpr size_t kLargeBufMaxSize = kLargeBufMaxSizeWithoutReserve - kDefaultHeaderReserve;
 
     /**
-     * Unified constant(both regular and large buffers) for the maximum size that an application can allocate with no
-     * protocol header reserve.
+     * Unified constants (both regular and large buffers) for the maximum buffer sizes.
+     * - kMaxAllocSize: The maximum size that an application can allocate with no protocol header reserve.
+     * - kBufMaxSize: The maximum size that an application can allocate with the default protocol header reserve.
      */
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     static constexpr size_t kMaxAllocSize = kLargeBufMaxSizeWithoutReserve;

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -646,8 +646,8 @@ inline constexpr uint16_t kMaxFooterSize = kMaxTagLen;
  */
 inline System::PacketBufferHandle New(size_t aAvailableSize)
 {
-    static_assert(System::PacketBuffer::kMaxSize > kMaxFooterSize, "inadequate capacity");
-    if (aAvailableSize > System::PacketBuffer::kMaxSize - kMaxFooterSize)
+    static_assert(System::PacketBuffer::kBufMaxSize > kMaxFooterSize, "inadequate capacity");
+    if (aAvailableSize > System::PacketBuffer::kBufMaxSize - kMaxFooterSize)
     {
         return System::PacketBufferHandle();
     }


### PR DESCRIPTION
### Summary

According to the Matter Specification (Section 11.22.1), the BDX Protocol can utilize both TCP and UDP, but the current SDK implementation only supports UDP transmission. 
To resolve this limitation, the code has been modified to allow BDX Protocol transmission over TCP.
Additionally, the maximum BlockSize, which was previously hardcoded to 1024, has been adjusted to dynamically reference the kMaxLargeAppMessageLen and kMaxAppMessageLen values declared in MessageHeader. To verify these changes, the ota-provider and ota-requestor example apps were updated, and the Android CHIPTool was also modified to support testing this new TCP transmission feature.

### Related issues
N/A

### Testing

Manually tested the TCP transmission using the updated example apps and Android CHIPTool. Since this adds TCP support to existing working scenarios, no new automated tests are required.

Verified the operation using the chip-ota-requestor-app example application. This was done by running the app with the newly added -l option and specifying the maxBDXBlockSize parameter.
Tested the functionality through the Android CHIPTool after completing the commissioning process. I navigated to the OTA Provider screen, enabled the large payload option, and clicked the "Start Firmware Update" button to confirm successful operation.
