### PR TITLE
Make push-av-stream-transport conditional again

### DIFF
--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -72,7 +72,6 @@ source_set("clusters") {
     "power-topology-server",
     "pressure-measurement-server",
     "proximity-ranging-server",
-    "push-av-stream-transport-server",
     "relative-humidity-measurement-server",
     "resource-monitoring-server",
     "scenes-server",
@@ -103,7 +102,11 @@ source_set("clusters") {
     # keep-sorted: end
   ]
 
+  # Separate enable/disable for things that have third_party dependendencies
+  # (give a choice if these dependencies are available or licenses are acceptable)
+
   if (chip_enable_push_av_stream_transport) {
+    # depends on third_party/uriparser
     public_deps += [ "push-av-stream-transport-server" ]
   }
 }


### PR DESCRIPTION
### Summary

#72959 added this unconditional, however we already had it conditional because it depends on a third-party library.
Added a clearer comment and removed the unconditional part.

Note #43343 that also complains about this...


### Testing

N/A - this is essentially are revert.