### PR TITLE
fix inverted device name length guard in BLE managers

### DIFF
--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -437,7 +437,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
 
     if (deviceName != NULL && deviceName[0] != 0)
     {
-        VerifyOrExit(strlen(deviceName) >= kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(strlen(deviceName) < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
         strcpy(mDeviceName, deviceName);
         // Configure the BLE device name.
 #if defined(CONFIG_MATTER_BLEMGR_ADAPTER) && CONFIG_MATTER_BLEMGR_ADAPTER

--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -437,7 +437,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
 
     if (deviceName != NULL && deviceName[0] != 0)
     {
-        VerifyOrExit(strlen(deviceName) < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(strlen(deviceName) <= kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
         strcpy(mDeviceName, deviceName);
         // Configure the BLE device name.
 #if defined(CONFIG_MATTER_BLEMGR_ADAPTER) && CONFIG_MATTER_BLEMGR_ADAPTER

--- a/src/platform/Beken/BLEManagerImpl.cpp
+++ b/src/platform/Beken/BLEManagerImpl.cpp
@@ -473,7 +473,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
 
     if (deviceName != NULL && deviceName[0] != 0)
     {
-        VerifyOrExit(strlen(deviceName) >= kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(strlen(deviceName) < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
         strcpy(mDeviceName, deviceName);
         mFlags.Set(Flags::kDeviceNameSet);
         ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);

--- a/src/platform/Beken/BLEManagerImpl.cpp
+++ b/src/platform/Beken/BLEManagerImpl.cpp
@@ -473,7 +473,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
 
     if (deviceName != NULL && deviceName[0] != 0)
     {
-        VerifyOrExit(strlen(deviceName) < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(strlen(deviceName) <= kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
         strcpy(mDeviceName, deviceName);
         mFlags.Set(Flags::kDeviceNameSet);
         ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -1000,7 +1000,7 @@ CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
                         ChipLogError(DeviceLayer, "bt_adapter_get_name() failed: %s", get_error_message(ret)));
 
     VerifyOrReturnError(deviceName, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(strlen(deviceName.get()) >= bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(strlen(deviceName.get()) < bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     chip::Platform::CopyString(buf, bufSize, deviceName.get());
     ChipLogProgress(DeviceLayer, "BLE device name: %s", buf);


### PR DESCRIPTION
### Summary

The Beken and Ameba `_SetDeviceName` guards read `VerifyOrExit(strlen(deviceName) >= kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT)`. `VerifyOrExit` takes the error path when its condition is false, so the comparison is backwards: every name that fits is rejected, and the unbounded `strcpy(mDeviceName, deviceName)` is reached only when the name is too long. `mDeviceName` is `char[kMaxDeviceNameLength + 1]` (17 bytes) in both headers, so a 40-character name coming through `ConnectivityMgr().SetBLEDeviceName()` writes 41 bytes over the adjacent members.

Tizen `_GetDeviceName` carries the same inversion against `bufSize`. `Platform::CopyString` keeps that one in bounds, but the function still reports `CHIP_ERROR_BUFFER_TOO_SMALL` for adapter names that do fit, and silently truncates the ones that do not.

The other thirteen platform BLE managers (Linux, NuttX, webos, ESP32 bluedroid/nimble, silabs efr32/SiWx, realtek freertos/zephyr, nxp, Infineon CYW30739/PSOC6) already use the `<` form, so this brings these three back in line rather than inventing a new shape.

### Related issues

None.

### Testing

These three platforms need their vendor toolchains, so I checked the logic with a standalone reproducer mirroring the guard and the 17-byte `mDeviceName` member. With the comparison as it is on master, a 40-character name gives an ASAN `heap-buffer-overflow WRITE of size 41` at the `strcpy`, and a valid 14-character name is turned away with `CHIP_ERROR_INVALID_ARGUMENT`. After flipping the comparison the long name is rejected and the valid one is accepted.

I did not add a test file, since there is no host-buildable test target covering these platform BLE managers. Happy to add one if you would rather see it somewhere.
