### PR TITLE
[messaging] Fix null SessionManager deref when an exchange outlives its ExchangeManager

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -435,7 +435,12 @@ void ExchangeContext::OnSessionReleased()
 
 CHIP_ERROR ExchangeContext::StartResponseTimer()
 {
-    System::Layer * lSystemLayer = mExchangeMgr->GetSessionManager()->SystemLayer();
+    // ExchangeManager::Shutdown() clears its SessionManager, so an exchange that outlives it
+    // can reach here with nothing to get the System::Layer from.
+    SessionManager * sessionManager = mExchangeMgr->GetSessionManager();
+    VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    System::Layer * lSystemLayer = sessionManager->SystemLayer();
     if (lSystemLayer == nullptr)
     {
         // this is an assertion error, which shall never happen
@@ -447,7 +452,12 @@ CHIP_ERROR ExchangeContext::StartResponseTimer()
 
 void ExchangeContext::CancelResponseTimer()
 {
-    System::Layer * lSystemLayer = mExchangeMgr->GetSessionManager()->SystemLayer();
+    // SessionManager::Shutdown() expires any remaining sessions, which notifies their exchanges.
+    // By then ExchangeManager::Shutdown() may already have cleared its SessionManager.
+    SessionManager * sessionManager = mExchangeMgr->GetSessionManager();
+    VerifyOrReturn(sessionManager != nullptr);
+
+    System::Layer * lSystemLayer = sessionManager->SystemLayer();
     if (lSystemLayer == nullptr)
     {
         // this is an assertion error, which shall never happen
@@ -664,7 +674,10 @@ void ExchangeContext::AbortAllOtherCommunicationOnFabric()
 
     SetIgnoreSessionRelease(true);
 
-    GetExchangeMgr()->GetSessionManager()->ExpireAllSessionsForFabric(mSession->GetFabricIndex());
+    SessionManager * sessionManager = GetExchangeMgr()->GetSessionManager();
+    VerifyOrReturn(sessionManager != nullptr);
+
+    sessionManager->ExpireAllSessionsForFabric(mSession->GetFabricIndex());
 
     mSession.GrabExpiredSession(session.Value());
 

--- a/src/messaging/tests/TestExchange.cpp
+++ b/src/messaging/tests/TestExchange.cpp
@@ -24,6 +24,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Pool.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
@@ -222,6 +223,30 @@ TEST_F(TestExchange, CheckBasicExchangeMessageDispatch)
                 EXPECT_EQ(delegate2.mReceivedMessageCount, 1u);
             });
     }
+}
+
+// An exchange that is still waiting for a response when the ExchangeManager has already been
+// shut down must not dereference the now-cleared SessionManager. SessionManager::Shutdown()
+// expires any remaining secure sessions, which notifies their exchanges, so this ordering is
+// reachable whenever a consumer tears down the ExchangeManager while a session is still alive.
+TEST_F(TestExchange, OnSessionReleasedAfterExchangeManagerShutdown)
+{
+    MockExchangeDelegate delegate;
+
+    ExchangeContext * ec = NewExchangeToBob(&delegate);
+    ASSERT_NE(ec, nullptr);
+
+    ec->SetResponseTimeout(System::Clock::Seconds16(1));
+    ASSERT_SUCCESS(ec->SendMessage(Protocols::SecureChannel::Id, kMsgType_TEST1,
+                                   System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                                   SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
+    DrainAndServiceIO();
+
+    // ExchangeManager::Shutdown() clears its SessionManager pointer.
+    GetExchangeManager().Shutdown();
+
+    // The exchange is still expecting a response, so this reaches CancelResponseTimer().
+    ec->OnSessionReleased();
 }
 
 // A crude test to exercise VerifyOrDieWithObject() in ObjectPool and


### PR DESCRIPTION
#### Problem

`ExchangeManager::Shutdown()` clears its `SessionManager` pointer. Both `ExchangeContext::StartResponseTimer()` and `ExchangeContext::CancelResponseTimer()` call `mExchangeMgr->GetSessionManager()->SystemLayer()` unconditionally. Each already has a null check, but it covers the returned `System::Layer` rather than the `SessionManager` itself, so it sits one dereference too late:

```cpp
System::Layer * lSystemLayer = mExchangeMgr->GetSessionManager()->SystemLayer();
if (lSystemLayer == nullptr)
{
    // this is an assertion error, which shall never happen
    return;
}
```

An exchange that outlives its `ExchangeManager` therefore dereferences a null `SessionManager`.

#### Why the ordering happens

`SessionManager::Shutdown()` expires any remaining secure sessions, which notifies their exchanges; an exchange still expecting a response reaches `CancelResponseTimer()` from `OnSessionReleased()`. `SessionManager::Shutdown()` already documents the hazard:

> Just in case some consumer forgot to do it, expire all our secure sessions. Note that this stands a good chance of crashing with a null-deref if there are in fact any secure sessions left, since they will try to notify their exchanges, which will then try to operate on partially-shut-down objects.

`Server::Shutdown()` avoids it by calling `ExpireAllSecureSessions()` before `mExchangeMgr.Shutdown()`, but that is a consumer-side workaround rather than a fix in the exchange layer.

#### Change

Check the `SessionManager` before use in both timer helpers. `AbortAllOtherCommunicationOnFabric()` has the same unguarded `GetSessionManager()->...` pattern and is updated for consistency.

#### Testing

Adds `TestExchange.OnSessionReleasedAfterExchangeManagerShutdown`, which sends a message expecting a response, shuts down the `ExchangeManager`, and then releases the session.

Verified red before / green after the change:

- without the change: `AddressSanitizer: SEGV on unknown address 0x000000000018 ... in chip::SessionManager::SystemLayer()`
- with the change: `[       OK ] TestExchange.OnSessionReleasedAfterExchangeManagerShutdown`

No regressions in `TestExchange`, `TestExchangeMgr`, `TestAbortExchangesForFabric`, `TestExchangeHolder`, `TestReliableMessageProtocol`, `TestSessionManager` (all pass under ASan).