### PR TITLE
[Silabs] Reverting the windows app fix changes

### DIFF
--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -678,12 +678,6 @@ void WindowManager::UpdateLCD()
         chip::app::DataModel::Nullable<uint16_t> tilt;
 
         chip::DeviceLayer::PlatformMgr().LockChipStack();
-        auto wc = FindClusterOnEndpoint(cover.mEndpoint);
-        if (wc == nullptr)
-        {
-            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-            return;
-        }
         Type type = TypeGet(cover.mEndpoint);
 
         Attributes::CurrentPositionLift::Get(cover.mEndpoint, lift);


### PR DESCRIPTION
### Summary
In the PR, https://github.com/project-chip/connectedhomeip/pull/73190/changes
the changes done on windows app is not valid only thermostat app is only required.

Reverting the windows app changes.

### Related issues
NA

### Testing
Tested the build locally