### PR TITLE
Fix TC_CNET_4_12 thread transition

### DIFF
--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -256,17 +256,14 @@ class TC_CNET_4_12(MatterBaseTest):
         asserts.assert_true(thread_dataset_2 is not None, "Missing required THREAD_2ND: PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET")
 
         # All required endpoint and Threads dataset are set and assigned, Thread dataset as str
-        log.info('Precondition: All required arguments are set and assigned, Thread dataset as str: '
-                 f'THREADS_ENDPOINT = {endpoint}, '
-                 f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1}, '
-                 f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2}')
+        log.info('Precondition: All required arguments are set and assigned, Thread dataset as str: THREADS_ENDPOINT = %s, THREAD_1ST_OPERATIONALDATASET = %s, PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = %s',
+                 endpoint, thread_dataset_1, thread_dataset_2)
         thread_dataset_1_bytes = thread_dataset_1
         thread_dataset_2_bytes = bytes.fromhex(thread_dataset_2)
 
         # All required arguments are set and assigned, Thread dataset as bytes
-        log.info('Precondition: All required arguments are set and assigned, Thread dataset as bytes: '
-                 f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1_bytes}, '
-                 f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2_bytes}')
+        log.info('Precondition: All required arguments are set and assigned, Thread dataset as bytes: THREAD_1ST_OPERATIONALDATASET = %s, PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = %s',
+                 thread_dataset_1_bytes, thread_dataset_2_bytes)
 
         # Validate the operational dataset structure (for both datasets)
         log.info("Precondition: Validating THREAD operational datasets")
@@ -276,9 +273,8 @@ class TC_CNET_4_12(MatterBaseTest):
         # CNET 4.10, ... (add other tests here)
         thread_network_id_bytes_th1 = await self.validate_thread_dataset(thread_dataset_1_bytes, "THREAD_1ST_OPERATIONALDATASET")
         thread_network_id_bytes_th2 = await self.validate_thread_dataset(thread_dataset_2_bytes, "THREAD_2ND_OPERATIONALDATASET")
-        log.info('Precondition: NetworkID : '
-                 f'NetworkID_THREAD_1ST_OPERATIONALDATASET = {thread_network_id_bytes_th1}, '
-                 f'NetworkID_THREAD_2ND_OPERATIONALDATASET = {thread_network_id_bytes_th2}')
+        log.info('Precondition: NetworkID : NetworkID_THREAD_1ST_OPERATIONALDATASET = %s, NetworkID_THREAD_2ND_OPERATIONALDATASET = %s',
+                 thread_network_id_bytes_th1, thread_network_id_bytes_th2)
 
         # Read the ConnectMaxTimeSeconds attribute after attempting to connect
         connect_max_time_seconds = await self.read_single_attribute_check_success(
@@ -396,9 +392,6 @@ class TC_CNET_4_12(MatterBaseTest):
             # device on the second network and by the networks attribute.
             pass
 
-        # TODO: Consider replacing the sleep (connect_max_time + fudge_factor) with dns-sd adverts check as improvement.
-        # Wait for the device to establish connection with the new Thread network
-        # Includes a fudge factor for SRP record propagation.
         log.info("Step #7: Awaiting device on SRP")
         srv_record = await self.wait_for_srp_update()
         asserts.assert_true(srv_record and srv_record.addresses, "No IP addresses found in SRP record")
@@ -453,7 +446,7 @@ class TC_CNET_4_12(MatterBaseTest):
 
         log.info("Step #11: Polling SRP until IP address changes from THREAD_2ND (%s)...", th2_ip)
         start_time = asyncio.get_running_loop().time()
-        timeout_seconds = 180
+        timeout_seconds = 60
 
         while asyncio.get_running_loop().time() - start_time < timeout_seconds:
             try:

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -26,11 +26,10 @@ from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
 from mobly import asserts, signals
 
 import matter.clusters as Clusters
+from matter.exceptions import ChipStackError
 from matter.testing.decorators import has_feature, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
-from matter.exceptions import ChipStackError
-
 
 log = logging.getLogger(__name__)
 
@@ -258,16 +257,16 @@ class TC_CNET_4_12(MatterBaseTest):
 
         # All required endpoint and Threads dataset are set and assigned, Thread dataset as str
         log.info('Precondition: All required arguments are set and assigned, Thread dataset as str: '
-                    f'THREADS_ENDPOINT = {endpoint}, '
-                    f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1}, '
-                    f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2}')
+                 f'THREADS_ENDPOINT = {endpoint}, '
+                 f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1}, '
+                 f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2}')
         thread_dataset_1_bytes = thread_dataset_1
         thread_dataset_2_bytes = bytes.fromhex(thread_dataset_2)
 
         # All required arguments are set and assigned, Thread dataset as bytes
         log.info('Precondition: All required arguments are set and assigned, Thread dataset as bytes: '
-                    f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1_bytes}, '
-                    f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2_bytes}')
+                 f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1_bytes}, '
+                 f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2_bytes}')
 
         # Validate the operational dataset structure (for both datasets)
         log.info("Precondition: Validating THREAD operational datasets")
@@ -278,8 +277,8 @@ class TC_CNET_4_12(MatterBaseTest):
         thread_network_id_bytes_th1 = await self.validate_thread_dataset(thread_dataset_1_bytes, "THREAD_1ST_OPERATIONALDATASET")
         thread_network_id_bytes_th2 = await self.validate_thread_dataset(thread_dataset_2_bytes, "THREAD_2ND_OPERATIONALDATASET")
         log.info('Precondition: NetworkID : '
-                    f'NetworkID_THREAD_1ST_OPERATIONALDATASET = {thread_network_id_bytes_th1}, '
-                    f'NetworkID_THREAD_2ND_OPERATIONALDATASET = {thread_network_id_bytes_th2}')
+                 f'NetworkID_THREAD_1ST_OPERATIONALDATASET = {thread_network_id_bytes_th1}, '
+                 f'NetworkID_THREAD_2ND_OPERATIONALDATASET = {thread_network_id_bytes_th2}')
 
         # Read the ConnectMaxTimeSeconds attribute after attempting to connect
         connect_max_time_seconds = await self.read_single_attribute_check_success(
@@ -463,13 +462,13 @@ class TC_CNET_4_12(MatterBaseTest):
                 if srv_record and srv_record.addresses and th2_ip not in srv_record.addresses:
                     log.info("Step #11: Device confirmed on THREAD_1ST with new address(es): %s", srv_record.addresses)
                     break
-            except (signals.TestFailure, AssertionError, asyncio.TimeoutError):
+            except (TimeoutError, signals.TestFailure, AssertionError):
                 # Catching expected assertion failures or timeouts from wait_for_srp_update while waiting for the SRP record to migrate subnets
                 pass
             await asyncio.sleep(1)
         else:
-            asserts.fail(f"Step #11: Timeout ({timeout_seconds}s) waiting for device to drop THREAD_2ND IP and return to THREAD_1ST")
-
+            asserts.fail(
+                f"Step #11: Timeout ({timeout_seconds}s) waiting for device to drop THREAD_2ND IP and return to THREAD_1ST")
 
         self.step(12)
         networks = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -22,12 +22,15 @@
 import asyncio
 import logging
 
-from mobly import asserts
+from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
+from mobly import asserts, signals
 
 import matter.clusters as Clusters
 from matter.testing.decorators import has_feature, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
+from matter.exceptions import ChipStackError
+
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +54,26 @@ class TC_CNET_4_12(MatterBaseTest):
     CLUSTER_DESC = Clusters.Descriptor
     CLUSTER_CGEN = Clusters.GeneralCommissioning
     failsafe_expiration_seconds = 900
+
+    def get_dut_instance_name(self) -> str:
+        # TODO: Consolidate this with other tests after SVE
+        node_id = self.dut_node_id
+        compressed_fabric_id = self.default_controller.GetCompressedFabricId()
+        return f'{compressed_fabric_id:016X}-{node_id:016X}'
+
+    async def wait_for_srp_update(self, timeout_seconds: int = 180):
+        instance_qname = f"{self.get_dut_instance_name()}.{MdnsServiceType.OPERATIONAL.value}"
+
+        mdns = MdnsDiscovery()
+        srv_record = await mdns.get_srv_record(
+            service_name=instance_qname,
+            service_type=MdnsServiceType.OPERATIONAL.value,
+            query_timeout_sec=timeout_seconds,
+            log_output=True
+        )
+        srv_record_returned = srv_record is not None and srv_record.service_name == instance_qname
+        asserts.assert_true(srv_record_returned, "Unable to find device")
+        return srv_record
 
     async def validate_thread_dataset(self, dataset_bytes, dataset_name):
         """
@@ -234,15 +257,17 @@ class TC_CNET_4_12(MatterBaseTest):
         asserts.assert_true(thread_dataset_2 is not None, "Missing required THREAD_2ND: PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET")
 
         # All required endpoint and Threads dataset are set and assigned, Thread dataset as str
-        log.info('Precondition: All required arguments are set and assigned, Thread dataset as str: THREADS_ENDPOINT = %s, THREAD_1ST_OPERATIONALDATASET = %s, PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = %s',
-                 endpoint, thread_dataset_1, thread_dataset_2)
-        # thread_dataset_1_bytes = bytes.fromhex(thread_dataset_1)
+        log.info('Precondition: All required arguments are set and assigned, Thread dataset as str: '
+                    f'THREADS_ENDPOINT = {endpoint}, '
+                    f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1}, '
+                    f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2}')
         thread_dataset_1_bytes = thread_dataset_1
         thread_dataset_2_bytes = bytes.fromhex(thread_dataset_2)
 
         # All required arguments are set and assigned, Thread dataset as bytes
-        log.info('Precondition: All required arguments are set and assigned, Thread dataset as bytes: THREAD_1ST_OPERATIONALDATASET = %s, PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = %s',
-                 thread_dataset_1_bytes, thread_dataset_2_bytes)
+        log.info('Precondition: All required arguments are set and assigned, Thread dataset as bytes: '
+                    f'THREAD_1ST_OPERATIONALDATASET = {thread_dataset_1_bytes}, '
+                    f'PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET = {thread_dataset_2_bytes}')
 
         # Validate the operational dataset structure (for both datasets)
         log.info("Precondition: Validating THREAD operational datasets")
@@ -252,8 +277,9 @@ class TC_CNET_4_12(MatterBaseTest):
         # CNET 4.10, ... (add other tests here)
         thread_network_id_bytes_th1 = await self.validate_thread_dataset(thread_dataset_1_bytes, "THREAD_1ST_OPERATIONALDATASET")
         thread_network_id_bytes_th2 = await self.validate_thread_dataset(thread_dataset_2_bytes, "THREAD_2ND_OPERATIONALDATASET")
-        log.info('Precondition: NetworkID : NetworkID_THREAD_1ST_OPERATIONALDATASET = %s, NetworkID_THREAD_2ND_OPERATIONALDATASET = %s',
-                 thread_network_id_bytes_th1, thread_network_id_bytes_th2)
+        log.info('Precondition: NetworkID : '
+                    f'NetworkID_THREAD_1ST_OPERATIONALDATASET = {thread_network_id_bytes_th1}, '
+                    f'NetworkID_THREAD_2ND_OPERATIONALDATASET = {thread_network_id_bytes_th2}')
 
         # Read the ConnectMaxTimeSeconds attribute after attempting to connect
         connect_max_time_seconds = await self.read_single_attribute_check_success(
@@ -357,22 +383,28 @@ class TC_CNET_4_12(MatterBaseTest):
         )
 
         self.step(7)
-        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        log.info('Step #7: ConnectNetwork resp for THREAD_2ND: (%s)', vars(resp))
-        log.info('Step #7: ConnectNetwork Status for THREAD_2ND is success: (%s)', resp.networkingStatus)
-        # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:  # chipstack-ok
+            # This is OK - if the device does not send the response before swapping networks
+            # then we will not receive a response and that is fine.
+            # Will will be able to tell if this succeeded by whether we can reach the
+            # device on the second network and by the networks attribute.
+            pass
 
         # TODO: Consider replacing the sleep (connect_max_time + fudge_factor) with dns-sd adverts check as improvement.
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        log.info("Step #7: Awaiting device on SRP")
+        srv_record = await self.wait_for_srp_update()
+        asserts.assert_true(srv_record and srv_record.addresses, "No IP addresses found in SRP record")
+        th2_ip = srv_record.addresses[0]
+        self.default_controller.ExpireSessions(self.dut_node_id)
         log.info("Step #7: Sleep completed for Thread network connection and SRP record propagation")
 
         self.step(8)
@@ -386,7 +418,7 @@ class TC_CNET_4_12(MatterBaseTest):
         await self.verify_thread_network_connected(networks, thread_network_id_bytes_th2, "THREAD_2ND", "#8")
 
         self.step(9)
-        # Expired session is re-established the new session reading attribute (Breadcrum)
+        # Expired session is re-established the new session reading attribute (Breadcrumb)
         breadcrumb_info = await self.read_single_attribute_check_success(
             cluster=Clusters.GeneralCommissioning,
             attribute=Clusters.GeneralCommissioning.Attributes.Breadcrumb
@@ -396,22 +428,48 @@ class TC_CNET_4_12(MatterBaseTest):
                              "The Breadcrumb attribute is not 2")
 
         self.step(10)
-        cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=0)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        # Verify that the DUT responds with ArmFailSafeResponse with ErrorCode as 'OK'(0)
-        log.info('Step #10: ArmFailSafeResponse with ErrorCode as OK: (%s)', resp.errorCode)
-        asserts.assert_equal(resp.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
-                             "Failure status returned from arm failsafe")
+        try:
+            cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=0)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+            # Verify that the DUT responds with ArmFailSafeResponse with ErrorCode as 'OK'(0)
+            log.info('Step #10: ArmFailSafeResponse with ErrorCode as OK: (%s)', resp.errorCode)
+            asserts.assert_equal(resp.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
+                                 "Failure status returned from arm failsafe")
+        except ChipStackError:  # chipstack-ok
+            # When ArmFailSafe expires or is disarmed to 0, the DUT immediately drops its interface
+            # on the secondary network to revert to the primary network. If interface teardown occurs
+            # before the response is transmitted, a ChipStackError is expected and spec-compliant.
+            pass
 
         self.step(11)
         # Step 11: When the failsafe is disarmed, the device should automatically return to THREAD_1ST.
         # This means the THREAD_2ND network will be removed,
         # and the device will reconnect to Thread 1 without further intervention.
         log.info('Step #11: DUT automatically return to THREAD_1ST')
+        self.default_controller.ExpireSessions(self.dut_node_id)
+
+        log.info("Step #11: Polling SRP until IP address changes from THREAD_2ND (%s)...", th2_ip)
+        start_time = asyncio.get_running_loop().time()
+        timeout_seconds = 180
+
+        while asyncio.get_running_loop().time() - start_time < timeout_seconds:
+            try:
+                srv_record = await self.wait_for_srp_update(timeout_seconds=5)
+                # Check if we got an IP list that does NOT contain the old THREAD_2ND IP
+                if srv_record and srv_record.addresses and th2_ip not in srv_record.addresses:
+                    log.info("Step #11: Device confirmed on THREAD_1ST with new address(es): %s", srv_record.addresses)
+                    break
+            except (signals.TestFailure, AssertionError, asyncio.TimeoutError):
+                # Catching expected assertion failures or timeouts from wait_for_srp_update while waiting for the SRP record to migrate subnets
+                pass
+            await asyncio.sleep(1)
+        else:
+            asserts.fail(f"Step #11: Timeout ({timeout_seconds}s) waiting for device to drop THREAD_2ND IP and return to THREAD_1ST")
+
 
         self.step(12)
         networks = await self.read_single_attribute_check_success(
@@ -420,20 +478,17 @@ class TC_CNET_4_12(MatterBaseTest):
         )
         log.info('Step #12: Networks attribute: %s', networks)
 
-        # Session expired and re-establish the new session reading attribute (Breadcrum)
-        await asyncio.sleep(connect_max_time_seconds + 5)
+        # Session expired and re-establish the new session reading attribute (Breadcrumb)
         breadcrumb_info = await self.read_single_attribute_check_success(
             cluster=Clusters.GeneralCommissioning,
             attribute=Clusters.GeneralCommissioning.Attributes.Breadcrumb
         )
         log.info('Step #12: Breadcrumb attribute: %s', breadcrumb_info)
-
-        await asyncio.sleep(connect_max_time_seconds + 5)
         networks = await self.read_single_attribute_check_success(
             cluster=Clusters.NetworkCommissioning,
             attribute=Clusters.NetworkCommissioning.Attributes.Networks
         )
-        log.info('Step #12: Networks attribute after read atribute: %s', networks)
+        log.info('Step #12: Networks attribute after read attribute: %s', networks)
         await self.verify_thread_network_connected(networks, thread_network_id_bytes_th1, "THREAD_1ST", "#12")
 
         self.step(13)
@@ -488,21 +543,26 @@ class TC_CNET_4_12(MatterBaseTest):
         )
         log.info('Step #16: Networks attribute: %s', networks)
 
-        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=3)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        log.info('Step #16: ConnectNetwork resp for THREAD_2ND: (%s)', vars(resp))
-        log.info('Step #16: ConnectNetwork Status for THREAD_2ND is success (%s)', resp.networkingStatus)
-        # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=3)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:  # chipstack-ok
+            # When ConnectNetwork is invoked, the DUT immediately tears down its active Thread interface
+            # to transition subnets. If interface teardown occurs before the response acknowledgment
+            # can be transmitted over the air, a ChipStackError is expected and spec-compliant.
+            # Connection success is verified via subsequent mDNS discovery and Networks attribute reads.
+            pass
 
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        log.info("Step #16: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
+
         log.info("Step #16: Sleep completed for Thread network connection and SRP record propagation")
 
         self.step(17)
@@ -594,24 +654,28 @@ class TC_CNET_4_12(MatterBaseTest):
 
         await self.verify_thread_network_response(resp)
 
-        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
-            networkID=thread_network_id_bytes_th1
-        )
-
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        log.info('Step #21: ConnectNetwork resp for for THREAD_1ST: (%s)', vars(resp))
-        # Verify that the DUT responds with ConnectNetwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
+                networkID=thread_network_id_bytes_th1
+            )
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:  # chipstack-ok
+            # When ConnectNetwork is invoked, the DUT immediately tears down its active Thread interface
+            # to transition subnets. If interface teardown occurs before the response acknowledgment
+            # can be transmitted over the air, a ChipStackError is expected and spec-compliant.
+            # Connection success is verified via subsequent mDNS discovery and Networks attribute reads.
+            pass
 
         # TODO: Consider replacing the sleep (connect_max_time + fudge_factor) with dns-sd adverts check as improvement.
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        log.info("Step #21: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
         log.info("Step #21: Sleep completed for Thread network connection and SRP record propagation")
 
         # THREAD_1ST Successfully connects to the DUT from previous step


### PR DESCRIPTION
#### Summary
Improves Thread network  transition handling and session recovery in `TC_CNET_4_12.py`.

##### Problem
- **Fragile Network Switching**: When commanded to switch Thread networks via `ConnectNetwork`, the DUT tears down its active network interface immediately.
  - **Transport Severances**: Interface teardown frequently occurs before the response acknowledgment can be transmitted over the air, causing `ConnectNetwork` to throw unhandled `ChipStackError` exceptions even when the subnet migration succeeds.
  - **Stale CASE Sessions**: When the device reappears on the new Thread network, the controller's existing CASE session is stale and times out on subsequent attribute reads unless explicitly expired.
- **Static Sleep Inefficiency**: Relying on hardcoded timer delays (`connect_max_time_seconds + fudge_factor_seconds`) to wait for network connection is both racy on slow CI runners and inefficient during fast local execution.

##### Solution
- Wrapped `ConnectNetwork` invocations in `try...except ChipStackError: pass` blocks accompanied by spec-compliance comments explaining that transport drops are expected during interface migration and are verified via subsequent `Networks` attribute reads.
- Replaced static timer waits after network switching with event-driven mDNS discovery (`await self.wait_for_srp_update()`) and explicit session expiration (`self.default_controller.ExpireSessions()`).
- Added active polling in Step 11 (`wait_for_srp_update` checks inside a timeout loop) to verify that the SRP record has migrated away from the secondary Thread subnet before resuming attribute verification on the primary network.

#### Testing
- Verified using test harness running one otbr locally in docker, and another external TBR. 