### PR TITLE
feat(tv-casting-app): add client support for new ContentLauncher, MediaPlayback, and MediaFileManagement features

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCEndpoint.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCEndpoint.mm
@@ -135,6 +135,15 @@
         return [[MCMediaPlaybackCluster alloc] initWithCppCluster:cppCluster];
     }
 
+    case MCEndpointClusterTypeMediaFileManagement: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::media_file_management::MediaFileManagementCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeMediaFileManagement GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCMediaFileManagementCluster alloc] initWithCppCluster:cppCluster];
+    }
+
     case MCEndpointClusterTypeOnOff: {
         auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::on_off::OnOffCluster>();
         if (cppCluster == nullptr) {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/templates/config-data.yaml
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/templates/config-data.yaml
@@ -27,6 +27,7 @@ MatterCastingClusters:
     - Keypad Input
     - Level Control
     - Media Playback
+    - Media File Management
     - On/Off
     - Target Navigator
     - Wake on LAN

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h
@@ -328,4 +328,33 @@
 @interface MCApplicationBasicClusterClusterRevisionAttribute : MCAttribute <NSNumber *>
 @end
 
+// MediaFileManagement cluster attributes:
+
+@interface MCMediaFileManagementClusterTotalStorageAttribute : MCAttribute <NSNumber *>
+@end
+
+@interface MCMediaFileManagementClusterAvailableStorageAttribute : MCAttribute <NSNumber *>
+@end
+
+@interface MCMediaFileManagementClusterAvailableFilesAttribute : MCAttribute <NSArray *>
+@end
+
+@interface MCMediaFileManagementClusterSupportedMimeTypesAttribute : MCAttribute <NSArray *>
+@end
+
+@interface MCMediaFileManagementClusterGeneratedCommandListAttribute : MCAttribute <NSArray *>
+@end
+
+@interface MCMediaFileManagementClusterAcceptedCommandListAttribute : MCAttribute <NSArray *>
+@end
+
+@interface MCMediaFileManagementClusterAttributeListAttribute : MCAttribute <NSArray *>
+@end
+
+@interface MCMediaFileManagementClusterFeatureMapAttribute : MCAttribute <NSNumber *>
+@end
+
+@interface MCMediaFileManagementClusterClusterRevisionAttribute : MCAttribute <NSNumber *>
+@end
+
 #endif /* MCAttributeObjects_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.mm
@@ -5416,3 +5416,519 @@
     return value;
 }
 @end
+
+// MediaFileManagement cluster attributes:
+
+@implementation MCMediaFileManagementClusterTotalStorageAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSNumber * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSNumber * _Nonnull value;
+        value = [NSNumber numberWithUnsignedLongLong:_cppValue];
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterAvailableStorageAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSNumber * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSNumber * _Nonnull value;
+        value = [NSNumber numberWithUnsignedLongLong:_cppValue];
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterAvailableFilesAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSArray * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSArray * _Nonnull value;
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = _cppValue.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                MCMediaFileManagementClusterFileDescriptionStruct * newElement_0;
+                newElement_0 = [MCMediaFileManagementClusterFileDescriptionStruct new];
+                newElement_0.fileID = [NSNumber numberWithUnsignedLongLong:entry_0.fileID];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                newElement_0.size = [NSNumber numberWithUnsignedLongLong:entry_0.size];
+                newElement_0.mimeType = AsString(entry_0.mimeType);
+                if (newElement_0.mimeType == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                newElement_0.imageUri = AsString(entry_0.imageUri);
+                if (newElement_0.imageUri == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                [array_0 addObject:newElement_0];
+            }
+            CHIP_ERROR err = iter_0.GetStatus();
+            if (err != CHIP_NO_ERROR) {
+                *aError = err;
+                return nil;
+            }
+            value = array_0;
+        }
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterSupportedMimeTypesAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSArray * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSArray * _Nonnull value;
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = _cppValue.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSString * newElement_0;
+                newElement_0 = AsString(entry_0);
+                if (newElement_0 == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                [array_0 addObject:newElement_0];
+            }
+            CHIP_ERROR err = iter_0.GetStatus();
+            if (err != CHIP_NO_ERROR) {
+                *aError = err;
+                return nil;
+            }
+            value = array_0;
+        }
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterGeneratedCommandListAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSArray * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSArray * _Nonnull value;
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = _cppValue.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                [array_0 addObject:newElement_0];
+            }
+            CHIP_ERROR err = iter_0.GetStatus();
+            if (err != CHIP_NO_ERROR) {
+                *aError = err;
+                return nil;
+            }
+            value = array_0;
+        }
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterAcceptedCommandListAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSArray * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSArray * _Nonnull value;
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = _cppValue.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                [array_0 addObject:newElement_0];
+            }
+            CHIP_ERROR err = iter_0.GetStatus();
+            if (err != CHIP_NO_ERROR) {
+                *aError = err;
+                return nil;
+            }
+            value = array_0;
+        }
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterAttributeListAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSArray * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSArray * _Nonnull value;
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = _cppValue.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                [array_0 addObject:newElement_0];
+            }
+            CHIP_ERROR err = iter_0.GetStatus();
+            if (err != CHIP_NO_ERROR) {
+                *aError = err;
+                return nil;
+            }
+            value = array_0;
+        }
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterFeatureMapAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSNumber * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSNumber * _Nonnull value;
+        value = [NSNumber numberWithUnsignedInt:_cppValue];
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end
+
+@implementation MCMediaFileManagementClusterClusterRevisionAttribute
+- (void)read:(void * _Nullable)context
+    completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->read(context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+        completion(context, before, after, err);
+        delete mcAttribute;
+    });
+}
+
+- (void)subscribe:(void * _Nullable)context
+       completion:(void (^_Nonnull __strong)(void * _Nullable, id _Nullable __strong before, id _Nullable __strong after, NSError * _Nullable __strong error))completion
+      minInterval:(NSNumber * _Nonnull)minInterval
+      maxInterval:(NSNumber * _Nonnull)maxInterval
+{
+    MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo> * mcAttribute = new MCAttributeTemplate<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo>(self.cppAttribute,
+        [self](std::any cppValue, CHIP_ERROR * errPtr) {
+            return [self getObjCTypeFromCpp:cppValue errorCode:errPtr];
+        });
+    mcAttribute->subscribe(
+        context, [mcAttribute, completion](void * context, id before, id after, NSError * err) {
+            completion(context, before, after, err);
+            delete mcAttribute;
+        }, minInterval, maxInterval);
+}
+
+- (id _Nullable)getObjCTypeFromCpp:(std::any)cppValue errorCode:(CHIP_ERROR *)aError
+{
+    NSNumber * value = nil;
+    if (cppValue.type() == typeid(std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo::DecodableType>)) {
+        std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo::DecodableType> sharedPtr = std::any_cast<std::shared_ptr<chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo::DecodableType>>(cppValue);
+        chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::TypeInfo::DecodableType _cppValue = *sharedPtr;
+        *aError = CHIP_NO_ERROR;
+        NSNumber * _Nonnull value;
+        value = [NSNumber numberWithUnsignedShort:_cppValue];
+        return value;
+    }
+    *aError = CHIP_ERROR_INTERNAL;
+    return value;
+}
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h
@@ -771,4 +771,83 @@
 - (MCApplicationBasicClusterClusterRevisionAttribute * _Nullable)clusterRevisionAttribute;
 @end
 
+// MediaFileManagement cluster:
+
+@interface MCMediaFileManagementCluster : MCCluster
+
+// MediaFileManagement cluster commands:
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterAddFileCommand if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterAddFileCommand * _Nullable)addFileCommand;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterDeleteFileCommand if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterDeleteFileCommand * _Nullable)deleteFileCommand;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterRequestSharedFilesCommand if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterRequestSharedFilesCommand * _Nullable)requestSharedFilesCommand;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterGetSharedFileCommand if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterGetSharedFileCommand * _Nullable)getSharedFileCommand;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterOfferFileCommand if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterOfferFileCommand * _Nullable)offerFileCommand;
+
+// MediaFileManagement cluster attributes:
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterTotalStorageAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterTotalStorageAttribute * _Nullable)totalStorageAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterAvailableStorageAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterAvailableStorageAttribute * _Nullable)availableStorageAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterAvailableFilesAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterAvailableFilesAttribute * _Nullable)availableFilesAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterSupportedMimeTypesAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterSupportedMimeTypesAttribute * _Nullable)supportedMimeTypesAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterGeneratedCommandListAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterGeneratedCommandListAttribute * _Nullable)generatedCommandListAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterAcceptedCommandListAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterAcceptedCommandListAttribute * _Nullable)acceptedCommandListAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterAttributeListAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterAttributeListAttribute * _Nullable)attributeListAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterFeatureMapAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterFeatureMapAttribute * _Nullable)featureMapAttribute;
+
+/**
+ * @brief Returns non-nil pointer to MCMediaFileManagementClusterClusterRevisionAttribute if supported, nil otherwise.
+ */
+- (MCMediaFileManagementClusterClusterRevisionAttribute * _Nullable)clusterRevisionAttribute;
+@end
+
 #endif /* MCClusterObjects_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.mm
@@ -907,3 +907,96 @@
     return cppAttribute != nil ? [[MCApplicationBasicClusterClusterRevisionAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
 }
 @end
+
+// MediaFileManagement cluster:
+
+@implementation MCMediaFileManagementCluster
+
+// MediaFileManagement cluster commands:
+
+- (id)addFileCommand
+{
+    void * cppCommand = self.cppCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::AddFile::Id);
+    return cppCommand != nil ? [[MCMediaFileManagementClusterAddFileCommand alloc] initWithCppCommand:cppCommand] : nil;
+}
+
+- (id)deleteFileCommand
+{
+    void * cppCommand = self.cppCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Id);
+    return cppCommand != nil ? [[MCMediaFileManagementClusterDeleteFileCommand alloc] initWithCppCommand:cppCommand] : nil;
+}
+
+- (id)requestSharedFilesCommand
+{
+    void * cppCommand = self.cppCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Id);
+    return cppCommand != nil ? [[MCMediaFileManagementClusterRequestSharedFilesCommand alloc] initWithCppCommand:cppCommand] : nil;
+}
+
+- (id)getSharedFileCommand
+{
+    void * cppCommand = self.cppCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Id);
+    return cppCommand != nil ? [[MCMediaFileManagementClusterGetSharedFileCommand alloc] initWithCppCommand:cppCommand] : nil;
+}
+
+- (id)offerFileCommand
+{
+    void * cppCommand = self.cppCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Id);
+    return cppCommand != nil ? [[MCMediaFileManagementClusterOfferFileCommand alloc] initWithCppCommand:cppCommand] : nil;
+}
+
+// MediaFileManagement cluster attributes:
+
+- (id)totalStorageAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterTotalStorageAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)availableStorageAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterAvailableStorageAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)availableFilesAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterAvailableFilesAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)supportedMimeTypesAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterSupportedMimeTypesAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)generatedCommandListAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::GeneratedCommandList::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterGeneratedCommandListAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)acceptedCommandListAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::AcceptedCommandList::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterAcceptedCommandListAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)attributeListAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::AttributeList::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterAttributeListAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)featureMapAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::FeatureMap::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterFeatureMapAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+
+- (id)clusterRevisionAttribute
+{
+    void * cppAttribute = self.cppCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::ClusterRevision::Id);
+    return cppAttribute != nil ? [[MCMediaFileManagementClusterClusterRevisionAttribute alloc] initWithCppAttribute:cppAttribute] : nil;
+}
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h
@@ -159,4 +159,21 @@
 
 // ApplicationBasic cluster:
 
+// MediaFileManagement cluster:
+
+@interface MCMediaFileManagementClusterAddFileCommand : MCCommand <MCMediaFileManagementClusterAddFileParams *, MCMediaFileManagementClusterAddFileResponseParams *>
+@end
+
+@interface MCMediaFileManagementClusterDeleteFileCommand : MCCommand <MCMediaFileManagementClusterDeleteFileParams *, MCNullObjectType *>
+@end
+
+@interface MCMediaFileManagementClusterRequestSharedFilesCommand : MCCommand <MCMediaFileManagementClusterRequestSharedFilesParams *, MCNullObjectType *>
+@end
+
+@interface MCMediaFileManagementClusterGetSharedFileCommand : MCCommand <MCMediaFileManagementClusterGetSharedFileParams *, MCMediaFileManagementClusterGetSharedFileResponseParams *>
+@end
+
+@interface MCMediaFileManagementClusterOfferFileCommand : MCCommand <MCMediaFileManagementClusterOfferFileParams *, MCNullObjectType *>
+@end
+
 #endif /* MCCommandObjects_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.mm
@@ -2030,3 +2030,265 @@
 @end
 
 // ApplicationBasic cluster:
+
+// MediaFileManagement cluster:
+
+@implementation MCMediaFileManagementClusterAddFileCommand
+- (void)invoke:(id)request
+                 context:(void * _Nullable)context
+              completion:(void (^_Nonnull __strong)(void *, NSError *, id))completion
+    timedInvokeTimeoutMs:(NSNumber * _Nullable)timedInvokeTimeoutMs
+{
+    MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type> * mcCommand = new MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type>(
+        self.cppCommand,
+        [self](id objCRequest) {
+            return [self getCppRequestFromObjC:objCRequest];
+        },
+        [self](std::any cppResponse) {
+            return [self getObjCResponseFromCpp:cppResponse];
+        });
+    mcCommand->invoke(
+        request, context, [mcCommand, completion](void * context, NSError * err, id response) {
+            completion(context, err, response);
+            delete mcCommand;
+        }, timedInvokeTimeoutMs);
+}
+
+- (std::any)getCppRequestFromObjC:(MCMediaFileManagementClusterAddFileParams *)objcRequest
+{
+    VerifyOrReturnValue(objcRequest != nil, nullptr);
+    std::any anyCppRequest = [objcRequest getCppRequestFromObjCRequest];
+    if (anyCppRequest.has_value()) {
+        try {
+            // Extract the object from std::any and convert it to a std::shared_ptr
+            auto & cppRequest = std::any_cast<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type &>(anyCppRequest);
+            return std::any(std::make_shared<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type>(cppRequest));
+        } catch (const std::bad_any_cast & e) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+- (id)getObjCResponseFromCpp:(std::any)cppResponse
+{
+    MCMediaFileManagementClusterAddFileResponseParams * objCResponse = nil;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (cppResponse.type() == typeid(std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type::ResponseType>)) {
+        objCResponse = [[MCMediaFileManagementClusterAddFileResponseParams
+            alloc] init];
+        // Set the ObjC response fields using the given cpp Response
+        err = [objCResponse setObjCResponseFromCppResponse:cppResponse];
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil, ChipLogError(AppServer, "MCMediaFileManagementClusterAddFileCommand getObjCResponseFromCpp() failed"));
+    }
+    return objCResponse;
+}
+@end
+
+@implementation MCMediaFileManagementClusterDeleteFileCommand
+- (void)invoke:(id)request
+                 context:(void * _Nullable)context
+              completion:(void (^_Nonnull __strong)(void *, NSError *, id))completion
+    timedInvokeTimeoutMs:(NSNumber * _Nullable)timedInvokeTimeoutMs
+{
+    MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type> * mcCommand = new MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type>(
+        self.cppCommand,
+        [self](id objCRequest) {
+            return [self getCppRequestFromObjC:objCRequest];
+        },
+        [self](std::any cppResponse) {
+            return [self getObjCResponseFromCpp:cppResponse];
+        });
+    mcCommand->invoke(
+        request, context, [mcCommand, completion](void * context, NSError * err, id response) {
+            completion(context, err, response);
+            delete mcCommand;
+        }, timedInvokeTimeoutMs);
+}
+
+- (std::any)getCppRequestFromObjC:(MCMediaFileManagementClusterDeleteFileParams *)objcRequest
+{
+    VerifyOrReturnValue(objcRequest != nil, nullptr);
+    std::any anyCppRequest = [objcRequest getCppRequestFromObjCRequest];
+    if (anyCppRequest.has_value()) {
+        try {
+            // Extract the object from std::any and convert it to a std::shared_ptr
+            auto & cppRequest = std::any_cast<chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type &>(anyCppRequest);
+            return std::any(std::make_shared<chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type>(cppRequest));
+        } catch (const std::bad_any_cast & e) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+- (id)getObjCResponseFromCpp:(std::any)cppResponse
+{
+    MCNullObjectType * objCResponse = nil;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (cppResponse.type() == typeid(std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type::ResponseType>)) {
+        objCResponse = [[MCNullObjectType
+            alloc] init];
+        // Set the ObjC response fields using the given cpp Response
+        err = [objCResponse setObjCResponseFromCppResponse:cppResponse];
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil, ChipLogError(AppServer, "MCMediaFileManagementClusterDeleteFileCommand getObjCResponseFromCpp() failed"));
+    }
+    return objCResponse;
+}
+@end
+
+@implementation MCMediaFileManagementClusterRequestSharedFilesCommand
+- (void)invoke:(id)request
+                 context:(void * _Nullable)context
+              completion:(void (^_Nonnull __strong)(void *, NSError *, id))completion
+    timedInvokeTimeoutMs:(NSNumber * _Nullable)timedInvokeTimeoutMs
+{
+    MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type> * mcCommand = new MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type>(
+        self.cppCommand,
+        [self](id objCRequest) {
+            return [self getCppRequestFromObjC:objCRequest];
+        },
+        [self](std::any cppResponse) {
+            return [self getObjCResponseFromCpp:cppResponse];
+        });
+    mcCommand->invoke(
+        request, context, [mcCommand, completion](void * context, NSError * err, id response) {
+            completion(context, err, response);
+            delete mcCommand;
+        }, timedInvokeTimeoutMs);
+}
+
+- (std::any)getCppRequestFromObjC:(MCMediaFileManagementClusterRequestSharedFilesParams *)objcRequest
+{
+    VerifyOrReturnValue(objcRequest != nil, nullptr);
+    std::any anyCppRequest = [objcRequest getCppRequestFromObjCRequest];
+    if (anyCppRequest.has_value()) {
+        try {
+            // Extract the object from std::any and convert it to a std::shared_ptr
+            auto & cppRequest = std::any_cast<chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type &>(anyCppRequest);
+            return std::any(std::make_shared<chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type>(cppRequest));
+        } catch (const std::bad_any_cast & e) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+- (id)getObjCResponseFromCpp:(std::any)cppResponse
+{
+    MCNullObjectType * objCResponse = nil;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (cppResponse.type() == typeid(std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type::ResponseType>)) {
+        objCResponse = [[MCNullObjectType
+            alloc] init];
+        // Set the ObjC response fields using the given cpp Response
+        err = [objCResponse setObjCResponseFromCppResponse:cppResponse];
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil, ChipLogError(AppServer, "MCMediaFileManagementClusterRequestSharedFilesCommand getObjCResponseFromCpp() failed"));
+    }
+    return objCResponse;
+}
+@end
+
+@implementation MCMediaFileManagementClusterGetSharedFileCommand
+- (void)invoke:(id)request
+                 context:(void * _Nullable)context
+              completion:(void (^_Nonnull __strong)(void *, NSError *, id))completion
+    timedInvokeTimeoutMs:(NSNumber * _Nullable)timedInvokeTimeoutMs
+{
+    MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type> * mcCommand = new MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type>(
+        self.cppCommand,
+        [self](id objCRequest) {
+            return [self getCppRequestFromObjC:objCRequest];
+        },
+        [self](std::any cppResponse) {
+            return [self getObjCResponseFromCpp:cppResponse];
+        });
+    mcCommand->invoke(
+        request, context, [mcCommand, completion](void * context, NSError * err, id response) {
+            completion(context, err, response);
+            delete mcCommand;
+        }, timedInvokeTimeoutMs);
+}
+
+- (std::any)getCppRequestFromObjC:(MCMediaFileManagementClusterGetSharedFileParams *)objcRequest
+{
+    VerifyOrReturnValue(objcRequest != nil, nullptr);
+    std::any anyCppRequest = [objcRequest getCppRequestFromObjCRequest];
+    if (anyCppRequest.has_value()) {
+        try {
+            // Extract the object from std::any and convert it to a std::shared_ptr
+            auto & cppRequest = std::any_cast<chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type &>(anyCppRequest);
+            return std::any(std::make_shared<chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type>(cppRequest));
+        } catch (const std::bad_any_cast & e) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+- (id)getObjCResponseFromCpp:(std::any)cppResponse
+{
+    MCMediaFileManagementClusterGetSharedFileResponseParams * objCResponse = nil;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (cppResponse.type() == typeid(std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type::ResponseType>)) {
+        objCResponse = [[MCMediaFileManagementClusterGetSharedFileResponseParams
+            alloc] init];
+        // Set the ObjC response fields using the given cpp Response
+        err = [objCResponse setObjCResponseFromCppResponse:cppResponse];
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil, ChipLogError(AppServer, "MCMediaFileManagementClusterGetSharedFileCommand getObjCResponseFromCpp() failed"));
+    }
+    return objCResponse;
+}
+@end
+
+@implementation MCMediaFileManagementClusterOfferFileCommand
+- (void)invoke:(id)request
+                 context:(void * _Nullable)context
+              completion:(void (^_Nonnull __strong)(void *, NSError *, id))completion
+    timedInvokeTimeoutMs:(NSNumber * _Nullable)timedInvokeTimeoutMs
+{
+    MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type> * mcCommand = new MCCommandTemplate<chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type>(
+        self.cppCommand,
+        [self](id objCRequest) {
+            return [self getCppRequestFromObjC:objCRequest];
+        },
+        [self](std::any cppResponse) {
+            return [self getObjCResponseFromCpp:cppResponse];
+        });
+    mcCommand->invoke(
+        request, context, [mcCommand, completion](void * context, NSError * err, id response) {
+            completion(context, err, response);
+            delete mcCommand;
+        }, timedInvokeTimeoutMs);
+}
+
+- (std::any)getCppRequestFromObjC:(MCMediaFileManagementClusterOfferFileParams *)objcRequest
+{
+    VerifyOrReturnValue(objcRequest != nil, nullptr);
+    std::any anyCppRequest = [objcRequest getCppRequestFromObjCRequest];
+    if (anyCppRequest.has_value()) {
+        try {
+            // Extract the object from std::any and convert it to a std::shared_ptr
+            auto & cppRequest = std::any_cast<chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type &>(anyCppRequest);
+            return std::any(std::make_shared<chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type>(cppRequest));
+        } catch (const std::bad_any_cast & e) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+- (id)getObjCResponseFromCpp:(std::any)cppResponse
+{
+    MCNullObjectType * objCResponse = nil;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (cppResponse.type() == typeid(std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type::ResponseType>)) {
+        objCResponse = [[MCNullObjectType
+            alloc] init];
+        // Set the ObjC response fields using the given cpp Response
+        err = [objCResponse setObjCResponseFromCppResponse:cppResponse];
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil, ChipLogError(AppServer, "MCMediaFileManagementClusterOfferFileCommand getObjCResponseFromCpp() failed"));
+    }
+    return objCResponse;
+}
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h
@@ -253,4 +253,45 @@ NS_ASSUME_NONNULL_BEGIN
 
 // ApplicationBasic cluster:
 
+// MediaFileManagement cluster:
+
+@interface MCMediaFileManagementClusterAddFileParams : MCAbstractPayload
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull size;
+@property (nonatomic, copy) NSString * _Nonnull mimeType;
+@property (nonatomic, copy) NSString * _Nonnull imageUri;
+@end
+
+@interface MCMediaFileManagementClusterAddFileResponseParams : MCAbstractPayload
+@property (nonatomic, copy) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nullable fileID;
+@end
+
+@interface MCMediaFileManagementClusterDeleteFileParams : MCAbstractPayload
+@property (nonatomic, copy) NSNumber * _Nonnull fileID;
+@end
+
+@interface MCMediaFileManagementClusterRequestSharedFilesParams : MCAbstractPayload
+@property (nonatomic, copy) NSString * _Nonnull clientName;
+@property (nonatomic, copy) NSNumber * _Nonnull requestID;
+@property (nonatomic, copy) NSArray * _Nullable supportedMimeTypes;
+@end
+
+@interface MCMediaFileManagementClusterGetSharedFileParams : MCAbstractPayload
+@property (nonatomic, copy) NSNumber * _Nonnull responseID;
+@end
+
+@interface MCMediaFileManagementClusterGetSharedFileResponseParams : MCAbstractPayload
+@property (nonatomic, copy) NSNumber * _Nonnull status;
+@property (nonatomic, copy) MCMediaFileManagementClusterFileDescriptionStruct * _Nullable fileDescription;
+@end
+
+@interface MCMediaFileManagementClusterOfferFileParams : MCAbstractPayload
+@property (nonatomic, copy) NSString * _Nonnull clientName;
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull size;
+@property (nonatomic, copy) NSString * _Nonnull mimeType;
+@property (nonatomic, copy) NSString * _Nonnull imageUri;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.mm
@@ -2745,4 +2745,431 @@ NS_ASSUME_NONNULL_BEGIN
 
 // ApplicationBasic cluster:
 
+// MediaFileManagement cluster:
+
+@implementation MCMediaFileManagementClusterAddFileParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _name = @"";
+
+        _size = @(0);
+
+        _mimeType = @"";
+
+        _imageUri = @"";
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterAddFileParams alloc] init];
+
+    other.name = self.name;
+    other.size = self.size;
+    other.mimeType = self.mimeType;
+    other.imageUri = self.imageUri;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: name:%@; size:%@; mimeType:%@; imageUri:%@; >", NSStringFromClass([self class]), _name, _size, _mimeType, _imageUri];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type cppStruct;
+    ListFreer listFreer;
+    {
+        cppStruct.name = AsCharSpan(self.name);
+    }
+    {
+        cppStruct.size = self.size.unsignedLongLongValue;
+    }
+    {
+        cppStruct.mimeType = AsCharSpan(self.mimeType);
+    }
+    {
+        cppStruct.imageUri = AsCharSpan(self.imageUri);
+    }
+
+    return std::any(cppStruct);
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppDecodableStruct
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterAddFileResponseParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _fileID = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterAddFileResponseParams alloc] init];
+
+    other.status = self.status;
+    other.fileID = self.fileID;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; fileID:%@; >", NSStringFromClass([self class]), _status, _fileID];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppResponse
+{
+    std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::AddFileResponse::DecodableType> responseSharedPtr = std::any_cast<std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::AddFileResponse::DecodableType>>(cppResponse);
+    const chip::app::Clusters::MediaFileManagement::Commands::AddFileResponse::DecodableType cppDecodableStruct = *responseSharedPtr;
+
+    {
+        self.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppDecodableStruct.status)];
+    }
+    {
+        if (cppDecodableStruct.fileID.IsNull()) {
+            self.fileID = nil;
+        } else {
+            self.fileID = [NSNumber numberWithUnsignedLongLong:cppDecodableStruct.fileID.Value()];
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterDeleteFileParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _fileID = @(0);
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterDeleteFileParams alloc] init];
+
+    other.fileID = self.fileID;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: fileID:%@; >", NSStringFromClass([self class]), _fileID];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type cppStruct;
+    ListFreer listFreer;
+    {
+        cppStruct.fileID = self.fileID.unsignedLongLongValue;
+    }
+
+    return std::any(cppStruct);
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppDecodableStruct
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterRequestSharedFilesParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _clientName = @"";
+
+        _requestID = @(0);
+
+        _supportedMimeTypes = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterRequestSharedFilesParams alloc] init];
+
+    other.clientName = self.clientName;
+    other.requestID = self.requestID;
+    other.supportedMimeTypes = self.supportedMimeTypes;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: clientName:%@; requestID:%@; supportedMimeTypes:%@; >", NSStringFromClass([self class]), _clientName, _requestID, _supportedMimeTypes];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type cppStruct;
+    ListFreer listFreer;
+    {
+        cppStruct.clientName = AsCharSpan(self.clientName);
+    }
+    {
+        cppStruct.requestID = self.requestID.unsignedShortValue;
+    }
+    {
+        if (self.supportedMimeTypes != nil) {
+            auto & definedValue_0 = cppStruct.supportedMimeTypes.Emplace();
+            if (self.supportedMimeTypes == nil) {
+                definedValue_0.SetNull();
+            } else {
+                auto & nonNullValue_1 = definedValue_0.SetNonNull();
+                {
+                    using ListType_2 = std::remove_reference_t<decltype(nonNullValue_1)>;
+                    using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                    if (self.supportedMimeTypes.count != 0) {
+                        auto * listHolder_2 = new ListHolder<ListMemberType_2>(self.supportedMimeTypes.count);
+                        if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                            return CHIP_ERROR_INVALID_ARGUMENT;
+                        }
+                        listFreer.add(listHolder_2);
+                        for (size_t i_2 = 0; i_2 < self.supportedMimeTypes.count; ++i_2) {
+                            if (![self.supportedMimeTypes[i_2] isKindOfClass:[NSString class]]) {
+                                // Wrong kind of value.
+                                return CHIP_ERROR_INVALID_ARGUMENT;
+                            }
+                            auto element_2 = (NSString *) self.supportedMimeTypes[i_2];
+                            listHolder_2->mList[i_2] = AsCharSpan(element_2);
+                        }
+                        nonNullValue_1 = ListType_2(listHolder_2->mList, self.supportedMimeTypes.count);
+                    } else {
+                        nonNullValue_1 = ListType_2();
+                    }
+                }
+            }
+        }
+    }
+
+    return std::any(cppStruct);
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppDecodableStruct
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterGetSharedFileParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _responseID = @(0);
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterGetSharedFileParams alloc] init];
+
+    other.responseID = self.responseID;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: responseID:%@; >", NSStringFromClass([self class]), _responseID];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type cppStruct;
+    ListFreer listFreer;
+    {
+        cppStruct.responseID = self.responseID.unsignedShortValue;
+    }
+
+    return std::any(cppStruct);
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppDecodableStruct
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterGetSharedFileResponseParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _fileDescription = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterGetSharedFileResponseParams alloc] init];
+
+    other.status = self.status;
+    other.fileDescription = self.fileDescription;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; fileDescription:%@; >", NSStringFromClass([self class]), _status, _fileDescription];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppResponse
+{
+    std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::GetSharedFileResponse::DecodableType> responseSharedPtr = std::any_cast<std::shared_ptr<const chip::app::Clusters::MediaFileManagement::Commands::GetSharedFileResponse::DecodableType>>(cppResponse);
+    const chip::app::Clusters::MediaFileManagement::Commands::GetSharedFileResponse::DecodableType cppDecodableStruct = *responseSharedPtr;
+
+    {
+        self.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppDecodableStruct.status)];
+    }
+    {
+        if (cppDecodableStruct.fileDescription.HasValue()) {
+            if (cppDecodableStruct.fileDescription.Value().IsNull()) {
+                self.fileDescription = nil;
+            } else {
+                self.fileDescription = [MCMediaFileManagementClusterFileDescriptionStruct new];
+                self.fileDescription.fileID = [NSNumber numberWithUnsignedLongLong:cppDecodableStruct.fileDescription.Value().Value().fileID];
+                self.fileDescription.name = AsString(cppDecodableStruct.fileDescription.Value().Value().name);
+                if (self.fileDescription.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    return err;
+                }
+                self.fileDescription.size = [NSNumber numberWithUnsignedLongLong:cppDecodableStruct.fileDescription.Value().Value().size];
+                self.fileDescription.mimeType = AsString(cppDecodableStruct.fileDescription.Value().Value().mimeType);
+                if (self.fileDescription.mimeType == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    return err;
+                }
+                self.fileDescription.imageUri = AsString(cppDecodableStruct.fileDescription.Value().Value().imageUri);
+                if (self.fileDescription.imageUri == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    return err;
+                }
+            }
+        } else {
+            self.fileDescription = nil;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+@end
+
+@implementation MCMediaFileManagementClusterOfferFileParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _clientName = @"";
+
+        _name = @"";
+
+        _size = @(0);
+
+        _mimeType = @"";
+
+        _imageUri = @"";
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MCMediaFileManagementClusterOfferFileParams alloc] init];
+
+    other.clientName = self.clientName;
+    other.name = self.name;
+    other.size = self.size;
+    other.mimeType = self.mimeType;
+    other.imageUri = self.imageUri;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: clientName:%@; name:%@; size:%@; mimeType:%@; imageUri:%@; >", NSStringFromClass([self class]), _clientName, _name, _size, _mimeType, _imageUri];
+    return descriptionString;
+}
+
+- (std::any)getCppRequestFromObjCRequest
+{
+    chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type cppStruct;
+    ListFreer listFreer;
+    {
+        cppStruct.clientName = AsCharSpan(self.clientName);
+    }
+    {
+        cppStruct.name = AsCharSpan(self.name);
+    }
+    {
+        cppStruct.size = self.size.unsignedLongLongValue;
+    }
+    {
+        cppStruct.mimeType = AsCharSpan(self.mimeType);
+    }
+    {
+        cppStruct.imageUri = AsCharSpan(self.imageUri);
+    }
+
+    return std::any(cppStruct);
+}
+
+- (CHIP_ERROR)setObjCResponseFromCppResponse:(std::any)cppDecodableStruct
+{
+    // Default implementation
+    return CHIP_NO_ERROR;
+}
+@end
+
 NS_ASSUME_NONNULL_END

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCEndpointClusterType.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCEndpointClusterType.h
@@ -25,6 +25,7 @@ typedef enum _MCEndpointClusterType
     MCEndpointClusterTypeContentLauncher,
     MCEndpointClusterTypeKeypadInput,
     MCEndpointClusterTypeMediaPlayback,
+    MCEndpointClusterTypeMediaFileManagement,
     MCEndpointClusterTypeOnOff,
     MCEndpointClusterTypeTargetNavigator
 } MCEndpointClusterType;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCInteractionModelStructs.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCInteractionModelStructs.h
@@ -149,4 +149,13 @@
 @property (nonatomic, copy) NSString * _Nonnull presetName;
 @end
 
+// MTR_PROVISIONALLY_AVAILABLE
+@interface MCMediaFileManagementClusterFileDescriptionStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull fileID;
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull size;
+@property (nonatomic, copy) NSString * _Nonnull mimeType;
+@property (nonatomic, copy) NSString * _Nonnull imageUri;
+@end
+
 #endif /* MCStructsObjc_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCInteractionModelStructs.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCInteractionModelStructs.mm
@@ -681,3 +681,34 @@
     return descriptionString;
 }
 @end
+
+@implementation MCMediaFileManagementClusterFileDescriptionStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _fileID = @(0);
+        _name = @"";
+        _size = @(0);
+        _mimeType = @"";
+        _imageUri = @"";
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone
+{
+    auto other = [[MCMediaFileManagementClusterFileDescriptionStruct alloc] init];
+    other.fileID = self.fileID;
+    other.name = self.name;
+    other.size = self.size;
+    other.mimeType = self.mimeType;
+    other.imageUri = self.imageUri;
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: fileID:%@; name:%@; size:%@; mimeType:%@; imageUri:%@; >", NSStringFromClass([self class]), _fileID, _name, _size, _mimeType, _imageUri];
+    return descriptionString;
+}
+@end

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -180,6 +180,132 @@ void SubscribeToMediaPlaybackCurrentState(matter::casting::memory::Strong<matter
         kMinIntervalFloorSeconds, kMaxIntervalCeilingSeconds);
 }
 
+void InvokeContentLauncherPlayPreset(matter::casting::memory::Strong<matter::casting::core::Endpoint> endpoint)
+{
+    // get contentLauncherCluster from the endpoint
+    matter::casting::memory::Strong<matter::casting::clusters::content_launcher::ContentLauncherCluster> contentLauncherCluster =
+        endpoint->GetCluster<matter::casting::clusters::content_launcher::ContentLauncherCluster>();
+    VerifyOrReturn(contentLauncherCluster != nullptr);
+
+    // get the playPresetCommand from the contentLauncherCluster
+    matter::casting::core::Command<chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type> * playPresetCommand =
+        static_cast<matter::casting::core::Command<chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type> *>(
+            contentLauncherCluster->GetCommand(chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Id));
+    VerifyOrReturn(playPresetCommand != nullptr,
+                   ChipLogError(AppServer, "PlayPreset command not found on ContentLauncherCluster"));
+
+    // create the PlayPreset request
+    chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type request;
+    request.presetID = kPlayPresetId;
+
+    // call Invoke on playPresetCommand while passing in success/failure callbacks. PlayPreset has no response payload.
+    playPresetCommand->Invoke(
+        request, nullptr,
+        [](void * context, const chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type::ResponseType & response) {
+            ChipLogProgress(AppServer, "PlayPreset Success");
+        },
+        [](void * context, CHIP_ERROR error) {
+            ChipLogError(AppServer, "PlayPreset Failure with err %" CHIP_ERROR_FORMAT, error.Format());
+        },
+        chip::MakeOptional(kTimedInvokeCommandTimeoutMs)); // time out after kTimedInvokeCommandTimeoutMs
+}
+
+void ReadContentLauncherMovable(matter::casting::memory::Strong<matter::casting::core::Endpoint> endpoint)
+{
+    // get contentLauncherCluster from the endpoint
+    matter::casting::memory::Strong<matter::casting::clusters::content_launcher::ContentLauncherCluster> contentLauncherCluster =
+        endpoint->GetCluster<matter::casting::clusters::content_launcher::ContentLauncherCluster>();
+    VerifyOrReturn(contentLauncherCluster != nullptr);
+
+    // get the movableAttribute from the contentLauncherCluster
+    matter::casting::core::Attribute<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo> * movableAttribute =
+        static_cast<matter::casting::core::Attribute<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo> *>(
+            contentLauncherCluster->GetAttribute(chip::app::Clusters::ContentLauncher::Attributes::Movable::Id));
+    VerifyOrReturn(movableAttribute != nullptr, ChipLogError(AppServer, "Movable attribute not found on ContentLauncherCluster"));
+
+    // call Read on movableAttribute while passing in success/failure callbacks
+    movableAttribute->Read(
+        nullptr,
+        [](void * context, chip::Optional<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo::DecodableArgType>
+                               before,
+           chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo::DecodableArgType after) {
+            ChipLogProgress(AppServer, "Read Movable value: %d", static_cast<int>(after));
+        },
+        [](void * context, CHIP_ERROR error) {
+            ChipLogError(AppServer, "Movable Read failure with err %" CHIP_ERROR_FORMAT, error.Format());
+        });
+}
+
+void InvokeMediaFileManagementAddFile(matter::casting::memory::Strong<matter::casting::core::Endpoint> endpoint)
+{
+    // get mediaFileManagementCluster from the endpoint
+    matter::casting::memory::Strong<matter::casting::clusters::media_file_management::MediaFileManagementCluster>
+        mediaFileManagementCluster =
+            endpoint->GetCluster<matter::casting::clusters::media_file_management::MediaFileManagementCluster>();
+    VerifyOrReturn(mediaFileManagementCluster != nullptr);
+
+    // get the addFileCommand from the mediaFileManagementCluster
+    matter::casting::core::Command<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type> * addFileCommand =
+        static_cast<matter::casting::core::Command<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type> *>(
+            mediaFileManagementCluster->GetCommand(chip::app::Clusters::MediaFileManagement::Commands::AddFile::Id));
+    VerifyOrReturn(addFileCommand != nullptr, ChipLogError(AppServer, "AddFile command not found on MediaFileManagementCluster"));
+
+    // create the AddFile request
+    chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type request;
+    request.name     = chip::CharSpan::fromCharString(kMediaFileName);
+    request.size     = kMediaFileSize;
+    request.mimeType = chip::CharSpan::fromCharString(kMediaFileMimeType);
+    request.imageUri = chip::CharSpan::fromCharString(kMediaFileImageUri);
+
+    // call Invoke on addFileCommand while passing in success/failure callbacks
+    addFileCommand->Invoke(
+        request, nullptr,
+        [](void * context, const chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type::ResponseType & response) {
+            if (response.fileID.IsNull())
+            {
+                ChipLogProgress(AppServer, "AddFile Success with status: %d (no fileID)", static_cast<int>(response.status));
+            }
+            else
+            {
+                ChipLogProgress(AppServer, "AddFile Success with status: %d, fileID: %" PRIu64,
+                                static_cast<int>(response.status), response.fileID.Value());
+            }
+        },
+        [](void * context, CHIP_ERROR error) {
+            ChipLogError(AppServer, "AddFile Failure with err %" CHIP_ERROR_FORMAT, error.Format());
+        },
+        chip::MakeOptional(kTimedInvokeCommandTimeoutMs)); // time out after kTimedInvokeCommandTimeoutMs
+}
+
+void ReadMediaFileManagementTotalStorage(matter::casting::memory::Strong<matter::casting::core::Endpoint> endpoint)
+{
+    // get mediaFileManagementCluster from the endpoint
+    matter::casting::memory::Strong<matter::casting::clusters::media_file_management::MediaFileManagementCluster>
+        mediaFileManagementCluster =
+            endpoint->GetCluster<matter::casting::clusters::media_file_management::MediaFileManagementCluster>();
+    VerifyOrReturn(mediaFileManagementCluster != nullptr);
+
+    // get the totalStorageAttribute from the mediaFileManagementCluster
+    matter::casting::core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo> *
+        totalStorageAttribute = static_cast<
+            matter::casting::core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo> *>(
+            mediaFileManagementCluster->GetAttribute(chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::Id));
+    VerifyOrReturn(totalStorageAttribute != nullptr,
+                   ChipLogError(AppServer, "TotalStorage attribute not found on MediaFileManagementCluster"));
+
+    // call Read on totalStorageAttribute while passing in success/failure callbacks
+    totalStorageAttribute->Read(
+        nullptr,
+        [](void * context,
+           chip::Optional<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableArgType> before,
+           chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo::DecodableArgType after) {
+            ChipLogProgress(AppServer, "Read TotalStorage value: %" PRIu64, after);
+        },
+        [](void * context, CHIP_ERROR error) {
+            ChipLogError(AppServer, "TotalStorage Read failure with err %" CHIP_ERROR_FORMAT, error.Format());
+        });
+}
+
 CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, LinuxDeviceOptions & options)
 {
     ChipLogProgress(Discovery, "InitCommissionableDataProvider()");
@@ -306,6 +432,18 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
         // demonstrate subscribing to an attribute
         ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling SubscribeToMediaPlaybackCurrentState()");
         SubscribeToMediaPlaybackCurrentState(endpoints[index]);
+
+        // demonstrate the new ContentLauncher features (PlayPreset command, Movable attribute)
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling InvokeContentLauncherPlayPreset()");
+        InvokeContentLauncherPlayPreset(endpoints[index]);
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling ReadContentLauncherMovable()");
+        ReadContentLauncherMovable(endpoints[index]);
+
+        // demonstrate the MediaFileManagement cluster (AddFile command, TotalStorage attribute)
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling InvokeMediaFileManagementAddFile()");
+        InvokeMediaFileManagementAddFile(endpoints[index]);
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling ReadMediaFileManagementTotalStorage()");
+        ReadMediaFileManagementTotalStorage(endpoints[index]);
     }
     else
     {

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -191,8 +191,7 @@ void InvokeContentLauncherPlayPreset(matter::casting::memory::Strong<matter::cas
     matter::casting::core::Command<chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type> * playPresetCommand =
         static_cast<matter::casting::core::Command<chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type> *>(
             contentLauncherCluster->GetCommand(chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Id));
-    VerifyOrReturn(playPresetCommand != nullptr,
-                   ChipLogError(AppServer, "PlayPreset command not found on ContentLauncherCluster"));
+    VerifyOrReturn(playPresetCommand != nullptr, ChipLogError(AppServer, "PlayPreset command not found on ContentLauncherCluster"));
 
     // create the PlayPreset request
     chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type request;
@@ -226,8 +225,8 @@ void ReadContentLauncherMovable(matter::casting::memory::Strong<matter::casting:
     // call Read on movableAttribute while passing in success/failure callbacks
     movableAttribute->Read(
         nullptr,
-        [](void * context, chip::Optional<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo::DecodableArgType>
-                               before,
+        [](void * context,
+           chip::Optional<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo::DecodableArgType> before,
            chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo::DecodableArgType after) {
             ChipLogProgress(AppServer, "Read Movable value: %d", static_cast<int>(after));
         },
@@ -267,8 +266,8 @@ void InvokeMediaFileManagementAddFile(matter::casting::memory::Strong<matter::ca
             }
             else
             {
-                ChipLogProgress(AppServer, "AddFile Success with status: %d, fileID: %" PRIu64,
-                                static_cast<int>(response.status), response.fileID.Value());
+                ChipLogProgress(AppServer, "AddFile Success with status: %d, fileID: %" PRIu64, static_cast<int>(response.status),
+                                response.fileID.Value());
             }
         },
         [](void * context, CHIP_ERROR error) {

--- a/examples/tv-casting-app/linux/simple-app-helper.h
+++ b/examples/tv-casting-app/linux/simple-app-helper.h
@@ -42,6 +42,15 @@ const unsigned short kTimedInvokeCommandTimeoutMs = 5 * 1000;
 const uint16_t kMinIntervalFloorSeconds           = 0;
 const uint16_t kMaxIntervalCeilingSeconds         = 1;
 
+// Demo values for the ContentLauncher PlayPreset command.
+const uint8_t kPlayPresetId = 1;
+
+// Demo values for the MediaFileManagement AddFile command.
+const char kMediaFileName[]     = "demo-clip.mp4";
+const uint64_t kMediaFileSize   = 1024;
+const char kMediaFileMimeType[] = "video/mp4";
+const char kMediaFileImageUri[] = "https://www.test.com/thumb.jpg";
+
 /**
  * @brief Singleton that reacts to CastingPlayer discovery results
  */

--- a/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
@@ -3386,7 +3386,6 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
 } // namespace Attributes
 } // namespace ContentAppObserver
 
-
 namespace MediaFileManagement {
 namespace Attributes {
 

--- a/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/Accessors-override.cpp
@@ -3386,6 +3386,201 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
 } // namespace Attributes
 } // namespace ContentAppObserver
 
+
+namespace MediaFileManagement {
+namespace Attributes {
+
+namespace TotalStorage {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint64_t * value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaFileManagement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+} // namespace TotalStorage
+
+namespace AvailableStorage {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint64_t * value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaFileManagement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT64U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint64_t value)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+} // namespace AvailableStorage
+
+namespace FeatureMap {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaFileManagement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
+{
+    using Traits = NumericAttributeTraits<uint32_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+}
+
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+
+Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    Traits::StorageType temp;
+    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
+    Protocols::InteractionModel::Status status =
+        emberAfReadAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, readable, sizeof(temp));
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    *value = Traits::StorageToWorking(temp);
+    return status;
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::MediaFileManagement::Id, Id),
+                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
+}
+
+Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
+{
+    using Traits = NumericAttributeTraits<uint16_t>;
+    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    {
+        return Protocols::InteractionModel::Status::ConstraintError;
+    }
+    Traits::StorageType storageValue;
+    Traits::WorkingToStorage(value, storageValue);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
+    return emberAfWriteAttribute(endpoint, Clusters::MediaFileManagement::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
+}
+
+} // namespace ClusterRevision
+
+} // namespace Attributes
+} // namespace MediaFileManagement
+
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/examples/tv-casting-app/tv-casting-common/CHIPAttributeTLVValueDecoder-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/CHIPAttributeTLVValueDecoder-override.cpp
@@ -4923,6 +4923,244 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
         break;
     }
 
+    case app::Clusters::MediaFileManagement::Id: {
+        using namespace app::Clusters::MediaFileManagement;
+        switch (aPath.mAttributeId)
+        {
+        case Attributes::TotalStorage::Id: {
+            using TypeInfo = Attributes::TotalStorage::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            std::string valueClassName     = "java/lang/Long";
+            std::string valueCtorSignature = "(J)V";
+            jlong jnivalue                 = static_cast<jlong>(cppValue);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                valueClassName.c_str(), valueCtorSignature.c_str(), jnivalue, value);
+            return value;
+        }
+        case Attributes::AvailableStorage::Id: {
+            using TypeInfo = Attributes::AvailableStorage::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            std::string valueClassName     = "java/lang/Long";
+            std::string valueCtorSignature = "(J)V";
+            jlong jnivalue                 = static_cast<jlong>(cppValue);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                valueClassName.c_str(), valueCtorSignature.c_str(), jnivalue, value);
+            return value;
+        }
+        case Attributes::AvailableFiles::Id: {
+            using TypeInfo = Attributes::AvailableFiles::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateArrayList(value);
+
+            auto iter_value_0 = cppValue.begin();
+            while (iter_value_0.Next())
+            {
+                auto & entry_0 = iter_value_0.GetValue();
+                jobject newElement_0;
+                jobject newElement_0_fileID;
+                std::string newElement_0_fileIDClassName     = "java/lang/Long";
+                std::string newElement_0_fileIDCtorSignature = "(J)V";
+                jlong jninewElement_0_fileID                 = static_cast<jlong>(entry_0.fileID);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                    newElement_0_fileIDClassName.c_str(), newElement_0_fileIDCtorSignature.c_str(), jninewElement_0_fileID,
+                    newElement_0_fileID);
+                jobject newElement_0_name;
+                LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.name, newElement_0_name));
+                jobject newElement_0_size;
+                std::string newElement_0_sizeClassName     = "java/lang/Long";
+                std::string newElement_0_sizeCtorSignature = "(J)V";
+                jlong jninewElement_0_size                 = static_cast<jlong>(entry_0.size);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                    newElement_0_sizeClassName.c_str(), newElement_0_sizeCtorSignature.c_str(), jninewElement_0_size,
+                    newElement_0_size);
+                jobject newElement_0_mimeType;
+                LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.mimeType, newElement_0_mimeType));
+                jobject newElement_0_imageUri;
+                LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.imageUri, newElement_0_imageUri));
+
+                {
+                    jclass fileDescriptionStructStructClass_1;
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
+                        env, "chip/devicecontroller/ChipStructs$MediaFileManagementClusterFileDescriptionStruct",
+                        fileDescriptionStructStructClass_1);
+                    if (err != CHIP_NO_ERROR)
+                    {
+                        ChipLogError(Zcl, "Could not find class ChipStructs$MediaFileManagementClusterFileDescriptionStruct");
+                        return nullptr;
+                    }
+
+                    jmethodID fileDescriptionStructStructCtor_1;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, fileDescriptionStructStructClass_1, "<init>",
+                        "(Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)V",
+                        &fileDescriptionStructStructCtor_1);
+                    if (err != CHIP_NO_ERROR || fileDescriptionStructStructCtor_1 == nullptr)
+                    {
+                        ChipLogError(Zcl, "Could not find ChipStructs$MediaFileManagementClusterFileDescriptionStruct constructor");
+                        return nullptr;
+                    }
+
+                    newElement_0 =
+                        env->NewObject(fileDescriptionStructStructClass_1, fileDescriptionStructStructCtor_1, newElement_0_fileID,
+                                       newElement_0_name, newElement_0_size, newElement_0_mimeType, newElement_0_imageUri);
+                }
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().AddToList(value, newElement_0);
+            }
+            return value;
+        }
+        case Attributes::SupportedMimeTypes::Id: {
+            using TypeInfo = Attributes::SupportedMimeTypes::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateArrayList(value);
+
+            auto iter_value_0 = cppValue.begin();
+            while (iter_value_0.Next())
+            {
+                auto & entry_0 = iter_value_0.GetValue();
+                jobject newElement_0;
+                LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0, newElement_0));
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().AddToList(value, newElement_0);
+            }
+            return value;
+        }
+        case Attributes::GeneratedCommandList::Id: {
+            using TypeInfo = Attributes::GeneratedCommandList::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateArrayList(value);
+
+            auto iter_value_0 = cppValue.begin();
+            while (iter_value_0.Next())
+            {
+                auto & entry_0 = iter_value_0.GetValue();
+                jobject newElement_0;
+                std::string newElement_0ClassName     = "java/lang/Long";
+                std::string newElement_0CtorSignature = "(J)V";
+                jlong jninewElement_0                 = static_cast<jlong>(entry_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                    newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), jninewElement_0, newElement_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().AddToList(value, newElement_0);
+            }
+            return value;
+        }
+        case Attributes::AcceptedCommandList::Id: {
+            using TypeInfo = Attributes::AcceptedCommandList::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateArrayList(value);
+
+            auto iter_value_0 = cppValue.begin();
+            while (iter_value_0.Next())
+            {
+                auto & entry_0 = iter_value_0.GetValue();
+                jobject newElement_0;
+                std::string newElement_0ClassName     = "java/lang/Long";
+                std::string newElement_0CtorSignature = "(J)V";
+                jlong jninewElement_0                 = static_cast<jlong>(entry_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                    newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), jninewElement_0, newElement_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().AddToList(value, newElement_0);
+            }
+            return value;
+        }
+        case Attributes::AttributeList::Id: {
+            using TypeInfo = Attributes::AttributeList::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateArrayList(value);
+
+            auto iter_value_0 = cppValue.begin();
+            while (iter_value_0.Next())
+            {
+                auto & entry_0 = iter_value_0.GetValue();
+                jobject newElement_0;
+                std::string newElement_0ClassName     = "java/lang/Long";
+                std::string newElement_0CtorSignature = "(J)V";
+                jlong jninewElement_0                 = static_cast<jlong>(entry_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                    newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), jninewElement_0, newElement_0);
+                TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().AddToList(value, newElement_0);
+            }
+            return value;
+        }
+        case Attributes::FeatureMap::Id: {
+            using TypeInfo = Attributes::FeatureMap::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            std::string valueClassName     = "java/lang/Long";
+            std::string valueCtorSignature = "(J)V";
+            jlong jnivalue                 = static_cast<jlong>(cppValue);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(
+                valueClassName.c_str(), valueCtorSignature.c_str(), jnivalue, value);
+            return value;
+        }
+        case Attributes::ClusterRevision::Id: {
+            using TypeInfo = Attributes::ClusterRevision::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            std::string valueClassName     = "java/lang/Integer";
+            std::string valueCtorSignature = "(I)V";
+            jint jnivalue                  = static_cast<jint>(cppValue);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jint>(
+                valueClassName.c_str(), valueCtorSignature.c_str(), jnivalue, value);
+            return value;
+        }
+        default:
+            *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
+            break;
+        }
+        break;
+    }
+
     default:
         *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
         break;

--- a/examples/tv-casting-app/tv-casting-common/CHIPEventTLVValueDecoder-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/CHIPEventTLVValueDecoder-override.cpp
@@ -612,6 +612,62 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
         }
         break;
     }
+    case app::Clusters::MediaFileManagement::Id: {
+        using namespace app::Clusters::MediaFileManagement;
+        switch (aPath.mEventId)
+        {
+        case Events::SharedFilesAdded::Id: {
+            Events::SharedFilesAdded::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value_requestID;
+            std::string value_requestIDClassName     = "java/lang/Integer";
+            std::string value_requestIDCtorSignature = "(I)V";
+            jint jnivalue_requestID                  = static_cast<jint>(cppValue.requestID);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jint>(
+                value_requestIDClassName.c_str(), value_requestIDCtorSignature.c_str(), jnivalue_requestID, value_requestID);
+
+            jobject value_responseID;
+            std::string value_responseIDClassName     = "java/lang/Integer";
+            std::string value_responseIDCtorSignature = "(I)V";
+            jint jnivalue_responseID                  = static_cast<jint>(cppValue.responseID);
+            TEMPORARY_RETURN_IGNORED chip::JniReferences::GetInstance().CreateBoxedObject<jint>(
+                value_responseIDClassName.c_str(), value_responseIDCtorSignature.c_str(), jnivalue_responseID, value_responseID);
+
+            jclass sharedFilesAddedStructClass;
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
+                env, "chip/devicecontroller/ChipEventStructs$MediaFileManagementClusterSharedFilesAddedEvent",
+                sharedFilesAddedStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipEventStructs$MediaFileManagementClusterSharedFilesAddedEvent");
+                return nullptr;
+            }
+
+            jmethodID sharedFilesAddedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, sharedFilesAddedStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &sharedFilesAddedStructCtor);
+            if (err != CHIP_NO_ERROR || sharedFilesAddedStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipEventStructs$MediaFileManagementClusterSharedFilesAddedEvent constructor");
+                return nullptr;
+            }
+
+            jobject value =
+                env->NewObject(sharedFilesAddedStructClass, sharedFilesAddedStructCtor, value_requestID, value_responseID);
+
+            return value;
+        }
+        default:
+            *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
+            break;
+        }
+        break;
+    }
     default:
         *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
         break;

--- a/examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml
+++ b/examples/tv-casting-app/tv-casting-common/casting-cluster-config.yaml
@@ -43,6 +43,7 @@ casting_clusters:
     - LevelControl
     - LowPower
     - MediaInput
+    - MediaFileManagement
     - MediaPlayback
     - Messages
     - OnOff
@@ -65,6 +66,7 @@ tlv_decoder_clusters:
     - LevelControl
     - LowPower
     - MediaInput
+    - MediaFileManagement
     - MediaPlayback
     - OnOff
     - TargetNavigator

--- a/examples/tv-casting-app/tv-casting-common/cluster-objects-override.cpp
+++ b/examples/tv-casting-app/tv-casting-common/cluster-objects-override.cpp
@@ -164,6 +164,11 @@
 #include <clusters/MediaInput/Events.ipp>
 #include <clusters/MediaInput/Structs.ipp>
 
+#include <clusters/MediaFileManagement/Attributes.ipp>
+#include <clusters/MediaFileManagement/Commands.ipp>
+#include <clusters/MediaFileManagement/Events.ipp>
+#include <clusters/MediaFileManagement/Structs.ipp>
+
 #include <clusters/MediaPlayback/Attributes.ipp>
 #include <clusters/MediaPlayback/Commands.ipp>
 #include <clusters/MediaPlayback/Events.ipp>

--- a/examples/tv-casting-app/tv-casting-common/clusters/Clusters.h
+++ b/examples/tv-casting-app/tv-casting-common/clusters/Clusters.h
@@ -130,11 +130,20 @@ public:
                         new core::Command<chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type>(GetEndpoint()));
         RegisterCommand(chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Id,
                         new core::Command<chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type>(GetEndpoint()));
+        RegisterCommand(
+            chip::app::Clusters::ContentLauncher::Commands::ContentReplicationRequest::Id,
+            new core::Command<chip::app::Clusters::ContentLauncher::Commands::ContentReplicationRequest::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Id,
+                        new core::Command<chip::app::Clusters::ContentLauncher::Commands::PlayPreset::Type>(GetEndpoint()));
 
         RegisterAttribute(
             chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id,
             new core::Attribute<chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo>(
                 GetEndpoint()));
+        RegisterAttribute(chip::app::Clusters::ContentLauncher::Attributes::Movable::Id,
+                          new core::Attribute<chip::app::Clusters::ContentLauncher::Attributes::Movable::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(chip::app::Clusters::ContentLauncher::Attributes::Presets::Id,
+                          new core::Attribute<chip::app::Clusters::ContentLauncher::Attributes::Presets::TypeInfo>(GetEndpoint()));
     }
 };
 }; // namespace content_launcher
@@ -291,9 +300,53 @@ public:
         RegisterAttribute(
             chip::app::Clusters::MediaPlayback::Attributes::AvailableTextTracks::Id,
             new core::Attribute<chip::app::Clusters::MediaPlayback::Attributes::AvailableTextTracks::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(
+            chip::app::Clusters::MediaPlayback::Attributes::AvailableCommands::Id,
+            new core::Attribute<chip::app::Clusters::MediaPlayback::Attributes::AvailableCommands::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(
+            chip::app::Clusters::MediaPlayback::Attributes::ContentInfo::Id,
+            new core::Attribute<chip::app::Clusters::MediaPlayback::Attributes::ContentInfo::TypeInfo>(GetEndpoint()));
     }
 };
 }; // namespace media_playback
+
+namespace media_file_management {
+class MediaFileManagementCluster : public core::BaseCluster
+{
+public:
+    MediaFileManagementCluster(memory::Weak<core::Endpoint> endpoint) : core::BaseCluster(endpoint) {}
+
+    void SetUp()
+    {
+        ChipLogProgress(AppServer, "Setting up MediaFileManagementCluster on EndpointId: %d", GetEndpoint().lock()->GetId());
+
+        RegisterCommand(chip::app::Clusters::MediaFileManagement::Commands::AddFile::Id,
+                        new core::Command<chip::app::Clusters::MediaFileManagement::Commands::AddFile::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Id,
+                        new core::Command<chip::app::Clusters::MediaFileManagement::Commands::DeleteFile::Type>(GetEndpoint()));
+        RegisterCommand(
+            chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Id,
+            new core::Command<chip::app::Clusters::MediaFileManagement::Commands::RequestSharedFiles::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Id,
+                        new core::Command<chip::app::Clusters::MediaFileManagement::Commands::GetSharedFile::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Id,
+                        new core::Command<chip::app::Clusters::MediaFileManagement::Commands::OfferFile::Type>(GetEndpoint()));
+
+        RegisterAttribute(
+            chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::Id,
+            new core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::TotalStorage::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(
+            chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::Id,
+            new core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::AvailableStorage::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(
+            chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::Id,
+            new core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::SupportedMimeTypes::TypeInfo>(GetEndpoint()));
+        RegisterAttribute(
+            chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::Id,
+            new core::Attribute<chip::app::Clusters::MediaFileManagement::Attributes::AvailableFiles::TypeInfo>(GetEndpoint()));
+    }
+};
+}; // namespace media_file_management
 
 namespace on_off {
 class OnOffCluster : public core::BaseCluster

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
@@ -60,6 +60,10 @@ void Endpoint::RegisterClusters(std::vector<chip::ClusterId> clusters)
             RegisterCluster<clusters::media_playback::MediaPlaybackCluster>(clusterId);
             break;
 
+        case chip::app::Clusters::MediaFileManagement::Id:
+            RegisterCluster<clusters::media_file_management::MediaFileManagementCluster>(clusterId);
+            break;
+
         case chip::app::Clusters::TargetNavigator::Id:
             RegisterCluster<clusters::target_navigator::TargetNavigatorCluster>(clusterId);
             break;


### PR DESCRIPTION
### Summary

Extends the modern Matter casting client stack (`matter::casting`) to cover the media-cluster features added by the recent Alchemy cluster updates, across all client surfaces.

**Core C++ (`matter::casting`)**
- **ContentLauncher**: register `ContentReplicationRequest` and `PlayPreset` commands, and `Movable` and `Presets` attributes.
- **MediaPlayback**: register `AvailableCommands` and `ContentInfo` attributes.
- **MediaFileManagement**: add `MediaFileManagementCluster` (`AddFile`, `DeleteFile`, `RequestSharedFiles`, `GetSharedFile`, `OfferFile` commands; `TotalStorage`, `AvailableStorage`, `SupportedMimeTypes`, `AvailableFiles` attributes) and wire it into `Endpoint::RegisterClusters()`.

**Linux CLI demo** (`simple-app-helper`): demonstrate `PlayPreset` invoke + `Movable` read, and MediaFileManagement `AddFile` invoke + `TotalStorage` read.

**Darwin bridge**: add Media File Management to `config-data.yaml` and the `MCEndpointClusterType` enum, handle it in `MCEndpoint clusterForType:`, and regenerate the `MC*` ZAP objects. Add the hand-maintained `MCMediaFileManagementClusterFileDescriptionStruct`.

**Slim overrides**: add MediaFileManagement to `casting-cluster-config.yaml` and splice the corresponding MFM entries into `cluster-objects-override.cpp` and the Android TLV/Accessors overrides.

**Android** reuses the shared reflection-based `ChipClusters` bindings, so no per-cluster tv-casting-app change is needed there.

### A note on the slim-override files

The slim-override generator (`generate_slim_overrides.py`) currently produces ~5000 lines of diff even for a no-op regen — the checked-in override files are stale relative to the generator (it reorders every cluster). To keep this PR reviewable, the MFM entries were added as **minimal additive edits** rather than a full regen. Refreshing those generated files against the current generator is left as separate follow-up work.

### Testing

- Darwin framework builds (`xcodebuild -scheme MatterTvCastingBridge`): **BUILD SUCCEEDED**
- Linux `chip-tv-casting-app` (`chip_casting_simplified=true`) links cleanly
- Android size-optimized override objects (`cluster-objects-override`, TLV decoders, Accessors) compile cleanly