### PR TITLE
feat(tv-app): Implement Account Login support for OAuth 2.0 Device Authorization Grant

### DIFF
--- a/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
@@ -170,6 +170,18 @@ void AccountLoginManager::GetSetupPin(char * setupPin, size_t setupPinSize, cons
     ChipLogProgress(Zcl, "Returning pin for content app for endpoint %d", mEndpointId);
 };
 
+void AccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper)
+{
+    ChipLogProgress(Zcl, "AccountLoginManager::HandleGetDeviceAuthURI");
+
+    GetDeviceAuthURIResponse response;
+    response.userCode        = CharSpan::fromCharString("ABCD-EFGH");
+    response.verificationURI = CharSpan::fromCharString("https://example.com/device");
+    response.expiresIn       = 1800;
+    response.interval        = 5;
+    TEMPORARY_RETURN_IGNORED helper.Success(response);
+}
+
 uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
 {
     if (endpoint >= MATTER_DM_CONTENT_LAUNCHER_CLUSTER_SERVER_ENDPOINT_COUNT)

--- a/examples/tv-app/android/include/account-login/AccountLoginManager.h
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.h
@@ -29,6 +29,7 @@ using chip::app::CommandResponseHelper;
 using chip::Platform::CopyString;
 using AccountLoginDelegate      = chip::app::Clusters::AccountLogin::Delegate;
 using GetSetupPINResponse       = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type;
+using GetDeviceAuthURIResponse  = chip::app::Clusters::AccountLogin::Commands::GetDeviceAuthURIResponse::Type;
 using ContentAppCommandDelegate = chip::AppPlatform::ContentAppCommandDelegate;
 
 class AccountLoginManager : public AccountLoginDelegate
@@ -46,15 +47,18 @@ public:
                            const CharSpan & tempAccountIdentifierString) override;
     void GetSetupPin(char * setupPin, size_t setupPinSize, const CharSpan & tempAccountIdentifierString) override;
     void SetEndpointId(EndpointId epId) { mEndpointId = epId; };
+    void HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper) override;
+    bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
 
 protected:
     static const size_t kSetupPinSize = 12;
     char mSetupPin[kSetupPinSize];
+    bool mOAuthLoggedIn = false;
 
 private:
     ContentAppCommandDelegate * mCommandDelegate;
     EndpointId mEndpointId;
 
-    static constexpr uint16_t kClusterRevision = 2;
+    static constexpr uint16_t kClusterRevision = 3;
 };

--- a/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
@@ -65,6 +65,18 @@ void AccountLoginManager::HandleGetSetupPin(CommandResponseHelper<GetSetupPINRes
     TEMPORARY_RETURN_IGNORED helper.Success(response);
 }
 
+void AccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper)
+{
+    ChipLogProgress(Zcl, "AccountLoginManager::HandleGetDeviceAuthURI");
+
+    GetDeviceAuthURIResponse response;
+    response.userCode        = CharSpan::fromCharString("ABCD-EFGH");
+    response.verificationURI = CharSpan::fromCharString("https://example.com/device");
+    response.expiresIn       = 1800;
+    response.interval        = 5;
+    TEMPORARY_RETURN_IGNORED helper.Success(response);
+}
+
 uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
 {
     if (endpoint >= MATTER_DM_CONTENT_LAUNCHER_CLUSTER_SERVER_ENDPOINT_COUNT)

--- a/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.h
@@ -25,8 +25,9 @@
 using chip::CharSpan;
 using chip::app::CommandResponseHelper;
 using chip::Platform::CopyString;
-using AccountLoginDelegate = chip::app::Clusters::AccountLogin::Delegate;
-using GetSetupPINResponse  = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type;
+using AccountLoginDelegate     = chip::app::Clusters::AccountLogin::Delegate;
+using GetSetupPINResponse      = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type;
+using GetDeviceAuthURIResponse = chip::app::Clusters::AccountLogin::Commands::GetDeviceAuthURIResponse::Type;
 
 class AccountLoginManager : public AccountLoginDelegate
 {
@@ -46,13 +47,17 @@ public:
         CopyString(setupPin, setupPinSize, mSetupPin);
     };
 
+    void HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper) override;
+    bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
+
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
 
 protected:
     static const size_t kSetupPinSize = 12;
     char mSetupPin[kSetupPinSize];
+    bool mOAuthLoggedIn = false;
 
 private:
     // TODO: set this based upon meta data from app
-    static constexpr uint16_t kClusterRevision = 2;
+    static constexpr uint16_t kClusterRevision = 3;
 };

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -4714,12 +4714,14 @@ endpoint 3 {
   }
 
   server cluster AccountLogin {
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
+    callback attribute OAuthLoggedIn;
+    ram      attribute featureMap default = 1;
+    ram      attribute clusterRevision default = 3;
 
     handle command GetSetupPIN;
     handle command Login;
     handle command Logout;
+    handle command GetDeviceAuthURI;
   }
 
   server cluster ContentControl {

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -8987,9 +8987,41 @@
               "source": "client",
               "isIncoming": 1,
               "isEnabled": 1
+            },
+            {
+              "name": "GetDeviceAuthURI",
+              "code": 4,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "GetDeviceAuthURIResponse",
+              "code": 5,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
             }
           ],
           "attributes": [
+            {
+              "name": "OAuthLoggedIn",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "boolean",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
             {
               "name": "FeatureMap",
               "code": 65532,
@@ -9000,7 +9032,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -9016,7 +9048,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "3",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -58,6 +58,7 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/app/cluster-building-blocks/tests",
       "${chip_root}/src/app/clusters/access-control-server/tests",
+      "${chip_root}/src/app/clusters/account-login-server/tests",
       "${chip_root}/src/app/clusters/administrator-commissioning-server/tests",
       "${chip_root}/src/app/clusters/ambient-context-sensing-server/tests",
       "${chip_root}/src/app/clusters/air-quality-server/tests",

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -58,7 +58,6 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/app/cluster-building-blocks/tests",
       "${chip_root}/src/app/clusters/access-control-server/tests",
-      "${chip_root}/src/app/clusters/account-login-server/tests",
       "${chip_root}/src/app/clusters/administrator-commissioning-server/tests",
       "${chip_root}/src/app/clusters/ambient-context-sensing-server/tests",
       "${chip_root}/src/app/clusters/air-quality-server/tests",
@@ -191,6 +190,7 @@ if (chip_build_tests) {
     if (chip_device_platform == "darwin" || chip_device_platform == "linux") {
       tests += [
         # keep-sorted: start
+        "${chip_root}/src/app/clusters/account-login-server/tests",
         "${chip_root}/src/app/clusters/actions-server/tests:tests-backwards-compatibility",
         "${chip_root}/src/app/clusters/chime-server/tests:tests-backwards-compatibility",
         "${chip_root}/src/app/clusters/concentration-measurement-server/tests:tests-backwards-compatibility",

--- a/src/app/clusters/account-login-server/account-login-delegate.h
+++ b/src/app/clusters/account-login-server/account-login-delegate.h
@@ -43,6 +43,9 @@ public:
                                    const chip::CharSpan & tempAccountIdentifierString)                                 = 0;
     virtual void GetSetupPin(char * setupPin, size_t setupPinSize, const chip::CharSpan & tempAccountIdentifierString) = 0;
 
+    virtual void HandleGetDeviceAuthURI(CommandResponseHelper<Commands::GetDeviceAuthURIResponse::Type> & helper) = 0;
+    virtual bool GetOAuthLoggedIn(chip::EndpointId endpoint)                                                      = 0;
+
     virtual uint16_t GetClusterRevision(chip::EndpointId endpoint) = 0;
 
     virtual ~Delegate() = default;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -129,6 +129,7 @@ public:
 
 private:
     CHIP_ERROR ReadRevisionAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
+    CHIP_ERROR ReadOAuthLoggedInAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
 };
 
 AccountLoginAttrAccess gAccountLoginAttrAccess;
@@ -142,6 +143,8 @@ CHIP_ERROR AccountLoginAttrAccess::Read(const app::ConcreteReadAttributePath & a
     {
     case app::Clusters::AccountLogin::Attributes::ClusterRevision::Id:
         return ReadRevisionAttribute(endpoint, aEncoder, delegate);
+    case app::Clusters::AccountLogin::Attributes::OAuthLoggedIn::Id:
+        return ReadOAuthLoggedInAttribute(endpoint, aEncoder, delegate);
     default:
         break;
     }
@@ -154,6 +157,12 @@ CHIP_ERROR AccountLoginAttrAccess::ReadRevisionAttribute(EndpointId endpoint, ap
 {
     uint16_t clusterRevision = delegate->GetClusterRevision(endpoint);
     return aEncoder.Encode(clusterRevision);
+}
+
+CHIP_ERROR AccountLoginAttrAccess::ReadOAuthLoggedInAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder,
+                                                              Delegate * delegate)
+{
+    return aEncoder.Encode(delegate->GetOAuthLoggedIn(endpoint));
 }
 
 } // anonymous namespace
@@ -180,6 +189,32 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterGetSetupPINCallback error: %s", err.AsString());
+
+        command->AddStatus(commandPath, Status::Failure);
+    }
+
+    return true;
+}
+
+bool emberAfAccountLoginClusterGetDeviceAuthURICallback(app::CommandHandler * command,
+                                                        const app::ConcreteCommandPath & commandPath,
+                                                        const Commands::GetDeviceAuthURI::DecodableType & /* commandData */)
+{
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Delegate * delegate = GetDelegate(endpoint);
+    app::CommandResponseHelper<Commands::GetDeviceAuthURIResponse::Type> responder(command, commandPath);
+
+    VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
+
+    {
+        delegate->HandleGetDeviceAuthURI(responder);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "emberAfAccountLoginClusterGetDeviceAuthURICallback error: %s", err.AsString());
 
         command->AddStatus(commandPath, Status::Failure);
     }

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -196,8 +196,7 @@ exit:
     return true;
 }
 
-bool emberAfAccountLoginClusterGetDeviceAuthURICallback(app::CommandHandler * command,
-                                                        const app::ConcreteCommandPath & commandPath,
+bool emberAfAccountLoginClusterGetDeviceAuthURICallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                         const Commands::GetDeviceAuthURI::DecodableType & /* commandData */)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
@@ -279,6 +278,7 @@ exit:
         // NodeId nodeId = getNodeId(commandObj);
         EventNumber eventNumber;
         LoggedOutEvent event{ .node = nodeId };
+        event.fabricIndex        = commandObj->GetAccessingFabricIndex();
         CHIP_ERROR logEventError = LogEvent(event, endpoint, eventNumber);
 
         if (CHIP_NO_ERROR != logEventError)

--- a/src/app/clusters/account-login-server/tests/BUILD.gn
+++ b/src/app/clusters/account-login-server/tests/BUILD.gn
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  import(
+      "${chip_root}/src/app/clusters/account-login-server/app_config_dependent_sources.gni")
+
+  output_name = "libTestAccountLoginCluster"
+
+  test_sources = [ "TestAccountLoginCluster.cpp" ]
+
+  # account-login-server.cpp is normally compiled directly into whichever example app
+  # includes it (via app_config_dependent_sources.gni), rather than as its own
+  # linkable library, so it's listed here directly for the test binary.
+  sources = []
+  foreach(file, app_config_dependent_sources) {
+    sources += [ "../" + file ]
+  }
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/common:cluster-objects",
+    "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/app/tests:app-test-stubs",
+    "${chip_root}/src/app/util/mock:mock_codegen_data_model",
+    "${chip_root}/src/app/util/mock:mock_ember",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
+++ b/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
@@ -81,9 +81,9 @@ public:
 
     uint16_t GetClusterRevision(EndpointId) override { return mClusterRevision; }
 
-    bool mLoginResult      = true;
-    bool mLogoutResult     = true;
-    bool mOAuthLoggedIn    = false;
+    bool mLoginResult         = true;
+    bool mLogoutResult        = true;
+    bool mOAuthLoggedIn       = false;
     uint16_t mClusterRevision = 3;
     CharSpan mSetupPin        = "1234"_span;
     CharSpan mUserCode        = "ABCD-EFGH"_span;
@@ -390,8 +390,7 @@ TEST_F(TestAccountLoginCluster, ReadClusterRevision)
     mDelegate.mClusterRevision = 3;
 
     uint16_t clusterRevision = 0;
-    EXPECT_EQ(ReadScalarAttributeViaAttrAccess(kTestEndpointId, Attributes::ClusterRevision::Id, clusterRevision),
-              CHIP_NO_ERROR);
+    EXPECT_EQ(ReadScalarAttributeViaAttrAccess(kTestEndpointId, Attributes::ClusterRevision::Id, clusterRevision), CHIP_NO_ERROR);
     EXPECT_EQ(clusterRevision, 3);
 }
 

--- a/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
+++ b/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
@@ -1,0 +1,408 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app-common/zap-generated/callback.h>
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/AttributeValueEncoder.h>
+#include <app/EventManagement.h>
+#include <app/MessageDef/AttributeReportIBs.h>
+#include <app/clusters/account-login-server/account-login-delegate.h>
+#include <app/clusters/account-login-server/account-login-server.h>
+#include <app/server-cluster/testing/MockCommandHandler.h>
+#include <app/tests/test-ember-api.h>
+#include <lib/support/CHIPCounter.h>
+#include <lib/support/CHIPMem.h>
+#include <protocols/interaction_model/StatusCode.h>
+#include <pw_unit_test/framework.h>
+
+// Not declared in any header included above -- forward-declared here the same way
+// TestChimeClusterBackwardsCompatibility.cpp does for its cluster's init callback.
+void MatterAccountLoginPluginServerInitCallback();
+void MatterAccountLoginPluginServerShutdownCallback();
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters::AccountLogin;
+using chip::Protocols::InteractionModel::Status;
+
+namespace {
+
+constexpr EndpointId kTestEndpointId = 1;
+
+// EventManagement backing storage, so the LoggedOut event (Critical priority) can actually be
+// logged; needed to observe whether emberAfAccountLoginClusterLogoutCallback fires it or not.
+uint8_t gDebugEventBuffer[128];
+uint8_t gInfoEventBuffer[128];
+uint8_t gCritEventBuffer[128];
+chip::app::CircularEventBuffer gCircularEventBuffer[3];
+
+class FakeAccountLoginDelegate : public Delegate
+{
+public:
+    void SetSetupPin(char *) override {}
+
+    bool HandleLogin(const CharSpan &, const CharSpan &, const chip::Optional<NodeId> &) override { return mLoginResult; }
+    bool HandleLogout(const chip::Optional<NodeId> &) override { return mLogoutResult; }
+
+    void HandleGetSetupPin(CommandResponseHelper<Commands::GetSetupPINResponse::Type> & helper, const CharSpan &) override
+    {
+        Commands::GetSetupPINResponse::Type response;
+        response.setupPIN = mSetupPin;
+        TEMPORARY_RETURN_IGNORED helper.Success(response);
+    }
+
+    void GetSetupPin(char *, size_t, const CharSpan &) override {}
+
+    void HandleGetDeviceAuthURI(CommandResponseHelper<Commands::GetDeviceAuthURIResponse::Type> & helper) override
+    {
+        Commands::GetDeviceAuthURIResponse::Type response;
+        response.userCode        = mUserCode;
+        response.verificationURI = mVerificationURI;
+        response.expiresIn       = 1800;
+        response.interval        = 5;
+        TEMPORARY_RETURN_IGNORED helper.Success(response);
+    }
+
+    bool GetOAuthLoggedIn(EndpointId) override { return mOAuthLoggedIn; }
+
+    uint16_t GetClusterRevision(EndpointId) override { return mClusterRevision; }
+
+    bool mLoginResult      = true;
+    bool mLogoutResult     = true;
+    bool mOAuthLoggedIn    = false;
+    uint16_t mClusterRevision = 3;
+    CharSpan mSetupPin        = "1234"_span;
+    CharSpan mUserCode        = "ABCD-EFGH"_span;
+    CharSpan mVerificationURI = "https://example.com/device"_span;
+};
+
+class TestAccountLoginCluster : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    void SetUp() override
+    {
+        chip::Testing::numEndpoints = kTestEndpointId + 1;
+        SetDefaultDelegate(kTestEndpointId, &mDelegate);
+        MatterAccountLoginPluginServerInitCallback();
+
+        const chip::app::LogStorageResources logStorageResources[] = {
+            { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
+            { &gInfoEventBuffer[0], sizeof(gInfoEventBuffer), chip::app::PriorityLevel::Info },
+            { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
+        };
+
+        ASSERT_EQ(mEventCounter.Init(0), CHIP_NO_ERROR);
+        chip::app::EventManagement::CreateEventManagement(nullptr, MATTER_ARRAY_SIZE(logStorageResources), gCircularEventBuffer,
+                                                          logStorageResources, &mEventCounter);
+    }
+
+    void TearDown() override
+    {
+        chip::app::EventManagement::DestroyEventManagement();
+        MatterAccountLoginPluginServerShutdownCallback();
+        SetDefaultDelegate(kTestEndpointId, nullptr);
+    }
+
+protected:
+    FakeAccountLoginDelegate mDelegate;
+    chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
+};
+
+ConcreteCommandPath MakeCommandPath(CommandId commandId)
+{
+    return ConcreteCommandPath(kTestEndpointId, Id, commandId);
+}
+
+// Reads a scalar attribute through the cluster's real, registered AttributeAccessInterface --
+// exercising AccountLoginAttrAccess::Read's attribute-ID dispatch, not just the delegate hook it
+// eventually calls into.
+template <typename T>
+CHIP_ERROR ReadScalarAttributeViaAttrAccess(EndpointId endpoint, AttributeId attributeId, T & outValue)
+{
+    AttributeAccessInterface * attrAccess = AttributeAccessInterfaceRegistry::Instance().Get(endpoint, Id);
+    VerifyOrReturnError(attrAccess != nullptr, CHIP_ERROR_NOT_FOUND);
+
+    uint8_t buf[128];
+    TLV::TLVWriter writer;
+    writer.Init(buf);
+
+    AttributeReportIBs::Builder builder;
+    ReturnErrorOnFailure(builder.Init(&writer));
+
+    ConcreteAttributePath path(endpoint, Id, attributeId);
+    ConcreteReadAttributePath readPath(path);
+    chip::DataVersion dataVersion(0);
+    Access::SubjectDescriptor subjectDescriptor;
+    AttributeValueEncoder encoder(builder, subjectDescriptor, path, dataVersion);
+
+    ReturnErrorOnFailure(attrAccess->Read(readPath, encoder));
+    builder.EndOfContainer();
+    ReturnErrorOnFailure(writer.Finalize());
+
+    TLV::TLVReader reader;
+    reader.Init(buf, writer.GetLengthWritten());
+
+    TLV::TLVReader attrReportsReader;
+    TLV::TLVReader attrReportReader;
+    TLV::TLVReader attrDataReader;
+
+    ReturnErrorOnFailure(reader.Next());
+    ReturnErrorOnFailure(reader.OpenContainer(attrReportsReader));
+    ReturnErrorOnFailure(attrReportsReader.Next());
+    ReturnErrorOnFailure(attrReportsReader.OpenContainer(attrReportReader));
+    ReturnErrorOnFailure(attrReportReader.Next());
+    ReturnErrorOnFailure(attrReportReader.OpenContainer(attrDataReader));
+
+    // Skip to the Data tag (context tag 2) within AttributeDataIB.
+    ReturnErrorOnFailure(attrDataReader.Next());
+    while (!(TLV::IsContextTag(attrDataReader.GetTag()) && TLV::TagNumFromTag(attrDataReader.GetTag()) == 2))
+    {
+        ReturnErrorOnFailure(attrDataReader.Next());
+    }
+
+    return attrDataReader.Get(outValue);
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// GetSetupPIN
+
+TEST_F(TestAccountLoginCluster, GetSetupPinSucceeds)
+{
+    mDelegate.mSetupPin = "5678"_span;
+
+    Commands::GetSetupPIN::DecodableType request;
+    request.tempAccountIdentifier = "account-1"_span;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::GetSetupPIN::Id);
+    emberAfAccountLoginClusterGetSetupPINCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasResponse());
+    Commands::GetSetupPINResponse::DecodableType response;
+    EXPECT_EQ(mockHandler.DecodeResponse(response), CHIP_NO_ERROR);
+    EXPECT_TRUE(response.setupPIN.data_equal("5678"_span));
+    EXPECT_FALSE(mockHandler.HasStatus());
+}
+
+TEST_F(TestAccountLoginCluster, GetSetupPinWithNoDelegateFails)
+{
+    SetDefaultDelegate(kTestEndpointId, nullptr);
+
+    Commands::GetSetupPIN::DecodableType request;
+    request.tempAccountIdentifier = "account-1"_span;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::GetSetupPIN::Id);
+    emberAfAccountLoginClusterGetSetupPINCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Failure);
+    EXPECT_FALSE(mockHandler.HasResponse());
+}
+
+// -----------------------------------------------------------------------------
+// GetDeviceAuthURI
+
+TEST_F(TestAccountLoginCluster, GetDeviceAuthUriSucceeds)
+{
+    Commands::GetDeviceAuthURI::DecodableType request;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::GetDeviceAuthURI::Id);
+    emberAfAccountLoginClusterGetDeviceAuthURICallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasResponse());
+    Commands::GetDeviceAuthURIResponse::DecodableType response;
+    EXPECT_EQ(mockHandler.DecodeResponse(response), CHIP_NO_ERROR);
+    EXPECT_TRUE(response.userCode.data_equal("ABCD-EFGH"_span));
+    EXPECT_TRUE(response.verificationURI.data_equal("https://example.com/device"_span));
+    EXPECT_EQ(response.interval, 5);
+    EXPECT_FALSE(mockHandler.HasStatus());
+}
+
+TEST_F(TestAccountLoginCluster, GetDeviceAuthUriWithNoDelegateFails)
+{
+    SetDefaultDelegate(kTestEndpointId, nullptr);
+
+    Commands::GetDeviceAuthURI::DecodableType request;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::GetDeviceAuthURI::Id);
+    emberAfAccountLoginClusterGetDeviceAuthURICallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Failure);
+    EXPECT_FALSE(mockHandler.HasResponse());
+}
+
+// -----------------------------------------------------------------------------
+// Login
+
+TEST_F(TestAccountLoginCluster, LoginSucceedsMapsToSuccess)
+{
+    mDelegate.mLoginResult = true;
+
+    Commands::Login::DecodableType request;
+    request.tempAccountIdentifier = "account-1"_span;
+    request.setupPIN              = "1234"_span;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Login::Id);
+    emberAfAccountLoginClusterLoginCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Success);
+}
+
+TEST_F(TestAccountLoginCluster, LoginFailureMapsToUnsupportedAccess)
+{
+    mDelegate.mLoginResult = false;
+
+    Commands::Login::DecodableType request;
+    request.tempAccountIdentifier = "account-1"_span;
+    request.setupPIN              = "wrong"_span;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Login::Id);
+    emberAfAccountLoginClusterLoginCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::UnsupportedAccess);
+}
+
+TEST_F(TestAccountLoginCluster, LoginWithNoDelegateFails)
+{
+    SetDefaultDelegate(kTestEndpointId, nullptr);
+
+    Commands::Login::DecodableType request;
+    request.tempAccountIdentifier = "account-1"_span;
+    request.setupPIN              = "1234"_span;
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Login::Id);
+    emberAfAccountLoginClusterLoginCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Failure);
+}
+
+// -----------------------------------------------------------------------------
+// Logout
+//
+// The current implementation logs the LoggedOut event whenever `node` is present,
+// regardless of whether HandleLogout succeeded -- these tests pin down that behavior
+// explicitly since it's easy to regress silently (event firing on a failure path).
+
+TEST_F(TestAccountLoginCluster, LogoutSucceedsAndFiresEventWhenNodePresent)
+{
+    mDelegate.mLogoutResult = true;
+
+    Commands::Logout::DecodableType request;
+    request.node = chip::MakeOptional(static_cast<NodeId>(1234));
+
+    EventNumber before = EventManagement::GetInstance().GetLastEventNumber();
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Logout::Id);
+    emberAfAccountLoginClusterLogoutCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Success);
+    EXPECT_GT(EventManagement::GetInstance().GetLastEventNumber(), before);
+}
+
+TEST_F(TestAccountLoginCluster, LogoutFailureStillFiresEventWhenNodePresent)
+{
+    mDelegate.mLogoutResult = false;
+
+    Commands::Logout::DecodableType request;
+    request.node = chip::MakeOptional(static_cast<NodeId>(1234));
+
+    EventNumber before = EventManagement::GetInstance().GetLastEventNumber();
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Logout::Id);
+    emberAfAccountLoginClusterLogoutCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Failure);
+    // Event fires even though the logout itself failed -- current (arguably surprising) behavior.
+    EXPECT_GT(EventManagement::GetInstance().GetLastEventNumber(), before);
+}
+
+TEST_F(TestAccountLoginCluster, LogoutWithoutNodeDoesNotFireEvent)
+{
+    mDelegate.mLogoutResult = true;
+
+    Commands::Logout::DecodableType request;
+    // node intentionally omitted.
+
+    EventNumber before = EventManagement::GetInstance().GetLastEventNumber();
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Logout::Id);
+    emberAfAccountLoginClusterLogoutCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Success);
+    EXPECT_EQ(EventManagement::GetInstance().GetLastEventNumber(), before);
+}
+
+TEST_F(TestAccountLoginCluster, LogoutWithNoDelegateFails)
+{
+    SetDefaultDelegate(kTestEndpointId, nullptr);
+
+    Commands::Logout::DecodableType request;
+    request.node = chip::MakeOptional(static_cast<NodeId>(1234));
+
+    chip::Testing::MockCommandHandler mockHandler;
+    auto commandPath = MakeCommandPath(Commands::Logout::Id);
+    emberAfAccountLoginClusterLogoutCallback(&mockHandler, commandPath, request);
+
+    ASSERT_TRUE(mockHandler.HasStatus());
+    EXPECT_EQ(mockHandler.GetLastStatus().status.GetStatus(), Status::Failure);
+}
+
+// -----------------------------------------------------------------------------
+// Attribute reads
+
+TEST_F(TestAccountLoginCluster, ReadClusterRevision)
+{
+    mDelegate.mClusterRevision = 3;
+
+    uint16_t clusterRevision = 0;
+    EXPECT_EQ(ReadScalarAttributeViaAttrAccess(kTestEndpointId, Attributes::ClusterRevision::Id, clusterRevision),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(clusterRevision, 3);
+}
+
+TEST_F(TestAccountLoginCluster, ReadOAuthLoggedIn)
+{
+    mDelegate.mOAuthLoggedIn = true;
+    bool loggedIn            = false;
+    EXPECT_EQ(ReadScalarAttributeViaAttrAccess(kTestEndpointId, Attributes::OAuthLoggedIn::Id, loggedIn), CHIP_NO_ERROR);
+    EXPECT_TRUE(loggedIn);
+
+    mDelegate.mOAuthLoggedIn = false;
+    EXPECT_EQ(ReadScalarAttributeViaAttrAccess(kTestEndpointId, Attributes::OAuthLoggedIn::Id, loggedIn), CHIP_NO_ERROR);
+    EXPECT_FALSE(loggedIn);
+}


### PR DESCRIPTION
### Summary

Adds the Matter 1.7 OAuth 2.0 Device Authorization Grant hooks for the
AccountLogin cluster (spec revision 3), also extends the `tv-app` to
support the new functionality.

### Testing

- Manually tested end-to-end with `chip-tv-app` + `chip-tool`:
  - Commissioned `chip-tv-app` on-network with `chip-tool`.
  - `ClusterRevision` reads back `3`; `FeatureMap` reads back `1` (the `OA`
    bit).
  - `OAuthLoggedIn` reads back `false` (was `UNSUPPORTED_ATTRIBUTE` before
    the `tv-app.zap` fix).
  - Sent `GetDeviceAuthURI` (with `--timedInteractionTimeoutMs`, required
    since the command is `mustUseTimedInvoke` per spec) and confirmed the
    `GetDeviceAuthURIResponse` came back with the stubbed `UserCode`,
    `VerificationURI`, `ExpiresIn: 1800`, and `Interval: 5`.