### PR TITLE
[TC-IDM-13.1] Add SDK default manufacturing date check

### DIFF
--- a/src/python_testing/TC_DefaultWarnings.py
+++ b/src/python_testing/TC_DefaultWarnings.py
@@ -29,7 +29,7 @@
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
-#       --bool-arg pixit_allow_test_in_product_name:True pixit_allow_test_in_vendor_name:True pixit_allow_default_vendor_id:True pixit_allow_fixed_label_default_values:True
+#       --bool-arg pixit_allow_test_in_product_name:True pixit_allow_test_in_vendor_name:True pixit_allow_default_vendor_id:True pixit_allow_fixed_label_default_values:True pixit_allow_default_manufacturing_date:True
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
@@ -40,7 +40,7 @@ from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.decorators import async_test_body
 from matter.testing.default_checker import (FLAG_DEFAULT_CALENDAR_FORMAT, FLAG_FAULT_INJECTION, FLAG_FIXED_LABEL_DEFAULT_VALUES,
                                             FLAG_FIXED_LABEL_EMPTY, FLAG_PRODUCT_NAME, FLAG_SAMPLE_MEI, FLAG_UNIT_TESTING,
-                                            FLAG_VENDOR_ID, FLAG_VENDOR_NAME, DefaultChecker)
+                                            FLAG_VENDOR_ID, FLAG_VENDOR_NAME, FLAG_MANUFACTURING_DATE, DefaultChecker)
 from matter.testing.runner import TestStep, default_matter_test_main
 
 
@@ -69,11 +69,11 @@ class TC_DefaultChecker(BasicCompositionTests, DefaultChecker):
                 TestStep(7, f"If the {FLAG_FAULT_INJECTION} flag is not set, check for the presence of a fault injection cluster on any endpoint",
                          "Fault injection cluster does not appear on any endpoint"),
                 TestStep(8, f"If the {FLAG_SAMPLE_MEI} flag is not set, check for the presence of a sample mei cluster on any endpoint",
-                         "Sample MEI cluster does not appear on any endpoint"),
-                TestStep(
-            9, f"If the {FLAG_FIXED_LABEL_EMPTY} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list is not empty", "List is not empty"),
-            TestStep(10, f"If the {FLAG_FIXED_LABEL_DEFAULT_VALUES} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list does not contain any of the default labels", "List does not contain default labels"),
-            TestStep(11, "Fail on any problems")
+                         "Sample MEI cluster does not appear on any endpoint"),            
+                TestStep(9, f"If the {FLAG_FIXED_LABEL_EMPTY} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list is not empty", "List is not empty"),
+                TestStep(10, f"If the {FLAG_FIXED_LABEL_DEFAULT_VALUES} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list does not contain any of the default labels", "List does not contain default labels"),
+                TestStep(11, f"If the {FLAG_MANUFACTURING_DATE} flag is not set, and the BasicInformation clusters ManufacturingDate attr is present on the device, check that the devices manufacturing date does not equal the SDK default manufacturing date", "Devices manufacturing date does not equal SDK default manufacturing date"),
+                TestStep(12, "Fail on any problems")
         ]
 
     def desc_TC_IDM_13_1(self):
@@ -101,6 +101,8 @@ class TC_DefaultChecker(BasicCompositionTests, DefaultChecker):
         self.step(10)
         self.check_fixed_label_cluster_defaults()
         self.step(11)
+        self.check_default_manufacturing_date()
+        self.step(12)
 
         if self.problems:
             asserts.fail("One or more default values found on device")

--- a/src/python_testing/TC_DefaultWarnings.py
+++ b/src/python_testing/TC_DefaultWarnings.py
@@ -39,8 +39,8 @@ from mobly import asserts
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.decorators import async_test_body
 from matter.testing.default_checker import (FLAG_DEFAULT_CALENDAR_FORMAT, FLAG_FAULT_INJECTION, FLAG_FIXED_LABEL_DEFAULT_VALUES,
-                                            FLAG_FIXED_LABEL_EMPTY, FLAG_PRODUCT_NAME, FLAG_SAMPLE_MEI, FLAG_UNIT_TESTING,
-                                            FLAG_VENDOR_ID, FLAG_VENDOR_NAME, FLAG_MANUFACTURING_DATE, DefaultChecker)
+                                            FLAG_FIXED_LABEL_EMPTY, FLAG_MANUFACTURING_DATE, FLAG_PRODUCT_NAME, FLAG_SAMPLE_MEI,
+                                            FLAG_UNIT_TESTING, FLAG_VENDOR_ID, FLAG_VENDOR_NAME, DefaultChecker)
 from matter.testing.runner import TestStep, default_matter_test_main
 
 
@@ -69,12 +69,14 @@ class TC_DefaultChecker(BasicCompositionTests, DefaultChecker):
                 TestStep(7, f"If the {FLAG_FAULT_INJECTION} flag is not set, check for the presence of a fault injection cluster on any endpoint",
                          "Fault injection cluster does not appear on any endpoint"),
                 TestStep(8, f"If the {FLAG_SAMPLE_MEI} flag is not set, check for the presence of a sample mei cluster on any endpoint",
-                         "Sample MEI cluster does not appear on any endpoint"),            
-                TestStep(9, f"If the {FLAG_FIXED_LABEL_EMPTY} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list is not empty", "List is not empty"),
+                         "Sample MEI cluster does not appear on any endpoint"),
+                TestStep(
+                    9, f"If the {FLAG_FIXED_LABEL_EMPTY} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list is not empty", "List is not empty"),
                 TestStep(10, f"If the {FLAG_FIXED_LABEL_DEFAULT_VALUES} flag is not set, and the FixedLabel cluster is present on the device, check that the fixed label cluster list does not contain any of the default labels", "List does not contain default labels"),
-                TestStep(11, f"If the {FLAG_MANUFACTURING_DATE} flag is not set, and the BasicInformation clusters ManufacturingDate attr is present on the device, check that the devices manufacturing date does not equal the SDK default manufacturing date", "Devices manufacturing date does not equal SDK default manufacturing date"),
+                TestStep(11, f"If the {FLAG_MANUFACTURING_DATE} flag is not set, and the BasicInformation clusters ManufacturingDate attr is present on the device, check that the devices manufacturing date does not equal the SDK default manufacturing date",
+                         "Devices manufacturing date does not equal SDK default manufacturing date"),
                 TestStep(12, "Fail on any problems")
-        ]
+                ]
 
     def desc_TC_IDM_13_1(self):
         return "[TC-IDM-13.1] Accidental defaults check - [DUT as Server]"

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
@@ -30,6 +30,7 @@ FLAG_FAULT_INJECTION = "pixit_allow_fault_injection_cluster"
 FLAG_SAMPLE_MEI = "pixit_allow_sample_mei_cluster"
 FLAG_FIXED_LABEL_EMPTY = "pixit_allow_empty_fixed_label_list"
 FLAG_FIXED_LABEL_DEFAULT_VALUES = "pixit_allow_fixed_label_default_values"
+FLAG_MANUFACTURING_DATE = "pixit_allow_default_manufacturing_date"
 
 
 DEFAULT_FIXED_LABEL_VALUES = [Clusters.FixedLabel.Structs.LabelStruct(label='room', value='bedroom 2'),
@@ -101,6 +102,19 @@ class DefaultChecker:
         for endpoint_num, endpoint in self.endpoints.items():
             if cluster.id in endpoint[Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList]:
                 return _problem(ClusterPathLocation(endpoint_num, cluster.id), f"{cluster.__name__} cluster found on device.")
+        return None
+
+    @warning_wrapper(FLAG_MANUFACTURING_DATE)
+    def check_default_manufacturing_date(self):
+        cluster = Clusters.BasicInformation
+        attr = cluster.Attributes.ManufacturingDate
+        if attr in self.endpoints[0][cluster]:
+            val = self.endpoints[0][cluster][attr]
+            sdk_default_date = "20200101"
+            if val[:8] == sdk_default_date:
+                return _problem(AttributePathLocation(0, cluster.id, attr.attribute_id), f"Manufacturing date ({val}) should not be the same as SDK default manufacturing date ({sdk_default_date})")
+        else:
+            self.mark_current_step_skipped()
         return None
 
     @warning_wrapper(FLAG_UNIT_TESTING)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
@@ -108,13 +108,12 @@ class DefaultChecker:
     def check_default_manufacturing_date(self):
         cluster = Clusters.BasicInformation
         attr = cluster.Attributes.ManufacturingDate
-        if attr in self.endpoints[0][cluster]:
-            val = self.endpoints[0][cluster][attr]
+        basic_info = self.endpoints[0][cluster]
+        if attr in basic_info:
+            val = basic_info[attr]
             sdk_default_date = "20200101"
             if val[:8] == sdk_default_date:
-                return _problem(AttributePathLocation(0, cluster.id, attr.attribute_id), f"Manufacturing date ({val}) should not be the same as SDK default manufacturing date ({sdk_default_date})")
-        else:
-            self.mark_current_step_skipped()
+                return _problem(AttributePathLocation(0, cluster.id, attr.attribute_id), f"WARNING: Manufacturing date ({val}) should not be the same as SDK default manufacturing date ({sdk_default_date})")
         return None
 
     @warning_wrapper(FLAG_UNIT_TESTING)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/default_checker.py
@@ -113,7 +113,9 @@ class DefaultChecker:
             val = basic_info[attr]
             sdk_default_date = "20200101"
             if val[:8] == sdk_default_date:
-                return _problem(AttributePathLocation(0, cluster.id, attr.attribute_id), f"WARNING: Manufacturing date ({val}) should not be the same as SDK default manufacturing date ({sdk_default_date})")
+                return _problem(AttributePathLocation(0, cluster.id, attr.attribute_id), f"Manufacturing date ({val}) should not be the same as SDK default manufacturing date ({sdk_default_date})")
+        else:
+            self.mark_current_step_skipped()
         return None
 
     @warning_wrapper(FLAG_UNIT_TESTING)

--- a/src/python_testing/test_testing/TestDefaultWarnings.py
+++ b/src/python_testing/test_testing/TestDefaultWarnings.py
@@ -63,6 +63,37 @@ class TestDefaultChecker(MatterBaseTest):
         run_check('OK name', set_override=True, expect_problem=False)
         asserts.assert_equal(self.skipped, 4, "Some override tests did not mark steps skipped")
 
+    def test_manufacturing_date_is_not_default_check(self):
+        def run_check(manufacturing_date: str, set_override: bool, expect_problem: bool):
+            self.test.user_params = {DefaultChecker.FLAG_MANUFACTURING_DATE: set_override}
+            self.test.problems = []
+            self.test.endpoints = {0: {Clusters.BasicInformation: {Clusters.BasicInformation.Attributes.ManufacturingDate: manufacturing_date}}}
+            self.test.check_default_manufacturing_date()
+            if expect_problem:
+                asserts.assert_equal(len(self.test.problems), 1,
+                                     f"did not generate expected problem when testing with manufacturing date {manufacturing_date} (override = {set_override})")
+            else:
+                asserts.assert_equal(len(self.test.problems), 0,
+                                     f"Unexpected problem when testing with manufacturing date {manufacturing_date} (override = {set_override})")
+
+        # Attribute not present -> should be skipped, no problem
+        self.skipped = 0
+        self.test.problems = []
+        self.test.user_params = {}
+        self.test.endpoints = {0: {Clusters.BasicInformation: {}}}
+        self.test.check_default_manufacturing_date()
+        asserts.assert_equal(len(self.test.problems), 0,
+                                "Unexpected problem when ManufacturingDate attribute is not present")
+        asserts.assert_equal(self.skipped, 1, "Absent ManufacturingDate did not mark step skipped")
+
+        self.skipped = 0
+        run_check('20200101', set_override=False, expect_problem=True)
+        run_check('20200102', set_override=False, expect_problem=False)
+        run_check('20200102', set_override=True, expect_problem=False)
+        run_check('20200101-test1', set_override=False, expect_problem=True)  
+        run_check('20200102-test2', set_override=False, expect_problem=False) 
+        asserts.assert_equal(self.skipped, 1, "Some override tests did not mark steps skipped")
+
     def test_vendor_name_is_not_default_check(self):
         def run_check(vendor_name: str, set_override: bool, expect_problem: bool):
             self.test.user_params = {DefaultChecker.FLAG_VENDOR_NAME: set_override}

--- a/src/python_testing/test_testing/TestDefaultWarnings.py
+++ b/src/python_testing/test_testing/TestDefaultWarnings.py
@@ -67,7 +67,8 @@ class TestDefaultChecker(MatterBaseTest):
         def run_check(manufacturing_date: str, set_override: bool, expect_problem: bool):
             self.test.user_params = {DefaultChecker.FLAG_MANUFACTURING_DATE: set_override}
             self.test.problems = []
-            self.test.endpoints = {0: {Clusters.BasicInformation: {Clusters.BasicInformation.Attributes.ManufacturingDate: manufacturing_date}}}
+            self.test.endpoints = {0: {Clusters.BasicInformation: {
+                Clusters.BasicInformation.Attributes.ManufacturingDate: manufacturing_date}}}
             self.test.check_default_manufacturing_date()
             if expect_problem:
                 asserts.assert_equal(len(self.test.problems), 1,
@@ -83,15 +84,15 @@ class TestDefaultChecker(MatterBaseTest):
         self.test.endpoints = {0: {Clusters.BasicInformation: {}}}
         self.test.check_default_manufacturing_date()
         asserts.assert_equal(len(self.test.problems), 0,
-                                "Unexpected problem when ManufacturingDate attribute is not present")
+                             "Unexpected problem when ManufacturingDate attribute is not present")
         asserts.assert_equal(self.skipped, 1, "Absent ManufacturingDate did not mark step skipped")
 
         self.skipped = 0
         run_check('20200101', set_override=False, expect_problem=True)
         run_check('20200102', set_override=False, expect_problem=False)
         run_check('20200102', set_override=True, expect_problem=False)
-        run_check('20200101-test1', set_override=False, expect_problem=True)  
-        run_check('20200102-test2', set_override=False, expect_problem=False) 
+        run_check('20200101-test1', set_override=False, expect_problem=True)
+        run_check('20200102-test2', set_override=False, expect_problem=False)
         asserts.assert_equal(self.skipped, 1, "Some override tests did not mark steps skipped")
 
     def test_vendor_name_is_not_default_check(self):

--- a/src/python_testing/test_testing/TestDefaultWarnings.py
+++ b/src/python_testing/test_testing/TestDefaultWarnings.py
@@ -91,9 +91,10 @@ class TestDefaultChecker(MatterBaseTest):
         run_check('20200101', set_override=False, expect_problem=True)
         run_check('20200102', set_override=False, expect_problem=False)
         run_check('20200102', set_override=True, expect_problem=False)
+        run_check('20200101', set_override=True, expect_problem=False)
         run_check('20200101-test1', set_override=False, expect_problem=True)
         run_check('20200102-test2', set_override=False, expect_problem=False)
-        asserts.assert_equal(self.skipped, 1, "Some override tests did not mark steps skipped")
+        asserts.assert_equal(self.skipped, 2, "Some override tests did not mark steps skipped")
 
     def test_vendor_name_is_not_default_check(self):
         def run_check(vendor_name: str, set_override: bool, expect_problem: bool):


### PR DESCRIPTION
### Summary

Flags devices whose ManufacturingDate matches the SDK default (2020-01-01), which indicates the value was potentially left unchanged. Gated behind pixit_allow_default_manufacturing_date.

### Related issues

Resolves: https://github.com/project-chip/matter-test-scripts/issues/736 
Test Plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6270

### Testing

TC_DefaultWarnings.py (TC-IDM-13-1) with all devices app:
```
scripts/tests/run_python_test.py --factory-reset --app out/linux-x64-all-devices-clang/all-devices-app --app-args "--discriminator 1234 --KVS kvs1 --device '*'" --script-args "--storage-path admin_storage.json --discriminator 1234 --passcode 20202021 --endpoint 0 --commissioning-method on-network --bool-arg pixit_allow_test_in_product_name:True pixit_allow_test_in_vendor_name:True pixit_allow_default_vendor_id:True pixit_allow_fixed_label_default_values:True pixit_allow_default_manufacturing_date:True" --script src/python_testing/TC_DefaultWarnings.py
```

Unit test example:
```
python3 src/python_testing/test_testing/TestDefaultWarnings.py 
```

Code reviewed by Claude locally before submission.
