### PR TITLE
[CI] Mount runner-root-volume in container jobs to maximize disk space

### DIFF
--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -39,6 +39,8 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-asr:200
             options: --user root
+            volumes:
+                - "/:/runner-root-volume"
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -41,6 +41,7 @@ jobs:
       image: ghcr.io/project-chip/chip-build-bouffalolab:200
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
+        - "/:/runner-root-volume"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -44,6 +44,7 @@ jobs:
       image: ghcr.io/project-chip/chip-build-efr32:200
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
+        - "/:/runner-root-volume"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -44,6 +44,7 @@ jobs:
                CY_TOOLS_PATHS: /opt/Tools/ModusToolbox/tools_3.2
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
+                - "/:/runner-root-volume"
         steps:
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -44,6 +44,7 @@ jobs:
             image: ghcr.io/project-chip/chip-build:200
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
+                - "/:/runner-root-volume"
         steps:
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
#### Summary
Bouffalo Lab (and potentially other) builds periodically fail on GHA runners with "No space left on device".
This happens because the `maximize-runner-disk` step (run during bootstrap) is skipped when running inside a container if `/runner-root-volume` is not mounted.

Mount `/:/runner-root-volume` in the container configuration for these jobs. This allows `maximize-runner-disk` to access the host filesystem and prune unnecessary directories (Android SDK, Dotnet, etc.), freeing up ~16GB of space.

This PR applies the fix to:
- `examples-bouffalolab.yaml`
- `examples-asr.yaml`
- `examples-infineon.yaml`
- `examples-stm32.yaml`
- `examples-efr32.yaml`

#### Testing
Verification relies on GHA PR run to ensure `maximize-runner-disk` runs successfully and builds complete.
