### PR TITLE
[Tests] Clean additional config paths on factory reset

### DIFF
--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -81,7 +81,7 @@ class LinuxWorkerProcess(WorkerProcess):
         tmp_dir = self._config.tmp_dir_worker_base / str(self._config.id)
 
         if self._config.tmp_dir_clear:
-            shutil.rmtree(tmp_dir)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
         tmp_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -81,7 +81,8 @@ class LinuxWorkerProcess(WorkerProcess):
         tmp_dir = self._config.tmp_dir_worker_base / str(self._config.id)
 
         if self._config.tmp_dir_clear:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+            with contextlib.suppress(FileNotFoundError):
+                shutil.rmtree(tmp_dir)
 
         tmp_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import logging
-import os
 import shlex
 import shutil
 import subprocess

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -45,13 +45,11 @@ TEST_PASSCODE = '20202021'
 TEST_SETUP_QR_CODE = 'MT:-24J042C00KA0648G00'
 TEST_THREAD_DATASET = '0e08000000000001000000030000104a0300001635060004001fffe0020884fa18779329ac770708fd269658e44aa21a030f4f70656e5468726561642d32386335010228c50c0402a0f7f8051000112233445566778899aabbccddeeff041000112233445566778899aabbccddeeff'
 
+# The Linux platform persists device configuration under these fixed paths (see src/platform/Linux/CHIPLinuxStorage.h). They are not
+# covered by --KVS, so they have to be removed explicitly on a factory reset. Otherwise an application inherits the vendor and
+# product ID persisted by whichever application booted first in the worker's /tmp, which makes tests using a hardcoded setup payload
+# fail with a product ID mismatch.
 PERSISTENT_CONFIG_PATHS = frozenset({'/tmp/chip_factory.ini', '/tmp/chip_config.ini', '/tmp/chip_counters.ini'})
-"""
-The Linux platform persists device configuration under these fixed paths (see src/platform/Linux/CHIPLinuxStorage.h). They are not
-covered by --KVS, so they have to be removed explicitly on a factory reset. Otherwise an application inherits the vendor and product
-ID persisted by whichever application booted first in the worker's /tmp, which makes tests using a hardcoded setup payload fail with
-a product ID mismatch.
-"""
 
 
 class App:

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -46,6 +46,14 @@ TEST_PASSCODE = '20202021'
 TEST_SETUP_QR_CODE = 'MT:-24J042C00KA0648G00'
 TEST_THREAD_DATASET = '0e08000000000001000000030000104a0300001635060004001fffe0020884fa18779329ac770708fd269658e44aa21a030f4f70656e5468726561642d32386335010228c50c0402a0f7f8051000112233445566778899aabbccddeeff041000112233445566778899aabbccddeeff'
 
+PERSISTENT_CONFIG_PATHS = frozenset({'/tmp/chip_factory.ini', '/tmp/chip_config.ini', '/tmp/chip_counters.ini'})
+"""
+The Linux platform persists device configuration under these fixed paths (see src/platform/Linux/CHIPLinuxStorage.h). They are not
+covered by --KVS, so they have to be removed explicitly on a factory reset. Otherwise an application inherits the vendor and product
+ID persisted by whichever application booted first in the worker's /tmp, which makes tests using a hardcoded setup payload fail with
+a product ID mismatch.
+"""
+
 
 class App:
     def __init__(self, runner: Runner, subproc: SubprocessInfo):
@@ -104,9 +112,8 @@ class App:
     def factoryReset(self) -> bool:
         wasRunning = (not self.killed) and self.stop()
 
-        for kvs in self.kvsPathSet:
-            if os.path.exists(kvs):
-                os.unlink(kvs)
+        for path in self.kvsPathSet | PERSISTENT_CONFIG_PATHS:
+            Path(path).unlink(missing_ok=True)
 
         if wasRunning:
             return self.start()


### PR DESCRIPTION
### Summary

The Linux platform persists device configuration under some fixed paths (see src/platform/Linux/CHIPLinuxStorage.h). They are not covered by `--KVS`, so they have to be removed explicitly on a factory reset. Otherwise an application inherits the vendor and product ID persisted by whichever application booted first in the worker's `/tmp`, which makes tests using a hardcoded setup payload fail with a product ID mismatch.

This fix will reduce flakyness of the test suite.

In addition, fix `/tmp` cleanup on Linux when `--clear-worker-state` is used and there is no previous state from earlier runs.

### Related issues

Uncovered while testing concurrent tests in some specific test order configurations.

### Testing

Extensive testing using WIP concurrent testing branch (`MarekPikula/test-pool`).
