### PR TITLE
Fix NPE in Kotlin InvokeCallbackJni for status-only invoke responses

### DIFF
--- a/src/controller/java/src/matter/controller/InvokeCallbackJni.kt
+++ b/src/controller/java/src/matter/controller/InvokeCallbackJni.kt
@@ -39,20 +39,25 @@ class InvokeCallbackJni(val wrappedInvokeCallback: InvokeCallback) {
     wrappedInvokeCallback.onError(e)
   }
 
+  // tlv and jsonString are null for status-only responses (e.g. OnOff::Toggle) —
+  // the native caller passes nullptr when the invoke response carries no data payload.
+  // A null InvokeResponse is the documented contract for that case (see InvokeCallback).
   private fun onResponse(
     endpointId: Int,
     clusterId: Long,
     commandId: Long,
-    tlv: ByteArray,
-    jsonString: String,
+    tlv: ByteArray?,
+    jsonString: String?,
     successCode: Long
   ) {
     wrappedInvokeCallback.onResponse(
-      InvokeResponse(
-        tlv,
-        CommandPath(endpointId.toUShort(), clusterId.toUInt(), commandId.toUInt()),
-        jsonString
-      ),
+      tlv?.let {
+        InvokeResponse(
+          it,
+          CommandPath(endpointId.toUShort(), clusterId.toUInt(), commandId.toUInt()),
+          jsonString
+        )
+      },
       successCode
     )
   }


### PR DESCRIPTION
Fixes #40854

## Problem

Invoking any command that replies with a **status-only response** (e.g. `OnOff::Toggle`) crashes the Kotlin Matter controller:

```
java.lang.NullPointerException: Parameter specified as non-null is null:
  method matter.controller.InvokeResponse.<init>, parameter payload
	at matter.controller.InvokeCallbackJni.onResponse(InvokeCallbackJni.kt:51)
```

Root cause chain:
1. For a data-less invoke response (`apData == nullptr`), `InvokeCallback::OnResponse` in `AndroidCallbacks.cpp` calls the Kotlin bridge with `nullptr` for both `tlv` and `jsonString`.
2. `InvokeCallbackJni.onResponse` declares `tlv: ByteArray` (non-null). Being `private`, the Kotlin compiler emits no parameter null-check at the JNI boundary, so the null only blows up at the public `InvokeResponse` constructor's intrinsic check.
3. The pending exception then poisons the next JNI call on that thread, taking down the whole process (`JNI DETECTED ERROR ... called with pending exception`).

## Fix

Make the JNI-called parameters nullable and pass `null` through to the wrapped callback. This activates the existing contract instead of adding a defaulting layer: the `InvokeCallback` interface already declares `onResponse(invokeResponse: InvokeResponse?, ...)` and documents null as the status-only case, and `MatterControllerImpl` already contains the null-handling branch — it was just unreachable because the bridge crashed first.

Kotlin nullability is not encoded in JVM method descriptors, so the JNI signature (`(IJJ[BLjava/lang/String;J)V`) and `AndroidCallbacks.cpp` are unchanged.

## Testing

Reproduced on a darwin host build (`darwin-arm64-kotlin-matter-controller` + `darwin-arm64-light-no-ble`):
- **Before**: commissioning succeeds, then `OnOff::Toggle`'s status response (`Status=0x0`) triggers the NPE above and the process aborts.
- **After**: the same scenario logs the toggle result and exits cleanly.

Note: the current example invoke command only exercises `UnitTesting.testAddArguments` (a data response), so status-only invokes have no CI coverage — the local repro required pointing the example at `OnOff::Toggle`. Happy to follow up with CI coverage for status-only invokes, and/or the `ExceptionClear()` hardening for the ART exception-poisoning layer described in the issue, per maintainer preference.
