### PR TITLE
[Tests] Kill all subprocesses in Executor cleanup

### DIFF
--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -148,9 +148,18 @@ class Executor(contextlib.ExitStack):
         cmd = subproc.to_cmd()
         name = TerminablePopen.__class__.__name__ + (f"({cmd[0]})" if cmd else "")
 
+        # Run each subprocess in a new session, so that TerminablePopen can tear down the whole process group it leads. Wrappers
+        # like chipyaml/chiptool.py spawn servers of their own, which would otherwise be reparented to init and outlive the test.
+        #
+        # A new session, rather than just a new process group (`process_group=0`), because the subprocess would otherwise become a
+        # background group of our controlling terminal. Apps built with the CHIP shell (chip-tv-app) call tcsetattr() on stdin
+        # during startup, which the kernel answers with SIGTTOU for a background group, stopping the app before it ever reaches its
+        # event loop. A session leader has no controlling terminal, so the call is allowed. setsid() also makes the process a group
+        # leader, so the teardown story is unchanged.
+        #
         # Seems like LogPipe has all what Popen needs to perceive it as stdout/stderr, but mypy doesn't think the same.
         terminable_process: TerminablePopen[bytes] = TerminablePopen(
-            lambda: subprocess.Popen(cmd, stdin=stdin,
+            lambda: subprocess.Popen(cmd, start_new_session=True, stdin=stdin,
                                      stdout=stdout, stderr=stderr),  # type: ignore[arg-type]
             name, terminate_debug_logging=False)
         return self.enter_context(terminable_process)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/concurrency/context.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/concurrency/context.py
@@ -14,6 +14,8 @@
 
 import contextlib
 import logging
+import os
+import signal
 import subprocess
 import threading
 from abc import abstractmethod
@@ -152,6 +154,36 @@ class TerminablePopen(TerminableResourceBase[subprocess.Popen[PopenT]]):
         self._process = self._create_popen()
         return self._process
 
+    @staticmethod
+    def _signal_process_group(process: subprocess.Popen[PopenT], sig: signal.Signals) -> None:
+        """
+        Signal the process group led by `process`, or just the process itself if it does not lead one.
+
+        A subprocess started as its own group leader (`start_new_session=True` or `process_group=0` in Popen) may have spawned
+        children of its own. Signalling only the process itself leaves those children reparented to init, outliving the harness.
+        Processes that were not started in their own group are signalled individually, since signalling their group would hit the
+        harness as well.
+
+        As in Popen.send_signal(), never signal a process already known to have exited: its pid may have been recycled, and for the
+        group case that would mean signalling an unrelated process group.
+        """
+        if process.poll() is not None:
+            return
+
+        try:
+            leads_group = os.getpgid(process.pid) == process.pid
+        except OSError:
+            # The process is gone already. Leave the race handling to send_signal().
+            leads_group = False
+
+        if not leads_group:
+            process.send_signal(sig)
+            return
+
+        with contextlib.suppress(ProcessLookupError):
+            # Same race as above, now between the check and the call. Any other error is a real failure to signal.
+            os.killpg(process.pid, sig)
+
     def resource_terminate(self) -> None:
         if self._process is None:
             return
@@ -165,7 +197,7 @@ class TerminablePopen(TerminableResourceBase[subprocess.Popen[PopenT]]):
             # SIGTERM
             log.debug('Terminating leftover process "%s"', cmd)
             try:
-                self._process.terminate()
+                self._signal_process_group(self._process, signal.SIGTERM)
             except OSError:
                 # Can occur in case of race condition when process exits between poll and terminate.
                 return
@@ -176,7 +208,7 @@ class TerminablePopen(TerminableResourceBase[subprocess.Popen[PopenT]]):
             # SIGKILL
             log.warning('Failed to terminate the process "%s". Killing instead', cmd)
             try:
-                self._process.kill()
+                self._signal_process_group(self._process, signal.SIGKILL)
             except OSError:
                 return
             with contextlib.suppress(subprocess.TimeoutExpired):


### PR DESCRIPTION
### Summary

Run each subprocess in a new session, so that `TerminablePopen` can tear down the whole process group it leads. Wrappers like `chipyaml/chiptool.py` spawn servers of their own, which would otherwise be reparented to init and outlive the test.

We need to use a new session, rather than just a new process group (`process_group=0`), because the subprocess would otherwise become a background group of our controlling terminal. Apps built with the CHIP shell (`chip-tv-app`) call `tcsetattr()` on stdin during startup, which the kernel answers with `SIGTTOU` for a background group, stopping the app before it ever reaches its
event loop. A session leader has no controlling terminal, so the call is allowed. `setsid()` also makes the process a group leader, so the teardown story is unchanged.

In the teardown we check if the process is a group leader, and execute `os.killpg()` on it to terminate/kill all subprocesses so that no orphaned processes are left.

### Related issues

Discovered while testing concurrent test behaviour.

### Testing

Multiple local tests with `run_test_suite.py` with SIGINT in different places.