### PR TITLE
bound component and forecast list length in commodity-price copy

### DIFF
--- a/src/app/clusters/commodity-price-server/commodity-price-server.cpp
+++ b/src/app/clusters/commodity-price-server/commodity-price-server.cpp
@@ -424,6 +424,10 @@ CHIP_ERROR Instance::CopyPrice(const DataModel::Nullable<Structs::CommodityPrice
         if (src.Value().components.HasValue())
         {
             auto & components = src.Value().components.Value();
+            if (components.size() > kMaxComponentsPerPriceEntry)
+            {
+                return CHIP_ERROR_BAD_REQUEST;
+            }
             if (!mOwnedCurrentPriceComponentBuffer.Calloc(components.size()))
             {
                 return CHIP_ERROR_NO_MEMORY;
@@ -586,6 +590,10 @@ CHIP_ERROR Instance::CopyPriceForecast(const DataModel::List<const Structs::Comm
     // At this point our local storage should be unallocated
 
     size_t entries = src.size();
+    if (entries > kMaxForecastEntries)
+    {
+        return CHIP_ERROR_BAD_REQUEST;
+    }
     if (!mOwnedForecastPriceStructBuffer.Calloc(entries))
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/app/clusters/commodity-price-server/commodity-price-server.cpp
+++ b/src/app/clusters/commodity-price-server/commodity-price-server.cpp
@@ -377,6 +377,12 @@ CHIP_ERROR Instance::CopyCharSpan(const CharSpan src, Platform::ScopedMemoryBuff
 
 CHIP_ERROR Instance::CopyPrice(const DataModel::Nullable<Structs::CommodityPriceStruct::Type> & src)
 {
+    // Reject an oversize component list before freeing the previous state so a
+    // rejected value leaves mCurrentPrice untouched.
+    if (!src.IsNull() && src.Value().components.HasValue() && (src.Value().components.Value().size() > kMaxComponentsPerPriceEntry))
+    {
+        return CHIP_ERROR_BAD_REQUEST;
+    }
 
     // Free the priceStruct
     if (mOwnedCurrentPriceStructBuffer.Get() != nullptr)
@@ -424,10 +430,6 @@ CHIP_ERROR Instance::CopyPrice(const DataModel::Nullable<Structs::CommodityPrice
         if (src.Value().components.HasValue())
         {
             auto & components = src.Value().components.Value();
-            if (components.size() > kMaxComponentsPerPriceEntry)
-            {
-                return CHIP_ERROR_BAD_REQUEST;
-            }
             if (!mOwnedCurrentPriceComponentBuffer.Calloc(components.size()))
             {
                 return CHIP_ERROR_NO_MEMORY;
@@ -585,15 +587,17 @@ CHIP_ERROR Instance::CopyPriceStructWithinForecast(
 
 CHIP_ERROR Instance::CopyPriceForecast(const DataModel::List<const Structs::CommodityPriceStruct::Type> & src)
 {
-
-    CheckAndFreeForecastBuffers();
-    // At this point our local storage should be unallocated
-
+    // Reject an oversize list before freeing the previous state so a rejected
+    // value leaves mPriceForecast untouched.
     size_t entries = src.size();
     if (entries > kMaxForecastEntries)
     {
         return CHIP_ERROR_BAD_REQUEST;
     }
+
+    CheckAndFreeForecastBuffers();
+    // At this point our local storage should be unallocated
+
     if (!mOwnedForecastPriceStructBuffer.Calloc(entries))
     {
         return CHIP_ERROR_NO_MEMORY;


### PR DESCRIPTION
### Summary

copyprice and copypriceforecast in commodity-price-server deep-copy an incoming price list into fixed member arrays without bounding the list length. copyprice indexes mOwnedCurrentPriceComponentDescriptionBuffer (sized kMaxComponentsPerPriceEntry) by components.size(), and copypriceforecast indexes the mOwnedForecastPrice* arrays (sized kMaxForecastEntries) by src.size(), so a list longer than the array writes past its end through the per-entry ScopedMemoryBuffer free/calloc/memcpy. the sibling copypricestructwithinforecast already rejects an oversize component list with CHIP_ERROR_BAD_REQUEST; add the same cap to both paths so they agree with it.

### Related issues

None.

### Testing

reproduced the out-of-bounds write with an address-sanitizer harness that mirrors the fixed-array indexing: clean at the array size, buffer-overflow once the list exceeds it, and with the caps in place both functions return CHIP_ERROR_BAD_REQUEST instead. no unit test is added because this cluster has no test harness and the setters run through the server reporting and event path.
