### PR TITLE
[IM] Reject chunked WriteRequest combined with SuppressResponse

### DIFF
--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -172,8 +172,11 @@ CHIP_ERROR WriteClient::StartNewMessage()
         ReturnErrorOnFailure(FinalizeMessage(true));
     }
 
-    // Per Matter specification: a Write Request that is part of a Timed Write Interaction SHALL NOT be chunked.
-    VerifyOrReturnError(!(mTimedWriteTimeoutMs.HasValue() && !mChunks.IsNull()), CHIP_ERROR_NO_MEMORY);
+    // Per the Matter specification a chunked Write Request cannot be part of a Timed Write Interaction, and it cannot
+    // suppress the response: intermediate WriteResponses are required to pace the chunks, so SuppressResponse must be
+    // false when the request is chunked.
+    VerifyOrReturnError(!((mTimedWriteTimeoutMs.HasValue() || mSuppressResponse) && !mChunks.IsNull()),
+                        CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
     System::PacketBufferHandle packet = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);
     VerifyOrReturnError(!packet.IsNull(), CHIP_ERROR_NO_MEMORY);
@@ -527,10 +530,10 @@ CHIP_ERROR WriteClient::SendWriteRequest()
     System::PacketBufferHandle data = mChunks.PopHead();
 
     bool isGroupWrite = mExchangeCtx->IsGroupExchangeContext();
-    if (!mChunks.IsNull() && isGroupWrite)
+    if (!mChunks.IsNull() && (isGroupWrite || mSuppressResponse))
     {
-        // Reject this request if we have more than one chunk (mChunks is not null after PopHead()), and this is a group
-        // exchange context.
+        // Reject this request if we have more than one chunk (mChunks is not null after PopHead()) and either this is a
+        // group exchange context or the response is suppressed; a chunked write requires intermediate WriteResponses.
         return CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -670,10 +670,14 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
     mStateFlags.Set(StateBits::kHasMoreChunks, boolValue);
 
     if (mStateFlags.Has(StateBits::kHasMoreChunks) &&
-        (mExchangeCtx->IsGroupExchangeContext() || mStateFlags.Has(StateBits::kIsTimedRequest)))
+        (mExchangeCtx->IsGroupExchangeContext() || mStateFlags.Has(StateBits::kIsTimedRequest) ||
+         mStateFlags.Has(StateBits::kSuppressResponse)))
     {
         // Sanity check: group exchange context should only have one chunk.
         // Also, timed requests should not have more than one chunk.
+        // A chunked write needs intermediate WriteResponses (sent with kExpectResponse) to keep the exchange
+        // alive and pace the sender, so SuppressResponse is incompatible with more chunks; rejecting the
+        // combination avoids leaving a handler allocated on an exchange that the messaging layer closes.
         ExitNow(err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
     }
 

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -171,11 +171,14 @@ public:
     void TestWriteInvalidMessage4();
     void TestWriteInvalidMessage5();
     void TestWriteClientSuppressResponseFlowWithInvalidAttribute();
+    void TestSuppressedChunkedWriteDoesNotLeakHandler();
+    void TestWriteClientRejectsSuppressedChunkedWrite();
 
     static void AddAttributeDataIB(WriteClient & aWriteClient, EncodingMethod encoding);
     static void AddInvalidAttributeDataIB(WriteClient & aWriteClient, EncodingMethod encoding);
     static void AddAttributeStatus(WriteHandler & aWriteHandler);
     static void GenerateWriteRequest(bool aIsTimedWrite, System::PacketBufferHandle & aPayload);
+    static void GenerateSuppressResponseChunkedWriteRequest(System::PacketBufferHandle & aPayload);
     static void GenerateWriteResponse(System::PacketBufferHandle & aPayload);
 
 private:
@@ -371,6 +374,56 @@ void TestWriteInteraction::GenerateWriteRequest(bool aIsTimedWrite, System::Pack
     EXPECT_EQ(writeRequestBuilder.GetError(), CHIP_NO_ERROR);
 
     EXPECT_EQ(writer.Finalize(&aPayload), CHIP_NO_ERROR);
+}
+
+// Builds a single WriteRequest that combines SuppressResponse=true with MoreChunkedMessages=true on one valid
+// AttributeDataIB. A conformant WriteClient never emits this combination; it is constructed directly here to
+// exercise the first-chunk handler lifecycle on the receive path.
+void TestWriteInteraction::GenerateSuppressResponseChunkedWriteRequest(System::PacketBufferHandle & aPayload)
+{
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(aPayload));
+
+    WriteRequestMessage::Builder writeRequestBuilder;
+    EXPECT_SUCCESS(writeRequestBuilder.Init(&writer));
+    writeRequestBuilder.SuppressResponse(true);
+    writeRequestBuilder.TimedRequest(false);
+    EXPECT_SUCCESS(writeRequestBuilder.GetError());
+    AttributeDataIBs::Builder & attributeDataIBsBuilder = writeRequestBuilder.CreateWriteRequests();
+    EXPECT_SUCCESS(writeRequestBuilder.GetError());
+    AttributeDataIB::Builder & attributeDataIBBuilder = attributeDataIBsBuilder.CreateAttributeDataIBBuilder();
+    EXPECT_SUCCESS(attributeDataIBsBuilder.GetError());
+
+    attributeDataIBBuilder.DataVersion(0);
+    EXPECT_SUCCESS(attributeDataIBBuilder.GetError());
+    AttributePathIB::Builder & attributePathBuilder = attributeDataIBBuilder.CreatePath();
+    EXPECT_SUCCESS(attributePathBuilder.GetError());
+    EXPECT_SUCCESS(attributePathBuilder.Node(1)
+                       .Endpoint(2)
+                       .Cluster(3)
+                       .Attribute(4)
+                       .ListIndex(DataModel::Nullable<ListIndex>())
+                       .EndOfAttributePathIB());
+
+    {
+        chip::TLV::TLVWriter * pWriter = attributeDataIBBuilder.GetWriter();
+        chip::TLV::TLVType dummyType   = chip::TLV::kTLVType_NotSpecified;
+        EXPECT_SUCCESS(
+            pWriter->StartContainer(chip::TLV::ContextTag(AttributeDataIB::Tag::kData), chip::TLV::kTLVType_Structure, dummyType));
+        EXPECT_SUCCESS(pWriter->PutBoolean(chip::TLV::ContextTag(1), true));
+        EXPECT_SUCCESS(pWriter->EndContainer(dummyType));
+    }
+
+    EXPECT_SUCCESS(attributeDataIBBuilder.EndOfAttributeDataIB());
+    EXPECT_SUCCESS(attributeDataIBBuilder.GetError());
+
+    EXPECT_SUCCESS(attributeDataIBsBuilder.EndOfAttributeDataIBs());
+    EXPECT_SUCCESS(attributeDataIBsBuilder.GetError());
+    // MoreChunkedMessages is emitted after the AttributeDataIBs, mirroring WriteClient::FinishMessage.
+    EXPECT_SUCCESS(writeRequestBuilder.MoreChunkedMessages(true).EndOfWriteRequestMessage());
+    EXPECT_SUCCESS(writeRequestBuilder.GetError());
+
+    EXPECT_SUCCESS(writer.Finalize(&aPayload));
 }
 
 void TestWriteInteraction::GenerateWriteResponse(System::PacketBufferHandle & aPayload)
@@ -926,6 +979,75 @@ TEST_F(TestWriteInteraction, TestWriteHandlerInvalidateFabric)
     EXPECT_SUCCESS(CreateAliceFabric());
     EXPECT_SUCCESS(CreateSessionAliceToBob());
     EXPECT_SUCCESS(CreateSessionBobToAlice());
+}
+
+// A first WriteRequest chunk that sets SuppressResponse=true together with MoreChunkedMessages=true keeps the
+// WriteHandler allocated waiting for the next chunk, yet nothing is sent on the exchange (SuppressResponse skips
+// the WriteResponse and WillSendMessage() is never called). The exchange layer then closes the exchange underneath
+// the handler, which would be left allocated with no exchange and never reclaimed. Because the handler pool is
+// bounded (CHIP_IM_MAX_NUM_WRITE_HANDLER), repeated such requests would exhaust it and further WriteRequests would
+// be answered with Busy.
+//
+// Expected behavior: such a first chunk must not leave a handler allocated once the exchange has been serviced, so
+// the active-handler count returns to 0 and the pool never fills.
+TEST_F_FROM_FIXTURE(TestWriteInteraction, TestSuppressedChunkedWriteDoesNotLeakHandler)
+{
+    using namespace Protocols::InteractionModel;
+
+    auto * engine = InteractionModelEngine::GetInstance();
+    EXPECT_SUCCESS(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()));
+
+    // One delegate outlives every exchange created below (through Shutdown/session teardown), so no exchange
+    // can reference a destroyed delegate.
+    TestExchangeDelegate delegate;
+
+    // Send more than the pool size to confirm each such request is released rather than accumulating.
+    for (uint32_t i = 0; i < CHIP_IM_MAX_NUM_WRITE_HANDLER + 1; ++i)
+    {
+        System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+        ASSERT_FALSE(buf.IsNull());
+        GenerateSuppressResponseChunkedWriteRequest(buf);
+
+        Messaging::ExchangeContext * exchange = NewExchangeToBob(&delegate);
+        ASSERT_NE(exchange, nullptr);
+
+        // SuppressResponse => the client does not expect a response back.
+        EXPECT_SUCCESS(exchange->SendMessage(MsgType::WriteRequest, std::move(buf), Messaging::SendMessageFlags::kNone));
+        DrainAndServiceIO();
+
+        EXPECT_EQ(engine->GetNumActiveWriteHandlers(), 0u);
+    }
+
+    engine->Shutdown();
+    ExpireSessionAliceToBob();
+    ExpireSessionBobToAlice();
+    EXPECT_SUCCESS(CreateSessionAliceToBob());
+    EXPECT_SUCCESS(CreateSessionBobToAlice());
+}
+
+// The sending side is guarded symmetrically: a WriteClient must not produce a chunked write that suppresses the
+// response (SuppressResponse SHALL be false when MoreChunkedMessages is true). When the payload is large enough to
+// require chunking, encoding fails rather than emitting the invalid combination.
+TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteClientRejectsSuppressedChunkedWrite)
+{
+    TestWriteClientCallback writeCallback;
+    auto * engine = InteractionModelEngine::GetInstance();
+    EXPECT_SUCCESS(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()));
+
+    // Reserve most of the buffer so the list is forced to chunk (same technique as the chunked-write tests above).
+    app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 60) /* reserved buffer size */);
+    writeClient.mSuppressResponse = true;
+
+    app::AttributePathParams attributePath(2, 3, 4);
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
+
+    // Encoding needs a second chunk, which is rejected because the response is suppressed.
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)),
+              CHIP_ERROR_INVALID_MESSAGE_TYPE);
+
+    engine->Shutdown();
 }
 
 #endif


### PR DESCRIPTION
#### Problem

A `WriteRequestMessage` can carry both `MoreChunkedMessages` and `SuppressResponse`. Per the data model encoding specification, `SuppressResponse` SHALL be false when `MoreChunkedMessages` is true, so a conformant `WriteClient` never sends this combination — but neither side enforced it.

`SuppressResponse` handling on the write path was added in #72003; this change enforces the constraint on both the receive and send sides.

On the receive side, `WriteHandler::ProcessWriteRequest` only rejected more-chunks for group and timed writes. A suppressed multi-chunk first message was therefore accepted, and the `WriteHandler` was kept alive waiting for the next chunk. Because the response was suppressed, nothing was sent on the exchange, so the messaging layer closed it and the handler was left allocated with no exchange and never released. As the handler pool is bounded (`CHIP_IM_MAX_NUM_WRITE_HANDLER`), repeated such requests exhaust it and subsequent `WriteRequest`s are answered with `Busy`.

#### Change

Receive side (`WriteHandler`):
- Reject `MoreChunkedMessages` combined with `SuppressResponse` at the same accept gate that already rejects it for group and timed writes.

Send side (`WriteClient`):
- Refuse to chunk a suppressed write in `StartNewMessage` and `SendWriteRequest`, alongside the existing timed and group guards, so the SDK client never produces the invalid combination.
- The timed + chunk rejection in `StartNewMessage` now returns `CHIP_ERROR_INVALID_MESSAGE_TYPE` instead of `CHIP_ERROR_NO_MEMORY` (more accurate for a spec-invalid request).

Tests:
- `TestSuppressedChunkedWriteDoesNotLeakHandler` drives such a first chunk through the exchange layer and asserts the handler is released — the active handler count returns to 0 and the pool never fills.
- `TestWriteClientRejectsSuppressedChunkedWrite` asserts a `WriteClient` with `SuppressResponse` set fails to encode a payload large enough to require chunking.

#### Testing

Both tests fail before their respective guards and pass after (verified under ASan).
