### PR TITLE
[NXP] Set LwIP default interface based on Thread/Wi-Fi state

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -112,6 +112,12 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     // Forward the event to the generic base classes as needed.
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET
+    if (event->Type == DeviceEventType::kThreadStateChange && event->ThreadStateChange.RoleChanged)
+    {
+        UpdateLwipDefaultNetIf();
+    }
+#endif
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET
     if (event->Type == kPlatformNxpIpChangeEvent)
@@ -290,6 +296,12 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState()
             BrHandleStateChange();
 #endif
         }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+        // Re-evaluate the default netif on IPv6 change.
+        UpdateLwipDefaultNetIf();
+#endif
+
         err = PlatformMgr().PostEvent(&event);
         SuccessOrDie(err);
 
@@ -297,6 +309,26 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState()
     }
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET
+
+#if (CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET) && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+void ConnectivityManagerImpl::UpdateLwipDefaultNetIf()
+{
+    struct netif * threadNetIf = ThreadStackMgrImpl().ThreadNetIf();
+
+    // Use the Thread netif as default only when Wi-Fi is not connected and Thread link is up.
+    // When Wi-Fi is brought up, default netif is already set to Wi-Fi interface.
+
+    LOCK_TCPIP_CORE();
+    if (!_IsWiFiStationConnected() && threadNetIf != nullptr && netif_is_link_up(threadNetIf))
+    {
+        if (netif_default != threadNetIf)
+        {
+            netif_set_default(threadNetIf);
+        }
+    }
+    UNLOCK_TCPIP_CORE();
+}
+#endif // (CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET) && CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -148,6 +148,10 @@ private:
     void UpdateInternetConnectivityState(void);
 #endif
 
+#if (CHIP_DEVICE_CONFIG_ENABLE_WPA || CONFIG_CHIP_ETHERNET) && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    void UpdateLwipDefaultNetIf();
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     ConnectivityManager::WiFiStationMode mWiFiStationMode;
     ConnectivityManager::WiFiStationState mWiFiStationState = kWiFiStationState_NotConnected;


### PR DESCRIPTION
While the border router is not yet fully up (Wi-Fi not connected) and the Thread link is up, the Thread netif is used as the default so that outbound connectivity is available over Thread during bring-up.

Once the border router is fully initialised (both Wi-Fi and Thread running), the explicit Thread default is cleared so LwIP selects the infrastructure interface, matching the border-router routing model.

The selection is refreshed on the events that can change interface state (Thread state changes and IPv6 connectivity changes) and the netif update is performed under LOCK_TCPIP_CORE()/UNLOCK_TCPIP_CORE() to stay atomic with respect to the TCP/IP core.

### Testing

Ran Thread commissioning via chip-tool against a border router device that, in a particular network setup, acts purely as a Thread device.