### PR TITLE
fix(android): strip symbols before copying libs to ensure optimised b…

### DIFF
--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -547,6 +547,9 @@ class AndroidBuilder(Builder):
                 title="Building JNI " + self.identifier,
             )
 
+            if self.options.build_profile in [BuildProfile.RELEASE, BuildProfile.RELEASE_SIZE] or self.optimize_size:
+                self.stripSymbols()
+
             exampleName = self.app.ExampleName()
             if exampleName is None:
                 self.copyToSrcAndroid()
@@ -647,9 +650,6 @@ class AndroidBuilder(Builder):
 
                 self.copyToExampleApp(jnilibs_dir, libs_dir, libs, jars)
                 self.gradlewBuildExampleAndroid()
-
-            if self.options.build_profile in [BuildProfile.RELEASE, BuildProfile.RELEASE_SIZE] or self.optimize_size:
-                self.stripSymbols()
 
     @lock_output_dir
     def build_outputs(self):


### PR DESCRIPTION
…uild variant packages stripped libs

### Summary

**Root cause:** In `scripts/build/builders/android.py`, `stripSymbols()` was
  called *after* `copyToExampleApp()` and `gradlewBuildExampleAndroid()`. Since
  `stripSymbols()` strips in-place inside `output_dir`, the `.so` files were
  already copied to `examples/tv-casting-app/android/App/app/libs/jniLibs/`
  *before* stripping occurred. As a result, the Gradle build packaged the
  unstripped (unoptimised) libs into the APK regardless of whether the
  `size-optimized` build variant was selected.

  **Fix:** Move the `stripSymbols()` call to *before* `copyToExampleApp()`, so
  that stripped (size-optimised) libs are what get copied into the app's
  `jniLibs` folder and subsequently packaged by Gradle.

### Related issues

N/A

### Testing

Manually tested — built `size-optimized` variant across multiple architectures:
  - `android-arm-tv-casting-app-size-optimized`
  - `android-arm64-tv-casting-app-size-optimized`
  - `android-x86-tv-casting-app-size-optimized`

  Confirmed that the `.so` files copied to
  `examples/tv-casting-app/android/App/app/libs/jniLibs/<ABI>/` are stripped
  in all cases.
No existing automated tests cover `AndroidBuilder._build()` internals.