### PR TITLE
Docker image build version increased.

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-206 : [Silabs] Prevent removal of libble_bgapi_gatt_client.a
+207 : [Silabs] Keep generative_ai; JDK 21; Bake SLT python/apack registry + slt CLI

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -1,28 +1,55 @@
 ARG VERSION=1
-FROM ghcr.io/project-chip/chip-build:${VERSION} as build
-LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
+FROM ghcr.io/project-chip/chip-build:${VERSION} AS build
+LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
 
 # Copy SLT manifests and Simplicity SDK keep-list from files-slt (build context: Dockerfile folder)
 COPY files-slt/sisdk-pkg.slt files-slt/wiseconnect-pkg.slt /tmp/
 COPY files-slt/simplicity_sdk_keep_folders.txt /tmp/keep_folders.txt
 
-# Setup SLT CLI (same as scripts/setup/silabs/install-packages.py)
+# Setup SLT CLI (kept in the final image on PATH as /opt/silabs/slt/slt)
 RUN set -x \
-    && mkdir -p /tmp/slt_install \
+    && mkdir -p /tmp/slt_install /tmp/slt_cli_bin \
     && wget -q https://www.silabs.com/documents/public/software/slt-cli-1.1.4-linux-x64.zip -O /tmp/slt.zip \
     && unzip -q /tmp/slt.zip -d /tmp/slt_install \
     && rm /tmp/slt.zip \
     && chmod +x /tmp/slt_install/slt \
+    && cp -a /tmp/slt_install/slt /tmp/slt_cli_bin/slt \
     && : # last line
 
-# Install packages via SLT (simplicity-sdk, wiseconnect, slc-cli) and copy to /tmp for final image
+# Install packages via SLT (simplicity-sdk, wiseconnect, slc-cli, python) and copy to /tmp for final image.
+#
+# agents_md Jinja generation loads the SLT python apack via Jep. SLC discovers that
+# apack through ~/.silabs/slt/apack_registry.json (+ local.json), not by scanning
+# installs/archive alone. Copying only python-v* leaves generation broken with:
+#   "python script did not properly register a template generator"
+# which is the same failure Silabs documents as needing `slt install python`
+# (that command regenerates the registry — bake the registry instead).
 RUN set -x \
     && /tmp/slt_install/slt install -f /tmp/wiseconnect-pkg.slt \
     && /tmp/slt_install/slt install slc-cli \
+    && /tmp/slt_install/slt install python \
     && cp -a $(/tmp/slt_install/slt where wiseconnect) /tmp/wifi_sdk \
     && cp -a $(/tmp/slt_install/slt where slc-cli) /tmp/slc_cli \
     && /tmp/slt_install/slt install -f /tmp/sisdk-pkg.slt \
     && cp -a $(/tmp/slt_install/slt where simplicity-sdk) /tmp/simplicity_sdk \
+    && mkdir -p /tmp/slt_home/installs/archive \
+    && cp -a /root/.silabs/slt/apack_registry.json /tmp/slt_home/ \
+    && cp -a /root/.silabs/slt/local.json /tmp/slt_home/ \
+    && (cp -a /root/.silabs/slt/apack_registry.lock /tmp/slt_home/ || true) \
+    # Copy unpacked apack dirs only (globs also match *.zip; a failed
+    # `[ -d ] && cp` as the last for-iteration aborts under set -e / &&).
+    && find /root/.silabs/slt/installs/archive -maxdepth 1 -type d \
+         \( -name 'python-v*' -o -name 'java21-v*' -o -name 'slc-cli-v*' \) \
+         -exec cp -a {} /tmp/slt_home/installs/archive/ \; \
+    && cp -a /root/.silabs/slt/installs/archive/local.json /tmp/slt_home/installs/archive/ \
+    && (cp -a /root/.silabs/slt/installs/archive/apack-link.json /tmp/slt_home/installs/archive/ || true) \
+    && test -f /tmp/slt_home/apack_registry.json \
+    && test -f /tmp/slt_home/local.json \
+    && PYTHON_DIR=$(find /tmp/slt_home/installs/archive -maxdepth 1 -type d -name 'python-v*' | sort -V | tail -1) \
+    && test -n "$PYTHON_DIR" \
+    && test -f "$PYTHON_DIR/python/apack.json" \
+    && grep -q '"python"' /tmp/slt_home/apack_registry.json \
+    && grep -q 'apack_directory' /tmp/slt_home/apack_registry.json \
     && rm -rf /tmp/slt_install /tmp/sisdk-pkg.slt /tmp/wiseconnect-pkg.slt \
     && : # last line
 
@@ -58,7 +85,7 @@ RUN set -x \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     gcc-arm-none-eabi \
     binutils-arm-none-eabi \
-    openjdk-17-jdk-headless \
+    openjdk-21-jdk-headless \
     ccache \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
@@ -71,8 +98,23 @@ RUN set -x \
 ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/
 ENV SISDK_ROOT=/opt/silabs/simplicity_sdk/
 ENV WIFI_SDK_ROOT=/opt/silabs/wifi_sdk/
-ENV PATH="${PATH}:/opt/silabs/slc_cli/"
+ENV PATH="/opt/silabs/slt:/opt/silabs/slc_cli:${PATH}"
 
 COPY --from=build /tmp/simplicity_sdk /opt/silabs/simplicity_sdk
 COPY --from=build /tmp/wifi_sdk /opt/silabs/wifi_sdk
 COPY --from=build /tmp/slc_cli /opt/silabs/slc_cli
+COPY --from=build /tmp/slt_cli_bin/slt /opt/silabs/slt/slt
+# Full SLT discovery state for agents_md (registry + python/java/slc apacks)
+COPY --from=build /tmp/slt_home/ /root/.silabs/slt/
+
+RUN set -e \
+    && chmod +x /opt/silabs/slt/slt \
+    && ln -sf /opt/silabs/slt/slt /usr/local/bin/slt \
+    && test -f /root/.silabs/slt/apack_registry.json \
+    && test -f /root/.silabs/slt/local.json \
+    && PYTHON_DIR=$(find /root/.silabs/slt/installs/archive -maxdepth 1 -type d -name 'python-v*' | sort -V | tail -1) \
+    && test -n "$PYTHON_DIR" \
+    && test -f "$PYTHON_DIR/python/apack.json" \
+    && grep -q '"python"' /root/.silabs/slt/apack_registry.json \
+    && slt --version \
+    && slc --version

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -175,8 +175,10 @@ bootloader
 cmsis
 common_15_4
 freertos
+generative_ai
 openthread
 openthread_stack
 platform_core
 rail_library
+security_sxsymcrypt
 segger


### PR DESCRIPTION
### Summary

* Docker image build version increased to 207
* Retains generative_ai in the trimmed SiSDK
* Installs SLT python and copies apack_registry.json / local.json plus the python, java21, and slc-cli apacks into /root/.silabs/slt so SLC Jinja/agents_md can find them
* Ships the slt binary on PATH
* Upgrades the image JDK from 17 to 21

### Related issues

[MATTER-6757](https://jira.silabs.com/browse/MATTER-6757).

### Testing

* Docker image built.
* Binaries built for EFR32 and Si917 PSA within the container:
  - Provision image
  - Generator firmware