### PR TITLE
feat(tv-app): Implement new Messages features

### DIFF
--- a/examples/tv-app/android/java/MessagesManager.cpp
+++ b/examples/tv-app/android/java/MessagesManager.cpp
@@ -304,7 +304,8 @@ exit:
 CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
     const ByteSpan & messageId, const MessagePriorityEnum & priority, const BitMask<MessageControlBitmap> & messageControl,
     const DataModel::Nullable<uint32_t> & startTime, const DataModel::Nullable<uint64_t> & duration, const CharSpan & messageText,
-    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses)
+    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses, const Optional<CharSpan> & /* languageCode */,
+    const Optional<CharSpan> & /* messageUri */)
 {
     DeviceLayer::StackUnlock unlock;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
@@ -416,6 +417,16 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
         }
     }
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MessagesManager::HandleGetSupportedLanguageCodes(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeEmptyList();
+}
+
+CHIP_ERROR MessagesManager::HandleGetSupportedMimeTypes(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeEmptyList();
 }
 
 CHIP_ERROR MessagesManager::HandleCancelMessagesRequest(const DataModel::DecodableList<ByteSpan> & messageIds)

--- a/examples/tv-app/android/java/MessagesManager.h
+++ b/examples/tv-app/android/java/MessagesManager.h
@@ -39,12 +39,15 @@ public:
         const chip::CharSpan & messageText,
         const chip::Optional<
             chip::app::DataModel::DecodableList<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type>> &
-            responses) override;
+            responses,
+        const chip::Optional<chip::CharSpan> & languageCode, const chip::Optional<chip::CharSpan> & messageUri) override;
     CHIP_ERROR HandleCancelMessagesRequest(const chip::app::DataModel::DecodableList<chip::ByteSpan> & messageIds) override;
 
     // Attributes
     CHIP_ERROR HandleGetMessages(chip::app::AttributeValueEncoder & aEncoder) override;
     CHIP_ERROR HandleGetActiveMessageIds(chip::app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR HandleGetSupportedLanguageCodes(chip::app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR HandleGetSupportedMimeTypes(chip::app::AttributeValueEncoder & aEncoder) override;
 
     // Global Attributes
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;

--- a/examples/tv-app/tv-common/clusters/messages/MessagesManager.cpp
+++ b/examples/tv-app/tv-common/clusters/messages/MessagesManager.cpp
@@ -31,13 +31,15 @@ using MessageResponseOption = chip::app::Clusters::Messages::Structs::MessageRes
 CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
     const ByteSpan & messageId, const MessagePriorityEnum & priority, const BitMask<MessageControlBitmap> & messageControl,
     const DataModel::Nullable<uint32_t> & startTime, const DataModel::Nullable<uint64_t> & duration, const CharSpan & messageText,
-    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses, const Optional<CharSpan> & /* languageCode */,
-    const Optional<CharSpan> & /* messageUri */)
+    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses, const Optional<CharSpan> & languageCode,
+    const Optional<CharSpan> & messageUri)
 {
     ChipLogProgress(Zcl, "HandlePresentMessagesRequest message:%s", std::string(messageText.data(), messageText.size()).c_str());
 
-    auto cachedMessage = CachedMessage(messageId, priority, messageControl, startTime, duration,
-                                       std::string(messageText.data(), messageText.size()));
+    auto cachedMessage = CachedMessage(
+        messageId, priority, messageControl, startTime, duration, std::string(messageText.data(), messageText.size()),
+        languageCode.HasValue() ? std::string(languageCode.Value().data(), languageCode.Value().size()) : std::string(),
+        messageUri.HasValue() ? std::string(messageUri.Value().data(), messageUri.Value().size()) : std::string());
     if (responses.HasValue())
     {
         auto iter = responses.Value().begin();
@@ -97,12 +99,19 @@ CHIP_ERROR MessagesManager::HandleGetActiveMessageIds(AttributeValueEncoder & aE
 
 CHIP_ERROR MessagesManager::HandleGetSupportedLanguageCodes(AttributeValueEncoder & aEncoder)
 {
-    return aEncoder.EncodeEmptyList();
+    return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
+        ReturnErrorOnFailure(encoder.Encode("en-US"_span));
+        return CHIP_NO_ERROR;
+    });
 }
 
 CHIP_ERROR MessagesManager::HandleGetSupportedMimeTypes(AttributeValueEncoder & aEncoder)
 {
-    return aEncoder.EncodeEmptyList();
+    return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
+        ReturnErrorOnFailure(encoder.Encode("audio/mpeg"_span));
+        ReturnErrorOnFailure(encoder.Encode("audio/ogg"_span));
+        return CHIP_NO_ERROR;
+    });
 }
 
 // Global Attributes
@@ -113,6 +122,9 @@ uint32_t MessagesManager::GetFeatureMap(EndpointId endpoint)
     FeatureMap.Set(Feature::kConfirmationResponse);
     FeatureMap.Set(Feature::kConfirmationReply);
     FeatureMap.Set(Feature::kProtectedMessages);
+    FeatureMap.Set(Feature::kSpokenMessages);
+    FeatureMap.Set(Feature::kAudioMessages);
+    FeatureMap.Set(Feature::kMultiModalMessages);
 
     uint32_t featureMap = FeatureMap.Raw();
     ChipLogProgress(Zcl, "GetFeatureMap featureMap=%d", featureMap);

--- a/examples/tv-app/tv-common/clusters/messages/MessagesManager.cpp
+++ b/examples/tv-app/tv-common/clusters/messages/MessagesManager.cpp
@@ -31,7 +31,8 @@ using MessageResponseOption = chip::app::Clusters::Messages::Structs::MessageRes
 CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
     const ByteSpan & messageId, const MessagePriorityEnum & priority, const BitMask<MessageControlBitmap> & messageControl,
     const DataModel::Nullable<uint32_t> & startTime, const DataModel::Nullable<uint64_t> & duration, const CharSpan & messageText,
-    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses)
+    const Optional<DataModel::DecodableList<MessageResponseOption>> & responses, const Optional<CharSpan> & /* languageCode */,
+    const Optional<CharSpan> & /* messageUri */)
 {
     ChipLogProgress(Zcl, "HandlePresentMessagesRequest message:%s", std::string(messageText.data(), messageText.size()).c_str());
 
@@ -92,6 +93,16 @@ CHIP_ERROR MessagesManager::HandleGetActiveMessageIds(AttributeValueEncoder & aE
         }
         return CHIP_NO_ERROR;
     });
+}
+
+CHIP_ERROR MessagesManager::HandleGetSupportedLanguageCodes(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeEmptyList();
+}
+
+CHIP_ERROR MessagesManager::HandleGetSupportedMimeTypes(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeEmptyList();
 }
 
 // Global Attributes

--- a/examples/tv-app/tv-common/clusters/messages/MessagesManager.h
+++ b/examples/tv-app/tv-common/clusters/messages/MessagesManager.h
@@ -50,7 +50,8 @@ struct CachedMessage
 {
     CachedMessage(const CachedMessage & message) :
         mPriority(message.mPriority), mMessageControl(message.mMessageControl), mStartTime(message.mStartTime),
-        mDuration(message.mDuration), mMessageText(message.mMessageText), mOptions(message.mOptions)
+        mDuration(message.mDuration), mMessageText(message.mMessageText), mLanguageCode(message.mLanguageCode),
+        mMessageUri(message.mMessageUri), mOptions(message.mOptions)
     {
         memcpy(mMessageIdBuffer, message.mMessageIdBuffer, sizeof(mMessageIdBuffer));
 
@@ -65,9 +66,11 @@ struct CachedMessage
     CachedMessage(const chip::ByteSpan & messageId, const chip::app::Clusters::Messages::MessagePriorityEnum & priority,
                   const chip::BitMask<chip::app::Clusters::Messages::MessageControlBitmap> & messageControl,
                   const chip::app::DataModel::Nullable<uint32_t> & startTime,
-                  const chip::app::DataModel::Nullable<uint64_t> & duration, std::string messageText) :
+                  const chip::app::DataModel::Nullable<uint64_t> & duration, std::string messageText,
+                  std::string languageCode, std::string messageUri) :
         mPriority(priority),
-        mMessageControl(messageControl), mStartTime(startTime), mDuration(duration), mMessageText(messageText)
+        mMessageControl(messageControl), mStartTime(startTime), mDuration(duration), mMessageText(messageText),
+        mLanguageCode(languageCode), mMessageUri(messageUri)
     {
         memcpy(mMessageIdBuffer, messageId.data(), sizeof(mMessageIdBuffer));
     }
@@ -82,26 +85,26 @@ struct CachedMessage
 
     chip::app::Clusters::Messages::Structs::MessageStruct::Type GetMessage()
     {
-        if (mResponseOptions.size() > 0)
-        {
-            chip::app::DataModel::List<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type> options(
-                mResponseOptions.data(), mResponseOptions.size());
-            chip::app::Clusters::Messages::Structs::MessageStruct::Type message{ chip::ByteSpan(mMessageIdBuffer),
-                                                                                 mPriority,
-                                                                                 mMessageControl,
-                                                                                 mStartTime,
-                                                                                 mDuration,
-                                                                                 chip::CharSpan::fromCharString(
-                                                                                     mMessageText.c_str()),
-                                                                                 chip::MakeOptional(options) };
-            return message;
-        }
         chip::app::Clusters::Messages::Structs::MessageStruct::Type message{ chip::ByteSpan(mMessageIdBuffer),
                                                                              mPriority,
                                                                              mMessageControl,
                                                                              mStartTime,
                                                                              mDuration,
                                                                              chip::CharSpan::fromCharString(mMessageText.c_str()) };
+        if (mResponseOptions.size() > 0)
+        {
+            chip::app::DataModel::List<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type> options(
+                mResponseOptions.data(), mResponseOptions.size());
+            message.responses = chip::MakeOptional(options);
+        }
+        if (!mLanguageCode.empty())
+        {
+            message.languageCode = chip::MakeOptional(chip::CharSpan::fromCharString(mLanguageCode.c_str()));
+        }
+        if (!mMessageUri.empty())
+        {
+            message.messageURI = chip::MakeOptional(chip::CharSpan::fromCharString(mMessageUri.c_str()));
+        }
         return message;
     }
 
@@ -114,6 +117,8 @@ protected:
     const chip::app::DataModel::Nullable<uint64_t> mDuration;
 
     std::string mMessageText;
+    std::string mLanguageCode;
+    std::string mMessageUri;
     uint8_t mMessageIdBuffer[chip::app::Clusters::Messages::kMessageIdLength];
 
     std::vector<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type> mResponseOptions;

--- a/examples/tv-app/tv-common/clusters/messages/MessagesManager.h
+++ b/examples/tv-app/tv-common/clusters/messages/MessagesManager.h
@@ -131,12 +131,15 @@ public:
         const chip::CharSpan & messageText,
         const chip::Optional<
             chip::app::DataModel::DecodableList<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type>> &
-            responses) override;
+            responses,
+        const chip::Optional<chip::CharSpan> & languageCode, const chip::Optional<chip::CharSpan> & messageUri) override;
     CHIP_ERROR HandleCancelMessagesRequest(const chip::app::DataModel::DecodableList<chip::ByteSpan> & messageIds) override;
 
     // Attributes
     CHIP_ERROR HandleGetMessages(chip::app::AttributeValueEncoder & aEncoder) override;
     CHIP_ERROR HandleGetActiveMessageIds(chip::app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR HandleGetSupportedLanguageCodes(chip::app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR HandleGetSupportedMimeTypes(chip::app::AttributeValueEncoder & aEncoder) override;
 
     // Global Attributes
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -4337,13 +4337,16 @@ endpoint 1 {
     emits event MessageQueued;
     emits event MessagePresented;
     emits event MessageComplete;
+    emits event MessageNotPresented;
     callback attribute messages;
     callback attribute activeMessageIDs;
+    callback attribute supportedLanguageCodes;
+    callback attribute supportedMimeTypes;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 3;
+    ram      attribute clusterRevision default = 4;
 
     handle command PresentMessagesRequest;
     handle command CancelMessagesRequest;

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -4863,6 +4863,38 @@
               "reportableChange": 0
             },
             {
+              "name": "SupportedLanguageCodes",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "SupportedMimeTypes",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "GeneratedCommandList",
               "code": 65528,
               "mfgCode": null,
@@ -4936,7 +4968,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "3",
+              "defaultValue": "4",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -4961,6 +4993,13 @@
             {
               "name": "MessageComplete",
               "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "MessageNotPresented",
+              "code": 3,
               "mfgCode": null,
               "side": "server",
               "included": 1

--- a/src/app/clusters/messages-server/messages-delegate.h
+++ b/src/app/clusters/messages-server/messages-delegate.h
@@ -28,11 +28,16 @@ namespace app {
 namespace Clusters {
 namespace Messages {
 
-constexpr static size_t kMessageIdLength               = 16;
-constexpr static size_t kMessageTextLengthMax          = 256;
-constexpr static size_t kMessageMaxOptionCount         = 4;
-constexpr static size_t kMessageResponseIdMin          = 1;
-constexpr static size_t kMessageResponseLabelMaxLength = 32;
+constexpr static size_t kMessageIdLength                  = 16;
+constexpr static size_t kMessageTextLengthMax             = 256;
+constexpr static size_t kMessageMaxOptionCount            = 4;
+constexpr static size_t kMessageResponseIdMin             = 1;
+constexpr static size_t kMessageResponseLabelMaxLength    = 32;
+constexpr static size_t kLanguageCodeLengthMax            = 32;
+constexpr static size_t kMessageUriLengthMax              = 256;
+constexpr static size_t kSupportedLanguageCodeMaxCount    = 32;
+constexpr static size_t kSupportedMimeTypeMaxCount        = 64;
+constexpr static size_t kSupportedMimeTypeLengthMax       = 256;
 
 class Delegate
 {
@@ -43,12 +48,15 @@ public:
         const chip::BitMask<MessageControlBitmap> & messageControl, const DataModel::Nullable<uint32_t> & startTime,
         const DataModel::Nullable<uint64_t> & duration, const CharSpan & messageText,
         const chip::Optional<DataModel::DecodableList<chip::app::Clusters::Messages::Structs::MessageResponseOptionStruct::Type>> &
-            responses)                                                                                          = 0;
+            responses,
+        const chip::Optional<CharSpan> & languageCode, const chip::Optional<CharSpan> & messageUri) = 0;
     virtual CHIP_ERROR HandleCancelMessagesRequest(const DataModel::DecodableList<chip::ByteSpan> & messageIds) = 0;
 
     // Attributes
-    virtual CHIP_ERROR HandleGetMessages(app::AttributeValueEncoder & aEncoder)         = 0;
-    virtual CHIP_ERROR HandleGetActiveMessageIds(app::AttributeValueEncoder & aEncoder) = 0;
+    virtual CHIP_ERROR HandleGetMessages(app::AttributeValueEncoder & aEncoder)              = 0;
+    virtual CHIP_ERROR HandleGetActiveMessageIds(app::AttributeValueEncoder & aEncoder)       = 0;
+    virtual CHIP_ERROR HandleGetSupportedLanguageCodes(app::AttributeValueEncoder & aEncoder) = 0;
+    virtual CHIP_ERROR HandleGetSupportedMimeTypes(app::AttributeValueEncoder & aEncoder)     = 0;
 
     // Global Attributes
     bool HasFeature(chip::EndpointId endpoint, Feature feature);
@@ -56,6 +64,9 @@ public:
 
     virtual ~Delegate() = default;
 };
+
+// Logs a MessageNotPresented event for the given endpoint.
+CHIP_ERROR LogMessageNotPresentedEvent(chip::EndpointId endpoint, const ByteSpan & messageId, bool removedFromQueue);
 
 } // namespace Messages
 } // namespace Clusters

--- a/src/app/clusters/messages-server/messages-server.cpp
+++ b/src/app/clusters/messages-server/messages-server.cpp
@@ -87,6 +87,19 @@ bool Delegate::HasFeature(chip::EndpointId endpoint, Feature feature)
     return (featureMap & chip::to_underlying(feature));
 }
 
+CHIP_ERROR LogMessageNotPresentedEvent(chip::EndpointId endpoint, const ByteSpan & messageId, bool removedFromQueue)
+{
+    Events::MessageNotPresented::Type event{ .messageID = messageId, .removedFromQueue = removedFromQueue };
+
+    EventNumber eventNumber;
+    CHIP_ERROR err = LogEvent(event, endpoint, eventNumber);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "LogMessageNotPresentedEvent: unable to send event: %s [endpointId=%d]", err.AsString(), endpoint);
+    }
+    return err;
+}
+
 } // namespace Messages
 } // namespace Clusters
 } // namespace app
@@ -107,6 +120,8 @@ public:
 private:
     CHIP_ERROR ReadMessages(app::AttributeValueEncoder & aEncoder, Delegate * delegate);
     CHIP_ERROR ReadActiveMessageIds(app::AttributeValueEncoder & aEncoder, Delegate * delegate);
+    CHIP_ERROR ReadSupportedLanguageCodes(app::AttributeValueEncoder & aEncoder, Delegate * delegate);
+    CHIP_ERROR ReadSupportedMimeTypes(app::AttributeValueEncoder & aEncoder, Delegate * delegate);
     CHIP_ERROR ReadFeatureFlagAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
 };
 
@@ -133,6 +148,20 @@ CHIP_ERROR MessagesAttrAccess::Read(const app::ConcreteReadAttributePath & aPath
         }
 
         return ReadActiveMessageIds(aEncoder, delegate);
+    case app::Clusters::Messages::Attributes::SupportedLanguageCodes::Id:
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.EncodeEmptyList();
+        }
+
+        return ReadSupportedLanguageCodes(aEncoder, delegate);
+    case app::Clusters::Messages::Attributes::SupportedMimeTypes::Id:
+        if (isDelegateNull(delegate, endpoint))
+        {
+            return aEncoder.EncodeEmptyList();
+        }
+
+        return ReadSupportedMimeTypes(aEncoder, delegate);
     case app::Clusters::Messages::Attributes::FeatureMap::Id:
         if (isDelegateNull(delegate, endpoint))
         {
@@ -164,6 +193,16 @@ CHIP_ERROR MessagesAttrAccess::ReadActiveMessageIds(app::AttributeValueEncoder &
     return delegate->HandleGetActiveMessageIds(aEncoder);
 }
 
+CHIP_ERROR MessagesAttrAccess::ReadSupportedLanguageCodes(app::AttributeValueEncoder & aEncoder, Delegate * delegate)
+{
+    return delegate->HandleGetSupportedLanguageCodes(aEncoder);
+}
+
+CHIP_ERROR MessagesAttrAccess::ReadSupportedMimeTypes(app::AttributeValueEncoder & aEncoder, Delegate * delegate)
+{
+    return delegate->HandleGetSupportedMimeTypes(aEncoder);
+}
+
 } // anonymous namespace
 
 bool emberAfMessagesClusterPresentMessagesRequestCallback(
@@ -181,6 +220,8 @@ bool emberAfMessagesClusterPresentMessagesRequestCallback(
     auto & duration       = commandData.duration;
     auto & messageText    = commandData.messageText;
     auto & responses      = commandData.responses;
+    auto & languageCode   = commandData.languageCode;
+    auto & messageUri     = commandData.messageURI;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, status = Status::NotFound);
@@ -192,6 +233,49 @@ bool emberAfMessagesClusterPresentMessagesRequestCallback(
     VerifyOrExit(messageText.size() <= kMessageTextLengthMax,
                  ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback invalid message text length");
                  status = Status::ConstraintError);
+
+    VerifyOrExit(!messageControl.Has(MessageControlBitmap::kSpokenMessage) ||
+                     delegate->HasFeature(endpoint, Feature::kSpokenMessages),
+                 ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback SpokenMessage bit set but "
+                                      "SpokenMessages feature not supported");
+                 status = Status::InvalidCommand);
+
+    VerifyOrExit(!messageControl.Has(MessageControlBitmap::kAudioMessage) ||
+                     delegate->HasFeature(endpoint, Feature::kAudioMessages),
+                 ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback AudioMessage bit set but "
+                                      "AudioMessages feature not supported");
+                 status = Status::InvalidCommand);
+
+    VerifyOrExit(!(messageControl.Has(MessageControlBitmap::kSpokenMessage) &&
+                    messageControl.Has(MessageControlBitmap::kAudioMessage)) ||
+                     delegate->HasFeature(endpoint, Feature::kMultiModalMessages),
+                 ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback SpokenMessage and AudioMessage "
+                                      "bits both set but MultiModalMessages feature not supported");
+                 status = Status::InvalidCommand);
+
+    if (languageCode.HasValue())
+    {
+        VerifyOrExit(delegate->HasFeature(endpoint, Feature::kSpokenMessages),
+                     ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback LanguageCode sent but "
+                                          "SpokenMessages feature not supported");
+                     status = Status::InvalidCommand);
+
+        VerifyOrExit(languageCode.Value().size() <= kLanguageCodeLengthMax,
+                     ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback invalid LanguageCode length");
+                     status = Status::ConstraintError);
+    }
+
+    if (messageUri.HasValue())
+    {
+        VerifyOrExit(delegate->HasFeature(endpoint, Feature::kAudioMessages),
+                     ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback MessageURI sent but "
+                                          "AudioMessages feature not supported");
+                     status = Status::InvalidCommand);
+
+        VerifyOrExit(messageUri.Value().size() <= kMessageUriLengthMax,
+                     ChipLogProgress(Zcl, "emberAfMessagesClusterPresentMessagesRequestCallback invalid MessageURI length");
+                     status = Status::ConstraintError);
+    }
 
     if (responses.HasValue())
     {
@@ -234,7 +318,8 @@ bool emberAfMessagesClusterPresentMessagesRequestCallback(
                      status = Status::InvalidAction);
     }
 
-    err = delegate->HandlePresentMessagesRequest(messageId, priority, messageControl, startTime, duration, messageText, responses);
+    err = delegate->HandlePresentMessagesRequest(messageId, priority, messageControl, startTime, duration, messageText, responses,
+                                                  languageCode, messageUri);
 
 exit:
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
### Summary

Adds the Matter 1.7 (`audio-messages`) revision-4 hooks for the Messages
cluster, which were previously codegen-only. Also adds basic support for
audio & spoken (TTS) messages to the TV App.

### Testing

- Manually tested end-to-end with `chip-tv-app` + `chip-tool`:
  - Commissioned `chip-tv-app` on-network with `chip-tool`.
  - `FeatureMap` reads back `127`, correctly including the 3 new feature
    bits alongside the original 4.
  - `ClusterRevision` reads back `4`.
  - `SupportedLanguageCodes` reads back `["en-US"]`;
    `SupportedMimeTypes` reads back `["audio/mpeg", "audio/ogg"]`
    (both were `UNSUPPORTED_ATTRIBUTE` before the `tv-app.zap` fix).
  - Sent `PresentMessagesRequest` with `--LanguageCode en-US` and with
    `--MessageURI https://example.com/msg.mp3`; both succeeded, and reading
    back the `Messages` attribute confirmed the fields were stored and
    echoed correctly.
  - Sent `PresentMessagesRequest` with an over-length (>256 char)
    `MessageURI` and confirmed it's rejected with `CONSTRAINT_ERROR`,
    verifying the length-constraint validation in `messages-server.cpp`.