### PR TITLE
reject zero receive window in HandleCapabilitiesRequestReceived

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1011,6 +1011,7 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBufferHandle && 
 
     // Select local and remote max receive window size based on local resources available for both incoming writes AND
     // GATT confirmations.
+    VerifyOrReturnError(req.mWindowSize > 0, CHIP_ERROR_INVALID_ARGUMENT);
     mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
         std::min(req.mWindowSize, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE));
     resp.mWindowSize = mReceiveWindowMaxSize;

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -113,10 +113,10 @@ public:
 
     // Passing capabilities request message to HandleWriteReceived should create
     // new BLE endpoint which later can be used to receive more data.
-    bool HandleWriteReceivedCapabilitiesRequest(BLE_CONNECTION_OBJECT connObj)
+    bool HandleWriteReceivedCapabilitiesRequest(BLE_CONNECTION_OBJECT connObj, uint8_t windowSize = BLE_MAX_RECEIVE_WINDOW_SIZE)
     {
-        constexpr uint8_t capReq[] = { 0x65, 0x6c, 0x54, 0x00, 0x00, 0x00, 0xc8, 0x00, 0x06 };
-        auto buf                   = System::PacketBufferHandle::NewWithData(capReq, sizeof(capReq));
+        const uint8_t capReq[] = { 0x65, 0x6c, 0x54, 0x00, 0x00, 0x00, 0xc8, 0x00, windowSize };
+        auto buf               = System::PacketBufferHandle::NewWithData(capReq, sizeof(capReq));
         return HandleWriteReceived(connObj, &CHIP_BLE_SVC_ID, &CHIP_BLE_CHAR_1_UUID, std::move(buf));
     }
 
@@ -232,6 +232,14 @@ TEST_F(TestBleLayer, HandleWriteReceivedCapabilitiesRequest)
 {
     auto connObj = GetConnectionObject();
     EXPECT_TRUE(HandleWriteReceivedCapabilitiesRequest(connObj));
+}
+
+// A window size of zero would underflow the receive window counters to 255 on the
+// first subscription and data fragment, so the handshake must be rejected.
+TEST_F(TestBleLayer, HandleWriteReceivedCapabilitiesRequestZeroWindowSize)
+{
+    auto connObj = GetConnectionObject();
+    EXPECT_FALSE(HandleWriteReceivedCapabilitiesRequest(connObj, 0));
 }
 
 TEST_F(TestBleLayer, HandleSubscribeReceivedInvalidUUID)


### PR DESCRIPTION
### Summary

`HandleCapabilitiesRequestReceived` takes the window size straight from the peer's BTP capabilities request and assigns it to `mRemoteReceiveWindowSize`, `mLocalReceiveWindowSize` and `mReceiveWindowMaxSize` without checking it is non-zero, and `req.mWindowSize` is a raw wire byte that `BleTransportCapabilitiesRequestMessage::Decode` does not range-check. When a central sends zero, all three `uint8_t` counters start at 0 and the two unconditional decrements, in `HandleSubscribeReceived` and in `Receive`, wrap them to 255, so the endpoint ends up believing it has a full window while the peer advertised no capacity at all and the `mRemoteReceiveWindowSize == 0` check in `DriveSending` never fires. The matching central-side handler `HandleCapabilitiesResponseReceived` already rejects a zero window a few lines below, and `Receive` already releases the connection when the capabilities request is refused, so the peripheral path just needs the same guard.

### Related issues

None.

### Testing

Added a `TestBleLayer` case that drives the peripheral handshake with a window size of zero; it fails on master, where the write is accepted, and passes with the guard in place. The existing `HandleWriteReceivedCapabilitiesRequest` helper now takes the window size as a parameter and defaults to the previous value, so the other cases are unchanged. All 36 `TestBleLayer` cases and the rest of the `src/ble` suites pass, and `darwin-arm64-tests-clang` builds clean.
