### PR TITLE
[CI] Mount runner-root-volume in Tizen workflow

### DIFF
--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -39,6 +39,8 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-tizen:200
             options: --user root
+            volumes:
+                - "/:/runner-root-volume"
 
         steps:
             - name: Checkout


### PR DESCRIPTION
#### Summary

Mounts the root volume to the container in the Tizen workflow to enable disk space maximization.

##### Problem

The Tizen CI workflow fails with the following error:
`Unable to maximize disk space, job is running inside a container and /runner-root-volume is not mounted`

This happens because the workflow runner attempts to maximize disk space but cannot access the root volume of the host from inside the Docker container.

##### Solution

Added `volumes: - "/:/runner-root-volume"` to the container configuration in `.github/workflows/examples-tizen.yaml`. This is consistent with how other workflows (like nRF Connect and Android) handle this requirement.

#### Testing

This is a CI configuration change. It cannot be easily tested locally.
Verification will happen when the PR is run in CI.
