### PR TITLE
[all-devices-app] Add support for "--dac_provider"

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/speaker/impl/LoggingSpeaker.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/speaker/impl/LoggingSpeaker.cpp
@@ -31,9 +31,9 @@ LoggingSpeaker::~LoggingSpeaker() {}
 
 void LoggingSpeaker::OnLevelChanged(uint8_t value)
 {
-    uint8_t min  = LevelControlCluster().GetMinLevel();
-    uint8_t max  = LevelControlCluster().GetMaxLevel();
-    uint32_t pct = (max > min) ? (static_cast<uint32_t>(value - min) * 100) / (max - min) : 0;
+    uint8_t min                   = LevelControlCluster().GetMinLevel();
+    uint8_t max                   = LevelControlCluster().GetMaxLevel();
+    [[maybe_unused]] uint32_t pct = (max > min) ? (static_cast<uint32_t>(value - min) * 100) / (max - min) : 0;
     ChipLogProgress(AppServer, "LoggingSpeaker: Volume set to %u (%" PRIu32 "%%)", value, pct);
 }
 

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
@@ -30,7 +30,7 @@ struct AllDevicesExampleDACProvider::FileProviderContext
     Credentials::Examples::TestHarnessDACProvider provider;
 };
 
-AllDevicesExampleDACProvider::AllDevicesExampleDACProvider() = default;
+AllDevicesExampleDACProvider::AllDevicesExampleDACProvider()  = default;
 AllDevicesExampleDACProvider::~AllDevicesExampleDACProvider() = default;
 
 CHIP_ERROR AllDevicesExampleDACProvider::Init(const std::optional<std::string> & filePath)
@@ -74,7 +74,7 @@ CHIP_ERROR AllDevicesExampleDACProvider::GetProductAttestationIntermediateCert(M
 }
 
 CHIP_ERROR AllDevicesExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign,
-                                                                     MutableByteSpan & out_signature_buffer)
+                                                                      MutableByteSpan & out_signature_buffer)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     return mDelegate->SignWithDeviceAttestationKey(message_to_sign, out_signature_buffer);

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
@@ -1,0 +1,84 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AllDevicesExampleDACProvider.h"
+
+#include <app/tests/suites/credentials/TestHarnessDACProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+struct AllDevicesExampleDACProvider::FileProviderContext
+{
+    Credentials::Examples::TestHarnessDACProvider provider;
+};
+
+AllDevicesExampleDACProvider::AllDevicesExampleDACProvider() = default;
+AllDevicesExampleDACProvider::~AllDevicesExampleDACProvider() = default;
+
+CHIP_ERROR AllDevicesExampleDACProvider::Init(const std::optional<std::string> & filePath)
+{
+    if (filePath.has_value() && !filePath.value().empty())
+    {
+        mFileContext = std::make_unique<FileProviderContext>();
+        mFileContext->provider.Init(filePath.value().c_str());
+        mDelegate = &mFileContext->provider;
+    }
+    else
+    {
+        mFileContext.reset();
+        mDelegate = Credentials::Examples::GetExampleDACProvider();
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AllDevicesExampleDACProvider::GetCertificationDeclaration(MutableByteSpan & out_cd_buffer)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return mDelegate->GetCertificationDeclaration(out_cd_buffer);
+}
+
+CHIP_ERROR AllDevicesExampleDACProvider::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return mDelegate->GetFirmwareInformation(out_firmware_info_buffer);
+}
+
+CHIP_ERROR AllDevicesExampleDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return mDelegate->GetDeviceAttestationCert(out_dac_buffer);
+}
+
+CHIP_ERROR AllDevicesExampleDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return mDelegate->GetProductAttestationIntermediateCert(out_pai_buffer);
+}
+
+CHIP_ERROR AllDevicesExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign,
+                                                                     MutableByteSpan & out_signature_buffer)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return mDelegate->SignWithDeviceAttestationKey(message_to_sign, out_signature_buffer);
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
@@ -22,6 +22,8 @@
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/support/CodeUtils.h>
 
+#include <fstream>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -37,9 +39,13 @@ CHIP_ERROR AllDevicesExampleDACProvider::Init(const std::optional<std::string> &
 {
     if (filePath.has_value() && !filePath.value().empty())
     {
-        mFileContext = std::make_unique<FileProviderContext>();
-        mFileContext->provider.Init(filePath.value().c_str());
-        mDelegate = &mFileContext->provider;
+        std::ifstream jsonFile(filePath.value().c_str(), std::ifstream::binary);
+        VerifyOrReturnError(jsonFile.is_open(), CHIP_ERROR_INVALID_ARGUMENT);
+
+        auto fileContext = std::make_unique<FileProviderContext>();
+        fileContext->provider.Init(filePath.value().c_str());
+        mFileContext = std::move(fileContext);
+        mDelegate    = &mFileContext->provider;
     }
     else
     {

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.cpp
@@ -27,14 +27,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-struct AllDevicesExampleDACProvider::FileProviderContext
-{
-    Credentials::Examples::TestHarnessDACProvider provider;
-};
-
-AllDevicesExampleDACProvider::AllDevicesExampleDACProvider()  = default;
-AllDevicesExampleDACProvider::~AllDevicesExampleDACProvider() = default;
-
 CHIP_ERROR AllDevicesExampleDACProvider::Init(const std::optional<std::string> & filePath)
 {
     if (filePath.has_value() && !filePath.value().empty())
@@ -42,14 +34,14 @@ CHIP_ERROR AllDevicesExampleDACProvider::Init(const std::optional<std::string> &
         std::ifstream jsonFile(filePath.value().c_str(), std::ifstream::binary);
         VerifyOrReturnError(jsonFile.is_open(), CHIP_ERROR_INVALID_ARGUMENT);
 
-        auto fileContext = std::make_unique<FileProviderContext>();
-        fileContext->provider.Init(filePath.value().c_str());
-        mFileContext = std::move(fileContext);
-        mDelegate    = &mFileContext->provider;
+        auto fileProvider = std::make_unique<Credentials::Examples::TestHarnessDACProvider>();
+        fileProvider->Init(filePath.value().c_str());
+        mDynamicProvider = std::move(fileProvider);
+        mDelegate        = mDynamicProvider.get();
     }
     else
     {
-        mFileContext.reset();
+        mDynamicProvider.reset();
         mDelegate = Credentials::Examples::GetExampleDACProvider();
     }
     return CHIP_NO_ERROR;

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
@@ -40,7 +40,7 @@ namespace DeviceLayer {
 class AllDevicesExampleDACProvider : public Credentials::DeviceAttestationCredentialsProvider
 {
 public:
-    AllDevicesExampleDACProvider()          = default;
+    AllDevicesExampleDACProvider()           = default;
     ~AllDevicesExampleDACProvider() override = default;
 
     /**

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
@@ -60,6 +60,7 @@ public:
 private:
     Credentials::DeviceAttestationCredentialsProvider * mDelegate = nullptr;
 
+    // Use PIMPL idiom to avoid leaking TestHarnessDACProvider test headers into the public provider interface.
     struct FileProviderContext;
     std::unique_ptr<FileProviderContext> mFileContext;
 };

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <lib/core/CHIPError.h>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * @brief DeviceAttestationCredentialsProvider implementation for all-devices-app.
+ *
+ * In simulation / test harness environments (such as POSIX CLI executions), this provider can load
+ * test DAC credentials dynamically from a JSON file path. If no path is provided, it falls back to
+ * the default example credentials.
+ *
+ * For commercial products, developers should replace this with a provider that binds directly to
+ * secure hardware storage (e.g. Hardware Secure Element, TPM, TrustZone, or platform factory partition).
+ */
+class AllDevicesExampleDACProvider : public Credentials::DeviceAttestationCredentialsProvider
+{
+public:
+    AllDevicesExampleDACProvider();
+    ~AllDevicesExampleDACProvider() override;
+
+    /**
+     * @brief Initializes the DAC credentials provider.
+     *
+     * @param[in] filePath Optional file path to a JSON DAC test vector. If not provided or empty,
+     *                     the default SDK example DAC provider is used.
+     */
+    CHIP_ERROR Init(const std::optional<std::string> & filePath = std::nullopt);
+
+    CHIP_ERROR GetCertificationDeclaration(MutableByteSpan & out_cd_buffer) override;
+    CHIP_ERROR GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer) override;
+    CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & message_to_sign, MutableByteSpan & out_signature_buffer) override;
+
+private:
+    Credentials::DeviceAttestationCredentialsProvider * mDelegate = nullptr;
+
+    struct FileProviderContext;
+    std::unique_ptr<FileProviderContext> mFileContext;
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
@@ -40,6 +40,7 @@ namespace DeviceLayer {
 class AllDevicesExampleDACProvider : public Credentials::DeviceAttestationCredentialsProvider
 {
 public:
+    // Defined in .cpp to allow std::unique_ptr<FileProviderContext> with forward-declared FileProviderContext.
     AllDevicesExampleDACProvider();
     ~AllDevicesExampleDACProvider() override;
 

--- a/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
+++ b/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h
@@ -40,9 +40,8 @@ namespace DeviceLayer {
 class AllDevicesExampleDACProvider : public Credentials::DeviceAttestationCredentialsProvider
 {
 public:
-    // Defined in .cpp to allow std::unique_ptr<FileProviderContext> with forward-declared FileProviderContext.
-    AllDevicesExampleDACProvider();
-    ~AllDevicesExampleDACProvider() override;
+    AllDevicesExampleDACProvider()          = default;
+    ~AllDevicesExampleDACProvider() override = default;
 
     /**
      * @brief Initializes the DAC credentials provider.
@@ -60,10 +59,7 @@ public:
 
 private:
     Credentials::DeviceAttestationCredentialsProvider * mDelegate = nullptr;
-
-    // Use PIMPL idiom to avoid leaking TestHarnessDACProvider test headers into the public provider interface.
-    struct FileProviderContext;
-    std::unique_ptr<FileProviderContext> mFileContext;
+    std::unique_ptr<Credentials::DeviceAttestationCredentialsProvider> mDynamicProvider;
 };
 
 } // namespace DeviceLayer

--- a/examples/all-devices-app/all-devices-common/providers/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/providers/BUILD.gn
@@ -53,3 +53,25 @@ source_set("all-devices-example-device-instance-info-provider") {
     "${chip_root}/src:includes",
   ]
 }
+
+source_set("all-devices-example-dac-provider") {
+  sources = [
+    "AllDevicesExampleDACProvider.cpp",
+    "AllDevicesExampleDACProvider.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/credentials",
+    "${chip_root}/src/lib/support",
+  ]
+
+  deps = [
+    "${chip_root}/src/app/tests/suites/credentials:dac_provider",
+  ]
+
+  public_configs = [
+    ":includes",
+    "${chip_root}/src:includes",
+  ]
+}
+

--- a/examples/all-devices-app/all-devices-common/providers/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/providers/BUILD.gn
@@ -65,13 +65,10 @@ source_set("all-devices-example-dac-provider") {
     "${chip_root}/src/lib/support",
   ]
 
-  deps = [
-    "${chip_root}/src/app/tests/suites/credentials:dac_provider",
-  ]
+  deps = [ "${chip_root}/src/app/tests/suites/credentials:dac_provider" ]
 
   public_configs = [
     ":includes",
     "${chip_root}/src:includes",
   ]
 }
-

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -11,11 +11,48 @@ delegates.
 
 ## Provider Overview
 
-| Provider Class                                                                                                                                                                                                           | Base SDK Interface                                                                                                                                                                | Description                                                                                                                                                                                                                                                      |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h)                                       | [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
-| [`AllDevicesExampleDeviceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInfoProviderImpl.h)                 | [`chip::DeviceLayer::DeviceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInfoProvider.h)                                          | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`.                                                                                                                                         |
-| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInstanceInfoProvider.h)                          | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed.                                                                                  |
+| Provider Class | Base SDK Interface | Description |
+| :--- | :--- | :--- |
+| [`AllDevicesExampleDACProvider`](AllDevicesExampleDACProvider.h) | [`chip::Credentials::DeviceAttestationCredentialsProvider`](../../../../src/credentials/DeviceAttestationCredsProvider.h) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
+| [`AllDevicesExampleDeviceInfoProviderImpl`](AllDevicesExampleDeviceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInfoProvider`](../../../../src/platform/DeviceInfoProvider.h) | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`. |
+| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](../../../../src/platform/DeviceInstanceInfoProvider.h) | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed. |
+
+---
+
+## DAC Test Vector JSON Schema
+
+When supplying a custom test vector file via `--dac_provider <path>`, the JSON file is parsed by `TestHarnessDACProvider` (`src/app/tests/suites/credentials/TestHarnessDACProvider.cpp`).
+
+The supported JSON keys are:
+
+| JSON Key | Type | Description |
+| :--- | :--- | :--- |
+| `dac_cert` | Hex String | DER-encoded Device Attestation Certificate (DAC). |
+| `dac_private_key` | Hex String | 32-byte SECP256r1 private key scalar used to sign the device attestation challenge. |
+| `dac_public_key` | Hex String *(Optional)* | 65-byte uncompressed SECP256r1 public key corresponding to `dac_private_key`. |
+| `pai_cert` | Hex String | DER-encoded Product Attestation Intermediate (PAI) certificate. |
+| `certification_declaration` | Hex String | CMS-signed DER-encoded Certification Declaration (CD) payload. |
+| `firmware_information` | Hex String *(Optional)* | Optional firmware information payload. |
+| `basic_info_pid` | Integer *(Optional)* | Expected Product ID matching the test vector. |
+| `description` | String *(Optional)* | Human-readable description of the test scenario. |
+| `is_success_case` | Boolean *(Optional)* | Indicates whether the test vector is expected to pass or fail attestation. |
+
+### Pre-Existing Test Vectors
+
+Pre-existing test vector JSON files are available in the Matter SDK repository under:
+[`credentials/development/commissioner_dut/`](../../../../credentials/development/commissioner_dut/)
+
+Examples:
+- **Valid CMS v3 CD Vector**: `credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json`
+- **Official CD Vector**: `credentials/development/commissioner_dut/struct_cd_official_cd/test_case_vector.json`
+- **Attestation Fallback / PID Mismatch Vector**: `credentials/development/commissioner_dut/struct_dac_subject_pid_mismatch/test_case_vector.json`
+
+Example invocation:
+```bash
+./out/linux-x64-all-devices-clang/all-devices-app \
+  --dac_provider credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json \
+  --product-id 0x8000
+```
 
 ---
 
@@ -27,7 +64,7 @@ In real commercial products, DAC private keys must never be stored in plaintext
 JSON files or memory accessible to user space.
 
 -   **Simulation / Test Harnesses (POSIX)**: The POSIX entrypoint
-    ([`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352))
+    ([`posix/main.cpp`](../../posix/main.cpp))
     initializes `AllDevicesExampleDACProvider` with
     `AppOptions::GetConfig().dacProvider` to allow test runners (such as WOCA
     and Python certification scripts) to supply test vectors dynamically.
@@ -38,7 +75,7 @@ JSON files or memory accessible to user space.
     `AllDevicesExampleDACProvider` with a provider that delegates signing
     directly to a Hardware Secure Element (e.g., `ATECC608`, NXP `SE050`), TPM,
     or platform Secure Enclave / TrustZone
-    ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+    ([`TrustyDACProvider`](../../../../src/platform/Linux/DeviceAttestationCredsTrusty.h)).
 
 ### 2. Device Instance Info
 

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -1,29 +1,48 @@
 # All-Devices Providers
 
-This directory contains `all-devices-app` providers that implement or wrap core Matter SDK provider interfaces.
+This directory contains `all-devices-app` providers that implement or wrap core
+Matter SDK provider interfaces.
 
-They provide clean separation between the application data model, POSIX test simulator overrides (such as dynamic CLI options), and platform hardware delegates.
+They provide clean separation between the application data model, POSIX test
+simulator overrides (such as dynamic CLI options), and platform hardware
+delegates.
 
 ---
 
 ## Provider Overview
 
-| Provider Class | Base SDK Interface | Description |
-| :--- | :--- | :--- |
-| [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h) | [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
-| [`AllDevicesExampleDeviceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInfoProvider.h) | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`. |
-| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInstanceInfoProvider.h) | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed. |
+| Provider Class                                                                                                                                                                                                           | Base SDK Interface                                                                                                                                                                | Description                                                                                                                                                                                                                                                      |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h)                                       | [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
+| [`AllDevicesExampleDeviceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInfoProviderImpl.h)                 | [`chip::DeviceLayer::DeviceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInfoProvider.h)                                          | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`.                                                                                                                                         |
+| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInstanceInfoProvider.h)                          | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed.                                                                                  |
 
 ---
 
 ## Production vs. Simulation Usage
 
 ### 1. Device Attestation Credentials (DAC)
-In real commercial products, DAC private keys must never be stored in plaintext JSON files or memory accessible to user space.
 
-- **Simulation / Test Harnesses (POSIX)**: The POSIX entrypoint ([`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352)) initializes `AllDevicesExampleDACProvider` with `AppOptions::GetConfig().dacProvider` to allow test runners (such as WOCA and Python certification scripts) to supply test vectors dynamically.
-- **Embedded MCUs (ESP32, Silicon Labs, Nordic)**: Hardware platforms initialize a `FactoryDataProvider` (which reads from secure flash or NVM) and register it at boot.
-- **Commercial Linux Gateways**: Real products replace `AllDevicesExampleDACProvider` with a provider that delegates signing directly to a Hardware Secure Element (e.g., ATECC608, NXP SE050), TPM, or platform Secure Enclave / TrustZone ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+In real commercial products, DAC private keys must never be stored in plaintext
+JSON files or memory accessible to user space.
+
+-   **Simulation / Test Harnesses (POSIX)**: The POSIX entrypoint
+    ([`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352))
+    initializes `AllDevicesExampleDACProvider` with
+    `AppOptions::GetConfig().dacProvider` to allow test runners (such as WOCA
+    and Python certification scripts) to supply test vectors dynamically.
+-   **Embedded MCUs (ESP32, Silicon Labs, Nordic)**: Hardware platforms
+    initialize a `FactoryDataProvider` (which reads from secure flash or NVM)
+    and register it at boot.
+-   **Commercial Linux Gateways**: Real products replace
+    `AllDevicesExampleDACProvider` with a provider that delegates signing
+    directly to a Hardware Secure Element (e.g., ATECC608, NXP SE050), TPM, or
+    platform Secure Enclave / TrustZone
+    ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
 
 ### 2. Device Instance Info
-`AllDevicesExampleDeviceInstanceInfoProviderImpl` demonstrates the decorator pattern: it intercepts basic info queries to allow CLI customization during development while forwarding hardware-level queries (such as rotating device ID, serial numbers, and manufacturing dates) to the underlying platform delegate.
+
+`AllDevicesExampleDeviceInstanceInfoProviderImpl` demonstrates the decorator
+pattern: it intercepts basic info queries to allow CLI customization during
+development while forwarding hardware-level queries (such as rotating device ID,
+serial numbers, and manufacturing dates) to the underlying platform delegate.

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -11,43 +11,51 @@ delegates.
 
 ## Provider Overview
 
-| Provider Class | Base SDK Interface | Description |
-| :--- | :--- | :--- |
-| [`AllDevicesExampleDACProvider`](AllDevicesExampleDACProvider.h) | [`chip::Credentials::DeviceAttestationCredentialsProvider`](../../../../src/credentials/DeviceAttestationCredsProvider.h) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
-| [`AllDevicesExampleDeviceInfoProviderImpl`](AllDevicesExampleDeviceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInfoProvider`](../../../../src/platform/DeviceInfoProvider.h) | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`. |
-| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](../../../../src/platform/DeviceInstanceInfoProvider.h) | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed. |
+| Provider Class                                                                                         | Base SDK Interface                                                                                                        | Description                                                                                                                                                                                                                                                      |
+| :----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`AllDevicesExampleDACProvider`](AllDevicesExampleDACProvider.h)                                       | [`chip::Credentials::DeviceAttestationCredentialsProvider`](../../../../src/credentials/DeviceAttestationCredsProvider.h) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
+| [`AllDevicesExampleDeviceInfoProviderImpl`](AllDevicesExampleDeviceInfoProviderImpl.h)                 | [`chip::DeviceLayer::DeviceInfoProvider`](../../../../src/platform/DeviceInfoProvider.h)                                  | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`.                                                                                                                                         |
+| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](../../../../src/platform/DeviceInstanceInfoProvider.h)                  | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed.                                                                                  |
 
 ---
 
 ## DAC Test Vector JSON Schema
 
-When supplying a custom test vector file via `--dac_provider <path>`, the JSON file is parsed by `TestHarnessDACProvider` (`src/app/tests/suites/credentials/TestHarnessDACProvider.cpp`).
+When supplying a custom test vector file via `--dac_provider <path>`, the JSON
+file is parsed by `TestHarnessDACProvider`
+(`src/app/tests/suites/credentials/TestHarnessDACProvider.cpp`).
 
 The supported JSON keys are:
 
-| JSON Key | Type | Description |
-| :--- | :--- | :--- |
-| `dac_cert` | Hex String | DER-encoded Device Attestation Certificate (DAC). |
-| `dac_private_key` | Hex String | 32-byte SECP256r1 private key scalar used to sign the device attestation challenge. |
-| `dac_public_key` | Hex String *(Optional)* | 65-byte uncompressed SECP256r1 public key corresponding to `dac_private_key`. |
-| `pai_cert` | Hex String | DER-encoded Product Attestation Intermediate (PAI) certificate. |
-| `certification_declaration` | Hex String | CMS-signed DER-encoded Certification Declaration (CD) payload. |
-| `firmware_information` | Hex String *(Optional)* | Optional firmware information payload. |
-| `basic_info_pid` | Integer *(Optional)* | Expected Product ID matching the test vector. |
-| `description` | String *(Optional)* | Human-readable description of the test scenario. |
-| `is_success_case` | Boolean *(Optional)* | Indicates whether the test vector is expected to pass or fail attestation. |
+| JSON Key                    | Type                    | Description                                                                         |
+| :-------------------------- | :---------------------- | :---------------------------------------------------------------------------------- |
+| `dac_cert`                  | Hex String              | DER-encoded Device Attestation Certificate (DAC).                                   |
+| `dac_private_key`           | Hex String              | 32-byte SECP256r1 private key scalar used to sign the device attestation challenge. |
+| `dac_public_key`            | Hex String _(Optional)_ | 65-byte uncompressed SECP256r1 public key corresponding to `dac_private_key`.       |
+| `pai_cert`                  | Hex String              | DER-encoded Product Attestation Intermediate (PAI) certificate.                     |
+| `certification_declaration` | Hex String              | CMS-signed DER-encoded Certification Declaration (CD) payload.                      |
+| `firmware_information`      | Hex String _(Optional)_ | Optional firmware information payload.                                              |
+| `basic_info_pid`            | Integer _(Optional)_    | Expected Product ID matching the test vector.                                       |
+| `description`               | String _(Optional)_     | Human-readable description of the test scenario.                                    |
+| `is_success_case`           | Boolean _(Optional)_    | Indicates whether the test vector is expected to pass or fail attestation.          |
 
 ### Pre-Existing Test Vectors
 
-Pre-existing test vector JSON files are available in the Matter SDK repository under:
+Pre-existing test vector JSON files are available in the Matter SDK repository
+under:
 [`credentials/development/commissioner_dut/`](../../../../credentials/development/commissioner_dut/)
 
 Examples:
-- **Valid CMS v3 CD Vector**: `credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json`
-- **Official CD Vector**: `credentials/development/commissioner_dut/struct_cd_official_cd/test_case_vector.json`
-- **Attestation Fallback / PID Mismatch Vector**: `credentials/development/commissioner_dut/struct_dac_subject_pid_mismatch/test_case_vector.json`
+
+-   **Valid CMS v3 CD Vector**:
+    `credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json`
+-   **Official CD Vector**:
+    `credentials/development/commissioner_dut/struct_cd_official_cd/test_case_vector.json`
+-   **Attestation Fallback / PID Mismatch Vector**:
+    `credentials/development/commissioner_dut/struct_dac_subject_pid_mismatch/test_case_vector.json`
 
 Example invocation:
+
 ```bash
 ./out/linux-x64-all-devices-clang/all-devices-app \
   --dac_provider credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json \
@@ -64,10 +72,10 @@ In real commercial products, DAC private keys must never be stored in plaintext
 JSON files or memory accessible to user space.
 
 -   **Simulation / Test Harnesses (POSIX)**: The POSIX entrypoint
-    ([`posix/main.cpp`](../../posix/main.cpp))
-    initializes `AllDevicesExampleDACProvider` with
-    `AppOptions::GetConfig().dacProvider` to allow test runners (such as WOCA
-    and Python certification scripts) to supply test vectors dynamically.
+    ([`posix/main.cpp`](../../posix/main.cpp)) initializes
+    `AllDevicesExampleDACProvider` with `AppOptions::GetConfig().dacProvider` to
+    allow test runners (such as WOCA and Python certification scripts) to supply
+    test vectors dynamically.
 -   **Embedded MCUs (ESP32, Silicon Labs, Nordic)**: Hardware platforms
     initialize a `FactoryDataProvider` (which reads from secure flash or NVM)
     and register it at boot.

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -36,8 +36,8 @@ JSON files or memory accessible to user space.
     and register it at boot.
 -   **Commercial Linux Gateways**: Real products replace
     `AllDevicesExampleDACProvider` with a provider that delegates signing
-    directly to a Hardware Secure Element (e.g., `ATECC608`, NXP `SE050`), TPM, or
-    platform Secure Enclave / TrustZone
+    directly to a Hardware Secure Element (e.g., `ATECC608`, NXP `SE050`), TPM,
+    or platform Secure Enclave / TrustZone
     ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
 
 ### 2. Device Instance Info

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -1,0 +1,29 @@
+# All-Devices Providers
+
+This directory contains `all-devices-app` providers that implement or wrap core Matter SDK provider interfaces.
+
+They provide clean separation between the application data model, POSIX test simulator overrides (such as dynamic CLI options), and platform hardware delegates.
+
+---
+
+## Provider Overview
+
+| Provider Class | Base SDK Interface | Description |
+| :--- | :--- | :--- |
+| [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h) | [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70) | Handles Device Attestation Credentials (DAC, PAI, CD, and DAC private key signing). In POSIX test/simulation environments, supports loading test credentials from a JSON vector file (`--dac_provider <path>`), falling back to default SDK example credentials. |
+| [`AllDevicesExampleDeviceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInfoProvider.h) | Provides fixed labels, user labels, supported locales, and calendar types across dynamic endpoints in `all-devices-app`. |
+| [`AllDevicesExampleDeviceInstanceInfoProviderImpl`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDeviceInstanceInfoProviderImpl.h) | [`chip::DeviceLayer::DeviceInstanceInfoProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/DeviceInstanceInfoProvider.h) | Wraps the underlying platform `DeviceInstanceInfoProvider` delegate and overrides Vendor ID and Product ID when custom `--vendor-id` and `--product-id` CLI options are passed. |
+
+---
+
+## Production vs. Simulation Usage
+
+### 1. Device Attestation Credentials (DAC)
+In real commercial products, DAC private keys must never be stored in plaintext JSON files or memory accessible to user space.
+
+- **Simulation / Test Harnesses (POSIX)**: The POSIX entrypoint ([`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352)) initializes `AllDevicesExampleDACProvider` with `AppOptions::GetConfig().dacProvider` to allow test runners (such as WOCA and Python certification scripts) to supply test vectors dynamically.
+- **Embedded MCUs (ESP32, Silicon Labs, Nordic)**: Hardware platforms initialize a `FactoryDataProvider` (which reads from secure flash or NVM) and register it at boot.
+- **Commercial Linux Gateways**: Real products replace `AllDevicesExampleDACProvider` with a provider that delegates signing directly to a Hardware Secure Element (e.g., ATECC608, NXP SE050), TPM, or platform Secure Enclave / TrustZone ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+
+### 2. Device Instance Info
+`AllDevicesExampleDeviceInstanceInfoProviderImpl` demonstrates the decorator pattern: it intercepts basic info queries to allow CLI customization during development while forwarding hardware-level queries (such as rotating device ID, serial numbers, and manufacturing dates) to the underlying platform delegate.

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -36,7 +36,7 @@ JSON files or memory accessible to user space.
     and register it at boot.
 -   **Commercial Linux Gateways**: Real products replace
     `AllDevicesExampleDACProvider` with a provider that delegates signing
-    directly to a Hardware Secure Element (e.g., ATECC608, NXP SE050), TPM, or
+    directly to a Hardware Secure Element (e.g., `ATECC608`, NXP `SE050`), TPM, or
     platform Secure Enclave / TrustZone
     ([`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
 

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -27,17 +27,17 @@ file is parsed by `TestHarnessDACProvider`
 
 The supported JSON keys are:
 
-| JSON Key                    | Type                    | Description                                                                         |
-| :-------------------------- | :---------------------- | :---------------------------------------------------------------------------------- |
-| `dac_cert`                  | Hex String              | DER-encoded Device Attestation Certificate (DAC).                                   |
+| JSON Key                    | Type                    | Description                                                                           |
+| :-------------------------- | :---------------------- | :------------------------------------------------------------------------------------ |
+| `dac_cert`                  | Hex String              | DER-encoded Device Attestation Certificate (DAC).                                     |
 | `dac_private_key`           | Hex String              | 32-byte P-256 ECDSA private key scalar used to sign the device attestation challenge. |
 | `dac_public_key`            | Hex String _(Optional)_ | 65-byte uncompressed P-256 public key corresponding to `dac_private_key`.             |
-| `pai_cert`                  | Hex String              | DER-encoded Product Attestation Intermediate (PAI) certificate.                     |
-| `certification_declaration` | Hex String              | CMS-signed DER-encoded Certification Declaration (CD) payload.                      |
-| `firmware_information`      | Hex String _(Optional)_ | Optional firmware information payload.                                              |
-| `basic_info_pid`            | Integer _(Optional)_    | Expected Product ID matching the test vector.                                       |
-| `description`               | String _(Optional)_     | Human-readable description of the test scenario.                                    |
-| `is_success_case`           | Boolean _(Optional)_    | Indicates whether the test vector is expected to pass or fail attestation.          |
+| `pai_cert`                  | Hex String              | DER-encoded Product Attestation Intermediate (PAI) certificate.                       |
+| `certification_declaration` | Hex String              | CMS-signed DER-encoded Certification Declaration (CD) payload.                        |
+| `firmware_information`      | Hex String _(Optional)_ | Optional firmware information payload.                                                |
+| `basic_info_pid`            | Integer _(Optional)_    | Expected Product ID matching the test vector.                                         |
+| `description`               | String _(Optional)_     | Human-readable description of the test scenario.                                      |
+| `is_success_case`           | Boolean _(Optional)_    | Indicates whether the test vector is expected to pass or fail attestation.            |
 
 ### Pre-Existing Test Vectors
 

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -30,8 +30,8 @@ The supported JSON keys are:
 | JSON Key                    | Type                    | Description                                                                         |
 | :-------------------------- | :---------------------- | :---------------------------------------------------------------------------------- |
 | `dac_cert`                  | Hex String              | DER-encoded Device Attestation Certificate (DAC).                                   |
-| `dac_private_key`           | Hex String              | 32-byte SECP256r1 private key scalar used to sign the device attestation challenge. |
-| `dac_public_key`            | Hex String _(Optional)_ | 65-byte uncompressed SECP256r1 public key corresponding to `dac_private_key`.       |
+| `dac_private_key`           | Hex String              | 32-byte P-256 ECDSA private key scalar used to sign the device attestation challenge. |
+| `dac_public_key`            | Hex String _(Optional)_ | 65-byte uncompressed P-256 public key corresponding to `dac_private_key`.             |
 | `pai_cert`                  | Hex String              | DER-encoded Product Attestation Intermediate (PAI) certificate.                     |
 | `certification_declaration` | Hex String              | CMS-signed DER-encoded Certification Declaration (CD) payload.                      |
 | `firmware_information`      | Hex String _(Optional)_ | Optional firmware information payload.                                              |

--- a/examples/all-devices-app/all-devices-common/providers/README.md
+++ b/examples/all-devices-app/all-devices-common/providers/README.md
@@ -43,22 +43,21 @@ The supported JSON keys are:
 
 Pre-existing test vector JSON files are available in the Matter SDK repository
 under:
-[`credentials/development/commissioner_dut/`](../../../../credentials/development/commissioner_dut/)
+[`credentials/development/attestation/`](../../../../credentials/development/attestation/)
 
 Examples:
 
--   **Valid CMS v3 CD Vector**:
-    `credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json`
--   **Official CD Vector**:
-    `credentials/development/commissioner_dut/struct_cd_official_cd/test_case_vector.json`
--   **Attestation Fallback / PID Mismatch Vector**:
-    `credentials/development/commissioner_dut/struct_dac_subject_pid_mismatch/test_case_vector.json`
+-   **Test Credentials for VID=0xFFF1 PID=0x8000**:
+    `credentials/development/attestation/TestCredentials-FFF1-8000.json`
+-   **Test Credentials for VID=0xFFF2 PID=0x8001**:
+    `credentials/development/attestation/TestCredentials-FFF2-8001.json`
 
 Example invocation:
 
 ```bash
 ./out/linux-x64-all-devices-clang/all-devices-app \
-  --dac_provider credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json \
+  --dac_provider credentials/development/attestation/TestCredentials-FFF1-8000.json \
+  --vendor-id 0xFFF1 \
   --product-id 0x8000
 ```
 

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -164,7 +164,37 @@ void ApplicationShutdownHook()
 
 ---
 
-## 5. Commercial Firmware Guidelines
+## 5. Device Attestation Credentials (DAC) Implementation & Production
+
+In the Matter data model, Device Attestation Credentials (DAC) provide cryptographic proof of a device's identity, vendor ID, product ID, and Matter certification.
+
+### DAC Implementation in `all-devices-app`
+
+The `all-devices-app` implementation provides a decoupled provider architecture:
+
+- **Reference Provider**: [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h) located in [`all-devices-common/providers/`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/).
+- **POSIX Simulator Boot**: In [`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352), the application initializes `AllDevicesExampleDACProvider` with `AppOptions::GetConfig().dacProvider`. This allows passing `--dac_provider <path.json>` on the command line to dynamically load JSON test vectors during CI/WOCA certification testing, or falling back to the SDK's built-in example credentials (`chip::Credentials::Examples::GetExampleDACProvider()`).
+- **Embedded MCU Boot**: On hardware targets like ESP32 ([`esp32/main/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/esp32/main/main.cpp#L416-L424)) or Silicon Labs ([`silabs/src/AppTask.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/silabs/src/AppTask.cpp#L167)), the platform boots with a hardware `FactoryDataProvider` that reads credentials from encrypted flash partitions.
+
+### Transitioning to Production Hardware
+
+Commercial products **must never use JSON files or plaintext DAC private keys on disk**. In real products:
+
+1. **Implement `DeviceAttestationCredentialsProvider`**: Implement the pure abstract interface [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70). Cryptographic signing operations (`SignWithDeviceAttestationKey`) must delegate directly to your secure hardware without exporting the private key into system RAM.
+2. **Platform Hardware Binding**:
+   - **Linux / Android Gateways**: Delegate signing to a Hardware Secure Element (e.g. ATECC608, NXP SE050 via I2C/PKCS#11), TPM, or platform Secure Enclave / TrustZone (see [`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+   - **Embedded MCUs (ESP32, Nordic, Silicon Labs)**: Use the platform's hardware factory data provider (e.g., [`ESP32FactoryDataProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/ESP32/ESP32FactoryDataProvider.h)) to read factory-flashed credentials and utilize on-chip crypto hardware.
+3. **Register at Boot**: Register your hardware provider before initializing the Matter server or starting the event loop:
+   ```cpp
+   #include <credentials/DeviceAttestationCredsProvider.h>
+
+   // Initialize your hardware/platform secure element DAC provider
+   SetDeviceAttestationCredentialsProvider(&gProductHardwareDACProvider);
+   ```
+
+---
+
+## 6. Commercial Firmware Guidelines
 
 1. **Link Specific Devices**: In `BUILD.gn` or `CMakeLists.txt`, link directly
    against required device modules (e.g.,
@@ -175,3 +205,6 @@ void ApplicationShutdownHook()
 3. **Persist Hardware State**: Replace simulated cluster implementations with
    hardware drivers (e.g., binding a PWM driver to WriteAttribute callbacks) and
    persist calibration data via storage delegates.
+4. **Hardware-Isolated Attestation**: Bind `DeviceAttestationCredentialsProvider`
+   directly to your secure element or factory partition driver rather than using
+   CLI/file-based credentials.

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -175,11 +175,11 @@ certification.
 The `all-devices-app` implementation provides a decoupled provider architecture:
 
 -   **Reference Provider**:
-    [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h)
+    [`AllDevicesExampleDACProvider`](../all-devices-common/providers/AllDevicesExampleDACProvider.h)
     located in
-    [`all-devices-common/providers/`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/).
+    [`all-devices-common/providers/`](../all-devices-common/providers/).
 -   **POSIX Simulator Boot**: In
-    [`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352),
+    [`posix/main.cpp`](../posix/main.cpp),
     the application initializes `AllDevicesExampleDACProvider` with
     `AppOptions::GetConfig().dacProvider`. This allows passing
     `--dac_provider <path.json>` on the command line to dynamically load JSON
@@ -187,9 +187,9 @@ The `all-devices-app` implementation provides a decoupled provider architecture:
     SDK's built-in example credentials
     (`chip::Credentials::Examples::GetExampleDACProvider()`).
 -   **Embedded MCU Boot**: On hardware targets like ESP32
-    ([`esp32/main/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/esp32/main/main.cpp#L416-L424))
+    ([`esp32/main/main.cpp`](../esp32/main/main.cpp))
     or Silicon Labs
-    ([`silabs/src/AppTask.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/silabs/src/AppTask.cpp#L167)),
+    ([`silabs/src/AppTask.cpp`](../silabs/src/AppTask.cpp)),
     the platform boots with a hardware `FactoryDataProvider` that reads
     credentials from encrypted flash partitions.
 
@@ -200,7 +200,7 @@ disk**. In real products:
 
 1. **Implement `DeviceAttestationCredentialsProvider`**: Implement the pure
    abstract interface
-   [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70).
+   [`chip::Credentials::DeviceAttestationCredentialsProvider`](../../../src/credentials/DeviceAttestationCredsProvider.h).
    Cryptographic signing operations (`SignWithDeviceAttestationKey`) must
    delegate directly to your secure hardware without exporting the private key
    into system RAM.
@@ -208,10 +208,10 @@ disk**. In real products:
     - **Linux / Android Gateways**: Delegate signing to a Hardware Secure
       Element (e.g. `ATECC608`, NXP `SE050` via I2C/PKCS#11), TPM, or platform
       Secure Enclave / TrustZone (see
-      [`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+      [`TrustyDACProvider`](../../../src/platform/Linux/DeviceAttestationCredsTrusty.h)).
     - **Embedded MCUs (ESP32, Nordic, Silicon Labs)**: Use the platform's
       hardware factory data provider (e.g.,
-      [`ESP32FactoryDataProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/ESP32/ESP32FactoryDataProvider.h))
+      [`ESP32FactoryDataProvider`](../../../src/platform/ESP32/ESP32FactoryDataProvider.h))
       to read factory-flashed credentials and utilize on-chip crypto hardware.
 3. **Register at Boot**: Register your hardware provider before initializing the
    Matter server or starting the event loop:

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -178,20 +178,18 @@ The `all-devices-app` implementation provides a decoupled provider architecture:
     [`AllDevicesExampleDACProvider`](../all-devices-common/providers/AllDevicesExampleDACProvider.h)
     located in
     [`all-devices-common/providers/`](../all-devices-common/providers/).
--   **POSIX Simulator Boot**: In
-    [`posix/main.cpp`](../posix/main.cpp),
-    the application initializes `AllDevicesExampleDACProvider` with
+-   **POSIX Simulator Boot**: In [`posix/main.cpp`](../posix/main.cpp), the
+    application initializes `AllDevicesExampleDACProvider` with
     `AppOptions::GetConfig().dacProvider`. This allows passing
     `--dac_provider <path.json>` on the command line to dynamically load JSON
     test vectors during CI/WOCA certification testing, or falling back to the
     SDK's built-in example credentials
     (`chip::Credentials::Examples::GetExampleDACProvider()`).
 -   **Embedded MCU Boot**: On hardware targets like ESP32
-    ([`esp32/main/main.cpp`](../esp32/main/main.cpp))
-    or Silicon Labs
-    ([`silabs/src/AppTask.cpp`](../silabs/src/AppTask.cpp)),
-    the platform boots with a hardware `FactoryDataProvider` that reads
-    credentials from encrypted flash partitions.
+    ([`esp32/main/main.cpp`](../esp32/main/main.cpp)) or Silicon Labs
+    ([`silabs/src/AppTask.cpp`](../silabs/src/AppTask.cpp)), the platform boots
+    with a hardware `FactoryDataProvider` that reads credentials from encrypted
+    flash partitions.
 
 ### Transitioning to Production Hardware
 

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -166,31 +166,62 @@ void ApplicationShutdownHook()
 
 ## 5. Device Attestation Credentials (DAC) Implementation & Production
 
-In the Matter data model, Device Attestation Credentials (DAC) provide cryptographic proof of a device's identity, vendor ID, product ID, and Matter certification.
+In the Matter data model, Device Attestation Credentials (DAC) provide
+cryptographic proof of a device's identity, vendor ID, product ID, and Matter
+certification.
 
 ### DAC Implementation in `all-devices-app`
 
 The `all-devices-app` implementation provides a decoupled provider architecture:
 
-- **Reference Provider**: [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h) located in [`all-devices-common/providers/`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/).
-- **POSIX Simulator Boot**: In [`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352), the application initializes `AllDevicesExampleDACProvider` with `AppOptions::GetConfig().dacProvider`. This allows passing `--dac_provider <path.json>` on the command line to dynamically load JSON test vectors during CI/WOCA certification testing, or falling back to the SDK's built-in example credentials (`chip::Credentials::Examples::GetExampleDACProvider()`).
-- **Embedded MCU Boot**: On hardware targets like ESP32 ([`esp32/main/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/esp32/main/main.cpp#L416-L424)) or Silicon Labs ([`silabs/src/AppTask.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/silabs/src/AppTask.cpp#L167)), the platform boots with a hardware `FactoryDataProvider` that reads credentials from encrypted flash partitions.
+-   **Reference Provider**:
+    [`AllDevicesExampleDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/AllDevicesExampleDACProvider.h)
+    located in
+    [`all-devices-common/providers/`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/all-devices-common/providers/).
+-   **POSIX Simulator Boot**: In
+    [`posix/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/posix/main.cpp#L347-L352),
+    the application initializes `AllDevicesExampleDACProvider` with
+    `AppOptions::GetConfig().dacProvider`. This allows passing
+    `--dac_provider <path.json>` on the command line to dynamically load JSON
+    test vectors during CI/WOCA certification testing, or falling back to the
+    SDK's built-in example credentials
+    (`chip::Credentials::Examples::GetExampleDACProvider()`).
+-   **Embedded MCU Boot**: On hardware targets like ESP32
+    ([`esp32/main/main.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/esp32/main/main.cpp#L416-L424))
+    or Silicon Labs
+    ([`silabs/src/AppTask.cpp`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/examples/all-devices-app/silabs/src/AppTask.cpp#L167)),
+    the platform boots with a hardware `FactoryDataProvider` that reads
+    credentials from encrypted flash partitions.
 
 ### Transitioning to Production Hardware
 
-Commercial products **must never use JSON files or plaintext DAC private keys on disk**. In real products:
+Commercial products **must never use JSON files or plaintext DAC private keys on
+disk**. In real products:
 
-1. **Implement `DeviceAttestationCredentialsProvider`**: Implement the pure abstract interface [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70). Cryptographic signing operations (`SignWithDeviceAttestationKey`) must delegate directly to your secure hardware without exporting the private key into system RAM.
+1. **Implement `DeviceAttestationCredentialsProvider`**: Implement the pure
+   abstract interface
+   [`chip::Credentials::DeviceAttestationCredentialsProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/credentials/DeviceAttestationCredsProvider.h#L34-L70).
+   Cryptographic signing operations (`SignWithDeviceAttestationKey`) must
+   delegate directly to your secure hardware without exporting the private key
+   into system RAM.
 2. **Platform Hardware Binding**:
-   - **Linux / Android Gateways**: Delegate signing to a Hardware Secure Element (e.g. ATECC608, NXP SE050 via I2C/PKCS#11), TPM, or platform Secure Enclave / TrustZone (see [`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
-   - **Embedded MCUs (ESP32, Nordic, Silicon Labs)**: Use the platform's hardware factory data provider (e.g., [`ESP32FactoryDataProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/ESP32/ESP32FactoryDataProvider.h)) to read factory-flashed credentials and utilize on-chip crypto hardware.
-3. **Register at Boot**: Register your hardware provider before initializing the Matter server or starting the event loop:
-   ```cpp
-   #include <credentials/DeviceAttestationCredsProvider.h>
+    - **Linux / Android Gateways**: Delegate signing to a Hardware Secure
+      Element (e.g. ATECC608, NXP SE050 via I2C/PKCS#11), TPM, or platform
+      Secure Enclave / TrustZone (see
+      [`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
+    - **Embedded MCUs (ESP32, Nordic, Silicon Labs)**: Use the platform's
+      hardware factory data provider (e.g.,
+      [`ESP32FactoryDataProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/ESP32/ESP32FactoryDataProvider.h))
+      to read factory-flashed credentials and utilize on-chip crypto hardware.
+3. **Register at Boot**: Register your hardware provider before initializing the
+   Matter server or starting the event loop:
 
-   // Initialize your hardware/platform secure element DAC provider
-   SetDeviceAttestationCredentialsProvider(&gProductHardwareDACProvider);
-   ```
+    ```cpp
+    #include <credentials/DeviceAttestationCredsProvider.h>
+
+    // Initialize your hardware/platform secure element DAC provider
+    SetDeviceAttestationCredentialsProvider(&gProductHardwareDACProvider);
+    ```
 
 ---
 
@@ -205,6 +236,6 @@ Commercial products **must never use JSON files or plaintext DAC private keys on
 3. **Persist Hardware State**: Replace simulated cluster implementations with
    hardware drivers (e.g., binding a PWM driver to WriteAttribute callbacks) and
    persist calibration data via storage delegates.
-4. **Hardware-Isolated Attestation**: Bind `DeviceAttestationCredentialsProvider`
-   directly to your secure element or factory partition driver rather than using
-   CLI/file-based credentials.
+4. **Hardware-Isolated Attestation**: Bind
+   `DeviceAttestationCredentialsProvider` directly to your secure element or
+   factory partition driver rather than using CLI/file-based credentials.

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -206,7 +206,7 @@ disk**. In real products:
    into system RAM.
 2. **Platform Hardware Binding**:
     - **Linux / Android Gateways**: Delegate signing to a Hardware Secure
-      Element (e.g. ATECC608, NXP SE050 via I2C/PKCS#11), TPM, or platform
+      Element (e.g. `ATECC608`, NXP `SE050` via I2C/PKCS#11), TPM, or platform
       Secure Enclave / TrustZone (see
       [`TrustyDACProvider`](file:///usr/local/google/home/sergiosoares/connectedhomeip2/src/platform/Linux/DeviceAttestationCredsTrusty.h#L26-L45)).
     - **Embedded MCUs (ESP32, Nordic, Silicon Labs)**: Use the platform's

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -182,9 +182,8 @@ The `all-devices-app` implementation provides a decoupled provider architecture:
     application initializes `AllDevicesExampleDACProvider` with
     `AppOptions::GetConfig().dacProvider`. This allows passing
     `--dac_provider <path.json>` on the command line to dynamically load JSON
-    test vectors during testing, or falling back to the
-    SDK's built-in example credentials
-    (`chip::Credentials::Examples::GetExampleDACProvider()`).
+    test vectors during testing, or falling back to the SDK's built-in example
+    credentials (`chip::Credentials::Examples::GetExampleDACProvider()`).
 -   **Embedded MCU Boot**: On hardware targets like ESP32
     ([`esp32/main/main.cpp`](../esp32/main/main.cpp)) or Silicon Labs
     ([`silabs/src/AppTask.cpp`](../silabs/src/AppTask.cpp)), the platform boots

--- a/examples/all-devices-app/docs/custom_product_baseline.md
+++ b/examples/all-devices-app/docs/custom_product_baseline.md
@@ -182,7 +182,7 @@ The `all-devices-app` implementation provides a decoupled provider architecture:
     application initializes `AllDevicesExampleDACProvider` with
     `AppOptions::GetConfig().dacProvider`. This allows passing
     `--dac_provider <path.json>` on the command line to dynamically load JSON
-    test vectors during CI/WOCA certification testing, or falling back to the
+    test vectors during testing, or falling back to the
     SDK's built-in example credentials
     (`chip::Credentials::Examples::GetExampleDACProvider()`).
 -   **Embedded MCU Boot**: On hardware targets like ESP32

--- a/examples/all-devices-app/docs/starting_up.md
+++ b/examples/all-devices-app/docs/starting_up.md
@@ -57,7 +57,8 @@ can be repeated multiple times to build composite or multi-endpoint topologies.
 > [!TIP] This application inherits the Matter SDK's complete baseline option
 > parser. For the complete, live list of available network commissioning
 > (`--wifi`, `--ble-controller`), operational binding (`--port`,
-> `--interface-id`), descriptor (`--discriminator`, `--vendor-id`), and
+> `--interface-id`), descriptor (`--discriminator`, `--vendor-id`, `--product-id`),
+> device attestation credentials (`--dac_provider`), and
 > persistent storage (`--KVS`) arguments, execute the binary with `--help`:
 >
 > ```bash

--- a/examples/all-devices-app/docs/starting_up.md
+++ b/examples/all-devices-app/docs/starting_up.md
@@ -57,8 +57,8 @@ can be repeated multiple times to build composite or multi-endpoint topologies.
 > [!TIP] This application inherits the Matter SDK's complete baseline option
 > parser. For the complete, live list of available network commissioning
 > (`--wifi`, `--ble-controller`), operational binding (`--port`,
-> `--interface-id`), descriptor (`--discriminator`, `--vendor-id`, `--product-id`),
-> device attestation credentials (`--dac_provider`), and
+> `--interface-id`), descriptor (`--discriminator`, `--vendor-id`,
+> `--product-id`), device attestation credentials (`--dac_provider`), and
 > persistent storage (`--KVS`) arguments, execute the binary with `--help`:
 >
 > ```bash

--- a/examples/all-devices-app/posix/BUILD.gn
+++ b/examples/all-devices-app/posix/BUILD.gn
@@ -76,6 +76,7 @@ executable("all-devices-app") {
     "${chip_root}/examples/all-devices-app/all-devices-common/device/types/speaker",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/types/water-valve",
     "${chip_root}/examples/all-devices-app/all-devices-common/oob-accessors:oob-accessors",
+    "${chip_root}/examples/all-devices-app/all-devices-common/providers:all-devices-example-dac-provider",
     "${chip_root}/examples/all-devices-app/all-devices-common/providers:all-devices-example-device-info-provider",
     "${chip_root}/examples/all-devices-app/all-devices-common/providers:all-devices-example-device-instance-info-provider",
     "${chip_root}/examples/all-devices-app/posix/app_options:app-options",

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -237,7 +237,11 @@ OptionSet * AppOptions::GetOptions()
 #endif
 
         result += "  --KVS <path>\n";
+#if defined(CHIP_CONFIG_KVS_PATH)
         result += "       Path to the Key Value Store file (default: " CHIP_CONFIG_KVS_PATH ")\n\n";
+#else
+        result += "       Path to the Key Value Store file\n\n";
+#endif
 
         result += "  --discriminator <number>\n";
         result += "       Discriminator value for commissioning (default: 3840)\n\n";

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -57,6 +57,7 @@ constexpr uint16_t kOptionBLE           = 0xffd9;
 constexpr uint16_t kOptionGroupcast     = 0xffda;
 constexpr uint16_t kOptionAppPipe       = 0xffdb;
 constexpr uint16_t kOptionTraceTo       = 0xffdc;
+constexpr uint16_t kOptionDacProvider   = 0xffdd;
 
 DeviceTypeParser AppOptions::sParser;
 AppOptions::AppConfig AppOptions::mConfig;
@@ -172,6 +173,10 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
         mConfig.traceTo.push_back(value);
         ChipLogProgress(AppServer, "Added trace destination: %s", value);
         return true;
+    case kOptionDacProvider:
+        mConfig.dacProvider = value;
+        ChipLogProgress(AppServer, "DAC provider file set to %s", value);
+        return true;
     default:
         ChipLogError(Support, "%s: INTERNAL ERROR: Unhandled option: %s\n", program, name);
         return false;
@@ -199,6 +204,7 @@ OptionSet * AppOptions::GetOptions()
         { "groupcast", kNoArgument, kOptionGroupcast },
         { "app-pipe", kArgumentRequired, kOptionAppPipe },
         { "trace-to", kArgumentRequired, kOptionTraceTo },
+        { "dac_provider", kArgumentRequired, kOptionDacProvider },
         {}, // need empty terminator
     };
 
@@ -256,6 +262,9 @@ OptionSet * AppOptions::GetOptions()
 
         result += "  --trace-to <destination>\n";
         result += "       Enable tracing destination (e.g., json:log, json:file_path)\n\n";
+
+        result += "  --dac_provider <path>\n";
+        result += "       Path to JSON file containing device attestation credentials\n\n";
 
         return result;
     }();

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -43,6 +43,7 @@ public:
         std::optional<uint16_t> productId;
         std::optional<uint32_t> interfaceId;
         std::string kvsPath;
+        std::optional<std::string> dacProvider;
         bool enableWiFi        = false;
         uint32_t bleController = 0;
     };

--- a/examples/all-devices-app/posix/app_options/tests/BUILD.gn
+++ b/examples/all-devices-app/posix/app_options/tests/BUILD.gn
@@ -26,6 +26,7 @@ if (chip_build_tests) {
     cflags = [ "-Wconversion" ]
 
     public_deps = [
+      "${chip_root}/examples/all-devices-app/posix/app_options:app-options",
       "${chip_root}/examples/all-devices-app/posix/app_options:device-type-parser",
       "${chip_root}/src/lib/support:testing",
       "${chip_root}/src/platform",

--- a/examples/all-devices-app/posix/app_options/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/posix/app_options/tests/TestDeviceTypeParser.cpp
@@ -458,6 +458,5 @@ TEST(TestAppOptions, Parse_DacProvider)
     ArgParser::OptionSet * options[] = { AppOptions::GetOptions(), nullptr };
     EXPECT_TRUE(ArgParser::ParseArgs("all-devices-app", 3, const_cast<char * const *>(argv), options));
     EXPECT_EQ(AppOptions::ValidateConfig(), CHIP_NO_ERROR);
-    EXPECT_TRUE(AppOptions::GetConfig().dacProvider.has_value());
-    EXPECT_EQ(AppOptions::GetConfig().dacProvider.value(), "path/to/dac.json");
+    EXPECT_EQ(AppOptions::GetConfig().dacProvider.value_or(""), "path/to/dac.json");
 }

--- a/examples/all-devices-app/posix/app_options/tests/TestDeviceTypeParser.cpp
+++ b/examples/all-devices-app/posix/app_options/tests/TestDeviceTypeParser.cpp
@@ -16,7 +16,9 @@
  *    limitations under the License.
  */
 
+#include <app_options/AppOptions.h>
 #include <app_options/DeviceTypeParser.h>
+#include <lib/support/CHIPArgParser.hpp>
 #include <pw_unit_test/framework.h>
 
 using namespace chip;
@@ -448,4 +450,14 @@ TEST_F(TestDeviceTypeParser, ValidateConfig_CycleDetected)
     std::vector<DeviceTypeParser::Entry> entries = { { .type = "chime", .endpoint = 2, .parentId = 3 },
                                                      { .type = "speaker", .endpoint = 3, .parentId = 2 } };
     EXPECT_NE(DeviceTypeParser::ValidateConfig(entries), CHIP_NO_ERROR);
+}
+
+TEST(TestAppOptions, Parse_DacProvider)
+{
+    const char * argv[]              = { "all-devices-app", "--dac_provider", "path/to/dac.json", nullptr };
+    ArgParser::OptionSet * options[] = { AppOptions::GetOptions(), nullptr };
+    EXPECT_TRUE(ArgParser::ParseArgs("all-devices-app", 3, const_cast<char * const *>(argv), options));
+    EXPECT_EQ(AppOptions::ValidateConfig(), CHIP_NO_ERROR);
+    EXPECT_TRUE(AppOptions::GetConfig().dacProvider.has_value());
+    EXPECT_EQ(AppOptions::GetConfig().dacProvider.value(), "path/to/dac.json");
 }

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -35,12 +35,12 @@
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
+#include <providers/AllDevicesExampleDACProvider.h>
 #include <providers/AllDevicesExampleDeviceInfoProviderImpl.h>
 #include <providers/AllDevicesExampleDeviceInstanceInfoProviderImpl.h>
 
 #include <app_options/AppOptions.h>
 #include <app_options/DeviceTypeParser.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <device-factory/DeviceFactory.h>
 #include <device/api/allocator/DynamicEndpointIdAllocator.h>
 #include <oob-accessors/OOBAccessor.h>
@@ -346,7 +346,9 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 
     // Set the global DAC provider before server/cluster init so any integration path that
     // snapshots the provider during construction sees a valid implementation.
-    SetDeviceAttestationCredentialsProvider(Credentials::Examples::GetExampleDACProvider());
+    static DeviceLayer::AllDevicesExampleDACProvider sDacProvider;
+    SuccessOrDie(sDacProvider.Init(AppOptions::GetConfig().dacProvider));
+    SetDeviceAttestationCredentialsProvider(&sDacProvider);
 
     static CodeDrivenDataModelDevices devices({
         .storageDelegate                = *initParams.persistentStorageDelegate,                   //


### PR DESCRIPTION
#### Summary

Adds support for the `--dac_provider <path_to_json>` CLI parameter in `all-devices-app` (POSIX), enabling dynamic injection of Device Attestation Credentials (DAC) test vectors during CI, WOCA, and Python certification testing.

##### Problem

- `all-devices-app` lacked support for the `--dac_provider` CLI option present in `all-clusters-app`.
- WOCA certification tests and CI test runners need to dynamically supply custom DAC test vectors (DAC cert, PAI cert, CD, and DAC private key) to test different Vendor IDs and Product IDs during device attestation.
- Without this flag, running `all-devices-app` with `--dac_provider` caused an unhandled command-line option error and immediate termination.

##### Solution

- Implemented `AllDevicesExampleDACProvider` in `examples/all-devices-app/all-devices-common/providers/`:
  - When `--dac_provider <path>` is specified, dynamically loads credentials from the provided JSON test vector file.
  - When `--dac_provider` is omitted, cleanly falls back to the default SDK example credentials provider (`chip::Credentials::Examples::GetExampleDACProvider()`).
- Updated `posix/main.cpp` and `posix/app_options/AppOptions` to parse and store the `--dac_provider` CLI parameter and initialize `AllDevicesExampleDACProvider`.
- Added a `README.md` in `all-devices-common/providers/` and updated `custom_product_baseline.md` and `starting_up.md` documentation to clarify provider architecture for simulation vs. commercial production.
- Added unit tests in `TestDeviceTypeParser` for `--dac_provider` argument parsing.

#### Testing

- Added unit tests verifying `--dac_provider` CLI option parsing in `examples/all-devices-app/posix/app_options/tests/TestDeviceTypeParser.cpp`.
- Manually tested across three scenarios using `chip-tool`:
  1. **Default DAC**: Ran without `--dac_provider`; verified commissioning succeeded with default VendorID (`0xFFF1`) and ProductID (`0x8001`).
  2. **Valid Custom DAC**: Ran with `--dac_provider credentials/development/commissioner_dut/struct_cd_cms_v3/test_case_vector.json` and `--product-id 0x8000`; verified commissioning succeeded and read `ProductID: 32768`.
  3. **Attestation Enforcement**: Ran with invalid DAC test vector `struct_dac_vidpid_fallback_encoding_08`; verified attestation was rejected with `err 303 (DAC format is invalid)` on standard commissioning, and passed when `--bypass-attestation-verifier true` was supplied.