### PR TITLE
[Silabs] : Remove redundant includes

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AirQualitySensorUI.h
+++ b/examples/air-quality-sensor-app/silabs/include/AirQualitySensorUI.h
@@ -21,7 +21,6 @@
 #include "demo-ui-bitmaps.h"
 #include "dmd.h"
 #include "glib.h"
-#include "lcd.h"
 
 class AirQualitySensorUI
 {

--- a/examples/air-quality-sensor-app/silabs/src/AirQualitySensorUI.cpp
+++ b/examples/air-quality-sensor-app/silabs/src/AirQualitySensorUI.cpp
@@ -26,7 +26,6 @@
 #include <air-quality-sensor-manager.h>
 #if SL_MATTER_DISPLAY_ENABLED
 #include "glib.h"
-#include "lcd.h"
 #endif // SL_MATTER_DISPLAY_ENABLED
 
 using namespace chip::app::Clusters;

--- a/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
+++ b/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
@@ -29,10 +29,6 @@
 
 #if SL_MATTER_DISPLAY_ENABLED
 #include "AirQualitySensorUI.h"
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
 #endif // SL_MATTER_DISPLAY_ENABLED
 
 #include <AirQualityConfig.h>

--- a/examples/chef/silabs/src/AppTask.cpp
+++ b/examples/chef/silabs/src/AppTask.cpp
@@ -23,13 +23,6 @@
 
 #include "LEDWidget.h"
 
-#if SL_MATTER_DISPLAY_ENABLED
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
-#endif // SL_MATTER_DISPLAY_ENABLED
-
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>

--- a/examples/closure-app/silabs/include/ClosureUI.h
+++ b/examples/closure-app/silabs/include/ClosureUI.h
@@ -20,7 +20,6 @@
 
 #include "ClosureUIStrings.h"
 #include "glib.h"
-#include "lcd.h"
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/closure-control-server/ClosureControlClusterObjects.h>
 #include <app/data-model/Nullable.h>

--- a/examples/closure-app/silabs/src/AppTask.cpp
+++ b/examples/closure-app/silabs/src/AppTask.cpp
@@ -25,10 +25,6 @@
 #if SL_MATTER_DISPLAY_ENABLED
 #include "ClosureUI.h"
 #include "ClosureUIStrings.h"
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
 #endif // SL_MATTER_DISPLAY_ENABLED
 
 #include <ClosureManager.h>

--- a/examples/closure-app/silabs/src/ClosureUI.cpp
+++ b/examples/closure-app/silabs/src/ClosureUI.cpp
@@ -24,7 +24,6 @@
 #include "demo-ui-bitmaps.h"
 #include "dmd.h"
 #include "glib.h"
-#include "lcd.h"
 
 // Only needed for wifi NCP devices
 #if defined(SL_WIFI) && SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -31,13 +31,6 @@
 #include "ShellCommands.h"
 #endif // defined(ENABLE_CHIP_SHELL)
 
-#if SL_MATTER_DISPLAY_ENABLED
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
-#endif // SL_MATTER_DISPLAY_ENABLED
-
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>

--- a/examples/lit-icd-app/silabs/src/AppTask.cpp
+++ b/examples/lit-icd-app/silabs/src/AppTask.cpp
@@ -26,13 +26,6 @@
 
 #include "LEDWidget.h"
 
-#if SL_MATTER_DISPLAY_ENABLED
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
-#endif // SL_MATTER_DISPLAY_ENABLED
-
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/server/Server.h>

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -32,13 +32,6 @@
 
 #include "LEDWidget.h"
 
-#if SL_MATTER_DISPLAY_ENABLED
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
-#endif // SL_MATTER_DISPLAY_ENABLED
-
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>

--- a/examples/refrigerator-app/silabs/include/RefrigeratorUI.h
+++ b/examples/refrigerator-app/silabs/include/RefrigeratorUI.h
@@ -20,7 +20,6 @@
 
 #include "RefrigeratorIcons.h"
 #include "glib.h"
-#include "lcd.h"
 
 class RefrigeratorUI
 {

--- a/examples/refrigerator-app/silabs/src/AppTask.cpp
+++ b/examples/refrigerator-app/silabs/src/AppTask.cpp
@@ -28,10 +28,6 @@
 
 #if SL_MATTER_DISPLAY_ENABLED
 #include "RefrigeratorUI.h"
-#include "lcd.h"
-#if SL_MATTER_QR_CODE_ENABLED
-#include "qrcodegen.h"
-#endif // SL_MATTER_QR_CODE_ENABLED
 #endif // SL_MATTER_DISPLAY_ENABLED
 
 #if defined(ENABLE_CHIP_SHELL)

--- a/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
+++ b/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
@@ -23,7 +23,6 @@
 #include "demo-ui-bitmaps.h"
 #include "dmd.h"
 #include "glib.h"
-#include "lcd.h"
 #include <lib/support/logging/CHIPLogging.h>
 
 // Only needed for wifi NCP devices

--- a/examples/thermostat/silabs/include/ThermostatUI.h
+++ b/examples/thermostat/silabs/include/ThermostatUI.h
@@ -20,7 +20,6 @@
 
 #include "ThermostatIcons.h"
 #include "glib.h"
-#include "lcd.h"
 
 class ThermostatUI
 {

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -25,7 +25,6 @@
 
 #if SL_MATTER_DISPLAY_ENABLED
 #include "ThermostatUI.h"
-#include "lcd.h"
 #endif // SL_MATTER_DISPLAY_ENABLED
 
 #include <app-common/zap-generated/attributes/Accessors.h>

--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -23,7 +23,6 @@
 #include "demo-ui-bitmaps.h"
 #include "dmd.h"
 #include "glib.h"
-#include "lcd.h"
 
 // Only needed for wifi NCP devices
 #if defined(SL_WIFI) && SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)


### PR DESCRIPTION
### Summary

#include "qrcodegen.h" & #include "lcd.h" are repeated acrodd all sample app, we already get it from BaseApplication https://github.com/project-chip/connectedhomeip/blob/master/examples/platform/silabs/BaseApplication.h#L45 ,

Removing redundant includes


### Related issues

N/A

### Testing

CI
