### PR TITLE
[crypto] Validate CSR subject key type on mbedTLS backend

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -99,6 +99,7 @@ CHIP_ERROR VerifyCertificateSigningRequest(const uint8_t * csr_buf, size_t csr_l
 #else
     {
         mbedtls_ecp_keypair * keypair = mbedtls_pk_ec(csr.CHIP_CRYPTO_PAL_PRIVATE_X509(pk));
+        VerifyOrExit(keypair != nullptr, error = CHIP_ERROR_WRONG_KEY_TYPE);
 
         // Copy the public key from the CSR
         result =


### PR DESCRIPTION
#### Summary

`VerifyCertificateSigningRequest()` on the pre-4.0 mbedTLS backend did not validate the subject public key type before extracting it. This adds that validation so it matches the PSA / mbedTLS 4.0 path, which validates the subject key type during `mbedtls_pk_import_into_psa()`.

#### Changes

- `src/crypto/CHIPCryptoPALmbedTLSCert.cpp`: validate the subject key type in `VerifyCertificateSigningRequest()`.

#### Testing

- `ninja -C out/linux-x64-tests-mbedtls-asan-clang src/crypto/tests:TestChipCryptoPAL` builds and the existing `TestChipCryptoPAL.TestCSR_Verify` suite passes.