### PR TITLE
[Silabs] Fixed Si917 compatibility with clang.

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -82,7 +82,23 @@ config("siwx917-common-config") {
     defines += [ "SL_MATTER_USE_CODE_DRIVEN_DATA_MODEL=0" ]
   }
 
-  ldflags = [ "-Wl,--no-warn-rwx-segment" ]
+  ldflags = []
+  if (is_clang) {
+    ldflags += [
+      "-Wl,--allow-multiple-definition",  # allow overrides from memory manager
+
+      # Group so lld resolves libc<-->nosys (_sbrk) regardless of -l order.
+      "-Wl,--start-group",
+      "-lc_nano",  # stdlib functions (e.g. snprintf)
+      "-lstdc++_nano",  # C++ stdlib functions (e.g. sprintf)
+      "-lgcc",  # ARM EABI runtime functions (soft-float, 64-bit ops, etc.)
+      "-lnosys",  # newlib syscall stubs (e.g. _sbrk); GCC gets this via
+                  # nosys.specs
+      "-Wl,--end-group",
+    ]
+  } else {
+    ldflags += [ "-Wl,--no-warn-rwx-segment" ]
+  }
 }
 
 source_set("siwx917-common") {

--- a/examples/platform/silabs/ldscripts/SiWx917-common-clang.ld
+++ b/examples/platform/silabs/ldscripts/SiWx917-common-clang.ld
@@ -79,6 +79,24 @@ SECTIONS
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)			
 	} > rom 
 	__exidx_end = .;
+	/* startup_si91x.c Copy_Table / Zero_Table */
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (LOADADDR(.data))
+		LONG (__data_start__)
+		LONG ((__data_end__ - __data_start__) / 4)
+		__copy_table_end__ = .;
+	} > rom
+
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		__zero_table_end__ = .;
+	} > rom
+
 	__etext = .;
 	
 

--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -36,6 +36,8 @@ source_set("storage") {
   if (wifi_soc) {
     if (sl_si91x_crypto_flavor == "psa") {
       libs = [ "${sl_provision_root}/libs/libProvisionPSA-si917.a" ]
+    } else if (is_clang) {
+      libs = [ "${sl_provision_root}/libs/libProvision-si917-clang.a" ]
     } else {
       libs = [ "${sl_provision_root}/libs/libProvision-si917.a" ]
     }

--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -35,7 +35,11 @@ source_set("storage") {
 
   if (wifi_soc) {
     if (sl_si91x_crypto_flavor == "psa") {
-      libs = [ "${sl_provision_root}/libs/libProvisionPSA-si917.a" ]
+      if (is_clang) {
+        libs = [ "${sl_provision_root}/libs/libProvisionPSA-si917-clang.a" ]
+      } else {
+        libs = [ "${sl_provision_root}/libs/libProvisionPSA-si917.a" ]
+      }
     } else if (is_clang) {
       libs = [ "${sl_provision_root}/libs/libProvision-si917-clang.a" ]
     } else {

--- a/examples/platform/silabs/syscalls_stubs.cpp
+++ b/examples/platform/silabs/syscalls_stubs.cpp
@@ -251,9 +251,8 @@ void __attribute__((weak)) exit(int status)
     static const char kExitMessage[] = "exit not supported, resetting system...\r\n";
     _write(0, kExitMessage, sizeof(kExitMessage) - 1);
     NVIC_SystemReset();
-    while (1)
-    {
-    } // Unreachable, satisfies noreturn attribute
+    // Unreachable, satisfies noreturn attribute
+    __builtin_unreachable();
 }
 
 #ifdef __cplusplus

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -155,6 +155,7 @@ typedef struct
 #if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE
 #define UART_MAX_QUEUE_SIZE 125
 #else
+static constexpr uint32_t kUartTxCompleteFlag = 1;
 #if CHIP_DETAIL_LOGGING
 #define UART_MAX_QUEUE_SIZE 60
 #else
@@ -166,7 +167,6 @@ typedef struct
 
 #define SILABS_TRUNCATED_TERMINATOR "....."
 
-static constexpr uint32_t kUartTxCompleteFlag = 1;
 static osThreadId_t sUartTaskHandle;
 constexpr uint32_t kUartTaskSize = 1024;
 static uint8_t uartStack[kUartTaskSize];

--- a/src/platform/silabs/ConnectivityManagerImpl.h
+++ b/src/platform/silabs/ConnectivityManagerImpl.h
@@ -36,7 +36,7 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-#include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
 #else
 #include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
 #endif

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -39,6 +39,8 @@
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.ipp>
 #endif
 
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
+
 #include "CHIPDevicePlatformConfig.h"
 #include <platform/silabs/wifi/WifiInterface.h>
 

--- a/src/platform/silabs/PlatformManagerImpl.cpp
+++ b/src/platform/silabs/PlatformManagerImpl.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 #endif // !SLI_SI91X_MCU_INTERFACE
     /* Set RNG function for tinycrypt operations. */
     rngMutexHandle = osMutexNew(nullptr);
-    VerifyOrExit((&rngMutexHandle != nullptr), err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit((rngMutexHandle != nullptr), err = CHIP_ERROR_NO_MEMORY);
     uECC_set_rng(PlatformManagerImpl::uECC_RNG_Function);
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 

--- a/src/platform/silabs/SiWx/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx/OTAImageProcessorImpl.cpp
@@ -312,8 +312,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
                     }
                     else
                     {
-                        ChipLogError(SoftwareUpdate, "ERROR: In HandleProcessBlock sl_si91x_fwup_load() error 0x%" PRIx32,
-                                     status);
+                        ChipLogError(SoftwareUpdate, "ERROR: In HandleProcessBlock sl_si91x_fwup_load() error 0x%" PRIx32, status);
                         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
                         return;
                     }

--- a/src/platform/silabs/SiWx/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx/OTAImageProcessorImpl.cpp
@@ -186,7 +186,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
         // Account for last bytes of the image not yet written to storage
         imageProcessor->mParams.downloadedBytes += writeBufOffset;
         status = sl_si91x_fwup_load(writeBuffer, writeBufOffset);
-        ChipLogProgress(SoftwareUpdate, "status: 0x%lX", status);
+        ChipLogProgress(SoftwareUpdate, "status: 0x%" PRIx32, static_cast<uint32_t>(status));
 
         if (status != SL_STATUS_OK)
         {
@@ -196,7 +196,8 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
             }
             else
             {
-                ChipLogError(SoftwareUpdate, "ERROR: In HandleFinalize for last chunk sl_si91x_fwup_load() error 0x%lx", status);
+                ChipLogError(SoftwareUpdate, "ERROR: In HandleFinalize for last chunk sl_si91x_fwup_load() error 0x%" PRIx32,
+                             static_cast<uint32_t>(status));
                 imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
                 return;
             }
@@ -311,7 +312,8 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
                     }
                     else
                     {
-                        ChipLogError(SoftwareUpdate, "ERROR: In HandleProcessBlock sl_si91x_fwup_load() error 0x%lx", status);
+                        ChipLogError(SoftwareUpdate, "ERROR: In HandleProcessBlock sl_si91x_fwup_load() error 0x%" PRIx32,
+                                     status);
                         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
                         return;
                     }
@@ -336,7 +338,7 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
         ReturnErrorOnFailure(error);
 
         // SL TODO -- store version somewhere
-        ChipLogProgress(SoftwareUpdate, "Image Header software version: %ld payload size: %lu", header.mSoftwareVersion,
+        ChipLogProgress(SoftwareUpdate, "Image Header software version: %" PRIu32 " payload size: %lu", header.mSoftwareVersion,
                         (long unsigned int) header.mPayloadSize);
         mParams.totalFileBytes = header.mPayloadSize;
         mHeaderParser.Clear();

--- a/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+++ b/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
@@ -28,6 +28,7 @@
 
 #include "sl_si91x_ble_init.h"
 #include <ble/Ble.h>
+#include <cinttypes>
 #include <crypto/RandUtils.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -81,8 +82,6 @@ namespace {
 #define TIMER_MS_2_TIMERTICK(ms) ((TIMER_CLK_FREQ * ms) / 1000)
 #define TIMER_S_2_TIMERTICK(s) (TIMER_CLK_FREQ * s)
 
-const uint8_t UUID_CHIPoBLEService[]      = { 0xFB, 0x34, 0x9B, 0x5F, 0x80, 0x00, 0x00, 0x80,
-                                              0x00, 0x10, 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x00 };
 const uint8_t ShortUUID_CHIPoBLEService[] = { 0xF6, 0xFF };
 
 static uint8_t randomAddrBLE[RSI_BLE_ADDR_LENGTH] = { 0 };
@@ -115,9 +114,9 @@ void rsi_ble_add_matter_service(void)
     constexpr uuid_t custom_characteristic_RX = { .size     = RSI_BLE_CUSTOM_CHARACTERISTIC_RX_SIZE,
                                                   .reserved = { RSI_BLE_CUSTOM_CHARACTERISTIC_RX_RESERVED },
                                                   .val      = { .val128 = {
-                                                                    .data1 = { RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_1 },
-                                                                    .data2 = { RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_2 },
-                                                                    .data3 = { RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_3 },
+                                                                    .data1 = RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_1,
+                                                                    .data2 = RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_2,
+                                                                    .data3 = RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_3,
                                                                     .data4 = { RSI_BLE_CUSTOM_CHARACTERISTIC_RX_VALUE_128_DATA_4 } } } };
 
     rsi_ble_resp_add_serv_t new_serv_resp = { 0 };
@@ -139,9 +138,9 @@ void rsi_ble_add_matter_service(void)
     constexpr uuid_t custom_characteristic_TX = { .size     = RSI_BLE_CUSTOM_CHARACTERISTIC_TX_SIZE,
                                                   .reserved = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_RESERVED },
                                                   .val      = { .val128 = {
-                                                                    .data1 = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_1 },
-                                                                    .data2 = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_2 },
-                                                                    .data3 = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_3 },
+                                                                    .data1 = RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_1,
+                                                                    .data2 = RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_2,
+                                                                    .data3 = RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_3,
                                                                     .data4 = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_VALUE_128_DATA_4 } } } };
 
     // Adding custom characteristic declaration to the custom service
@@ -241,7 +240,7 @@ void BLEManagerImpl::BlePostEvent(SilabsBleWrapper::BleEvent_t * event)
     sl_status_t status = osMessageQueuePut(sInstance.sBleEventQueue, event, 0, 0);
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "BlePostEvent: failed to post event: 0x%lx", status);
+        ChipLogError(DeviceLayer, "BlePostEvent: failed to post event: 0x%" PRIx32, static_cast<uint32_t>(status));
         // TODO: Handle error, requeue event depending on queue size or notify relevant task, Chipdie, etc.
     }
 }
@@ -274,7 +273,8 @@ void BLEManagerImpl::sl_ble_event_handling_task(void * args)
         }
         else
         {
-            ChipLogError(DeviceLayer, "sl_ble_event_handling_task: get event failed: 0x%lx", static_cast<uint32_t>(status));
+            ChipLogError(DeviceLayer, "sl_ble_event_handling_task: get event failed: 0x%" PRIx32,
+                         static_cast<uint32_t>(status));
         }
     }
 }
@@ -519,7 +519,7 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Chi
     status         = rsi_ble_indicate_value(dev_address, rsi_ble_measurement_hndl, data->DataLength(), data->Start());
     if (status != RSI_SUCCESS)
     {
-        ChipLogProgress(DeviceLayer, "indication failed with error code %lx ", status);
+        ChipLogProgress(DeviceLayer, "indication failed with error code 0x%" PRIx32, static_cast<uint32_t>(status));
         return BLE_ERROR_GATT_INDICATE_FAILED;
     }
 
@@ -661,12 +661,12 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     if (result != SL_STATUS_OK)
     {
         //    err = MapBLEError(result);
-        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() failed: %ld", result);
+        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() failed: 0x%" PRIx32, static_cast<uint32_t>(result));
         ExitNow();
     }
     else
     {
-        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() success: %ld", result);
+        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() success: 0x%" PRIx32, static_cast<uint32_t>(result));
     }
     index                 = 0;
     responseData[index++] = 0x02;                     // length
@@ -703,7 +703,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         status = rsi_ble_stop_advertising();
         if (status != RSI_SUCCESS)
         {
-            ChipLogProgress(DeviceLayer, "advertising failed to stop, with status = 0x%lx ", status);
+            ChipLogProgress(DeviceLayer, "advertising failed to stop, with status = 0x%" PRIx32, static_cast<uint32_t>(status));
         }
     }
     else
@@ -744,7 +744,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     }
     else
     {
-        ChipLogProgress(DeviceLayer, "rsi_ble_start_advertising Failed with status: %lx", status);
+        ChipLogProgress(DeviceLayer, "rsi_ble_start_advertising Failed with status: 0x%" PRIx32, static_cast<uint32_t>(status));
     }
 
 exit:

--- a/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+++ b/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
@@ -273,8 +273,7 @@ void BLEManagerImpl::sl_ble_event_handling_task(void * args)
         }
         else
         {
-            ChipLogError(DeviceLayer, "sl_ble_event_handling_task: get event failed: 0x%" PRIx32,
-                         static_cast<uint32_t>(status));
+            ChipLogError(DeviceLayer, "sl_ble_event_handling_task: get event failed: 0x%" PRIx32, static_cast<uint32_t>(status));
         }
     }
 }

--- a/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+++ b/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
@@ -661,12 +661,12 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     if (result != SL_STATUS_OK)
     {
         //    err = MapBLEError(result);
-        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() failed: 0x%" PRIx32, static_cast<uint32_t>(result));
+        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() failed: %" PRIu32, static_cast<uint32_t>(result));
         ExitNow();
     }
     else
     {
-        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() success: 0x%" PRIx32, static_cast<uint32_t>(result));
+        ChipLogError(DeviceLayer, "rsi_ble_set_advertise_data() success: %" PRIu32, static_cast<uint32_t>(result));
     }
     index                 = 0;
     responseData[index++] = 0x02;                     // length

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -126,7 +126,7 @@ int soc_pll_config(void)
     status                                  = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
     if (status != RSI_OK)
     {
-        ChipLogError(DeviceLayer, "Failed to Config Interface PLL Clock, status: %ld", status);
+        ChipLogError(DeviceLayer, "Failed to Config Interface PLL Clock, status: 0x%" PRIx32, status);
     }
     else
     {

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -807,7 +807,7 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
 {
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%" PRIx32, error));
+                        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: %" PRIu32, error));
 
     sl_wifi_performance_profile_v2_t wifi_profile = { .profile           = ConvertPowerSaveConfiguration(configuration),
                                                       .dtim_aligned_type = SL_SI91X_ALIGN_WITH_BEACON,

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -241,21 +241,23 @@ sl_status_t SiWxPlatformInit(void)
     // SoC Configurations
     uint8_t xtal_enable = 1;
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, nullptr);
-    VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, status,
+        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 #endif // SLI_SI91X_MCU_INTERFACE
 
     sl_wifi_firmware_version_t version = { 0 };
     status                             = sl_wifi_get_firmware_version(&version);
-    VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, status,
+        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     ChipLogDetail(DeviceLayer, "Firmware version is: %x%x.%d.%d.%d.%d.%d.%d", version.chip_id, version.rom_id, version.major,
                   version.minor, version.security_version, version.patch_num, version.customer_id, version.build_num);
 
     status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, reinterpret_cast<sl_mac_address_t *>(wfx_rsi.sta_mac.data()));
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%lx", static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
 #ifdef SL_MBEDTLS_USE_TINYCRYPT
     constexpr uint32_t trngKey[TRNG_KEY_SIZE] = { 0x16157E2B, 0xA6D2AE28, 0x8815F7AB, 0x3C4FCF09 };
@@ -263,12 +265,13 @@ sl_status_t SiWxPlatformInit(void)
     // To check the Entropy of TRNG and verify TRNG functioning.
     status = sl_si91x_trng_entropy();
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%lx", static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     // Initiate and program the key required for TRNG hardware engine
     status = sl_si91x_trng_program_key((uint32_t *) trngKey, TRNG_KEY_SIZE);
-    VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, status,
+        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 
     wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationInit);
@@ -283,7 +286,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
         if (scan_result != nullptr)
         {
             status = *reinterpret_cast<sl_status_t *>(scan_result);
-            ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%lx", status);
+            ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%" PRIx32, status);
         }
         // SET FALLBACK VALUES FOR THE SCAN
         wfx_rsi.ap_chan = SL_WIFI_AUTO_CHANNEL;
@@ -307,7 +310,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
 sl_status_t InitiateScan()
 {
     sl_status_t status                                   = SL_STATUS_OK;
-    sl_wifi_ssid_t ssid                                  = { 0 };
+    sl_wifi_ssid_t ssid                                  = { { 0 } };
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 
     ssid.length = wfx_rsi.credentials.ssidLen;
@@ -329,7 +332,8 @@ sl_status_t InitiateScan()
     }
 
     osMutexRelease(sScanInProgressSemaphore);
-    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogProgress(DeviceLayer, "sl_wifi_start_scan failed: 0x%lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, status,
+                        ChipLogProgress(DeviceLayer, "sl_wifi_start_scan failed: 0x%" PRIx32, status));
 
     return status;
 }
@@ -345,7 +349,7 @@ sl_status_t SetWifiConfigurations()
     };
     status = sl_wifi_set_listen_interval_v2(SL_WIFI_CLIENT_INTERFACE, sleep_interval);
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_listen_interval_v2 failed: 0x%lx", status));
+                        ChipLogError(DeviceLayer, "sl_wifi_set_listen_interval_v2 failed: 0x%" PRIx32, status));
 
     // This is be triggered on the disconnect use case, providing the amount of TA tries
     // Setting the TA retry to 1 and giving the control to the M4 for improved power efficiency
@@ -353,7 +357,7 @@ sl_status_t SetWifiConfigurations()
     sl_wifi_advanced_client_configuration_t client_config = { .max_retry_attempts = 1 };
     status = sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_advanced_client_configuration failed: 0x%lx", status));
+                        ChipLogError(DeviceLayer, "sl_wifi_set_advanced_client_configuration failed: 0x%" PRIx32, status));
     join_feature_bitmap |= SL_SI91X_JOIN_FEAT_PS_CMD_LISTEN_INTERVAL_VALID;
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
@@ -362,7 +366,7 @@ sl_status_t SetWifiConfigurations()
         status = sl_net_set_credential(SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID, SL_NET_WIFI_PSK, &wfx_rsi.credentials.key[0],
                                        wfx_rsi.credentials.keyLen);
         VerifyOrReturnError(status == SL_STATUS_OK, status,
-                            ChipLogError(DeviceLayer, "sl_net_set_credential failed: 0x%lx", status));
+                            ChipLogError(DeviceLayer, "sl_net_set_credential failed: 0x%" PRIx32, status));
     }
 
     sl_net_wifi_client_profile_t profile = {
@@ -416,10 +420,11 @@ sl_status_t SetWifiConfigurations()
 
     status = sl_wifi_set_join_configuration(SL_WIFI_CLIENT_INTERFACE, join_feature_bitmap);
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_join_configuration failed: 0x%lx", status));
+                        ChipLogError(DeviceLayer, "sl_wifi_set_join_configuration failed: 0x%" PRIx32, status));
 
     status = sl_net_set_profile(SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID, &profile);
-    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, status,
+                        ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%" PRIx32, status));
 
     return status;
 }
@@ -478,8 +483,9 @@ void WifiInterfaceImpl::MatterWifiTask(void * arg)
     sl_status_t status = SL_STATUS_OK;
 
     status = SiWxPlatformInit();
-    VerifyOrReturn(status == SL_STATUS_OK,
-                   ChipLogError(DeviceLayer, "MatterWifiTask: SiWxPlatformInit failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturn(
+        status == SL_STATUS_OK,
+        ChipLogError(DeviceLayer, "MatterWifiTask: SiWxPlatformInit failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Remove High performance request after the device is initialized
@@ -497,7 +503,7 @@ void WifiInterfaceImpl::MatterWifiTask(void * arg)
         }
         else
         {
-            ChipLogError(DeviceLayer, "MatterWifiTask: get event failed: 0x%lx", static_cast<uint32_t>(status));
+            ChipLogError(DeviceLayer, "MatterWifiTask: get event failed: 0x%" PRIx32, static_cast<uint32_t>(status));
         }
     }
 }
@@ -515,7 +521,8 @@ CHIP_ERROR WifiInterfaceImpl::InitWiFiStack(void)
     sl_wifi_device_configuration_t deviceConfiguration = SLNetGetDeviceConfig();
 
     status = sl_net_init(SL_NET_WIFI_CLIENT_INTERFACE, &deviceConfiguration, &wifi_client_context, nullptr);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "sl_net_init failed: %lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "sl_net_init failed: 0x%" PRIx32, status));
 
     // Create Sempaphore for scan completion
     sScanCompleteSemaphore = osSemaphoreNew(1, 0, nullptr);
@@ -531,7 +538,7 @@ CHIP_ERROR WifiInterfaceImpl::InitWiFiStack(void)
 #ifndef SL_MBEDTLS_USE_TINYCRYPT
     // PSA Crypto initialization
     VerifyOrReturnError(psa_crypto_init() == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "psa_crypto_init failed: %lx", static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "psa_crypto_init failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 #endif // SL_MBEDTLS_USE_TINYCRYPT
     return CHIP_NO_ERROR;
 }
@@ -586,6 +593,7 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
     case WifiPlatformEvent::kConnectionComplete:
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kConnectionComplete");
         NotifySuccessfulConnection();
+        break;
 
     default:
         break;
@@ -652,7 +660,7 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
     }
 
     // failure only happens when the firmware returns an error
-    ChipLogError(DeviceLayer, "sl_net_up failed: 0x%lx", static_cast<uint32_t>(status));
+    ChipLogError(DeviceLayer, "sl_net_up failed: 0x%" PRIx32, static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting).Clear(WifiInterface::WifiState::kStationConnected);
     mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
@@ -681,7 +689,7 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         status = *reinterpret_cast<sl_status_t *>(result);
-        ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%" PRIx32, status);
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
 
         mInstance.mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
@@ -780,7 +788,7 @@ void WifiInterfaceImpl::PostWifiPlatformEvent(WifiPlatformEvent event)
 
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "PostWifiPlatformEvent: failed to post event with status: %ld", status);
+        ChipLogError(DeviceLayer, "PostWifiPlatformEvent: failed to post event with status: 0x%" PRIx32, status);
         // TODO: Handle error, requeue event depending on queue size or notify relevant task,
         // Chipdie, etc.
     }
@@ -789,7 +797,7 @@ void WifiInterfaceImpl::PostWifiPlatformEvent(WifiPlatformEvent event)
 sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 {
     sl_status_t status = sl_net_down(SL_NET_WIFI_CLIENT_INTERFACE);
-    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_down failed: 0x%lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_down failed: 0x%" PRIx32, status));
 
     return SL_STATUS_OK;
 }
@@ -799,7 +807,7 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
 {
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: %ld", error));
+                        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%" PRIx32, error));
 
     sl_wifi_performance_profile_v2_t wifi_profile = { .profile           = ConvertPowerSaveConfiguration(configuration),
                                                       .dtim_aligned_type = SL_SI91X_ALIGN_WITH_BEACON,
@@ -807,7 +815,7 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
 
     sl_status_t status = sl_wifi_set_performance_profile_v2(&wifi_profile);
     VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile_v2 failed: 0x%lx", status));
+                        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile_v2 failed: 0x%" PRIx32, status));
 
     return CHIP_NO_ERROR;
 }
@@ -820,8 +828,9 @@ CHIP_ERROR WifiInterfaceImpl::ConfigureBroadcastFilter(bool enableBroadcastFilte
     uint8_t filterBcastInTim     = (enableBroadcastFilter) ? 1 : 0;
 
     status = sl_wifi_filter_broadcast(beaconDropThreshold, filterBcastInTim, 1 /* valid till next update*/);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     return CHIP_NO_ERROR;
 }
@@ -875,7 +884,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     if (status != SL_STATUS_OK)
     {
         // Since the log is required for debugging and the error log is present in the invoker itself
-        ChipLogDetail(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%lx", static_cast<uint32_t>(status));
+        ChipLogDetail(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%" PRIx32, static_cast<uint32_t>(status));
 
         // Reset the scan state in case of failure
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kScanStarted);
@@ -885,7 +894,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     }
 
     // If an ssid was not provided, we need to call sl_wifi_start_scan with nullptr to scan all Wi-Fi networks
-    sl_wifi_ssid_t requestedSsid      = { 0 };
+    sl_wifi_ssid_t requestedSsid      = { { 0 } };
     sl_wifi_ssid_t * requestedSsidPtr = nullptr;
 
     if (!ssid.empty())
@@ -916,7 +925,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     if (status != SL_STATUS_OK && status != SL_STATUS_IN_PROGRESS)
     {
         // Since the log is required for debugging and the error log is present in the invoker itself
-        ChipLogDetail(DeviceLayer, "sl_wifi_start_scan failed: 0x%04lx", static_cast<uint32_t>(status));
+        ChipLogDetail(DeviceLayer, "sl_wifi_start_scan failed: 0x04%" PRIx32, static_cast<uint32_t>(status));
 
         // Reset the scan state in case of failure
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kScanStarted);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -269,9 +269,8 @@ sl_status_t SiWxPlatformInit(void)
 
     // Initiate and program the key required for TRNG hardware engine
     status = sl_si91x_trng_program_key((uint32_t *) trngKey, TRNG_KEY_SIZE);
-    VerifyOrReturnError(
-        status == SL_STATUS_OK, status,
-        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
+    VerifyOrReturnError(status == SL_STATUS_OK, status,
+                        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 
     wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationInit);
@@ -423,8 +422,7 @@ sl_status_t SetWifiConfigurations()
                         ChipLogError(DeviceLayer, "sl_wifi_set_join_configuration failed: 0x%" PRIx32, status));
 
     status = sl_net_set_profile(SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID, &profile);
-    VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%" PRIx32, status));
+    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%" PRIx32, status));
 
     return status;
 }
@@ -483,9 +481,8 @@ void WifiInterfaceImpl::MatterWifiTask(void * arg)
     sl_status_t status = SL_STATUS_OK;
 
     status = SiWxPlatformInit();
-    VerifyOrReturn(
-        status == SL_STATUS_OK,
-        ChipLogError(DeviceLayer, "MatterWifiTask: SiWxPlatformInit failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
+    VerifyOrReturn(status == SL_STATUS_OK,
+                   ChipLogError(DeviceLayer, "MatterWifiTask: SiWxPlatformInit failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Remove High performance request after the device is initialized
@@ -828,9 +825,8 @@ CHIP_ERROR WifiInterfaceImpl::ConfigureBroadcastFilter(bool enableBroadcastFilte
     uint8_t filterBcastInTim     = (enableBroadcastFilter) ? 1 : 0;
 
     status = sl_wifi_filter_broadcast(beaconDropThreshold, filterBcastInTim, 1 /* valid till next update*/);
-    VerifyOrReturnError(
-        status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -124,7 +124,7 @@ void WifiInterface::ResetIPNotificationStates()
 
 void WifiInterface::NotifyWifiTaskInitialized(void)
 {
-    sl_wfx_startup_ind_t evt = { 0 };
+    sl_wfx_startup_ind_t evt = { { 0 } };
 
     // TODO: We should move this to the init function and not the notification function
     // Creating a timer which will be used to retry connection with AP


### PR DESCRIPTION
### Summary

Fix build errors found when compiling Si917 with clang.

### Related issues

[MATTER-6757](https://jira.silabs.com/browse/MATTER-6757)

### Testing

* BRD4338A built with clang, and commission successfully.
* BRD4338A built without clang, and commission successfully.
