### PR TITLE
Add Python Controller Group Cleanup Code

### DIFF
--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -726,6 +726,30 @@ PyChipError pychip_OpCreds_SetGroupKey(chip::Controller::DeviceCommissioner * de
     return ToPyChipError(err);
 }
 
+PyChipError pychip_OpCreds_RemoveGroupInfo(chip::Controller::DeviceCommissioner * devCtrl, uint16_t groupId)
+{
+    VerifyOrReturnError(devCtrl != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+
+    CHIP_ERROR err = sGroupDataProvider.RemoveGroupInfo(devCtrl->GetFabricIndex(), groupId);
+    return ToPyChipError(err);
+}
+
+PyChipError pychip_OpCreds_RemoveKeySet(chip::Controller::DeviceCommissioner * devCtrl, uint16_t keysetId)
+{
+    VerifyOrReturnError(devCtrl != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+
+    CHIP_ERROR err = sGroupDataProvider.RemoveKeySet(devCtrl->GetFabricIndex(), keysetId);
+    return ToPyChipError(err);
+}
+
+PyChipError pychip_OpCreds_RemoveGroupKeys(chip::Controller::DeviceCommissioner * devCtrl)
+{
+    VerifyOrReturnError(devCtrl != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+
+    CHIP_ERROR err = sGroupDataProvider.RemoveGroupKeys(devCtrl->GetFabricIndex());
+    return ToPyChipError(err);
+}
+
 PyChipError pychip_OpCreds_SetMaximallyLargeCertsUsed(OpCredsContext * context, bool enabled)
 {
     VerifyOrReturnError(context != nullptr && context->mAdapter != nullptr, ToPyChipError(CHIP_ERROR_INCORRECT_STATE));

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -2660,6 +2660,39 @@ class ChipDeviceControllerBase:
                 self.devCtrl, group_id, keyset_id)
         ).raise_on_error()
 
+    def RemoveGroupInfo(self, group_id: int):
+        '''
+        Removes a group entry from the controller's GroupDataProvider for this fabric.
+        '''
+        self.CheckIsActive()
+
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_OpCreds_RemoveGroupInfo(
+                self.devCtrl, group_id)
+        ).raise_on_error()
+
+    def RemoveKeySet(self, keyset_id: int):
+        '''
+        Removes a KeySet from the controller's GroupDataProvider for this fabric.
+        '''
+        self.CheckIsActive()
+
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_OpCreds_RemoveKeySet(
+                self.devCtrl, keyset_id)
+        ).raise_on_error()
+
+    def RemoveGroupKeys(self):
+        '''
+        Removes all GroupKey mappings from the controller's GroupDataProvider for this fabric.
+        '''
+        self.CheckIsActive()
+
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_OpCreds_RemoveGroupKeys(
+                self.devCtrl)
+        ).raise_on_error()
+
     def CreateManualCode(self, discriminator: int, passcode: int) -> str:
         '''
         Creates a standard flow manual code from the given discriminator and passcode.
@@ -2961,6 +2994,15 @@ class ChipDeviceControllerBase:
 
             self._dmLib.pychip_OpCreds_SetGroupKey.argtypes = [c_void_p, c_uint16, c_uint16]
             self._dmLib.pychip_OpCreds_SetGroupKey.restype = PyChipError
+
+            self._dmLib.pychip_OpCreds_RemoveGroupInfo.argtypes = [c_void_p, c_uint16]
+            self._dmLib.pychip_OpCreds_RemoveGroupInfo.restype = PyChipError
+
+            self._dmLib.pychip_OpCreds_RemoveKeySet.argtypes = [c_void_p, c_uint16]
+            self._dmLib.pychip_OpCreds_RemoveKeySet.restype = PyChipError
+
+            self._dmLib.pychip_OpCreds_RemoveGroupKeys.argtypes = [c_void_p]
+            self._dmLib.pychip_OpCreds_RemoveGroupKeys.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_SetIssueNOCChainCallbackPythonCallback.argtypes = [
                 _IssueNOCChainCallbackPythonCallbackFunct]

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -738,5 +738,6 @@ class TC_ACE_1_6(MatterBaseTest):
             self.default_controller.RemoveKeySet(keyset_id)
         self.default_controller.RemoveGroupKeys()
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_ACE_1_6.py
+++ b/src/python_testing/TC_ACE_1_6.py
@@ -731,6 +731,12 @@ class TC_ACE_1_6(MatterBaseTest):
         # Shut down the unified subscription
         unified_sub.Shutdown()
 
+        # Controller cleanup at end
+        for group_id in [groupID1, groupID2, groupID3]:
+            self.default_controller.RemoveGroupInfo(group_id)
+        for keyset_id in [keySetID1, keySetID3]:
+            self.default_controller.RemoveKeySet(keyset_id)
+        self.default_controller.RemoveGroupKeys()
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -541,6 +541,12 @@ class TC_SC_5_2(MatterBaseTest):
         ]
         await dev_ctrl.WriteAttribute(node_id, [(0, Clusters.AccessControl.Attributes.Acl(acl))])
 
+        # Controller cleanup at end
+        for group_id in [groupId0101, groupId0102, groupId0300, groupId0201]:
+            dev_ctrl.RemoveGroupInfo(group_id)
+        for keyset_id in [keySetId01a3, keySetId01a4]:
+            dev_ctrl.RemoveKeySet(keyset_id)
+        dev_ctrl.RemoveGroupKeys()
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_SC_5_2.py
+++ b/src/python_testing/TC_SC_5_2.py
@@ -548,5 +548,6 @@ class TC_SC_5_2(MatterBaseTest):
             dev_ctrl.RemoveKeySet(keyset_id)
         dev_ctrl.RemoveGroupKeys()
 
+
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
### Summary

This PR adds some cleanup code to the python controller. When some group related tests were run back to back on the same commissioning window (with the same storage path), failures could occur as the tests weren't cleaning up the group information they added to the controller, only the info added to the DUT. This change ensures group information is also removed from the controller as to not have potential conflict between tests when running them back to back. For example, a test could run into an issue with reaching the maximum number of supported groups on the controller side if this wasn't cleaned up correctly.

### Testing

- CI should still pass
- Ran TC_ACE_1_6 and TC_SC_5_2 on same commissioning window without issues
