### PR TITLE
silabs/zephyr: fix support for ccache

### DIFF
--- a/config/silabs/CMakeLists.txt
+++ b/config/silabs/CMakeLists.txt
@@ -80,13 +80,11 @@ if (NOT CONFIG_CHIP_DEBUG_SYMBOLS)
     set_compiler_property(PROPERTY debug -g0)
 endif()
 
-# Determine if ccache should be used
-
-get_property(CHIP_COMPILER_LAUNCHER GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
-
 # ==============================================================================
 # Generate configuration for CHIP GN build system
 # ==============================================================================
+
+get_property(ZEPHYR_COMMAND_LAUNCHER GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 
 matter_common_gn_args(
     DEBUG           CONFIG_DEBUG
@@ -98,6 +96,9 @@ matter_common_gn_args(
 matter_add_gn_arg_string("zephyr_ar"                              ${CMAKE_AR})
 matter_add_gn_arg_string("zephyr_cc"                              ${CMAKE_C_COMPILER})
 matter_add_gn_arg_string("zephyr_cxx"                             ${CMAKE_CXX_COMPILER})
+if (ZEPHYR_COMMAND_LAUNCHER)
+    matter_add_gn_arg_string("zephyr_command_launcher"           "${ZEPHYR_COMMAND_LAUNCHER} ")
+endif()
 
 matter_add_gn_arg_string("chip_crypto"                           ${CONFIG_CHIP_CRYPTO})
 

--- a/config/silabs/chip-gn/toolchain/BUILD.gn
+++ b/config/silabs/chip-gn/toolchain/BUILD.gn
@@ -16,12 +16,13 @@ declare_args() {
   zephyr_ar = ""
   zephyr_cc = ""
   zephyr_cxx = ""
+  zephyr_command_launcher = ""
 }
 
 toolchain("zephyr") {
   tool("cc") {
     depfile = "{{output}}.d"
-    command = "\"${zephyr_cc}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c \"{{source}}\" -o \"{{output}}\""
+    command = "${zephyr_command_launcher}\"${zephyr_cc}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c \"{{source}}\" -o \"{{output}}\""
     depsformat = "gcc"
     outputs =
         [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
@@ -30,7 +31,7 @@ toolchain("zephyr") {
 
   tool("cxx") {
     depfile = "{{output}}.d"
-    command = "\"${zephyr_cxx}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c \"{{source}}\" -o \"{{output}}\""
+    command = "${zephyr_command_launcher}\"${zephyr_cxx}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c \"{{source}}\" -o \"{{output}}\""
     depsformat = "gcc"
     outputs =
         [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
@@ -39,7 +40,7 @@ toolchain("zephyr") {
 
   tool("asm") {
     depfile = "{{output}}.d"
-    command = "\"${zephyr_cc}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{asmflags}} -c \"{{source}}\" -o \"{{output}}\""
+    command = "${zephyr_command_launcher}\"${zephyr_cc}\" -MMD -MF \"$depfile\" {{defines}} {{include_dirs}} {{asmflags}} -c \"{{source}}\" -o \"{{output}}\""
     depsformat = "gcc"
     outputs =
         [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]


### PR DESCRIPTION
### Summary

Zephyr fills `RULE_LAUNCH_COMPILE` cmake property with `ccache` if relevant. The property was properly retrieved in `config/silabs/CMakeLists.txt`, but it was not forwarded to gn.

Note variable pw_command_launcher also exists. However, `RULE_LAUNCH_COMPILE` is not related to pigweed (and a Zephyr user may compile without cloning pigweed), so this patch rather use zephyr_command_launcher variable.

### Testing

Ccache performances are still limited by use of `__TIME__` and `__DATE__` in the header files. With this patch and `CCACHE_SLOPPINESS=time_macros`, I am able to improve compilation time by 15-20x (25s instead of 400s).

    $ CCACHE_SLOPPINESS=time_macros west build -b siwx917_rb4338a matter/examples/lighting-app/silabs/zephyr/ -p always
    [...]
    $ time CCACHE_SLOPPINESS=time_macros west build -b siwx917_rb4338a matter/examples/lighting-app/silabs/zephyr/ -p always
    west ...  in 25.87s (U:66.34s S:22.34s -> 222% CPU)
