### PR TITLE
reject oversized byte strings in TlvToJson base64 encoding

### DIFF
--- a/src/lib/support/jsontlv/TlvToJson.cpp
+++ b/src/lib/support/jsontlv/TlvToJson.cpp
@@ -247,6 +247,12 @@ CHIP_ERROR TlvToJson(TLV::TLVReader & reader, Json::Value & jsonObj)
         ByteSpan span;
         ReturnErrorOnFailure(reader.Get(span));
 
+        // Base64Encode takes and returns a uint16_t length, so a byte string whose raw or
+        // base64-encoded size exceeds 65535 would be silently truncated instead of encoded.
+        // Reject it, matching the guard the sibling Json<->TLV converters already apply.
+        VerifyOrReturnError(CanCastTo<uint16_t>(span.size()), CHIP_ERROR_INVALID_TLV_ELEMENT);
+        VerifyOrReturnError(CanCastTo<uint16_t>(BASE64_ENCODED_LEN(span.size())), CHIP_ERROR_INVALID_TLV_ELEMENT);
+
         Platform::ScopedMemoryBuffer<char> byteString;
         byteString.Alloc(BASE64_ENCODED_LEN(span.size()) + 1);
         VerifyOrReturnError(byteString.Get() != nullptr, CHIP_ERROR_NO_MEMORY);

--- a/src/lib/support/tests/TestJsonToTlvToJson.cpp
+++ b/src/lib/support/tests/TestJsonToTlvToJson.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <vector>
 
 #include <pw_unit_test/framework.h>
 
@@ -1861,5 +1862,30 @@ TEST_F(TestJsonToTlvToJson, TestConverter_Struct_MEITags)
 
     ByteSpan tlvSpan(buf, writer.GetLengthWritten());
     CheckValidConversion(jsonString, tlvSpan, jsonString);
+}
+
+// Octet string whose base64 encoding does not fit the uint16_t length Base64Encode uses.
+// TlvToJson must reject it rather than silently emit a truncated value.
+TEST_F(TestJsonToTlvToJson, TestConverter_OctetString_TooLargeForBase64)
+{
+    // BASE64_ENCODED_LEN(49152) == 65536, which does not fit the uint16_t length that
+    // Base64Encode consumes and returns.
+    constexpr size_t kOversizedLength = 49152;
+
+    std::vector<uint8_t> value(kOversizedLength, 0xAB);
+    std::vector<uint8_t> buf(kOversizedLength + 64);
+
+    TLV::TLVWriter writer;
+    TLV::TLVType containerType;
+    writer.Init(buf.data(), static_cast<uint32_t>(buf.size()));
+    EXPECT_EQ(CHIP_NO_ERROR, writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, containerType));
+    EXPECT_EQ(CHIP_NO_ERROR, writer.PutBytes(TLV::ContextTag(1), value.data(), static_cast<uint32_t>(value.size())));
+    EXPECT_EQ(CHIP_NO_ERROR, writer.EndContainer(containerType));
+    EXPECT_EQ(CHIP_NO_ERROR, writer.Finalize());
+
+    ByteSpan tlvSpan(buf.data(), writer.GetLengthWritten());
+    std::string jsonString;
+    // Without the guard this silently truncated the base64 output and returned CHIP_NO_ERROR.
+    EXPECT_NE(CHIP_NO_ERROR, TlvToJson(tlvSpan, jsonString));
 }
 } // namespace


### PR DESCRIPTION
### Summary

The `kTLVType_ByteString` branch of `TlvToJson` passes `static_cast<uint16_t>(span.size())` to `Base64Encode`, whose length argument and return value are both `uint16_t`. A byte string whose base64 encoding is larger than 65535 bytes (raw size of roughly 49150 and up) is therefore written as a truncated or empty value while the conversion still returns `CHIP_NO_ERROR`. It is reachable from device-supplied attribute and event report data through the Android controller's `ConvertReportTlvToJson` path. The sibling converters in `TlvJson.cpp` and `JsonToTlv.cpp` already guard this same narrowing, but this branch did not. The fix guards `span.size()` and its base64-encoded length with `CanCastTo<uint16_t>`, so oversized input is rejected with `CHIP_ERROR_INVALID_TLV_ELEMENT` instead of being silently corrupted.

### Related issues

None.

### Testing

Added a `TestJsonToTlvToJson` regression that encodes a 49152-byte octet string. It fails on the current tree, where the conversion returns `CHIP_NO_ERROR` with truncated output, and passes with the fix, where the oversized value is rejected. The full `TestJsonToTlvToJson` suite is green (49 tests) on a darwin host build.
