### PR TITLE
Disable zephyr nxp builds due to perma-breakage

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -144,7 +144,16 @@ jobs:
         name: ZEPHYR
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        # TODO: disabled for now due to failure on CI:
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters: CMake Error at /opt/nxp-zephyr/zephyrproject/modules/lib/nxp_iot_agent/zephyr/CMakeLists.txt:110 (if):
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:   if given arguments:
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:     "CONFIG_EL2GO_SIGN_USING_NXPIMAGE" "OR" "(" "DEFINED" "ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE}" "AND" "STREQUAL" "y" ")" "AND" "(" "frdm_rw612/rw612" "STREQUAL" "rd_rw612_bga/rw612/ns" "OR" "frdm_rw612/rw612" "STREQUAL" "frdm_rw612/rw612/ns" ")"
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:
+        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:   Unknown arguments specified
+        #
+        # if: github.actor != 'restyled-io[bot]'
+        if: false
 
         container:
             image: ghcr.io/project-chip/chip-build-nxp-zephyr:203


### PR DESCRIPTION
### Summary

NZP zephyr builds seem perma-broken in master. This disables them until they are fixed.

### Testing

just a disable.