### PR TITLE
Initial draft for adding steps 13b 15b in TC_STAT_2_2

### DIFF
--- a/src/python_testing/TC_TSTAT_2_2.py
+++ b/src/python_testing/TC_TSTAT_2_2.py
@@ -41,7 +41,7 @@ from mobly import asserts
 from TC_TSTAT_Utils import ThermostatSimulator, ThermostatState
 
 import matter.clusters as Clusters
-from matter.interaction_model import Status
+from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
@@ -98,9 +98,11 @@ class TC_TSTAT_2_2(MatterBaseTest):
             TestStep("11b", "Test Harness Writes the value below MinSetpointDeadBand"),
             TestStep("11c", "Test Harness Writes the min limit of MinSetpointDeadBand"),
             TestStep("12", "Test Harness Reads ControlSequenceOfOperation from Server DUT, if TSTAT.S.F01 is true"),
-            TestStep("13", "Sets OccupiedCoolingSetpoint to default value"),
+            TestStep("13a", "Test Harness sends SetpointRaiseLower Heat down and verifies setpoint change"),
+            TestStep("13b", "Test Harness sends SetpointRaiseLower Heat on device without heating feature; expect INVALID_COMMAND"),
             TestStep("14", "Sets OccupiedHeatingSetpoint to default value"),
-            TestStep("15", "Test Harness Sends SetpointRaise Command Cool Only"),
+            TestStep("15a", "Test Harness sends SetpointRaiseLower Cool down and verifies setpoint change"),
+            TestStep("15b", "Test Harness sends SetpointRaiseLower Cool on device without cooling feature; expect INVALID_COMMAND"),
             TestStep("16", "Sets OccupiedCoolingSetpoint to default value"),
             TestStep("17", "Sets OccupiedCoolingSetpoint to default value"),
             TestStep("18", "Sets OccupiedCoolingSetpoint to default value"),
@@ -238,6 +240,8 @@ class TC_TSTAT_2_2(MatterBaseTest):
         hasCoolingFeature = self.check_pics("TSTAT.S.F01")
         # Thermostat is capable of managing a heating device
         hasHeatingFeature = self.check_pics("TSTAT.S.F00")
+        # Does the device implement the SetpointRaiseLower command?
+        hasSetpointRaiseLowerCommand = self.check_pics("TSTAT.S.C00.Rsp")
         # Supports Occupied and Unoccupied setpoints
         hasOccupancyFeature = self.check_pics("TSTAT.S.F02")
 
@@ -655,21 +659,43 @@ class TC_TSTAT_2_2(MatterBaseTest):
             if val != ControlSequenceOfOperation:
                 asserts.assert_equal(val, cluster.Enums.ControlSequenceOfOperationEnum.kCoolingAndHeating)
 
-        self.step("13")
+        self.step("13a")
         if self.pics_guard(hasCoolingFeature):
             await self.write_setpoint(cluster.Attributes.OccupiedCoolingSetpoint, OccupiedCoolingSetpointValue)
         if self.pics_guard(hasHeatingFeature):
             await self.write_setpoint(cluster.Attributes.OccupiedHeatingSetpoint, OccupiedHeatingSetpointValue)
             await self.send_raise_lower_and_verify(mode=cluster.Enums.SetpointRaiseLowerModeEnum.kHeat, amount=-30)
 
+        self.step("13b")
+        if self.pics_guard(hasSetpointRaiseLowerCommand and not hasHeatingFeature):
+            try:
+                await self.send_single_cmd(
+                    cmd=Clusters.Objects.Thermostat.Commands.SetpointRaiseLower(
+                        mode=cluster.Enums.SetpointRaiseLowerModeEnum.kHeat, amount=-30),
+                    endpoint=endpoint)
+                asserts.fail("Expected INVALID_COMMAND for Heat mode on device without heating feature")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.InvalidCommand)
+
         self.step("14")
         if self.pics_guard(hasHeatingFeature):
             await self.write_setpoint(cluster.Attributes.OccupiedHeatingSetpoint, OccupiedHeatingSetpointValue)
             await self.send_raise_lower_and_verify(mode=cluster.Enums.SetpointRaiseLowerModeEnum.kHeat, amount=30)
 
-        self.step("15")
+        self.step("15a")
         if self.pics_guard(hasCoolingFeature):
             await self.send_raise_lower_and_verify(mode=cluster.Enums.SetpointRaiseLowerModeEnum.kCool, amount=-30)
+
+        self.step("15b")
+        if self.pics_guard(hasSetpointRaiseLowerCommand and not hasCoolingFeature):
+            try:
+                await self.send_single_cmd(
+                    cmd=Clusters.Objects.Thermostat.Commands.SetpointRaiseLower(
+                        mode=cluster.Enums.SetpointRaiseLowerModeEnum.kCool, amount=-30),
+                    endpoint=endpoint)
+                asserts.fail("Expected INVALID_COMMAND for Cool mode on device without cooling feature")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.InvalidCommand)
 
         self.step("16")
         if self.pics_guard(hasCoolingFeature):


### PR DESCRIPTION
#### Summary

Aligns `TC_TSTAT_2_2.py` with the TC-TSTAT-2.2 test plan by adding steps **13b** and **15b** for negative `SetpointRaiseLower` behavior.

##### Problem

- The Python certification script implements the positive `SetpointRaiseLower` paths (steps 13 and 15) but is missing the negative sub-steps added in [chip-test-plans#4630](https://github.com/CHIP-Specifications/chip-test-plans/pull/4630).
- Without steps **13b** and **15b**, the harness does not verify that `SetpointRaiseLower` returns **`INVALID_COMMAND (0x85)`** when:
  - **Heat** mode is sent on a DUT that supports the command but does **not** have the heating feature (`!TSTAT.S.F00`).
  - **Cool** mode is sent on a DUT that supports the command but does **not** have the cooling feature (`!TSTAT.S.F01`).

##### Solution

- Renamed existing steps **13** and **15** to **13a** and **15a** to match the test plan.
- Added **13b** and **15b** with PICS guards on `TSTAT.S.C00.Rsp` and the absence of the corresponding thermostat feature.
- Negative paths send `SetpointRaiseLower` with `amount = -30` and assert `Status.InvalidCommand` via `InteractionModelError`.

##### Notes

- On default CI PICS (`ci-pics-values`), `all-clusters-app` has both heating and cooling enabled, so **13b** and **15b** are **skipped** by `pics_guard`. This matches the test plan intent; execution requires a cool-only or heat-only DUT configuration.

#### Related issues

Fixes #38320

Test plan: [chip-test-plans#4630](https://github.com/CHIP-Specifications/chip-test-plans/pull/4630)

#### Testing

Ran `TC_TSTAT_2_2` locally on Linux against `chip-all-clusters-app` with CI PICS (`ci-pics-values`).

**Terminal 1** — DUT:

```bash
cd /path/to/connectedhomeip
rm -f kvs1 admin_storage_tstat_2_2.json

./out/linux-x64-all-clusters-clang/chip-all-clusters-app \
  --discriminator 1234 \
  --KVS kvs1