### PR TITLE
[CI] Maximize runner disk space in Cirque workflow

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -53,6 +53,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            - name: Maximize runner disk
+              uses: ./.github/actions/maximize-runner-disk
             - name: Checkout submodules
               uses: ./.github/actions/checkout-submodules
               with:


### PR DESCRIPTION
### Summary

This pull request integrates the `maximize-runner-disk` composite action into the Cirque CI workflow (`cirque.yaml`).

### Rationale

The Cirque binary compilation step currently runs on the host virtual machine (`ubuntu-latest`) and frequently runs out of storage space (failing with `No space left on device`). This change reclaims approximately 16GB of disk space before the build starts by pruning pre-installed but unused system directories (such as Android SDKs, .NET, Haskell, and Swift), ensuring sufficient storage for compilation.

### Testing

N/A - GitHub Actions CI workflow configuration change.
