### PR TITLE
[controller] Guard kRemoveWiFiNetworkConfig against unset Wi-Fi credentials

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3930,6 +3930,15 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         break;
     }
     case CommissioningStage::kRemoveWiFiNetworkConfig: {
+        if (!params.GetWiFiCredentials().HasValue())
+        {
+            // Match the guard in kRemoveThreadNetworkConfig below: without configured Wi-Fi
+            // credentials there is no network to remove, so complete the stage with an error
+            // instead of reading the unset credentials Optional.
+            ChipLogError(Controller, "No Wi-Fi credentials configured at commissioner!");
+            CommissioningStageComplete(CHIP_ERROR_INVALID_ARGUMENT);
+            return;
+        }
         NetworkCommissioning::Commands::RemoveNetwork::Type request;
         request.networkID = params.GetWiFiCredentials().Value().ssid;
         request.breadcrumb.Emplace(breadcrumb);

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -18,7 +18,9 @@
 
 #include <pw_unit_test/framework.h>
 
+#include <app/DeviceProxy.h>
 #include <controller/AutoCommissioner.h>
+#include <controller/CHIPDeviceController.h>
 #include <controller/CommissioningDelegate.h>
 #include <controller/tests/AutoCommissionerTestAccess.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -687,5 +689,59 @@ TEST_F(AutoCommissionerTest, IsSecondaryNetworkSupportedCombinations)
         }
         EXPECT_EQ(result, c.isSecondaryNetworkSupported);
     }
+}
+
+// Minimal DeviceProxy: only GetDeviceId() is exercised on the guarded path.
+class FakeDeviceProxy : public DeviceProxy
+{
+public:
+    void Disconnect() override {}
+    NodeId GetDeviceId() const override { return 0x1122334455667788ULL; }
+    Messaging::ExchangeManager * GetExchangeManager() const override { return nullptr; }
+    Optional<SessionHandle> GetSecureSession() const override { return NullOptional; }
+    bool IsSecureConnected() const override { return false; }
+};
+
+// Captures the CHIP_ERROR that PerformCommissioningStep reports for the stage.
+class CapturingCommissioningDelegate : public CommissioningDelegate
+{
+public:
+    CHIP_ERROR SetCommissioningParameters(const CommissioningParameters & params) override
+    {
+        mParams = params;
+        return CHIP_NO_ERROR;
+    }
+    const CommissioningParameters & GetCommissioningParameters() const override { return mParams; }
+    void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate *) override {}
+    CHIP_ERROR StartCommissioning(DeviceCommissioner *, CommissioneeDeviceProxy *) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningReport) override
+    {
+        mCalled  = true;
+        mLastErr = err;
+        return CHIP_NO_ERROR; // return success so CommissioningStageComplete does not enter the cleanup path
+    }
+
+    bool mCalled       = false;
+    CHIP_ERROR mLastErr = CHIP_NO_ERROR;
+
+private:
+    CommissioningParameters mParams;
+};
+
+// The kRemoveWiFiNetworkConfig stage should behave like its kRemoveThreadNetworkConfig
+// sibling: when no Wi-Fi credentials are configured there is no network to remove, so the
+// stage completes with CHIP_ERROR_INVALID_ARGUMENT rather than reading the unset Optional.
+TEST(DeviceCommissionerNetworkConfigRemovalTest, RemoveWiFiNetworkConfigWithoutCredentialsFailsGracefully)
+{
+    DeviceCommissioner commissioner; // lightweight ctor + empty dtor; no Init() needed for this path
+    FakeDeviceProxy proxy;
+    CapturingCommissioningDelegate delegate;
+    CommissioningParameters params; // deliberately no Wi-Fi credentials
+
+    commissioner.PerformCommissioningStep(&proxy, CommissioningStage::kRemoveWiFiNetworkConfig, params, &delegate,
+                                          kRootEndpointId, NullOptional);
+
+    EXPECT_TRUE(delegate.mCalled);
+    EXPECT_EQ(delegate.mLastErr, CHIP_ERROR_INVALID_ARGUMENT);
 }
 } // namespace

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -721,7 +721,7 @@ public:
         return CHIP_NO_ERROR; // return success so CommissioningStageComplete does not enter the cleanup path
     }
 
-    bool mCalled       = false;
+    bool mCalled        = false;
     CHIP_ERROR mLastErr = CHIP_NO_ERROR;
 
 private:
@@ -738,8 +738,8 @@ TEST(DeviceCommissionerNetworkConfigRemovalTest, RemoveWiFiNetworkConfigWithoutC
     CapturingCommissioningDelegate delegate;
     CommissioningParameters params; // deliberately no Wi-Fi credentials
 
-    commissioner.PerformCommissioningStep(&proxy, CommissioningStage::kRemoveWiFiNetworkConfig, params, &delegate,
-                                          kRootEndpointId, NullOptional);
+    commissioner.PerformCommissioningStep(&proxy, CommissioningStage::kRemoveWiFiNetworkConfig, params, &delegate, kRootEndpointId,
+                                          NullOptional);
 
     EXPECT_TRUE(delegate.mCalled);
     EXPECT_EQ(delegate.mLastErr, CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
#### Summary

`DeviceCommissioner::PerformCommissioningStep` handled the `kRemoveWiFiNetworkConfig` stage by reading `params.GetWiFiCredentials().Value()` unconditionally, while the sibling `kRemoveThreadNetworkConfig` stage already checks `HasValue()` before using its operational dataset. This aligns the two network-removal branches.

When no Wi-Fi credentials are configured there is no network to remove, so the stage now completes with `CHIP_ERROR_INVALID_ARGUMENT` (matching the Thread sibling) instead of reading the unset `Optional`.

#### Testing

Adds `DeviceCommissionerNetworkConfigRemovalTest.RemoveWiFiNetworkConfigWithoutCredentialsFailsGracefully`, which drives `PerformCommissioningStep(kRemoveWiFiNetworkConfig, ...)` with no credentials and verifies the stage completes with `CHIP_ERROR_INVALID_ARGUMENT`.

Run: `ninja -C out/linux-x64-tests-clang src/controller/tests:TestAutoCommissioner.run`
