### PR TITLE
[ESP32]: remove esp_rcp_update require

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -493,10 +493,6 @@ elseif("mdns" IN_LIST build_components)
     list(APPEND matter_requires mdns)
 endif()
 
-if (CONFIG_OPENTHREAD_BORDER_ROUTER)
-    list(APPEND matter_requires espressif__esp_rcp_update)
-endif()
-
 if (CONFIG_SEC_CERT_DAC_PROVIDER)
     list(APPEND matter_requires espressif__esp_secure_cert_mgr)
 endif()


### PR DESCRIPTION
### Summary
Remove esp_rcp_update from chip component, which is not required now.

### Testing
Test `thread-br-app` with `CONFIG_AUTO_UPDATE_RCP=y`.
