### PR TITLE
Allow AUX feature

### DIFF
--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -56,9 +56,11 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.clusters import Objects as Clusters
 from matter.testing.decorators import async_test_body
 # TODO: Enable 10.5 in CI once the door lock OTA requestor problem is sorted.
 from matter.testing.device_conformance_tests import DeviceConformanceTests
+from matter.testing.matter_testing import ProblemSeverity
 from matter.testing.runner import TestStep, default_matter_test_main
 
 
@@ -68,6 +70,31 @@ class TC_DeviceConformance(DeviceConformanceTests):
     async def setup_class(self):
         super().setup_class()
         await self.setup_class_helper()
+
+    def _filter_unsupported_described_conformance(self, problems, success):
+        # TODO: Remove allow_unsupported_described_conformance after 1.6.1 once <describedConform /> is supported in spec parsing
+        allow_unsupported_described_conformance = self.user_params.get(
+            "allow_unsupported_described_conformance", True)
+
+        # Curated list of cluster features using <describedConform /> that are currently unhandled in spec parsing
+        described_conformance_ignore_features = {
+            Clusters.AccessControl.id: [0x04],
+        }
+
+        if allow_unsupported_described_conformance and not success:
+            filtered_problems = []
+            for p in problems:
+                if p.location and p.location.cluster_id in described_conformance_ignore_features:
+                    ignored_masks = described_conformance_ignore_features[p.location.cluster_id]
+                    if any(f"0x{mask:02x}" in p.problem for mask in ignored_masks):
+                        continue
+                filtered_problems.append(p)
+
+            if len(filtered_problems) < len(problems):
+                problems = filtered_problems
+                success = not any(p.severity == ProblemSeverity.ERROR for p in problems)
+
+        return success, problems
 
     def test_TC_IDM_10_2(self):
         # TODO: Turn this off after TE2
@@ -79,6 +106,8 @@ class TC_DeviceConformance(DeviceConformanceTests):
         success, problems = self.check_conformance(ignore_in_progress_test_event_only_disallowed_for_certification,
                                                    self.is_pics_sdk_ci_only,
                                                    allow_provisional_test_event_only_disallowed_for_certification)
+        # TODO: Remove this filter after 1.6.1 once <describedConform /> is supported in spec parsing
+        success, problems = self._filter_unsupported_described_conformance(problems, success)
         self.problems.extend(problems)
         if not success:
             self.fail_current_test("Problems with conformance")

--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -57,11 +57,12 @@
 # === END CI TEST ARGUMENTS ===
 
 from matter.clusters import Objects as Clusters
+from matter.testing.conformance import optional
 from matter.testing.decorators import async_test_body
 # TODO: Enable 10.5 in CI once the door lock OTA requestor problem is sorted.
 from matter.testing.device_conformance_tests import DeviceConformanceTests
-from matter.testing.matter_testing import ProblemSeverity
 from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.spec_parsing import XmlFeature
 
 
 class TC_DeviceConformance(DeviceConformanceTests):
@@ -71,30 +72,24 @@ class TC_DeviceConformance(DeviceConformanceTests):
         super().setup_class()
         await self.setup_class_helper()
 
-    def _filter_unsupported_described_conformance(self, problems, success):
+    def _inject_unsupported_described_conformance(self):
         # TODO: Remove allow_unsupported_described_conformance after 1.6.1 once <describedConform /> is supported in spec parsing
         allow_unsupported_described_conformance = self.user_params.get(
             "allow_unsupported_described_conformance", True)
+        if not allow_unsupported_described_conformance:
+            return
 
         # Curated list of cluster features using <describedConform /> that are currently unhandled in spec parsing
         described_conformance_ignore_features = {
-            Clusters.AccessControl.id: [0x04],
+            Clusters.AccessControl.id: {
+                0x04: XmlFeature(code="AUX", name="AuxiliaryAuthentication", conformance=optional()),
+            }
         }
-
-        if allow_unsupported_described_conformance and not success:
-            filtered_problems = []
-            for p in problems:
-                if p.location and p.location.cluster_id in described_conformance_ignore_features:
-                    ignored_masks = described_conformance_ignore_features[p.location.cluster_id]
-                    if any(f"0x{mask:02x}" in p.problem for mask in ignored_masks):
-                        continue
-                filtered_problems.append(p)
-
-            if len(filtered_problems) < len(problems):
-                problems = filtered_problems
-                success = not any(p.severity == ProblemSeverity.ERROR for p in problems)
-
-        return success, problems
+        for cluster_id, features in described_conformance_ignore_features.items():
+            if cluster_id in self.xml_clusters:
+                for mask, feature in features.items():
+                    if mask not in self.xml_clusters[cluster_id].features:
+                        self.xml_clusters[cluster_id].features[mask] = feature
 
     def test_TC_IDM_10_2(self):
         # TODO: Turn this off after TE2
@@ -103,11 +98,10 @@ class TC_DeviceConformance(DeviceConformanceTests):
             "ignore_in_progress_test_event_only_disallowed_for_certification", True)
         allow_provisional_test_event_only_disallowed_for_certification = self.user_params.get(
             "allow_provisional_test_event_only_disallowed_for_certification", False)
+        self._inject_unsupported_described_conformance()
         success, problems = self.check_conformance(ignore_in_progress_test_event_only_disallowed_for_certification,
                                                    self.is_pics_sdk_ci_only,
                                                    allow_provisional_test_event_only_disallowed_for_certification)
-        # TODO: Remove this filter after 1.6.1 once <describedConform /> is supported in spec parsing
-        success, problems = self._filter_unsupported_described_conformance(problems, success)
         self.problems.extend(problems)
         if not success:
             self.fail_current_test("Problems with conformance")


### PR DESCRIPTION
### Summary

Fix device conformance test failure for clusters containing features with `<describedConform />` (specifically `AccessControl` feature bit `0x04` / `AUX`).

### Problem

In the Matter 1.6.1 specification XMLs, the `AccessControl` cluster's `AUX` feature (bit `0x04`) uses `<describedConform />`. Because `<describedConform />` is currently unhandled during spec parsing in the test harness, bit `0x04` is omitted from the parsed cluster feature dictionary (`xml_clusters[AccessControl].features`). 
When running `TC_DeviceConformance.py` against devices that implement this feature (such as `all-devices-app`), `check_conformance()` reports a conformance error (`Unknown feature with mask 0x04`).

### Solution

As side-loading testing infrastructure is not feasible for Test Harness, this change pre-populates `self.xml_clusters` with the missing described conformance features prior to running conformance checks:
1. Introduced `_inject_unsupported_described_conformance()` helper in `TC_DeviceConformance.py` that injects `AUX` (`0x04`) into `self.xml_clusters[AccessControl.id].features` with `optional()` conformance.
2. Controlled via a user parameter flag `allow_unsupported_described_conformance` (defaulting to `True`).
3. Added a `TODO` comment noting that the flag and injection helper should be removed after 1.6.1 once `<describedConform />` is natively handled in spec parsing.
By injecting the feature into `xml_clusters`, the conformance engine natively validates bit `0x04` as optional, avoiding false positives without requiring string matching or regex filtering.

### Related issues

https://github.com/project-chip/certification-tool/issues/1056

### Testing

Verified `TC-IDM-10.2` against `all-devices-app` (`test_TC_IDM_10_2 PASS`).
