### PR TITLE
Disabe wildcard subscription for IDT tests

### DIFF
--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -161,6 +161,7 @@ class DclCheck(BasicCompositionTests):
 
     @async_test_body
     async def setup_class(self):
+        super().setup_class()
         setupCode = self.matter_test_config.qr_code_content or self.matter_test_config.manual_code
         await self.default_controller.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
         bi = Clusters.BasicInformation
@@ -415,6 +416,10 @@ class TestConfig:
         global_test_params = {'use_pase_only': True, 'post_cert_test': True}
         self.config = MatterTestConfig(endpoint=0, dut_node_ids=[
             1], global_test_params=global_test_params, storage_path=self.admin_storage)
+        # These tests run over PASE against an uncommissioned device: the background
+        # wildcard subscription cannot be established (it requires CASE), and its
+        # setup/teardown delays let a BLE PASE transport idle out between tests.
+        self.config.no_wildcard_subscription = True
         if code_type == SetupCodeType.QR:
             self.config.qr_code_content = [code]
         else:


### PR DESCRIPTION
### Summary

Make sure that IDT tests are compatible with the most recent changes related to wildcard subscriptions added to `MatterBaseTest`. Since this machinery adds additional timeouts the PASE session gets expired (see example below). This PR just disables wildcard subscriptions for DCL tests.

Example:

```
[MatterTest] 07-01 17:09:42.738 ERROR Exception occurred in test_TC_DA_1_2.
Traceback (most recent call last):
  File "/home/kali/idt/venv/lib/python3.11/site-packages/mobly/base_test.py", line 801, in exec_one_test
    test_method()
  File "/home/kali/idt/venv/lib/python3.11/site-packages/matter/testing/decorators.py", line 266, in async_runner
    return _async_runner(body, self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/idt/venv/lib/python3.11/site-packages/matter/testing/decorators.py", line 253, in _async_runner
    return test_instance.event_loop.run_until_complete(asyncio.wait_for(body(test_instance, *args, **kwargs), timeout=timeout)                                                                                                                                                                )
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                ^
  File "/home/kali/.local/share/uv/python/cpython-3.11.14-linux-aarch64-gnu/lib/python3.11/asyncio/base_events.py", line 654,                                                                                                                                                                 in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/kali/.local/share/uv/python/cpython-3.11.14-linux-aarch64-gnu/lib/python3.11/asyncio/tasks.py", line 489, in wai                                                                                                                                                                t_for
    return fut.result()
           ^^^^^^^^^^^^
  File "/home/kali/idt/venv/lib/python3.11/site-packages/chip/testing/idt/TC_DA_1_2.py", line 233, in test_TC_DA_1_2
    await self.default_controller.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
  File "/home/kali/idt/venv/lib/python3.11/site-packages/matter/ChipDeviceCtrl.py", line 1487, in FindOrEstablishPASESession
    await self.EstablishPASESession(setupCode, nodeId)
  File "/home/kali/idt/venv/lib/python3.11/site-packages/matter/ChipDeviceCtrl.py", line 1062, in EstablishPASESession
    await self._establishPASESession(
  File "/home/kali/idt/venv/lib/python3.11/site-packages/matter/ChipDeviceCtrl.py", line 984, in _establishPASESession
    await asyncio.futures.wrap_future(ctx.future)
matter.exceptions.ChipStackError: src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp:101: CHIP Error 0                                                                                                                                                                x00000003: Incorrect state
[MatterTest] 07-01 17:09:42.775 ERROR
```

### Related issues

None

### Testing

To be tested on IDT
