### PR TITLE
Add type-aware variants of chip::Platform::MemoryAlloc/MemoryCalloc, and start using them

### DIFF
--- a/examples/camera-controller/commands/clusters/CustomArgument.h
+++ b/examples/camera-controller/commands/clusters/CustomArgument.h
@@ -265,7 +265,7 @@ public:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(mDataMaxLen, sizeof(uint8_t)));
         VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
 
         chip::TLV::TLVWriter writer;

--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -259,7 +259,7 @@ public:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(mDataMaxLen, sizeof(uint8_t)));
         VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
 
         chip::TLV::TLVWriter writer;

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -130,7 +130,7 @@ private:
         chip::TLV::TLVWriter writer;
         chip::TLV::TLVReader reader;
 
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(mDataMaxLen, sizeof(uint8_t)));
         VerifyOrExit(mData != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
         writer.Init(mData, mDataMaxLen);

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -153,7 +153,7 @@ private:
         chip::TLV::TLVWriter writer;
         chip::TLV::TLVReader reader;
 
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(mDataMaxLen, sizeof(uint8_t)));
         VerifyOrExit(mData != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
         writer.Init(mData, mDataMaxLen);

--- a/examples/fabric-admin/commands/clusters/CustomArgument.h
+++ b/examples/fabric-admin/commands/clusters/CustomArgument.h
@@ -265,7 +265,7 @@ public:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(mDataMaxLen, sizeof(uint8_t)));
         VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
 
         chip::TLV::TLVWriter writer;

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -127,6 +127,7 @@ source_set("memory") {
   sources = [
     "CHIPMem.cpp",
     "CHIPMem.h",
+    "CHIPMemTyped.h",
     "CHIPPlatformMemory.cpp",
     "CHIPPlatformMemory.h",
   ]

--- a/src/lib/support/CHIPMem-Malloc.cpp
+++ b/src/lib/support/CHIPMem-Malloc.cpp
@@ -90,6 +90,33 @@ void MemoryAllocatorShutdown()
 #endif // CHIP_CONFIG_MEMORY_DEBUG_DMALLOC
 }
 
+#if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+
+CHIP_MALLOC_WRAPPER_BEGIN
+
+void * MemoryAllocTyped(size_t size, malloc_type_id_t typeId)
+{
+    VERIFY_INITIALIZED();
+    return malloc_type_malloc(size, typeId);
+}
+
+void * MemoryCallocTyped(size_t num, size_t size, malloc_type_id_t typeId)
+{
+    VERIFY_INITIALIZED();
+    return malloc_type_calloc(num, size, typeId);
+}
+
+void * MemoryReallocTyped(void * p, size_t size, malloc_type_id_t typeId)
+{
+    VERIFY_INITIALIZED();
+    VERIFY_POINTER(p);
+    return malloc_type_realloc(p, size, typeId);
+}
+
+CHIP_MALLOC_WRAPPER_END
+
+#else
+
 void * MemoryAlloc(size_t size)
 {
     VERIFY_INITIALIZED();
@@ -108,6 +135,8 @@ void * MemoryRealloc(void * p, size_t size)
     VERIFY_POINTER(p);
     return realloc(p, size);
 }
+
+#endif
 
 void MemoryFree(void * p)
 {

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -34,6 +34,42 @@
 namespace chip {
 namespace Platform {
 
+// If type-aware malloc is available and enabled, then we'll try to use it.
+// We define CHIP_SYSTEM_CONFIG_TYPED_MALLOC to 1 in that case (0 if disabled).
+// We also provide a CHIP_OVERRIDE_MALLOC_TYPED macro, which can be added to
+// malloc-like wrappers, and allows the compiler to automatically replace the
+// wrapper with the corresponding type-aware variant. The
+// CHIP_OVERRIDE_MALLOC_TYPED macro has two arguments, the first one points to
+// the relevant type-aware replacement, and the second is a 1-based index that
+// points to the argument that can be used to perform type inference over.
+// (See https://discourse.llvm.org/t/rfc-typed-allocator-support/79720 for
+// information on how clang/llvm uses this).
+#ifndef CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+#if defined(__APPLE__) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 1
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos) _MALLOC_TYPED(override, type_param_pos)
+#else
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 0
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos)
+#endif
+#endif
+
+#if defined(__APPLE__) && CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+// Macros to turn off warnings for allocator wrappers. We use this to turn off
+// the warnings for our own type-aware wrappers.
+#define CHIP_MALLOC_WRAPPER_BEGIN _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wallocator-wrappers\"")
+#define CHIP_MALLOC_WRAPPER_END _Pragma("clang diagnostic pop")
+#else
+#define CHIP_MALLOC_WRAPPER_BEGIN
+#define CHIP_MALLOC_WRAPPER_END
+#endif
+
+#if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+extern void * MemoryAllocTyped(size_t size, malloc_type_id_t typeId);
+extern void * MemoryCallocTyped(size_t num, size_t size, malloc_type_id_t typeId);
+extern void * MemoryReallocTyped(void * p, size_t size, malloc_type_id_t typeId);
+#endif
+
 #define CHIP_ZERO_AT(value)                                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
@@ -86,7 +122,17 @@ extern void MemoryShutdown();
  * @retval  NULL-pointer if memory allocation fails.
  *
  */
-extern void * MemoryAlloc(size_t size);
+extern void * MemoryAlloc(size_t size) CHIP_OVERRIDE_MALLOC_TYPED(MemoryAllocTyped, 1);
+
+CHIP_MALLOC_WRAPPER_BEGIN
+
+template <typename T>
+T * MemoryAllocTyped(size_t num)
+{
+    return static_cast<T *>(MemoryAlloc(num * sizeof(T)));
+}
+
+CHIP_MALLOC_WRAPPER_END
 
 /**
  * This function is called by the CHIP layer to allocate a block of memory for an array of num
@@ -100,7 +146,17 @@ extern void * MemoryAlloc(size_t size);
  * @retval  NULL-pointer if memory allocation fails.
  *
  */
-extern void * MemoryCalloc(size_t num, size_t size);
+extern void * MemoryCalloc(size_t num, size_t size) CHIP_OVERRIDE_MALLOC_TYPED(MemoryCallocTyped, 2);
+
+CHIP_MALLOC_WRAPPER_BEGIN
+
+template <typename T>
+T * MemoryCallocTyped(size_t num)
+{
+    return static_cast<T *>(MemoryCalloc(num, sizeof(T)));
+}
+
+CHIP_MALLOC_WRAPPER_END
 
 /**
  * This function is called by the Chip layer to change the size of the memory block pointed to by p.
@@ -120,7 +176,7 @@ extern void * MemoryCalloc(size_t num, size_t size);
  * @retval  NULL-pointer if memory allocation fails.
  *
  */
-extern void * MemoryRealloc(void * p, size_t size);
+extern void * MemoryRealloc(void * p, size_t size) CHIP_OVERRIDE_MALLOC_TYPED(MemoryReallocTyped, 2);
 
 /**
  * This function is called by the Chip layer to release a memory block allocated by
@@ -142,7 +198,7 @@ extern void MemoryFree(void * p);
 template <typename T, typename... Args>
 inline T * New(Args &&... args)
 {
-    void * p = MemoryAlloc(sizeof(T));
+    void * p = MemoryAllocTyped<T>(1);
     if (p != nullptr)
     {
         return new (p) T(std::forward<Args>(args)...);

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <lib/core/CriticalFailure.h>
+#include <lib/support/CHIPMemTyped.h>
+#include <limits>
 #include <stdlib.h>
 
 #include <memory>
@@ -33,36 +35,6 @@
 
 namespace chip {
 namespace Platform {
-
-// If type-aware malloc is available and enabled, then we'll try to use it.
-// We define CHIP_SYSTEM_CONFIG_TYPED_MALLOC to 1 in that case (0 if disabled).
-// We also provide a CHIP_OVERRIDE_MALLOC_TYPED macro, which can be added to
-// malloc-like wrappers, and allows the compiler to automatically replace the
-// wrapper with the corresponding type-aware variant. The
-// CHIP_OVERRIDE_MALLOC_TYPED macro has two arguments, the first one points to
-// the relevant type-aware replacement, and the second is a 1-based index that
-// points to the argument that can be used to perform type inference over.
-// (See https://discourse.llvm.org/t/rfc-typed-allocator-support/79720 for
-// information on how clang/llvm uses this).
-#ifndef CHIP_SYSTEM_CONFIG_TYPED_MALLOC
-#if defined(__APPLE__) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
-#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 1
-#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos) _MALLOC_TYPED(override, type_param_pos)
-#else
-#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 0
-#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos)
-#endif
-#endif
-
-#if defined(__APPLE__) && CHIP_SYSTEM_CONFIG_TYPED_MALLOC
-// Macros to turn off warnings for allocator wrappers. We use this to turn off
-// the warnings for our own type-aware wrappers.
-#define CHIP_MALLOC_WRAPPER_BEGIN _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wallocator-wrappers\"")
-#define CHIP_MALLOC_WRAPPER_END _Pragma("clang diagnostic pop")
-#else
-#define CHIP_MALLOC_WRAPPER_BEGIN
-#define CHIP_MALLOC_WRAPPER_END
-#endif
 
 #if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
 extern void * MemoryAllocTyped(size_t size, malloc_type_id_t typeId);
@@ -126,9 +98,22 @@ extern void * MemoryAlloc(size_t size) CHIP_OVERRIDE_MALLOC_TYPED(MemoryAllocTyp
 
 CHIP_MALLOC_WRAPPER_BEGIN
 
+/**
+ * This is a helper mainly intended for implementing wrappers that forward to MemoryAlloc.
+ *
+ * @param[in]  num              Specifies number of elements (of size sizeof(T)) to allocate.
+ *
+ * @retval  Pointer to a memory block in case of success.
+ * @retval  NULL-pointer if memory allocation fails.
+ *
+ */
 template <typename T>
 T * MemoryAllocTyped(size_t num)
 {
+    if (num > std::numeric_limits<size_t>::max() / sizeof(T))
+    {
+        return nullptr;
+    }
     return static_cast<T *>(MemoryAlloc(num * sizeof(T)));
 }
 
@@ -150,6 +135,15 @@ extern void * MemoryCalloc(size_t num, size_t size) CHIP_OVERRIDE_MALLOC_TYPED(M
 
 CHIP_MALLOC_WRAPPER_BEGIN
 
+/**
+ * This is a helper mainly intended for implementing wrappers that forward to MemoryCalloc.
+ *
+ * @param[in]  num              Specifies number of elements (of size sizeof(T)) to allocate.
+ *
+ * @retval  Pointer to a memory block in case of success.
+ * @retval  NULL-pointer if memory allocation fails.
+ *
+ */
 template <typename T>
 T * MemoryCallocTyped(size_t num)
 {
@@ -198,7 +192,7 @@ extern void MemoryFree(void * p);
 template <typename T, typename... Args>
 inline T * New(Args &&... args)
 {
-    void * p = MemoryAllocTyped<T>(1);
+    void * p = MemoryAlloc(sizeof(T));
     if (p != nullptr)
     {
         return new (p) T(std::forward<Args>(args)...);

--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -163,7 +163,7 @@ inline void CopyString(char (&dest)[N], CharSpan source)
 inline char * MemoryAllocString(const char * string, size_t length)
 {
     size_t lengthWithNull = length + 1;
-    char * result         = static_cast<char *>(MemoryAlloc(lengthWithNull));
+    char * result         = MemoryAllocTyped<char>(lengthWithNull);
     CopyString(result, lengthWithNull, string);
     return result;
 }

--- a/src/lib/support/CHIPMemTyped.h
+++ b/src/lib/support/CHIPMemTyped.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines some macros for type-aware memory allocation for CHIP.
+ *
+ */
+
+#pragma once
+
+// If type-aware malloc is available and enabled, then we'll try to use it.
+// We define CHIP_SYSTEM_CONFIG_TYPED_MALLOC to 1 in that case (0 if disabled).
+//
+// We also provide a CHIP_OVERRIDE_MALLOC_TYPED macro, which can be added to
+// malloc-like wrappers, and allows the compiler to automatically replace the
+// wrapper with the corresponding type-aware variant. The
+// CHIP_OVERRIDE_MALLOC_TYPED macro has two arguments, the first one points to
+// the relevant type-aware replacement, and the second is a 1-based index that
+// points to the argument that can be used to perform type inference over.
+//
+// For example, if we have a calloc wrapper CallocWrapper, with a corresponding
+// typed variant CallocTypedWrapper, the CallocWrapper declaration would be
+// annotated as follows:
+//
+//   void * CallocTypedWrapper(size_t num, size_t size,
+//     malloc_type_id_t typeId);
+//   void * CallocWrapper(size_t num, size_t size)
+//     CHIP_OVERRIDE_MALLOC_TYPED(CallocTypedWrapper, 2);
+//
+// This signals to the compiler that the typed variant is CallocTypedWrapper,
+// and the second argument of CallocWrapper should be used to do the type
+// inference used to replace it with the typed variant.
+//
+// (See https://discourse.llvm.org/t/rfc-typed-allocator-support/79720 for
+// information on how clang/llvm uses this).
+#ifndef CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+#if defined(__APPLE__) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 1
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos) _MALLOC_TYPED(override, type_param_pos)
+#else
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 0
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos)
+#endif
+#endif
+
+// Macros to turn off warnings for allocator wrappers. We use this to turn off
+// the warnings for our own type-aware wrappers when they are enabled. For
+// example, to turn off the warning for MemoryAllocTyped because it is a
+// type-aware wrapper:
+//
+// CHIP_MALLOC_WRAPPER_BEGIN
+// T * MemoryAllocTyped(size_t num)
+// {
+//     …
+// }
+// CHIP_MALLOC_WRAPPER_END
+//
+#if defined(__APPLE__) && CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+#define CHIP_MALLOC_WRAPPER_BEGIN _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wallocator-wrappers\"")
+#define CHIP_MALLOC_WRAPPER_END _Pragma("clang diagnostic pop")
+#else
+#define CHIP_MALLOC_WRAPPER_BEGIN
+#define CHIP_MALLOC_WRAPPER_END
+#endif

--- a/src/lib/support/CHIPPlatformMemory.cpp
+++ b/src/lib/support/CHIPPlatformMemory.cpp
@@ -34,6 +34,25 @@ extern void CHIPPlatformMemoryShutdown()
     return chip::Platform::MemoryShutdown();
 }
 
+#if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+
+extern void * CHIPPlatformMemoryAllocTyped(size_t size, malloc_type_id_t typeId)
+{
+    return chip::Platform::MemoryAllocTyped(size, typeId);
+}
+
+extern void * CHIPPlatformMemoryCallocTyped(size_t num, size_t size, malloc_type_id_t typeId)
+{
+    return chip::Platform::MemoryCallocTyped(num, size, typeId);
+}
+
+extern void * CHIPPlatformMemoryReallocTyped(void * p, size_t size, malloc_type_id_t typeId)
+{
+    return chip::Platform::MemoryReallocTyped(p, size, typeId);
+}
+
+#else
+
 extern void * CHIPPlatformMemoryAlloc(size_t size)
 {
     return chip::Platform::MemoryAlloc(size);
@@ -48,6 +67,8 @@ extern void * CHIPPlatformMemoryRealloc(void * p, size_t size)
 {
     return chip::Platform::MemoryRealloc(p, size);
 }
+
+#endif
 
 extern void CHIPPlatformMemoryFree(void * p)
 {

--- a/src/lib/support/CHIPPlatformMemory.h
+++ b/src/lib/support/CHIPPlatformMemory.h
@@ -25,19 +25,9 @@
 #ifndef CHIP_PLATFORM_MEMORY_H
 #define CHIP_PLATFORM_MEMORY_H
 
+#include <lib/support/CHIPMemTyped.h>
 #include <stdbool.h>
 #include <stdlib.h>
-
-// See src/lib/support/CHIPMem.h for information on type-aware malloc usage.
-#ifndef CHIP_SYSTEM_CONFIG_TYPED_MALLOC
-#if defined(__APPLE__) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
-#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 1
-#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos) _MALLOC_TYPED(override, type_param_pos)
-#else
-#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 0
-#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos)
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/lib/support/CHIPPlatformMemory.h
+++ b/src/lib/support/CHIPPlatformMemory.h
@@ -28,15 +28,32 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+// See src/lib/support/CHIPMem.h for information on type-aware malloc usage.
+#ifndef CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+#if defined(__APPLE__) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 1
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos) _MALLOC_TYPED(override, type_param_pos)
+#else
+#define CHIP_SYSTEM_CONFIG_TYPED_MALLOC 0
+#define CHIP_OVERRIDE_MALLOC_TYPED(override, type_param_pos)
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+extern void * CHIPPlatformMemoryAllocTyped(size_t size, malloc_type_id_t typeId);
+extern void * CHIPPlatformMemoryCallocTyped(size_t num, size_t size, malloc_type_id_t typeId);
+extern void * CHIPPlatformMemoryReallocTyped(void * p, size_t size, malloc_type_id_t typeId);
+#endif
+
 extern int CHIPPlatformMemoryInit(void * buf, size_t bufSize);
 extern void CHIPPlatformMemoryShutdown();
-extern void * CHIPPlatformMemoryAlloc(size_t size);
-extern void * CHIPPlatformMemoryCalloc(size_t num, size_t size);
-extern void * CHIPPlatformMemoryRealloc(void * p, size_t size);
+extern void * CHIPPlatformMemoryAlloc(size_t size) CHIP_OVERRIDE_MALLOC_TYPED(CHIPPlatformMemoryAllocTyped, 1);
+extern void * CHIPPlatformMemoryCalloc(size_t num, size_t size) CHIP_OVERRIDE_MALLOC_TYPED(CHIPPlatformMemoryCallocTyped, 2);
+extern void * CHIPPlatformMemoryRealloc(void * p, size_t size) CHIP_OVERRIDE_MALLOC_TYPED(CHIPPlatformMemoryReallocTyped, 2);
 extern void CHIPPlatformMemoryFree(void * p);
 
 #ifdef __cplusplus

--- a/src/lib/support/ReadOnlyBuffer.cpp
+++ b/src/lib/support/ReadOnlyBuffer.cpp
@@ -52,7 +52,7 @@ GenericAppendOnlyBuffer & GenericAppendOnlyBuffer::operator=(GenericAppendOnlyBu
 
     if (mBufferIsAllocated && (mBuffer != nullptr))
     {
-        Platform::Impl::PlatformMemoryManagement::MemoryFree(mBuffer);
+        Platform::MemoryFree(mBuffer);
     }
 
     // take over the data

--- a/src/lib/support/ScopedMemoryBuffer.h
+++ b/src/lib/support/ScopedMemoryBuffer.h
@@ -98,16 +98,18 @@ protected:
         return buffer;
     }
 
-    void Alloc(size_t size)
+    template <typename T>
+    void Alloc(size_t elementCount)
     {
         Free();
-        mBuffer = Impl::MemoryAlloc(size);
+        mBuffer = Impl::template MemoryAlloc<T>(elementCount);
     }
 
-    void Calloc(size_t elementCount, size_t elementSize)
+    template <typename T>
+    void Calloc(size_t elementCount)
     {
         Free();
-        mBuffer = Impl::MemoryCalloc(elementCount, elementSize);
+        mBuffer = Impl::template MemoryCalloc<T>(elementCount);
     }
 
 private:
@@ -121,8 +123,16 @@ class PlatformMemoryManagement
 {
 public:
     static void MemoryFree(void * p) { chip::Platform::MemoryFree(p); }
-    static void * MemoryAlloc(size_t size) { return chip::Platform::MemoryAlloc(size); }
-    static void * MemoryCalloc(size_t num, size_t size) { return chip::Platform::MemoryCalloc(num, size); }
+    template <typename T>
+    static void * MemoryAlloc(size_t num)
+    {
+        return chip::Platform::MemoryAllocTyped<T>(num);
+    }
+    template <typename T>
+    static void * MemoryCalloc(size_t num)
+    {
+        return chip::Platform::MemoryCallocTyped<T>(num);
+    }
 };
 
 } // namespace Impl
@@ -160,14 +170,14 @@ public:
 
     ScopedMemoryBuffer & Calloc(size_t elementCount)
     {
-        Base::Calloc(elementCount, sizeof(T));
+        Base::template Calloc<T>(elementCount);
         ExecuteConstructors(elementCount);
         return *this;
     }
 
     ScopedMemoryBuffer & Alloc(size_t elementCount)
     {
-        Base::Alloc(elementCount * sizeof(T));
+        Base::template Alloc<T>(elementCount);
         ExecuteConstructors(elementCount);
         return *this;
     }

--- a/src/lib/support/ScopedMemoryBuffer.h
+++ b/src/lib/support/ScopedMemoryBuffer.h
@@ -98,18 +98,16 @@ protected:
         return buffer;
     }
 
-    template <typename T>
-    void Alloc(size_t elementCount)
+    void Alloc(size_t elementCount, size_t elementSize)
     {
         Free();
-        mBuffer = Impl::template MemoryAlloc<T>(elementCount);
+        mBuffer = Impl::MemoryAlloc(elementCount, elementSize);
     }
 
-    template <typename T>
-    void Calloc(size_t elementCount)
+    void Calloc(size_t elementCount, size_t elementSize)
     {
         Free();
-        mBuffer = Impl::template MemoryCalloc<T>(elementCount);
+        mBuffer = Impl::MemoryCalloc(elementCount, elementSize);
     }
 
 private:
@@ -118,22 +116,30 @@ private:
 
 /**
  * Helper class that forwards memory management tasks to Platform::Memory* calls.
+ * Note that it is required that the second size_t argument passed to
+ * MemoryAlloc/MemoryCalloc by ScopedMemoryBuffer is the size of the
+ * ScopedMemoryBuffer's T parameter.
  */
+#if CHIP_SYSTEM_CONFIG_TYPED_MALLOC
+template <typename T>
 class PlatformMemoryManagement
 {
 public:
     static void MemoryFree(void * p) { chip::Platform::MemoryFree(p); }
-    template <typename T>
-    static void * MemoryAlloc(size_t num)
-    {
-        return chip::Platform::MemoryAllocTyped<T>(num);
-    }
-    template <typename T>
-    static void * MemoryCalloc(size_t num)
-    {
-        return chip::Platform::MemoryCallocTyped<T>(num);
-    }
+    static void * MemoryAlloc(size_t num, size_t) { return chip::Platform::MemoryAllocTyped<T>(num); }
+    static void * MemoryCalloc(size_t num, size_t) { return chip::Platform::MemoryCallocTyped<T>(num); }
 };
+#else
+class SimplePlatformMemoryManagement
+{
+public:
+    static void MemoryFree(void * p) { chip::Platform::MemoryFree(p); }
+    static void * MemoryAlloc(size_t num, size_t size) { return chip::Platform::MemoryAlloc(num * size); }
+    static void * MemoryCalloc(size_t num, size_t size) { return chip::Platform::MemoryCalloc(num, size); }
+};
+template <typename T>
+using PlatformMemoryManagement = SimplePlatformMemoryManagement;
+#endif
 
 } // namespace Impl
 
@@ -145,7 +151,7 @@ public:
  *
  * For a single element RAII with dtor, use Platform::UniquePtr<>
  */
-template <typename T, class MemoryManagement = Impl::PlatformMemoryManagement>
+template <typename T, typename MemoryManagement = Impl::PlatformMemoryManagement<T>>
 class ScopedMemoryBuffer : public Impl::ScopedMemoryBufferBase<MemoryManagement>
 {
     friend class Impl::ScopedMemoryBufferBase<MemoryManagement>;
@@ -170,14 +176,14 @@ public:
 
     ScopedMemoryBuffer & Calloc(size_t elementCount)
     {
-        Base::template Calloc<T>(elementCount);
+        Base::Calloc(elementCount, sizeof(T));
         ExecuteConstructors(elementCount);
         return *this;
     }
 
     ScopedMemoryBuffer & Alloc(size_t elementCount)
     {
-        Base::template Alloc<T>(elementCount);
+        Base::Alloc(elementCount, sizeof(T));
         ExecuteConstructors(elementCount);
         return *this;
     }

--- a/src/lib/support/tests/TestScopedMemoryBuffer.cpp
+++ b/src/lib/support/tests/TestScopedMemoryBuffer.cpp
@@ -40,16 +40,17 @@ public:
         mAllocCount--;
         chip::Platform::MemoryFree(p);
     }
-    static void * MemoryAlloc(size_t size)
+    template <typename T>
+    static void * MemoryAlloc(size_t num)
     {
         mAllocCount++;
-        return chip::Platform::MemoryAlloc(size);
+        return chip::Platform::MemoryAllocTyped<T>(num);
     }
-    static void * MemoryCalloc(size_t num, size_t size)
+    template <typename T>
+    static void * MemoryCalloc(size_t num)
     {
-
         mAllocCount++;
-        return chip::Platform::MemoryCalloc(num, size);
+        return chip::Platform::MemoryCallocTyped<T>(num);
     }
 
 private:

--- a/src/lib/support/tests/TestScopedMemoryBuffer.cpp
+++ b/src/lib/support/tests/TestScopedMemoryBuffer.cpp
@@ -40,17 +40,15 @@ public:
         mAllocCount--;
         chip::Platform::MemoryFree(p);
     }
-    template <typename T>
-    static void * MemoryAlloc(size_t num)
+    static void * MemoryAlloc(size_t num, size_t)
     {
         mAllocCount++;
-        return chip::Platform::MemoryAllocTyped<T>(num);
+        return chip::Platform::MemoryAllocTyped<char>(num);
     }
-    template <typename T>
-    static void * MemoryCalloc(size_t num)
+    static void * MemoryCalloc(size_t num, size_t)
     {
         mAllocCount++;
-        return chip::Platform::MemoryCallocTyped<T>(num);
+        return chip::Platform::MemoryCallocTyped<char>(num);
     }
 
 private:


### PR DESCRIPTION
### Summary

Use type-aware malloc if available. This will be enabled on Apple builds with clang for now, if built with the right flags for type-aware malloc (see https://developer.apple.com/documentation/xcode/adopting-type-aware-memory-allocation and https://discourse.llvm.org/t/rfc-typed-allocator-support/79720).

### Related issues

### Testing

Built with an Xcode/clang that supports type-aware malloc and the relevant build flags enabled.