### PR TITLE
[v1.4.2] fix(android): strip symbols before copying libs to ensure optimised build variant packages stripped libs (#73204)

### DIFF
--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -562,6 +562,9 @@ class AndroidBuilder(Builder):
                 title="Building JNI " + self.identifier,
             )
 
+            if (self.profile != AndroidProfile.DEBUG) or self.optimize_size:
+                self.stripSymbols()
+
             exampleName = self.app.ExampleName()
             if exampleName is None:
                 self.copyToSrcAndroid()
@@ -662,9 +665,6 @@ class AndroidBuilder(Builder):
 
                 self.copyToExampleApp(jnilibs_dir, libs_dir, libs, jars)
                 self.gradlewBuildExampleAndroid()
-
-            if (self.profile != AndroidProfile.DEBUG) or self.optimize_size:
-                self.stripSymbols()
 
     def build_outputs(self):
         if self.board.IsIde():


### PR DESCRIPTION
Backport of #73204 to `v1.4.2-branch`.

Cherry-pick (`git cherry-pick -x`) of commit 563854796fb09ee5e732baa695beb6dba27fb678 (the squash-merge of #73204 on master).

#### Original description

Strip symbols before copying libs to ensure the optimised build variant packages stripped libs. The `stripSymbols()` call was previously invoked *after* the example-app libs were copied and the Android app was built, so the packaged APK/example still contained unstripped `.so` files. Moving the strip step to run right after the JNI build (before the copy/gradle step) ensures the libraries that get packaged are the stripped ones.

#### Backport notes

Conflict in `scripts/build/builders/android.py`: `v1.4.2-branch` uses a different profile API than master. Master gates the strip on `self.options.build_profile in [BuildProfile.RELEASE, BuildProfile.RELEASE_SIZE] or self.optimize_size`, but `BuildProfile` / `self.options.build_profile` do not exist on this branch — v1.4.2 uses `AndroidProfile` / `self.profile`.

Resolved by preserving the branch's existing condition expression while applying the PR's move: the `stripSymbols()` call now runs after "Building JNI" and before `copyToExampleApp`/`gradlewBuildExampleAndroid`, using the branch-native guard:

```python
if (self.profile != AndroidProfile.DEBUG) or self.optimize_size:
    self.stripSymbols()
```

The net diff vs the `v1.4.2-branch` base is exactly this move (the block is added in the new location and removed from the old one); no other lines change. The `@lock_output_dir` decorator that exists on master's `build_outputs` is not present on `v1.4.2-branch`, so it is intentionally not introduced here.

`python3 -m py_compile` passes on the resolved file.

### Testing

build, CI, Android