### PR TITLE
chiptest: fix cross-process lost-wakeup hang in CancellableQueue.get()

### DIFF
--- a/scripts/tests/chiptest/concurrency/work_queue.py
+++ b/scripts/tests/chiptest/concurrency/work_queue.py
@@ -166,6 +166,8 @@ class CancellableQueue(TerminableResource, Generic[QueueElementT]):
         # during proxy round-trips) and be lost. Relying on the notify() edge alone would then
         # block forever with an item already enqueued; polling the state bounds that to one
         # interval. Polling also keeps the wait KeyboardInterrupt-catchable.
+        if timeout is not None and timeout < 0:
+            raise ValueError("'timeout' must be a non-negative number")
         end = None if timeout is None else time.monotonic() + timeout
         while True:
             with self._cond:

--- a/scripts/tests/chiptest/concurrency/work_queue.py
+++ b/scripts/tests/chiptest/concurrency/work_queue.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import queue
 import threading
 import time
@@ -160,31 +159,36 @@ class CancellableQueue(TerminableResource, Generic[QueueElementT]):
             TimeoutError: on timeout if `timeout` is not None.
             queue.Empty: if called with `timeout=0` and the queue is empty while the queue is neither cancelled nor closed.
         """
-        with self._cond:
-            if timeout != 0:
-                # First check without waiting, to avoid race conditions and unnecessary waiting. Allows to pass QueueCancelled and
-                # EndOfQueue exceptions to the consumer without waiting for the condition.
-                with contextlib.suppress(queue.Empty):
-                    return self.get(timeout=0)
+        # Level-triggered wait: re-check the real queue/cancel/close state on every poll and
+        # treat the condition notify() only as a wakeup hint. Because the queue may be backed by
+        # a multiprocessing.Manager with the producer and consumer in different processes, a
+        # notify() can be delivered while the consumer is not parked in wait() (between polls or
+        # during proxy round-trips) and be lost. Relying on the notify() edge alone would then
+        # block forever with an item already enqueued; polling the state bounds that to one
+        # interval. Polling also keeps the wait KeyboardInterrupt-catchable.
+        end = None if timeout is None else time.monotonic() + timeout
+        while True:
+            with self._cond:
+                if self._cancel_event.is_set():
+                    raise QueueCancelled
 
-                # We wait for the condition within the timeout (or infinitely when timeout=None).
-                if not wait_for_mp_managed(self._cond, timeout_sec=timeout):
-                    raise TimeoutError("Timeout when waiting for queue item")
+                try:
+                    # Use block=False since we've already synchronized via self._cond.
+                    return self._queue.get(block=False)
+                except queue.Empty:
+                    if self._end_of_queue.is_set():
+                        raise EndOfQueue
+                    # timeout=0 is a non-blocking poll: surface the empty queue to the caller.
+                    if timeout == 0:
+                        raise
 
-            # Check for cancel event.
-            if self._cancel_event.is_set():
-                raise QueueCancelled
-
-            # Check for the end of queue sentinel.
-            try:
-                # Check if there is a new queue element. Use block=False since we've already synchronized via self._cond.
-                return self._queue.get(block=False)
-            except queue.Empty:
-                # If there is no new queue element, check if the end of queue event is set. If not, re-raise the exception to
-                # indicate an empty queue, which should not normally happen.
-                if self._end_of_queue.is_set():
-                    raise EndOfQueue
-                raise
+                if end is None:
+                    self._cond.wait(0.1)
+                else:
+                    remaining = end - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError("Timeout when waiting for queue item")
+                    self._cond.wait(min(0.1, remaining))
 
     def cancel(self) -> None:
         """Set cancel event and notify all consumers."""


### PR DESCRIPTION
#### Problem

`chiptest.concurrency.work_queue.CancellableQueue.get()` can miss a cross-process `notify()` and then block forever with an item already sitting in the queue. In the `chip_tool_python` runner this intermittently hangs an accessory XML-RPC call (most visibly `Start`) until the CI job-level timeout cancels the run.

Introduced with the worker/process isolation rework in #72527, which moved the accessory XML-RPC server into a separate (network-namespace-isolated) process and now passes RPC request/response across processes via a `multiprocessing.Manager`-backed `CancellableQueue`.

Representative log (second `Stop`/`Start` cycle of `TestDiscovery`):

```
[XmlRpcProc/Server] Response for stop: True
[XmlRpcProc/Server] Call: start('default', ['--discriminator', '3840'])
[XmlRpcMgr] RunSubprocess starting application ...
[XmlRpcMgr] Success waiting for: ['APP STATUS: Starting event loop', 'mDNS service published:']
<no further output — hangs until job cancellation>
```

The accessory boots fully and the manager thread finishes `App.start()`, but `Response for start: True` is never logged: the result never crosses back to the XML-RPC server process, so chip-tool blocks on the call. An identical earlier `Start` in the same test succeeds, and fast calls like `Stop` are almost never affected — the classic signature of a lost wakeup, with the slower `Start` widening the race window.

#### Root cause

`get()` (blocking path) leaves its wait only when it catches a `notify()` inside a `Condition.wait()` window (`wait_for_mp_managed()` with no predicate) and never re-checks the actual queue state. With the queue backed by a `multiprocessing.Manager` and producer/consumer in different processes, `put()`'s `notify()` can reach the manager-side condition while the consumer is not parked in `wait()` (between polls, or during proxy round-trips). The notify wakes no waiter and is lost; the loop then waits for a next notify that never comes, even though the item is already enqueued. The initial non-blocking `get(timeout=0)` check does not cover an item enqueued while the consumer transitions into `wait()`.

#### Fix

Make `get()` level-triggered: re-check queue/cancel/close state on every poll and treat the `notify()` as a wakeup hint only. A lost notify costs at most one poll interval instead of hanging. Public semantics (`timeout=0` non-blocking, `timeout=None` block, `timeout>0` bounded, cancel/close behavior, KeyboardInterrupt-catchable polling) are preserved.

#### Testing

Verified against the core chiptool YAML suites (the previously intermittently-hanging `TestDiscovery` and the full core set) across repeated runs: the suites now complete instead of stalling on the accessory `Start` RPC.

Fixes #73180
