### PR TITLE
[BuildEnv] Bump Pigweed and pin ARM GCC toolchain to 12.2.1

### DIFF
--- a/scripts/setup/arm.json
+++ b/scripts/setup/arm.json
@@ -1,0 +1,24 @@
+{
+  "_comment": [
+    "This file is a local copy of third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
+    "It overrides the default ARM GCC version selected by Pigweed to pin it to version 12.2,",
+    "avoiding compilation/linker relocation errors introduced in GCC 15.2.",
+    "Python has been removed from this file as it is managed separately by Matter's bootstrap.sh."
+  ],
+  "packages": [
+    {
+      "path": "fuchsia/third_party/armgcc/${platform}",
+      "platforms": [
+        "linux-amd64",
+        "linux-arm64",
+        "mac-amd64",
+        "mac-arm64",
+        "windows-amd64"
+      ],
+      "tags": [
+        "version:2@12.2.MPACBTI-Rel1.1"
+      ],
+      "version_file": ".versions/gcc-arm-none-eabi.version"
+    }
+  ]
+}

--- a/scripts/setup/arm.json
+++ b/scripts/setup/arm.json
@@ -1,24 +1,22 @@
 {
-  "_comment": [
-    "This file is a local copy of third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
-    "It overrides the default ARM GCC version selected by Pigweed to pin it to version 12.2,",
-    "avoiding compilation/linker relocation errors introduced in GCC 15.2.",
-    "Python has been removed from this file as it is managed separately by Matter's bootstrap.sh."
-  ],
-  "packages": [
-    {
-      "path": "fuchsia/third_party/armgcc/${platform}",
-      "platforms": [
-        "linux-amd64",
-        "linux-arm64",
-        "mac-amd64",
-        "mac-arm64",
-        "windows-amd64"
-      ],
-      "tags": [
-        "version:2@12.2.MPACBTI-Rel1.1"
-      ],
-      "version_file": ".versions/gcc-arm-none-eabi.version"
-    }
-  ]
+    "_comment": [
+        "This file is a local copy of third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
+        "It overrides the default ARM GCC version selected by Pigweed to pin it to version 12.2,",
+        "avoiding compilation/linker relocation errors introduced in GCC 15.2.",
+        "Python has been removed from this file as it is managed separately by Matter's bootstrap.sh."
+    ],
+    "packages": [
+        {
+            "path": "fuchsia/third_party/armgcc/${platform}",
+            "platforms": [
+                "linux-amd64",
+                "linux-arm64",
+                "mac-amd64",
+                "mac-arm64",
+                "windows-amd64"
+            ],
+            "tags": ["version:2@12.2.MPACBTI-Rel1.1"],
+            "version_file": ".versions/gcc-arm-none-eabi.version"
+        }
+    ]
 }

--- a/scripts/setup/environment.json
+++ b/scripts/setup/environment.json
@@ -1,6 +1,6 @@
 {
     "cipd_package_files": [
-        "third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
+        "scripts/setup/arm.json",
         "scripts/setup/zap.json"
     ],
     "virtualenv": {

--- a/scripts/setup/environment.json
+++ b/scripts/setup/environment.json
@@ -1,8 +1,5 @@
 {
-    "cipd_package_files": [
-        "scripts/setup/arm.json",
-        "scripts/setup/zap.json"
-    ],
+    "cipd_package_files": ["scripts/setup/arm.json", "scripts/setup/zap.json"],
     "virtualenv": {
         "gn_root": ".",
         "gn_targets": [":python_packages.install"],


### PR DESCRIPTION
#### Summary

Bumps Pigweed to version `ef4e131` and pins the ARM GCC toolchain to 12.2 in Matter's environment setup to avoid compilation and linker errors caused by Pigweed's compiler upgrade.

##### Problem

- Upgrading the Pigweed submodule to the latest version introduces a toolchain upgrade for ARM GCC to version 15.2.1.
- This compiler version generates thread-local storage accesses using `__aeabi_read_tp`, which is not supported or implemented on several bare-metal and RTOS platforms (`cc32xx`, `Infineon`, `QPG`, `Ameba`, `stm32`, `cc13xx_26xx`, `EFR32`).
- Consequently, builds for these platforms fail during the linking stage with `undefined reference to '__aeabi_read_tp'` errors.
- Additionally, it triggers relocation errors in precompiled libraries (such as NXP's `lib_crypto_m33.a`) and stricter warnings-as-errors for implicit function declarations in Realtek's OpenThread port.

##### Solution

- Bumped the `third_party/pigweed/repo` submodule to `ef4e131`.
- To prevent this upgrade from breaking the build, copied the ARM CIPD package manifest `arm.json` from Pigweed to a local path (`scripts/setup/arm.json`) and pinned the GCC version to the working GCC 12.2.1 version (`version:2@12.2.MPACBTI-Rel1.1`).
- Removed the Python package from this local `arm.json` copy, as Python versioning is already managed independently in Matter's `bootstrap.sh`.
- Updated `scripts/setup/environment.json` to point to the local `scripts/setup/arm.json` instead of the Pigweed submodule file, effectively overriding Pigweed's default GCC compiler selection for Matter builds.

#### Testing

- Successfully ran `scripts/bootstrap.sh` locally with the overridden configuration and updated Pigweed submodule.
- Verified that the toolchain installed in `.environment` remains at GCC version `12.2.1`.
- Verified that the bootstrap succeeds and correctly maintains the pinned GCC version.
- CI will validate that things keep compiling
