### PR TITLE
[Silabs] : Update the SDK versions in install-packages.py script

### DIFF
--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -88,7 +88,7 @@ def parse_version_from_slt(file_path):
 
 
 def version_tuple(version_str):
-    """Convert version string to tuple of integers for comparison (e.g. 2025.12.2 -> (2025, 12, 2))."""
+    """Convert version string to tuple of integers for comparison (e.g. 2026.6.0 -> (2026, 6, 0))."""
     if not version_str:
         return ()
     main = version_str.split("-")[0].split("+")[0]
@@ -484,8 +484,8 @@ def setup_slt_environment(verbose=False):
     check_silabs_not_submodules(repo_root)
 
     # Using exact version to avoid ambiguity when multiple versions are installed.
-    simplicity_sdk_path = slt_where(slt_cli_path, "simplicity-sdk/2025.12.2")
-    wiseconnect_path = slt_where(slt_cli_path, "wiseconnect/4.0.1")
+    simplicity_sdk_path = slt_where(slt_cli_path, "simplicity-sdk/2026.6.0")
+    wiseconnect_path = slt_where(slt_cli_path, "wiseconnect/4.1.0")
     create_sdk_symlinks(simplicity_sdk_path, wiseconnect_path)
 
     versions = get_installed_sdk_versions(repo_root)


### PR DESCRIPTION
### Summary

Need to update versions in install packages script to tackle the following issue
`[ERROR] 'slt where simplicity-sdk/2025.12.2' failed (exit code 1): Error:
no results found
[ERROR] 'slt where wiseconnect/4.0.1' failed (exit code 1): Error:
no results found`


### Related issues

N/A

### Testing

Ran the ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs out/lock BRD4187C locally and got past this issue, fails for other issues, needs investigation on those
