### PR TITLE
[CI] Mount runner-root-volume in Telink workflow

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -76,6 +76,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-telink:200
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:
@@ -460,6 +461,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:200
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:


### PR DESCRIPTION
#### Summary

Mounts the root volume to the containers in the Telink workflow to enable disk space maximization.

##### Problem

The Telink CI workflow fails because it is unable to maximize disk space when running inside a container without the root volume mounted.

##### Solution

Added `/:/runner-root-volume` to the `volumes` list for both `zephyr_latest` and `zephyr_3_3` jobs in `.github/workflows/examples-telink.yaml`.

#### Testing

CI configuration change, to be verified in CI.
