### PR TITLE
[TSTAT-2.1] Update step 24 to match latest spec change

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -484,7 +484,7 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: 0
+              minValue: 1
               maxValue: 1440
 
     - label:


### PR DESCRIPTION
### Summary

Updated step 24 in TSTAT-2.1 to match the latest spec change to disallow a value of 0.

### Related issues

Spec change: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12667

### Testing

CI pass with no errors
