### PR TITLE
Make PacketBufferWriter tolerate a null packet buffer

### DIFF
--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -784,7 +784,7 @@ public:
      *  @param[in]  aPacket A handle to PacketBuffer, to be used as backing store for the BufferWriter.
      *                      May be null, e.g. when it holds the result of a failed allocation; the
      *                      resulting BufferWriter is null and accepts no data.
-     *  @param[in]  aSize   Maximum number of octects to write into the packet buffer.
+     *  @param[in]  aSize   Maximum number of octets to write into the packet buffer.
      */
     PacketBufferWriterBase(System::PacketBufferHandle && aPacket, size_t aSize) : Writer(WritableSpan(aPacket, aSize))
     {

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -36,6 +36,7 @@
 #include <system/SystemError.h>
 
 #include <stddef.h>
+#include <stdint.h>
 #include <utility>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -755,12 +756,12 @@ private:
  *
  * Typical use:
  *  @code
- *      PacketBufferWriter buf(maximumLength);
+ *      PacketBufferWriter buf(PacketBufferHandle::New(maximumLength));
  *      if (buf.IsNull()) { return CHIP_ERROR_NO_MEMORY; }
  *      buf.Put(...);
  *      ...
  *      PacketBufferHandle handle = buf.Finalize();
- *      if (buf.IsNull()) { return CHIP_ERROR_BUFFER_TOO_SMALL; }
+ *      if (handle.IsNull()) { return CHIP_ERROR_BUFFER_TOO_SMALL; }
  *      // valid data
  *  @endcode
  */
@@ -772,21 +773,20 @@ public:
      * Constructs a BufferWriter that writes into a packet buffer, using all available space.
      *
      *  @param[in]  aPacket  A handle to PacketBuffer, to be used as backing store for the BufferWriter.
+     *                       May be null, e.g. when it holds the result of a failed allocation; the
+     *                       resulting BufferWriter is null and accepts no data.
      */
-    PacketBufferWriterBase(System::PacketBufferHandle && aPacket) :
-        Writer(aPacket->Start() + aPacket->DataLength(), aPacket->AvailableDataLength())
-    {
-        mPacket = std::move(aPacket);
-    }
+    PacketBufferWriterBase(System::PacketBufferHandle && aPacket) : Writer(WritableSpan(aPacket)) { mPacket = std::move(aPacket); }
 
     /**
      * Constructs a BufferWriter that writes into a packet buffer, using no more than the requested space.
      *
      *  @param[in]  aPacket A handle to PacketBuffer, to be used as backing store for the BufferWriter.
+     *                      May be null, e.g. when it holds the result of a failed allocation; the
+     *                      resulting BufferWriter is null and accepts no data.
      *  @param[in]  aSize   Maximum number of octects to write into the packet buffer.
      */
-    PacketBufferWriterBase(System::PacketBufferHandle && aPacket, size_t aSize) :
-        Writer(aPacket->Start() + aPacket->DataLength(), std::min(aSize, static_cast<size_t>(aPacket->AvailableDataLength())))
+    PacketBufferWriterBase(System::PacketBufferHandle && aPacket, size_t aSize) : Writer(WritableSpan(aPacket, aSize))
     {
         mPacket = std::move(aPacket);
     }
@@ -813,6 +813,17 @@ public:
     System::PacketBufferHandle Finalize() { return PacketBufferWriterUtil::Finalize(*this, mPacket); }
 
 private:
+    /**
+     * The region of \a aPacket available for writing, truncated to \a aMaxSize. Empty if the handle is
+     * null, which is how a failed allocation reaches the constructors.
+     */
+    static MutableByteSpan WritableSpan(const System::PacketBufferHandle & aPacket, size_t aMaxSize = SIZE_MAX)
+    {
+        VerifyOrReturnValue(!aPacket.IsNull(), MutableByteSpan());
+        return MutableByteSpan(aPacket->Start() + aPacket->DataLength(),
+                               std::min(aMaxSize, static_cast<size_t>(aPacket->AvailableDataLength())));
+    }
+
     System::PacketBufferHandle mPacket;
 };
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1744,5 +1744,26 @@ TEST_F(TestSystemPacketBuffer, CheckPacketBufferWriter)
     EXPECT_EQ(memcmp(yayBuffer->Start(), kPayload, sizeof kPayload), 0);
 }
 
+TEST_F(TestSystemPacketBuffer, CheckPacketBufferWriterNullBuffer)
+{
+    static const char kPayload[] = "Hello, world!";
+
+    // A failed allocation reaches the writer as a null handle. Construction must leave the
+    // writer null instead of dereferencing it, so that callers can test IsNull() as documented.
+    PacketBufferWriter sized(PacketBufferHandle(), sizeof(kPayload));
+    EXPECT_TRUE(sized.IsNull());
+    EXPECT_EQ(sized.Size(), static_cast<size_t>(0));
+
+    PacketBufferHandle empty;
+    PacketBufferWriter unsized(std::move(empty));
+    EXPECT_TRUE(unsized.IsNull());
+    EXPECT_EQ(unsized.Size(), static_cast<size_t>(0));
+
+    // Writing to a null writer must be inert, and Finalize() must yield a null handle.
+    sized.Put(kPayload);
+    EXPECT_FALSE(sized.Fit());
+    EXPECT_TRUE(sized.Finalize().IsNull());
+}
+
 } // namespace System
 } // namespace chip

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1761,8 +1761,8 @@ TEST_F(TestSystemPacketBuffer, CheckPacketBufferWriterNullBuffer)
     EXPECT_FALSE(sized.Fit());
     EXPECT_TRUE(sized.Finalize().IsNull());
 
-    // Unsized constructor, never written, so Fit() is true; only the null result of Finalize() keeps
-    // a caller from mistaking a failed allocation for an empty buffer.
+    // Unsized constructor, never written, so Fit() is true: it reflects capacity, not validity, and
+    // gives no warning here. A caller that skipped the IsNull() check still sees Finalize() yield null.
     PacketBufferHandle empty;
     PacketBufferWriter unsized(std::move(empty));
     EXPECT_TRUE(unsized.IsNull());

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1748,25 +1748,25 @@ TEST_F(TestSystemPacketBuffer, CheckPacketBufferWriterNullBuffer)
 {
     static const char kPayload[] = "Hello, world!";
 
-    // A failed allocation reaches the writer as a null handle. Construction must leave the
-    // writer null instead of dereferencing it, so that callers can test IsNull() as documented.
+    // A failed allocation reaches the writer as a null handle. Construction must leave the writer
+    // null instead of dereferencing it, so that callers can test IsNull() as documented, and writing
+    // to it must be inert. Fit() reports only whether the input fit, so it does not by itself
+    // distinguish a null writer from a usable one; Finalize() is null in both cases below.
+
+    // Sized constructor, written past its zero capacity, so Fit() is false.
     PacketBufferWriter sized(PacketBufferHandle(), sizeof(kPayload));
     EXPECT_TRUE(sized.IsNull());
     EXPECT_EQ(sized.Size(), static_cast<size_t>(0));
-
-    PacketBufferHandle empty;
-    PacketBufferWriter unsized(std::move(empty));
-    EXPECT_TRUE(unsized.IsNull());
-    EXPECT_EQ(unsized.Size(), static_cast<size_t>(0));
-
-    // Writing to a null writer must be inert, and Finalize() must yield a null handle.
     sized.Put(kPayload);
     EXPECT_FALSE(sized.Fit());
     EXPECT_TRUE(sized.Finalize().IsNull());
 
-    // A null writer that was never written to trivially fits, so Fit() alone does not distinguish it
-    // from a usable writer. Finalize() must still yield a null handle, so that a caller checking only
-    // its result cannot mistake a failed allocation for an empty buffer.
+    // Unsized constructor, never written, so Fit() is true; only the null result of Finalize() keeps
+    // a caller from mistaking a failed allocation for an empty buffer.
+    PacketBufferHandle empty;
+    PacketBufferWriter unsized(std::move(empty));
+    EXPECT_TRUE(unsized.IsNull());
+    EXPECT_EQ(unsized.Size(), static_cast<size_t>(0));
     EXPECT_TRUE(unsized.Fit());
     EXPECT_TRUE(unsized.Finalize().IsNull());
 }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1763,6 +1763,12 @@ TEST_F(TestSystemPacketBuffer, CheckPacketBufferWriterNullBuffer)
     sized.Put(kPayload);
     EXPECT_FALSE(sized.Fit());
     EXPECT_TRUE(sized.Finalize().IsNull());
+
+    // A null writer that was never written to trivially fits, so Fit() alone does not distinguish it
+    // from a usable writer. Finalize() must still yield a null handle, so that a caller checking only
+    // its result cannot mistake a failed allocation for an empty buffer.
+    EXPECT_TRUE(unsized.Fit());
+    EXPECT_TRUE(unsized.Finalize().IsNull());
 }
 
 } // namespace System


### PR DESCRIPTION
#### Summary

Makes `PacketBufferWriter` handle a null packet buffer instead of crashing, so the allocation-failure paths its callers already implement can actually run.

##### Problem

-   `PacketBufferWriterBase`'s two constructors dereference the handle in their **member-initializer lists** (`aPacket->Start()`, `aPacket->DataLength()`, `aPacket->AvailableDataLength()`), which are evaluated before the constructor body and before any caller-side check can run.
-   The class documents the opposite contract: `IsNull()` states that a true result "implies either that construction failed, or that `Finalize()` has previously been called", and the `@code` example checks `IsNull()` immediately after construction.
-   Consequence: when `PacketBufferHandle::New()` / `MessagePacketBuffer::New()` returns null — an oversized request, or an allocation failure under memory pressure — construction crashes instead of yielding a null writer.
    -   The `CHIP_ERROR_NO_MEMORY` branches that callers such as `BdxTransferSession::WriteToPacketBuffer` implement are **unreachable**, since the crash happens one line earlier.
    -   The constructors are the **sole outlier**: every other part of the writer already tolerates a null buffer.

##### Solution

-   Both constructors now obtain their pointer and length from a single helper returning `MutableByteSpan`, empty when the handle is null. Returning a span rather than a separate pointer and length keeps the two inseparable, so they cannot disagree.
-   No call site changes were needed. The rest of the chain already degrades correctly: `BufferWriter`'s constructor forces `mSize = 0` on a null pointer, `Put` no-ops at zero capacity, and `Finalize` checks `IsNull()` before use.
-   Corrects the class's `@code` example, which used a constructor that does not exist and checked the writer rather than the returned handle after `Finalize()` — where the writer is always null, so the example's second check was unconditionally true.

##### Caveats

-   For a caller that checks neither `IsNull()` nor the `Finalize()` result, an allocation failure now yields an empty message instead of a crash. All in-tree construction sites check one or the other, so no current caller changes behavior.

#### Testing

-   Added `CheckPacketBufferWriterNullBuffer` in `src/system/tests/TestSystemPacketBuffer.cpp`, covering both constructors plus `Put` / `Fit` / `Finalize` on a null writer. Verified it fails before this change (SEGV in `PacketBuffer::Start()` during construction) and passes after.
-   `ninja -C out/linux-x64-tests-asan-clang check` passes in full.
