### PR TITLE
[Infra] Update Mergify config for new release branches and supported backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,19 +42,35 @@ pull_request_rules:
               method: squash
 
     # Backport rules - cherry-pick the squashed master commit after merge.
-    # Apply label request-backport-sve or request-backport-supported on the master PR
-    # (before or after merge) to trigger the corresponding backport.
-    - name: Backport to v1.6-sve-branch
+    # Apply a request-backport-* label (such as request-backport-latest or
+    # request-backport-supported) on the master PR (before or after merge)
+    # to trigger the corresponding backport.
+    - name: Backport to v1.6.1-branch
       conditions:
           - merged
           - base=master
-          - label="request-backport-sve"
+          - or:
+                - label="request-backport-latest"
+                - label="request-backport-latest-mve-sve"
+                - label="request-backport-supported"
       actions:
           backport:
               branches:
-                  - v1.6-sve-branch
+                  - v1.6.1-branch
               labels:
-                  - backport-v1.6-sve-branch
+                  - backport-v1.6.1-branch
+
+    - name: Backport to v1.6.1-mve-branch
+      conditions:
+          - merged
+          - base=master
+          - label="request-backport-latest-mve-sve"
+      actions:
+          backport:
+              branches:
+                  - v1.6.1-mve-branch
+              labels:
+                  - backport-v1.6.1-mve-branch
 
     - name: Backport to v1.6-branch
       conditions:
@@ -99,7 +115,8 @@ pull_request_rules:
     - name: Auto-merge clean backport PRs
       conditions:
           - or:
-                - label="backport-v1.6-sve-branch"
+                - label="backport-v1.6.1-branch"
+                - label="backport-v1.6.1-mve-branch"
                 - label="backport-v1.6-branch"
                 - label="backport-v1.5-branch"
                 - label="backport-v1.4.2-branch"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -108,6 +108,17 @@ pull_request_rules:
               labels:
                   - backport-v1.4.2-branch
 
+    - name: Request review for MVE/SVE backports
+      conditions:
+          - author=mergify[bot]
+          - or:
+                - label~=mve-branch
+                - label~=sve-branch
+      actions:
+          request_reviews:
+              users:
+                  - cecille
+
     # Auto-merge backport PRs when CI is green and there are no conflicts.
     # If a cherry-pick has conflicts or CI fails, the PR is left open for manual resolution.
     # WARNING: If the rule name below is changed, you must also update the
@@ -116,7 +127,6 @@ pull_request_rules:
       conditions:
           - or:
                 - label="backport-v1.6.1-branch"
-                - label="backport-v1.6.1-mve-branch"
                 - label="backport-v1.6-branch"
                 - label="backport-v1.5-branch"
                 - label="backport-v1.4.2-branch"


### PR DESCRIPTION
#### Summary

Update `.mergify.yml` to support automated cherry-picks for the new release branches `v1.6.1-branch` and `v1.6.1-mve-branch`, and clean up obsolete rules.

- Introduced generic labels:
  - `request-backport-latest` -> targets `v1.6.1-branch`
  - `request-backport-latest-mve-sve` -> targets both `v1.6.1-branch` and `v1.6.1-mve-branch`
- Added `v1.6.1-branch` to `request-backport-supported` targets.
- Removed obsolete `Backport to v1.6-sve-branch` rule and `request-backport-sve` handling.
- Updated the auto-merge rule:
  - Added `backport-v1.6.1-branch` and `backport-v1.6.1-mve-branch` labels.
  - Removed `backport-v1.6-sve-branch` label.

#### Testing

Manual verification of the `.mergify.yml` structure.
