### PR TITLE
Fix miniaudio GCC compilation by defining __has_feature fallback

### DIFF
--- a/third_party/miniaudio/miniaudio.cpp
+++ b/third_party/miniaudio/miniaudio.cpp
@@ -31,7 +31,11 @@
 // "don't dlclose anything when testing under asan/lsan", we stub dlclose() to a no-op when
 // compiling under AddressSanitizer. This keeps the dynamic libraries mapped in memory at process
 // exit, enabling LSan to scan their static data sections and correctly recognize allocations as reachable.
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
 #include <dlfcn.h>
 static inline int dummy_dlclose(void * handle)
 {


### PR DESCRIPTION
#### Summary

Fixes a compilation blocker when building with GCC due to Clang-specific `__has_feature` builtin usage in miniaudio wrapper.

##### Problem

- `third_party/miniaudio/miniaudio.cpp` uses `__has_feature(address_sanitizer)` to detect AddressSanitizer.
- `__has_feature` is a Clang-specific builtin macro and is not defined in GCC.
- When compiling with GCC, the preprocessor fails to parse the expression `(defined(__has_feature) && __has_feature(address_sanitizer))` because `__has_feature` expands to a syntax error, resulting in:
  `error: missing binary operator before token "("`

##### Solution

- Defined a fallback macro `#define __has_feature(x) 0` when `__has_feature` is not defined (which is the case for GCC).
- Simplified the preprocessor check to `#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)`.

#### Testing

- Verified that `linux-x64-all-devices` (built with GCC) now compiles successfully.
- Verified that `linux-x64-all-devices-clang` (built with Clang) continues to compile successfully.
