### PR TITLE
[Silabs]  Docker list missing library

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-205 : [NXP] Update VSCode Docker image (NXP Zephyr update)
+206 : [Silabs] Prevent removal of libble_bgapi_gatt_client.a

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -88,7 +88,7 @@ bluetooth_le_host/build/llvm/cortex-m33/bgstack/release/libbondingdb_stub.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_stub_gatt_client.a
-bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
+bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_client.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_system/release/libble_system.a
 bluetooth_le_host/build/llvm/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
 bluetooth_le_host/build/llvm/cortex-m33/core/release/libble_host_core.a

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -69,6 +69,7 @@ bluetooth_le_host/build/gcc/cortex-m33/bgstack/release/libbondingdb_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi.a
 bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
 bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_stub_gatt_client.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_client.a
 bluetooth_le_host/build/gcc/cortex-m33/ble_system/release/libble_system.a
 bluetooth_le_host/build/gcc/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/core/release/libble_host_core.a
@@ -87,6 +88,7 @@ bluetooth_le_host/build/llvm/cortex-m33/bgstack/release/libbondingdb_stub.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_stub_gatt_client.a
+bluetooth_le_host/build/llvm/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
 bluetooth_le_host/build/llvm/cortex-m33/ble_system/release/libble_system.a
 bluetooth_le_host/build/llvm/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
 bluetooth_le_host/build/llvm/cortex-m33/core/release/libble_host_core.a


### PR DESCRIPTION
### Summary

Updated the list of keep files in the silabs docker

### Related issues

One specific build required a library that was getting cleared from the docker to optimize space.

### Testing

CI passed with new docker.