### PR TITLE
[Camera] Ensure ICE candidates are sent by the Camera App once gathered

### DIFF
--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -60,6 +60,7 @@ using OnLocalDescriptionCallback = std::function<void(const std::string & sdp, S
 using OnICECandidateCallback     = std::function<void(const ICECandidateInfo & candidateInfo)>;
 using OnConnectionStateCallback  = std::function<void(bool connected)>;
 using OnTrackCallback            = std::function<void(std::shared_ptr<WebRTCTrack> track)>;
+using OnGatheringStateCallback   = std::function<void(bool getheringComplete)>;
 
 // Abstract track interface
 class WebRTCTrack
@@ -80,7 +81,8 @@ public:
     virtual ~WebRTCPeerConnection() = default;
 
     virtual void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
-                              OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack)              = 0;
+                              OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack,
+                              OnGatheringStateCallback onGatheringstate)              = 0;
     virtual void Close()                                                                                         = 0;
     virtual void CreateOffer()                                                                                   = 0;
     virtual void CreateAnswer()                                                                                  = 0;

--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -82,7 +82,7 @@ public:
 
     virtual void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
                               OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack,
-                              OnGatheringStateCallback onGatheringstate)              = 0;
+                              OnGatheringStateCallback onGatheringstate)                                         = 0;
     virtual void Close()                                                                                         = 0;
     virtual void CreateOffer()                                                                                   = 0;
     virtual void CreateAnswer()                                                                                  = 0;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -29,7 +29,7 @@
 
 using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
 using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
-using OnTransportGatheringStateCallback   = std::function<void(bool onGatheringComplete, const int16_t sessionId)>; 
+using OnTransportGatheringStateCallback   = std::function<void(bool onGatheringComplete, const int16_t sessionId)>;
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
@@ -69,7 +69,7 @@ public:
     ~WebrtcTransport();
 
     void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState,
-                        OnTransportGatheringStateCallback onGatheringState);
+                      OnTransportGatheringStateCallback onGatheringState);
 
     void MoveToState(const State targetState);
     const char * GetStateStr() const;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -29,6 +29,7 @@
 
 using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
 using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
+using OnTransportGatheringStateCallback   = std::function<void(bool onGatheringComplete, const int16_t sessionId)>; 
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
@@ -67,7 +68,8 @@ public:
 
     ~WebrtcTransport();
 
-    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState);
+    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState,
+                        OnTransportGatheringStateCallback onGatheringState);
 
     void MoveToState(const State targetState);
     const char * GetStateStr() const;
@@ -127,6 +129,7 @@ public:
     void OnICECandidate(const ICECandidateInfo & candidateInfo);
     void OnConnectionStateChanged(bool connected);
     void OnTrack(std::shared_ptr<WebRTCTrack> track);
+    void OnGatheringStateChanged(bool gatheringComplete);
 
     void SetRequestArgs(const RequestArgs & args);
     RequestArgs & GetRequestArgs();
@@ -148,6 +151,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+    OnTransportConnectionStateCallback mOnGatheringState    = nullptr;
     std::vector<ICEServerInfo> mICEServers;
 
     std::mutex mTrackStatusLock;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -1045,7 +1045,7 @@ void WebRTCProviderManager::CleanupSession(uint16_t sessionId)
 
     // Remove from session maps
     mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
-
+    
     // Finally, remove and destroy the transport
     mWebrtcTransportMap.erase(sessionId);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -1045,7 +1045,7 @@ void WebRTCProviderManager::CleanupSession(uint16_t sessionId)
 
     // Remove from session maps
     mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
-    
+
     // Finally, remove and destroy the transport
     mWebrtcTransportMap.erase(sessionId);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -238,7 +238,8 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
             [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
                 this->OnLocalDescription(sdp, type, sessionId);
             },
-            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); },
+            [](bool gatheringComplete, const uint16_t sessionId) {});
     }
 
     transport->SetRequestArgs(requestArgs);
@@ -464,7 +465,17 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
             [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
                 this->OnLocalDescription(sdp, type, sessionId);
             },
-            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); },
+            [this](bool gatheringComplete, const uint16_t sessionId) {
+                if (gatheringComplete)
+                {
+                    if (WebrtcTransport * transport = this->GetTransport(sessionId))
+                    {
+                        transport->MoveToState(WebrtcTransport::State::SendingICECandidates);
+                        this->ScheduleICECandidatesSend(sessionId);
+                    }
+                }
+            });
     }
 
     // Check resource availability before proceeding

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -298,7 +298,8 @@ public:
     }
 
     void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
-                      OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack) override
+                      OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack,
+                      OnGatheringStateCallback onGatheringState) override
     {
         mPeerConnection->onLocalDescription([onLocalDescription, onICECandidate](rtc::Description desc) {
             // First, notify about the local description
@@ -348,8 +349,13 @@ public:
             }
         });
 
-        mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
+        mPeerConnection->onGatheringStateChange([onGatheringState](rtc::PeerConnection::GatheringState state) {
             ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
+            if (onGatheringState)
+            {
+                bool complete = (state == rtc::PeerConnection::GatheringState::Complete);
+                onGatheringState(complete);
+            }
         });
 
         mPeerConnection->onTrack(

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -51,10 +51,12 @@ WebrtcTransport::~WebrtcTransport()
 }
 
 void WebrtcTransport::SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription,
-                                   OnTransportConnectionStateCallback onConnectionState)
+                                   OnTransportConnectionStateCallback onConnectionState,
+                                   OnTransportGatheringStateCallback onGatheringState)
 {
     mOnLocalDescription = onLocalDescription;
     mOnConnectionState  = onConnectionState;
+    mOnGatheringState   = onGatheringState;
 }
 
 void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
@@ -205,7 +207,13 @@ void WebrtcTransport::Start()
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },
                                   [this](bool connected) { this->OnConnectionStateChanged(connected); },
-                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); });
+                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); },
+                                  [this](bool gatheringComplete) {
+                                    if (mOnGatheringState)
+                                    {
+                                        mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
+                                    }
+                                  });
 }
 
 void WebrtcTransport::Stop()
@@ -218,6 +226,16 @@ void WebrtcTransport::Stop()
 
     mLocalVideoTrack = nullptr;
     mLocalAudioTrack = nullptr;
+}
+
+void WebrtcTransport::OnGatheringStateChanged(bool gatheringComplete) 
+{
+    ChipLogProgress(Camera, "OnGatheringStateChanged for sessionId %u, complete %d", mRequestArgs.sessionId,
+                                static_cast<int>(gatheringComplete));
+    if (gatheringComplete && mOnGatheringState)
+    {
+        mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
+    }
 }
 
 void WebrtcTransport::AddVideoTrack(const std::string & videoMid, int payloadType)

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -208,12 +208,7 @@ void WebrtcTransport::Start()
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },
                                   [this](bool connected) { this->OnConnectionStateChanged(connected); },
                                   [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); },
-                                  [this](bool gatheringComplete) {
-                                      if (mOnGatheringState)
-                                      {
-                                          mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
-                                      }
-                                  });
+                                  [this](bool gatheringComplete) { this->OnGatheringStateChanged(gatheringComplete); });
 }
 
 void WebrtcTransport::Stop()

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -209,10 +209,10 @@ void WebrtcTransport::Start()
                                   [this](bool connected) { this->OnConnectionStateChanged(connected); },
                                   [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); },
                                   [this](bool gatheringComplete) {
-                                    if (mOnGatheringState)
-                                    {
-                                        mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
-                                    }
+                                      if (mOnGatheringState)
+                                      {
+                                          mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
+                                      }
                                   });
 }
 
@@ -228,10 +228,10 @@ void WebrtcTransport::Stop()
     mLocalAudioTrack = nullptr;
 }
 
-void WebrtcTransport::OnGatheringStateChanged(bool gatheringComplete) 
+void WebrtcTransport::OnGatheringStateChanged(bool gatheringComplete)
 {
     ChipLogProgress(Camera, "OnGatheringStateChanged for sessionId %u, complete %d", mRequestArgs.sessionId,
-                                static_cast<int>(gatheringComplete));
+                    static_cast<int>(gatheringComplete));
     if (gatheringComplete && mOnGatheringState)
     {
         mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);


### PR DESCRIPTION
### Summary

If the offer SDP in a ProvideOffer contains ICE candidates, the camera app will never provide its own candidates (even though they have been gathered), unless explicitly triggered via a ProvideICECandidates from the controller (which results in an ICECandidates being sent).  

This PR ensures that gathered candidates are always sent by the camera app post Answer. 

### Related issues

Fixes #41660 

### Testing

Create a local version of WebRTC_1_7, modify that to send an offer with ICE candidates. Ensure that the answer does not, but the ICE candidates are sent on gathering being completed.  Re-run regular WebRTC_1_7 to make sure no regression. 
