### PR TITLE
[NXP] Fix NXP Zephyr builds

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -144,16 +144,7 @@ jobs:
         name: ZEPHYR
 
         runs-on: ubuntu-latest
-        # TODO: disabled for now due to failure on CI:
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters: CMake Error at /opt/nxp-zephyr/zephyrproject/modules/lib/nxp_iot_agent/zephyr/CMakeLists.txt:110 (if):
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:   if given arguments:
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:     "CONFIG_EL2GO_SIGN_USING_NXPIMAGE" "OR" "(" "DEFINED" "ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE}" "AND" "STREQUAL" "y" ")" "AND" "(" "frdm_rw612/rw612" "STREQUAL" "rd_rw612_bga/rw612/ns" "OR" "frdm_rw612/rw612" "STREQUAL" "frdm_rw612/rw612/ns" ")"
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:
-        #        WARNING Generating nxp-rw61x-zephyr-all-clusters:   Unknown arguments specified
-        #
-        # if: github.actor != 'restyled-io[bot]'
-        if: false
+        if: github.actor != 'restyled-io[bot]'
 
         container:
             image: ghcr.io/project-chip/chip-build-nxp-zephyr:203

--- a/config/nxp/app/pre-zephyr.cmake
+++ b/config/nxp/app/pre-zephyr.cmake
@@ -13,3 +13,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+# Workaround: the nxp_iot_agent module has an if() with an unquoted
+# $ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE} that CMake >= 4.4.0 rejects when unset
+# ("Unknown arguments specified"). Seed a value before find_package(Zephyr) so
+# the token is non-empty; the guarded path stays disabled. Remove once fixed upstream.
+if(NOT DEFINED ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE})
+    set(ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE} "n")
+endif()

--- a/src/test_driver/nxp/zephyr/CMakeLists.txt
+++ b/src/test_driver/nxp/zephyr/CMakeLists.txt
@@ -17,6 +17,9 @@ cmake_minimum_required(VERSION 3.20)
 
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
+# Perform common operations before find_package(Zephyr)
+include(${CHIP_ROOT}/config/nxp/app/pre-zephyr.cmake)
+
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/zephyr/chip-module)
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/third_party/pigweed/repo)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
### Summary

This PR applies a workaround to fix NXP Zephyr builds which fail at CMake configure time inside the Zephyr "nxp_iot_agent" module. Error message:

```
WARNING Generating nxp-rw61x-zephyr-all-clusters: CMake Error at /opt/nxp-zephyr/zephyrproject/modules/lib/nxp_iot_agent/zephyr/CMakeLists.txt:110 (if):
WARNING Generating nxp-rw61x-zephyr-all-clusters:   if given arguments:
WARNING Generating nxp-rw61x-zephyr-all-clusters: 
WARNING Generating nxp-rw61x-zephyr-all-clusters:     "CONFIG_EL2GO_SIGN_USING_NXPIMAGE" "OR" "(" "DEFINED" "ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE}" "AND" "STREQUAL" "y" ")" "AND" "(" "frdm_rw612/rw612" "STREQUAL" "rd_rw612_bga/rw612/ns" "OR" "frdm_rw612/rw612" "STREQUAL" "frdm_rw612/rw612/ns" ")"
WARNING Generating nxp-rw61x-zephyr-all-clusters: 
WARNING Generating nxp-rw61x-zephyr-all-clusters:   Unknown arguments specified
```

The root cause is that the module's CMakeLists.txt has an "if()" guarding that uses an unquoted $ENV{CONFIG_EL2GO_SIGN_USING_NXPIMAGE}
 
When the variable is unset (the normal case) the unquoted expansion produces zero tokens, so the argument list becomes "... AND STREQUAL y" - a STREQUAL with no left-hand operand. Reproduced on CMake 4.4.0; previously tolerated on CMake 4.3.2.

The workaround is defining the environment variable as "n" in "config/nxp/app/pre-zephyr.cmake" to keep the token non-empty. It is applied to unblock Matter NXP Zephyr builds in the CI.

The proper fix belongs upstream in the "nxp_iot_agent" module, a dedicated issue has been raised. This workaround can be removed once the module is fixed and the Zephyr manifest is bumped.

### Related issues

PR disabling NXP Zephyr builds #73028 
Build failure showcasing the issue: https://github.com/project-chip/connectedhomeip/actions/runs/29261793775/job/86856712079 

### Testing

This should be covered by the CI builds in this PR.
