### PR TITLE
[1.6.1-branch] Chery pick pr#73054

### DIFF
--- a/src/python_testing/TC_IDM_4_3.py
+++ b/src/python_testing/TC_IDM_4_3.py
@@ -82,6 +82,8 @@ class TC_IDM_4_3(IDMBaseTest):
 
     def steps_TC_IDM_4_3(self):
         return [
+            TestStep(0, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(1, "DUT and TH activate the subscription for an attribute. Do not change the value of the attribute which has been subscribed.",
                      "Verify that there is an empty report data message sent from the DUT to the TH after the MinInterval time and no later than the MaxInterval time plus an additional duration equal to the total retransmission time according to negotiated MRP parameters."),
             TestStep(2, "Activate the subscription between the DUT and the TH for an attribute. Change the value of the attribute which has been subscribed on the DUT by sending a Write command from the TH.",
@@ -123,6 +125,9 @@ class TC_IDM_4_3(IDMBaseTest):
 
     @async_test_body
     async def test_TC_IDM_4_3(self):
+
+        self.step(0)
+
         node_label_attr = Clusters.BasicInformation.Attributes.NodeLabel
         TH: ChipDeviceController = self.default_controller
 

--- a/src/python_testing/TC_SMOKECO_2_1.py
+++ b/src/python_testing/TC_SMOKECO_2_1.py
@@ -55,7 +55,8 @@ class TC_SMOKECO_2_1(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_1(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH reads from the DUT the ExpressedState attribute.",
                      "Verify that the DUT response contains a value between 0 and 9"),
             TestStep(3, "TH reads from the DUT the SmokeState attribute.",

--- a/src/python_testing/TC_SMOKECO_2_2.py
+++ b/src/python_testing/TC_SMOKECO_2_2.py
@@ -60,7 +60,8 @@ class TC_SMOKECO_2_2(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_2(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH subscribes to SmokeState attribute from DUT",
                      "Verify that SmokeState attribute has a value of 0 (Normal)"),
             TestStep(3, "TH reads ExpressedState attribute from DUT",

--- a/src/python_testing/TC_SMOKECO_2_3.py
+++ b/src/python_testing/TC_SMOKECO_2_3.py
@@ -57,7 +57,8 @@ class TC_SMOKECO_2_3(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_3(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH subscribes to COState attribute from DUT", "Verify that COState attribute has a value of 0 (Normal)"),
             TestStep(3, "TH reads ExpressedState attribute from DUT",
                      "Verify that ExpressedState attribute has a value of 0 (Normal)"),

--- a/src/python_testing/TC_SMOKECO_2_4.py
+++ b/src/python_testing/TC_SMOKECO_2_4.py
@@ -63,7 +63,8 @@ class TC_SMOKECO_2_4(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_4(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH subscribes to BatteryAlert attribute from DUT",
                      "Verify that BatteryAlert attribute has a value of 0 (Normal)"),
             TestStep(3, "TH reads ExpressedState attribute from DUT",

--- a/src/python_testing/TC_SMOKECO_2_5.py
+++ b/src/python_testing/TC_SMOKECO_2_5.py
@@ -63,7 +63,8 @@ class TC_SMOKECO_2_5(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_5(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH subscribes to InterconnectSmokeAlarm attribute from DUT",
                      "Verify that InterconnectSmokeAlarm attribute has a value of 0 (Normal)"),
             TestStep(3, "TH reads ExpressedState attribute from DUT",

--- a/src/python_testing/TC_SMOKECO_2_6.py
+++ b/src/python_testing/TC_SMOKECO_2_6.py
@@ -81,7 +81,8 @@ class TC_SMOKECO_2_6(SmokeCoBaseTest):
 
     def steps_TC_SMOKECO_2_6(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commission DUT to TH"),
+            TestStep(1, "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     "DUT is commissioned to TH.", is_commissioning=True),
             TestStep(2, "TH reads ExpressedState attribute from DUT",
                      "Verify that ExpressedState attribute has a value of 0 (Normal)"),
             TestStep(3, "TH subscribes to BatteryAlert attribute from DUT",


### PR DESCRIPTION
### Summary

To execute the following test cases, the TH and DUT must be commissioned before entering the actual test steps. However, the current script is missing is_commissioning=True, which is required to perform the commissioning automatically.

Because of this, the test fails when the TH and DUT have not already been commissioned. This change adds the missing is_commissioning=True to ensure the required commissioning is performed before test execution.

- Cherry_pick PR: https://github.com/project-chip/connectedhomeip/pull/73054

### Related issues


### Testing

Side loaded the updated script in latest 1.6.1 TH(Version: v2.15.1-beta1+summer2026) and tested.
