### PR TITLE
fix transposed extents of AutoCommissioner mTimeZoneNames

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
                 params.GetTimeZone().Value()[i].name.Value().size() <= kMaxTimeZoneNameLen)
             {
                 auto span = MutableCharSpan(mTimeZoneNames[i], kMaxTimeZoneNameLen);
-                // The buffer backing "span" is statically allocated and is of size kMaxSupportedTimeZones, so this should never
+                // The buffer backing "span" is statically allocated and is of size kMaxTimeZoneNameLen, so this should never
                 // fail.
                 TEMPORARY_RETURN_IGNORED CopyCharSpanToMutableCharSpan(params.GetTimeZone().Value()[i].name.Value(), span);
                 mTimeZoneBuf[i].name.SetValue(span);

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -165,7 +165,7 @@ private:
     static constexpr size_t kMaxSupportedTimeZones = 2;
     app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type mTimeZoneBuf[kMaxSupportedTimeZones];
     static constexpr size_t kMaxTimeZoneNameLen = 64;
-    char mTimeZoneNames[kMaxTimeZoneNameLen][kMaxSupportedTimeZones];
+    char mTimeZoneNames[kMaxSupportedTimeZones][kMaxTimeZoneNameLen];
 
     // DSTOffsetStructs are similarly not trivially destructible. They don't have a defined size, but we're
     // going to do static allocation of the buffers anyway until we replace chip::Optional with std::optional.

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -157,6 +157,39 @@ TEST_F(AutoCommissionerTest, FeaturesPassedTimeZoneValue)
     ASSERT_TRUE(commissioning_params.GetTimeZone().Value()[0].name.Value().data_equal("ARG"_span));
 }
 
+// Each stored time zone name must get its own row of mTimeZoneNames, so a second entry
+// cannot overwrite the first one's characters.
+TEST_F(AutoCommissionerTest, FeaturesPassedTimeZoneValuesDoNotOverlap)
+{
+    app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type sTimeZoneBuf[2];
+
+    constexpr CharSpan firstName  = "America/New_York"_span;
+    constexpr CharSpan secondName = "Europe/Berlin"_span;
+
+    sTimeZoneBuf[0].offset  = int32_t{ 10 };
+    sTimeZoneBuf[0].validAt = epochJanFirst2000;
+    sTimeZoneBuf[0].name.SetValue(firstName);
+
+    sTimeZoneBuf[1].offset  = int32_t{ 20 };
+    sTimeZoneBuf[1].validAt = epochJanFirst2001;
+    sTimeZoneBuf[1].name.SetValue(secondName);
+
+    app::DataModel::List<app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type> list(sTimeZoneBuf, 2);
+    mParams.SetTimeZone(list);
+
+    auto r = mCommissioner.SetCommissioningParameters(mParams);
+
+    auto commissioning_params = mCommissioner.GetCommissioningParameters();
+
+    ASSERT_EQ(r, CHIP_NO_ERROR);
+    ASSERT_TRUE(commissioning_params.GetTimeZone().HasValue());
+    ASSERT_EQ(commissioning_params.GetTimeZone().Value().size(), size_t{ 2 });
+    ASSERT_TRUE(commissioning_params.GetTimeZone().Value()[0].name.HasValue());
+    ASSERT_TRUE(commissioning_params.GetTimeZone().Value()[1].name.HasValue());
+    EXPECT_TRUE(commissioning_params.GetTimeZone().Value()[0].name.Value().data_equal(firstName));
+    EXPECT_TRUE(commissioning_params.GetTimeZone().Value()[1].name.Value().data_equal(secondName));
+}
+
 TEST_F(AutoCommissionerTest, FeaturesPassedNTPValue)
 {
     constexpr CharSpan defaultNTPBuffer = "default"_span;


### PR DESCRIPTION
### Summary

`mTimeZoneNames` in `AutoCommissioner` is declared `char[kMaxTimeZoneNameLen][kMaxSupportedTimeZones]`, so the two extents are the wrong way round: 64 rows of 2 bytes rather than 2 rows of 64. `SetCommissioningParameters` then builds `MutableCharSpan(mTimeZoneNames[i], kMaxTimeZoneNameLen)` and hands it to `CopyCharSpanToMutableCharSpan`, which memmoves up to 64 bytes into a row that is only 2 bytes wide. Since the row stride is 2, the second entry starts two bytes into the first, so any two time zone names longer than two characters overlap and the spans published through `SetTimeZone` alias each other. Swapping the extents leaves the footprint at 128 bytes either way, and matches the `[count][size]` order the other two-dimensional buffers in the tree already use (`Ipv4AddressesBuffer`, `gListFabricScoped_fabricSensitiveCharBuf`). The comment above the copy named `kMaxSupportedTimeZones` as the row length, which is what the declaration got backwards, so it is corrected too.

### Related issues

None.

### Testing

Added `FeaturesPassedTimeZoneValuesDoNotOverlap` to `TestAutoCommissioner.cpp`: it passes two time zones named `America/New_York` and `Europe/Berlin`, then reads both back through `GetCommissioningParameters`. Before the swap the first name comes back as `AmEurope/Berlink`; after it both survive intact. The existing `FeaturesPassedTimeZoneValue` passes either way because it sets a single three-character name, which is why this went unnoticed.
