### PR TITLE
[Silabs] SiWx917 errors suppressed.

### DIFF
--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -392,6 +392,12 @@ template("siwx917_sdk") {
     # Suppress VLA warnings for wifi-sdk files that use variable-length arrays
     cflags += [ "-Wno-vla" ]
 
+    # WiSeConnect sl_debug_log() forwards a non-literal format to vprintf
+    cflags += [
+      "-Wno-missing-format-attribute",
+      "-Wno-format-nonliteral",
+    ]
+
     foreach(include_dir, _include_dirs) {
       cflags += [ "-isystem" + rebase_path(include_dir, root_build_dir) ]
     }


### PR DESCRIPTION
### Summary

WiSeConnect compilation error suppressed when compiling with clang.

### Related issues

[MATTER-6757](https://jira.silabs.com/browse/MATTER-6757).

### Testing

Docker image built.
* Provision libraries built for EFR32 and Si917 PSA with LLVM
