### PR TITLE
Coalesce duplicate DNS-SD discovery results when doing PASE setup.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -33,6 +33,7 @@
 #include <platform/internal/NFCCommissioningManager.h>
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>
+#include <utility>
 #include <vector>
 
 constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS * chip::kMillisecondsPerSecond;
@@ -742,17 +743,34 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonRe
         // If the discovery type does not want the PASE auto retry mechanism, we will just store
         // a single IP. So the discovery process is stopped as it won't be of any help anymore.
         TEMPORARY_RETURN_IGNORED StopDiscoveryOverDNSSD();
-        mDiscoveredParameters.emplace_back(resolutionData, matchedLongDiscriminator, 0);
+        EnqueueDiscoveredParametersIfNotDuplicate(SetUpCodePairerParameters(resolutionData, matchedLongDiscriminator, 0));
     }
     else
     {
         for (size_t i = 0; i < resolutionData.numIPs; i++)
         {
-            mDiscoveredParameters.emplace_back(resolutionData, matchedLongDiscriminator, i);
+            EnqueueDiscoveredParametersIfNotDuplicate(SetUpCodePairerParameters(resolutionData, matchedLongDiscriminator, i));
         }
     }
 
     ConnectToDiscoveredDevice();
+}
+
+void SetUpCodePairer::EnqueueDiscoveredParametersIfNotDuplicate(SetUpCodePairerParameters && params)
+{
+    // The same device can be advertised more than once -- most notably the same non-link-local
+    // address arriving on multiple interfaces -- producing candidates that would drive an identical
+    // PASE attempt. Retrying the same attempt just wastes it and adds latency, so drop duplicates.
+    for (const SetUpCodePairerParameters & existing : mDiscoveredParameters)
+    {
+        if (existing.CanCoalesceWith(params))
+        {
+            ChipLogDetail(Controller, "SetUpCodePairer: dropping duplicate discovered rendezvous parameters");
+            return;
+        }
+    }
+
+    mDiscoveredParameters.emplace_back(std::move(params));
 }
 
 bool SetUpCodePairer::StopPairing(NodeId remoteId)

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -89,6 +89,18 @@ public:
     // this member, if set, is always a long discriminator that was actually advertised by the
     // device represented by our PeerAddress.
     std::optional<uint16_t> mLongDiscriminator = std::nullopt;
+
+    // Whether this discovered candidate would drive the same PASE attempt as `other`, so one of the
+    // two can be dropped.  The comparison is the full RendezvousParameters base (all PASE connection
+    // inputs) plus mLongDiscriminator, which selects which setup payload's passcode we use.  mHostName
+    // and mInterfaceId are discovery bookkeeping, not connection inputs, and are intentionally
+    // excluded: the same non-link-local address advertised on multiple interfaces yields the same
+    // interface-less PeerAddress and identical mLongDiscriminator, and should coalesce to a single
+    // attempt.  Deliberately not operator==, since it does not compare all members.
+    bool CanCoalesceWith(const SetUpCodePairerParameters & other) const
+    {
+        return RendezvousParameters::operator==(other) && mLongDiscriminator == other.mLongDiscriminator;
+    }
 };
 
 enum class SetupCodePairerBehaviour : uint8_t
@@ -233,6 +245,11 @@ private:
 
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::CommonResolutionData & resolutionData,
                                               std::optional<uint16_t> matchedLongDiscriminator);
+
+    // Append newly discovered parameters to mDiscoveredParameters, unless they would drive the same
+    // PASE attempt as something already queued (see SetUpCodePairerParameters::CanCoalesceWith), in
+    // which case they are dropped.
+    void EnqueueDiscoveredParametersIfNotDuplicate(SetUpCodePairerParameters && params);
 
     static void OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, void * context);
 

--- a/src/controller/tests/SetUpCodePairerTestAccess.h
+++ b/src/controller/tests/SetUpCodePairerTestAccess.h
@@ -53,6 +53,14 @@ public:
 
     void ExpectPASEEstablishment() { mPairer->ExpectPASEEstablishment(); }
 
+    void NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData,
+                                              std::optional<uint16_t> matchedLongDiscriminator)
+    {
+        mPairer->NotifyCommissionableDeviceDiscovered(resolutionData, matchedLongDiscriminator);
+    }
+
+    size_t GetDiscoveredParametersCount() const { return mPairer->mDiscoveredParameters.size(); }
+
     void CallOnPairingComplete(CHIP_ERROR error) { mPairer->OnPairingComplete(error, std::nullopt, std::nullopt); }
 
     void FireTimeoutCallback() { Controller::SetUpCodePairer::OnDeviceDiscoveredTimeoutCallback(nullptr, mPairer); }

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -282,8 +282,7 @@ TEST_F(TestSetUpCodePairer, NotifyDiscovered_CoalescesAcrossCallbacks)
     EXPECT_EQ(Access().GetDiscoveredParametersCount(), 1u);
 
     // Different address -> new entry.
-    Access().NotifyCommissionableDeviceDiscovered(MakeResolutionData(ParseIP("2001:db8::2"), MakeInterfaceId(1)),
-                                                  kDiscriminatorA);
+    Access().NotifyCommissionableDeviceDiscovered(MakeResolutionData(ParseIP("2001:db8::2"), MakeInterfaceId(1)), kDiscriminatorA);
     EXPECT_EQ(Access().GetDiscoveredParametersCount(), 2u);
 }
 

--- a/src/controller/tests/TestSetUpCodePairer.cpp
+++ b/src/controller/tests/TestSetUpCodePairer.cpp
@@ -22,7 +22,11 @@
 #include <controller/SetUpCodePairer.h>
 #include <controller/tests/SetUpCodePairerTestAccess.h>
 #include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
 #include <lib/core/CHIPError.h>
+#include <lib/dnssd/Types.h>
+#include <lib/support/CodeUtils.h>
+#include <system/SystemClock.h>
 #include <transport/raw/PeerAddress.h>
 
 #include <memory>
@@ -32,6 +36,35 @@ using namespace chip::Controller;
 using PairerAccess = chip::Testing::SetUpCodePairerTestAccess;
 
 namespace {
+
+constexpr uint16_t kDiscriminatorA = 0xABC;
+constexpr uint16_t kDiscriminatorB = 0xDEF;
+
+Inet::IPAddress ParseIP(const char * str)
+{
+    Inet::IPAddress addr;
+    // The callers pass valid literals; treat a parse failure as a test bug.
+    VerifyOrDie(Inet::IPAddress::FromString(str, addr));
+    return addr;
+}
+
+// InterfaceId::PlatformType is an integer on the host builds these tests run on; cast explicitly so
+// the suite's -Wconversion stays clean regardless of the exact underlying type.
+Inet::InterfaceId MakeInterfaceId(unsigned int id)
+{
+    return Inet::InterfaceId(static_cast<Inet::InterfaceId::PlatformType>(id));
+}
+
+// Build a single-address commissionable-node resolution record for the given address and interface.
+Dnssd::CommonResolutionData MakeResolutionData(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId)
+{
+    Dnssd::CommonResolutionData data;
+    data.interfaceId  = interfaceId;
+    data.numIPs       = 1;
+    data.ipAddress[0] = ip;
+    data.port         = 5540;
+    return data;
+}
 
 // DeviceCommissioner is too large to embed in a test fixture (it exceeds
 // the pw_unit_test light backend's static memory pool).  Heap-allocate it
@@ -160,6 +193,98 @@ TEST_F(TestSetUpCodePairer, SyncPASEFailure_ClearsCurrentPASEParameters)
     // mCurrentPASEParameters must be cleared — stale UDP params must not
     // survive to confuse a later ReconfirmRecord check.
     EXPECT_FALSE(Access().HasCurrentPASEParameters());
+}
+
+// A non-link-local address advertised on two different interfaces resolves to the same
+// interface-less PeerAddress (we rely on the routing table, not the discovery interface), so the
+// two candidates must be treated as coalescible.
+TEST_F(TestSetUpCodePairer, CanCoalesce_NonLinkLocalSameAddressDifferentInterfaces)
+{
+    const Inet::IPAddress global = ParseIP("2001:db8::1");
+    SetUpCodePairerParameters a(MakeResolutionData(global, MakeInterfaceId(1)), kDiscriminatorA, 0);
+    SetUpCodePairerParameters b(MakeResolutionData(global, MakeInterfaceId(2)), kDiscriminatorA, 0);
+    EXPECT_TRUE(a.CanCoalesceWith(b));
+}
+
+// A link-local address keeps its interface in the PeerAddress, so the same address on two
+// interfaces is two genuinely distinct destinations and must not coalesce.
+TEST_F(TestSetUpCodePairer, CannotCoalesce_LinkLocalSameAddressDifferentInterfaces)
+{
+    const Inet::IPAddress lla = ParseIP("fe80::1");
+    SetUpCodePairerParameters a(MakeResolutionData(lla, MakeInterfaceId(1)), kDiscriminatorA, 0);
+    SetUpCodePairerParameters b(MakeResolutionData(lla, MakeInterfaceId(2)), kDiscriminatorA, 0);
+    EXPECT_FALSE(a.CanCoalesceWith(b));
+}
+
+// The long discriminator selects which setup payload's passcode we use, so candidates that share a
+// PeerAddress but carry different discriminators must not coalesce.
+TEST_F(TestSetUpCodePairer, CannotCoalesce_DifferentLongDiscriminator)
+{
+    const Inet::IPAddress global = ParseIP("2001:db8::1");
+    SetUpCodePairerParameters a(MakeResolutionData(global, Inet::InterfaceId::Null()), kDiscriminatorA, 0);
+    SetUpCodePairerParameters b(MakeResolutionData(global, Inet::InterfaceId::Null()), kDiscriminatorB, 0);
+    EXPECT_FALSE(a.CanCoalesceWith(b));
+}
+
+// MRP configuration is a PASE connection input; candidates that differ only in their MRP intervals
+// must not coalesce.
+TEST_F(TestSetUpCodePairer, CannotCoalesce_DifferentMRPConfig)
+{
+    const Inet::IPAddress global = ParseIP("2001:db8::1");
+    auto dataA                   = MakeResolutionData(global, Inet::InterfaceId::Null());
+    dataA.mrpRetryIntervalIdle   = System::Clock::Milliseconds32(1000);
+    auto dataB                   = MakeResolutionData(global, Inet::InterfaceId::Null());
+    dataB.mrpRetryIntervalIdle   = System::Clock::Milliseconds32(2000);
+    SetUpCodePairerParameters a(dataA, kDiscriminatorA, 0);
+    SetUpCodePairerParameters b(dataB, kDiscriminatorA, 0);
+    EXPECT_FALSE(a.CanCoalesceWith(b));
+}
+
+// Different IP addresses are different destinations and must not coalesce.
+TEST_F(TestSetUpCodePairer, CannotCoalesce_DifferentAddress)
+{
+    SetUpCodePairerParameters a(MakeResolutionData(ParseIP("2001:db8::1"), Inet::InterfaceId::Null()), kDiscriminatorA, 0);
+    SetUpCodePairerParameters b(MakeResolutionData(ParseIP("2001:db8::2"), Inet::InterfaceId::Null()), kDiscriminatorA, 0);
+    EXPECT_FALSE(a.CanCoalesceWith(b));
+}
+
+// NotifyCommissionableDeviceDiscovered must drop a duplicate address within a single advertisement
+// (the same non-link-local IP listed twice) instead of queuing a redundant PASE attempt.  Waiting
+// for PASE is asserted so ConnectToDiscoveredDevice does not drain the queue before we inspect it.
+TEST_F(TestSetUpCodePairer, NotifyDiscovered_DropsDuplicateAddressesInOneRecord)
+{
+    Access().SetRemoteId(1);
+    Access().SetWaitingForPASE(true);
+
+    const Inet::IPAddress global = ParseIP("2001:db8::1");
+    auto data                    = MakeResolutionData(global, Inet::InterfaceId::Null());
+    data.numIPs                  = 2;
+    data.ipAddress[0]            = global;
+    data.ipAddress[1]            = global; // same address advertised twice
+
+    Access().NotifyCommissionableDeviceDiscovered(data, kDiscriminatorA);
+    EXPECT_EQ(Access().GetDiscoveredParametersCount(), 1u);
+}
+
+// The same non-link-local device rediscovered on a second interface must not add a second identical
+// queue entry, but a genuinely different address must.
+TEST_F(TestSetUpCodePairer, NotifyDiscovered_CoalescesAcrossCallbacks)
+{
+    Access().SetRemoteId(1);
+    Access().SetWaitingForPASE(true);
+
+    const Inet::IPAddress global = ParseIP("2001:db8::1");
+    Access().NotifyCommissionableDeviceDiscovered(MakeResolutionData(global, MakeInterfaceId(1)), kDiscriminatorA);
+    EXPECT_EQ(Access().GetDiscoveredParametersCount(), 1u);
+
+    // Same non-link-local address, different interface -> coalesces.
+    Access().NotifyCommissionableDeviceDiscovered(MakeResolutionData(global, MakeInterfaceId(2)), kDiscriminatorA);
+    EXPECT_EQ(Access().GetDiscoveredParametersCount(), 1u);
+
+    // Different address -> new entry.
+    Access().NotifyCommissionableDeviceDiscovered(MakeResolutionData(ParseIP("2001:db8::2"), MakeInterfaceId(1)),
+                                                  kDiscriminatorA);
+    EXPECT_EQ(Access().GetDiscoveredParametersCount(), 2u);
 }
 
 } // namespace

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -164,6 +164,23 @@ public:
         return *this;
     }
 
+    // Value equality over every member: they are all inputs to the rendezvous/PASE attempt, so two
+    // sets of parameters are interchangeable only if all of them match.
+    bool operator==(const RendezvousParameters & other) const
+    {
+        return mPeerAddress == other.mPeerAddress &&            //
+            mSetupPINCode == other.mSetupPINCode &&             //
+            mSetupDiscriminator == other.mSetupDiscriminator && //
+            mMRPConfig == other.mMRPConfig
+#if CONFIG_NETWORK_LAYER_BLE
+            && mBleLayer == other.mBleLayer &&                  //
+            mConnectionObject == other.mConnectionObject &&     //
+            mDiscoveredObject == other.mDiscoveredObject
+#endif // CONFIG_NETWORK_LAYER_BLE
+            ;
+    }
+    bool operator!=(const RendezvousParameters & other) const { return !(*this == other); }
+
 private:
     Transport::PeerAddress mPeerAddress; ///< the peer node address
     uint32_t mSetupPINCode = 0;          ///< the target peripheral setup PIN Code

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -173,8 +173,8 @@ public:
             mSetupDiscriminator == other.mSetupDiscriminator && //
             mMRPConfig == other.mMRPConfig
 #if CONFIG_NETWORK_LAYER_BLE
-            && mBleLayer == other.mBleLayer &&                  //
-            mConnectionObject == other.mConnectionObject &&     //
+            && mBleLayer == other.mBleLayer &&              //
+            mConnectionObject == other.mConnectionObject && //
             mDiscoveredObject == other.mDiscoveredObject
 #endif // CONFIG_NETWORK_LAYER_BLE
             ;


### PR DESCRIPTION
We already coalesce duplicates in CASE setup, but for PASE we just tried them multiple times.

### Summary

Stop trying the same IP/port multiple times when we do PASE just because we got multiple DNS-SD results (e.g. on different interfaces) with that information.

### Testing

Ran the unit tests, plus some manual testing of commissioning.