### PR TITLE
[ProximityRanging] Implement HMAC-SHA256 BLE beacon obfuscation

### DIFF
--- a/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.cpp
+++ b/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.cpp
@@ -28,30 +28,12 @@
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/RandUtils.h>
-#include <lib/support/BufferReader.h>
+#include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/Span.h>
 
 #include <cstring>
-
-/**
- * Build-time switch selecting how the BLEDeviceID is carried in the beacon
- * advertisement payload.
- *
- * By default (undefined or 0) the BLEDeviceID is obfuscated with
- * HMAC-SHA256(sessionKey, BLEDeviceID || messageCounter) so passive observers
- * cannot recover or correlate the raw identifier across beacons.
- *
- * When defined as 1, obfuscation is disabled and the raw BLEDeviceID is placed
- * in the advertisement in plaintext. This exists only to let two ranging
- * devices interoperate during bring-up/interop without a shared session key;
- * both peers must set this flag. It leaks the device identifier on air and MUST
- * NOT be enabled in production.
- */
-#ifndef CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
-#define CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING 0
-#endif
 
 /// Number of CSPRNG attempts GenerateBleDeviceId will make before
 /// giving up. The probability of three consecutive zero draws from a
@@ -59,77 +41,70 @@
 /// pathological RNG implementations.
 static constexpr uint8_t kBleDeviceIdGenerationAttempts = 3;
 
-/// Length of the ObfuscatedBLEDeviceId field carried in the advertisement payload.
-/// Shared by both the secure (HMAC) and plaintext beaconing paths.
-constexpr size_t kBleObfuscatedIdLength = sizeof(chip::Ble::ChipBLEProximityRangingIdentificationInfo::ObfuscatedBLEDeviceId);
-
-namespace {
-
-/**
- * Fill @p outObfuscatedId with the value that goes into the beacon's
- * ObfuscatedBLEDeviceId field for a given (BLEDeviceID, messageCounter) following
- * the Proximity Ranging cluster specification.
- *
- * When CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING is set for
- * insecure testing, the raw bleDeviceId in ble-endian form is set into the obfuscatedId field.
- */
-CHIP_ERROR ComputeObfuscatedBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, chip::ByteSpan sessionKey,
-                                        uint8_t (&outObfuscatedId)[kBleObfuscatedIdLength])
-{
-#if CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
-    // Test-only: publish the BLEDeviceID in plaintext, no session key needed.
-    (void) sessionKey;
-    memset(outObfuscatedId, 0, kBleObfuscatedIdLength);
-    chip::Encoding::BigEndian::Put64(outObfuscatedId, bleDeviceId);
-    return CHIP_NO_ERROR;
-#else
-    // HMAC message: BLEDeviceID (8 bytes, big-endian) || BLERBCMessageCounter (2 bytes, big-endian).
-    uint8_t message[sizeof(bleDeviceId) + sizeof(messageCounter)] = {};
-    chip::Encoding::BigEndian::Put64(message, bleDeviceId);
-    chip::Encoding::BigEndian::Put16(message + sizeof(bleDeviceId), messageCounter);
-
-    uint8_t hmacTag[chip::Crypto::kSHA256_Hash_Length] = {};
-    chip::Crypto::HMAC_sha hmac;
-    ReturnErrorOnFailure(
-        hmac.HMAC_SHA256(sessionKey.data(), sessionKey.size(), message, sizeof(message), hmacTag, sizeof(hmacTag)));
-
-    // The ObfuscatedBLEDeviceId field is 16 bytes; take the first 16 bytes of the 32-byte HMAC output.
-    static_assert(sizeof(hmacTag) >= kBleObfuscatedIdLength,
-                  "HMAC-SHA256 output must be at least as large as ObfuscatedBLEDeviceId");
-    memcpy(outObfuscatedId, hmacTag, kBleObfuscatedIdLength);
-    return CHIP_NO_ERROR;
-#endif // CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
-}
-
-} // namespace
-
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace ProximityRanging {
 namespace BleRssi {
 
+CHIP_ERROR HmacObfuscateBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, ByteSpan sessionKey,
+                                    MutableByteSpan outObfuscatedId)
+{
+    VerifyOrReturnError(outObfuscatedId.size() >= kBleObfuscatedIdLength, CHIP_ERROR_BUFFER_TOO_SMALL);
+    // An empty key is accepted by some HMAC implementations but is never
+    // meaningful here and would silently produce a keyless tag.
+    VerifyOrReturnError(!sessionKey.empty(), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // HMAC message: BLEDeviceID (8 bytes, big-endian) || BLERBCMessageCounter (2 bytes, big-endian).
+    uint8_t message[sizeof(bleDeviceId) + sizeof(messageCounter)] = {};
+    Encoding::BigEndian::Put64(message, bleDeviceId);
+    Encoding::BigEndian::Put16(message + sizeof(bleDeviceId), messageCounter);
+
+    uint8_t hmacTag[Crypto::kSHA256_Hash_Length] = {};
+    Crypto::HMAC_sha hmac;
+    ReturnErrorOnFailure(
+        hmac.HMAC_SHA256(sessionKey.data(), sessionKey.size(), message, sizeof(message), hmacTag, sizeof(hmacTag)));
+
+    // The ObfuscatedBLEDeviceId field is 16 bytes; take the first 16 bytes of the 32-byte HMAC output.
+    static_assert(sizeof(hmacTag) >= kBleObfuscatedIdLength,
+                  "HMAC-SHA256 output must be at least as large as ObfuscatedBLEDeviceId");
+    memcpy(outObfuscatedId.data(), hmacTag, kBleObfuscatedIdLength);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlaintextObfuscateBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, ByteSpan sessionKey,
+                                         MutableByteSpan outObfuscatedId)
+{
+    VerifyOrReturnError(outObfuscatedId.size() >= kBleObfuscatedIdLength, CHIP_ERROR_BUFFER_TOO_SMALL);
+    // Insecure bring-up path: publish the BLEDeviceID in plaintext, no key needed.
+    (void) messageCounter;
+    (void) sessionKey;
+    memset(outObfuscatedId.data(), 0, outObfuscatedId.size());
+    Encoding::BigEndian::Put64(outObfuscatedId.data(), bleDeviceId);
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, int8_t txPower, ByteSpan sessionKey,
-                               Ble::ChipBLEProximityRangingIdentificationInfo & outPayload)
+                               Ble::ChipBLEProximityRangingIdentificationInfo & outPayload, ObfuscateBleDeviceIdFunction obfuscate)
 {
     outPayload.Init();
     outPayload.SetMsgCounter(messageCounter);
     outPayload.SetTxPower(txPower);
 
     uint8_t obfuscatedId[kBleObfuscatedIdLength] = {};
-    ReturnErrorOnFailure(ComputeObfuscatedBleDeviceId(bleDeviceId, messageCounter, sessionKey, obfuscatedId));
+    ReturnErrorOnFailure(obfuscate(bleDeviceId, messageCounter, sessionKey, MutableByteSpan(obfuscatedId)));
     outPayload.SetObfuscatedBLEDeviceId(obfuscatedId);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DecodeBeaconPayload(const Ble::ChipBLEProximityRangingIdentificationInfo & payload, uint64_t candidateBleDeviceId,
-                               ByteSpan sessionKey)
+                               ByteSpan sessionKey, ObfuscateBleDeviceIdFunction obfuscate)
 {
     // Recompute the expected obfuscated ID from the candidate BLEDeviceID and the
     // message counter carried in the received payload, then compare against the
     // ObfuscatedBLEDeviceId in the payload to verify the advertiser's identity.
     uint8_t expected[kBleObfuscatedIdLength] = {};
-    ReturnErrorOnFailure(ComputeObfuscatedBleDeviceId(candidateBleDeviceId, payload.GetMsgCounter(), sessionKey, expected));
+    ReturnErrorOnFailure(obfuscate(candidateBleDeviceId, payload.GetMsgCounter(), sessionKey, MutableByteSpan(expected)));
 
     // Use a constant-time comparison to avoid leaking, via timing, how many
     // leading bytes of the tag matched.

--- a/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.cpp
+++ b/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.cpp
@@ -26,6 +26,7 @@
 
 #include "BleRssiRangingHelpers.h"
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <crypto/RandUtils.h>
 #include <lib/support/BufferReader.h>
 #include <lib/support/CodeUtils.h>
@@ -34,11 +35,73 @@
 
 #include <cstring>
 
+/**
+ * Build-time switch selecting how the BLEDeviceID is carried in the beacon
+ * advertisement payload.
+ *
+ * By default (undefined or 0) the BLEDeviceID is obfuscated with
+ * HMAC-SHA256(sessionKey, BLEDeviceID || messageCounter) so passive observers
+ * cannot recover or correlate the raw identifier across beacons.
+ *
+ * When defined as 1, obfuscation is disabled and the raw BLEDeviceID is placed
+ * in the advertisement in plaintext. This exists only to let two ranging
+ * devices interoperate during bring-up/interop without a shared session key;
+ * both peers must set this flag. It leaks the device identifier on air and MUST
+ * NOT be enabled in production.
+ */
+#ifndef CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
+#define CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING 0
+#endif
+
 /// Number of CSPRNG attempts GenerateBleDeviceId will make before
 /// giving up. The probability of three consecutive zero draws from a
 /// well-seeded 64-bit RNG is 2^-192, so this is effectively a safety net for
 /// pathological RNG implementations.
 static constexpr uint8_t kBleDeviceIdGenerationAttempts = 3;
+
+/// Length of the ObfuscatedBLEDeviceId field carried in the advertisement payload.
+/// Shared by both the secure (HMAC) and plaintext beaconing paths.
+constexpr size_t kBleObfuscatedIdLength = sizeof(chip::Ble::ChipBLEProximityRangingIdentificationInfo::ObfuscatedBLEDeviceId);
+
+namespace {
+
+/**
+ * Fill @p outObfuscatedId with the value that goes into the beacon's
+ * ObfuscatedBLEDeviceId field for a given (BLEDeviceID, messageCounter) following
+ * the Proximity Ranging cluster specification.
+ *
+ * When CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING is set for
+ * insecure testing, the raw bleDeviceId in ble-endian form is set into the obfuscatedId field.
+ */
+CHIP_ERROR ComputeObfuscatedBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, chip::ByteSpan sessionKey,
+                                        uint8_t (&outObfuscatedId)[kBleObfuscatedIdLength])
+{
+#if CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
+    // Test-only: publish the BLEDeviceID in plaintext, no session key needed.
+    (void) sessionKey;
+    memset(outObfuscatedId, 0, kBleObfuscatedIdLength);
+    chip::Encoding::BigEndian::Put64(outObfuscatedId, bleDeviceId);
+    return CHIP_NO_ERROR;
+#else
+    // HMAC message: BLEDeviceID (8 bytes, big-endian) || BLERBCMessageCounter (2 bytes, big-endian).
+    uint8_t message[sizeof(bleDeviceId) + sizeof(messageCounter)] = {};
+    chip::Encoding::BigEndian::Put64(message, bleDeviceId);
+    chip::Encoding::BigEndian::Put16(message + sizeof(bleDeviceId), messageCounter);
+
+    uint8_t hmacTag[chip::Crypto::kSHA256_Hash_Length] = {};
+    chip::Crypto::HMAC_sha hmac;
+    ReturnErrorOnFailure(
+        hmac.HMAC_SHA256(sessionKey.data(), sessionKey.size(), message, sizeof(message), hmacTag, sizeof(hmacTag)));
+
+    // The ObfuscatedBLEDeviceId field is 16 bytes; take the first 16 bytes of the 32-byte HMAC output.
+    static_assert(sizeof(hmacTag) >= kBleObfuscatedIdLength,
+                  "HMAC-SHA256 output must be at least as large as ObfuscatedBLEDeviceId");
+    memcpy(outObfuscatedId, hmacTag, kBleObfuscatedIdLength);
+    return CHIP_NO_ERROR;
+#endif // CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
+}
+
+} // namespace
 
 namespace chip {
 namespace app {
@@ -53,33 +116,24 @@ CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, in
     outPayload.SetMsgCounter(messageCounter);
     outPayload.SetTxPower(txPower);
 
-    // TODO(spec): Apply HMAC-SHA256 obfuscation keyed on `sessionKey` over
-    // (bleDeviceId || messageCounter) and copy the truncated tag into the
-    // 16-byte ObfuscatedBLEDeviceId field. Until that lands, encode the
-    // BLEDeviceID in plain big-endian form in the first 8 bytes so adapter
-    // and cert-test plumbing can be exercised end-to-end.
-    (void) sessionKey;
-
-    uint8_t plain[16] = {};
-    Encoding::BigEndian::Put64(plain, bleDeviceId);
-    outPayload.SetObfuscatedBLEDeviceId(plain);
-
+    uint8_t obfuscatedId[kBleObfuscatedIdLength] = {};
+    ReturnErrorOnFailure(ComputeObfuscatedBleDeviceId(bleDeviceId, messageCounter, sessionKey, obfuscatedId));
+    outPayload.SetObfuscatedBLEDeviceId(obfuscatedId);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DecodeBeaconPayload(const Ble::ChipBLEProximityRangingIdentificationInfo & payload, uint64_t candidateBleDeviceId,
                                ByteSpan sessionKey)
 {
-    // TODO(spec): mirror EncodeBeaconPayload - when HMAC obfuscation lands,
-    // recompute the expected tag from `candidateBleDeviceId`, `payload`'s
-    // message counter, and `sessionKey`, then constant-time compare against
-    // payload.ObfuscatedBLEDeviceId.
-    (void) sessionKey;
+    // Recompute the expected obfuscated ID from the candidate BLEDeviceID and the
+    // message counter carried in the received payload, then compare against the
+    // ObfuscatedBLEDeviceId in the payload to verify the advertiser's identity.
+    uint8_t expected[kBleObfuscatedIdLength] = {};
+    ReturnErrorOnFailure(ComputeObfuscatedBleDeviceId(candidateBleDeviceId, payload.GetMsgCounter(), sessionKey, expected));
 
-    uint8_t expected[16] = {};
-    Encoding::BigEndian::Put64(expected, candidateBleDeviceId);
-
-    if (memcmp(payload.GetObfuscatedBLEDeviceId(), expected, sizeof(expected)) != 0)
+    // Use a constant-time comparison to avoid leaking, via timing, how many
+    // leading bytes of the tag matched.
+    if (!Crypto::IsBufferContentEqualConstantTime(payload.GetObfuscatedBLEDeviceId(), expected, kBleObfuscatedIdLength))
     {
         return CHIP_ERROR_NOT_FOUND;
     }

--- a/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.h
+++ b/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.h
@@ -21,6 +21,7 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/Span.h>
 
+#include <cstddef>
 #include <cstdint>
 
 namespace chip {
@@ -33,26 +34,66 @@ namespace BleRssi {
 /// equal this value. Platform adapters should re-roll on collision.
 inline constexpr uint64_t kInvalidBleDeviceId = 0;
 
+/// Length of the ObfuscatedBLEDeviceId field carried in the advertisement
+/// payload. An obfuscation function fills exactly this many bytes.
+inline constexpr size_t kBleObfuscatedIdLength = sizeof(Ble::ChipBLEProximityRangingIdentificationInfo::ObfuscatedBLEDeviceId);
+
+/**
+ * Function type to produce BLE RSSI ObfuscatedBLEDeviceId beacon field from a
+ * (BLEDeviceID, messageCounter, sessionKey) tuple.
+ *
+ * @param bleDeviceId     The BLEDeviceID to obfuscate.
+ * @param messageCounter  Beacon message counter mixed into the output.
+ * @param sessionKey      Per-session key.
+ * @param outObfuscatedId Output span of exactly kBleObfuscatedIdLength bytes.
+ *
+ * @return CHIP_NO_ERROR on success; an error otherwise (e.g.
+ *         CHIP_ERROR_INVALID_ARGUMENT for an empty key, or a crypto error).
+ */
+using ObfuscateBleDeviceIdFunction = CHIP_ERROR (*)(uint64_t bleDeviceId, uint16_t messageCounter, ByteSpan sessionKey,
+                                                    MutableByteSpan outObfuscatedId);
+
+/**
+ * Produces the ObfuscatedBLEDeviceId according to the Proximity Ranging cluster specification
+ * using HMAC-SHA256(sessionKey, BLEDeviceID (big-endian) || messageCounter (big-endian)).
+ *
+ * @return CHIP_NO_ERROR on success; CHIP_ERROR_INVALID_ARGUMENT if @p sessionKey
+ *         is empty; CHIP_ERROR_BUFFER_TOO_SMALL if @p outObfuscatedId is too small;
+ *         a crypto error if HMAC computation fails.
+ */
+CHIP_ERROR HmacObfuscateBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, ByteSpan sessionKey,
+                                    MutableByteSpan outObfuscatedId);
+
+/**
+ * Produces raw BLEDeviceId in big-endian form and ignores @p sessionKey.
+ *
+ * @note This leaks the device identifier over air and MUST NOT be used in production; it exists
+ * for testing purposes only without requiring shared session key. Both ranging peers need to use this
+ * unsecure function when testing.
+ */
+CHIP_ERROR PlaintextObfuscateBleDeviceId(uint64_t bleDeviceId, uint16_t messageCounter, ByteSpan sessionKey,
+                                         MutableByteSpan outObfuscatedId);
+
 /**
  * Encode a BLEDeviceID into a Proximity Ranging BLE advertisement payload.
  *
  * Populates @p outPayload with the OpCode, message counter, Tx power, and
  * obfuscated BLEDeviceID fields per the Matter Proximity Ranging spec's
- * advertisement format. The BLEDeviceID is obfuscated with HMAC-SHA256 keyed
- * on @p sessionKey unless the test-only
- * CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING flag is set, in which
- * case it is carried in plaintext and @p sessionKey is ignored.
+ * advertisement format. The BLEDeviceID is obfuscated by @p obfuscate, which
+ * defaults to the secure HMAC-SHA256 strategy.
  *
  * @param bleDeviceId    The local device's 64-bit BLEDeviceID.
  * @param messageCounter Monotonic counter for replay protection.
  * @param txPower        Transmit power in dBm reported in the advertisement.
- * @param sessionKey     Per-session HMAC key.
+ * @param sessionKey     Per-session key passed through to @p obfuscate.
  * @param outPayload     Output. Initialised in-place; caller need not pre-init.
+ * @param obfuscate      Obfuscation strategy; defaults to HmacObfuscateBleDeviceId.
  *
- * @return CHIP_NO_ERROR on success; a crypto error if HMAC computation fails.
+ * @return CHIP_NO_ERROR on success; whatever error @p obfuscate returns.
  */
 CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, int8_t txPower, ByteSpan sessionKey,
-                               Ble::ChipBLEProximityRangingIdentificationInfo & outPayload);
+                               Ble::ChipBLEProximityRangingIdentificationInfo & outPayload,
+                               ObfuscateBleDeviceIdFunction obfuscate = HmacObfuscateBleDeviceId);
 
 /**
  * Verify that a received BLE Proximity Ranging advertisement matches a
@@ -60,20 +101,20 @@ CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, in
  *
  * Used by adapters in BLE-Scanning role to test whether an observed beacon
  * was emitted by a peer whose BLEDeviceID is @p candidateBleDeviceId. Mirrors
- * EncodeBeaconPayload: it recomputes the expected obfuscated field the same way
- * (HMAC by default, plaintext under
- * CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING) and constant-time
- * compares it against the payload.
+ * EncodeBeaconPayload: it recomputes the expected obfuscated field with the
+ * same @p obfuscate strategy and constant-time compares it against the payload.
+ * The caller MUST pass the same strategy used to encode.
  *
  * @param payload              The decoded advertisement payload.
  * @param candidateBleDeviceId The BLEDeviceID to verify against.
- * @param sessionKey           Per-session HMAC key.
+ * @param sessionKey           Per-session key passed through to @p obfuscate.
+ * @param obfuscate            Obfuscation strategy; defaults to HmacObfuscateBleDeviceId.
  *
- * @return CHIP_NO_ERROR on match, CHIP_ERROR_NOT_FOUND on mismatch; a crypto
- *         error if HMAC computation fails.
+ * @return CHIP_NO_ERROR on match, CHIP_ERROR_NOT_FOUND on mismatch; whatever
+ *         error @p obfuscate returns if the expected field cannot be computed.
  */
 CHIP_ERROR DecodeBeaconPayload(const Ble::ChipBLEProximityRangingIdentificationInfo & payload, uint64_t candidateBleDeviceId,
-                               ByteSpan sessionKey);
+                               ByteSpan sessionKey, ObfuscateBleDeviceIdFunction obfuscate = HmacObfuscateBleDeviceId);
 
 /**
  * Generate a non-zero random 64-bit BLEDeviceID using the platform CSPRNG.

--- a/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.h
+++ b/src/app/clusters/proximity-ranging-server/BleRssiRangingHelpers.h
@@ -38,20 +38,18 @@ inline constexpr uint64_t kInvalidBleDeviceId = 0;
  *
  * Populates @p outPayload with the OpCode, message counter, Tx power, and
  * obfuscated BLEDeviceID fields per the Matter Proximity Ranging spec's
- * advertisement format.
- *
- * @note The current implementation encodes the BLEDeviceID in plain
- *       big-endian form in the first 8 bytes of the obfuscated field. The
- *       HMAC-based obfuscation step keyed on @p sessionKey is a TODO; until
- *       it lands, @p sessionKey is unused and may be empty.
+ * advertisement format. The BLEDeviceID is obfuscated with HMAC-SHA256 keyed
+ * on @p sessionKey unless the test-only
+ * CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING flag is set, in which
+ * case it is carried in plaintext and @p sessionKey is ignored.
  *
  * @param bleDeviceId    The local device's 64-bit BLEDeviceID.
  * @param messageCounter Monotonic counter for replay protection.
  * @param txPower        Transmit power in dBm reported in the advertisement.
- * @param sessionKey     Per-session HMAC key (unused until obfuscation is wired up).
+ * @param sessionKey     Per-session HMAC key.
  * @param outPayload     Output. Initialised in-place; caller need not pre-init.
  *
- * @return CHIP_NO_ERROR on success.
+ * @return CHIP_NO_ERROR on success; a crypto error if HMAC computation fails.
  */
 CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, int8_t txPower, ByteSpan sessionKey,
                                Ble::ChipBLEProximityRangingIdentificationInfo & outPayload);
@@ -61,16 +59,18 @@ CHIP_ERROR EncodeBeaconPayload(uint64_t bleDeviceId, uint16_t messageCounter, in
  * candidate BLEDeviceID.
  *
  * Used by adapters in BLE-Scanning role to test whether an observed beacon
- * was emitted by a peer whose BLEDeviceID is @p candidateBleDeviceId.
- *
- * @note Mirrors EncodeBeaconPayload - when HMAC obfuscation lands, this will
- *       compute the expected HMAC tag rather than comparing plain bytes.
+ * was emitted by a peer whose BLEDeviceID is @p candidateBleDeviceId. Mirrors
+ * EncodeBeaconPayload: it recomputes the expected obfuscated field the same way
+ * (HMAC by default, plaintext under
+ * CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING) and constant-time
+ * compares it against the payload.
  *
  * @param payload              The decoded advertisement payload.
  * @param candidateBleDeviceId The BLEDeviceID to verify against.
- * @param sessionKey           Per-session HMAC key (unused until obfuscation is wired up).
+ * @param sessionKey           Per-session HMAC key.
  *
- * @return CHIP_NO_ERROR on match, CHIP_ERROR_NOT_FOUND on mismatch.
+ * @return CHIP_NO_ERROR on match, CHIP_ERROR_NOT_FOUND on mismatch; a crypto
+ *         error if HMAC computation fails.
  */
 CHIP_ERROR DecodeBeaconPayload(const Ble::ChipBLEProximityRangingIdentificationInfo & payload, uint64_t candidateBleDeviceId,
                                ByteSpan sessionKey);

--- a/src/app/clusters/proximity-ranging-server/tests/BUILD.gn
+++ b/src/app/clusters/proximity-ranging-server/tests/BUILD.gn
@@ -19,6 +19,7 @@ chip_test_suite("tests") {
   output_name = "TestProximityRanging"
 
   test_sources = [
+    "TestBleRssiRangingHelpers.cpp",
     "TestProximityRangingCluster.cpp",
     "TestProximityRangingDriver.cpp",
   ]
@@ -27,6 +28,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app/clusters/proximity-ranging-server",
+    "${chip_root}/src/app/clusters/proximity-ranging-server:ble-rssi-helpers",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/proximity-ranging-server/tests/TestBleRssiRangingHelpers.cpp
+++ b/src/app/clusters/proximity-ranging-server/tests/TestBleRssiRangingHelpers.cpp
@@ -18,13 +18,11 @@
 // encode/decode round-trip and the BLEDeviceID generation / persistence
 // helpers.
 //
-// These tests assume the helpers are compiled in their default, secure
-// configuration (CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
-// undefined or 0), where the ObfuscatedBLEDeviceId field is an HMAC-SHA256 tag
-// over (BLEDeviceID || messageCounter). That is how the ble-rssi-helpers
-// source_set builds in CI; the plaintext flag is a test-only bring-up escape
-// hatch that is never set in normal builds, so obfuscation-specific assertions
-// (e.g. sensitivity to the session key) are valid here.
+// EncodeBeaconPayload / DecodeBeaconPayload default to the secure
+// HmacObfuscateBleDeviceId strategy, where the ObfuscatedBLEDeviceId field is an
+// HMAC-SHA256 tag over (BLEDeviceID || messageCounter). The obfuscation strategy
+// is injectable, so the obfuscation helpers and the insecure plaintext strategy
+// are exercised directly below rather than behind a build flag.
 
 #include <pw_unit_test/framework.h>
 
@@ -208,6 +206,65 @@ TEST_F(TestBleRssiRangingHelpers, GenerateProducesValidId)
         ASSERT_EQ(GenerateBleDeviceId(id), CHIP_NO_ERROR);
         EXPECT_NE(id, kInvalidBleDeviceId);
     }
+}
+
+// The HMAC obfuscator rejects an empty session key rather than producing a
+// keyless tag.
+TEST_F(TestBleRssiRangingHelpers, HmacObfuscateRejectsEmptySessionKey)
+{
+    uint8_t out[kObfuscatedLen] = {};
+    EXPECT_EQ(HmacObfuscateBleDeviceId(kDeviceId, kMsgCounter, ByteSpan(), MutableByteSpan(out)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+// The HMAC obfuscator rejects an output buffer smaller than the
+// ObfuscatedBLEDeviceId field rather than writing past its end. A valid key is
+// passed so the size guard (checked before the key guard) is what fires.
+TEST_F(TestBleRssiRangingHelpers, HmacObfuscateRejectsTooSmallBuffer)
+{
+    uint8_t out[kObfuscatedLen - 1] = {};
+    EXPECT_EQ(HmacObfuscateBleDeviceId(kDeviceId, kMsgCounter, ByteSpan(kSessionKey), MutableByteSpan(out)),
+              CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
+// EncodeBeaconPayload surfaces the empty-key failure from the default HMAC
+// strategy rather than emitting an unkeyed beacon.
+TEST_F(TestBleRssiRangingHelpers, EncodeRejectsEmptySessionKey)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    EXPECT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(), payload), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+// The plaintext strategy writes the raw big-endian BLEDeviceID and ignores the
+// session key (it is the insecure bring-up path).
+TEST_F(TestBleRssiRangingHelpers, PlaintextObfuscateWritesRawBigEndianId)
+{
+    uint8_t out[kObfuscatedLen] = {};
+    ASSERT_EQ(PlaintextObfuscateBleDeviceId(kDeviceId, kMsgCounter, ByteSpan(), MutableByteSpan(out)), CHIP_NO_ERROR);
+
+    uint8_t expected[kObfuscatedLen] = {};
+    Encoding::BigEndian::Put64(expected, kDeviceId);
+    EXPECT_EQ(memcmp(out, expected, kObfuscatedLen), 0);
+}
+
+// The plaintext obfuscator also rejects an output buffer smaller than the
+// ObfuscatedBLEDeviceId field rather than writing past its end.
+TEST_F(TestBleRssiRangingHelpers, PlaintextObfuscateRejectsTooSmallBuffer)
+{
+    uint8_t out[kObfuscatedLen - 1] = {};
+    EXPECT_EQ(PlaintextObfuscateBleDeviceId(kDeviceId, kMsgCounter, ByteSpan(), MutableByteSpan(out)), CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
+// A payload encoded with an injected strategy round-trips when decoded with the
+// same strategy: this is what lets two peers interoperate on the plaintext path
+// without a shared key.
+TEST_F(TestBleRssiRangingHelpers, EncodeDecodeRoundTripsWithInjectedPlaintextStrategy)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(), payload, PlaintextObfuscateBleDeviceId),
+              CHIP_NO_ERROR);
+
+    EXPECT_EQ(DecodeBeaconPayload(payload, kDeviceId, ByteSpan(), PlaintextObfuscateBleDeviceId), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeBeaconPayload(payload, kOtherDeviceId, ByteSpan(), PlaintextObfuscateBleDeviceId), CHIP_ERROR_NOT_FOUND);
 }
 
 // First use on empty storage: generate a valid ID and persist it.

--- a/src/app/clusters/proximity-ranging-server/tests/TestBleRssiRangingHelpers.cpp
+++ b/src/app/clusters/proximity-ranging-server/tests/TestBleRssiRangingHelpers.cpp
@@ -1,0 +1,296 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// Unit tests for BleRssiRangingHelpers: the advertisement payload
+// encode/decode round-trip and the BLEDeviceID generation / persistence
+// helpers.
+//
+// These tests assume the helpers are compiled in their default, secure
+// configuration (CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING
+// undefined or 0), where the ObfuscatedBLEDeviceId field is an HMAC-SHA256 tag
+// over (BLEDeviceID || messageCounter). That is how the ble-rssi-helpers
+// source_set builds in CI; the plaintext flag is a test-only bring-up escape
+// hatch that is never set in normal builds, so obfuscation-specific assertions
+// (e.g. sensitivity to the session key) are valid here.
+
+#include <pw_unit_test/framework.h>
+
+#include <app/clusters/proximity-ranging-server/BleRssiRangingHelpers.h>
+#include <ble/CHIPBleServiceData.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+#include <lib/support/Span.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::app::Clusters::ProximityRanging::BleRssi;
+
+using Ble::ChipBLEProximityRangingIdentificationInfo;
+
+constexpr uint64_t kDeviceId      = 0x0102030405060708ULL;
+constexpr uint64_t kOtherDeviceId = 0x1112131415161718ULL;
+constexpr uint16_t kMsgCounter    = 0x2A2B;
+constexpr int8_t kTxPower         = -42;
+
+// Two distinct HMAC keys; obfuscation must differ between them.
+constexpr uint8_t kSessionKey[] = {
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
+};
+constexpr uint8_t kOtherSessionKey[] = { 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88,
+                                         0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00 };
+
+constexpr size_t kObfuscatedLen = sizeof(ChipBLEProximityRangingIdentificationInfo::ObfuscatedBLEDeviceId);
+
+class TestBleRssiRangingHelpers : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+// Encode populates the OpCode, message counter, and Tx power exactly as passed.
+TEST_F(TestBleRssiRangingHelpers, EncodeSetsHeaderFields)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    EXPECT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    EXPECT_EQ(payload.OpCode, ChipBLEProximityRangingIdentificationInfo::kOpCode);
+    EXPECT_EQ(payload.GetMsgCounter(), kMsgCounter);
+    EXPECT_EQ(payload.GetTxPower(), kTxPower);
+}
+
+// In secure mode the obfuscated field must NOT be the plaintext big-endian
+// BLEDeviceID: it is an HMAC tag, so the raw identifier does not appear on air.
+TEST_F(TestBleRssiRangingHelpers, EncodeObfuscatesDeviceId)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    uint8_t plaintext[kObfuscatedLen] = {};
+    Encoding::BigEndian::Put64(plaintext, kDeviceId);
+    EXPECT_NE(memcmp(payload.GetObfuscatedBLEDeviceId(), plaintext, kObfuscatedLen), 0);
+}
+
+// Known-answer test: pins the exact on-air obfuscated bytes so the wire format
+// cannot drift silently. The expected value is HMAC-SHA256(kSessionKey,
+// kDeviceId_BE || kMsgCounter_BE) truncated to the leading kObfuscatedLen bytes,
+// computed by an independent implementation (Python's hmac module) rather than
+// by the code under test:
+//
+//   message  = 01 02 03 04 05 06 07 08 2A 2B
+//   full tag = a9e1319f58876ae42c29485c6f6466866c4f296fca290a30650a355a18594d05
+//
+// The round-trip and property tests share EncodeBeaconPayload's internal HMAC
+// helper, so a systematic layout bug (wrong endianness, wrong truncation,
+// counter mis-placed) would pass those but fail here.
+TEST_F(TestBleRssiRangingHelpers, EncodeMatchesKnownAnswerVector)
+{
+    static constexpr uint8_t kExpectedObfuscatedId[kObfuscatedLen] = {
+        0xA9, 0xE1, 0x31, 0x9F, 0x58, 0x87, 0x6A, 0xE4, 0x2C, 0x29, 0x48, 0x5C, 0x6F, 0x64, 0x66, 0x86,
+    };
+
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    EXPECT_EQ(memcmp(payload.GetObfuscatedBLEDeviceId(), kExpectedObfuscatedId, kObfuscatedLen), 0);
+}
+
+// Encoding is a pure function of its inputs: identical inputs yield identical
+// obfuscated output.
+TEST_F(TestBleRssiRangingHelpers, EncodeIsDeterministic)
+{
+    ChipBLEProximityRangingIdentificationInfo a;
+    ChipBLEProximityRangingIdentificationInfo b;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), a), CHIP_NO_ERROR);
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), b), CHIP_NO_ERROR);
+
+    EXPECT_EQ(memcmp(a.GetObfuscatedBLEDeviceId(), b.GetObfuscatedBLEDeviceId(), kObfuscatedLen), 0);
+}
+
+// The message counter is mixed into the HMAC, so bumping it changes the tag
+// (this is what gives passive observers a rolling, uncorrelatable identifier).
+TEST_F(TestBleRssiRangingHelpers, EncodeVariesWithMessageCounter)
+{
+    ChipBLEProximityRangingIdentificationInfo a;
+    ChipBLEProximityRangingIdentificationInfo b;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), a), CHIP_NO_ERROR);
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, static_cast<uint16_t>(kMsgCounter + 1), kTxPower, ByteSpan(kSessionKey), b),
+              CHIP_NO_ERROR);
+
+    EXPECT_NE(memcmp(a.GetObfuscatedBLEDeviceId(), b.GetObfuscatedBLEDeviceId(), kObfuscatedLen), 0);
+}
+
+// A different session key produces a different tag for the same device ID.
+TEST_F(TestBleRssiRangingHelpers, EncodeVariesWithSessionKey)
+{
+    ChipBLEProximityRangingIdentificationInfo a;
+    ChipBLEProximityRangingIdentificationInfo b;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), a), CHIP_NO_ERROR);
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kOtherSessionKey), b), CHIP_NO_ERROR);
+
+    EXPECT_NE(memcmp(a.GetObfuscatedBLEDeviceId(), b.GetObfuscatedBLEDeviceId(), kObfuscatedLen), 0);
+}
+
+// The core contract: a payload encoded for a device verifies against that same
+// device ID and key.
+TEST_F(TestBleRssiRangingHelpers, DecodeMatchesEncodedPayload)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    EXPECT_EQ(DecodeBeaconPayload(payload, kDeviceId, ByteSpan(kSessionKey)), CHIP_NO_ERROR);
+}
+
+// A candidate ID that did not emit the beacon does not verify.
+TEST_F(TestBleRssiRangingHelpers, DecodeRejectsWrongDeviceId)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    EXPECT_EQ(DecodeBeaconPayload(payload, kOtherDeviceId, ByteSpan(kSessionKey)), CHIP_ERROR_NOT_FOUND);
+}
+
+// Verifying with the wrong session key fails: the peers must share the key.
+TEST_F(TestBleRssiRangingHelpers, DecodeRejectsWrongSessionKey)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    EXPECT_EQ(DecodeBeaconPayload(payload, kDeviceId, ByteSpan(kOtherSessionKey)), CHIP_ERROR_NOT_FOUND);
+}
+
+// Decode recomputes the expected tag from the counter carried in the payload,
+// so a tampered counter no longer matches the stored obfuscated field.
+TEST_F(TestBleRssiRangingHelpers, DecodeRejectsTamperedMessageCounter)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    payload.SetMsgCounter(static_cast<uint16_t>(kMsgCounter + 1));
+    EXPECT_EQ(DecodeBeaconPayload(payload, kDeviceId, ByteSpan(kSessionKey)), CHIP_ERROR_NOT_FOUND);
+}
+
+// Flipping a byte of the obfuscated field breaks verification.
+TEST_F(TestBleRssiRangingHelpers, DecodeRejectsTamperedObfuscatedField)
+{
+    ChipBLEProximityRangingIdentificationInfo payload;
+    ASSERT_EQ(EncodeBeaconPayload(kDeviceId, kMsgCounter, kTxPower, ByteSpan(kSessionKey), payload), CHIP_NO_ERROR);
+
+    payload.ObfuscatedBLEDeviceId[0] = static_cast<uint8_t>(payload.ObfuscatedBLEDeviceId[0] ^ 0xFF);
+    EXPECT_EQ(DecodeBeaconPayload(payload, kDeviceId, ByteSpan(kSessionKey)), CHIP_ERROR_NOT_FOUND);
+}
+
+// GenerateBleDeviceId always yields a valid (non-reserved) identifier.
+TEST_F(TestBleRssiRangingHelpers, GenerateProducesValidId)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        uint64_t id = kInvalidBleDeviceId;
+        ASSERT_EQ(GenerateBleDeviceId(id), CHIP_NO_ERROR);
+        EXPECT_NE(id, kInvalidBleDeviceId);
+    }
+}
+
+// First use on empty storage: generate a valid ID and persist it.
+TEST_F(TestBleRssiRangingHelpers, RetrieveGeneratesAndPersistsOnFirstUse)
+{
+    TestPersistentStorageDelegate storage;
+    // Hold the StorageKeyName in a local: its destructor zeroes the underlying
+    // buffer, so a raw const char * captured from a temporary would dangle.
+    StorageKeyName key = DefaultStorageKeyAllocator::ProximityRangingBleDeviceId();
+
+    uint64_t id = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, id), CHIP_NO_ERROR);
+    EXPECT_NE(id, kInvalidBleDeviceId);
+    EXPECT_TRUE(storage.HasKey(key.KeyName()));
+}
+
+// The generated ID is stable across calls (i.e. across simulated reboots).
+TEST_F(TestBleRssiRangingHelpers, RetrieveReturnsStableIdAcrossCalls)
+{
+    TestPersistentStorageDelegate storage;
+
+    uint64_t first = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, first), CHIP_NO_ERROR);
+
+    uint64_t second = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, second), CHIP_NO_ERROR);
+
+    EXPECT_EQ(first, second);
+}
+
+// A previously persisted valid ID is returned verbatim, without regeneration.
+TEST_F(TestBleRssiRangingHelpers, RetrieveReturnsPersistedValue)
+{
+    TestPersistentStorageDelegate storage;
+    StorageKeyName key         = DefaultStorageKeyAllocator::ProximityRangingBleDeviceId();
+    constexpr uint64_t kStored = 0xDEADBEEFCAFEF00DULL;
+    ASSERT_EQ(storage.SyncSetKeyValue(key.KeyName(), &kStored, sizeof(kStored)), CHIP_NO_ERROR);
+
+    uint64_t id = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, id), CHIP_NO_ERROR);
+    EXPECT_EQ(id, kStored);
+}
+
+// A stored reserved value (kInvalidBleDeviceId) is treated as absent and a
+// fresh valid ID is generated and persisted in its place.
+TEST_F(TestBleRssiRangingHelpers, RetrieveRegeneratesWhenStoredValueIsInvalid)
+{
+    TestPersistentStorageDelegate storage;
+    StorageKeyName key          = DefaultStorageKeyAllocator::ProximityRangingBleDeviceId();
+    constexpr uint64_t kInvalid = kInvalidBleDeviceId;
+    ASSERT_EQ(storage.SyncSetKeyValue(key.KeyName(), &kInvalid, sizeof(kInvalid)), CHIP_NO_ERROR);
+
+    uint64_t id = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, id), CHIP_NO_ERROR);
+    EXPECT_NE(id, kInvalidBleDeviceId);
+}
+
+// A stored value of the wrong size is treated as corrupt and regenerated.
+TEST_F(TestBleRssiRangingHelpers, RetrieveRegeneratesWhenStoredValueHasWrongSize)
+{
+    TestPersistentStorageDelegate storage;
+    StorageKeyName key          = DefaultStorageKeyAllocator::ProximityRangingBleDeviceId();
+    const uint8_t kTruncated[4] = { 0xAA, 0xBB, 0xCC, 0xDD };
+    ASSERT_EQ(storage.SyncSetKeyValue(key.KeyName(), kTruncated, sizeof(kTruncated)), CHIP_NO_ERROR);
+
+    uint64_t id = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, id), CHIP_NO_ERROR);
+    EXPECT_NE(id, kInvalidBleDeviceId);
+
+    // The regenerated ID must now be persisted as a full 8-byte value.
+    uint64_t reread = kInvalidBleDeviceId;
+    ASSERT_EQ(RetrieveGenerateBleDeviceId(storage, reread), CHIP_NO_ERROR);
+    EXPECT_EQ(reread, id);
+}
+
+// If persisting the freshly generated ID fails, the failure is propagated.
+TEST_F(TestBleRssiRangingHelpers, RetrievePropagatesPersistFailure)
+{
+    TestPersistentStorageDelegate storage;
+    storage.SetRejectWrites(true);
+
+    uint64_t id = kInvalidBleDeviceId;
+    EXPECT_EQ(RetrieveGenerateBleDeviceId(storage, id), CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+}
+
+} // namespace


### PR DESCRIPTION
Replace the plaintext big-endian placeholder in the BLE Beacon RSSI Ranging helpers with the spec-defined obfuscation: the ObfuscatedBLEDeviceId field is now HMAC-SHA256(sessionKey, BLEDeviceID_BE || messageCounter_BE) truncated to the leading 16 bytes. EncodeBeaconPayload and DecodeBeaconPayload share a single internal ComputeObfuscatedBleDeviceId helper so the two paths cannot drift, and Decode uses a constant-time comparison to avoid leaking how many leading tag bytes matched.

A build-time CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING escape hatch (default 0) preserves the plaintext path for bring-up/interop only.

Add TestBleRssiRangingHelpers.cpp covering the four public helpers: header field population, obfuscation (determinism, sensitivity to counter and session key, a known-answer vector computed by an independent HMAC implementation), encode/decode round-trip and rejection of wrong device ID / key / tampered counter / tampered tag, and the BLEDeviceID generation and persistence logic (generate-and-persist on first use, stability across calls, regeneration on invalid/wrong-size stored values, and persist-failure propagation).

### Summary

The BLE Beacon RSSI Ranging helpers previously carried the `BLEDeviceID` in the advertisement as a plaintext big-endian value — a placeholder left in place of the spec-defined obfuscation. That leaks a stable device identifier on air and lets a passive observer correlate a device across every beacon it emits, defeating the purpose of the obfuscated field.

**This is an on-air / wire-format change**, not a test-only change:

- `ObfuscatedBLEDeviceId` is now `HMAC-SHA256(sessionKey, BLEDeviceID_BE || BLERBCMessageCounter_BE)` truncated to the leading 16 bytes. Mixing the message counter into the HMAC gives passive observers a rolling, uncorrelatable identifier.
- `EncodeBeaconPayload` and `DecodeBeaconPayload` share a single internal `ComputeObfuscatedBleDeviceId` helper, so the advertise and verify paths cannot drift out of sync.
- `DecodeBeaconPayload` verifies with `Crypto::IsBufferContentEqualConstantTime` rather than `memcmp`, so it does not leak — via timing — how many leading tag bytes matched.
- A build-time `CHIP_CLUSTER_PROXIMITY_RANGING_DISABLE_SECURE_BLE_BEACONING` switch (default `0` = secure) preserves the plaintext path solely for bring-up/interop between two peers without a shared session key. It leaks the identifier on air and must never be enabled in production; both peers must set it.

Because both peers derive the tag from a shared session key and the counter carried in the payload, the verify path stays a pure function of its inputs and needs no additional state.

### Related issues

N/A

### Testing

- **Added unit tests:** `src/app/clusters/proximity-ranging-server/tests/TestBleRssiRangingHelpers.cpp` (18 tests) covering the four public helpers:
  - **Encode:** OpCode / message counter / Tx power population; obfuscated field is not the plaintext BLEDeviceID; determinism; sensitivity to message counter and session key.
  - **Known-answer test:** pins the exact 16 on-air bytes against a vector computed by an independent implementation (Python's `hmac` module) rather than the code under test, so a systematic layout bug (wrong endianness, mis-placed counter, wrong truncation) that the round-trip/property tests would miss fails loudly here.
  - **Decode:** encode/decode round-trip succeeds; rejects wrong device ID, wrong session key, tampered message counter, and a tampered obfuscated tag (all `CHIP_ERROR_NOT_FOUND`).
  - **BLEDeviceID generation/persistence:** `GenerateBleDeviceId` never returns the reserved value; `RetrieveGenerateBleDeviceId` generates-and-persists on first use, is stable across calls (simulated reboots), returns a persisted value verbatim, regenerates on invalid/wrong-size stored values, and propagates persist failures.
- Built and ran locally: `TestBleRssiRangingHelpers` — **18/18 passing**; sibling proximity-ranging test targets still link and pass.