### PR TITLE
[fuzz] Initialize PASE fuzz harness state before the code under test reads it

### DIFF
--- a/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
@@ -295,7 +295,9 @@ FUZZ_TEST(FuzzPASE_PW, PASESession_Unbounded)
 void FuzzSpake2pVerifier(const vector<uint8_t> & aW0, const vector<uint8_t> & aL, const vector<uint8_t> & aSalt,
                          const uint32_t fuzzedPBKDF2Iter, const uint32_t fuzzedSetupPasscode)
 {
-    Spake2pVerifier fuzzedSpake2pVerifier;
+    // Zero-initialize: aW0/aL may be shorter than mW0/mL, so the copy_n calls below leave the tail unset and
+    // BeginVerifier()/FELoad() would read uninitialized bytes. Production verifiers come from Generate()/Deserialize().
+    Spake2pVerifier fuzzedSpake2pVerifier{};
 
     copy_n(aW0.data(), aW0.size(), fuzzedSpake2pVerifier.mW0);
     copy_n(aL.data(), aL.size(), fuzzedSpake2pVerifier.mL);
@@ -494,6 +496,10 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
     // inject it here to be able to pass that check
     memcpy(&pairingCommissioner.mPBKDFLocalRandomData[0], fuzzPBKDFLocalRandomDataInitiator.data(),
            fuzzPBKDFLocalRandomDataInitiator.size());
+
+    // This harness skips Init()/Pair(), which normally set mSetupPINCode; HandlePBKDFParamResponse() -> ComputeWS()
+    // reads it. Set a fixed valid passcode (production always initializes it via Init()/Pair()).
+    pairingCommissioner.mSetupPINCode = 20202021;
 
     // In order to cover the Code path where the Commissioner has PBKDF Parameters before Starting PASE, as such, the Accessory will
     // not send the PBKDF Parameters in the Response message


### PR DESCRIPTION
#### Problem

Two harnesses in `FuzzPASE_PW.cpp` left an object partially uninitialized before the code they exercise read it, which the OSS-Fuzz memory (MSan) build flagged as use-of-uninitialized-value:

- **`FuzzHandlePBKDFParamResponse`** prepares the commissioner `PASESession` by hand and skips `Init()`/`Pair()`, which normally set `mSetupPINCode`. The exercised path `HandlePBKDFParamResponse() -> SetupSpake2p() -> Spake2pVerifier::ComputeWS()` reads `mSetupPINCode`.
- **`FuzzSpake2pVerifier`** copies fuzzed vectors that may be shorter than `mW0[kP256_FE_Length]` / `mL[kP256_Point_Length]` into an uninitialized `Spake2pVerifier`, leaving the tail bytes unset; `BeginVerifier() -> FELoad()` later reads them.

#### Fix

- Set a fixed valid passcode on the hand-prepared commissioner session.
- Zero-initialize the `Spake2pVerifier`, which keeps the short-input coverage the domains intend.

Both are test-harness gaps, not product bugs: production always initializes `mSetupPINCode` via `Init()`/`Pair()`, and production verifiers come from `Generate()`/`Deserialize()`, which populate the whole struct.

#### Testing

- Builds and all `FuzzPASE_PW` FuzzTests pass in the pw_fuzztest unit-test build.
- Verified under a local MemorySanitizer build: the exercised paths report use-of-uninitialized-value before this change and are clean after.