### PR TITLE
Bound Allure report history on gh-pages to stop CI runner disk exhaustion

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -338,6 +338,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
 
+            # The gh-pages Allure history is handled several times over on this
+            # runner (checkout, history copy, deploy clone), so free up disk first.
+            - name: Maximize runner disk
+              uses: ./.github/actions/maximize-runner-disk
+
             - name: Download all JUnit XML results
               uses: actions/download-artifact@v8
               with:
@@ -386,7 +391,9 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: allure-history/allure-report/nightly
                   destination_dir: allure-report/nightly
-                  keep_files: true
+                  # keep_files: false prunes reports beyond keep_reports from the
+                  # branch; scoped to destination_dir, so other subfolders are kept.
+                  keep_files: false
 
             - name: Notify Slack on Failure
               if: failure()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1295,6 +1295,11 @@ jobs:
           - name: Checkout
             uses: actions/checkout@v7
 
+          # The gh-pages Allure history is handled several times over on this
+          # runner (checkout, history copy, deploy clone), so free up disk first.
+          - name: Maximize runner disk
+            uses: ./.github/actions/maximize-runner-disk
+
           - name: Download all JUnit XML results
             uses: actions/download-artifact@v8
             with:
@@ -1324,7 +1329,7 @@ jobs:
                 gh_pages: gh-pages
                 allure_history: allure-history
                 subfolder: allure-report/ci_tests
-                keep_reports: 2000
+                keep_reports: 100
                 # This is the name that will show up in the Dashboard Overview
                 report_name: "CI Tests"
 
@@ -1343,7 +1348,9 @@ jobs:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
                 publish_dir: allure-history/allure-report/ci_tests
                 destination_dir: allure-report/ci_tests
-                keep_files: true
+                # keep_files: false prunes reports beyond keep_reports from the
+                # branch; scoped to destination_dir, so other subfolders are kept.
+                keep_files: false
 
           - name: Notify Slack on Failure
             if: failure()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1329,7 +1329,7 @@ jobs:
                 gh_pages: gh-pages
                 allure_history: allure-history
                 subfolder: allure-report/ci_tests
-                keep_reports: 100
+                keep_reports: 200
                 # This is the name that will show up in the Dashboard Overview
                 report_name: "CI Tests"
 


### PR DESCRIPTION
#### Summary

Fixes the recurring `No space left on device` failure in the `REPL Tests - Linux (REPORT RESULTS)` job on master pushes (e.g. [run 29030642554](https://github.com/project-chip/connectedhomeip/actions/runs/29030642554/job/86174911973)) by bounding the Allure report history published to `gh-pages`.

##### Problem

- `allure-report/ci_tests` on `gh-pages` currently holds **~815 reports** (~6 MB / ~313 files each, ~5 GB working tree), growing by one report per master push.
- The report job handles that history **roughly four times over** on one runner: `gh-pages` checkout, `allure-report-action` copy into `allure-history`, `actions-gh-pages` branch clone, publish copy. Peak disk usage exceeds the hosted-runner disk and the runner worker itself crashes (the `Deploy to GitHub Pages` step ends with no conclusion; the failure only surfaces as a check-run annotation).
- The history is **unbounded** because of two settings that must change together:
    - `keep_reports: 2000` — pruning never triggers (at ~815 today).
    - `keep_files: true` — even if the Allure action pruned its copy, `peaceiris/actions-gh-pages` never deletes anything from the branch.

##### Solution

- `keep_reports: 2000` -> `200` in `tests.yaml`, so the Allure action prunes its history copy to the last 200 reports (roughly 2-4 weeks of master pushes, ~1.2 GB tip tree).
- `keep_files: true` -> `false` in both `tests.yaml` and `nightly.yaml` (same latent issue, currently 96 of 120 reports), so pruning propagates to the branch. With `destination_dir` set, `actions-gh-pages` scopes the deletion to that subdirectory only, so the two report subfolders and the other `gh-pages` content do not affect each other. Allure trend history (`last-history/`) lives inside the published directory and is preserved.
- Added the repo-local `maximize-runner-disk` action to both report jobs: the first post-merge run still pays the full ~5 GB handling before pruning lands on the branch, and needs the extra headroom.
- The first post-merge deploy shrinks the `gh-pages` tip from ~5 GB to ~1.2 GB, after which every subsequent report job stays within disk limits.

##### Caveats

- The first deploy after merge permanently removes reports older than the last 200 from the `gh-pages` tip. Individual reports remain downloadable as workflow artifacts for 30 days (`Upload Allure Report` step), and Allure's trend widgets are unaffected (they only ever use the last 20 builds carried in `last-history/`).
- This cannot be exercised on a PR (the deploy step only runs on push to master); the first post-merge master run is the verification.

#### Testing

- N/A for local execution: the failing path (gh-pages checkout + history copy + deploy) only runs on push events to master. Sizing was measured via the GitHub API (report count, per-report size, failure annotation of run 29030642554) and both workflow files pass YAML validation. Verification plan: watch the first post-merge master `Tests` run complete the report job and confirm the `gh-pages` tip shrinks to ~200 reports.
