### PR TITLE
[chip-tool] Add verify command

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -93,7 +93,6 @@ static_library("chip-tool-utils") {
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/pairing/ToTLVCert.cpp",
-    "commands/verify/VerifyCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
@@ -101,6 +100,7 @@ static_library("chip-tool-utils") {
     "commands/session-management/CloseSessionCommand.cpp",
     "commands/session-management/CloseSessionCommand.h",
     "commands/storage/StorageManagementCommand.cpp",
+    "commands/verify/VerifyCommand.cpp",
   ]
 
   deps = [ "${chip_root}/src/app:events" ]

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -93,6 +93,7 @@ static_library("chip-tool-utils") {
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/pairing/ToTLVCert.cpp",
+    "commands/verify/VerifyCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/verify/Commands.h
+++ b/examples/chip-tool/commands/verify/Commands.h
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "commands/common/Commands.h"
+#include "commands/verify/VerifyCommand.h"
+
+#include <app/server/Dnssd.h>
+#include <commands/common/CredentialIssuerCommands.h>
+#include <lib/dnssd/Resolver.h>
+
+class VerifyWithPayload : public VerifyCommand
+{
+public:
+    VerifyWithPayload(CredentialIssuerCommands * credsIssuerConfig) : VerifyCommand("with-payload", credsIssuerConfig) {}
+};
+
+void registerCommandsVerify(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
+{
+    const char * clusterName = "Verify";
+
+    commands_list clusterCommands = {
+        make_unique<VerifyWithPayload>(credsIssuerConfig),
+    };
+
+    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for commissioning devices.");
+}

--- a/examples/chip-tool/commands/verify/Commands.h
+++ b/examples/chip-tool/commands/verify/Commands.h
@@ -39,5 +39,6 @@ void registerCommandsVerify(Commands & commands, CredentialIssuerCommands * cred
         make_unique<VerifyWithPayload>(credsIssuerConfig),
     };
 
-    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for commissioning devices.");
+    commands.RegisterCommandSet(clusterName, clusterCommands,
+                                "Commands for verifying device attestation information without commissioning.");
 }

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -1,0 +1,169 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "VerifyCommand.h"
+#include <commands/common/DeviceScanner.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPSafeCasts.h>
+#include <lib/dnssd/Types.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/CHIPMemString.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/ThreadDiscoveryCode.h>
+#include <lib/support/ThreadOperationalDataset.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <protocols/secure_channel/PASESession.h>
+
+#include <setup_payload/ManualSetupPayloadParser.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
+
+#include "../dcl/DCLClient.h"
+#include "../dcl/DisplayTermsAndConditions.h"
+
+#include <inttypes.h>
+#include <iostream>
+#include <memory>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <string>
+#include <sys/socket.h>
+
+using namespace ::chip;
+using namespace ::chip::Controller;
+using namespace ::chip::Crypto;
+
+CHIP_ERROR VerifyCommand::Run()
+{
+    CHIP_ERROR err = CHIPCommand::Run();
+    PrintDeviceInformation();
+    return err;
+}
+
+CHIP_ERROR VerifyCommand::RunCommand()
+{
+    CurrentCommissioner().RegisterPairingDelegate(this);
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = CurrentCommissioner().EstablishPASEConnection(mNodeId, mOnboardingPayload, DiscoveryType::kAll);
+
+    return err;
+}
+
+chip::Optional<uint16_t> VerifyCommand::FailSafeExpiryTimeoutSecs() const
+{
+    return Optional<uint16_t>();
+}
+
+void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommissioner * deviceCommissioner,
+                                                 chip::DeviceProxy * device,
+                                                 const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
+                                                 chip::Credentials::AttestationVerificationResult attestationResult)
+{
+    ByteSpan dac = info.dacDerBuffer();
+    ByteSpan pai = info.paiDerBuffer();
+
+    mDacDerBuffer      = dac;
+    mPaiDerBuffer      = pai;
+    mVendorId          = info.BasicInformationVendorId();
+    mProductId         = info.BasicInformationProductId();
+    mAttestationResult = attestationResult;
+
+    CHIP_ERROR err = CurrentCommissioner().StopPairing(mNodeId);
+    VerifyOrDie(err == CHIP_NO_ERROR);
+}
+
+bool VerifyCommand::ShouldWaitAfterDeviceAttestation()
+{
+    return true; // Required to force OnDeviceAttestationCompleted to run
+}
+
+void VerifyCommand::OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) {}
+void VerifyCommand::OnPairingComplete(CHIP_ERROR error)
+{
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(chipTool, "PASE failed: %" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
+
+    ChipLogProgress(chipTool, "PASE complete, starting commissioning for certificate fetch");
+
+    CommissioningParameters params;
+    params.SetDeviceAttestationDelegate(this);
+    CHIP_ERROR err = CurrentCommissioner().Commission(mNodeId, params);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(chipTool, "Failed to start commissioning: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+void VerifyCommand::OnPairingDeleted(CHIP_ERROR error) {}
+void VerifyCommand::OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) {}
+void VerifyCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error)
+{
+    SetCommandExitStatus(CHIP_NO_ERROR); // Stop the command
+}
+void VerifyCommand::OnICDRegistrationComplete(chip::ScopedNodeId deviceId, uint32_t icdCounter) {}
+void VerifyCommand::OnICDStayActiveComplete(chip::ScopedNodeId deviceId, uint32_t promisedActiveDuration) {}
+void VerifyCommand::OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) {}
+CHIP_ERROR VerifyCommand::WiFiCredentialsNeeded(chip::EndpointId endpoint)
+{
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR VerifyCommand::ThreadCredentialsNeeded(chip::EndpointId endpoint)
+{
+    return CHIP_NO_ERROR;
+}
+
+void VerifyCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) {}
+
+void VerifyCommand::PrintDeviceInformation()
+{
+
+    printf("VendorId: %d\n", mVendorId);
+    printf("ProductId: %d\n", mProductId);
+
+    PrintCert("DAC", mDacDerBuffer);
+    PrintCert("PAI", mPaiDerBuffer);
+
+    if (mAttestationResult == chip::Credentials::AttestationVerificationResult::kSuccess)
+    {
+        printf("Valid certs\n");
+    }
+    else
+    {
+        printf("Invalid cert: %d\n", mAttestationResult);
+    }
+}
+
+void VerifyCommand::PrintCert(const char * name, chip::ByteSpan & buffer)
+{
+    PemEncoder encoder(name, buffer);
+    const char * line = encoder.NextLine();
+    while (line != nullptr)
+    {
+        printf("%s\n", line);
+        line = encoder.NextLine();
+    }
+}

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -81,14 +81,30 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
                                                  const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
                                                  chip::Credentials::AttestationVerificationResult attestationResult)
 {
-    ByteSpan dac = info.dacDerBuffer();
-    ByteSpan pai = info.paiDerBuffer();
+    ByteSpan dac          = info.dacDerBuffer();
+    ByteSpan pai          = info.paiDerBuffer();
+    Optional<ByteSpan> cd = info.cdBuffer();
 
     mDacDerBuffer      = dac;
     mPaiDerBuffer      = pai;
+    mCdBuffer          = cd;
     mVendorId          = info.BasicInformationVendorId();
     mProductId         = info.BasicInformationProductId();
     mAttestationResult = attestationResult;
+
+    uint8_t paiAkidBuf[chip::Crypto::kAuthorityKeyIdentifierLength];
+    chip::MutableByteSpan paiAkid(paiAkidBuf);
+    if (chip::Crypto::ExtractAKIDFromX509Cert(pai, paiAkid) == CHIP_NO_ERROR)
+    {
+        chip::MutableByteSpan paaDerBuffer(mPaaCertBuf);
+
+        const chip::Credentials::AttestationTrustStore * trustStore = chip::Credentials::GetTestAttestationTrustStore();
+
+        if (trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer) == CHIP_NO_ERROR)
+        {
+            mPaaDerBuffer = Optional(ByteSpan(paaDerBuffer.data(), paaDerBuffer.size()));
+        }
+    }
 
     CHIP_ERROR err = CurrentCommissioner().StopPairing(mNodeId);
     VerifyOrDie(err == CHIP_NO_ERROR);
@@ -141,11 +157,38 @@ void VerifyCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & n
 void VerifyCommand::PrintDeviceInformation()
 {
 
-    printf("VendorId: %d\n", mVendorId);
-    printf("ProductId: %d\n", mProductId);
+    printf("VendorId: 0x%04X\n", mVendorId);
+    printf("ProductId: 0x%04X\n", mProductId);
 
-    PrintCert("DAC", mDacDerBuffer);
-    PrintCert("PAI", mPaiDerBuffer);
+    printf("DAC:\n");
+    PrintCert("CERTIFICATE", mDacDerBuffer);
+    printf("PAI:\n");
+    PrintCert("CERTIFICATE", mPaiDerBuffer);
+
+    if (mCdBuffer.HasValue())
+    {
+        auto & cdBuffer = mCdBuffer.Value();
+        printf("CD:\n");
+        for (size_t i = 0; i < cdBuffer.size(); i++)
+        {
+            printf("%02x", cdBuffer[i]);
+        }
+        printf("\n");
+    }
+    else
+    {
+        printf("No CD\n");
+    }
+
+    if (mPaaDerBuffer.HasValue())
+    {
+        printf("PAA:\n");
+        PrintCert("CERTIFICATE", mPaaDerBuffer.Value());
+    }
+    else
+    {
+        printf("No PAA\n");
+    }
 
     if (mAttestationResult == chip::Credentials::AttestationVerificationResult::kSuccess)
     {

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -185,6 +185,16 @@ void VerifyCommand::PrintDeviceInformation()
     printf("PAI:\n");
     PrintCert("CERTIFICATE", PaiDerBuffer().Value());
 
+    if (PaaDerBuffer().HasValue())
+    {
+        printf("PAA:\n");
+        PrintCert("CERTIFICATE", PaaDerBuffer().Value());
+    }
+    else
+    {
+        printf("No PAA\n");
+    }
+
     if (CdBuffer().HasValue())
     {
         auto cdBuffer = CdBuffer().Value();
@@ -198,16 +208,6 @@ void VerifyCommand::PrintDeviceInformation()
     else
     {
         printf("No CD\n");
-    }
-
-    if (PaaDerBuffer().HasValue())
-    {
-        printf("PAA:\n");
-        PrintCert("CERTIFICATE", PaaDerBuffer().Value());
-    }
-    else
-    {
-        printf("No PAA\n");
     }
 
     printf("Attestation: %s\n", GetAttestationResultDescription(mAttestationResult));

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -98,9 +98,18 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
     {
         chip::MutableByteSpan paaDerBuffer(mPaaCertBuf);
 
-        const chip::Credentials::AttestationTrustStore * trustStore = chip::Credentials::GetTestAttestationTrustStore();
+        auto * verifier        = CurrentCommissioner().GetDeviceAttestationVerifier();
+        auto * defaultVerifier = static_cast<chip::Credentials::DefaultDACVerifier *>(verifier);
+        const chip::Credentials::AttestationTrustStore * trustStore     = defaultVerifier->GetAttestationTrustStore();
+        const chip::Credentials::AttestationTrustStore * testTrustStore = chip::Credentials::GetTestAttestationTrustStore();
 
-        if (trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer) == CHIP_NO_ERROR)
+        CHIP_ERROR err = trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
+        if (err == CHIP_ERROR_NOT_IMPLEMENTED)
+        {
+            // Use test trust store as fallback.
+            err = testTrustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
+        }
+        if (err == CHIP_NO_ERROR)
         {
             mPaaDerBuffer = Optional(ByteSpan(paaDerBuffer.data(), paaDerBuffer.size()));
         }

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -81,13 +81,19 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
                                                  const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
                                                  chip::Credentials::AttestationVerificationResult attestationResult)
 {
-    ByteSpan dac          = info.dacDerBuffer();
-    ByteSpan pai          = info.paiDerBuffer();
-    Optional<ByteSpan> cd = info.cdBuffer();
 
-    mDacDerBuffer      = dac;
-    mPaiDerBuffer      = pai;
-    mCdBuffer          = cd;
+    auto dac      = info.dacDerBuffer();
+    auto pai      = info.paiDerBuffer();
+    auto cdBuffer = info.cdBuffer();
+
+    VerifyOrDie(SetBuffer(mDacCertBuf, dac) == CHIP_NO_ERROR);
+    VerifyOrDie(SetBuffer(mPaiCertBuf, pai) == CHIP_NO_ERROR);
+
+    if (cdBuffer.HasValue())
+    {
+        VerifyOrDie(SetBuffer(mCdBuf, cdBuffer.Value()) == CHIP_NO_ERROR);
+    }
+
     mVendorId          = info.BasicInformationVendorId();
     mProductId         = info.BasicInformationProductId();
     mAttestationResult = attestationResult;
@@ -96,12 +102,13 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
     chip::MutableByteSpan paiAkid(paiAkidBuf);
     if (chip::Crypto::ExtractAKIDFromX509Cert(pai, paiAkid) == CHIP_NO_ERROR)
     {
-        chip::MutableByteSpan paaDerBuffer(mPaaCertBuf);
-
         auto * verifier        = CurrentCommissioner().GetDeviceAttestationVerifier();
         auto * defaultVerifier = static_cast<chip::Credentials::DefaultDACVerifier *>(verifier);
         const chip::Credentials::AttestationTrustStore * trustStore     = defaultVerifier->GetAttestationTrustStore();
         const chip::Credentials::AttestationTrustStore * testTrustStore = chip::Credentials::GetTestAttestationTrustStore();
+
+        uint8_t paaScratchBuf[chip::Credentials::kMaxDERCertLength];
+        chip::MutableByteSpan paaDerBuffer(paaScratchBuf);
 
         CHIP_ERROR err = trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
         if (err == CHIP_ERROR_NOT_IMPLEMENTED)
@@ -111,7 +118,7 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
         }
         if (err == CHIP_NO_ERROR)
         {
-            mPaaDerBuffer = Optional(ByteSpan(paaDerBuffer.data(), paaDerBuffer.size()));
+            VerifyOrDie(SetBuffer(mPaaCertBuf, chip::ByteSpan(paaDerBuffer.data(), paaDerBuffer.size())) == CHIP_NO_ERROR);
         }
     }
 
@@ -170,13 +177,13 @@ void VerifyCommand::PrintDeviceInformation()
     printf("ProductId: 0x%04X\n", mProductId);
 
     printf("DAC:\n");
-    PrintCert("CERTIFICATE", mDacDerBuffer);
+    PrintCert("CERTIFICATE", DacDerBuffer().Value());
     printf("PAI:\n");
-    PrintCert("CERTIFICATE", mPaiDerBuffer);
+    PrintCert("CERTIFICATE", PaiDerBuffer().Value());
 
-    if (mCdBuffer.HasValue())
+    if (CdBuffer().HasValue())
     {
-        auto & cdBuffer = mCdBuffer.Value();
+        auto cdBuffer = CdBuffer().Value();
         printf("CD:\n");
         for (size_t i = 0; i < cdBuffer.size(); i++)
         {
@@ -189,10 +196,10 @@ void VerifyCommand::PrintDeviceInformation()
         printf("No CD\n");
     }
 
-    if (mPaaDerBuffer.HasValue())
+    if (PaaDerBuffer().HasValue())
     {
         printf("PAA:\n");
-        PrintCert("CERTIFICATE", mPaaDerBuffer.Value());
+        PrintCert("CERTIFICATE", PaaDerBuffer().Value());
     }
     else
     {
@@ -202,7 +209,7 @@ void VerifyCommand::PrintDeviceInformation()
     printf("Attestation: %s\n", GetAttestationResultDescription(mAttestationResult));
 }
 
-void VerifyCommand::PrintCert(const char * name, chip::ByteSpan & buffer)
+void VerifyCommand::PrintCert(const char * name, chip::ByteSpan buffer)
 {
     PemEncoder encoder(name, buffer);
     const char * line = encoder.NextLine();

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -199,14 +199,7 @@ void VerifyCommand::PrintDeviceInformation()
         printf("No PAA\n");
     }
 
-    if (mAttestationResult == chip::Credentials::AttestationVerificationResult::kSuccess)
-    {
-        printf("Valid certs\n");
-    }
-    else
-    {
-        printf("Invalid cert: %u\n", static_cast<uint16_t>(mAttestationResult));
-    }
+    printf("Attestation: %s\n", GetAttestationResultDescription(mAttestationResult));
 }
 
 void VerifyCommand::PrintCert(const char * name, chip::ByteSpan & buffer)

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -63,7 +63,6 @@ CHIP_ERROR VerifyCommand::Run()
 CHIP_ERROR VerifyCommand::RunCommand()
 {
     CurrentCommissioner().RegisterPairingDelegate(this);
-    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     err = CurrentCommissioner().EstablishPASEConnection(mNodeId, mOnboardingPayload, DiscoveryType::kAll);
@@ -165,8 +164,6 @@ CHIP_ERROR VerifyCommand::ThreadCredentialsNeeded(chip::EndpointId endpoint)
 {
     return CHIP_NO_ERROR;
 }
-
-void VerifyCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) {}
 
 void VerifyCommand::PrintDeviceInformation()
 {

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -196,7 +196,7 @@ void VerifyCommand::PrintDeviceInformation()
     }
     else
     {
-        printf("Invalid cert: %d\n", mAttestationResult);
+        printf("Invalid cert: %u\n", static_cast<uint16_t>(mAttestationResult));
     }
 }
 

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -104,8 +104,7 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
     {
         auto * verifier        = CurrentCommissioner().GetDeviceAttestationVerifier();
         auto * defaultVerifier = static_cast<chip::Credentials::DefaultDACVerifier *>(verifier);
-        const chip::Credentials::AttestationTrustStore * trustStore     = defaultVerifier->GetAttestationTrustStore();
-        const chip::Credentials::AttestationTrustStore * testTrustStore = chip::Credentials::GetTestAttestationTrustStore();
+        const chip::Credentials::AttestationTrustStore * trustStore = defaultVerifier->GetAttestationTrustStore();
 
         uint8_t paaScratchBuf[chip::Credentials::kMaxDERCertLength];
         chip::MutableByteSpan paaDerBuffer(paaScratchBuf);
@@ -114,11 +113,6 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
         if (trustStore != nullptr)
         {
             err = trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
-        }
-        if (err == CHIP_ERROR_NOT_IMPLEMENTED)
-        {
-            // Use test trust store as fallback.
-            err = testTrustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
         }
         if (err == CHIP_NO_ERROR)
         {

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -63,11 +63,7 @@ CHIP_ERROR VerifyCommand::Run()
 CHIP_ERROR VerifyCommand::RunCommand()
 {
     CurrentCommissioner().RegisterPairingDelegate(this);
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    err = CurrentCommissioner().EstablishPASEConnection(mNodeId, mOnboardingPayload, DiscoveryType::kAll);
-
-    return err;
+    return CurrentCommissioner().EstablishPASEConnection(mNodeId, mOnboardingPayload, DiscoveryType::kAll);
 }
 
 chip::Optional<uint16_t> VerifyCommand::FailSafeExpiryTimeoutSecs() const

--- a/examples/chip-tool/commands/verify/VerifyCommand.cpp
+++ b/examples/chip-tool/commands/verify/VerifyCommand.cpp
@@ -110,7 +110,11 @@ void VerifyCommand::OnDeviceAttestationCompleted(chip::Controller::DeviceCommiss
         uint8_t paaScratchBuf[chip::Credentials::kMaxDERCertLength];
         chip::MutableByteSpan paaDerBuffer(paaScratchBuf);
 
-        CHIP_ERROR err = trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
+        CHIP_ERROR err = CHIP_ERROR_NOT_IMPLEMENTED;
+        if (trustStore != nullptr)
+        {
+            err = trustStore->GetProductAttestationAuthorityCert(paiAkid, paaDerBuffer);
+        }
         if (err == CHIP_ERROR_NOT_IMPLEMENTED)
         {
             // Use test trust store as fallback.

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -104,7 +104,9 @@ private:
     // Device attestation information
     chip::ByteSpan mDacDerBuffer;
     chip::ByteSpan mPaiDerBuffer;
-    chip::ByteSpan mCdBuffer;
+    chip::Optional<chip::ByteSpan> mCdBuffer;
+    uint8_t mPaaCertBuf[chip::Credentials::kMaxDERCertLength];
+    chip::Optional<chip::ByteSpan> mPaaDerBuffer;
     uint16_t mVendorId;
     uint16_t mProductId;
     chip::Credentials::AttestationVerificationResult mAttestationResult;

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -30,34 +30,6 @@
 #include <optional>
 #include <thread>
 
-enum class VerifyMode
-{
-    None,
-    Code,
-    CodePaseOnly,
-    Ble,
-    SoftAP,
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    WiFiPAF,
-#endif
-    AlreadyDiscovered,
-    AlreadyDiscoveredByIndex,
-    AlreadyDiscoveredByIndexWithCode,
-    OnNetwork,
-    Nfc,
-#if CHIP_SUPPORT_THREAD_MESHCOP
-    ThreadMeshcop,
-#endif
-};
-
-enum class VerifyNetworkType
-{
-    None,
-    WiFi,
-    Thread,
-    WiFiOrThread,
-};
-
 class VerifyCommand : public CHIPCommand,
                       public chip::Controller::DevicePairingDelegate,
                       public chip::Controller::DeviceDiscoveryDelegate,

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -1,0 +1,114 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+#include <controller/CommissioningDelegate.h>
+#include <controller/CurrentFabricRemover.h>
+
+#include <commands/common/CredentialIssuerCommands.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/Span.h>
+#include <lib/support/ThreadOperationalDataset.h>
+
+#include <optional>
+#include <thread>
+
+enum class VerifyMode
+{
+    None,
+    Code,
+    CodePaseOnly,
+    Ble,
+    SoftAP,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    WiFiPAF,
+#endif
+    AlreadyDiscovered,
+    AlreadyDiscoveredByIndex,
+    AlreadyDiscoveredByIndexWithCode,
+    OnNetwork,
+    Nfc,
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    ThreadMeshcop,
+#endif
+};
+
+enum class VerifyNetworkType
+{
+    None,
+    WiFi,
+    Thread,
+    WiFiOrThread,
+};
+
+class VerifyCommand : public CHIPCommand,
+                      public chip::Controller::DevicePairingDelegate,
+                      public chip::Controller::DeviceDiscoveryDelegate,
+                      public chip::Credentials::DeviceAttestationDelegate
+{
+public:
+    VerifyCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds) : CHIPCommand(commandName, credIssuerCmds)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument("payload", &mOnboardingPayload);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR Run() override;
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); };
+
+    /////////// DevicePairingDelegate Interface /////////
+    void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
+    void OnPairingComplete(CHIP_ERROR error) override;
+    void OnPairingDeleted(CHIP_ERROR error) override;
+    void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
+    void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
+    void OnICDRegistrationComplete(chip::ScopedNodeId deviceId, uint32_t icdCounter) override;
+    void OnICDStayActiveComplete(chip::ScopedNodeId deviceId, uint32_t promisedActiveDuration) override;
+    void OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) override;
+    CHIP_ERROR WiFiCredentialsNeeded(chip::EndpointId endpoint) override;
+    CHIP_ERROR ThreadCredentialsNeeded(chip::EndpointId endpoint) override;
+
+    /////////// DeviceDiscoveryDelegate Interface /////////
+    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;
+
+    /////////// DeviceAttestationDelegate /////////
+    chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override;
+    void OnDeviceAttestationCompleted(chip::Controller::DeviceCommissioner * deviceCommissioner, chip::DeviceProxy * device,
+                                      const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
+                                      chip::Credentials::AttestationVerificationResult attestationResult) override;
+    bool ShouldWaitAfterDeviceAttestation() override;
+
+private:
+    void PrintDeviceInformation();
+    void PrintCert(const char * name, chip::ByteSpan & buffer);
+
+    // Device attestation information
+    chip::ByteSpan mDacDerBuffer;
+    chip::ByteSpan mPaiDerBuffer;
+    chip::ByteSpan mCdBuffer;
+    uint16_t mVendorId;
+    uint16_t mProductId;
+    chip::Credentials::AttestationVerificationResult mAttestationResult;
+
+    NodeId mNodeId            = chip::kUndefinedNodeId;
+    char * mOnboardingPayload = nullptr;
+};

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -23,6 +23,7 @@
 #include <controller/CurrentFabricRemover.h>
 
 #include <commands/common/CredentialIssuerCommands.h>
+#include <credentials/CertificationDeclaration.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
@@ -71,14 +72,34 @@ public:
 
 private:
     void PrintDeviceInformation();
-    void PrintCert(const char * name, chip::ByteSpan & buffer);
+    void PrintCert(const char * name, chip::ByteSpan buffer);
+
+    CHIP_ERROR SetBuffer(chip::Platform::ScopedMemoryBufferWithSize<uint8_t> & buf, const chip::ByteSpan & span)
+    {
+        VerifyOrReturnError(buf.Alloc(span.size()), CHIP_ERROR_NO_MEMORY);
+        memcpy(buf.Get(), span.data(), span.size());
+        return CHIP_NO_ERROR;
+    }
+
+    chip::Optional<chip::ByteSpan> GetBuffer(const chip::Platform::ScopedMemoryBufferWithSize<uint8_t> & buf) const
+    {
+        if (!buf.Get())
+        {
+            return chip::Optional<chip::ByteSpan>();
+        }
+        return chip::MakeOptional(chip::ByteSpan(buf.Get(), buf.AllocatedSize()));
+    }
+
+    chip::Optional<chip::ByteSpan> DacDerBuffer() const { return GetBuffer(mDacCertBuf); }
+    chip::Optional<chip::ByteSpan> PaiDerBuffer() const { return GetBuffer(mPaiCertBuf); }
+    chip::Optional<chip::ByteSpan> CdBuffer() const { return GetBuffer(mCdBuf); }
+    chip::Optional<chip::ByteSpan> PaaDerBuffer() const { return GetBuffer(mPaaCertBuf); }
 
     // Device attestation information
-    chip::ByteSpan mDacDerBuffer;
-    chip::ByteSpan mPaiDerBuffer;
-    chip::Optional<chip::ByteSpan> mCdBuffer;
-    uint8_t mPaaCertBuf[chip::Credentials::kMaxDERCertLength];
-    chip::Optional<chip::ByteSpan> mPaaDerBuffer;
+    chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mDacCertBuf;
+    chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mPaiCertBuf;
+    chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mCdBuf;
+    chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mPaaCertBuf;
     uint16_t mVendorId;
     uint16_t mProductId;
     chip::Credentials::AttestationVerificationResult mAttestationResult;

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -33,7 +33,6 @@
 
 class VerifyCommand : public CHIPCommand,
                       public chip::Controller::DevicePairingDelegate,
-                      public chip::Controller::DeviceDiscoveryDelegate,
                       public chip::Credentials::DeviceAttestationDelegate
 {
 public:
@@ -59,9 +58,6 @@ public:
     void OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) override;
     CHIP_ERROR WiFiCredentialsNeeded(chip::EndpointId endpoint) override;
     CHIP_ERROR ThreadCredentialsNeeded(chip::EndpointId endpoint) override;
-
-    /////////// DeviceDiscoveryDelegate Interface /////////
-    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;
 
     /////////// DeviceAttestationDelegate /////////
     chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override;

--- a/examples/chip-tool/commands/verify/VerifyCommand.h
+++ b/examples/chip-tool/commands/verify/VerifyCommand.h
@@ -100,9 +100,10 @@ private:
     chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mPaiCertBuf;
     chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mCdBuf;
     chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mPaaCertBuf;
-    uint16_t mVendorId;
-    uint16_t mProductId;
-    chip::Credentials::AttestationVerificationResult mAttestationResult;
+    uint16_t mVendorId  = 0;
+    uint16_t mProductId = 0;
+    chip::Credentials::AttestationVerificationResult mAttestationResult =
+        chip::Credentials::AttestationVerificationResult::kInternalError;
 
     NodeId mNodeId            = chip::kUndefinedNodeId;
     char * mOnboardingPayload = nullptr;

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -30,6 +30,7 @@
 #include "commands/payload/Commands.h"
 #include "commands/session-management/Commands.h"
 #include "commands/storage/Commands.h"
+#include "commands/verify/Commands.h"
 
 #include <zap-generated/cluster/Commands.h>
 
@@ -47,6 +48,7 @@ int main(int argc, char * argv[])
     registerCommandsInteractive(commands, &credIssuerCommands);
     registerCommandsPayload(commands);
     registerCommandsPairing(commands, &credIssuerCommands);
+    registerCommandsVerify(commands, &credIssuerCommands);
     registerCommandsGroup(commands, &credIssuerCommands);
     registerClusters(commands, &credIssuerCommands);
     registerCommandsSubscriptions(commands, &credIssuerCommands);

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h
@@ -82,7 +82,7 @@ public:
                                  Callback::Callback<OnAttestationInformationVerification> * onCompletion) override;
 
     CsaCdKeysTrustStore * GetCertificationDeclarationTrustStore() override { return &mCdKeysTrustStore; }
-    const AttestationTrustStore * GetAttestationTrustStore() { return mAttestationTrustStore; }
+    const AttestationTrustStore * GetAttestationTrustStore() const { return mAttestationTrustStore; }
 
     CHIP_ERROR SetRevocationDelegate(DeviceAttestationRevocationDelegate * revocationDelegate) override
     {

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h
@@ -82,6 +82,7 @@ public:
                                  Callback::Callback<OnAttestationInformationVerification> * onCompletion) override;
 
     CsaCdKeysTrustStore * GetCertificationDeclarationTrustStore() override { return &mCdKeysTrustStore; }
+    const AttestationTrustStore * GetAttestationTrustStore() { return mAttestationTrustStore; }
 
     CHIP_ERROR SetRevocationDelegate(DeviceAttestationRevocationDelegate * revocationDelegate) override
     {


### PR DESCRIPTION
### Summary
Add a new command for `chip-tool` that prints vendor id, product id, DAC, PAI, CD and the corresponding PAA as well as the information whether the certificates are valid, without commissioning the device. This command is useful in troubleshooting devices that have trouble fully commissioning or in situations when commissioning is undesired. The report is printed after all the logs. The format of the data is `chip-cert`-compatible.

Example usage `./chip-tool verify with-payload 1234 MT:-24J042C00KA0648G00`.
Example report:
```
VendorId: 0xFFF1
ProductId: 0x8001
DAC:
-----BEGIN CERTIFICATE-----
MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwc
TWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZG
RjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMM
HE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARG
RkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEH
A0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYL
gpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/
BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAW
gBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0Rh
DuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUj
lUXhCOTlTnCXE1M=
-----END CERTIFICATE-----
PAI:
-----BEGIN CERTIFICATE-----
MIIByzCCAXGgAwIBAgIIVq2CIq2UW2QwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP
TWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMjAyMDUw
MDAwMDBaGA85OTk5MTIzMTIzNTk1OVowPTElMCMGA1UEAwwcTWF0dGVyIERldiBQ
QUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwWTATBgcqhkjO
PQIBBggqhkjOPQMBBwNCAARBmpMVwhc+DIyHbQPM/JRIUmR/f+xeUIL0BZko7KiU
xZQVEwmsYx5MsDOSr2hLC6+35ls7gWLC9Sv5MbjneqqCo2YwZDASBgNVHRMBAf8E
CDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUY1QOR/ZLHDjROISk
YtFsGV2P+zwwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGhcX4wCgYIKoZI
zj0EAwIDSAAwRQIhALLvJ/Sa6bUPuR7qyUxNC9u415KcbLiPrOUpNo0SBUwMAiBl
Xckrhr2QmIKmxiF3uCXX0F7b58Ivn+pxIg5+pwP4kQ==
-----END CERTIFICATE-----
PAA:
-----BEGIN CERTIFICATE-----
MIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP
TWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx
NDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg
UEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH
A0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ
NUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD
VR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV
HSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ
qoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH
mUkpxyqvChVI1A0DTVFLJd4=
-----END CERTIFICATE-----
CD:
3082021706092a864886f70d010702a082020830820204020103310d300b06096086480165030402013082017006092a864886f70d010701a08201610482015d152400012501f1ff3602050080050180050280050380050480050580050680050780050880050980050a80050b80050c80050d80050e80050f80051080051180051280051380051480051580051680051780051880051980051a80051b80051c80051d80051e80051f80052080052180052280052380052480052580052680052780052880052980052a80052b80052c80052d80052e80052f80053080053180053280053380053480053580053680053780053880053980053a80053b80053c80053d80053e80053f80054080054180054280054380054480054580054680054780054880054980054a80054b80054c80054d80054e80054f80055080055180055280055380055480055580055680055780055880055980055a80055b80055c80055d80055e80055f80056080056180056280056380182403162c0413435341303030303053574330303030302d303024050024060024070124080018317c307a0201038014fe343f959947763b61ee4539131338494fe67d8e300b0609608648016503040201300a06082a8648ce3d0403020446304402204a12f8d42f90235c05a77121cbebae15d590146558e9c9b47a1a38f7a36a7dc5022020a4742897c30aeda0a56b36e14ebbc85bbdb74493f993581eb0444ed6ca940b
Attestation: Success
```

### Testing
Tested with examples like `all-clusters` and `./chip-tool verify with-payload` as well as `chip-cert`.