### PR TITLE
check snprintf return before offsetting in MakeServiceSubtype

### DIFF
--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -141,6 +141,10 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         break;
     case DiscoveryFilterType::kCompressedFabricId:
         requiredSize = snprintf(buffer, bufferLen, "_I");
+        // snprintf returns the length it would have written, so it can exceed bufferLen. Guard it
+        // before using it as an offset and subtracting it, otherwise bufferLen - requiredSize
+        // underflows and Uint64ToHex writes past the buffer.
+        VerifyOrReturnError(requiredSize >= 0 && static_cast<size_t>(requiredSize) < bufferLen, CHIP_ERROR_NO_MEMORY);
         return Encoding::Uint64ToHex(subtype.code, &buffer[requiredSize], bufferLen - static_cast<size_t>(requiredSize),
                                      Encoding::HexFlags::kUppercaseAndNullTerminate);
         break;

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -144,8 +144,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         // Uint64ToHex validates that the remaining space holds the hex-encoded fabric id.
         VerifyOrReturnError(bufferLen >= 3, CHIP_ERROR_BUFFER_TOO_SMALL);
         strcpy(buffer, "_I");
-        return Encoding::Uint64ToHex(subtype.code, &buffer[2], bufferLen - 2,
-                                     Encoding::HexFlags::kUppercaseAndNullTerminate);
+        return Encoding::Uint64ToHex(subtype.code, &buffer[2], bufferLen - 2, Encoding::HexFlags::kUppercaseAndNullTerminate);
     case DiscoveryFilterType::kInstanceName:
         requiredSize = snprintf(buffer, bufferLen, "%s", subtype.instanceName);
         break;

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -140,14 +140,12 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         requiredSize = snprintf(buffer, bufferLen, "_D%u", static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kCompressedFabricId:
-        requiredSize = snprintf(buffer, bufferLen, "_I");
-        // snprintf returns the length it would have written, so it can exceed bufferLen. Guard it
-        // before using it as an offset and subtracting it, otherwise bufferLen - requiredSize
-        // underflows and Uint64ToHex writes past the buffer.
-        VerifyOrReturnError(requiredSize >= 0 && static_cast<size_t>(requiredSize) < bufferLen, CHIP_ERROR_BUFFER_TOO_SMALL);
-        return Encoding::Uint64ToHex(subtype.code, &buffer[requiredSize], bufferLen - static_cast<size_t>(requiredSize),
+        // Make sure the "_I" prefix (2 chars + null) fits before writing it and offsetting past it;
+        // Uint64ToHex validates that the remaining space holds the hex-encoded fabric id.
+        VerifyOrReturnError(bufferLen >= 3, CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buffer, "_I");
+        return Encoding::Uint64ToHex(subtype.code, &buffer[2], bufferLen - 2,
                                      Encoding::HexFlags::kUppercaseAndNullTerminate);
-        break;
     case DiscoveryFilterType::kInstanceName:
         requiredSize = snprintf(buffer, bufferLen, "%s", subtype.instanceName);
         break;

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -144,7 +144,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         // snprintf returns the length it would have written, so it can exceed bufferLen. Guard it
         // before using it as an offset and subtracting it, otherwise bufferLen - requiredSize
         // underflows and Uint64ToHex writes past the buffer.
-        VerifyOrReturnError(requiredSize >= 0 && static_cast<size_t>(requiredSize) < bufferLen, CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(requiredSize >= 0 && static_cast<size_t>(requiredSize) < bufferLen, CHIP_ERROR_BUFFER_TOO_SMALL);
         return Encoding::Uint64ToHex(subtype.code, &buffer[requiredSize], bufferLen - static_cast<size_t>(requiredSize),
                                      Encoding::HexFlags::kUppercaseAndNullTerminate);
         break;

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -156,7 +156,7 @@ TEST(TestServiceNaming, TestMakeServiceNameSubtype)
 
     // A buffer too small for the "_I" prefix must be rejected, not written past.
     char tinyBuffer[1];
-    EXPECT_NE(MakeServiceSubtype(tinyBuffer, sizeof(tinyBuffer), filter), CHIP_NO_ERROR);
+    EXPECT_EQ(MakeServiceSubtype(tinyBuffer, sizeof(tinyBuffer), filter), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // None tests.
     filter.type = DiscoveryFilterType::kNone;

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -155,8 +155,7 @@ TEST(TestServiceNaming, TestMakeServiceNameSubtype)
     EXPECT_STREQ(buffer, "_IABCD12341111BBBB");
 
     // A buffer too small for the "_I" prefix must be rejected, not written past.
-    char tinyBuffer[1];
-    EXPECT_EQ(MakeServiceSubtype(tinyBuffer, sizeof(tinyBuffer), filter), CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(MakeServiceSubtype(buffer, 2, filter), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // None tests.
     filter.type = DiscoveryFilterType::kNone;

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -154,6 +154,10 @@ TEST(TestServiceNaming, TestMakeServiceNameSubtype)
     EXPECT_EQ(MakeServiceSubtype(buffer, sizeof(buffer), filter), CHIP_NO_ERROR);
     EXPECT_STREQ(buffer, "_IABCD12341111BBBB");
 
+    // A buffer too small for the "_I" prefix must be rejected, not written past.
+    char tinyBuffer[1];
+    EXPECT_NE(MakeServiceSubtype(tinyBuffer, sizeof(tinyBuffer), filter), CHIP_NO_ERROR);
+
     // None tests.
     filter.type = DiscoveryFilterType::kNone;
     EXPECT_EQ(MakeServiceSubtype(buffer, sizeof(buffer), filter), CHIP_NO_ERROR);


### PR DESCRIPTION
### Summary

`MakeServiceSubtype` writes the compressed-fabric-id prefix with `snprintf` and then uses its return value both as the write offset for `Uint64ToHex` and as the amount subtracted from `bufferLen`. `snprintf` returns the length it would have written regardless of the buffer size, so a buffer shorter than the two-byte prefix makes `bufferLen - requiredSize` underflow to a large `size_t` and `&buffer[requiredSize]` point past the end, so the hex write lands out of bounds. This is the only subtype branch that consumes the `snprintf` return directly instead of falling through to the shared fit check at the end of the function, so it needs its own guard.

### Related issues

None.

### Testing

Added a unit test in `TestServiceNaming` that passes a one-byte buffer for the compressed-fabric-id subtype and confirms it returns an error rather than writing past the buffer. Building the same call under AddressSanitizer reports a stack-buffer-overflow write in `Uint64ToHex` before the change and runs clean after it.