### PR TITLE
[DataModelRevision] Update DataModelRevision value to 20 for Matter version 1.5.1

### DIFF
--- a/src/app/SpecificationDefinedRevisions.h
+++ b/src/app/SpecificationDefinedRevisions.h
@@ -41,7 +41,7 @@ inline constexpr uint8_t kInteractionModelRevisionTag               = 0xFF;
  * See section 7.1.1. "Revision History" in the "Data Model Specification"
  * chapter of the core Matter specification.
  */
-inline constexpr uint16_t kDataModelRevision = 19;
+inline constexpr uint16_t kDataModelRevision = 20;
 
 /*
  * A number identifying the specification version against which the

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -89,7 +89,7 @@ tests:
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
-          value: 19
+          value: 20
           saveAs: DataModelRevisionValue
           constraints:
               type: int16u


### PR DESCRIPTION
### Summary

Adapted backport of #72874 for Matter 1.5.1.

- Updates the SDK kDataModelRevision value from 19 to 20 to match the spec for 1.5.1 ([Data Model Revision History](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Data-Model.adoc#ref_DataModelRevisionHistory)). This is consistent with kSpecificationVersion on this branch, which is already 0x01050100 (1.5.1).
- Updated Test_TC_BINFO_2_1.yaml test step 2 to validate the value change for kDataModelRevision, since the TC_BINFO_2_1 python3 test module is not on this branch.

### Related issues

Backport change to DataModelRevision value from PR: https://github.com/project-chip/connectedhomeip/pull/72874

### Testing

