### PR TITLE
TC-DA-1.1 - Fix second PASE session failing for DUTs with real vendor/product IDs

### DIFF
--- a/src/python_testing/TC_DA_1_1.py
+++ b/src/python_testing/TC_DA_1_1.py
@@ -119,10 +119,20 @@ class TC_DA_1_1(MatterBaseTest):
         if not setupPayloadInfo:
             asserts.fail(f"Setup payload info is required for commissioning, found '{setupPayloadInfo}'")
 
-        # Build setup parameters for commissioning
+        # Vendor ID and Product ID are set to 0x0000, the pair the spec prescribes for
+        # commissioner-generated onboarding payloads not bound to a product identity.
+        vendor_id = 0
+        product_id = 0
+
+        # Build setup parameters for commissioning.
+        # - With no VID/PID claim in the QR, PASE discovery matches the DUT on long
+        #   discriminator and passcode alone instead of rejecting DUTs whose advertised
+        #   VID/PID differ from fabricated values.
         setup_params = SetupParameters(
             discriminator=setupPayloadInfo[0].filter_value,
-            passcode=setupPayloadInfo[0].passcode
+            passcode=setupPayloadInfo[0].passcode,
+            vendor_id=vendor_id,
+            product_id=product_id
         )
 
         # Setup


### PR DESCRIPTION
### Summary

Fix for

Step 4 (TH2 opens a PASE session with the DUT after factory reset) fails against any DUT whose advertised Vendor ID / Product ID differ from the SDK test values, with: `Discovered device product ID (32768) does not match our product ID (32769)`

### Related issues

[[Bug] DA-1.1 uses wrong expectations in Step 4 for second PASE connection
 #1057](https://github.com/project-chip/certification-tool/issues/1057)

### Testing


