### PR TITLE
[nxp] Mount /runner-root-volume in examples-nxp CI jobs

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -45,6 +45,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-nxp:200
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
             - name: Checkout
@@ -148,6 +149,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-nxp-zephyr:203
+            volumes:
+                - "/:/runner-root-volume"
 
         steps:
             - name: Checkout


### PR DESCRIPTION
### Summary

Fix for insufficient space issue reported in https://github.com/project-chip/connectedhomeip/actions/runs/29602651922/job/87958240881

Mount /runner-root-volume in examples-nxp CI jobs.

### Testing

CI would validate NXP builds.
