### PR TITLE
[ESP32] avoid reinitializing WiFi in InitWiFiStack

### DIFF
--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -282,11 +282,15 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     }
 
     // Initialize the ESP WiFi layer.
-    cfg = WIFI_INIT_CONFIG_DEFAULT();
-    err = esp_wifi_init(&cfg);
-    if (err != ESP_OK)
+    wifi_mode_t mode = WIFI_MODE_NULL;
+    if (esp_wifi_get_mode(&mode) == ESP_ERR_WIFI_NOT_INIT)
     {
-        return ESP32Utils::MapError(err);
+        cfg = WIFI_INIT_CONFIG_DEFAULT();
+        err = esp_wifi_init(&cfg);
+        if (err != ESP_OK)
+        {
+            return ESP32Utils::MapError(err);
+        }
     }
 
     err = esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);


### PR DESCRIPTION
### Summary

`esp_wifi_init` no longer return `ESP_OK` while doing reinitialization in ESP-IDF v6.1: https://github.com/espressif/esp-idf/commit/7b79f8c67190eaac4b3abf8db886dc867b7a5653

No API for getting the inner initialized flag directly, using `esp_wifi_get_mode` as a workaround


### Related issues

N/A

### Testing

Testing has been done on ESP-IDF `v5.5.3` and `v6.1-beta1-338-g76f1151d72c`
