### PR TITLE
[NXP] Add NXP Worklow to the platform_maintainers.yaml file

### DIFF
--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -23,6 +23,7 @@ nxp:
     - "third_party/simw-top-mini/**"
     - "third_party/openthread/platforms/nxp/**"
     - "config/nxp/**"
+    - ".github/workflows/examples-nxp.yaml"
 
 silabs:
   maintainers:


### PR DESCRIPTION
### Summary

Adding .github/workflows/examples-nxp.yaml to the platform_maintainers.yaml file.

### Testing

Verified by Github CI jobs.
