### PR TITLE
[SIlabs] : Fix light switch app compile issues

### DIFF
--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -429,8 +429,7 @@ void AppTask::ProcessOnOffBindingCommand(CommandId commandId, const Binding::Tab
     {
         VerifyOrDie(peer_device->ConnectionReady());
         Messaging::ExchangeManager * exchangeMgr = peer_device->GetExchangeManager();
-        auto optionalSession                     = peer_device->GetSecureSession();
-        const SessionHandle & sessionHandle      = optionalSession.Value();
+        SessionHandle sessionHandle              = peer_device->GetSecureSession().Value();
 
         switch (commandId)
         {

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -429,7 +429,8 @@ void AppTask::ProcessOnOffBindingCommand(CommandId commandId, const Binding::Tab
     {
         VerifyOrDie(peer_device->ConnectionReady());
         Messaging::ExchangeManager * exchangeMgr = peer_device->GetExchangeManager();
-        SessionHandle sessionHandle              = peer_device->GetSecureSession().Value();
+        auto optionalSession                     = peer_device->GetSecureSession();
+        const SessionHandle & sessionHandle      = optionalSession.Value();
 
         switch (commandId)
         {

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -429,7 +429,8 @@ void AppTask::ProcessOnOffBindingCommand(CommandId commandId, const Binding::Tab
     {
         VerifyOrDie(peer_device->ConnectionReady());
         Messaging::ExchangeManager * exchangeMgr = peer_device->GetExchangeManager();
-        const SessionHandle & sessionHandle      = peer_device->GetSecureSession().Value();
+        auto optionalSession                     = peer_device->GetSecureSession();
+        const SessionHandle & sessionHandle      = optionalSession.Value();
 
         switch (commandId)
         {


### PR DESCRIPTION
### Summary

Light switch fails on the 2.9 release stream,
peer_device->GetSecureSession() returns an Optional by value. Calling .Value() on that rvalue gives a reference into the temporary optional. Storing that in const SessionHandle & sessionHandle leaves a reference to storage that is gone after the initializer, which triggers -Wdangling-reference / -Wdangling-pointer with -Werror

### Related issues

N/A

### Testing

Tested in matter_sdk release_2.9 CI