### PR TITLE
Darwin:  Fix availability annotation of private ID constants

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
@@ -7,7 +7,7 @@
 #pragma mark - Private Cluster IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateClusterIDType) {
-    MTRPrivateClusterIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateClusterIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
@@ -21,7 +21,7 @@ typedef NS_ENUM(uint32_t, MTRPrivateClusterIDType) {
 #pragma mark - Private Attribute IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateAttributeIDType) {
-    MTRPrivateAttributeIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateAttributeIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 {{#*inline "attributeIDs"}}
@@ -63,7 +63,7 @@ typedef NS_ENUM(uint32_t, MTRPrivateAttributeIDType) {
 #pragma mark - Private Command IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateCommandIDType) {
-    MTRPrivateCommandIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateCommandIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 {{#*inline "commandIDs"}}
@@ -101,7 +101,7 @@ typedef NS_ENUM(uint32_t, MTRPrivateCommandIDType) {
 #pragma mark - Private Event IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateEventIDType) {
-    MTRPrivateEventIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateEventIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 {{#*inline "eventIDs"}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants_Private.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants_Private.h
@@ -22,23 +22,23 @@
 #pragma mark - Private Cluster IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateClusterIDType) {
-    MTRPrivateClusterIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateClusterIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 };
 
 #pragma mark - Private Attribute IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateAttributeIDType) {
-    MTRPrivateAttributeIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateAttributeIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 };
 
 #pragma mark - Private Command IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateCommandIDType) {
-    MTRPrivateCommandIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateCommandIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 };
 
 #pragma mark - Private Event IDs
 
 typedef NS_ENUM(uint32_t, MTRPrivateEventIDType) {
-    MTRPrivateEventIDTypeReserved MTR_NEWLY_AVAILABLE = 0xFFFFFFFF,
+    MTRPrivateEventIDTypeReserved MTR_PROVISIONALLY_AVAILABLE = 0xFFFFFFFF,
 };


### PR DESCRIPTION
### Summary

Previously used `NEWLY_AVAILABLE` annotation; that was incorrect.  `PROVISIONALLY_AVAILABLE` gives the correct visibility.

### Testing

`./scripts/tools/zap_regen_all.py --type specific` and check that the generated `MTRClusterConstants_Private.h` uses `PROVISIONALLY_AVAILABLE` annotations.
