### PR TITLE
[Zephyr] Minor fixes for LLVM support

### DIFF
--- a/config/zephyr/zephyr-util.cmake
+++ b/config/zephyr/zephyr-util.cmake
@@ -36,9 +36,9 @@ function(zephyr_get_compile_flags VAR LANG)
     zephyr_get_compile_options_for_lang_as_string(${LANG} FLAGS)
 
     if("${LANG}" STREQUAL "CXX" AND CMAKE_CXX_COMPILER_TARGET)
-        list(APPEND FLAGS --target=${CMAKE_CXX_COMPILER_TARGET})
+        string(APPEND FLAGS " --target=${CMAKE_CXX_COMPILER_TARGET}")
     elseif(CMAKE_C_COMPILER_TARGET)
-        list(APPEND FLAGS --target=${CMAKE_C_COMPILER_TARGET})
+        string(APPEND FLAGS " --target=${CMAKE_C_COMPILER_TARGET}")
     endif()
 
     set(${VAR} ${INCLUDES} ${SYSTEM_INCLUDES} ${DEFINES} ${FLAGS} ${${VAR}} PARENT_SCOPE)

--- a/config/zephyr/zephyr-util.cmake
+++ b/config/zephyr/zephyr-util.cmake
@@ -34,6 +34,13 @@ function(zephyr_get_compile_flags VAR LANG)
     zephyr_get_system_include_directories_for_lang_as_string(${LANG} SYSTEM_INCLUDES)
     zephyr_get_compile_definitions_for_lang_as_string(${LANG} DEFINES)
     zephyr_get_compile_options_for_lang_as_string(${LANG} FLAGS)
+
+    if("${LANG}" STREQUAL "CXX" AND CMAKE_CXX_COMPILER_TARGET)
+        list(APPEND FLAGS --target=${CMAKE_CXX_COMPILER_TARGET})
+    elseif(CMAKE_C_COMPILER_TARGET)
+        list(APPEND FLAGS --target=${CMAKE_C_COMPILER_TARGET})
+    endif()
+
     set(${VAR} ${INCLUDES} ${SYSTEM_INCLUDES} ${DEFINES} ${FLAGS} ${${VAR}} PARENT_SCOPE)
 endfunction()
 

--- a/src/lib/shell/streamer_zephyr.cpp
+++ b/src/lib/shell/streamer_zephyr.cpp
@@ -51,7 +51,7 @@ ssize_t streamer_zephyr_write(streamer_t * streamer, const char * buffer, size_t
     if (sShellInstance)
         shell_fprintf(sShellInstance, SHELL_NORMAL, "%.*s", length, buffer);
 
-    return length;
+    return static_cast<ssize_t>(length);
 }
 
 streamer_t sStreamer = {

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -75,7 +75,7 @@ private:
 
     // ===== Members that implement virtual methods on BleApplicationDelegate.
 
-    void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId);
+    void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) override;
     void CheckNonConcurrentBleClosing() override;
 
     // ===== Private members reserved for use by this class only.

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
@@ -204,7 +204,7 @@ void LoadOneAndVerifyResult(const char * fullkey, void * dest_buf, size_t dest_s
         *result = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 
-    *readSize = (bytesRead > 0) ? bytesRead : 0;
+    *readSize = (bytesRead > 0) ? static_cast<size_t>(bytesRead) : 0;
 
     return;
 }

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -61,6 +61,9 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     // help, apparently.  Just turn off that warning around this switch.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
     switch (category)
     {
     case kLogCategory_Error:

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -115,7 +115,7 @@ int ConfigValueCallback(const char * name, size_t configSize, settings_read_cb r
     // Found requested key
     const ssize_t bytesRead = readCb(cbArg, request.destination, request.bufferSize);
     request.result          = bytesRead > 0 ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    request.configSize      = bytesRead > 0 ? bytesRead : 0;
+    request.configSize      = bytesRead > 0 ? static_cast<size_t>(bytesRead) : 0;
 
     // Return 1 to stop processing further keys
     return 1;
@@ -288,7 +288,7 @@ void ZephyrConfig::RunConfigUnitTest()
     ::chip::DeviceLayer::Internal::RunConfigUnitTest<ZephyrConfig>();
 }
 
-bool ZephyrConfig::BuildCounterConfigKey(::chip::Platform::PersistedStorage::Key counterId, char key[SETTINGS_MAX_NAME_LEN])
+bool ZephyrConfig::BuildCounterConfigKey(::chip::Platform::PersistedStorage::Key counterId, char key[])
 {
     constexpr size_t KEY_PREFIX_LEN = sizeof(NAMESPACE_COUNTERS) - 1;
     const size_t keySuffixLen       = strlen(counterId) + 1; // including null-character


### PR DESCRIPTION
### Summary

Zephyr common code changes to have a successful LLVM build. Other changes were required on the Silabs side (PR WIP), but these are the common code changes required to get it working.

### Related issues

N/A

### Testing

Compiled successfully and ran on brd4187c using `ZEPHYR_TOOLCHAIN_VARIANT=zephyr/llvm` (with other Silabs specific changes)
Confirmed still compiles and runs using GCC on brd4187c `ZEPHYR_TOOLCHAIN_VARIANT=zephyr` (SDK 1.0.1)
