### PR TITLE
[Beken][stm32] Guard the first-block header copy against short blocks

### DIFF
--- a/src/platform/Beken/OTAImageProcessorImpl.cpp
+++ b/src/platform/Beken/OTAImageProcessorImpl.cpp
@@ -206,11 +206,21 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     if (!imageProcessor->readHeader) // First block received, process header
     {
+        if (block.size() < sizeof(ota_data_struct_t))
+        {
+            ChipLogError(SoftwareUpdate, "Block of %u bytes is too small to hold the image descriptor (%u bytes)",
+                         static_cast<unsigned>(block.size()), static_cast<unsigned>(sizeof(ota_data_struct_t)));
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_BUFFER_TOO_SMALL);
+            return;
+        }
+
         ota_data_struct_t * tempBuf = (ota_data_struct_t *) chip::Platform::MemoryAlloc(sizeof(ota_data_struct_t));
 
         if (NULL == tempBuf)
         {
             ChipLogError(SoftwareUpdate, "%s [%d] malloc failed  ", __FUNCTION__, __LINE__);
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_NO_MEMORY);
+            return;
         }
         memset((char *) tempBuf, 0, sizeof(ota_data_struct_t));
         memcpy((char *) &(imageProcessor->pOtaTgtHdr), block.data(), sizeof(ota_data_struct_t));

--- a/src/platform/Beken/OTAImageProcessorImpl.cpp
+++ b/src/platform/Beken/OTAImageProcessorImpl.cpp
@@ -206,11 +206,21 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     if (!imageProcessor->readHeader) // First block received, process header
     {
+        if (block.size() < sizeof(ota_data_struct_t))
+        {
+            ChipLogError(SoftwareUpdate, "Block of %u bytes is too small to hold the image descriptor (%u bytes)",
+                         static_cast<unsigned>(block.size()), static_cast<unsigned>(sizeof(ota_data_struct_t)));
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_ARGUMENT);
+            return;
+        }
+
         ota_data_struct_t * tempBuf = (ota_data_struct_t *) chip::Platform::MemoryAlloc(sizeof(ota_data_struct_t));
 
         if (NULL == tempBuf)
         {
             ChipLogError(SoftwareUpdate, "%s [%d] malloc failed  ", __FUNCTION__, __LINE__);
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_NO_MEMORY);
+            return;
         }
         memset((char *) tempBuf, 0, sizeof(ota_data_struct_t));
         memcpy((char *) &(imageProcessor->pOtaTgtHdr), block.data(), sizeof(ota_data_struct_t));

--- a/src/platform/stm32/OTAImageProcessorImpl.cpp
+++ b/src/platform/stm32/OTAImageProcessorImpl.cpp
@@ -265,6 +265,14 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         { // get STM_Header
             uint8_t STMHeader[STM_HEADER_SIZE];
 
+            if (imageProcessor->mBlock.size() < sizeof(STMHeader))
+            {
+                ChipLogError(SoftwareUpdate, "Block of %u bytes is too small to hold the STM header (%u bytes)",
+                             static_cast<unsigned>(imageProcessor->mBlock.size()), static_cast<unsigned>(sizeof(STMHeader)));
+                imageProcessor->mDownloader->EndDownload(CHIP_ERROR_DECODE_FAILED);
+                return;
+            }
+
             memcpy(STMHeader, reinterpret_cast<std::uint8_t *>(imageProcessor->mBlock.data()), sizeof(STMHeader));
 
             // retrieve the cpu1/2 size with STM header

--- a/src/platform/stm32/stm32wba/OTAImageProcessorImpl.cpp
+++ b/src/platform/stm32/stm32wba/OTAImageProcessorImpl.cpp
@@ -415,6 +415,14 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         // first block received, get STM_Header
         uint8_t STMHeader[STM_HEADER_SIZE];
 
+        if (imageProcessor->mBlock.size() < sizeof(STMHeader))
+        {
+            ChipLogError(SoftwareUpdate, "Block of %u bytes is too small to hold the STM header (%u bytes)",
+                         static_cast<unsigned>(imageProcessor->mBlock.size()), static_cast<unsigned>(sizeof(STMHeader)));
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_DECODE_FAILED);
+            return;
+        }
+
         memcpy(STMHeader, reinterpret_cast<std::uint8_t *>(imageProcessor->mBlock.data()), sizeof(STMHeader));
 
         memset(tempBUF, TEMPBUF_PADDING, TEMPBUF_SIZE);


### PR DESCRIPTION
#### Problem

The Beken and stm32wba OTA image processors both copy a fixed-size header out of the first received block without checking that the block actually holds that many bytes:

- `src/platform/Beken/OTAImageProcessorImpl.cpp` copies `sizeof(ota_data_struct_t)` bytes into `pOtaTgtHdr`
- `src/platform/stm32/stm32wba/OTAImageProcessorImpl.cpp` copies `STM_HEADER_SIZE` bytes into `STMHeader`

`mBlock` is allocated to the size of the block that was actually delivered, so a shorter first block makes the copy read past the end of that buffer. On stm32wba the same condition also makes the following `mBlock.size() - STM_HEADER_SIZE` length arithmetic underflow, which then feeds a flash write length.

The other platform processors already bound this same copy — `ti/cc13x4` checks `mBlock.size() + downloadedBytes < sizeof(header)`, `bouffalolab` clamps to `min(block.size(), remaining)`, ESP32 checks `headerDataRead + size < SIZE`, and nrfconnect rejects with `CHIP_ERROR_BUFFER_TOO_SMALL` — so this brings the two remaining processors in line with them.

Separately, the Beken allocation-failure path logs `malloc failed` but then falls through and uses the null pointer in `memset()` and `bk_read_ota_data_in_flash()`.

#### Change overview

- Beken: return early with `CHIP_ERROR_BUFFER_TOO_SMALL` when the block is smaller than the image descriptor, and end the download with `CHIP_ERROR_NO_MEMORY` on allocation failure instead of continuing with a null pointer.
- stm32wba: return early with `CHIP_ERROR_DECODE_FAILED` when the block is smaller than the STM header, matching the error already used by the header sanity check immediately below it.

Both paths call `mDownloader->EndDownload()` and return, the same way the existing flash-write and decode failures in these functions do, so a short block ends the transfer with an error rather than proceeding with an incomplete header.

#### Testing

No unit test: neither platform builds in the Linux host test environment, so there is no in-tree harness that can exercise `HandleProcessBlock` for these targets. Verified by inspection against the bound-checked equivalents listed above, and both files are clang-format clean. Compile coverage relies on the platform build jobs in CI.

