### PR TITLE
[Camera] Fix double-free crash in PushAVClipRecorder

### DIFF
--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -512,17 +512,20 @@ void PushAVClipRecorder::Stop()
             ChipLogError(Camera, "PushAVClipRecorder::Stop - Cluster server reference is null for connection %u", mConnectionID);
         }
 
-        while (!mVideoQueue.empty())
         {
-            AVPacket * packet = mVideoQueue.front();
-            mVideoQueue.pop();
-            av_packet_free(&packet);
-        }
-        while (!mAudioQueue.empty())
-        {
-            AVPacket * packet = mAudioQueue.front();
-            mAudioQueue.pop();
-            av_packet_free(&packet);
+            std::lock_guard<std::mutex> lock(mQueueMutex);
+            while (!mVideoQueue.empty())
+            {
+                AVPacket * packet = mVideoQueue.front();
+                mVideoQueue.pop();
+                av_packet_free(&packet);
+            }
+            while (!mAudioQueue.empty())
+            {
+                AVPacket * packet = mAudioQueue.front();
+                mAudioQueue.pop();
+                av_packet_free(&packet);
+            }
         }
     }
     else
@@ -653,7 +656,9 @@ RecorderStatus PushAVClipRecorder::StartClipRecording()
         {
             ChipLogError(Camera, "Error processing buffers and writing");
             result = RecorderStatus::kFail;
+            lock.unlock(); // Unlock before calling Stop() to avoid deadlock
             Stop();
+            break;
         }
         else if (status == RecorderStatus::kWarning)
         {


### PR DESCRIPTION
#### Summary

Fixes a crash in the `chip-camera-app` caused by a double-free in `PushAVClipRecorder`.

##### Problem

A race condition exists between the main thread (destructor/Stop) and the recorder worker thread:
- **Main Thread**: Clears `mVideoQueue` and `mAudioQueue` and frees all packets using `av_packet_free()` without acquiring `mQueueMutex`.
- **Worker Thread**: Processes a packet from the queue in `ProcessBuffersAndWrite()`. It holds a pointer to the packet (`pkt`).
- If the main thread runs while the worker thread is processing, the main thread frees the packet. The worker thread then finishes and attempts to free the same packet via `av_packet_free(&pkt)`, resulting in a double-free crash.

Example failure:
- https://github.com/project-chip/connectedhomeip/actions/runs/29104596404/job/86406336828

##### Solution

- Lock `mQueueMutex` in `Stop()` while clearing the queues to prevent concurrent access/freeing.
- Unlock the queue mutex in `StartClipRecording()` before calling `Stop()` to avoid deadlock (since `StartClipRecording` holds the lock, and `Stop()` now acquires it).
- Exit the worker thread loop immediately after calling `Stop()` on failure.

#### Testing

- Verified with `TC_PAVST_2_12.py` using `chip-camera-app` built with ASAN.
