### PR TITLE
[CI] Fix Allure report generation (missing xargs in action base image)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -365,7 +365,8 @@ jobs:
                   path: gh-pages
 
             - name: Generate Allure Report
-              uses: simple-elf/allure-report-action@v1.14
+              # findutils fix; no tag past v1.14 yet (simple-elf#78)
+              uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
               with:
                   allure_results: junit-results
                   allure_report: allure-report

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -365,8 +365,7 @@ jobs:
                   path: gh-pages
 
             - name: Generate Allure Report
-              # findutils fix; no tag past v1.14 yet (simple-elf#78)
-              uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
+              uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 # v1.15
               with:
                   allure_results: junit-results
                   allure_report: allure-report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1323,8 +1323,7 @@ jobs:
                 path: gh-pages
 
           - name: Generate Allure Report
-            # findutils fix; no tag past v1.14 yet (simple-elf#78)
-            uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
+            uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 # v1.15
             with:
                 allure_results: junit-results
                 allure_report: allure-report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1323,7 +1323,8 @@ jobs:
                 path: gh-pages
 
           - name: Generate Allure Report
-            uses: simple-elf/allure-report-action@v1.14
+            # findutils fix; no tag past v1.14 yet (simple-elf#78)
+            uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
             with:
                 allure_results: junit-results
                 allure_report: allure-report


### PR DESCRIPTION
#### Problem

The `Generate Allure Report` step in `tests.yaml` and `nightly.yaml` started failing with no repo-side change:

```
/entrypoint.sh: line 38: xargs: command not found
generating report from junit-results to allure-report ...
xargs is not available
cp: cannot stat './allure-report/.': No such file or directory
```

`simple-elf/allure-report-action` is a Dockerfile-based action whose image is rebuilt from the floating `amazoncorretto:8` base tag on every run. That base image was updated and no longer ships `findutils`, so `xargs` is missing. The bundled `allure` launcher hard-requires `xargs` and aborts before generating anything, so the report directory never exists and the subsequent `cp` fails the step.

#### Fix

Pinning the action tag does not help: `v1.14`'s Dockerfile also lacks `findutils`, and no fixed release tag exists yet. This pins both workflows to the upstream commit that adds `findutils` to the action's Dockerfile (simple-elf/allure-report-action#78, fixes simple-elf/allure-report-action#77).

Once upstream cuts a release past `v1.14`, this can be re-pinned to that tag.


#### Testing

This can only be tested post-merge