### PR TITLE
[AVSM tests] Remove background wildcard subscription

### DIFF
--- a/src/python_testing/TC_AVSM_2_18.py
+++ b/src/python_testing/TC_AVSM_2_18.py
@@ -50,6 +50,7 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVSM_2_18(MatterBaseTest, AVSMTestBase):
+    disable_wildcard_subscription = True
 
     def desc_TC_AVSM_2_18(self) -> str:
         return "[TC-AVSM-2.18] Validate persistence of allocated video streams with DUT"

--- a/src/python_testing/TC_AVSM_2_19.py
+++ b/src/python_testing/TC_AVSM_2_19.py
@@ -50,6 +50,7 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVSM_2_19(MatterBaseTest, AVSMTestBase):
+    disable_wildcard_subscription = True
 
     def desc_TC_AVSM_2_19(self) -> str:
         return "[TC-AVSM-2.19] Validate persistence of allocated audio streams with DUT"

--- a/src/python_testing/TC_AVSM_2_20.py
+++ b/src/python_testing/TC_AVSM_2_20.py
@@ -50,6 +50,7 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVSM_2_20(MatterBaseTest, AVSMTestBase):
+    disable_wildcard_subscription = True
 
     def desc_TC_AVSM_2_20(self) -> str:
         return "[TC-AVSM-2.20] Validate persistence of allocated snapshot streams with DUT"


### PR DESCRIPTION
### Summary

- Removes framework background wildcard subscription from AVSM 2.18-2.20 due to reboot during tests causes possible problems as reported during 1.6.1 MVE.

### Related issues

Fixes: https://github.com/project-chip/connectedhomeip/issues/73252

### Testing
AVSM_2_18 example:
```
- python3 src/python_testing/TC_AVSM_2_18.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1 --int-arg minFrameRate:15 --timeout 100000

- app command: out/linux-x64-camera/chip-camera-app
```

AVSM_2_19 example:
```
- python3 src/python_testing/TC_AVSM_2_19.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1 --int-arg minFrameRate:15 --timeout 100000

- app command: out/linux-x64-camera/chip-camera-app
```

AVSM_2_20 example:
```
- python3 src/python_testing/TC_AVSM_2_20.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1 --int-arg minFrameRate:15 --timeout 100000

- app command: out/linux-x64-camera/chip-camera-app
```