### PR TITLE
[Silabs] MATTER-6655: Add briefs to refactored AppTask methods (#998)

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -59,6 +59,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -68,6 +69,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -90,6 +92,7 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
@@ -102,13 +105,13 @@ public:
      */
     CHIP_ERROR GetAirQualityValue(int32_t & air_quality);
 
-    // Reads new generated sensor value, stores it, and updates local Air Quality attribute
+    /** @brief Reads new generated sensor value, stores it, and updates local Air Quality attribute */
     static void SensorTimerEventHandler(void * arg);
 
 protected:
-    /** Override of `BaseApplication::AppInit()`. */
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading. */
+    /** @brief Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading. */
     CHIP_ERROR InitAirQualitySensor();
 };

--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -91,7 +91,7 @@ public:
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
     /**
-     * @brief Matter stack callback after a server attribute write, logs Identify cluster changes.
+     * @brief Matter stack callback triggered after a server attribute changes.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
      * @param type          TLV encoding type of @p value

--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -59,7 +59,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -69,7 +68,6 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -92,7 +90,14 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-    /** @brief Data model hook invoked when a cluster attribute changes */
+    /**
+     * @brief Data model hook invoked when a cluster attribute changes
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
+     * @param value         Pointer to the new attribute value
+     */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
@@ -105,13 +110,22 @@ public:
      */
     CHIP_ERROR GetAirQualityValue(int32_t & air_quality);
 
-    /** @brief Reads new generated sensor value, stores it, and updates local Air Quality attribute */
+    /**
+     * @brief Reads new generated sensor value, stores it, and updates local Air Quality attribute.
+     *
+     * @param arg CMSIS timer callback argument
+     */
     static void SensorTimerEventHandler(void * arg);
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** @brief Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading. */
+    /**
+     * @brief Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading.
+     *
+     * @return CHIP_NO_ERROR on success, otherwise APP_ERROR_CREATE_TIMER_FAILED if the sensor timer
+     *         could not be created, or MATTER_PLATFORM_ERROR(...) if the air quality sensor driver
+     *         init fails when USE_AIR_QUALITY_SENSOR is set.
+     */
     CHIP_ERROR InitAirQualitySensor();
 };

--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -91,7 +91,7 @@ public:
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
     /**
-     * @brief Data model hook invoked when a cluster attribute changes
+     * @brief Matter stack callback after a server attribute write, logs Identify cluster changes.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
      * @param type          TLV encoding type of @p value

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -104,34 +104,60 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
+    /**
+     * @brief AppTask task main loop function
+     *
+     * @param pvParameter FreeRTOS task parameter
+     */
     static void AppTaskMain(void * pvParameter);
+
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
+    /**
+     * @brief Event handler when a button is pressed
+     *
+     * @param button    APP_FUNCTION_BUTTON or the action button
+     * @param btnAction SL_SIMPLE_BUTTON_PRESSED, SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
+     */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
+
+    /** @brief AppTask thread event handler for queued button events */
     static void AppEventHandler(AppEvent * aEvent);
 
+    /** @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch command */
     static void SwitchWorkerFunction(intptr_t context);
+
+    /** @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action */
     static void GenericSwitchWorkerFunction(intptr_t context);
 
+    /** @brief Sends an OnOff cluster command to the bound peer device for the given binding entry */
     static void ProcessOnOffBindingCommand(chip::CommandId commandId, const chip::app::Clusters::Binding::TableEntry & binding,
                                            chip::OperationalDeviceProxy * peer_device);
 
+    /** @brief Sends a LevelControl cluster command to the bound peer device for the given binding entry */
     static void ProcessLevelControlBindingCommand(BindingCommandData * data,
                                                   const chip::app::Clusters::Binding::TableEntry & binding,
                                                   chip::OperationalDeviceProxy * peer_device);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief Binding manager callback invoked per bound device to send a switch command to the target light */
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry & binding,
                                           chip::OperationalDeviceProxy * peer_device, void * context);
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
+    /** @brief Light switch specific initialization */
     CHIP_ERROR InitLightSwitch(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
+    /** @brief Handler scheduled on the Matter thread to set up the binding table */
     static void InitBindingHandler(intptr_t arg);
 };

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -119,7 +119,7 @@ public:
      * @brief Event handler when a button is pressed
      *
      * @param button    APP_FUNCTION_BUTTON or the action button
-     * @param btnAction SL_SIMPLE_BUTTON_PRESSED, SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
+     * @param btnAction SL_SIMPLE_BUTTON_PRESSED, SL_SIMPLE_BUTTON_RELEASED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -128,7 +128,8 @@ public:
     /** @brief AppTask thread event handler for queued button events */
     static void AppEventHandler(AppEvent * aEvent);
 
-    /** @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch command */
+    /** @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch
+     * command */
     static void SwitchWorkerFunction(intptr_t context);
 
     /** @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action */

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -161,7 +161,7 @@ public:
                                                   chip::OperationalDeviceProxy * peer_device);
 
     /**
-     * @brief Data model hook invoked when a cluster attribute changes.
+     * @brief Matter stack callback after a server attribute write, logs Identify cluster changes.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
      * @param type          TLV encoding type of @p value

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -126,14 +126,15 @@ public:
     static void AppEventHandler(AppEvent * aEvent);
 
     /**
-     * @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch
+     * @brief Notifies the binding manager that a bound cluster changed to drive the outgoing switch. This action is queued to
+     *        the Matter thread/task.
      *
      * @param context Work item pointer passed to PlatformMgr::ScheduleWork
      */
     static void SwitchWorkerFunction(intptr_t context);
 
     /**
-     * @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action.
+     * @brief Handler scheduled on the Matter thread to emit a Generic Switch cluster event for the queued switch action.
      *
      * @param context Pointer to a GenericSwitchEventData allocated for this work item
      */

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -104,7 +104,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -114,7 +113,6 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -125,40 +123,73 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-    /** @brief AppTask thread event handler for queued button events */
     static void AppEventHandler(AppEvent * aEvent);
 
-    /** @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch
-     * command */
+    /**
+     * @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch
+     *
+     * @param context Work item pointer passed to PlatformMgr::ScheduleWork
+     */
     static void SwitchWorkerFunction(intptr_t context);
 
-    /** @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action */
+    /**
+     * @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action.
+     *
+     * @param context Pointer to a GenericSwitchEventData allocated for this work item
+     */
     static void GenericSwitchWorkerFunction(intptr_t context);
 
-    /** @brief Sends an OnOff cluster command to the bound peer device for the given binding entry */
+    /**
+     * @brief Sends an OnOff cluster command to the bound peer device for the given binding entry.
+     *
+     * @param commandId   OnOff cluster command to send
+     * @param binding     Binding table entry identifying the target
+     * @param peer_device Operational session to the bound peer, or nullptr for group bindings
+     */
     static void ProcessOnOffBindingCommand(chip::CommandId commandId, const chip::app::Clusters::Binding::TableEntry & binding,
                                            chip::OperationalDeviceProxy * peer_device);
 
-    /** @brief Sends a LevelControl cluster command to the bound peer device for the given binding entry */
+    /**
+     * @brief Sends a LevelControl cluster command to the bound peer device for the given binding entry.
+     *
+     * @param data        LevelControl command payload and local endpoint context
+     * @param binding     Binding table entry identifying the target
+     * @param peer_device Operational session to the bound peer, or nullptr for group bindings
+     */
     static void ProcessLevelControlBindingCommand(BindingCommandData * data,
                                                   const chip::app::Clusters::Binding::TableEntry & binding,
                                                   chip::OperationalDeviceProxy * peer_device);
 
-    /** @brief Data model hook invoked when a cluster attribute changes */
+    /**
+     * @brief Data model hook invoked when a cluster attribute changes.
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
+     * @param value         Pointer to the new attribute value
+     */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
-    /** @brief Binding manager callback invoked per bound device to send a switch command to the target light */
+    /**
+     * @brief Binding manager callback invoked per bound device to send a switch command to the target light.
+     *
+     * @param binding     Binding table entry for the peer light
+     * @param peer_device Operational session to the bound peer
+     * @param context     Opaque context from the binding manager
+     */
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry & binding,
                                           chip::OperationalDeviceProxy * peer_device, void * context);
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** @brief Light switch specific initialization */
     CHIP_ERROR InitLightSwitch(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
-    /** @brief Handler scheduled on the Matter thread to set up the binding table */
+    /**
+     * @brief Handler scheduled on the Matter thread to set up the binding table.
+     *
+     * @param arg Opaque argument passed to PlatformMgr::ScheduleWork
+     */
     static void InitBindingHandler(intptr_t arg);
 };

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -100,7 +100,7 @@ protected:
     CHIP_ERROR InitLight();
 
     /**
-     * @brief Chip-thread work item, push the OnOff cluster state through `OnOffServer::setOnOffValue`.
+     * @brief Handler scheduled on the Matter thread to push the OnOff cluster state through `OnOffServer::setOnOffValue`.
      *
      * @param context Opaque work item pointer passed to PlatformMgr::ScheduleWork
      */

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -43,7 +43,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -53,7 +52,6 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -64,31 +62,46 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-    /** @brief OnOff cluster callback for the off with effect command */
     static void OnTriggerOffWithEffect(OnOffEffect * effect);
 
-    /** @brief Data model hook invoked when a cluster attribute changes */
+    /**
+     * @brief Data model hook invoked when a cluster attribute changes
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
+     * @param value         Pointer to the new attribute value
+     */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
-    /** @brief AppTask thread event handler that applies a light action */
     static void LightActionEventHandler(AppEvent * aEvent);
 
-    /** @brief Timer expiry callback driving timed light transitions */
+    /**
+     * @brief Timer expiry callback driving timed light transitions.
+     *
+     * @param timerCbArg CMSIS timer callback argument
+     */
     static void LightTimerEventHandler(void * timerCbArg);
 
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
-    /** @brief AppTask thread event handler for RGB LED control */
     static void LightControlEventHandler(AppEvent * aEvent);
 #endif
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** @brief Light specific initialization */
+    /**
+     * @brief Create the light transition timer and read initial OnOff/level/color state from the data model.
+     *
+     * @return CHIP_NO_ERROR on success, or APP_ERROR_CREATE_TIMER_FAILED if the timer could not be created.
+     */
     CHIP_ERROR InitLight();
 
-    /** @brief Chip-thread work item: push the OnOff cluster state through `OnOffServer::setOnOffValue` */
+    /**
+     * @brief Chip-thread work item, push the OnOff cluster state through `OnOffServer::setOnOffValue`.
+     *
+     * @param context Opaque work item pointer passed to PlatformMgr::ScheduleWork
+     */
     static void UpdateOnOffClusterState(intptr_t context);
 };

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -43,6 +43,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -52,6 +53,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -62,22 +64,31 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief OnOff cluster callback for the off with effect command */
     static void OnTriggerOffWithEffect(OnOffEffect * effect);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief AppTask thread event handler that applies a light action */
     static void LightActionEventHandler(AppEvent * aEvent);
 
+    /** @brief Timer expiry callback driving timed light transitions */
     static void LightTimerEventHandler(void * timerCbArg);
 
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+    /** @brief AppTask thread event handler for RGB LED control */
     static void LightControlEventHandler(AppEvent * aEvent);
 #endif
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Light specific initialization */
     CHIP_ERROR InitLight();
 
+    /** @brief Chip-thread work item: push the OnOff cluster state through `OnOffServer::setOnOffValue` */
     static void UpdateOnOffClusterState(intptr_t context);
 };

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -65,7 +65,7 @@ public:
     static void OnTriggerOffWithEffect(OnOffEffect * effect);
 
     /**
-     * @brief Matter stack callback after a server attribute write, syncs OnOff, LevelControl, and
+     * @brief Matter stack callback after a server attribute change, syncs OnOff, LevelControl, and
      *        ColorControl changes to the LED and display.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -65,7 +65,8 @@ public:
     static void OnTriggerOffWithEffect(OnOffEffect * effect);
 
     /**
-     * @brief Data model hook invoked when a cluster attribute changes
+     * @brief Matter stack callback after a server attribute write, syncs OnOff, LevelControl, and
+     *        ColorControl changes to the LED and display.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
      * @param type          TLV encoding type of @p value

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -32,6 +32,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -41,8 +42,10 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
+    /** @brief Requests a refresh of the thermostat LCD UI */
     static void UpdateThermoStatUI();
 
     /**
@@ -91,7 +94,7 @@ public:
     CHIP_ERROR GetTemperature(int16_t & temperature);
 
 protected:
-    /** Override of `BaseApplication::AppInit()`. */
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
     /** Bring up the thermostat app: sensor timer, sensor driver, first UI paint. */

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -65,8 +65,8 @@ public:
     static void TemperatureUpdateEventHandler(AppEvent * aEvent);
 
     /**
-     * @brief Thermostat-cluster post-attribute-change callback. Logs per-attribute info and
-     *        triggers a UI refresh. Also fans out to the AWS hook when SL_MATTER_ENABLE_AWS is set.
+     * @brief Matter stack callback after a server attribute write, logs Thermostat attributes and
+     *        refreshes the UI.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
      * @param type          TLV encoding type of @p value

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -32,7 +32,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -42,10 +41,8 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
-    /** @brief Requests a refresh of the thermostat LCD UI */
     static void UpdateThermoStatUI();
 
     /**
@@ -70,6 +67,11 @@ public:
     /**
      * @brief Thermostat-cluster post-attribute-change callback. Logs per-attribute info and
      *        triggers a UI refresh. Also fans out to the AWS hook when SL_MATTER_ENABLE_AWS is set.
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
+     * @param value         Pointer to the new attribute value
      */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
@@ -94,9 +96,13 @@ public:
     CHIP_ERROR GetTemperature(int16_t & temperature);
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** Bring up the thermostat app: sensor timer, sensor driver, first UI paint. */
+    /**
+     * @brief Bring up the thermostat app: sensor timer, sensor driver, first UI paint.
+     *
+     * @return CHIP_NO_ERROR on success, otherwise APP_ERROR_CREATE_TIMER_FAILED if the sensor timer
+     *         could not be created, or an error propagated from InitSensor().
+     */
     CHIP_ERROR InitThermostat();
 };

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -65,7 +65,7 @@ public:
     static void TemperatureUpdateEventHandler(AppEvent * aEvent);
 
     /**
-     * @brief Matter stack callback after a server attribute write, logs Thermostat attributes and
+     * @brief Matter stack callback after a server attribute change, logs Thermostat attributes and
      *        refreshes the UI.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed


### PR DESCRIPTION
### Summary
Late in cycle point was made to add doxygen style briefs to all AppTask methods in AppTask.h. Some apps/methods have this, but there are some gaps.

Add doxygen style briefs to refactored app APIs where they are missing

### Related issues
MATTER-6655

### Testing
n/a comment only