### PR TITLE
[CI] Skip Allure history report generation on PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1291,15 +1291,18 @@ jobs:
       permissions:
           contents: write
           checks: write
+      env:
+          # The Allure history report is only ever published to gh-pages
+          # post-merge (see "Deploy to GitHub Pages"). On pull_request /
+          # merge_group the deploy is skipped, so generating the report -- and
+          # especially checking out the gh-pages history branch -- is wasted
+          # work. Gate the publish-only steps on this so PRs keep just the
+          # JUnit test annotations.
+          PUBLISH_ALLURE_HISTORY: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
       steps:
           - name: Checkout
             uses: actions/checkout@v7
-
-          # The gh-pages Allure history is handled several times over on this
-          # runner (checkout, history copy, deploy clone), so free up disk first.
-          - name: Maximize runner disk
-            uses: ./.github/actions/maximize-runner-disk
 
           - name: Download all JUnit XML results
             uses: actions/download-artifact@v8
@@ -1316,13 +1319,21 @@ jobs:
                 require_tests: false
                 annotate_only: true
 
+          # The gh-pages Allure history is handled several times over on this
+          # runner (checkout, history copy, deploy clone), so free up disk first.
+          - name: Maximize runner disk
+            if: ${{ env.PUBLISH_ALLURE_HISTORY == 'true' }}
+            uses: ./.github/actions/maximize-runner-disk
+
           - name: Checkout gh-pages for Allure history
+            if: ${{ env.PUBLISH_ALLURE_HISTORY == 'true' }}
             uses: actions/checkout@v7
             with:
                 ref: gh-pages
                 path: gh-pages
 
           - name: Generate Allure Report
+            if: ${{ env.PUBLISH_ALLURE_HISTORY == 'true' }}
             uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 # v1.15
             with:
                 allure_results: junit-results
@@ -1335,6 +1346,7 @@ jobs:
                 report_name: "CI Tests"
 
           - name: Upload Allure Report
+            if: ${{ env.PUBLISH_ALLURE_HISTORY == 'true' }}
             uses: actions/upload-artifact@v7
             with:
                 name: allure-report-ci-repl
@@ -1343,7 +1355,7 @@ jobs:
                 if-no-files-found: warn
 
           - name: Deploy to GitHub Pages
-            if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+            if: ${{ env.PUBLISH_ALLURE_HISTORY == 'true' }}
             uses: peaceiris/actions-gh-pages@v4
             with:
                 github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1292,12 +1292,9 @@ jobs:
           contents: write
           checks: write
       env:
-          # The Allure history report is only ever published to gh-pages
-          # post-merge (see "Deploy to GitHub Pages"). On pull_request /
-          # merge_group the deploy is skipped, so generating the report -- and
-          # especially checking out the gh-pages history branch -- is wasted
-          # work. Gate the publish-only steps on this so PRs keep just the
-          # JUnit test annotations.
+          # Allure is only deployed to gh-pages post-merge; on PRs / merge_group
+          # the deploy no-ops, so building it (and cloning the gh-pages history)
+          # is wasted work. Gate the publish-only steps below on this.
           PUBLISH_ALLURE_HISTORY: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
       steps:


### PR DESCRIPTION
#### Background

In the `REPL Tests - Linux (REPORT RESULTS)` job, the Allure report is only published to `gh-pages` **post-merge** — the `Deploy to GitHub Pages` step already no-ops on `pull_request` / `merge_group`. But the steps that *build* that report still run on PRs:

- `Checkout gh-pages for Allure history` clones the entire `gh-pages` history branch (currently ~200 report folders — the same growth that required #72981).
- `Generate Allure Report` builds a report and prunes history in a local copy.
- `Upload Allure Report` uploads it as an artifact.

On a PR none of this is deployed, so the whole sequence is thrown away. The artifact (`allure-report-ci-repl`) is not consumed by any other workflow.

#### Change

Gate the publish-only steps (runner-disk maximize, gh-pages checkout, report generation, artifact upload, Pages deploy) on a `PUBLISH_ALLURE_HISTORY` env flag that is true only for events that actually deploy. Pull requests keep the `mikepenz/action-junit-report` step, which is what surfaces test failures as annotations in the checks UI — that behavior is unchanged.

Net effect on PRs: the heavy `gh-pages` checkout and report generation are skipped; post-merge runs are unaffected.

#### Note

Stacked on #73225 (the `xargs`/findutils fix). Until that merges, the diff here also shows those commits; once it lands, this PR reduces to the gating change alone.

#### Testing

In CI, observe that we are not running the Allure Report Generation steps