### PR TITLE
[CI] Split REPL Linux tests into 6 contiguous ranges targeting ~30 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1050,11 +1050,11 @@ jobs:
             fail-fast: false
             matrix:
                 # This list is empirically created to have a reasonable time split of ~30 minutes each.
-                filter: ["", "TC_[A-A]", "TC_[B-C]", "TC_[D-F]", "TC_[G-M]", "TC_[N-S]", "!TC_[A-S]"]
+                filter: ["", "TC_A", "TC_[B-C]", "TC_[D-F]", "TC_[G-M]", "TC_[N-S]", "!TC_[A-S]"]
                 include:
                     - filter: ""
                       junitxml: out/junit-results/Other-results.xml
-                    - filter: "TC_[A-A]"
+                    - filter: "TC_A"
                       junitxml: out/junit-results/TC_A-results.xml
                     - filter: "TC_[B-C]"
                       junitxml: out/junit-results/TC_B-C-results.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1040,8 +1040,8 @@ jobs:
     repl_tests_linux_run:
         name: REPL Tests - Linux (RUN)
         needs: repl_tests_linux_build
-        # Updating the timeout for REPL Tests - Linux (RUN)(TC_[D-O]) takes over 60 minutes consistently in CI
-        timeout-minutes: 70
+        # Updating the timeout for REPL Tests - Linux (RUN) since splits now run in under 30 minutes
+        timeout-minutes: 45
 
         if: github.actor != 'restyled-io[bot]'
 
@@ -1049,18 +1049,23 @@ jobs:
             # Since some of these tests can be flaky, do not fail all matrix parts when a single one fails
             fail-fast: false
             matrix:
-                # This list is empirically created to have a reasonable time split. The "" that runs the "other"
-                # tests is reasonably fast, the others take about 20-30 minutes each at the time this was split.
-                filter: ["", "TC_[A-C]", "TC_[D-O]", "!TC_[A-O]" ]
+                # This list is empirically created to have a reasonable time split of ~30 minutes each.
+                filter: ["", "TC_[A-A]", "TC_[B-C]", "TC_[D-F]", "TC_[G-M]", "TC_[N-S]", "!TC_[A-S]"]
                 include:
                     - filter: ""
                       junitxml: out/junit-results/Other-results.xml
-                    - filter: "TC_[A-C]"
-                      junitxml: out/junit-results/TC_A-C-results.xml
-                    - filter: "TC_[D-O]"
-                      junitxml: out/junit-results/TC_D-O-results.xml
-                    - filter: "!TC_[A-O]"
-                      junitxml: out/junit-results/TC_Non-A-O-results.xml
+                    - filter: "TC_[A-A]"
+                      junitxml: out/junit-results/TC_A-results.xml
+                    - filter: "TC_[B-C]"
+                      junitxml: out/junit-results/TC_B-C-results.xml
+                    - filter: "TC_[D-F]"
+                      junitxml: out/junit-results/TC_D-F-results.xml
+                    - filter: "TC_[G-M]"
+                      junitxml: out/junit-results/TC_G-M-results.xml
+                    - filter: "TC_[N-S]"
+                      junitxml: out/junit-results/TC_N-S-results.xml
+                    - filter: "!TC_[A-S]"
+                      junitxml: out/junit-results/TC_Non-A-S-results.xml
 
         env:
             BUILD_VARIANT: ipv6only-no-ble-no-wifi-asan


### PR DESCRIPTION
#### Summary

**Problem:**
The `REPL Tests - Linux (RUN) (TC_[D-O])` matrix job consistently fails due to a 70-minute workflow timeout in GitHub Actions because test execution alone takes over 63 minutes.

**Solution:**
Re-balanced the test splits into 6 contiguous ranges targeting roughly 30 minutes of runtime per split:
- `TC_A` (~13.8 mins)
- `TC_[B-C]` (~28.0 mins)
- `TC_[D-F]` (~29.1 mins)
- `TC_[G-M]` (~27.2 mins)
- `TC_[N-S]` (~28.4 mins)
- `!TC_[A-S]` (~30.0 mins)

This ensures all jobs run in under 30 minutes with a healthy safety margin. Lowered the job timeout limit to 45 minutes.

#### Testing
The splits are verified by aggregating and analyzing the exact test timings from run `29018577820`. All range durations are projected to complete in under 30 minutes.

#### Slow Tests (>= 30 seconds)
<details>
<summary>Click to expand/collapse list of slow tests</summary>

| Test File | Duration (seconds) | Projected Split |
| --- | --- | --- |
| `TC_AccessChecker.py` | 305.13s | `TC_A` |
| `TC_DeviceConformance.py` | 300.31s | `TC_[D-F]` |
| `TC_CADMIN_1_5.py` | 266.18s | `TC_[B-C]` |
| `TC_CADMIN_1_3_4.py` | 211.70s | `TC_[B-C]` |
| `TC_DD_1_16_17.py` | 196.19s | `TC_[D-F]` |
| `mobile-device-test.py` | 191.32s | `individual` |
| `TC_SC_4_1.py` | 168.86s | `TC_[N-S]` |
| `TC_IDM_4_3.py` | 156.09s | `TC_[G-M]` |
| `TestCommissioningStatusDetectionIntegration.py` | 150.62s | `individual` |
| `TC_DeviceBasicComposition.py` | 141.07s | `TC_[D-F]` |
| `TC_ICDB_2_1_2_2.py` | 128.31s | `TC_[G-M]` |
| `TC_JFADMIN_1_4.py` | 123.28s | `TC_[G-M]` |
| `TC_PAVST_2_13.py` | 109.13s | `TC_[N-S]` |
| `TC_TIMESYNC_2_8.py` | 100.84s | `!TC_[A-S]` |
| `TC_SWTCH.py` | 94.68s | `TC_[N-S]` |
| `TC_OPSTATE_2_5.py` | 91.62s | `TC_[N-S]` |
| `TC_ACE_1_6.py` | 79.39s | `TC_A` |
| `TC_SC_5_1.py` | 78.00s | `TC_[N-S]` |
| `TC_TestAttrAvail.py` | 75.85s | `!TC_[A-S]` |
| `TC_ICDB_2_3.py` | 73.56s | `TC_[G-M]` |
| `TC_ICDB_2_4.py` | 66.66s | `TC_[G-M]` |
| `TC_WEBRTCR_2_3.py` | 63.14s | `!TC_[A-S]` |
| `TC_WEBRTCR_2_7.py` | 62.99s | `!TC_[A-S]` |
| `TC_WEBRTCR_2_6.py` | 62.98s | `!TC_[A-S]` |
| `TC_LVL_2_3.py` | 62.92s | `TC_[G-M]` |
| `TC_WEBRTCR_2_1.py` | 62.85s | `!TC_[A-S]` |
| `TC_WEBRTCR_2_5.py` | 62.16s | `!TC_[A-S]` |
| `TC_ECOINFO_2_2.py` | 62.15s | `TC_[D-F]` |
| `TC_WEBRTCR_2_2.py` | 62.09s | `!TC_[A-S]` |
| `TC_WEBRTCR_2_4.py` | 61.54s | `!TC_[A-S]` |
| `TestSpecParsingDeviceType.py` | 61.10s | `individual` |
| `TC_ECOINFO_2_1.py` | 57.20s | `TC_[D-F]` |
| `TC_SC_3_5.py` | 54.38s | `TC_[N-S]` |
| `TestFactoryResetRequests.py` | 54.27s | `individual` |
| `TC_JFADMIN_2_2.py` | 53.04s | `TC_[G-M]` |
| `TC_JFADMIN_2_1.py` | 51.42s | `TC_[G-M]` |
| `TC_CGEN_2_6.py` | 51.29s | `TC_[B-C]` |
| `TC_CGEN_2_8.py` | 51.28s | `TC_[B-C]` |
| `TC_SC_7_1.py` | 51.18s | `TC_[N-S]` |
| `TC_CGEN_2_5.py` | 51.11s | `TC_[B-C]` |
| `TC_CGEN_2_11.py` | 51.11s | `TC_[B-C]` |
| `TC_CGEN_2_10.py` | 51.04s | `TC_[B-C]` |
| `TC_CGEN_2_9.py` | 51.00s | `TC_[B-C]` |
| `TC_CGEN_2_7.py` | 50.99s | `TC_[B-C]` |
| `TC_JFDS_2_2.py` | 48.71s | `TC_[G-M]` |
| `TC_SC_5_2.py` | 48.37s | `TC_[N-S]` |
| `TC_JFDS_2_4.py` | 47.89s | `TC_[G-M]` |
| `TC_JFDS_2_1.py` | 47.88s | `TC_[G-M]` |
| `TC_DA_1_9.py` | 47.64s | `TC_[D-F]` |
| `TC_JFDS_2_3.py` | 47.56s | `TC_[G-M]` |
| `TC_JFADMIN_1_2.py` | 47.46s | `TC_[G-M]` |
| `TC_JFADMIN_1_1.py` | 47.32s | `TC_[G-M]` |
| `TestFrameworkArgParsing.py` | 47.13s | `!TC_[A-S]` |
| `TestCreateNewController.py` | 46.74s | `individual` |
| `TC_ZONEMGMT_2_4.py` | 45.88s | `!TC_[A-S]` |
| `TC_OPSTATE_2_6.py` | 44.68s | `TC_[N-S]` |
| `TC_DEM_2_10.py` | 42.43s | `TC_[D-F]` |
| `TC_CLCTRL_4_1.py` | 41.04s | `TC_[B-C]` |
| `TC_PS_2_3.py` | 41.01s | `TC_[N-S]` |
| `TC_TIMESYNC_2_11.py` | 40.41s | `!TC_[A-S]` |
| `TC_DRLK_2_3.py` | 39.12s | `TC_[D-F]` |
| `TestTimeSyncTrustedTimeSourceRunner.py` | 38.92s | `individual` |
| `TC_DRLK_2_12.py` | 37.93s | `TC_[D-F]` |
| `TC_CLDIM_4_1.py` | 37.42s | `TC_[B-C]` |
| `TC_CADMIN_1_10.py` | 33.64s | `TC_[B-C]` |
| `TC_OPCREDS_3_4.py` | 33.42s | `TC_[N-S]` |
| `TCP_Tests.py` | 33.24s | `!TC_[A-S]` |
| `TC_FAN_4_1.py` | 32.68s | `TC_[D-F]` |
| `TC_GC_2_8.py` | 32.33s | `TC_[G-M]` |
| `TC_MCORE_FS_1_5.py` | 32.04s | `TC_[G-M]` |
| `TC_FAN_3_5.py` | 31.97s | `TC_[D-F]` |
| `TC_FAN_3_1.py` | 30.83s | `TC_[D-F]` |
| `TC_MCORE_FS_1_3.py` | 30.44s | `TC_[G-M]` |
| `TC_EEVSE_2_6.py` | 30.07s | `TC_[D-F]` |

</details>
