### PR TITLE
fix arg list allocation size when growing in SplitArgs

### DIFF
--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -1361,7 +1361,7 @@ static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg)
         if (argListSize == static_cast<size_t>(argCount + 1))
         {
             argListSize *= 2;
-            argList = static_cast<char **>(chip::Platform::MemoryRealloc(argList, argListSize));
+            argList = static_cast<char **>(chip::Platform::MemoryRealloc(argList, sizeof(char *) * argListSize));
             if (argList == nullptr)
                 return -1;
         }

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -1361,9 +1361,10 @@ static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg)
         if (argListSize == static_cast<size_t>(argCount + 1))
         {
             argListSize *= 2;
-            argList = static_cast<char **>(chip::Platform::MemoryRealloc(argList, sizeof(char *) * argListSize));
-            if (argList == nullptr)
+            char ** newArgList = static_cast<char **>(chip::Platform::MemoryRealloc(argList, sizeof(char *) * argListSize));
+            if (newArgList == nullptr)
                 return -1;
+            argList = newArgList;
         }
 
         // Append the argument.

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -664,6 +664,29 @@ TEST_F(TestCHIPArgParser, MissingValueTest_MissingLongOptionValue)
     VerifyArgErrorContains(0, "--run");
 }
 
+TEST_F(TestCHIPArgParser, ParseArgsFromStringTest_MoreArgsThanInitialListSize)
+{
+    bool res;
+
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
+
+    // SplitArgs() starts with room for 10 entries and grows from there, so pass enough
+    // arguments to force it to grow more than once.
+    static const char argStr[] = "--foo -s arg-1 arg-2 arg-3 arg-4 arg-5 arg-6 arg-7 arg-8 arg-9 arg-10 arg-11 arg-12";
+
+    ClearCallbackRecords();
+    PrintArgError = HandleArgError;
+
+    res = ParseArgsFromString(__FUNCTION__, argStr, optionSets, HandleNonOptionArgs);
+    ASSERT_TRUE(res) << "ParseArgsFromString() returned false";
+    ASSERT_EQ(sCallbackRecordCount, 15u) << "Invalid value returned for sCallbackRecordCount";
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
+    VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
+    VerifyHandleNonOptionArgsCallback(2, __FUNCTION__, 12);
+    VerifyNonOptionArg(3, "arg-1");
+    VerifyNonOptionArg(14, "arg-12");
+}
+
 static void ClearCallbackRecords()
 {
     for (size_t i = 0; i < sCallbackRecordCount; i++)


### PR DESCRIPTION
### Summary

`SplitArgs()` tracks `argListSize` as an element count, and the initial allocation matches that with `MemoryAlloc(sizeof(char *) * InitialArgListSize)`. The growth path lost the multiplier and passes the element count straight to `MemoryRealloc()` as a byte count, so on a 64-bit host the first growth takes the block from 80 bytes down to 20, room for two pointers, right before the code writes `argList[9]`. Each later doubling stays eight times too small, so the overflow keeps widening as more arguments are parsed.

Any argument string with nine or more whitespace-separated tokens reaches it through `ParseArgsFromString()` or `ParseArgsFromEnvVar()`. I swept the other `MemoryRealloc()` call sites in the tree and this was the only one passing an element count, so the fix is just restoring the `sizeof(char *)` factor here.

### Related issues

None that I could find.

### Testing

Added a `TestCHIPArgParser` case that drives `ParseArgsFromString()` with enough arguments to force two growths. Against the unpatched tree it aborts under ASAN:

```
==48590==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000005e78
WRITE of size 8 at 0x603000005e78 thread T0
    #0 chip::ArgParser::SplitArgs(char*, char**&, char*)
    #1 chip::ArgParser::ParseArgsFromString(...)
0x603000005e78 is located 52 bytes after 20-byte region [0x603000005e30,0x603000005e44)
allocated by thread T0 here:
    #1 chip::Platform::MemoryRealloc(void*, unsigned long)
    #2 chip::ArgParser::SplitArgs(char*, char**&, char*)
```

With the fix the same input allocates 160 bytes and the case passes. Full `src/lib/support/tests` suite is green on `darwin-arm64-tests-asan-clang` (214 targets, no sanitizer reports), and clang-format is clean on both files.
