### PR TITLE
[TC-BIND-2.2, 2.3] Manual Yaml script has been updated as per the VS document.

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -90,9 +90,16 @@ tests:
       verification: |
           Run this command for [nrf54L15-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 1,
-          "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000}' 74 0
+          ./chip-tool groupkeymanagement key-set-write '{
+          "groupKeySetID": 1,
+          "groupKeySecurityPolicy": 0,
+          "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime0": 2220000,
+          "epochKey1": "000102030405060708090a0b0c0d0e0f",
+          "epochStartTime1": 2220001,
+          "epochKey2": "101112131415161718191a1b1c1d1e1f",
+          "epochStartTime2": 2220002
+          }' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
 
@@ -129,9 +136,16 @@ tests:
 
           Run this command for lighting app in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 1,
-          "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000}' 2 0
+          ./chip-tool groupkeymanagement key-set-write '{
+          "groupKeySetID": 1,
+          "groupKeySecurityPolicy": 0,
+          "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime0": 2220000,
+          "epochKey1": "e0e1e2e3e4e5e6e7e8e9eaebecedeeef",
+          "epochStartTime1": 2220001,
+          "epochKey2": "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+          "epochStartTime2": 2220002
+           }' 2 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
 

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_2.yaml
@@ -95,10 +95,10 @@ tests:
           "groupKeySecurityPolicy": 0,
           "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
           "epochStartTime0": 2220000,
-          "epochKey1": "000102030405060708090a0b0c0d0e0f",
-          "epochStartTime1": 2220001,
-          "epochKey2": "101112131415161718191a1b1c1d1e1f",
-          "epochStartTime2": 2220002
+          "epochKey1": null,
+          "epochStartTime1": null,
+          "epochKey2": null,
+          "epochStartTime2": null
           }' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
@@ -141,10 +141,10 @@ tests:
           "groupKeySecurityPolicy": 0,
           "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
           "epochStartTime0": 2220000,
-          "epochKey1": "e0e1e2e3e4e5e6e7e8e9eaebecedeeef",
-          "epochStartTime1": 2220001,
-          "epochKey2": "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-          "epochStartTime2": 2220002
+          "epochKey1": null,
+          "epochStartTime1": null,
+          "epochKey2": null,
+          "epochStartTime2": null
            }' 2 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
@@ -90,9 +90,16 @@ tests:
       verification: |
           Run this command for [ nRF52840-DK ]Thread device in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 417,
-          "groupKeySecurityPolicy": 0, "epochKey0":
-          "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000}' 74 0
+          ./chip-tool groupkeymanagement key-set-write '{
+          "groupKeySetID": 417,
+          "groupKeySecurityPolicy": 0,
+          "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime0": 2220000,
+          "epochKey1": "e0e1e2e3e4e5e6e7e8e9eaebecedeeef",
+          "epochStartTime1": 2220001,
+          "epochKey2": "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+          "epochStartTime2": 2220002
+          }' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
 
@@ -128,7 +135,16 @@ tests:
 
           Run this command for lighting app in chip-tool:
 
-          ./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 417, "groupKeySecurityPolicy": 0, "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001 }' 2 0
+          ./chip-tool groupkeymanagement key-set-write '{
+          "groupKeySetID": 417,
+          "groupKeySecurityPolicy": 0,
+          "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime0": 2220000,
+          "epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime1": 2220001,
+          "epochKey2": "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+          "epochStartTime2": 2220002
+          }' 2 0
 
           On TH1, Verify the success response for KeySetWrite
 

--- a/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_2_3.yaml
@@ -95,10 +95,10 @@ tests:
           "groupKeySecurityPolicy": 0,
           "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
           "epochStartTime0": 2220000,
-          "epochKey1": "e0e1e2e3e4e5e6e7e8e9eaebecedeeef",
-          "epochStartTime1": 2220001,
-          "epochKey2": "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-          "epochStartTime2": 2220002
+          "epochKey1": null,
+          "epochStartTime1": null,
+          "epochKey2": null,
+          "epochStartTime2": null
           }' 74 0
 
           On TH1(Chip-tool), Verify the success response for KeySetWrite
@@ -140,10 +140,10 @@ tests:
           "groupKeySecurityPolicy": 0,
           "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
           "epochStartTime0": 2220000,
-          "epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf",
-          "epochStartTime1": 2220001,
-          "epochKey2": "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf",
-          "epochStartTime2": 2220002
+          "epochKey1": null,
+          "epochStartTime1": null,
+          "epochKey2": null,
+          "epochStartTime2": null
           }' 2 0
 
           On TH1, Verify the success response for KeySetWrite


### PR DESCRIPTION
### Summary
TC-BIND-2.2, 2.3 - In step 6 Key Set Write Chip-tool command has been updated as per the Verification step document in Yaml-Manual script.

Updated the **groupkeymanagement key-set-write**  Chip-tool command to match the  GroupKeySetStruct schema.

### Related issues
Fixed for issue: https://github.com/project-chip/matter-test-scripts/issues/793

### Testing


