### PR TITLE
Add dependabot auto-merging

### DIFF
--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-from datetime import UTC, datetime
 import json
 import logging
 import os
 import urllib.request
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Iterable, NamedTuple
 
@@ -42,7 +42,6 @@ ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
 
 # Age threshold (in seconds) to ignore stuck check suites (2 hours)
 STUCK_CHECK_SUITE_THRESHOLD_SECONDS = 7200
-
 
 
 class ValidationCheck(Enum):

--- a/scripts/tools/platform_merge_bot.py
+++ b/scripts/tools/platform_merge_bot.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from datetime import UTC, datetime
 import json
 import logging
 import os
@@ -38,6 +39,10 @@ DEFAULT_REPOSITORY = "project-chip/connectedhomeip"
 DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
 
 ELIGIBILITY_COMMENT_MARKER = "<!-- platform-merge-bot-eligibility-marker -->"
+
+# Age threshold (in seconds) to ignore stuck check suites (2 hours)
+STUCK_CHECK_SUITE_THRESHOLD_SECONDS = 7200
+
 
 
 class ValidationCheck(Enum):
@@ -100,7 +105,7 @@ class PlatformMergeBot:
         self.skip_checks = {ValidationCheck(c) for c in (skip_checks or [])}
         self.single_pr_mode = False
         self.groups: dict[str, PlatformGroup] = {}
-        self._bot_username = None
+        self._bot_username: str | None = None
         self.load_config()
 
     @property
@@ -229,6 +234,7 @@ class PlatformMergeBot:
 
         pr_author = pr.user.login
         log.info("Checking PR #%d: '%s' (Author: %s)", pr.number, pr.title, pr_author)
+        is_dependabot = pr_author.lower() == "dependabot[bot]"
 
         if pr.state != "open":
             if self.dry_run and self.single_pr_mode:
@@ -258,7 +264,7 @@ class PlatformMergeBot:
         # Perform file analysis first (saves API calls for ineligible PRs)
         matched_files, uncovered_files = self.analyze_pr_files(pr)
 
-        if uncovered_files:
+        if uncovered_files and not is_dependabot:
             log.info(
                 "PR #%d contains files outside the platform-maintained scope. Skipping. Uncovered files: %s",
                 pr.number,
@@ -269,16 +275,19 @@ class PlatformMergeBot:
 
         # Determine which groups are active (i.e. have changed files)
         active_groups = {name: files for name, files in matched_files.items() if files}
-        if not active_groups:
+        if not active_groups and not is_dependabot:
             log.info("PR #%d has no changed files? Skipping.", pr.number)
             self.remove_eligibility_comment(pr)
             return
 
-        log.info(
-            "PR #%d is fully covered by platform groups: %s",
-            pr.number,
-            list(active_groups.keys()),
-        )
+        if is_dependabot:
+            log.info("PR #%d is a Dependabot PR. Bypassing group coverage checks.", pr.number)
+        else:
+            log.info(
+                "PR #%d is fully covered by platform groups: %s",
+                pr.number,
+                list(active_groups.keys()),
+            )
 
         # Get the commit object once for subsequent status/CI checks
         commit = self.repo.get_commit(sha=pr.head.sha)
@@ -315,16 +324,17 @@ class PlatformMergeBot:
         missing_approvals: dict[str, PlatformGroup] = {}
         valid_approvals_per_group: dict[str, GroupApproval] = {}
 
-        for group_name, files in active_groups.items():
-            group = self.groups[group_name]
-            group_approvers = approvers.intersection(group.maintainers)
-            if not group_approvers:
-                missing_approvals[group_name] = group
-            else:
-                # Pick the first matched approver for documentation
-                valid_approvals_per_group[group_name] = GroupApproval(
-                    sorted(group_approvers)[0], files
-                )
+        if not is_dependabot:
+            for group_name, files in active_groups.items():
+                group = self.groups[group_name]
+                group_approvers = approvers.intersection(group.maintainers)
+                if not group_approvers:
+                    missing_approvals[group_name] = group
+                else:
+                    # Pick the first matched approver for documentation
+                    valid_approvals_per_group[group_name] = GroupApproval(
+                        sorted(group_approvers)[0], files
+                    )
 
         unresolved_threads = []
         if ValidationCheck.COMMENTS not in self.skip_checks:
@@ -343,25 +353,30 @@ class PlatformMergeBot:
         )
 
         if not is_ready:
-            log.info(
-                "PR #%d is eligible but not ready to merge. Updating status comment.",
-                pr.number,
+            reasons = (
+                f"missing_approvals={list(missing_approvals.keys())}, "
+                f"unresolved_threads={len(unresolved_threads)}, "
+                f"ci_passed={ci_passed}, "
+                f"is_mergeable={is_mergeable}"
             )
-            self.post_eligibility_comment(
-                pr,
-                active_groups,
-                missing_approvals,
-                unresolved_threads,
-                ci_passed,
-                is_mergeable,
-            )
+            log.info("PR #%d is not ready to merge. Blocked by: %s", pr.number, reasons)
+            if not is_dependabot:
+                log.info("Updating status comment for PR #%d", pr.number)
+                self.post_eligibility_comment(
+                    pr,
+                    active_groups,
+                    missing_approvals,
+                    unresolved_threads,
+                    ci_passed,
+                    is_mergeable,
+                )
             return
 
         log.info(
             "PR #%d is fully approved, CI passed, no unresolved comments, and ready to merge!",
             pr.number,
         )
-        self.merge_pr(pr, valid_approvals_per_group)
+        self.merge_pr(pr, valid_approvals_per_group, is_dependabot=is_dependabot)
 
     def _is_pullapprove_green(self, commit: Commit) -> bool:
         """Returns True if the pullapprove check exists and is in the 'success' state."""
@@ -517,6 +532,25 @@ class PlatformMergeBot:
 
         for suite in check_suites:
             if suite.status != "completed":
+                # Handle potential timezone-naive datetimes from the API to avoid comparison errors
+                created_at = suite.created_at
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=UTC)
+                age = datetime.now(UTC) - created_at
+
+                # Ignore stuck check suites that don't run on PRs and remain
+                # 'queued' with 0 runs (invisible in UI but visible in API).
+                if suite.latest_check_runs_count == 0 and age.total_seconds() > STUCK_CHECK_SUITE_THRESHOLD_SECONDS:
+                    log.info(
+                        "PR #%d HEAD commit %s check suite '%s' is not completed (status: '%s') but has 0 runs and is old (%s). Ignoring.",
+                        pr.number,
+                        pr.head.sha[:8],
+                        suite.id,
+                        suite.status,
+                        age,
+                    )
+                    continue
+
                 log.info(
                     "PR #%d HEAD commit %s check suite '%s' is not completed (status: '%s')",
                     pr.number,
@@ -678,18 +712,27 @@ class PlatformMergeBot:
                     log.error("Failed to delete stale comment #%d: %s", comment.id, e)
 
     def merge_pr(
-        self, pr: PullRequest, valid_approvals_per_group: dict[str, GroupApproval]
+        self,
+        pr: PullRequest,
+        valid_approvals_per_group: dict[str, GroupApproval],
+        is_dependabot: bool = False,
     ) -> None:
         """Merges the PR and posts a comment explaining the approvals."""
-        # Generate merge comment explaining reasons
-        merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
-        merge_reason_comment += "This PR has been automatically merged. It contains changes restricted to platform-maintained paths and received the required maintainer approvals:\n\n"
+        if is_dependabot:
+            merge_reason_comment = "### Dependabot Auto-Merge Executed\n"
+            merge_reason_comment += "This PR has been automatically merged because it passed all CI checks.\n"
+            commit_title = f"{pr.title} (Auto-merged by bot)"
+        else:
+            # Generate merge comment explaining reasons
+            merge_reason_comment = "### Platform Maintainers Auto-Merge Executed\n"
+            merge_reason_comment += "This PR has been automatically merged. It contains changes restricted to platform-maintained paths and received the required maintainer approvals:\n\n"
 
-        for group_name, approval in valid_approvals_per_group.items():
-            group = self.groups[group_name]
-            matched_globs = group.get_matched_globs(approval.files)
-            globs_str = ", ".join([f"`{g}`" for g in matched_globs])
-            merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approval.approver}\n"
+            for group_name, approval in valid_approvals_per_group.items():
+                group = self.groups[group_name]
+                matched_globs = group.get_matched_globs(approval.files)
+                globs_str = ", ".join([f"`{g}`" for g in matched_globs])
+                merge_reason_comment += f"- **{group_name}** changes (matching {globs_str}) approved by @{approval.approver}\n"
+            commit_title = f"{pr.title} (Auto-merged by platform-bot)"
 
         if self.dry_run:
             log.info(
@@ -703,7 +746,7 @@ class PlatformMergeBot:
             # Use squash merge
             pr.merge(
                 merge_method="squash",
-                commit_title=f"{pr.title} (Auto-merged by platform-bot)",
+                commit_title=commit_title,
                 sha=pr.head.sha,
             )
 
@@ -721,7 +764,7 @@ class PlatformMergeBot:
         """Runs the bot, either scanning all open PRs or processing a single PR."""
         self.single_pr_mode = pr_number is not None
         has_errors = False
-        if self.single_pr_mode:
+        if pr_number is not None:
             log.info("Processing single PR #%d...", pr_number)
             try:
                 pr = self.repo.get_pull(pr_number)

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+from datetime import UTC, datetime, timedelta
 import json
 import os
 import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
+from typing import cast
 
 # Ensure the parent directory is in the path so we can import platform_merge_bot
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -28,7 +30,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from platform_merge_bot import ELIGIBILITY_COMMENT_MARKER, PlatformMergeBot  # noqa: E402
+from platform_merge_bot import ELIGIBILITY_COMMENT_MARKER, PlatformMergeBot, STUCK_CHECK_SUITE_THRESHOLD_SECONDS  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
@@ -275,7 +277,7 @@ esp32:
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
-        reviews = []
+        reviews: list[MagicMock] = []
         # Existing eligibility comment with different body
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
@@ -296,7 +298,7 @@ esp32:
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
-        reviews = []
+        reviews: list[MagicMock] = []
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
 
         # First run: posts the eligibility comment
@@ -458,7 +460,7 @@ esp32:
 
     def test_check_and_process_pr_removes_comment_when_no_changed_files(self) -> None:
         """Tests that a stale eligibility comment is deleted if the PR has no changed files."""
-        files = []  # No changed files
+        files: list[MagicMock] = []  # No changed files
         mock_comment = MagicMock()
         mock_comment.user.login = "platform-merge-bot"
         mock_comment.body = f"{ELIGIBILITY_COMMENT_MARKER}\nSome status info..."
@@ -476,7 +478,7 @@ esp32:
         files = [
             self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp"),
         ]
-        reviews = []
+        reviews: list[MagicMock] = []
 
         # We have two eligibility comments
         mock_comment1 = MagicMock()
@@ -617,10 +619,12 @@ esp32:
         reviews = [self.create_mock_review("doru91", "APPROVED")]
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
 
-        # Mock in_progress check suite
+        # Mock in_progress check suite (new, so it blocks)
         mock_suite = MagicMock()
         mock_suite.status = "in_progress"
         mock_suite.conclusion = None
+        mock_suite.created_at = datetime.now(UTC)
+        mock_suite.latest_check_runs_count = 0
         mock_success_suite = MagicMock()
         mock_success_suite.status = "completed"
         mock_success_suite.conclusion = "success"
@@ -672,7 +676,7 @@ esp32:
         )
 
         # Mock pullapprove green
-        self.bot._is_pullapprove_green.return_value = True
+        cast(MagicMock, self.bot._is_pullapprove_green).return_value = True
 
         self.bot.check_and_process_pr(mock_pr)
 
@@ -688,7 +692,7 @@ esp32:
         mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
 
         # Mock an unresolved thread
-        self.bot._get_unresolved_threads.return_value = [
+        cast(MagicMock, self.bot._get_unresolved_threads).return_value = [
             {
                 "author": "jmartinez-silabs",
                 "body_preview": "Maybe we could check...",
@@ -731,7 +735,6 @@ esp32:
         self.bot.check_and_process_pr(mock_pr)
 
         # Should log and say "Would merge" in dry-run (which means checking passed and didn't return early)
-        # Note: merge is not called in dry-run, but mock_pr.merge should not be called either.
         # We can assert that analyze_pr_files was called, proving it bypassed the state check.
         mock_pr.get_files.assert_called_once()
 
@@ -747,7 +750,7 @@ esp32:
         self.bot.skip_checks = {ValidationCheck.COMMENTS}
 
         # Mock unresolved threads (should be ignored)
-        self.bot._get_unresolved_threads.return_value = [
+        cast(MagicMock, self.bot._get_unresolved_threads).return_value = [
             {
                 "author": "jmartinez-silabs",
                 "body_preview": "unresolved",
@@ -899,6 +902,144 @@ esp32:
         mock_pr.create_issue_comment.assert_called_once()
         comment_body = mock_pr.create_issue_comment.call_args[0][0]
         self.assertIn("Mergeability state is computing", comment_body)
+
+    def test_check_and_process_pr_dependabot_success(self) -> None:
+        """Tests that a Dependabot PR with passing CI is merged."""
+        files = [
+            self.create_mock_file("some/file.txt"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Bump dep", "dependabot[bot]", files, [])
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_called_once_with(
+            merge_method="squash",
+            commit_title="Bump dep (Auto-merged by bot)",
+            sha="dummy_sha",
+        )
+        mock_pr.create_issue_comment.assert_called_once()
+        self.assertIn(
+            "Dependabot Auto-Merge Executed",
+            mock_pr.create_issue_comment.call_args[0][0],
+        )
+
+    def test_check_and_process_pr_dependabot_failing_ci(self) -> None:
+        """Tests that a Dependabot PR with failing CI is not merged."""
+        files = [
+            self.create_mock_file("some/file.txt"),
+        ]
+        mock_pr = self.create_mock_pr(1, "Bump dep", "dependabot[bot]", files, [])
+
+        # Mock failing CI
+        mock_suite = MagicMock()
+        mock_suite.status = "completed"
+        mock_suite.conclusion = "failure"
+        # 1 failing, 9 succeeding to meet the 10 checks requirement
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        # Should not post eligibility comment for dependabot
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_dependabot_unresolved_comments_does_not_merge(self) -> None:
+        """Tests that a Dependabot PR with unresolved comments is not merged."""
+        files = [self.create_mock_file("some/file.txt")]
+        mock_pr = self.create_mock_pr(1, "Bump dep", "dependabot[bot]", files, [])
+
+        # Mock an unresolved thread
+        cast(MagicMock, self.bot._get_unresolved_threads).return_value = [
+            {
+                "author": "some_user",
+                "body_preview": "unresolved comment",
+                "url": "https://github.com/...",
+            }
+        ]
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+
+    def test_check_and_process_pr_dependabot_merge_conflicts_does_not_merge(self) -> None:
+        """Tests that a Dependabot PR with merge conflicts is not merged."""
+        files = [self.create_mock_file("some/file.txt")]
+        mock_pr = self.create_mock_pr(1, "Bump dep", "dependabot[bot]", files, [])
+        mock_pr.mergeable = False
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+        mock_pr.create_issue_comment.assert_not_called()
+    def test_check_and_process_pr_stuck_check_suite_ignored_merges(self) -> None:
+        """Tests that an incomplete check suite with 0 runs and old age is ignored, allowing merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock stuck check suite (in_progress, 0 runs, 3 hours old)
+        mock_suite = MagicMock()
+        mock_suite.status = "in_progress"
+        mock_suite.conclusion = None
+        mock_suite.created_at = datetime.now(UTC) - timedelta(seconds=STUCK_CHECK_SUITE_THRESHOLD_SECONDS + 3600)
+        mock_suite.latest_check_runs_count = 0
+
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_called_once()
+
+    def test_check_and_process_pr_new_incomplete_check_suite_blocks(self) -> None:
+        """Tests that a new incomplete check suite with 0 runs blocks merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock new incomplete check suite (in_progress, 0 runs, 1 hour old)
+        mock_suite = MagicMock()
+        mock_suite.status = "in_progress"
+        mock_suite.conclusion = None
+        mock_suite.created_at = datetime.now(UTC) - timedelta(seconds=STUCK_CHECK_SUITE_THRESHOLD_SECONDS - 3600)
+        mock_suite.latest_check_runs_count = 0
+
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
+
+    def test_check_and_process_pr_active_incomplete_check_suite_blocks(self) -> None:
+        """Tests that an old incomplete check suite with runs (>0) blocks merge."""
+        files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]
+        reviews = [self.create_mock_review("doru91", "APPROVED")]
+        mock_pr = self.create_mock_pr(1, "Test PR", "author", files, reviews)
+
+        # Mock active old check suite (in_progress, 1 run, 3 hours old)
+        mock_suite = MagicMock()
+        mock_suite.status = "in_progress"
+        mock_suite.conclusion = None
+        mock_suite.created_at = datetime.now(UTC) - timedelta(seconds=STUCK_CHECK_SUITE_THRESHOLD_SECONDS + 3600)
+        mock_suite.latest_check_runs_count = 1
+
+        mock_success_suite = MagicMock()
+        mock_success_suite.status = "completed"
+        mock_success_suite.conclusion = "success"
+        self.mock_commit.get_check_suites.return_value = [mock_suite] + [mock_success_suite] * 9
+
+        self.bot.check_and_process_pr(mock_pr)
+
+        mock_pr.merge.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_platform_merge_bot.py
+++ b/scripts/tools/tests/test_platform_merge_bot.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-from datetime import UTC, datetime, timedelta
 import json
 import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime, timedelta
 from typing import cast
+from unittest.mock import MagicMock, patch
 
 # Ensure the parent directory is in the path so we can import platform_merge_bot
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from platform_merge_bot import ELIGIBILITY_COMMENT_MARKER, PlatformMergeBot, STUCK_CHECK_SUITE_THRESHOLD_SECONDS  # noqa: E402
+from platform_merge_bot import ELIGIBILITY_COMMENT_MARKER, STUCK_CHECK_SUITE_THRESHOLD_SECONDS, PlatformMergeBot  # noqa: E402
 
 
 class TestPlatformMergeBot(unittest.TestCase):
@@ -975,6 +975,7 @@ esp32:
 
         mock_pr.merge.assert_not_called()
         mock_pr.create_issue_comment.assert_not_called()
+
     def test_check_and_process_pr_stuck_check_suite_ignored_merges(self) -> None:
         """Tests that an incomplete check suite with 0 runs and old age is ignored, allowing merge."""
         files = [self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")]


### PR DESCRIPTION
### Summary

Integrates Dependabot auto-merge into platform_merge_bot.py and implements a bypass for stuck CI checks to improve merge reliability.

  Dependabot Auto-Merge:
  This script will now automatically merge pull requests authored by  dependabot[bot]  that meet the following
  requirements (bypassing the standard platform maintainer approval checks):

  1. Passing CI Checks: All registered CI checks must pass
  2. No Unresolved Comments: Any review threads or comments must be resolved.
  3. No Merge Conflicts: The PR must be in a mergeable state.

  - Stuck CI Checks Bypass: Ignores inactive check suites (queued/in-progress with 0 runs and > 2 hours old) to prevent
  blocking merges.
  - Static Analysis Fixes: Resolved Mypy and Pylance/Pyright type errors in both the bot script and its unit tests.

### Related issues

None

### Testing

Added and updated unit tests.

  Coverage:

  • Dependabot: Tested merge success on passing CI, and verified that merge is blocked by failing CI, unresolved
  comments, or merge conflicts.
  • Stuck Suites: Tested that check suites are ignored if they have 0 runs and are older than 2 hours. Verified they
  still block if they are new (under 2 hours) or active (have > 0 runs).

  Command to manually run tests (dry run, need GitHub PAT token):

    scripts/tools/tests/test_platform_merge_bot.py --dry-run --pr (PR_NUMBER) --token-file directory/to/file.txt
   
