### PR TITLE
[Linux] Fail Publish Instead of Advertising an Unresolvable mDNS Service

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -472,6 +472,7 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
     {
         // we need to establish a matter hostname separately from the platform's default hostname
         char b[chip::Inet::IPAddress::kMaxStringLength];
+        size_t numAddressesAdded = 0;
         SuccessOrExit(error = service.mInterface.GetInterfaceName(b, chip::Inet::IPAddress::kMaxStringLength));
         ChipLogDetail(DeviceLayer, "Using addresses from interface id=%d name=%s", service.mInterface.GetPlatformInterface(), b);
         matterHostname = std::string(service.mHostName) + ".local";
@@ -518,9 +519,33 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
 
                         ExitNow(error = CHIP_ERROR_INTERNAL);
                     }
+
+                    ChipLogDetail(DeviceLayer, "Added address %s (if=%d) for %s", b, static_cast<int>(thisinterface),
+                                  matterHostname.c_str());
+
+                    numAddressesAdded++;
                 }
             }
         }
+
+        // A dedicated Matter hostname is only resolvable if at least one A/AAAA
+        // record backs it. Publishing SRV/PTR/TXT without any address records
+        // yields a service that browses but can never be resolved, and nothing
+        // downstream would ever detect or repair it. Fail loudly instead so the
+        // caller can retry (for example, on a subsequent connectivity-change event).
+
+        if (numAddressesAdded == 0)
+        {
+            ChipLogError(DeviceLayer,
+                         "No publishable addresses for hostname %s (interface id=%d): "
+                         "advertising interface has no usable addresses yet; "
+                         "refusing to publish unresolvable service %s",
+                         matterHostname.c_str(), service.mInterface.GetPlatformInterface(), key.c_str());
+
+            ExitNow(error = CHIP_ERROR_INCORRECT_STATE);
+        }
+
+        ChipLogProgress(DeviceLayer, "Published %zu address record(s) for %s", numAddressesAdded, matterHostname.c_str());
     }
 
     // create the service

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -432,6 +432,7 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
     std::string type = GetFullType(service.mType, service.mProtocol);
     std::string matterHostname;
     CHIP_ERROR error          = CHIP_NO_ERROR;
+    int avahiRet              = AVAHI_OK;
     AvahiStringList * text    = nullptr;
     AvahiEntryGroup * group   = nullptr;
     const char * mainHostname = nullptr;
@@ -446,7 +447,7 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
     if (publishedgroups_it != mPublishedGroups.end())
     {
         // same service was already published, we need to de-publish it first
-        int avahiRet = avahi_entry_group_free(publishedgroups_it->second);
+        avahiRet = avahi_entry_group_free(publishedgroups_it->second);
         if (avahiRet != AVAHI_OK)
         {
             ChipLogError(DeviceLayer, "Cannot remove avahi group: %s", avahi_strerror(avahiRet));
@@ -504,14 +505,19 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
                     AvahiIfIndex thisinterface = static_cast<AvahiIfIndex>(addr_it.GetInterfaceId().GetPlatformInterface());
                     // Note: NO_REVERSE publish flag is needed because otherwise we can't have more than one hostname
                     //   for reverse resolving IP addresses back to hostnames
-                    VerifyOrExit(avahi_entry_group_add_address(group,                        // group
-                                                               thisinterface,                // interface
-                                                               ToAvahiProtocol(addr.Type()), // protocol
-                                                               AVAHI_PUBLISH_NO_REVERSE,     // publish flags
-                                                               matterHostname.c_str(),       // hostname
-                                                               &a                            // address
-                                                               ) == 0,
-                                 error = CHIP_ERROR_INTERNAL);
+                    avahiRet = avahi_entry_group_add_address(group,                        // group
+                                                             thisinterface,                // interface
+                                                             ToAvahiProtocol(addr.Type()), // protocol
+                                                             AVAHI_PUBLISH_NO_REVERSE,     // publish flags
+                                                             matterHostname.c_str(),       // hostname
+                                                             &a);
+                    if (avahiRet != AVAHI_OK)
+                    {
+                        ChipLogError(DeviceLayer, "Cannot add avahi group address for %s (%d) for %s: %d: %s", b,
+                                     static_cast<int>(thisinterface), matterHostname.c_str(), avahiRet, avahi_strerror(avahiRet));
+
+                        ExitNow(error = CHIP_ERROR_INTERNAL);
+                    }
                 }
             }
         }
@@ -520,15 +526,20 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
     // create the service
     SuccessOrExit(error = MakeAvahiStringListFromTextEntries(service.mTextEntries, service.mTextEntrySize, &text));
 
-    VerifyOrExit(avahi_entry_group_add_service_strlst(group, interface, protocol,        // group, interface, protocol
-                                                      static_cast<AvahiPublishFlags>(0), // publish flags
-                                                      service.mName,                     // service name
-                                                      type.c_str(),                      // type
-                                                      nullptr,                           // domain
-                                                      matterHostname.c_str(),            // host
-                                                      service.mPort,                     // port
-                                                      text) == 0,                        // TXT records StringList
-                 error = CHIP_ERROR_INTERNAL);
+    avahiRet = avahi_entry_group_add_service_strlst(group, interface, protocol,        // group, interface, protocol
+                                                    static_cast<AvahiPublishFlags>(0), // publish flags
+                                                    service.mName,                     // service name
+                                                    type.c_str(),                      // type
+                                                    nullptr,                           // domain
+                                                    matterHostname.c_str(),            // host
+                                                    service.mPort,                     // port
+                                                    text);                             // TXT records StringList
+    if (avahiRet != AVAHI_OK)
+    {
+        ChipLogError(DeviceLayer, "Cannot add avahi service string list: %d: %s", avahiRet, avahi_strerror(avahiRet));
+
+        ExitNow(error = CHIP_ERROR_INTERNAL);
+    }
 
     // add the subtypes
     for (size_t i = 0; i < service.mSubTypeSize; i++)
@@ -537,9 +548,15 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service, DnssdPublishC
 
         sstream << service.mSubTypes[i] << "._sub." << type;
 
-        VerifyOrExit(avahi_entry_group_add_service_subtype(group, interface, protocol, static_cast<AvahiPublishFlags>(0),
-                                                           service.mName, type.c_str(), nullptr, sstream.str().c_str()) == 0,
-                     error = CHIP_ERROR_INTERNAL);
+        avahiRet = avahi_entry_group_add_service_subtype(group, interface, protocol, static_cast<AvahiPublishFlags>(0),
+                                                         service.mName, type.c_str(), nullptr, sstream.str().c_str());
+
+        if (avahiRet != AVAHI_OK)
+        {
+            ChipLogError(DeviceLayer, "Cannot add avahi service string subtype: %d: %s", avahiRet, avahi_strerror(avahiRet));
+
+            ExitNow(error = CHIP_ERROR_INTERNAL);
+        }
     }
     VerifyOrExit(avahi_entry_group_commit(group) == 0, error = CHIP_ERROR_INTERNAL);
 


### PR DESCRIPTION
### Summary

#### Problem

On the Linux platform, `MdnsAvahi::PublishService` snapshots the advertising interface's addresses and adds one Avahi address record per entry. When the snapshot is empty at publish time (for example, the interface is up but the underlying network management implementation has not yet finished IP configuration) the address loop adds **nothing**, but the function still adds the `SRV`/`PTR`/`TXT` records, commits the entry group, and returns `CHIP_NO_ERROR`.

That produces a service which appears in browse results but fails **every** resolve, because its hostname has no `A`/`AAAA` record. Since publish reported success, no retry is ever triggered and commissioners time out.
This affects every Linux Matter device that can reach `PublishService` before its advertising interface is fully configured, and the failure is invisible in logs.

#### Change overview

Two commits:

1. Surface the Avahi entry-group errors that were previously collapsed into an opaque `CHIP_ERROR_INTERNAL`, logging the decoded `avahi_strerror()` for each failing call. No functional change (NFC).
2. Track how many address records were actually added. If none, log the offending interface and return `CHIP_ERROR_INCORRECT_STATE` rather than committing an unresolvable service, so the caller can retry once addresses are available.

#### Testing

Cold-boot commissioning on Linux over Ethernet and Wi-Fi, before versus after. Prior to the change, a publish racing interface configuration commits a browse-only service and the commissioner times out on resolve; after, that publish fails with `CHIP_ERROR_INCORRECT_STATE` and is retried on the next connectivity-change event, yielding a resolvable service.

### Related issues

Fixes #72979

### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using both the iOS 26.5 Apple "Home" app and `chip-tool` with a both a Connectivity Manager and wpa_supplicant implementation using this infrastructure.