### PR TITLE
feat(tv-app): Integrate Media File Management cluster with file-backed delegate

### DIFF
--- a/examples/tv-app/linux/main.cpp
+++ b/examples/tv-app/linux/main.cpp
@@ -49,7 +49,11 @@ constexpr EndpointId kMediaFileManagementEndpointId = 1;
 // The Media File Management cluster is code-driven, so the application owns the
 // delegate and the cluster registration lifecycle (unlike the legacy Ember
 // clusters wired up via SetDefaultDelegate in ZCLCallbacks.cpp).
-MediaFileManagement::MediaFileManagementManager gMediaFileManagementManager;
+//
+// Both are constructed in ApplicationInit() (not as eagerly-constructed globals)
+// because the manager's constructor performs filesystem I/O and logging, which
+// must not run during static initialization before the SDK is ready.
+std::optional<MediaFileManagement::MediaFileManagementManager> gMediaFileManagementManager;
 std::optional<MediaFileManagement::MediaFileManagementServer> gMediaFileManagementServer;
 
 } // namespace
@@ -59,12 +63,14 @@ void ApplicationInit()
     ChipLogProgress(Zcl, "TV Linux App: ApplicationInit()");
 
     // Register the code-driven Media File Management cluster on endpoint 1.
-    gMediaFileManagementServer.emplace(kMediaFileManagementEndpointId, gMediaFileManagementManager);
+    gMediaFileManagementManager.emplace();
+    gMediaFileManagementServer.emplace(kMediaFileManagementEndpointId, *gMediaFileManagementManager);
     CHIP_ERROR err = gMediaFileManagementServer->Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "TV Linux App: MediaFileManagement init failed: %" CHIP_ERROR_FORMAT, err.Format());
         gMediaFileManagementServer.reset();
+        gMediaFileManagementManager.reset();
     }
 
     // Disable last fixed endpoint, which is used as a placeholder for all of the
@@ -101,10 +107,11 @@ void ApplicationInit()
 
 void ApplicationShutdown()
 {
+    // Unregister the cluster from the data model provider. Shutdown() mirrors
+    // Init(); the optionals are left intact and torn down at process exit.
     if (gMediaFileManagementServer.has_value())
     {
         gMediaFileManagementServer->Shutdown();
-        gMediaFileManagementServer.reset();
     }
 }
 

--- a/examples/tv-app/linux/main.cpp
+++ b/examples/tv-app/linux/main.cpp
@@ -19,12 +19,17 @@
 #include "AppMain.h"
 #include "AppTv.h"
 
+#include "media-file-management/MediaFileManagementManager.h"
+
 #include <access/AccessControl.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/app-platform/ContentAppPlatform.h>
+#include <app/clusters/media-file-management-server/CodegenIntegration.h>
 #include <app/util/endpoint-config-api.h>
+
+#include <optional>
 
 #if defined(ENABLE_CHIP_SHELL)
 #include "AppTvShellCommands.h"
@@ -36,9 +41,31 @@ using namespace chip::DeviceLayer;
 using namespace chip::AppPlatform;
 using namespace chip::app::Clusters;
 
+namespace {
+
+// Endpoint that hosts the Media File Management cluster in tv-app.zap.
+constexpr EndpointId kMediaFileManagementEndpointId = 1;
+
+// The Media File Management cluster is code-driven, so the application owns the
+// delegate and the cluster registration lifecycle (unlike the legacy Ember
+// clusters wired up via SetDefaultDelegate in ZCLCallbacks.cpp).
+MediaFileManagement::MediaFileManagementManager gMediaFileManagementManager;
+std::optional<MediaFileManagement::MediaFileManagementServer> gMediaFileManagementServer;
+
+} // namespace
+
 void ApplicationInit()
 {
     ChipLogProgress(Zcl, "TV Linux App: ApplicationInit()");
+
+    // Register the code-driven Media File Management cluster on endpoint 1.
+    gMediaFileManagementServer.emplace(kMediaFileManagementEndpointId, gMediaFileManagementManager);
+    CHIP_ERROR err = gMediaFileManagementServer->Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "TV Linux App: MediaFileManagement init failed: %" CHIP_ERROR_FORMAT, err.Format());
+        gMediaFileManagementServer.reset();
+    }
 
     // Disable last fixed endpoint, which is used as a placeholder for all of the
     // supported clusters so that ZAP will generated the requisite code.
@@ -72,7 +99,14 @@ void ApplicationInit()
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 }
 
-void ApplicationShutdown() {}
+void ApplicationShutdown()
+{
+    if (gMediaFileManagementServer.has_value())
+    {
+        gMediaFileManagementServer->Shutdown();
+        gMediaFileManagementServer.reset();
+    }
+}
 
 int main(int argc, char * argv[])
 {

--- a/examples/tv-app/tv-common/BUILD.gn
+++ b/examples/tv-app/tv-common/BUILD.gn
@@ -36,6 +36,7 @@ source_set("tv-common-sources") {
   deps = [
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/examples/tv-app/tv-common",
+    "${chip_root}/src/app/clusters/media-file-management-server",
     "${chip_root}/src/lib",
   ]
   public_configs = [ ":config" ]
@@ -58,6 +59,8 @@ source_set("tv-common-sources") {
     "clusters/keypad-input/KeypadInputManager.h",
     "clusters/low-power/LowPowerManager.cpp",
     "clusters/low-power/LowPowerManager.h",
+    "clusters/media-file-management/MediaFileManagementManager.cpp",
+    "clusters/media-file-management/MediaFileManagementManager.h",
     "clusters/media-input/MediaInputManager.cpp",
     "clusters/media-input/MediaInputManager.h",
     "clusters/media-playback/MediaPlaybackManager.cpp",

--- a/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
@@ -1,0 +1,295 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "MediaFileManagementManager.h"
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace MediaFileManagement {
+
+using Protocols::InteractionModel::Status;
+
+const std::vector<std::string> MediaFileManagementManager::kSupportedMimeTypes = {
+    "video/mp4",
+    "audio/mpeg",
+    "image/jpeg",
+};
+
+namespace {
+
+// The index file stores one record per line, tab-separated, in the form:
+//   <fileID>\t<size>\t<mimeType>\t<imageUri>\t<name>
+// `name` is last because it is the only field permitted to contain spaces (but
+// not tabs or newlines, which we sanitize on write).
+constexpr char kFieldSep = '\t';
+
+std::string Sanitize(const CharSpan & span)
+{
+    std::string out(span.data(), span.size());
+    for (char & c : out)
+    {
+        if (c == '\t' || c == '\n' || c == '\r')
+        {
+            c = ' ';
+        }
+    }
+    return out;
+}
+
+} // namespace
+
+MediaFileManagementManager::MediaFileManagementManager(std::string storageDir) : mStorageDir(std::move(storageDir))
+{
+    if (!EnsureStorageDir())
+    {
+        ChipLogError(Zcl, "MediaFileManagementManager: failed to create storage dir %s", mStorageDir.c_str());
+        return;
+    }
+    LoadIndex();
+}
+
+std::string MediaFileManagementManager::DataFilePath(uint64_t fileID) const
+{
+    return mStorageDir + "/" + std::to_string(fileID) + ".bin";
+}
+
+std::string MediaFileManagementManager::IndexFilePath() const
+{
+    return mStorageDir + "/index.txt";
+}
+
+bool MediaFileManagementManager::EnsureStorageDir()
+{
+    struct stat st;
+    if (stat(mStorageDir.c_str(), &st) == 0)
+    {
+        return S_ISDIR(st.st_mode);
+    }
+    // 0755: owner rwx, group/other rx.
+    return mkdir(mStorageDir.c_str(), 0755) == 0;
+}
+
+void MediaFileManagementManager::LoadIndex()
+{
+    mFiles.clear();
+    mNextFileID = 1;
+
+    std::ifstream in(IndexFilePath());
+    if (!in.is_open())
+    {
+        return; // No index yet; start empty.
+    }
+
+    std::string line;
+    while (std::getline(in, line))
+    {
+        if (line.empty())
+        {
+            continue;
+        }
+
+        // Parse the first four tab-delimited fields; the remainder is the name.
+        FileEntry entry;
+        size_t p0 = line.find(kFieldSep);
+        size_t p1 = (p0 == std::string::npos) ? std::string::npos : line.find(kFieldSep, p0 + 1);
+        size_t p2 = (p1 == std::string::npos) ? std::string::npos : line.find(kFieldSep, p1 + 1);
+        size_t p3 = (p2 == std::string::npos) ? std::string::npos : line.find(kFieldSep, p2 + 1);
+        if (p3 == std::string::npos)
+        {
+            ChipLogError(Zcl, "MediaFileManagementManager: skipping malformed index line");
+            continue;
+        }
+
+        entry.fileID   = strtoull(line.substr(0, p0).c_str(), nullptr, 10);
+        entry.size     = strtoull(line.substr(p0 + 1, p1 - p0 - 1).c_str(), nullptr, 10);
+        entry.mimeType = line.substr(p1 + 1, p2 - p1 - 1);
+        entry.imageUri = line.substr(p2 + 1, p3 - p2 - 1);
+        entry.name     = line.substr(p3 + 1);
+
+        if (entry.fileID >= mNextFileID)
+        {
+            mNextFileID = entry.fileID + 1;
+        }
+        mFiles.push_back(std::move(entry));
+    }
+    ChipLogProgress(Zcl, "MediaFileManagementManager: loaded %u file(s) from %s", static_cast<unsigned>(mFiles.size()),
+                    IndexFilePath().c_str());
+}
+
+void MediaFileManagementManager::SaveIndex()
+{
+    std::ofstream out(IndexFilePath(), std::ios::trunc);
+    if (!out.is_open())
+    {
+        ChipLogError(Zcl, "MediaFileManagementManager: failed to write index %s", IndexFilePath().c_str());
+        return;
+    }
+    for (const FileEntry & entry : mFiles)
+    {
+        out << entry.fileID << kFieldSep << entry.size << kFieldSep << entry.mimeType << kFieldSep << entry.imageUri << kFieldSep
+            << entry.name << '\n';
+    }
+}
+
+MediaFileManagementManager::FileEntry * MediaFileManagementManager::FindEntry(uint64_t fileID)
+{
+    for (FileEntry & entry : mFiles)
+    {
+        if (entry.fileID == fileID)
+        {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+uint64_t MediaFileManagementManager::GetTotalStorage()
+{
+    return kTotalStorageBytes;
+}
+
+uint64_t MediaFileManagementManager::GetAvailableStorage()
+{
+    uint64_t used = 0;
+    for (const FileEntry & entry : mFiles)
+    {
+        used += entry.size;
+    }
+    return (used >= kTotalStorageBytes) ? 0 : (kTotalStorageBytes - used);
+}
+
+CHIP_ERROR MediaFileManagementManager::GetFileAtIndex(size_t index, Structs::FileDescriptionStruct::Type & file)
+{
+    VerifyOrReturnError(index < mFiles.size(), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+
+    const FileEntry & entry = mFiles[index];
+    file.fileID             = entry.fileID;
+    file.name               = CharSpan(entry.name.data(), entry.name.size());
+    file.size               = entry.size;
+    file.mimeType           = CharSpan(entry.mimeType.data(), entry.mimeType.size());
+    file.imageUri           = CharSpan(entry.imageUri.data(), entry.imageUri.size());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MediaFileManagementManager::GetSupportedMimeTypeAtIndex(size_t index, MutableCharSpan & mimeType)
+{
+    VerifyOrReturnError(index < kSupportedMimeTypes.size(), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+    return CopyCharSpanToMutableCharSpan(
+        CharSpan(kSupportedMimeTypes[index].data(), kSupportedMimeTypes[index].size()), mimeType);
+}
+
+Status MediaFileManagementManager::HandleAddFile(const CharSpan & name, uint64_t size, const CharSpan & mimeType,
+                                                 const CharSpan & imageUri, Commands::AddFileResponse::Type & response)
+{
+    // Reject files that would exceed the advertised capacity.
+    if (size > GetAvailableStorage())
+    {
+        response.status = FileStatusEnum::kInsufficientStorage;
+        return Status::Success;
+    }
+
+    FileEntry entry;
+    entry.fileID   = mNextFileID++;
+    entry.name     = Sanitize(name);
+    entry.size     = size;
+    entry.mimeType = Sanitize(mimeType);
+    entry.imageUri = Sanitize(imageUri);
+
+    // Create an (empty) data blob for the file. Actual bytes would be delivered
+    // out-of-band (BDX) in a full implementation.
+    std::ofstream data(DataFilePath(entry.fileID), std::ios::trunc | std::ios::binary);
+    if (!data.is_open())
+    {
+        ChipLogError(Zcl, "MediaFileManagementManager: failed to create data file for id %llu",
+                     static_cast<unsigned long long>(entry.fileID));
+        response.status = FileStatusEnum::kInsufficientStorage;
+        return Status::Success;
+    }
+    data.close();
+
+    const uint64_t assignedID = entry.fileID;
+    mFiles.push_back(std::move(entry));
+    SaveIndex();
+
+    ChipLogProgress(Zcl, "MediaFileManagementManager: added file id %llu (%llu bytes)",
+                    static_cast<unsigned long long>(assignedID), static_cast<unsigned long long>(size));
+
+    response.status = FileStatusEnum::kSuccess;
+    response.fileID.SetNonNull(assignedID);
+    return Status::Success;
+}
+
+Status MediaFileManagementManager::HandleDeleteFile(uint64_t fileID)
+{
+    for (auto it = mFiles.begin(); it != mFiles.end(); ++it)
+    {
+        if (it->fileID == fileID)
+        {
+            std::remove(DataFilePath(fileID).c_str());
+            mFiles.erase(it);
+            SaveIndex();
+            ChipLogProgress(Zcl, "MediaFileManagementManager: deleted file id %llu", static_cast<unsigned long long>(fileID));
+            return Status::Success;
+        }
+    }
+    ChipLogProgress(Zcl, "MediaFileManagementManager: DeleteFile - id %llu not found",
+                    static_cast<unsigned long long>(fileID));
+    return Status::NotFound;
+}
+
+Status MediaFileManagementManager::HandleRequestSharedFiles(
+    const CharSpan & clientName, uint16_t requestID,
+    const Optional<DataModel::Nullable<DataModel::DecodableList<CharSpan>>> & supportedMimeTypes)
+{
+    // Example app does not implement cross-device sharing; accept and report no
+    // shared files. A full implementation would emit SharedFilesAdded once
+    // matching files are located.
+    ChipLogProgress(Zcl, "MediaFileManagementManager: RequestSharedFiles requestID=%u", requestID);
+    return Status::Success;
+}
+
+Status MediaFileManagementManager::HandleGetSharedFile(uint16_t responseID, Commands::GetSharedFileResponse::Type & response)
+{
+    // No shared files are offered by the example app.
+    ChipLogProgress(Zcl, "MediaFileManagementManager: GetSharedFile responseID=%u", responseID);
+    response.status = FileStatusEnum::kFileNotAvailable;
+    return Status::Success;
+}
+
+Status MediaFileManagementManager::HandleOfferFile(const CharSpan & clientName, const CharSpan & name, uint64_t size,
+                                                   const CharSpan & mimeType, const CharSpan & imageUri)
+{
+    ChipLogProgress(Zcl, "MediaFileManagementManager: OfferFile from client, size %llu", static_cast<unsigned long long>(size));
+    return Status::Success;
+}
+
+} // namespace MediaFileManagement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
@@ -200,8 +200,7 @@ CHIP_ERROR MediaFileManagementManager::GetFileAtIndex(size_t index, Structs::Fil
 CHIP_ERROR MediaFileManagementManager::GetSupportedMimeTypeAtIndex(size_t index, MutableCharSpan & mimeType)
 {
     VerifyOrReturnError(index < kSupportedMimeTypes.size(), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
-    return CopyCharSpanToMutableCharSpan(
-        CharSpan(kSupportedMimeTypes[index].data(), kSupportedMimeTypes[index].size()), mimeType);
+    return CopyCharSpanToMutableCharSpan(CharSpan(kSupportedMimeTypes[index].data(), kSupportedMimeTypes[index].size()), mimeType);
 }
 
 Status MediaFileManagementManager::HandleAddFile(const CharSpan & name, uint64_t size, const CharSpan & mimeType,
@@ -237,8 +236,8 @@ Status MediaFileManagementManager::HandleAddFile(const CharSpan & name, uint64_t
     mFiles.push_back(std::move(entry));
     SaveIndex();
 
-    ChipLogProgress(Zcl, "MediaFileManagementManager: added file id %llu (%llu bytes)",
-                    static_cast<unsigned long long>(assignedID), static_cast<unsigned long long>(size));
+    ChipLogProgress(Zcl, "MediaFileManagementManager: added file id %llu (%llu bytes)", static_cast<unsigned long long>(assignedID),
+                    static_cast<unsigned long long>(size));
 
     response.status = FileStatusEnum::kSuccess;
     response.fileID.SetNonNull(assignedID);
@@ -258,8 +257,7 @@ Status MediaFileManagementManager::HandleDeleteFile(uint64_t fileID)
             return Status::Success;
         }
     }
-    ChipLogProgress(Zcl, "MediaFileManagementManager: DeleteFile - id %llu not found",
-                    static_cast<unsigned long long>(fileID));
+    ChipLogProgress(Zcl, "MediaFileManagementManager: DeleteFile - id %llu not found", static_cast<unsigned long long>(fileID));
     return Status::NotFound;
 }
 

--- a/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp
@@ -51,6 +51,12 @@ constexpr char kFieldSep = '\t';
 
 std::string Sanitize(const CharSpan & span)
 {
+    // An empty CharSpan may carry a null data pointer; constructing a
+    // std::string from (nullptr, 0) is undefined behavior.
+    if (span.empty())
+    {
+        return "";
+    }
     std::string out(span.data(), span.size());
     for (char & c : out)
     {
@@ -155,18 +161,6 @@ void MediaFileManagementManager::SaveIndex()
         out << entry.fileID << kFieldSep << entry.size << kFieldSep << entry.mimeType << kFieldSep << entry.imageUri << kFieldSep
             << entry.name << '\n';
     }
-}
-
-MediaFileManagementManager::FileEntry * MediaFileManagementManager::FindEntry(uint64_t fileID)
-{
-    for (FileEntry & entry : mFiles)
-    {
-        if (entry.fileID == fileID)
-        {
-            return &entry;
-        }
-    }
-    return nullptr;
 }
 
 uint64_t MediaFileManagementManager::GetTotalStorage()

--- a/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.h
+++ b/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.h
@@ -91,9 +91,6 @@ private:
     void LoadIndex();
     void SaveIndex();
 
-    // Find an entry by fileID; returns nullptr if not present.
-    FileEntry * FindEntry(uint64_t fileID);
-
     std::string mStorageDir;
     std::vector<FileEntry> mFiles;
     uint64_t mNextFileID = 1;

--- a/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.h
+++ b/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.h
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/media-file-management-server/MediaFileManagementDelegate.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace MediaFileManagement {
+
+/**
+ * Example file-backed Media File Management delegate for the Linux tv-app.
+ *
+ * Files and their metadata are persisted under a storage directory on disk
+ * (default: /tmp/chip-media-files), similar to how the example KVS store keeps
+ * its artifacts under /tmp. Each managed file is represented by:
+ *   - a data blob `<storageDir>/<fileID>.bin` (created empty on AddFile; the
+ *     actual bytes would arrive out-of-band via BDX in a full implementation),
+ *   - a line in `<storageDir>/index.txt` holding the metadata record.
+ *
+ * The index is loaded into memory at construction and rewritten on every
+ * mutation so state survives restarts.
+ */
+class MediaFileManagementManager : public Delegate
+{
+public:
+    static constexpr const char * kDefaultStorageDir = "/tmp/chip-media-files";
+
+    explicit MediaFileManagementManager(std::string storageDir = kDefaultStorageDir);
+    ~MediaFileManagementManager() override = default;
+
+    // --- Attribute data providers ---
+    uint64_t GetTotalStorage() override;
+    uint64_t GetAvailableStorage() override;
+    CHIP_ERROR GetFileAtIndex(size_t index, Structs::FileDescriptionStruct::Type & file) override;
+    CHIP_ERROR GetSupportedMimeTypeAtIndex(size_t index, MutableCharSpan & mimeType) override;
+
+    // --- Command handlers ---
+    Protocols::InteractionModel::Status HandleAddFile(const CharSpan & name, uint64_t size, const CharSpan & mimeType,
+                                                      const CharSpan & imageUri,
+                                                      Commands::AddFileResponse::Type & response) override;
+    Protocols::InteractionModel::Status HandleDeleteFile(uint64_t fileID) override;
+    Protocols::InteractionModel::Status
+    HandleRequestSharedFiles(const CharSpan & clientName, uint16_t requestID,
+                             const Optional<DataModel::Nullable<DataModel::DecodableList<CharSpan>>> & supportedMimeTypes) override;
+    Protocols::InteractionModel::Status HandleGetSharedFile(uint16_t responseID,
+                                                            Commands::GetSharedFileResponse::Type & response) override;
+    Protocols::InteractionModel::Status HandleOfferFile(const CharSpan & clientName, const CharSpan & name, uint64_t size,
+                                                        const CharSpan & mimeType, const CharSpan & imageUri) override;
+
+private:
+    // In-memory representation of a single managed file's metadata. Char span
+    // members returned to the cluster point at these owned strings.
+    struct FileEntry
+    {
+        uint64_t fileID = 0;
+        std::string name;
+        uint64_t size = 0;
+        std::string mimeType;
+        std::string imageUri;
+    };
+
+    std::string DataFilePath(uint64_t fileID) const;
+    std::string IndexFilePath() const;
+
+    // Ensure the storage directory exists; returns false on failure.
+    bool EnsureStorageDir();
+
+    // Load/save the metadata index from/to disk.
+    void LoadIndex();
+    void SaveIndex();
+
+    // Find an entry by fileID; returns nullptr if not present.
+    FileEntry * FindEntry(uint64_t fileID);
+
+    std::string mStorageDir;
+    std::vector<FileEntry> mFiles;
+    uint64_t mNextFileID = 1;
+
+    // Total capacity advertised for the (virtual) media store, in bytes.
+    static constexpr uint64_t kTotalStorageBytes = 1024ull * 1024ull * 1024ull; // 1 GiB
+
+    // Supported MIME types advertised via the SupportedMimeTypes attribute.
+    static const std::vector<std::string> kSupportedMimeTypes;
+};
+
+} // namespace MediaFileManagement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/tv-app/tv-common/clusters/media-file-management/tests/BUILD.gn
+++ b/examples/tv-app/tv-common/clusters/media-file-management/tests/BUILD.gn
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "TestMediaFileManagementManager"
+
+  test_sources = [ "TestMediaFileManagementManager.cpp" ]
+
+  # Compile the delegate under test directly; it is a self-contained,
+  # file-backed implementation with no dependency on the tv-app server sources.
+  sources = [
+    "${chip_root}/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.cpp",
+    "${chip_root}/examples/tv-app/tv-common/clusters/media-file-management/MediaFileManagementManager.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/media-file-management-server",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/examples/tv-app/tv-common/clusters/media-file-management/tests/TestMediaFileManagementManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-file-management/tests/TestMediaFileManagementManager.cpp
@@ -1,0 +1,210 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include "../MediaFileManagementManager.h"
+
+#include <lib/support/CHIPMem.h>
+#include <lib/support/Span.h>
+
+#include <cstdio>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::MediaFileManagement;
+using Protocols::InteractionModel::Status;
+
+// A unique per-test storage directory under /tmp so tests never collide with a
+// running app's real store and are independent of one another.
+std::string MakeTempDir(const char * suffix)
+{
+    std::string dir = std::string("/tmp/chip-mfm-test-") + suffix + "-" + std::to_string(getpid());
+    // Best-effort clean slate.
+    std::string index = dir + "/index.txt";
+    std::remove(index.c_str());
+    rmdir(dir.c_str());
+    return dir;
+}
+
+Commands::AddFileResponse::Type AddFile(MediaFileManagementManager & mgr, const char * name, uint64_t size, const char * mime,
+                                        const char * uri)
+{
+    Commands::AddFileResponse::Type response;
+    Status status = mgr.HandleAddFile(CharSpan::fromCharString(name), size, CharSpan::fromCharString(mime),
+                                      CharSpan::fromCharString(uri), response);
+    EXPECT_EQ(status, Status::Success);
+    return response;
+}
+
+struct TestMediaFileManagementManager : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestMediaFileManagementManager, StartsEmpty)
+{
+    MediaFileManagementManager mgr(MakeTempDir("empty"));
+
+    Structs::FileDescriptionStruct::Type file;
+    EXPECT_EQ(mgr.GetFileAtIndex(0, file), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+    EXPECT_EQ(mgr.GetAvailableStorage(), mgr.GetTotalStorage());
+}
+
+TEST_F(TestMediaFileManagementManager, AddFileAssignsIncrementingIdsAndAppearsInList)
+{
+    MediaFileManagementManager mgr(MakeTempDir("add"));
+
+    auto r1 = AddFile(mgr, "Song.mp3", 3500, "audio/mpeg", "bdx://n/1.jpg");
+    ASSERT_EQ(r1.status, FileStatusEnum::kSuccess);
+    ASSERT_FALSE(r1.fileID.IsNull());
+
+    auto r2 = AddFile(mgr, "Movie.mp4", 9000, "video/mp4", "bdx://n/2.jpg");
+    ASSERT_EQ(r2.status, FileStatusEnum::kSuccess);
+    ASSERT_FALSE(r2.fileID.IsNull());
+
+    // IDs are unique and monotonically increasing.
+    EXPECT_NE(r1.fileID.Value(), r2.fileID.Value());
+    EXPECT_LT(r1.fileID.Value(), r2.fileID.Value());
+
+    // Both files are enumerable.
+    Structs::FileDescriptionStruct::Type file0;
+    Structs::FileDescriptionStruct::Type file1;
+    ASSERT_EQ(mgr.GetFileAtIndex(0, file0), CHIP_NO_ERROR);
+    ASSERT_EQ(mgr.GetFileAtIndex(1, file1), CHIP_NO_ERROR);
+    EXPECT_EQ(mgr.GetFileAtIndex(2, file0), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+
+    EXPECT_EQ(file0.fileID, r1.fileID.Value());
+    EXPECT_TRUE(file0.name.data_equal(CharSpan::fromCharString("Song.mp3")));
+    EXPECT_EQ(file0.size, 3500u);
+    EXPECT_TRUE(file0.mimeType.data_equal(CharSpan::fromCharString("audio/mpeg")));
+}
+
+TEST_F(TestMediaFileManagementManager, AvailableStorageTracksAddedFiles)
+{
+    MediaFileManagementManager mgr(MakeTempDir("storage"));
+
+    const uint64_t total = mgr.GetTotalStorage();
+    AddFile(mgr, "a", 1000, "video/mp4", "u");
+    EXPECT_EQ(mgr.GetAvailableStorage(), total - 1000);
+    AddFile(mgr, "b", 2500, "video/mp4", "u");
+    EXPECT_EQ(mgr.GetAvailableStorage(), total - 3500);
+}
+
+TEST_F(TestMediaFileManagementManager, AddFileRejectedWhenExceedingCapacity)
+{
+    MediaFileManagementManager mgr(MakeTempDir("capacity"));
+
+    Commands::AddFileResponse::Type response;
+    Status status = mgr.HandleAddFile(CharSpan::fromCharString("huge"), mgr.GetTotalStorage() + 1,
+                                      CharSpan::fromCharString("video/mp4"), CharSpan::fromCharString("u"), response);
+    EXPECT_EQ(status, Status::Success);
+    EXPECT_EQ(response.status, FileStatusEnum::kInsufficientStorage);
+    EXPECT_TRUE(response.fileID.IsNull());
+}
+
+TEST_F(TestMediaFileManagementManager, DeleteFileRemovesEntry)
+{
+    MediaFileManagementManager mgr(MakeTempDir("delete"));
+
+    auto r1 = AddFile(mgr, "a", 1000, "video/mp4", "u");
+    AddFile(mgr, "b", 2000, "video/mp4", "u");
+
+    EXPECT_EQ(mgr.HandleDeleteFile(r1.fileID.Value()), Status::Success);
+
+    // Only one file remains.
+    Structs::FileDescriptionStruct::Type file;
+    ASSERT_EQ(mgr.GetFileAtIndex(0, file), CHIP_NO_ERROR);
+    EXPECT_EQ(mgr.GetFileAtIndex(1, file), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+    EXPECT_TRUE(file.name.data_equal(CharSpan::fromCharString("b")));
+}
+
+TEST_F(TestMediaFileManagementManager, DeleteUnknownFileReturnsNotFound)
+{
+    MediaFileManagementManager mgr(MakeTempDir("delete-unknown"));
+    EXPECT_EQ(mgr.HandleDeleteFile(9999), Status::NotFound);
+}
+
+TEST_F(TestMediaFileManagementManager, StatePersistsAcrossInstances)
+{
+    const std::string dir = MakeTempDir("persist");
+
+    uint64_t savedID = 0;
+    {
+        MediaFileManagementManager mgr(dir);
+        auto r = AddFile(mgr, "persisted.mp4", 4096, "video/mp4", "bdx://n/p.jpg");
+        savedID = r.fileID.Value();
+    }
+
+    // A fresh manager over the same directory reloads the persisted file.
+    MediaFileManagementManager reopened(dir);
+    Structs::FileDescriptionStruct::Type file;
+    ASSERT_EQ(reopened.GetFileAtIndex(0, file), CHIP_NO_ERROR);
+    EXPECT_EQ(file.fileID, savedID);
+    EXPECT_TRUE(file.name.data_equal(CharSpan::fromCharString("persisted.mp4")));
+    EXPECT_EQ(file.size, 4096u);
+
+    // A newly added file must not reuse the persisted ID.
+    auto r2 = AddFile(reopened, "next.mp4", 100, "video/mp4", "u");
+    EXPECT_GT(r2.fileID.Value(), savedID);
+}
+
+TEST_F(TestMediaFileManagementManager, SupportedMimeTypesEnumerable)
+{
+    MediaFileManagementManager mgr(MakeTempDir("mime"));
+
+    char buffer[64];
+    size_t count = 0;
+    while (true)
+    {
+        MutableCharSpan span(buffer);
+        CHIP_ERROR err = mgr.GetSupportedMimeTypeAtIndex(count, span);
+        if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
+        {
+            break;
+        }
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_GT(span.size(), 0u);
+        count++;
+    }
+    EXPECT_GT(count, 0u);
+}
+
+TEST_F(TestMediaFileManagementManager, NameWithTabIsSanitizedAndSurvivesReload)
+{
+    const std::string dir = MakeTempDir("sanitize");
+    {
+        MediaFileManagementManager mgr(dir);
+        // A tab in the name would corrupt the tab-delimited index if not sanitized.
+        AddFile(mgr, "bad\tname", 10, "video/mp4", "u");
+    }
+    MediaFileManagementManager reopened(dir);
+    Structs::FileDescriptionStruct::Type file;
+    ASSERT_EQ(reopened.GetFileAtIndex(0, file), CHIP_NO_ERROR);
+    // The tab was replaced with a space, and the record round-tripped intact.
+    EXPECT_TRUE(file.name.data_equal(CharSpan::fromCharString("bad name")));
+    EXPECT_EQ(file.size, 10u);
+}
+
+} // namespace

--- a/examples/tv-app/tv-common/clusters/media-file-management/tests/TestMediaFileManagementManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-file-management/tests/TestMediaFileManagementManager.cpp
@@ -153,7 +153,7 @@ TEST_F(TestMediaFileManagementManager, StatePersistsAcrossInstances)
     uint64_t savedID = 0;
     {
         MediaFileManagementManager mgr(dir);
-        auto r = AddFile(mgr, "persisted.mp4", 4096, "video/mp4", "bdx://n/p.jpg");
+        auto r  = AddFile(mgr, "persisted.mp4", 4096, "video/mp4", "bdx://n/p.jpg");
         savedID = r.fileID.Value();
     }
 

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -303,6 +303,12 @@ if (chip_build_tests) {
         chip_device_platform != "nxp" && current_os != "android") {
       tests += [ "${chip_root}/examples/evse-app/evse-common/tests" ]
     }
+
+    # tv-app Media File Management delegate test. Excluded on embedded targets
+    # where the example's filesystem-backed delegate has no /tmp to write to.
+    if (chip_device_platform == "linux" || chip_device_platform == "darwin") {
+      tests += [ "${chip_root}/examples/tv-app/tv-common/clusters/media-file-management/tests" ]
+    }
   }
 
   chip_test_group("fake_platform_tests") {


### PR DESCRIPTION
### Summary

Wires the code-driven **Media File Management** cluster (`0x0511`) into the Linux tv-app, mirroring the earlier ContentLauncher / MediaPlayback integrations.

The cluster server itself was migrated to the code-driven `DefaultServerCluster` pattern in #72946 / the MFM code-driven migration; this PR adds the **application delegate + registration** in the tv-app so the cluster is actually functional on a running example.

## Key design note

Unlike the legacy Ember media clusters (registered via `SetDefaultDelegate` in `ZCLCallbacks.cpp`), MediaFileManagement is **code-driven**, so the application owns the delegate and the cluster registration lifecycle. MediaFileManagement was already enabled in `tv-app.zap` (from #72946), so no ZAP regen is required.

## Changes

- **`MediaFileManagementManager`** (`examples/tv-app/tv-common/clusters/media-file-management/`) — a file-backed `MediaFileManagement::Delegate`:
  - Persists file metadata (tab-delimited `index.txt`) and per-file blobs (`<fileID>.bin`) under `/tmp/chip-media-files`, similar to how the example KVS store keeps its artifacts under `/tmp`.
  - Tracks storage usage against a 1 GiB advertised capacity, assigns monotonic file IDs, rejects over-capacity `AddFile` requests, and reloads its index on construction so state survives restarts.
  - Sanitizes tabs/newlines out of names so the flat index cannot be corrupted.
- **tv-app lifecycle** — `examples/tv-app/linux/main.cpp` instantiates a `MediaFileManagementServer` + the manager and calls `Init()` in `ApplicationInit()` (endpoint 1) / `Shutdown()` in `ApplicationShutdown()`.
- **BUILD.gn** — tv-common and the linux app link the `media-file-management-server` library and compile the new manager sources.
- **Unit tests** — 9 tests for the manager (add/delete, incrementing IDs, storage accounting, capacity rejection, not-found delete, cross-instance persistence, MIME enumeration, index sanitization), registered in the `example_tests` group for linux/darwin.

### Testing

- `TestMediaFileManagementManager` — **9/9 pass**.
- Darwin `chip-tv-app` builds and links cleanly with the new registration.