### PR TITLE
reject non-digit bytes in MakeU32FromAsciiDecimal

### DIFF
--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -81,6 +81,15 @@ uint32_t MakeU32FromAsciiDecimal(const ByteSpan & val, uint32_t defaultValue = 0
     if (val.size() > 1 && *val.data() == static_cast<uint8_t>('0'))
         return defaultValue;
 
+    // value must be decimal digits only: strtoul() otherwise accepts a leading
+    // sign or whitespace, so a nonconformant TXT value like "+5" or " 5" would
+    // parse as 5 instead of being rejected.
+    for (size_t i = 0; i < val.size(); ++i)
+    {
+        if (val.data()[i] < '0' || val.data()[i] > '9')
+            return defaultValue;
+    }
+
     Platform::CopyString(nullTerminatedValue, sizeof(nullTerminatedValue), val);
 
     char * endPtr;

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -84,9 +84,9 @@ uint32_t MakeU32FromAsciiDecimal(const ByteSpan & val, uint32_t defaultValue = 0
     // value must be decimal digits only: strtoul() otherwise accepts a leading
     // sign or whitespace, so a nonconformant TXT value like "+5" or " 5" would
     // parse as 5 instead of being rejected.
-    for (size_t i = 0; i < val.size(); ++i)
+    for (uint8_t b : val)
     {
-        if (val.data()[i] < '0' || val.data()[i] > '9')
+        if (b < '0' || b > '9')
             return defaultValue;
     }
 

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -229,6 +229,33 @@ TEST(TestTxtFields, TestGetDeviceType)
     EXPECT_EQ(GetDeviceType(GetSpan(dt)), 0u);
 }
 
+// TXT numeric values are strict decimal ASCII per the spec. A leading sign or
+// whitespace is not a digit and must be rejected rather than silently accepted
+// by strtoul() (e.g. "+5"/" 5" must not parse as 5).
+TEST(TestTxtFields, TestNumericDecimalStrictness)
+{
+    char buf[64];
+
+    strcpy(buf, "+5");
+    EXPECT_EQ(GetLongDiscriminator(GetSpan(buf)), 0);
+    strcpy(buf, " 5");
+    EXPECT_EQ(GetLongDiscriminator(GetSpan(buf)), 0);
+    strcpy(buf, "-5");
+    EXPECT_EQ(GetLongDiscriminator(GetSpan(buf)), 0);
+
+    strcpy(buf, "+5");
+    EXPECT_EQ(GetDeviceType(GetSpan(buf)), 0u);
+    strcpy(buf, " 5");
+    EXPECT_EQ(GetDeviceType(GetSpan(buf)), 0u);
+
+    strcpy(buf, "+1");
+    EXPECT_EQ(GetCommissioningMode(GetSpan(buf)), 0);
+
+    // A well-formed decimal value is still accepted.
+    strcpy(buf, "5");
+    EXPECT_EQ(GetLongDiscriminator(GetSpan(buf)), 5);
+}
+
 TEST(TestTxtFields, TestGetDeviceName)
 {
     char name[kMaxDeviceNameLen + 1] = "";


### PR DESCRIPTION
### Summary

`MakeU32FromAsciiDecimal` parses the numeric mDNS TXT fields used during discovery (long discriminator, device type, commissioning mode, pairing hint, vendor/product, retry interval). It already rejects over-long values and leading zeros, but the trailing `strtoul` call still accepts a leading sign or whitespace, so a nonconformant value such as `+5` or ` 5` from any advertiser on the network parses as `5` instead of being rejected. Scan the value for decimal digits before the conversion so only strict decimal input is accepted; well-formed values are unchanged.

### Related issues

None.

### Testing

Added a `TestTxtFields` regression (`TestNumericDecimalStrictness`) that feeds a leading `+`, space and `-` to the discriminator, device-type and commissioning-mode parsers and confirms they are rejected while a plain decimal value still parses. It fails on the current code (the values parse as `5`) and passes with this change; the full `TestTxtFields` suite stays green (`darwin-arm64-tests`).
