### PR TITLE
TC-OPCREDS-3.8: fixes to let test run with pre-existing fabric

### DIFF
--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -443,8 +443,6 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
         if not storage_path_found:
             commission_tokens.extend(['--storage-path', './admin_storage_pre.json'])
 
-        commission_args = shlex.join(commission_tokens)
-
         commission_command = [
             sys.executable, "-X", "faulthandler",
             script,
@@ -452,7 +450,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
             "--paa-trust-store-path",
             os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
             "--commission-only-re-open-window"
-        ] + shlex.split(commission_args)
+        ] + commission_tokens
 
         log.info(
             "Running python script to commission device on a pre-existing fabric and "

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -449,11 +449,14 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
             sys.executable, "-X", "faulthandler",
             script,
             "--fail-on-skipped",
-            "--paa-trust-store-path", os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+            "--paa-trust-store-path",
+            os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
             "--commission-only-re-open-window"
         ] + shlex.split(commission_args)
 
-        log.info("Running python script to commission device on a pre-existing fabric and open commissioning window...")
+        log.info(
+            "Running python script to commission device on a pre-existing fabric and "
+            "open commissioning window...")
         log.info("Command: %s", ' '.join(commission_command))
         commission_proc = Subprocess(commission_command[0], *commission_command[1:],
                                      output_cb=process_mon_output, f_stdout=stream_output, f_stderr=stream_output)

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -238,10 +238,12 @@ def run_timeout(run: Metadata) -> float:
 @click.option("--ip-packet-capture-dir", type=click.Path(file_okay=False, writable=True, path_type=pathlib.Path),
               default=pathlib.Path.cwd() / "out/ip_packet_captures", help="Storage for capture files.")
 @click.option("--app-filter", type=str, default=None, help="Run only for the specified app(s). Comma separated.")
+@click.option("--pre-existing-fabric", is_flag=True, default=False,
+              help="Commission app to a chip-tool fabric and open a commissioning window before running test script.")
 def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
          app_ready_pattern: str, app_stdin_pipe: str, script: str, script_args: str,
          script_gdb: bool, quiet: bool, load_from_env, run, ip_packet_capture: bool, ip_packet_capture_dir: pathlib.Path,
-         app_filter):
+         app_filter, pre_existing_fabric: bool):
     if load_from_env:
         reader = MetadataReader(load_from_env)
         runs = reader.parse_script(script)
@@ -256,6 +258,7 @@ def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: 
                 app_stdin_pipe=app_stdin_pipe,
                 script_args=script_args,
                 script_gdb=script_gdb,
+                pre_existing_fabric=pre_existing_fabric,
             )
         ]
 
@@ -284,12 +287,14 @@ def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: 
             run.script_gdb = script_gdb
         if quiet is not None:
             run.quiet = quiet
+        if pre_existing_fabric:
+            run.pre_existing_fabric = pre_existing_fabric
 
     for run in runs:
         log.info("Executing '%s' '%s'", run.py_script_path.split('/')[-1], run.run)
         main_impl(run.app, run.factory_reset, run.factory_reset_app_only, run.app_args or "", run.app_ready_pattern,
                   run.app_stdin_pipe, run.py_script_path, run.script_args or "", run.script_gdb, ip_packet_capture,
-                  ip_packet_capture_dir, run_timeout(run), run.quiet, run.run)
+                  ip_packet_capture_dir, run_timeout(run), run.quiet, run.run, run.pre_existing_fabric)
 
 
 class AppRestartMonitor:
@@ -361,7 +366,7 @@ class AppRestartMonitor:
 def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
               app_ready_pattern: str, app_stdin_pipe: str, script: str, script_args: str,
               script_gdb: bool, ip_packet_capture: bool, ip_packet_capture_dir: pathlib.Path,
-              run_timeout: float, quiet: bool, run_name: str):
+              run_timeout: float, quiet: bool, run_name: str, pre_existing_fabric: bool = False):
 
     app_args = app_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
     script_args = script_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
@@ -404,6 +409,59 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
     # TODO: Remove this below workaround once we understand if mobile-device-test needs to be run through Cirque and through this script for CI test pipeline, task PR: https://github.com/project-chip/matter-test-scripts/issues/681
     if "mobile-device-test.py" not in script:
         script_args += f" --restart-flag-file {restart_flag_file}"
+
+    if pre_existing_fabric:
+        # Some devices (custom commissioning) may show up at cert with a fabric already on the device
+        # to simulate this in the CI, this option allows the user to pre-commission the device onto
+        # an ephermeral fabric.
+        # This is done using the commission-only-re-open-window flag in the device testing framework.
+        # That flag commissions the device and then re-opens the commissioning window with the same
+        # discriminator and passcode.
+        p = matter_test_args_parser()
+        args, _ = p.parse_known_args(shlex.split(script_args))
+
+        if not args.commissioning_method or args.commissioning_method != "on-network":
+            raise click.ClickException(
+                "When using --pre-existing-fabric, script-args must include --commissioning-method on-network."
+            )
+
+        commission_tokens = shlex.split(script_args)
+        storage_path_found = False
+        for idx, token in enumerate(commission_tokens):
+            if token == '--storage-path':
+                if idx + 1 < len(commission_tokens):
+                    path_val = commission_tokens[idx + 1]
+                    name, ext = os.path.splitext(path_val)
+                    commission_tokens[idx + 1] = f"{name}_pre{ext}"
+                    storage_path_found = True
+            elif token.startswith('--storage-path='):
+                path_val = token.split('=', 1)[1]
+                name, ext = os.path.splitext(path_val)
+                commission_tokens[idx] = f"--storage-path={name}_pre{ext}"
+                storage_path_found = True
+
+        if not storage_path_found:
+            commission_tokens.extend(['--storage-path', './admin_storage_pre.json'])
+
+        commission_args = shlex.join(commission_tokens)
+
+        commission_command = [
+            sys.executable, "-X", "faulthandler",
+            script,
+            "--fail-on-skipped",
+            "--paa-trust-store-path", os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+            "--commission-only-re-open-window"
+        ] + shlex.split(commission_args)
+
+        log.info("Running python script to commission device on a pre-existing fabric and open commissioning window...")
+        log.info("Command: %s", ' '.join(commission_command))
+        commission_proc = Subprocess(commission_command[0], *commission_command[1:],
+                                     output_cb=process_mon_output, f_stdout=stream_output, f_stderr=stream_output)
+        commission_proc.start()
+        commission_exit = commission_proc.wait(120)
+        if commission_exit != 0:
+            log.error("Commissioning run failed with exit code %d", commission_exit)
+            sys.exit(commission_exit)
 
     script_command = [
         script,

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -413,7 +413,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
     if pre_existing_fabric:
         # Some devices (custom commissioning) may show up at cert with a fabric already on the device
         # to simulate this in the CI, this option allows the user to pre-commission the device onto
-        # an ephermeral fabric.
+        # an ephemeral fabric.
         # This is done using the commission-only-re-open-window flag in the device testing framework.
         # That flag commissions the device and then re-opens the commissioning window with the same
         # discriminator and passcode.

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -201,7 +201,7 @@ PyChipError pychip_DeviceController_PostTaskOnChipThread(ChipThreadTaskRunnerFun
 PyChipError pychip_DeviceController_OpenCommissioningWindow(chip::Controller::DeviceCommissioner * devCtrl,
                                                             chip::Controller::ScriptDevicePairingDelegate * pairingDelegate,
                                                             chip::NodeId nodeid, uint16_t timeout, uint32_t iteration,
-                                                            uint16_t discriminator, uint8_t optionInt);
+                                                            uint16_t discriminator, uint8_t optionInt, uint32_t passcode);
 PyChipError pychip_DeviceController_ContinueCommissioningAfterConnectNetworkRequest(chip::Controller::DeviceCommissioner * devCtrl,
                                                                                     chip::NodeId remoteDeviceId);
 
@@ -929,7 +929,7 @@ PyChipError pychip_ScriptDevicePairingDelegate_SetOpenWindowCompleteCallback(
 PyChipError pychip_DeviceController_OpenCommissioningWindow(chip::Controller::DeviceCommissioner * devCtrl,
                                                             chip::Controller::ScriptDevicePairingDelegate * pairingDelegate,
                                                             chip::NodeId nodeid, uint16_t timeout, uint32_t iteration,
-                                                            uint16_t discriminator, uint8_t optionInt)
+                                                            uint16_t discriminator, uint8_t optionInt, uint32_t passcode)
 {
     const auto option = static_cast<Controller::CommissioningWindowOpener::CommissioningWindowOption>(optionInt);
     if (option == Controller::CommissioningWindowOpener::CommissioningWindowOption::kOriginalSetupCode)
@@ -938,19 +938,23 @@ PyChipError pychip_DeviceController_OpenCommissioningWindow(chip::Controller::De
             devCtrl, nodeid, System::Clock::Seconds16(timeout)));
     }
 
-    if (option == Controller::CommissioningWindowOpener::CommissioningWindowOption::kTokenWithRandomPIN)
+    if (option == Controller::CommissioningWindowOpener::CommissioningWindowOption::kTokenWithRandomPIN ||
+        option == Controller::CommissioningWindowOpener::CommissioningWindowOption::kTokenWithProvidedPIN)
     {
         SetupPayload payload;
         auto opener =
             Platform::New<Controller::CommissioningWindowOpener>(static_cast<chip::Controller::DeviceController *>(devCtrl));
-        PyChipError err =
-            ToPyChipError(opener->OpenCommissioningWindow(Controller::CommissioningWindowPasscodeParams()
-                                                              .SetNodeId(nodeid)
-                                                              .SetTimeout(timeout)
-                                                              .SetIteration(iteration)
-                                                              .SetDiscriminator(discriminator)
-                                                              .SetCallback(pairingDelegate->GetOpenWindowCallback(opener)),
-                                                          payload));
+        auto params = Controller::CommissioningWindowPasscodeParams()
+                          .SetNodeId(nodeid)
+                          .SetTimeout(timeout)
+                          .SetIteration(iteration)
+                          .SetDiscriminator(discriminator)
+                          .SetCallback(pairingDelegate->GetOpenWindowCallback(opener));
+        if (option == Controller::CommissioningWindowOpener::CommissioningWindowOption::kTokenWithProvidedPIN)
+        {
+            params.SetSetupPIN(passcode);
+        }
+        PyChipError err = ToPyChipError(opener->OpenCommissioningWindow(params, payload));
         return err;
     }
 

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1359,9 +1359,10 @@ class ChipDeviceControllerBase:
     class CommissioningWindowPasscode(enum.IntEnum):
         kOriginalSetupCode = 0
         kTokenWithRandomPin = 1
+        kTokenWithProvidedPin = 2
 
     async def OpenCommissioningWindow(self, nodeId: int, timeout: int, iteration: int,
-                                      discriminator: int, option: CommissioningWindowPasscode) -> CommissioningParameters:
+                                      discriminator: int, option: CommissioningWindowPasscode, setupPinCode: int = 0) -> CommissioningParameters:
         '''
         Opens a commissioning window on the device with the given node ID.
 
@@ -1376,6 +1377,8 @@ class ChipDeviceControllerBase:
             option (int):
                 0 = kOriginalSetupCode
                 1 = kTokenWithRandomPIN
+                2 = kTokenWithProvidedPIN
+            setupPinCode (int): The setup PIN code to use. Ignored if option != 2
 
             Returns:
                 CommissioningParameters
@@ -1385,7 +1388,7 @@ class ChipDeviceControllerBase:
         async with self._open_window_context as ctx:
             await self._ChipStack.CallAsync(
                 lambda: self._dmLib.pychip_DeviceController_OpenCommissioningWindow(
-                    self.devCtrl, self.pairingDelegate, nodeId, timeout, iteration, discriminator, option)
+                    self.devCtrl, self.pairingDelegate, nodeId, timeout, iteration, discriminator, option, setupPinCode)
             )
 
             return await asyncio.futures.wrap_future(ctx.future)
@@ -2935,7 +2938,7 @@ class ChipDeviceControllerBase:
             self._dmLib.pychip_DeviceController_GetCompressedFabricId.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_OpenCommissioningWindow.argtypes = [
-                c_void_p, c_void_p, c_uint64, c_uint16, c_uint32, c_uint16, c_uint8]
+                c_void_p, c_void_p, c_uint64, c_uint16, c_uint32, c_uint16, c_uint8, c_uint32]
             self._dmLib.pychip_DeviceController_OpenCommissioningWindow.restype = PyChipError
 
             try:

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1361,8 +1361,10 @@ class ChipDeviceControllerBase:
         kTokenWithRandomPin = 1
         kTokenWithProvidedPin = 2
 
-    async def OpenCommissioningWindow(self, nodeId: int, timeout: int, iteration: int,
-                                      discriminator: int, option: CommissioningWindowPasscode, setupPinCode: int = 0) -> CommissioningParameters:
+    async def OpenCommissioningWindow(
+            self, nodeId: int, timeout: int, iteration: int,
+            discriminator: int, option: CommissioningWindowPasscode,
+            setupPinCode: int = 0) -> CommissioningParameters:
         '''
         Opens a commissioning window on the device with the given node ID.
 

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -413,7 +413,8 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
                         break
                 except (ValueError, IndexError, KeyError, TypeError):
                     continue
-            asserts.assert_is_not_none(th1_root_cert, "Could not find TH1's root certificate in TrustedRootCertificates")
+            asserts.assert_is_not_none(
+                th1_root_cert, "Could not find TH1's root certificate in TrustedRootCertificates")
 
             try:
                 th1_root_parser = MatterCertParser(th1_root_cert)

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -34,6 +34,21 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run2:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 0
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+#     pre-existing-fabric: true
 # === END CI TEST ARGUMENTS ===
 
 import enum
@@ -384,15 +399,24 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
                 dev_ctrl=th1_dev_ctrl,
                 node_id=th1_dut_node_id,
                 cluster=opcreds,
-                attribute=opcreds.Attributes.TrustedRootCertificates,
-                fabric_filtered=True
+                attribute=opcreds.Attributes.TrustedRootCertificates
             )
-            asserts.assert_true(len(root_certs) == 1,
-                                f"Expecting exactly one root from TrustedRootCertificates (TH1's), got {len(root_certs)}")
 
             log.info("Parsing root certificate for TH1's fabric")
+            th1_root_public_key = th1_dev_ctrl.rootPublicKeyBytes
+            th1_root_cert = None
+            for cert in root_certs:
+                try:
+                    parser = MatterCertParser(cert)
+                    if parser.get_public_key_bytes() == th1_root_public_key:
+                        th1_root_cert = cert
+                        break
+                except (ValueError, IndexError, KeyError, TypeError):
+                    continue
+            asserts.assert_is_not_none(th1_root_cert, "Could not find TH1's root certificate in TrustedRootCertificates")
+
             try:
-                th1_root_parser = MatterCertParser(root_certs[0])
+                th1_root_parser = MatterCertParser(th1_root_cert)
                 th1_root_public_key = th1_root_parser.get_public_key_bytes()
             except (ValueError, IndexError, KeyError, TypeError) as e:
                 asserts.fail(f"Failed to parse root certificate for TH1's fabric: {str(e)}")
@@ -542,7 +566,8 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
 
         with test_step(5, description="Send bad SignVIDVerificationRequest commands and verify failures"):
             # Must fail with correct client challenge but non-existent fabric.
-            unassigned_fabric_index = get_unassigned_fabric_index(fabric_indices.values())
+            assigned_fabric_indices = [noc_struct.fabricIndex for noc_struct in nocs_list]
+            unassigned_fabric_index = get_unassigned_fabric_index(assigned_fabric_indices)
             with asserts.assert_raises(InteractionModelError) as exception_context:
                 await self.send_single_cmd(cmd=opcreds.Commands.SignVIDVerificationRequest(fabricIndex=unassigned_fabric_index, clientChallenge=client_challenge))
 

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -416,11 +416,6 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
             asserts.assert_is_not_none(
                 th1_root_cert, "Could not find TH1's root certificate in TrustedRootCertificates")
 
-            try:
-                th1_root_parser = MatterCertParser(th1_root_cert)
-                th1_root_public_key = th1_root_parser.get_public_key_bytes()
-            except (ValueError, IndexError, KeyError, TypeError) as e:
-                asserts.fail(f"Failed to parse root certificate for TH1's fabric: {str(e)}")
             log.info("Parsed TH1's RCAC successfully.")
             log.info("  -> Root public key bytes: %s", to_octet_string(th1_root_public_key))
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
@@ -70,15 +70,18 @@ class CommissionDeviceTest(MatterBaseTest):
 
         if self.matter_test_config.commission_only_re_open_window:
             for node_id, setup_payload in zip(self.dut_node_ids, self.setup_payloads):
-                logger.info(f"Opening commissioning window on node {node_id} using ECM with passcode {setup_payload.passcode}...")
+                logger.info(
+                    f"Opening commissioning window on node {node_id} using ECM with passcode "
+                    f"{setup_payload.passcode}...")
                 try:
+                    params = self.default_controller.CommissioningWindowPasscode
                     self.event_loop.run_until_complete(
                         self.default_controller.OpenCommissioningWindow(
                             nodeId=node_id,
                             timeout=900,
                             iteration=1000,
                             discriminator=setup_payload.filter_value,
-                            option=self.default_controller.CommissioningWindowPasscode.kTokenWithProvidedPin,
+                            option=params.kTokenWithProvidedPin,
                             setupPinCode=setup_payload.passcode
                         )
                     )

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
@@ -20,10 +20,13 @@ This module contains CommissionDeviceTest class designed to handle the commissio
 """
 
 
+import logging
 from mobly import signals
 
 from matter.testing.commissioning import CommissioningInfo, SetupPayloadInfo, commission_devices
 from matter.testing.matter_testing import MatterBaseTest
+
+logger = logging.getLogger(__name__)
 
 
 class CommissionDeviceTest(MatterBaseTest):
@@ -63,3 +66,22 @@ class CommissionDeviceTest(MatterBaseTest):
             commissioning_info=self.commissioning_info
         )):
             raise signals.TestAbortAll("Failed to commission node(s)")
+
+        if self.matter_test_config.commission_only_re_open_window:
+            for node_id, setup_payload in zip(self.dut_node_ids, self.setup_payloads):
+                logger.info(f"Opening commissioning window on node {node_id} using ECM with passcode {setup_payload.passcode}...")
+                try:
+                    self.event_loop.run_until_complete(
+                        self.default_controller.OpenCommissioningWindow(
+                            nodeId=node_id,
+                            timeout=900,
+                            iteration=1000,
+                            discriminator=setup_payload.filter_value,
+                            option=self.default_controller.CommissioningWindowPasscode.kTokenWithProvidedPin,
+                            setupPinCode=setup_payload.passcode
+                        )
+                    )
+                    logger.info("Commissioning window opened successfully.")
+                except Exception as e:
+                    logger.exception(f"Failed to open commissioning window on node {node_id}")
+                    raise signals.TestAbortAll(f"Failed to open commissioning window on node {node_id}: {str(e)}")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
@@ -21,6 +21,7 @@ This module contains CommissionDeviceTest class designed to handle the commissio
 
 
 import logging
+
 from mobly import signals
 
 from matter.testing.commissioning import CommissioningInfo, SetupPayloadInfo, commission_devices

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/CommissioningPreTest.py
@@ -70,9 +70,7 @@ class CommissionDeviceTest(MatterBaseTest):
 
         if self.matter_test_config.commission_only_re_open_window:
             for node_id, setup_payload in zip(self.dut_node_ids, self.setup_payloads):
-                logger.info(
-                    f"Opening commissioning window on node {node_id} using ECM with passcode "
-                    f"{setup_payload.passcode}...")
+                logger.info("Re-opening commissioning window on DUT")
                 try:
                     params = self.default_controller.CommissioningWindowPasscode
                     self.event_loop.run_until_complete(
@@ -87,5 +85,5 @@ class CommissionDeviceTest(MatterBaseTest):
                     )
                     logger.info("Commissioning window opened successfully.")
                 except Exception as e:
-                    logger.exception(f"Failed to open commissioning window on node {node_id}")
+                    logger.exception("Failed to open commissioning window")
                     raise signals.TestAbortAll(f"Failed to open commissioning window on node {node_id}: {str(e)}")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
@@ -29,6 +29,7 @@ class MatterTestConfig:
     paa_trust_store_path: pathlib.Path | None = None
     ble_controller: int | None = None
     commission_only: bool = False
+    commission_only_re_open_window: bool = False
     spec_errata_path: str | Traversable | None = None
 
     admin_vendor_id: int = TestingDefaults.ADMIN_VENDOR_ID

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
@@ -35,6 +35,7 @@ class Metadata:
     script_gdb: bool = False
     timeout: float | None = None
     quiet: bool = False
+    pre_existing_fabric: bool = False
 
 
 class NamedStringIO(StringIO):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
@@ -156,9 +156,9 @@ class MetadataReader:
                 script_args=attr.get("script-args"),
                 factory_reset=str(attr.get("factory-reset", False)).lower() == 'true',
                 timeout=float(attr["timeout"]) if "timeout" in attr else None,
-timeout=float(attr["timeout"]) if "timeout" in attr else None,
-quiet=str(attr.get("quiet", True)).lower() == 'true',
-pre_existing_fabric=str(attr.get("pre-existing-fabric", False)).lower() == 'true',
+                timeout=float(attr["timeout"]) if "timeout" in attr else None,
+                quiet=str(attr.get("quiet", True)).lower() == 'true',
+                pre_existing_fabric=str(attr.get("pre-existing-fabric", False)).lower() == 'true',
             ))
 
         return runs_metadata

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
@@ -158,6 +158,6 @@ class MetadataReader:
                 timeout=float(attr["timeout"]) if "timeout" in attr else None,
                 quiet=str(attr.get("quiet", True)).lower() == 'true',
                 pre_existing_fabric=str(attr.get("pre-existing-fabric", False)).lower() == 'true',
-))
+            ))
 
         return runs_metadata

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
@@ -156,7 +156,9 @@ class MetadataReader:
                 script_args=attr.get("script-args"),
                 factory_reset=str(attr.get("factory-reset", False)).lower() == 'true',
                 timeout=float(attr["timeout"]) if "timeout" in attr else None,
-                quiet=str(attr.get("quiet", True)).lower() == 'true',
+timeout=float(attr["timeout"]) if "timeout" in attr else None,
+quiet=str(attr.get("quiet", True)).lower() == 'true',
+pre_existing_fabric=str(attr.get("pre-existing-fabric", False)).lower() == 'true',
             ))
 
         return runs_metadata

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/metadata.py
@@ -156,9 +156,8 @@ class MetadataReader:
                 script_args=attr.get("script-args"),
                 factory_reset=str(attr.get("factory-reset", False)).lower() == 'true',
                 timeout=float(attr["timeout"]) if "timeout" in attr else None,
-                timeout=float(attr["timeout"]) if "timeout" in attr else None,
                 quiet=str(attr.get("quiet", True)).lower() == 'true',
                 pre_existing_fabric=str(attr.get("pre-existing-fabric", False)).lower() == 'true',
-            ))
+))
 
         return runs_metadata

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -460,7 +460,7 @@ def run_tests_no_exit(
                 runner.add_test_class(test_config, CommissionDeviceTest, None)
 
             # Add the tests selected unless we have a commission-only request
-            if not matter_test_config.commission_only:
+            if not matter_test_config.commission_only and not matter_test_config.commission_only_re_open_window:
                 runner.add_test_class(test_config, test_class, tests)
 
             if hooks:
@@ -633,6 +633,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
     config.commissioning_method = args.commissioning_method
     config.in_test_commissioning_method = args.in_test_commissioning_method
     config.commission_only = args.commission_only
+    config.commission_only_re_open_window = args.commission_only_re_open_window
 
     config.qr_code_content.extend(args.qr_code)
     config.manual_code.extend(args.manual_code)
@@ -1041,6 +1042,8 @@ def matter_test_args_parser() -> argparse.ArgumentParser:
 
     commission_group.add_argument('--commission-only', action="store_true", default=False,
                                   help="If true, test exits after commissioning without running subsequent tests")
+    commission_group.add_argument('--commission-only-re-open-window', action="store_true", default=False,
+                                  help="If true, test commissions, opens a commissioning window using the original passcode/discriminator, and then exits without running subsequent tests")
 
     commission_group.add_argument('--tc-version-to-simulate', type=int, help="Terms and conditions version")
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -1043,7 +1043,8 @@ def matter_test_args_parser() -> argparse.ArgumentParser:
     commission_group.add_argument('--commission-only', action="store_true", default=False,
                                   help="If true, test exits after commissioning without running subsequent tests")
     commission_group.add_argument('--commission-only-re-open-window', action="store_true", default=False,
-                                  help="If true, test commissions, opens a commissioning window using the original passcode/discriminator, and then exits without running subsequent tests")
+                                  help="If true, test commissions, opens a commissioning window using the original "
+                                       "passcode/discriminator, and then exits without running subsequent tests")
 
     commission_group.add_argument('--tc-version-to-simulate', type=int, help="Terms and conditions version")
 


### PR DESCRIPTION
Also includes changes to the python test runner to simulate this condition.

### Summary

This change lets OPCREDS-3.8 run if there is an existing fabric on the device. This can happen if the device uses custom commissioning. 

Also includes changes to allow the runner to simulate this condition.

For now, I'm only using this option on this one test, but eventually the plan is to run this condition on the nightly against all tests because we've had this issue show up a couple of times and it's hard to keep in mind when writing tests because it's such a weird corner case that doesn't happen on a lot of devices.

### Related issues

CCB 4370

### Testing

Add a runner to simulate this condition and a run on the test in the CI. Also validated locally. The plan in the future is to expand that check to all tests somehow, but for now this will check the changes in this PR.
