### PR TITLE
[Silabs] : Compilation fix

### DIFF
--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -36,6 +36,7 @@
 #include <app/clusters/thermostat-server/ThermostatCluster.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <thermostat-delegate-impl.h>
 #include <cmsis_os2.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -36,7 +36,6 @@
 #include <app/clusters/thermostat-server/ThermostatCluster.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
-#include <thermostat-delegate-impl.h>
 #include <cmsis_os2.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>
@@ -44,6 +43,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformError.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+#include <thermostat-delegate-impl.h>
 
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
 #include "Si70xxSensor.h"

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -677,7 +677,7 @@ void WindowManager::UpdateLCD()
         chip::app::DataModel::Nullable<uint16_t> tilt;
 
         chip::DeviceLayer::PlatformMgr().LockChipStack();
-        auto wc = FindClusterOnEndpoint(Endpoint());
+        auto wc = FindClusterOnEndpoint(cover.mEndpoint);
         VerifyOrReturn(wc != nullptr);
         Type type = TypeGet(cover.mEndpoint);
 

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -676,13 +676,18 @@ void WindowManager::UpdateLCD()
         chip::app::DataModel::Nullable<uint16_t> lift;
         chip::app::DataModel::Nullable<uint16_t> tilt;
 
-        chip::DeviceLayer::StackLock lock;
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
         auto wc = FindClusterOnEndpoint(cover.mEndpoint);
-        VerifyOrReturn(wc != nullptr);
+        if (wc == nullptr)
+        {
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+            return;
+        }
         Type type = TypeGet(cover.mEndpoint);
 
         lift = wc->GetCurrentPositionLiftPercent100ths();
         tilt = wc->GetCurrentPositionTiltPercent100ths();
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
         if (!tilt.IsNull() && !lift.IsNull())
         {

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -676,18 +676,13 @@ void WindowManager::UpdateLCD()
         chip::app::DataModel::Nullable<uint16_t> lift;
         chip::app::DataModel::Nullable<uint16_t> tilt;
 
-        chip::DeviceLayer::PlatformMgr().LockChipStack();
+        chip::DeviceLayer::StackLock lock;
         auto wc = FindClusterOnEndpoint(cover.mEndpoint);
-        if (wc == nullptr)
-        {
-            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-            return;
-        }
+        VerifyOrReturn(wc != nullptr);
         Type type = TypeGet(cover.mEndpoint);
 
         lift = wc->GetCurrentPositionLiftPercent100ths();
         tilt = wc->GetCurrentPositionTiltPercent100ths();
-        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
         if (!tilt.IsNull() && !lift.IsNull())
         {

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -678,7 +678,11 @@ void WindowManager::UpdateLCD()
 
         chip::DeviceLayer::PlatformMgr().LockChipStack();
         auto wc = FindClusterOnEndpoint(cover.mEndpoint);
-        VerifyOrReturn(wc != nullptr);
+        if (wc == nullptr)
+        {
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+            return;
+        }
         Type type = TypeGet(cover.mEndpoint);
 
         lift = wc->GetCurrentPositionLiftPercent100ths();


### PR DESCRIPTION
### Summary

Fix Window App 
`  ../../../../examples/window-app/silabs/src/WindowManager.cpp: In member function 'void WindowManager::UpdateLCD()':
  ../../../../examples/window-app/silabs/src/WindowManager.cpp:680:41: error: 'Endpoint' was not declared in this scope
    680 |         auto wc = FindClusterOnEndpoint(Endpoint());`

And Thermostat App
`  ../../../../examples/thermostat/silabs/src/AppTask.cpp:358:23: error: 'ThermostatDelegate' has not been declared
    358 |     auto & delegate = ThermostatDelegate::GetInstance();
        |                       ^~~~~~~~~~~~~~~~~~
  At global scope:`
  Issues
### Related issues
N/A

### Testing
CI
https://github.com/SiliconLabsSoftware/matter_sdk/pull/1084 ( now shows more delta as it ran overnight and new changes made into it)