### PR TITLE
Enable Connman as Concrete Linux Platform Connectivity Management Network Management Implementation

### DIFF
--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -29,6 +29,7 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
 
 chip_enable_additional_data_advertising = true
+chip_enable_ethernet = true
 chip_enable_rotating_device_id = true
 
 chip_enable_read_client = false

--- a/examples/lock-app/linux/args.gni
+++ b/examples/lock-app/linux/args.gni
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_enable_ethernet = true
 chip_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_system_project_config_include = "<SystemProjectConfig.h>"
 

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -76,7 +76,8 @@ declare_args() {
   # cross-interface policy.
   #
   # In the future, this might be "connman", "iwd", "networkmanager",
-  # or "wpa_supplicant". At present, this must be "wpa_supplicant".
+  # or "wpa_supplicant". At present, this may be either "connman" or
+  # "wpa_supplicant".
   chip_linux_network_manager = "wpa_supplicant"
 
   # The Linux Wi-Fi Neighbor Awareness Networking (NAN)
@@ -277,16 +278,33 @@ static_library("Linux") {
       "CHIP_LINUX_WIFI_PAF_MANAGER=\"${chip_linux_wifi_paf_manager}\"",
     ]
 
-    if (chip_linux_network_manager == "wpa_supplicant") {
-      defines += [ "CHIP_LINUX_NETWORK_MANAGER_WPA_SUPPLICANT=1" ]
+    if (chip_linux_network_manager == "connman") {
+      defines += [
+        "CHIP_LINUX_NETWORK_MANAGER_CONNMAN=1",
+        "CHIP_LINUX_NETWORK_MANAGER_WPA_SUPPLICANT=0",
+      ]
 
-      sources +=
-          [ "ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp" ]
+      sources += [
+        "ConnectivityManagerImpl_NetworkManagementConnMan.cpp",
+        "ConnectivityManagerImpl_NetworkManagementConnMan.h",
+      ]
+
+      public_deps += [ "dbus/connman" ]
+    } else if (chip_linux_network_manager == "wpa_supplicant") {
+      defines += [
+        "CHIP_LINUX_NETWORK_MANAGER_CONNMAN=0",
+        "CHIP_LINUX_NETWORK_MANAGER_WPA_SUPPLICANT=1",
+      ]
+
+      sources += [
+        "ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp",
+        "ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h",
+      ]
     } else {
-      assert(false,
-             "Linux network manager not specified or not supported: " +
-                 chip_linux_network_manager +
-                 ". chip_linux_network_manager must be 'wpa_supplicant'.")
+      assert(
+          false,
+          "Linux network manager not specified or not supported: " +
+              chip_linux_network_manager + ". chip_linux_network_manager must be 'connman' or 'wpa_supplicant'.")
     }
 
     # If Wi-Fi is enabled, validate and setup the Wi-Fi Neighbor
@@ -300,7 +318,10 @@ static_library("Linux") {
       } else if (chip_linux_wifi_paf_manager == "wpa_supplicant") {
         defines += [ "CHIP_LINUX_WIFI_PAF_MANAGER_WPA_SUPPLICANT=1" ]
 
-        sources += [ "ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp" ]
+        sources += [
+          "ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp",
+          "ConnectivityManagerImpl_WiFiPafWpaSupplicant.h",
+        ]
       } else {
         assert(
             false,

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -43,7 +43,19 @@
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
 #endif
 
+#if CHIP_LINUX_NETWORK_MANAGER_CONNMAN
+#include "ConnectivityManagerImpl_NetworkManagementConnMan.h"
+#elif CHIP_LINUX_NETWORK_MANAGER_WPA_SUPPLICANT
+#include "ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h"
+#endif // CHIP_LINUX_NETWORK_MANAGER_CONNMAN
+
+#if CHIP_LINUX_WIFI_PAF_MANAGER_WPA_SUPPLICANT
+#include "ConnectivityManagerImpl_WiFiPafWpaSupplicant.h"
+#endif // CHIP_LINUX_WIFI_PAF_MANAGER_WPA_SUPPLICANT
+
 #include "ConnectivityManagerImpl.h"
+#include "ConnectivityManagerImpl_NetworkManagementInterface.h"
+#include "ConnectivityManagerImpl_WiFiPafInterface.h"
 #include "ConnectivityUtils.h"
 
 using namespace ::chip::DeviceLayer::Internal;
@@ -55,7 +67,26 @@ using namespace ::chip::WiFiPAF;
 namespace chip {
 namespace DeviceLayer {
 
-// MARK: Singleton
+// Matter Linux Platform Connectivity Manager Implementation
+
+template <typename T>
+void ConnectivityManagerImpl::Deleter<T>::operator()(T * inPointer) const noexcept
+{
+    delete inPointer;
+}
+
+// Explicit Instantiations of private implementation (PIMPL) pattern deleters.
+
+template struct ConnectivityManagerImpl::Deleter<Internal::NetworkManagementInterface>;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+template struct ConnectivityManagerImpl::Deleter<Internal::WiFiPafInterface>;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+// Destruction
+
+ConnectivityManagerImpl::~ConnectivityManagerImpl() = default;
+
+// Singleton
 
 ConnectivityManagerImpl & ConnectivityManagerImpl::GetDefaultInstance()
 {
@@ -82,77 +113,44 @@ void ConnectivityManagerImpl::SetNetworkStatusChangeCallback(NetworkStatusChange
     mpStatusChangeCallback = inStatusChangeCallback;
 }
 
+// Generic
+
+CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->CommitConfig();
+}
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+// Ethernet Control Plane Management
+
+// Observation
+
+const char * ConnectivityManagerImpl::GetEthernetIfName()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, nullptr);
+
+    return mNetworkManagementImplementation->GetEthernetIfName();
+}
+
+// Helper
+
 void ConnectivityManagerImpl::UpdateEthernetNetworkingStatus()
 {
-    if (mpStatusChangeCallback != nullptr)
-    {
-        if (mEthIfName[0] != '\0')
-        {
-            ByteSpan ifNameSpan(reinterpret_cast<unsigned char *>(mEthIfName),
-                                strnlen(mEthIfName, Inet::InterfaceId::kMaxIfNameLength));
-            mpStatusChangeCallback->OnNetworkingStatusChange(Status::kSuccess, MakeOptional(ifNameSpan), NullOptional);
-        }
-    }
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->UpdateEthernetNetworkingStatus();
 }
-
-CHIP_ERROR ConnectivityManagerImpl::_Init()
-{
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    mWiFiStationMode              = kWiFiStationMode_Disabled;
-    mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
-#endif
-    SetNetworkStatusChangeCallback(nullptr);
-    SetOneShotConnectCallback(nullptr);
-    SetOneShotScanCallback(nullptr);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    ReturnErrorOnFailure(WpaSupplicantClient::Init(*this));
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-
-    if (ConnectivityUtils::GetEthInterfaceName(mEthIfName, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(DeviceLayer, "Got Ethernet interface: %s", mEthIfName);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "Failed to get Ethernet interface");
-        mEthIfName[0] = '\0';
-    }
-
-    if (GetDiagnosticDataProvider().ResetEthNetworkDiagnosticsCounts() != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to reset Ethernet statistic counts");
-    }
-
-    // Initialize the generic base classes that require it.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
-#endif
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (ConnectivityUtils::GetWiFiInterfaceName(sWiFiIfName, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(DeviceLayer, "Got WiFi interface: %s", sWiFiIfName);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "Failed to get WiFi interface");
-        sWiFiIfName[0] = '\0';
-    }
+// Wi-Fi Control Plane Management
 
-    if (GetDiagnosticDataProvider().ResetWiFiNetworkDiagnosticsCounts() != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to reset WiFi statistic counts");
-    }
-#endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    return WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Init(&DeviceLayer::SystemLayer());
-#else
-    return CHIP_NO_ERROR;
-#endif
-}
+// Wi-Fi Station Control Plane Management
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+// Introspection
+
 bool ConnectivityManagerImpl::IsWiFiStationConnecting() const noexcept
 {
     return mpOneShotConnectCallback != nullptr;
@@ -162,87 +160,419 @@ bool ConnectivityManagerImpl::IsWiFiStationScanning() const noexcept
 {
     return mpOneShotScanCallback != nullptr;
 }
+
+bool ConnectivityManagerImpl::IsWiFiManagementStarted()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, false);
+
+    return mNetworkManagementImplementation->IsWiFiManagementStarted();
+}
+
+// Observation
+
+CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->GetConfiguredNetwork(outNetwork);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & outWiFiBssId)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->GetWiFiBssId(outWiFiBssId);
+}
+
+const char * ConnectivityManagerImpl::GetWiFiIfName()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, nullptr);
+
+    return mNetworkManagementImplementation->GetWiFiIfName();
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl::GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outWiFiSecurityType)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->GetWiFiSecurityType(outWiFiSecurityType);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outWiFiVersion)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->GetWiFiVersion(outWiFiVersion);
+}
+
+// Worker
+
+void ConnectivityManagerImpl::StartWiFiManagement()
+{
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->StartWiFiManagement();
+}
+
+void ConnectivityManagerImpl::StopWiFiManagement()
+{
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->StopWiFiManagement();
+}
+
+CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkAsync(
+    ByteSpan inSsid, ByteSpan inCredentials, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->ConnectWiFiNetworkAsync(inSsid, inCredentials, inConnectCallback);
+}
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkWithPDCAsync(
+    ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity, const Crypto::P256Keypair & inClientIdentityKeypair,
+    NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->ConnectWiFiNetworkWithPDCAsync(inSsid, inNetworkIdentity, inClientIdentity,
+                                                                            inClientIdentityKeypair, inConnectCallback);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+
+CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan inSsid, NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->StartWiFiScan(inSsid, inScanCallback);
+}
+
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
+// Curiously-recurring template pattern (CRTP) "Public" Connectivity Manager Members
+
+// Initialization
+
+CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
-    // Forward the event to the generic base classes as needed.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
-#endif
+    VerifyOrReturnError(mNetworkManagementImplementation == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    WiFiPAFLayer & WiFiPafLayer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
-    switch (event->Type)
+    VerifyOrReturnError(mWiFiPafImplementation == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+    // Initialize the generic base classes that require it.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
+#endif
+
+    SetNetworkStatusChangeCallback(nullptr);
+    SetOneShotConnectCallback(nullptr);
+    SetOneShotScanCallback(nullptr);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    if (GetDiagnosticDataProvider().ResetEthNetworkDiagnosticsCounts() != CHIP_NO_ERROR)
     {
-    case DeviceEventType::kCHIPoWiFiPAFReceived: {
-        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFReceived");
-        WiFiPAFSession RxInfo;
-        memcpy(&RxInfo, &event->CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
-        WiFiPafLayer.OnWiFiPAFMessageReceived(RxInfo, System::PacketBufferHandle::Adopt(event->CHIPoWiFiPAFReceived.Data));
-        break;
+        ChipLogError(DeviceLayer, "Failed to reset Ethernet statistic counts");
     }
-    case DeviceEventType::kCHIPoWiFiPAFConnected: {
-        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFConnected");
-        WiFiPAF::WiFiPAFSession SessionInfo;
-        memcpy(&SessionInfo, &event->CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
-        TEMPORARY_RETURN_IGNORED WiFiPafLayer.HandleTransportConnectionInitiated(SessionInfo, mOnPafSubscribeComplete, mAppState,
-                                                                                 mOnPafSubscribeError);
-        break;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    if (GetDiagnosticDataProvider().ResetWiFiNetworkDiagnosticsCounts() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to reset Wi-Fi statistic counts");
     }
-    case DeviceEventType::kCHIPoWiFiPAFCancelConnect: {
-        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFCancelConnect");
-        if (mOnPafSubscribeError != nullptr)
-        {
-            mOnPafSubscribeError(mAppState, CHIP_ERROR_CANCELLED);
-            mOnPafSubscribeError = nullptr;
-        }
-        break;
-    }
-    case DeviceEventType::kCHIPoWiFiPAFWriteDone: {
-        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFWriteDone");
-        WiFiPAF::WiFiPAFSession TxInfo;
-        memcpy(&TxInfo, &event->CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
-        TEMPORARY_RETURN_IGNORED WiFiPafLayer.HandleWriteConfirmed(TxInfo, event->CHIPoWiFiPAFReceived.result);
-        break;
-    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+    {
+        Internal::NetworkManagementBasis * basis = nullptr;
+
+#if CHIP_LINUX_NETWORK_MANAGER_CONNMAN
+        ConnectivityManagerImpl_NetworkManagementConnMan * instance =
+            chip::Platform::New<ConnectivityManagerImpl_NetworkManagementConnMan>();
+        basis = static_cast<Internal::NetworkManagementBasis *>(instance);
+        mNetworkManagementImplementation.reset(instance);
+#elif CHIP_LINUX_NETWORK_MANAGER_WPA_SUPPLICANT
+        ConnectivityManagerImpl_NetworkManagementWpaSupplicant * instance =
+            chip::Platform::New<ConnectivityManagerImpl_NetworkManagementWpaSupplicant>();
+        basis = static_cast<Internal::NetworkManagementBasis *>(instance);
+        mNetworkManagementImplementation.reset(instance);
+#endif
+        VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        ReturnErrorOnFailure(mNetworkManagementImplementation->Init(*this));
+
+        basis->SetDelegate(this);
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#if CHIP_LINUX_WIFI_PAF_MANAGER_WPA_SUPPLICANT
+    mWiFiPafImplementation.reset(chip::Platform::New<ConnectivityManagerImpl_WiFiPafWpaSupplicant>());
+#endif // CHIP_LINUX_WIFI_PAF_MANAGER_WPA_SUPPLICANT
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    ReturnErrorOnFailure(mWiFiPafImplementation->Init(*this));
+
+    ReturnErrorOnFailure(WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Init(&DeviceLayer::SystemLayer()));
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+    return CHIP_NO_ERROR;
+}
+
+// Event Handling
+
+void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * inDeviceEvent)
+{
+    // Forward the event to the generic base classes as needed.
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(inDeviceEvent);
+#endif
+
+    if ((inDeviceEvent != nullptr) && (mNetworkManagementImplementation != nullptr))
+        mNetworkManagementImplementation->OnPlatformEvent(*inDeviceEvent);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if ((inDeviceEvent != nullptr) && (mWiFiPafImplementation != nullptr))
+        mWiFiPafImplementation->OnPlatformEvent(*inDeviceEvent);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 }
 
-ConnectivityManagerImpl & ConnectivityMgrImpl()
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+// Wi-Fi Control Plane Management
+
+// Wi-Fi Station Control Plane Management
+
+// Introspection
+
+bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
 {
-    return ConnectivityManagerImpl::GetDefaultInstance();
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, false);
+
+    return mNetworkManagementImplementation->IsWiFiStationApplicationControlled();
 }
+
+bool ConnectivityManagerImpl::_IsWiFiStationConnected()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, false);
+
+    return mNetworkManagementImplementation->IsWiFiStationConnected();
+}
+
+bool ConnectivityManagerImpl::_IsWiFiStationEnabled()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, false);
+
+    return mNetworkManagementImplementation->IsWiFiStationEnabled();
+}
+
+// Observation
+
+ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, ConnectivityManager::kWiFiStationMode_NotSupported);
+
+    return mNetworkManagementImplementation->GetWiFiStationMode();
+}
+
+// Mutation
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(ConnectivityManager::WiFiStationMode inWiFiStationMode)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->SetWiFiStationMode(inWiFiStationMode);
+}
+
+// Wi-Fi Soft Access Point Control Plane Management
+
+// Observation
+
+ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
+{
+    VerifyOrReturnValue(mNetworkManagementImplementation != nullptr, ConnectivityManager::kWiFiAPMode_NotSupported);
+
+    return mNetworkManagementImplementation->GetWiFiApMode();
+}
+
+// Mutation
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode inWiFiApMode)
+{
+    VerifyOrReturnError(mNetworkManagementImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mNetworkManagementImplementation->SetWiFiApMode(inWiFiApMode);
+}
+
+// Control
+
+void ConnectivityManagerImpl::_DemandStartWiFiAP()
+{
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->DemandStartWiFiAp();
+}
+
+void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP()
+{
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->MaintainOnDemandWiFiAp();
+}
+
+void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
+{
+    VerifyOrReturn(mNetworkManagementImplementation != nullptr);
+
+    mNetworkManagementImplementation->StopOnDemandWiFiAp();
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+// Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+// Service Discovery (USD) / Public Action Frame (PAF)
+// Commissioning Transport
+
+// Initialization
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFShutdown(uint32_t inPublishId, WiFiPAF::WiFiPafRole inWiFiPafRole)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafShutdown(inPublishId, inWiFiPafRole);
+}
+
+// Introspection
+
+bool ConnectivityManagerImpl::_WiFiPAFResourceAvailable()
+{
+    VerifyOrReturnValue(mWiFiPafImplementation != nullptr, false);
+
+    return mWiFiPafImplementation->IsWiFiPafResourceAvailable();
+}
+
+// Mutation
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiPAFAdvertisingEnabled(bool inEnabled, uint32_t & inOutPublishId)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafSetAdvertisingEnabled(inEnabled, inOutPublishId);
+}
+
+void ConnectivityManagerImpl::_WiFiPafSetApFreq(const uint16_t inFrequency)
+{
+    VerifyOrReturn(mWiFiPafImplementation != nullptr);
+
+    mWiFiPafImplementation->WiFiPafSetSubscribeFreq(inFrequency);
+}
+
+void ConnectivityManagerImpl::_WiFiPAFSetParam(const WiFiPAFAdvertiseParam & inWiFiPAFAdvertiseParams)
+{
+    VerifyOrReturn(mWiFiPafImplementation != nullptr);
+
+    mWiFiPafImplementation->WiFiPafSetParam(inWiFiPAFAdvertiseParams);
+}
+
+// Publish-and-subscribe
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFPublish(WiFiPAFAdvertiseParam & inWiFiPafAdvertiseParams)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafPublish(inWiFiPafAdvertiseParams);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelPublish(uint32_t inPublishId)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafCancelPublish(inPublishId);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & inDiscriminator, void * inContext,
+                                                      OnConnectionCompleteFunct onSuccessFunc, OnConnectionErrorFunct onErrorFunc)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafSubscribe(inDiscriminator, inContext, onSuccessFunc, onErrorFunc);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelSubscribe(uint32_t inSubscribeId)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafCancelSubscribe(inSubscribeId);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelIncompleteSubscribe()
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafCancelIncompleteSubscribe();
+}
+
+// Data Transmission
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession & inWiFiPafSession,
+                                                 chip::System::PacketBufferHandle && inOutMessageBuffer)
+{
+    VerifyOrReturnError(mWiFiPafImplementation != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    return mWiFiPafImplementation->WiFiPafSend(inWiFiPafSession, std::move(inOutMessageBuffer));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
 // Network Commissioning Action Delegation Methods
 
 void ConnectivityManagerImpl::OnScanFinished(NetworkCommissioning::Status inStatus, CharSpan inDebugText,
                                              NetworkCommissioning::WiFiScanResponseIterator * inNetworks) noexcept
 {
-    VerifyOrReturn(mpOneShotScanCallback != nullptr);
+    if (mpOneShotScanCallback != nullptr)
+    {
+        mpOneShotScanCallback->OnFinished(inStatus, inDebugText, inNetworks);
 
-    mpOneShotScanCallback->OnFinished(inStatus, inDebugText, inNetworks);
-
-    mpOneShotScanCallback = nullptr;
+        mpOneShotScanCallback = nullptr;
+    }
 }
 
-void ConnectivityManagerImpl::OnConnectResult(NetworkCommissioning::Status inCommissioningError, CharSpan inDebugText,
-                                              int32_t inConnectStatus) noexcept
+void ConnectivityManagerImpl::OnConnectResult(NetworkCommissioning::Status inCommissioningError,
+                                              CharSpan inDebugText, int32_t inConnectStatus) noexcept
 {
-    VerifyOrReturn(mpOneShotConnectCallback != nullptr);
+    if (mpOneShotConnectCallback != nullptr)
+    {
+        mpOneShotConnectCallback->OnResult(inCommissioningError, inDebugText, inConnectStatus);
 
-    mpOneShotConnectCallback->OnResult(inCommissioningError, inDebugText, inConnectStatus);
-
-    mpOneShotConnectCallback = nullptr;
+        mpOneShotConnectCallback = nullptr;
+    }
 }
 
-void ConnectivityManagerImpl::OnStatusChange(NetworkCommissioning::Status inCommissioningError, Optional<ByteSpan> inNetworkId,
+void ConnectivityManagerImpl::OnStatusChange(NetworkCommissioning::Status inCommissioningError,
+                                             Optional<ByteSpan> inNetworkId,
                                              Optional<int32_t> inConnectStatus) noexcept
 {
-    VerifyOrReturn(mpStatusChangeCallback != nullptr);
+    if (mpStatusChangeCallback != nullptr)
+    {
+        mpStatusChangeCallback->OnNetworkingStatusChange(inCommissioningError, inNetworkId, inConnectStatus);
+    }
+}
 
-    mpStatusChangeCallback->OnNetworkingStatusChange(inCommissioningError, inNetworkId, inConnectStatus);
+// Network Management Delegate Method
+
+void ConnectivityManagerImpl::OnWiFiMediumAvailable(Internal::NetworkManagementBasis & inOutNetworkManagement, bool inAvailable)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if (mWiFiPafImplementation != nullptr)
+    {
+        RETURN_SAFELY_IGNORED mWiFiPafImplementation->WiFiPafSetResourceAvailable(inAvailable);
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+}
+
+ConnectivityManagerImpl & ConnectivityMgrImpl()
+{
+    return ConnectivityManagerImpl::GetDefaultInstance();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2026 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,12 @@
 
 #pragma once
 
+#include <memory>
+
+#include <stdint.h>
+
 #include <lib/support/FixedBuffer.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
 #include <platform/internal/GenericConnectivityManagerImpl_UDP.h>
@@ -29,38 +34,51 @@
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.h>
 #else
 #include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
-#endif
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/internal/GenericConnectivityManagerImpl_Thread.h>
 #else
 #include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
-#endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
 #else
 #include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-#include <wifipaf/WiFiPAFEndPoint.h>
-#include <wifipaf/WiFiPAFLayer.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #include <platform/Linux/NetworkCommissioningDriver.h>
 #include <platform/NetworkCommissioning.h>
-#include <vector>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-#include "WpaSupplicantClient.h"
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+#include "ConnectivityManagerImpl_NetworkManagementDelegate.h"
 
 namespace chip {
 namespace DeviceLayer {
 
+namespace Internal {
+
+// Forward Declarations
+
+class NetworkManagementInterface;
+class WiFiPafInterface;
+
+} // namespace Internal
+
 /**
- * Concrete implementation of the ConnectivityManager singleton object for Linux platforms.
+ *  This provides a concrete implementation of the public Connectivity
+ *  Manager Curiously-recurring Template Pattern (CRTP) singleton
+ *  object interface for Linux platforms.
+ *
+ *  This fans out those CRTP interface methods into one of two
+ *  abstract virtual interfaces:
+ *
+ *    1. High-level network management, if any, that owns network
+ *       policy and state and orchestrates connectivity decisions and
+ *       cross-interface policy.
+ *    2. Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+ *       Service Discovery (USD) / Public Action Frame (PAF)
+ *       commissioning transport management.
+ *
+ *  The implementations of which are allocated, instantiated, and
+ *  initialized in the #Init method.
  */
 class ConnectivityManagerImpl final : public ConnectivityManager,
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
@@ -82,74 +100,20 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
                                       public Internal::GenericConnectivityManagerImpl_TCP<ConnectivityManagerImpl>,
 #endif
-                                      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    ,
-                                      public Internal::WpaSupplicantClient
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+                                      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+                                      public Internal::NetworkManagementDelegate
 {
     // Allow the ConnectivityManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend class ConnectivityManager;
 
 public:
+    ConnectivityManagerImpl() = default;
+    ~ConnectivityManagerImpl();
+
     // Singleton
 
-    static ConnectivityManagerImpl & GetDefaultInstance(void);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    CHIP_ERROR ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credentials,
-                                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
-    CHIP_ERROR ConnectWiFiNetworkWithPDCAsync(ByteSpan ssid, ByteSpan networkIdentity, ByteSpan clientIdentity,
-                                              const Crypto::P256Keypair & clientIdentityKeypair,
-                                              NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    void PostWpaInterfaceProxyReady() CHIP_REQUIRES(mWpaSupplicantMutex);
-    void _WiFiPAFSetParam(const WiFiPAFAdvertiseParam & pafAdvParam);
-    CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool enabled, uint32_t & publishId);
-    CHIP_ERROR _WiFiPAFSubscribe(const uint16_t & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
-                                 OnConnectionErrorFunct onError);
-    CHIP_ERROR _WiFiPAFCancelSubscribe(uint32_t SubscribeId);
-    CHIP_ERROR _WiFiPAFCancelIncompleteSubscribe();
-    void OnDiscoveryResult(GVariant * obj);
-    void OnReplied(GVariant * obj);
-    void OnNanReceive(GVariant * obj);
-    void OnNanPublishTerminated(guint public_id, gchar * reason);
-    void OnNanSubscribeTerminated(guint subscribe_id, gchar * reason);
-    CHIP_ERROR _WiFiPAFSend(const WiFiPAF::WiFiPAFSession & TxInfo, chip::System::PacketBufferHandle && msgBuf);
-    void _WiFiPafSetApFreq(const uint16_t freq) { mApFreq = freq; }
-    CHIP_ERROR _WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role);
-#else
-    inline void PostWpaInterfaceProxyReady() CHIP_REQUIRES(mWpaSupplicantMutex) {}
-#endif
-
-    void PostNetworkConnect();
-    CHIP_ERROR CommitConfig();
-
-    void StartWiFiManagement();
-    // Release GLib objects before the GLib main loop is quit.
-    // Must be called from PlatformManagerImpl::_Shutdown() before g_main_loop_quit().
-    void StopWiFiManagement();
-    bool IsWiFiManagementStarted();
-    void StartNonConcurrentWiFiManagement();
-    int32_t GetDisconnectReason();
-    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value);
-    CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType);
-    CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
-    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);
-    CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
-
-private:
-    CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
-                                        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
-        CHIP_REQUIRES(mWpaSupplicantMutex);
-#endif
-
-public:
-    const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }
-    void UpdateEthernetNetworkingStatus();
+    static ConnectivityManagerImpl & GetDefaultInstance();
 
     using NetworkStatusChangeCallback = NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback;
     using OneShotScanCallback         = NetworkCommissioning::WiFiDriver::ScanCallback;
@@ -159,6 +123,53 @@ public:
     void SetOneShotScanCallback(OneShotScanCallback * inOneShotScanCallback) noexcept;
     void SetNetworkStatusChangeCallback(NetworkStatusChangeCallback * inStatusChangeCallback) noexcept;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    // Ethernet Control Plane Management
+
+    // Observation
+
+    const char * GetEthernetIfName();
+
+    // Helper
+
+    void UpdateEthernetNetworkingStatus();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Wi-Fi Control Plane Management
+
+    // Wi-Fi Station Control Plane Management
+
+    // Introspection
+
+    bool IsWiFiStationConnecting() const noexcept;
+    bool IsWiFiStationScanning() const noexcept;
+    bool IsWiFiManagementStarted();
+
+    // Observation
+
+    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork);
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & outBssId);
+    const char * GetWiFiIfName();
+    CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outSecurityType);
+    CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outVersion);
+
+    // Worker
+
+    CHIP_ERROR ConnectWiFiNetworkAsync(ByteSpan inSsid, ByteSpan inCredentials,
+                                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback);
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+    CHIP_ERROR ConnectWiFiNetworkWithPDCAsync(ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity,
+                                              const Crypto::P256Keypair & inClientIdentityKeypair,
+                                              NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+
+    CHIP_ERROR CommitConfig();
+    void StartWiFiManagement();
+    void StopWiFiManagement();
+    CHIP_ERROR StartWiFiScan(ByteSpan inSsid, NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
     // Network Commissioning Action Delegation Methods
 
     void OnScanFinished(NetworkCommissioning::Status inStatus, CharSpan inDebugText,
@@ -167,107 +178,106 @@ public:
     void OnStatusChange(NetworkCommissioning::Status inCommissioningError, Optional<ByteSpan> inNetworkId,
                         Optional<int32_t> inConnectStatus) noexcept;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
-#endif
-
 private:
-    // ===== Members that implement the ConnectivityManager abstract interface.
+    // Curiously-recurring template pattern (CRTP) members that
+    // implement the public Connectivity Manager interface which, on
+    // Linux, are further dispatched via one of two private
+    // implmentation pointer (PImpl) interfaces.
+
+    // Initialization
 
     CHIP_ERROR _Init();
-    void _OnPlatformEvent(const ChipDeviceEvent * event);
+
+    // Event Handling
+
+    void _OnPlatformEvent(const ChipDeviceEvent * inDeviceEvent);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    bool IsWiFiStationConnecting() const noexcept;
-    bool IsWiFiStationScanning() const noexcept;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Wi-Fi Control Plane Management
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    WiFiStationMode _GetWiFiStationMode();
-    CHIP_ERROR _SetWiFiStationMode(ConnectivityManager::WiFiStationMode val);
-    System::Clock::Timeout _GetWiFiStationReconnectInterval();
-    CHIP_ERROR _SetWiFiStationReconnectInterval(System::Clock::Timeout val);
-    bool _IsWiFiStationEnabled();
-    bool _IsWiFiStationConnected();
+    // Wi-Fi Station Control Plane Management
+
+    // Introspection
+
     bool _IsWiFiStationApplicationControlled();
-    bool _IsWiFiStationProvisioned();
-    void _ClearWiFiStationProvision();
+    bool _IsWiFiStationConnected();
+    bool _IsWiFiStationEnabled();
+
+    // Observation
+
+    WiFiStationMode _GetWiFiStationMode();
+
+    // Mutation
+
+    CHIP_ERROR _SetWiFiStationMode(ConnectivityManager::WiFiStationMode inWiFiStationMode);
+
+    // Wi-Fi Soft Access Point Control Plane Management
+
+    // Observation
 
     WiFiAPMode _GetWiFiAPMode();
-    CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);
-    bool _IsWiFiAPActive();
-    bool _IsWiFiAPApplicationControlled();
+
+    // Mutation
+
+    CHIP_ERROR _SetWiFiAPMode(WiFiAPMode inWiFiAPMode);
+
+    // Control
+
     void _DemandStartWiFiAP();
-    void _StopOnDemandWiFiAP();
     void _MaintainOnDemandWiFiAP();
-    System::Clock::Timeout _GetWiFiAPIdleTimeout();
-    void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
-    void NotifyWiFiConnectivityChange(ConnectivityChange change);
-    void UpdateNetworkStatus();
-    CHIP_ERROR StopAutoScan();
+    void _StopOnDemandWiFiAP();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-    void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path);
-    void _OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const char * path, GVariant * properties);
-    void _OnWpaPropertiesChanged(WpaSupplicant1Interface * iface, GVariant * properties);
-    void _OnWpaInterfaceScanDone(WpaSupplicant1Interface * iface, gboolean success);
-    void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
-    CHIP_ERROR StartWiFiManagementSync();
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    WiFiPAFAdvertiseParam mPafAdvParam;
-    OnConnectionCompleteFunct mOnPafSubscribeComplete;
-    OnConnectionErrorFunct mOnPafSubscribeError;
-    WiFiPAF::WiFiPAFEndPoint mWiFiPAFEndPoint;
-    void * mAppState;
-    uint16_t mApFreq;
-    CHIP_ERROR _WiFiPAFPublish(WiFiPAFAdvertiseParam & args);
-    CHIP_ERROR _WiFiPAFCancelPublish(uint32_t PublishId);
-    bool _WiFiPAFResourceAvailable() { return mPafChannelAvailable; };
-    // The resource checking is needed right before sending data packets that they are initialized and connected.
-    bool mPafChannelAvailable = true;
-#endif
+    // Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+    // Service Discovery (USD) / Public Action Frame (PAF)
+    // Commissioning Transport
 
-    CHIP_ERROR _GetBssInfo(const char * bssPath, NetworkCommissioning::WiFiScanResponse & result);
+    // Initialization
 
-    CHIP_ERROR _StartWiFiManagement();
-    CHIP_ERROR _StopWiFiManagement();
+    CHIP_ERROR _WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole inWiFiPafRole);
 
-    bool mAssociationStarted             = false;
-    unsigned int mAssociationRetriesLeft = 0;
+    // Introspection
 
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+    bool _WiFiPAFResourceAvailable();
+
+    // Mutation
+
+    CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool inEnabled, uint32_t & inOutPublishId);
+    void _WiFiPafSetApFreq(const uint16_t inFrequency);
+    void _WiFiPAFSetParam(const WiFiPAFAdvertiseParam & inWiFiPAFAdvertiseParams);
+
+    // Publish-and-subscribe
+
+    CHIP_ERROR _WiFiPAFPublish(WiFiPAFAdvertiseParam & inWiFiPafAdvertiseParams);
+    CHIP_ERROR _WiFiPAFCancelPublish(uint32_t inPublishId);
+    CHIP_ERROR _WiFiPAFSubscribe(const uint16_t & inConnectionDiscriminator, void * inContext,
+                                 OnConnectionCompleteFunct inOnSuccessFunc, OnConnectionErrorFunct inOnErrorFunc);
+    CHIP_ERROR _WiFiPAFCancelSubscribe(uint32_t inSubscribeId);
+    CHIP_ERROR _WiFiPAFCancelIncompleteSubscribe();
+
+    // Data Transmission
+
+    CHIP_ERROR _WiFiPAFSend(const WiFiPAF::WiFiPAFSession & inWiFiPafSession, chip::System::PacketBufferHandle && inMessageBuffer);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+    // Network Management Delegate Method
+
+    void OnWiFiMediumAvailable(Internal::NetworkManagementBasis & inOutNetworkManagement, bool inAvailable) override final;
 
 private:
-    // ==================== ConnectivityManager Private Methods ====================
+    template <typename T>
+    struct Deleter
+    {
+        void operator()(T * inPointer) const noexcept;
+    };
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    void DriveAPState();
-    CHIP_ERROR ConfigureWiFiAP();
-    void ChangeWiFiAPState(WiFiAPState newState);
-    static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState);
-#endif
+    using NetworkManagementUniquePtr =
+        std::unique_ptr<Internal::NetworkManagementInterface, Deleter<Internal::NetworkManagementInterface>>;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    using WiFiPafUniquePtr = std::unique_ptr<Internal::WiFiPafInterface, Deleter<Internal::WiFiPafInterface>>;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
-    // ===== Private members reserved for use by this class only.
-
-    char mEthIfName[Inet::InterfaceId::kMaxIfNameLength];
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    ConnectivityManager::WiFiStationMode mWiFiStationMode;
-    ConnectivityManager::WiFiAPMode mWiFiAPMode;
-    WiFiAPState mWiFiAPState;
-    System::Clock::Timestamp mLastAPDemandTime;
-    System::Clock::Timeout mWiFiStationReconnectInterval;
-    System::Clock::Timeout mWiFiAPIdleTimeout;
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    char sWiFiIfName[Inet::InterfaceId::kMaxIfNameLength];
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    Internal::WiFiSSIDFixedBuffer mInterestedSSID;
-#endif
     /**
      *  A callback through which, when non-null, the Wi-Fi driver
      *  'OnFinished' method is invoked after a Wi-Fi scan is
@@ -289,6 +299,10 @@ private:
      */
     OneShotConnectCallback * mpOneShotConnectCallback;
     NetworkStatusChangeCallback * mpStatusChangeCallback;
+    NetworkManagementUniquePtr mNetworkManagementImplementation;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    WiFiPafUniquePtr mWiFiPafImplementation;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -2558,23 +2558,42 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::BuildWiFiScanRespon
     response.channel  = 0;
     response.wiFiBand = WiFiBandEnum::k5g;
 
-    // By default, ConnMan virtualizes all wireless signal strength in
-    // the qualitative range 0-100; indicate and set the value as
-    // such. In the future, we may be able to return dBm quantiatively
-    // via nl80211 or the Wi-Fi backend. Alternatively, in the future,
-    // the specification and the Network Commissioning Cluster would
+    // connman virtualizes wireless signal strength (cellular and
+    // Wi-Fi alike) into a qualitative 0-100 range. For Wi-Fi it
+    // derives that from the supplicant's dBm in
+    // plugins/wifi.c:calculate_strength():
+    //
+    //     strength = min(120 + dBm, 100)
+    //
+    // which is lossy only at the top: everything at or above -20 dBm
+    // saturates to 100. Nothing on the connman D-Bus surface exposes
+    // the original value.
+    //
+    // The Network Commissioning Cluster's 'ScanNetworksResponse'
+    // carries RSSI in dBm, signed (it has no qualitative
+    // representation, though the SDK-internal WiFiScanResponse does)
+    // so invert the conversion. The result is exact below the
+    // saturation point. Alternatively, in the future, the
+    // specification and the Network Commissioning Cluster would
     // support and pass through a qualitative wireless signal
-    // assessment.
+    // assessment as the SDK-internal structure allows.
+    //
+    // Note the clamp in GetWiFiServiceStrengthLocked is load-bearing:
+    // calculate_strength() has no *lower* bound and returns unsigned
+    // char, so a signal below -120 dBm would wrap. Not reachable from
+    // wpa_supplicant in practice, but the getter's clamp keeps the
+    // arithmetic here total.
     //
     // Strength is best-effort and cosmetic; a failed read leaves the
-    // zero-initialized default. It must not gate the scan result, which
-    // has already been assembled and is about to be reported successful.
+    // zero-initialized default. It must not gate the scan result,
+    // which has already been assembled and is about to be reported
+    // successful.
 
     int8_t strength = 0;
     RETURN_SAFELY_IGNORED GetWiFiServiceStrengthLocked(inProperties, strength);
 
-    response.signal.type     = WirelessSignalType::kQualitative;
-    response.signal.strength = strength;
+    response.signal.type     = WirelessSignalType::kdBm;
+    response.signal.strength = static_cast<int8_t>(strength - 120);
 
     outResponse = response;
 

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -4244,14 +4244,18 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingSc
         ReturnErrorOnFailure(BuildWiFiScanResponseFromServicePropertiesLocked(properties.get(), response));
         services->push_back(response);
 
-        // Snapshot the SSID for debug text BEFORE Reset(); the dispatch helper
-        // copies these bytes by value, so the reset cannot race the deferred
-        // callback.
+        // Snapshot the SSID for the debug text before the reset; the dispatch
+        // helpers copy these bytes by value, so the reset cannot race the
+        // deferred callback.
 
-        const CharSpan debug(reinterpret_cast<const char *>(inOutScanState.mSsid.data()), inOutScanState.mSsid.size());
+        const Internal::WiFiSSIDFixedBuffer ssid = inOutScanState.mSsid;
+        const CharSpan debug(reinterpret_cast<const char *>(ssid.data()), ssid.size());
 
-        // Directed scan resolved: clear scan state so mCount == 0 restores the
-        // idle invariant. Ordering matters -- capture `debug` above first.
+        // Directed scan resolved; reset the SSID and scan count.
+        //
+        // Clear the operation's scan state BEFORE dispatching the
+        // completion result; the snapshot above keeps the reported SSID
+        // stable across the reset.
 
         inOutScanState.Reset();
 
@@ -4490,7 +4494,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiUnresolve
         // Reset the SSID and scan count.
         //
         // Clear the operation's scan state BEFORE dispatching the
-        // terminal result; the snapshot above keeps the reported SSID
+        // completion result; the snapshot above keeps the reported SSID
         // stable across the reset.
 
         inOutScanState.Reset();

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -3582,6 +3582,24 @@ ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectRequestLoc
     VerifyOrDie(inOutLock.owns_lock());
     VerifyOrReturnError(inService != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    // Matter's AddOrUpdateWiFiNetwork/ConnectNetwork is
+    // authoritative: the commissioner is the source of truth for the
+    // credential. connman consults the agent only when the service
+    // has no passphrase -- service_connect() short-circuits on a
+    // cached one, and the sticky invalid-key error that would
+    // otherwise force a re-prompt is cleared by connman itself on the
+    // failure -> idle transition. Unconditionally remove any cached
+    // provisioning so that service_connect() is guaranteed to yield
+    // -ENOKEY and drive Agent.RequestInput, which is the only
+    // sanctioned path by which we may supply the credential.
+    //
+    // connman returns net.connman.Error.NotSupported (mapped to
+    // EOPNOTSUPP) when the service was never provisioned (not
+    // favorite, no cached passphrase); which is the state we are
+    // trying to reach. Treat it as success.
+
+    ReturnErrorOnFailure(ServiceRemoveLocked(inOutLock, inService).NoErrorIf(ChipError(ChipError::Range::kPOSIX, EOPNOTSUPP)));
+
     // On any failure below, `Service.Connect()` either was not issued or will
     // not complete; unwind the D-Bus-call-scoped state. Disarmed on success,
     // where HandleServiceConnectComplete assumes that responsibility.
@@ -4980,6 +4998,33 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ServiceConnectLocke
                     inSelf_->OnServiceConnectReady(sourceObject_, res_);
                 }),
             this);
+
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ServiceRemoveLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                 ConnManService * inService) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inService != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GAutoPtr<ConnManService> service(static_cast<ConnManService *>(g_object_ref(inService)));
+
+    return UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        GAutoPtr<GError> err;
+        gboolean status = conn_man_service_call_remove_sync(service.get(), nullptr, &err.GetReceiver());
+        if (!status || err)
+        {
+            const CHIP_ERROR mapped = MapClientError(err.get());
+
+            ChipLogError(
+                DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to remove service %s: %s (%" CHIP_ERROR_FORMAT ")",
+                g_dbus_proxy_get_object_path(G_DBUS_PROXY(service.get())), err ? err->message : "unknown", mapped.Format());
+
+            return mapped;
+        }
 
         return CHIP_NO_ERROR;
     });

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -1656,6 +1656,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::Init(ConnectivityMa
         mNetworkServiceStates[i].mDescription = sNetworkServiceTypeDescriptors[i].mDescription;
     }
 
+    mConnManStarted = false;
     mWiFiActiveScanState.Reset();
     mWiFiClientConnectPassphrase.reset();
     mWiFiClusterConnectAssociationStarted = false;
@@ -1899,6 +1900,8 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::StartWiFiManagement()
 
     mConnManClient = GDBusConnManClient{};
 
+    mConnManStarted = true;
+
     // IMPORTANT: Do not synchronously wait on the GLib thread while
     //            holding mConnManMutex.
     //
@@ -1908,7 +1911,104 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::StartWiFiManagement()
 
     CHIP_ERROR err = UnlockAndInvokeOnGLibContextSync(lock, [this]() -> CHIP_ERROR { return StartNetworkManagementOnGLib(); });
 
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start Wi-Fi management"));
+    VerifyOrReturn(err == CHIP_NO_ERROR, mConnManStarted = false; ChipLogError(DeviceLayer, "Failed to start Wi-Fi management"));
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::StopNetworkManagementOnGLib(GDBusConnManClient & inOutClient) noexcept
+{
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Stop network management");
+
+    // Disconnect explicitly rather than relying on final unref: an
+    // in-flight asynchronous call may still hold a proxy reference,
+    // and the handler user data is 'this'.
+
+    ObjectsUnregisterPropertyChangedOnGLib(inOutClient.mServiceProxies.get());
+    ObjectsUnregisterPropertyChangedOnGLib(inOutClient.mTechnologyProxies.get());
+
+    if (inOutClient.mManagerProxy)
+    {
+        g_signal_handlers_disconnect_by_data(inOutClient.mManagerProxy.get(), this);
+    }
+
+    inOutClient = GDBusConnManClient{};
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::StopWiFiManagement()
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+    GDBusConnManClient client;
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Stop Wi-Fi management");
+
+    // 1. Retire everything connman can still call *into* us with: the
+    //    registered agent, the pending service against which agent
+    //    requests are path-matched, and the cached credential. May
+    //    temporarily drop the lock.
+
+    ShutdownClientConnectSessionLocked(lock);
+
+    // 2. Retire Matter-thread work we have armed.
+
+    DeviceLayer::SystemLayer().CancelTimer(HandleNetworkServiceConnectivityDebounce, this);
+
+    // 3. Note any outstanding cluster operation. Stop is a terminator
+    //    for the Matter connect/scan scope, and that scope's
+    //    exactly-once completion guarantee is ours to honor; the
+    //    completions are dispatched in step 6, once this object is
+    //    fully stopped, because the dispatch fallback path completes
+    //    synchronously off the lock and may re-enter.
+
+    const bool connectPending = mWiFiClusterConnectPending;
+    const bool scanActive     = mWiFiActiveScanState.IsActive();
+
+    // 4. Quiesce session state so that any completion that wins a
+    //    race with this teardown finds nothing to do.
+
+    mWiFiActiveScanState.Reset();
+    mWiFiClusterConnectScanState.Reset();
+    mWiFiClusterConnectAssociationStarted = false;
+    mWiFiClusterConnectPending            = false;
+    mWiFiClusterConnectServiceError.reset();
+    mWiFiStationConnected = false;
+
+    // 5. Detach the D-Bus client state under the lock, so that
+    //    IsWiFiManagementStarted() is false the instant the lock is
+    //    released, independent of when the GLib-side destruction
+    //    runs. Clearing the started flag additionally disarms any
+    //    manager-proxy creation still in flight, which would
+    //    otherwise install itself in #OnManagerReady and silently
+    //    restart management behind this stop.
+
+    client         = std::move(mConnManClient);
+    mConnManClient = GDBusConnManClient{};
+
+    mConnManStarted = false;
+
+    // 6. Destroy the detached state on the GLib thread, where the
+    //    proxies were created and their signals are dispatched.
+
+    if (client.mManagerProxy)
+    {
+        LogErrorOnFailure(
+            UnlockAndInvokeOnGLibContextSync(lock, [&]() -> CHIP_ERROR { return StopNetworkManagementOnGLib(client); }));
+    }
+
+    // 7. Complete any operation noted in step 3, now that a
+    //    re-entrant completion can only observe a stopped object.
+
+    if (connectPending)
+    {
+        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(lock, Status::kUnknownError, CharSpan(), 0));
+    }
+
+    if (scanActive)
+    {
+        LogErrorOnFailure(DispatchWiFiScanFinishedLocked(lock, Status::kUnknownError, CharSpan(), nullptr));
+    }
 }
 
 // Introspection
@@ -4679,7 +4779,10 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::ScrubWiFiClientConnectPas
  *  connman may still reach into while a connect request is
  *  outstanding: the registered agent, the pending service proxy
  *  against which agent requests are path-matched, and the cached
- *  credential from which `Agent.RequestInput` is answered.
+ *  credential from which `Agent.RequestInput` is answered. It
+ *  additionally retires an agent that was exported but never
+ *  registered, which connman cannot reach but which would otherwise
+ *  outlive the session.
  *
  *  @note
  *    Which to call: *"can connman still call my agent?"* -- if it can,
@@ -4692,10 +4795,18 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::ScrubWiFiClientConnectPas
  *    point until it does.
  *
  *  @note
+ *    The reachability test admits one exception: an agent exported
+ *    without a completed registration is unreachable by connman, yet
+ *    is still retired here, because #ManagerRegisterAgentLocked
+ *    refuses the next export with #CHIP_ERROR_ALREADY_INITIALIZED
+ *    until it is.
+ *
+ *  @note
  *    The `Locked` suffix denotes the precondition that the caller
  *    holds `mConnManMutex`; this is verified by assertion. The lock
- *    may be temporarily released by the agent unregistration, which is
- *    why this takes the lock and #ConcludeWiFiClusterConnectLocked does not.
+ *    may be temporarily released by the agent unregistration, which
+ *    is why this takes the lock and #ConcludeWiFiClusterConnectLocked
+ *    does not.
  *
  *  @param[in,out]  inOutLock
  *    A reference to the mutable, held class lock.
@@ -4713,7 +4824,19 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::ShutdownClientConnectSess
 
     if (mConnManAgentServer.mRegistered)
     {
+        // Unregistration retires the export as part of its own
+        // teardown; see ManagerUnregisterAgentLocked.
+
         LogErrorOnFailure(ManagerUnregisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH));
+    }
+    else if (mConnManAgentServer.mExported)
+    {
+        // Exported without registration: connman cannot reach the
+        // skeleton, but ManagerRegisterAgentLocked refuses the next
+        // connect with CHIP_ERROR_ALREADY_INITIALIZED until the
+        // export is retired.
+
+        ShutdownAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
     }
 
     mConnManAgentServer.mPendingService.reset();
@@ -4999,6 +5122,61 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerUnregisterAg
     return retval;
 }
 
+/**
+ *  @brief
+ *    Disconnect the property-changed handlers this object installed
+ *    on every proxy in a connman object proxy table.
+ *
+ *  The peer of `ServiceRegisterPropertyChangedOnGLib` and
+ *  `TechnologyRegisterPropertyChangedOnGLib`. Handlers are matched by
+ *  closure data rather than by retained handler identifier: `this` is
+ *  unique to the object, the tables map path to proxy with no room
+ *  for a parallel identifier without an owning value struct, and
+ *  `G_SIGNAL_MATCH_DATA` is type-agnostic across the service and
+ *  technology proxy types. Proxy-internal handlers are not registered
+ *  with `this` and are therefore untouched.
+ *
+ *  @note
+ *    Disconnection is explicit rather than implicit in the final
+ *    unref because an in-flight asynchronous call may still hold a
+ *    proxy reference past the teardown.
+ *
+ *  @note
+ *    The `OnGLib` suffix denotes the precondition that this runs on
+ *    the GLib thread and holds no class lock; the former is verified
+ *    by assertion.
+ *
+ *  @param[in]  inProxies
+ *    A pointer to the mutable connman object proxy table to sweep.
+ *
+ *  @sa ServiceRegisterPropertyChangedOnGLib
+ *  @sa TechnologyRegisterPropertyChangedOnGLib
+ *
+ *  @private
+ *
+ */
+void ConnectivityManagerImpl_NetworkManagementConnMan::ObjectsUnregisterPropertyChangedOnGLib(GHashTable * inProxies) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    VerifyOrReturn(inProxies != nullptr);
+
+    g_hash_table_iter_init(&iter, inProxies);
+
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        (void) key;
+
+        VerifyOrReturn(value != nullptr);
+
+        g_signal_handlers_disconnect_by_data(G_OBJECT(value), this);
+    }
+}
+
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ServiceConnectLocked(std::unique_lock<std::mutex> & inOutLock,
                                                                                   ConnManService * inService) noexcept
 {
@@ -5229,7 +5407,6 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::ReportNetworkServiceConne
 void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerReady(GObject * inObject, GAsyncResult * inResult)
 {
     std::lock_guard<std::mutex> lock(mConnManMutex);
-    ConnManManager * manager;
     GAutoPtr<GError> err;
 
     ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to manager");
@@ -5243,13 +5420,23 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerReady(GObject * 
 
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
-    manager = conn_man_manager_proxy_new_for_bus_finish(inResult, &err.GetReceiver());
+    // Adopt the result immediately: every path below this point,
+    // including the early return, must dispose of it.
+
+    GAutoPtr<ConnManManager> manager(conn_man_manager_proxy_new_for_bus_finish(inResult, &err.GetReceiver()));
+
+    // A stop may have run while this call was in flight. Installing
+    // the proxy now would reconnect the manager signal handlers and
+    // silently restart management with no start outstanding.
+
+    VerifyOrReturn(mConnManStarted,
+                   ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "manager ready after stop; discarding"));
 
     if (manager && err.get() == nullptr)
     {
         ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connected to manager");
 
-        mConnManClient.mManagerProxy.reset(manager);
+        mConnManClient.mManagerProxy.reset(manager.release());
 
         // Establish manager signal handlers.
 

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -158,6 +158,12 @@ struct NetworkServiceTypeDescriptor
     const char * mDescription;
 };
 
+struct ClientErrorTableEntry
+{
+    const char * mName;
+    int mErrno;
+};
+
 // Global Variables
 
 // clang-format off
@@ -332,6 +338,53 @@ static constexpr std::array sNetworkServiceTypeDescriptors = {
     NetworkServiceTypeDescriptor{ kConnManObjectPropertyTypeWiFiValue, "Wi-Fi" },
 #endif
 };
+
+/**
+ *  Maps connman's client D-Bus error name space
+ *  (`net.connman.Error.*` and `net.connman.Agent.Error.*`) onto POSIX
+ *  errno values, carried in CHIP_ERROR's kPOSIX range.
+ *
+ *  These are the *synchronous* errors returned from method calls on
+ *  the connman manager, service, and technology interfaces --
+ *  distinct from the closed vocabulary of the service "Error"
+ *  *property*, which describes an asynchronous connection failure and
+ *  is a separate concern.
+ *
+ *  @sa MapClientError
+ */
+// clang-format off
+static constexpr std::array<ClientErrorTableEntry, 25> kClientErrorTable =
+{{
+    { "net.connman.Error.AlreadyConnected",    EISCONN      },
+    { "net.connman.Error.AlreadyDisabled",     EALREADY     },
+    { "net.connman.Error.AlreadyEnabled",      EALREADY     },
+    { "net.connman.Error.AlreadyExists",       EEXIST       },
+    { "net.connman.Error.Canceled",            ECANCELED    },
+    { "net.connman.Error.InProgress",          EINPROGRESS  },
+    { "net.connman.Error.InvalidArguments",    EINVAL       },
+    { "net.connman.Error.InvalidProperty",     EINVAL       },
+    { "net.connman.Error.InvalidService",      EINVAL       },
+    { "net.connman.Error.NoCarrier",           ENOLINK      },
+    { "net.connman.Error.NotConnected",        ENOTCONN     },
+    { "net.connman.Error.NotFound",            ENOENT       },
+    { "net.connman.Error.NotImplemented",      ENOSYS       },
+    { "net.connman.Error.NotRegistered",       ESRCH        },
+    { "net.connman.Error.NotSupported",        EOPNOTSUPP   },
+    { "net.connman.Error.NotUnique",           ENOTUNIQ     },
+    { "net.connman.Error.OperationAborted",    ECONNABORTED },
+    { "net.connman.Error.OperationCanceled",   ECANCELED    },
+    { "net.connman.Error.OperationTimeout",    ETIMEDOUT    },
+    { "net.connman.Error.PassphraseRequired",  ENOKEY       },
+    { "net.connman.Error.PermissionDenied",    EACCES       },
+    { "net.connman.Agent.Error.Canceled",      ECANCELED    },
+    { "net.connman.Agent.Error.Rejected",      ECONNREFUSED },
+    { "net.connman.Agent.Error.Retry",         EAGAIN       }
+
+    // net.connman.Error.Failed is deliberately absent: it is
+    // connman's catch-all and carries no information beyond the caller's
+    // default.
+}};
+// clang-format on
 
 // Function and Method Implementation
 
@@ -1213,6 +1266,40 @@ static CHIP_ERROR UnlockAndInvokeOnGLibContextSync(LockT & inOutLock, Callable &
     VerifyOrDie(inOutLock.owns_lock());
 
     return UnlockAndInvoke(inOutLock, [&]() { return InvokeOnGLibContextSync(std::forward<Callable>(inCallable)); });
+}
+
+static CHIP_ERROR MapClientError(const GError * inError, CHIP_ERROR inDefaultError) noexcept
+{
+    VerifyOrReturnValue(inError != nullptr, inDefaultError);
+
+    // Only a *remote* GError carries a D-Bus error name. A local
+    // GLib/GIO failure (transport teardown, timeout, cancellation)
+    // does not, and must not be run through the connman table.
+    //
+    // NOTE: this depends on the GError not having been passed through
+    // g_dbus_error_strip_remote_error(), which destroys the name.
+
+    VerifyOrReturnValue(g_dbus_error_is_remote_error(inError), inDefaultError);
+
+    GAutoPtr<char> name(g_dbus_error_get_remote_error(inError));
+    VerifyOrReturnValue(name, inDefaultError);
+
+    for (const auto & entry : kClientErrorTable)
+    {
+        if (strcmp(entry.mName, name.get()) == 0)
+        {
+            return ChipError(ChipError::Range::kPOSIX, entry.mErrno);
+        }
+    }
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "unrecognized client error '%s'", name.get());
+
+    return inDefaultError;
+}
+
+static CHIP_ERROR MapClientError(const GError * inError) noexcept
+{
+    return MapClientError(inError, CHIP_ERROR_INTERNAL);
 }
 
 } // namespace
@@ -4236,10 +4323,15 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::TechnologySetProper
             conn_man_technology_call_set_property_sync(technology.get(), key.get(), value.get(), nullptr, &err.GetReceiver());
         if (!status || err)
         {
-            ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to set technology %s property %s: %s",
-                         g_dbus_proxy_get_object_path(G_DBUS_PROXY(technology.get())), key.get(), err ? err->message : "unknown");
+            const CHIP_ERROR mapped = MapClientError(err.get());
 
-            return CHIP_ERROR_INTERNAL;
+            ChipLogError(DeviceLayer,
+                         CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to set technology %s property %s: %s (%" CHIP_ERROR_FORMAT
+                                                                 ")",
+                         g_dbus_proxy_get_object_path(G_DBUS_PROXY(technology.get())), key.get(), err ? err->message : "unknown",
+                         mapped.Format());
+
+            return mapped;
         }
 
         return CHIP_NO_ERROR;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -2604,7 +2604,7 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetServices(
 
             ReturnOnFailure(GetObjectTypeFromPropertiesLocked(props, type));
 
-            ReturnOnFailure(HandleServicePropertiesChangedLocked(G_DBUS_PROXY(service), path, type, props));
+            ReturnOnFailure(HandleServicePropertiesChangedLocked(lock, G_DBUS_PROXY(service), path, type, props));
         }
     }
     else
@@ -2646,7 +2646,7 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetTechnolog
 
             ReturnOnFailure(GetObjectTypeFromPropertiesLocked(props, type));
 
-            ReturnOnFailure(HandleTechnologyPropertiesChangedLocked(G_DBUS_PROXY(technology), path, type, props));
+            ReturnOnFailure(HandleTechnologyPropertiesChangedLocked(lock, G_DBUS_PROXY(technology), path, type, props));
         }
     }
     else
@@ -2809,7 +2809,7 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerServicesChan
         status            = GetObjectTypeFromPropertiesLocked(current, type);
         VerifyOrReturn(status == CHIP_NO_ERROR);
 
-        status = HandleServicePropertiesChangedLocked(G_DBUS_PROXY(service), path, type, props);
+        status = HandleServicePropertiesChangedLocked(inOutLock, G_DBUS_PROXY(service), path, type, props);
         VerifyOrReturn(status == CHIP_NO_ERROR);
     }
 }
@@ -2865,7 +2865,7 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerTechnologyAd
     status = GetObjectTypeFromPathLocked(mConnManClient.mTechnologies.get(), inPath, type);
     ReturnOnFailure(status);
 
-    status = HandleTechnologyPropertiesChangedLocked(G_DBUS_PROXY(technology), inPath, type, inProperties);
+    status = HandleTechnologyPropertiesChangedLocked(lock, G_DBUS_PROXY(technology), inPath, type, inProperties);
     ReturnOnFailure(status);
 }
 
@@ -2942,7 +2942,8 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropert
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropertiesChangedLocked(
-    const char * inDescription, GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties,
+    std::unique_lock<std::mutex> & inOutLock, const char * inDescription, GDBusProxy * inProxy, const char * inPath,
+    const char * inType, GVariant * inProperties,
     TypedObjectPropertiesChangedAnyLockedMethod inTypedObjectPropertiesChangedAnyLockedMethod) noexcept
 {
     VerifyOrReturnError(inDescription != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -2970,7 +2971,8 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropert
             VerifyOrReturnError(key != nullptr, CHIP_ERROR_INTERNAL);
             VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_INTERNAL);
 
-            ReturnErrorOnFailure((this->*inTypedObjectPropertiesChangedAnyLockedMethod)(inProxy, inPath, inType, key, boxed.get()));
+            ReturnErrorOnFailure(
+                (this->*inTypedObjectPropertiesChangedAnyLockedMethod)(inOutLock, inProxy, inPath, inType, key, boxed.get()));
         }
     }
 
@@ -2978,8 +2980,8 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropert
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropertyChangedAnyLocked(
-    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant,
-    TypedObjectPropertyChangedLockedMethod inTypedObjectPropertyChangedLockedMethod) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey,
+    GVariant * inMaybeVariant, TypedObjectPropertyChangedLockedMethod inTypedObjectPropertyChangedLockedMethod) noexcept
 {
     VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -2991,7 +2993,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropert
     UnboxedVariant value(inMaybeVariant);
     VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
 
-    ReturnErrorOnFailure((this->*inTypedObjectPropertyChangedLockedMethod)(inProxy, inPath, inType, inKey, value.get()));
+    ReturnErrorOnFailure((this->*inTypedObjectPropertyChangedLockedMethod)(inOutLock, inProxy, inPath, inType, inKey, value.get()));
 
     return CHIP_NO_ERROR;
 }
@@ -3117,22 +3119,21 @@ ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectRequestLoc
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertiesChangedLocked(GDBusProxy * inProxy,
-                                                                                                  const char * inPath,
-                                                                                                  const char * inType,
-                                                                                                  GVariant * inProperties) noexcept
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertiesChangedLocked(
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType,
+    GVariant * inProperties) noexcept
 {
     static const char * const kDescription = "service";
 
     return HandleObjectPropertiesChangedLocked(
-        kDescription, inProxy, inPath, inType, inProperties,
+        inOutLock, kDescription, inProxy, inPath, inType, inProperties,
         &ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedAnyLocked);
 }
 
 void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChanged(ConnManService * inService, const char * inKey,
                                                                                     GVariant * inValue) noexcept
 {
-    std::lock_guard<std::mutex> lock(mConnManMutex);
+    std::unique_lock<std::mutex> lock(mConnManMutex);
     const char * path = nullptr;
     const char * type = nullptr;
     CHIP_ERROR status;
@@ -3155,13 +3156,16 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChan
     status = GetObjectTypeFromPathLocked(mConnManClient.mServices.get(), path, type);
     ReturnOnFailure(status);
 
-    status = HandleServicePropertyChangedAnyLocked(G_DBUS_PROXY(inService), path, type, inKey, inValue);
+    status = HandleServicePropertyChangedAnyLocked(lock, G_DBUS_PROXY(inService), path, type, inKey, inValue);
     ReturnOnFailure(status);
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedLocked(
-    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey,
+    GVariant * inValue) noexcept
 {
+    VerifyOrDie(inOutLock.owns_lock());
+
     VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -3194,20 +3198,22 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceProper
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedAnyLocked(
-    GDBusProxy * inService, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inService, const char * inPath, const char * inType, const char * inKey,
+    GVariant * inMaybeVariant) noexcept
 {
     return HandleObjectPropertyChangedAnyLocked(
-        G_DBUS_PROXY(inService), inPath, inType, inKey, inMaybeVariant,
+        inOutLock, G_DBUS_PROXY(inService), inPath, inType, inKey, inMaybeVariant,
         &ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedLocked);
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertiesChangedLocked(
-    GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType,
+    GVariant * inProperties) noexcept
 {
     static const char * const kDescription = "technology";
 
     return HandleObjectPropertiesChangedLocked(
-        kDescription, inProxy, inPath, inType, inProperties,
+        inOutLock, kDescription, inProxy, inPath, inType, inProperties,
         &ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedAnyLocked);
 }
 
@@ -3215,7 +3221,7 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyC
                                                                                        const char * inKey,
                                                                                        GVariant * inValue) noexcept
 {
-    std::lock_guard<std::mutex> lock(mConnManMutex);
+    std::unique_lock<std::mutex> lock(mConnManMutex);
     const char * path = nullptr;
     const char * type = nullptr;
     CHIP_ERROR status;
@@ -3238,13 +3244,16 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyC
     status = GetObjectTypeFromPathLocked(mConnManClient.mTechnologies.get(), path, type);
     ReturnOnFailure(status);
 
-    status = HandleTechnologyPropertyChangedAnyLocked(G_DBUS_PROXY(inTechnology), path, type, inKey, inValue);
+    status = HandleTechnologyPropertyChangedAnyLocked(lock, G_DBUS_PROXY(inTechnology), path, type, inKey, inValue);
     ReturnOnFailure(status);
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedLocked(
-    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey,
+    GVariant * inValue) noexcept
 {
+    VerifyOrDie(inOutLock.owns_lock());
+
     VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -3299,10 +3308,11 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPro
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedAnyLocked(
-    GDBusProxy * inTechnology, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept
+    std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inTechnology, const char * inPath, const char * inType,
+    const char * inKey, GVariant * inMaybeVariant) noexcept
 {
     return HandleObjectPropertyChangedAnyLocked(
-        inTechnology, inPath, inType, inKey, inMaybeVariant,
+        inOutLock, inTechnology, inPath, inType, inKey, inMaybeVariant,
         &ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedLocked);
 }
 

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -1,0 +1,4927 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *    This implements a C++ binding for a Linux platform
+ *    implementation of the Matter Connectivity Manager against the
+ *    third-party, open source D-Bus-based Connection Manager (also
+ *    known as, connman) network manager.
+ *
+ *  As with other D-Bus based Matter Linux platform infrastructure,
+ *  this implementation relies upon the dedicated GLib thread context
+ *  for animating and dispatching connman D-Bus connection activity.
+ *
+ *  Because there is coordination between the Matter thread context
+ *  and the GLib thread context, cross-thread mutual exclusion is
+ *  absolutely required and a few, short, mechanical rules must be
+ *  observed:
+ *
+ *    1. There shall be no invocation of the synchronous (that is,
+ *       blocking) `InvokeOnGLibMainLoopSync` while holding the class
+ *       lock.
+ *    2. `*Locked` methods may temporarily unlock via
+ *       `UnlockAndInvoke*` to perform a cross-thread synchronous
+ *       scheduling/D-Bus call, but shall not wait for an asynchronous
+ *       D-Bus completion under lock.
+ *    3. All cross-thread  synchronous  calls  shall  be  wrapped by
+ *      `UnlockAndInvoke*`.
+ *    4. All `*OnGLib` methods shall not hold the class lock and shall
+ *       not call `*Locked` methods or functions directly.
+ *
+ *  As for the class lock itself, there are three further rules:
+ *
+ *    1. Any method named `*Locked` shall not take a lock parameter and
+ *       shall not manipulate the class lock. It simply requires that
+ *       the class lock is held; this is verified and enforced by
+ *       assertion.
+ *    2. Any method that might need to temporarily unlock shall use a
+ *       `std::unique_lock` in the parent "orchestrator" method.
+ *    3. In any scope where something is passed to `UnlockAndInvoke`,
+ *       a `std::unique_lock` instance of the class lock shall be held.
+ *
+ *  Where possible, all meaningful work is transitioned from the GLib
+ *  thread context to the Matter context throught the use of
+ *  `ScheduleLambda`.
+ *
+ */
+
+#include "ConnectivityManagerImpl_NetworkManagementConnMan.h"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include <errno.h>
+
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/DeviceControlServer.h>
+#include <platform/DiagnosticDataProvider.h>
+#include <platform/PlatformManager.h>
+
+#include "ConnectivityManagerImpl.h"
+#include "WirelessDefs.h"
+
+using namespace ::chip;
+using namespace ::chip::Credentials;
+using namespace ::chip::DeviceLayer::NetworkCommissioning;
+using namespace ::chip::app::Clusters::GeneralDiagnostics;
+using namespace ::chip::app::Clusters::WiFiNetworkDiagnostics;
+
+// Preprocessor Definitions
+
+// clang-format off
+#define CONNMAN_SERVICE                                "net.connman"
+
+#define CONNMAN_AGENT_INTERFACE                        CONNMAN_SERVICE ".Agent"
+
+#define CONNMAN_MANAGER_INTERFACE                      CONNMAN_SERVICE ".Manager"
+#define CONNMAN_MANAGER_PATH                           "/"
+#define CONNMAN_MANAGER_OBJECT_PATH_STEM               CONNMAN_MANAGER_PATH "net/connman"
+#define CONNMAN_MANAGER_SERVICE_PATH_STEM              CONNMAN_MANAGER_OBJECT_PATH_STEM "/service"
+#define CONNMAN_MANAGER_TECHNOLOGY_PATH_STEM           CONNMAN_MANAGER_OBJECT_PATH_STEM "/technology"
+
+#define CONNMAN_SERVICE_INTERFACE                      CONNMAN_SERVICE ".Service"
+#define CONNMAN_TECHNOLOGY_INTERFACE                   CONNMAN_SERVICE ".Technology"
+
+// Note that dashes ("-") are not allowed in D-Bus
+// paths.
+
+#define MATTER_PATH                                    "/org/csa/matter"
+#define MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH MATTER_PATH "/ConnectivityManager"
+
+#define kConnManObjectPropertyNameKey                  "Name"
+
+#define kConnManObjectPropertyStateKey                 "State"
+
+#define kConnManObjectPropertyStateIdleValue           "idle"
+#define kConnManObjectPropertyStateOfflineValue        "offline"
+#define kConnManObjectPropertyStateOnlineValue         "online"
+#define kConnManObjectPropertyStateReadyValue          "ready"
+
+#define kConnManObjectPropertyTypeKey                  "Type"
+
+#define kConnManObjectPropertyTypeEthernetValue        "ethernet"
+#define kConnManObjectPropertyTypeWiFiValue            "wifi"
+
+#define CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX        "connman: "
+// clang-format on
+
+namespace chip {
+namespace DeviceLayer {
+
+namespace {
+
+// Type Declarations
+
+template <typename Callable>
+struct GLibInvokeContext
+{
+    Callable mCallable;
+    CHIP_ERROR mStatus = CHIP_NO_ERROR;
+};
+
+class UnboxedVariant
+{
+public:
+    explicit UnboxedVariant(GVariant * inMaybeVariant) noexcept;
+
+    GVariant * get() const noexcept;
+    explicit operator bool() const noexcept;
+
+private:
+    GAutoPtr<GVariant> mOwned;   // owns unboxed value if we had to unbox
+    GVariant * mValue = nullptr; // points to either inMaybeVariant or mOwned.get()
+};
+
+struct NetworkServiceTypeDescriptor
+{
+    const char * mType;
+    const char * mDescription;
+};
+
+// Global Variables
+
+// clang-format off
+static constexpr char kConnManServiceName[]                                       = CONNMAN_SERVICE;
+static constexpr char kConnManManagerInterface[]                                  = CONNMAN_MANAGER_INTERFACE;
+static constexpr char kConnManManagerPath[]                                       = CONNMAN_MANAGER_PATH;
+
+// Service Agent Object Property Keys and Values
+
+static constexpr char kConnManServiceAgentPropertyAlternatesKey[]                 = "Alternates";
+static constexpr char kConnManServiceAgentPropertyIdentityKey[]                   = "Identity";
+static constexpr char kConnManServiceAgentPropertyNameKey[]                       = "Name";
+static constexpr char kConnManServiceAgentPropertyPassphraseKey[]                 = "Passphrase";
+static constexpr char kConnManServiceAgentPropertyPasswordKey[]                   = "Password";
+static constexpr char kConnManServiceAgentPropertyPreviousPassphraseKey[]         = "PreviousPassphrase";
+
+static constexpr char kConnManServiceAgentPropertyRequirementKey[] = "Requirement";
+
+static constexpr char kConnManServiceAgentPropertyRequirementAlternateValue[]     = "alternate";
+static constexpr char kConnManServiceAgentPropertyRequirementInformationalValue[] = "informational";
+static constexpr char kConnManServiceAgentPropertyRequirementMandatoryValue[]     = "mandatory";
+static constexpr char kConnManServiceAgentPropertyRequirementOptionalValue[]      = "optional";
+
+static constexpr char kConnManServiceAgentPropertySSIDKey[]                       = "SSID";
+
+static constexpr char kConnManServiceAgentPropertyTypeKey[]                       = "Type";
+
+static constexpr char kConnManServiceAgentPropertyTypePassphraseValue[]           = "passphrase";
+static constexpr char kConnManServiceAgentPropertyTypePSKValue[]                  = "psk";
+static constexpr char kConnManServiceAgentPropertyTypeResponseValue[]             = "response";
+static constexpr char kConnManServiceAgentPropertyTypeSSIDValue[]                 = "ssid";
+static constexpr char kConnManServiceAgentPropertyTypeStringValue[]               = "string";
+static constexpr char kConnManServiceAgentPropertyTypeWEPValue[]                  = "wep";
+static constexpr char kConnManServiceAgentPropertyTypeWPSPINValue[]               = "wpspin";
+
+static constexpr char kConnManServiceAgentPropertyUsernameKey[]                   = "Username";
+static constexpr char kConnManServiceAgentPropertyValueKey[]                      = "Value";
+static constexpr char kConnManServiceAgentPropertyWPSKey[]                        = "WPS";
+
+// Manager Object Property Keys and Values
+
+static constexpr char kConnManManagerPropertyStateKey[]                           = kConnManObjectPropertyStateKey;
+
+static constexpr char kConnManManagerPropertyStateIdleValue[]                     = kConnManObjectPropertyStateIdleValue;
+static constexpr char kConnManManagerPropertyStateOfflineValue[]                  = kConnManObjectPropertyStateOfflineValue;
+static constexpr char kConnManManagerPropertyStateOnlineValue[]                   = kConnManObjectPropertyStateOnlineValue;
+static constexpr char kConnManManagerPropertyStateReadyValue[]                    = kConnManObjectPropertyStateReadyValue;
+static constexpr char kConnManManagerPropertyStateUnavailableValue[]              = "unavailable";
+
+// Service Object Property Keys and Values
+
+static constexpr char kConnManServicePropertyAutoConnectKey[]                     = "AutoConnect";
+static constexpr char kConnManServicePropertyDomainsKey[]                         = "Domains";
+static constexpr char kConnManServicePropertyDomainsConfigurationKey[]            = "Domains.Configuration";
+
+static constexpr char kConnManServicePropertyErrorKey[]                           = "Error";
+
+static constexpr char kConnManServicePropertyErrorAuthFailedValue[]               = "auth-failed";
+static constexpr char kConnManServicePropertyErrorBlockedValue[]                  = "blocked";
+static constexpr char kConnManServicePropertyErrorConnectFailedValue[]            = "connect-failed";
+static constexpr char kConnManServicePropertyErrorDHCPFailedValue[]               = "dhcp-failed";
+static constexpr char kConnManServicePropertyErrorInvalidKeyValue[]               = "invalid-key";
+static constexpr char kConnManServicePropertyErrorLoginFailedValue[]              = "login-failed";
+static constexpr char kConnManServicePropertyErrorOnlineCheckFailedValue[]        = "online-check-failed";
+static constexpr char kConnManServicePropertyErrorOutOfRangeValue[]               = "out-of-range";
+static constexpr char kConnManServicePropertyErrorPINMissingValue[]               = "pin-missing";
+
+static constexpr char kConnManServicePropertyEthernetKey[]                        = "Ethernet";
+
+static constexpr char kConnManServicePropertyEthernetAddressKey[]                 = "Address";
+static constexpr char kConnManServicePropertyEthernetInterfaceKey[]               = "Interface";
+static constexpr char kConnManServicePropertyEthernetMTUKey[]                     = "MTU";
+static constexpr char kConnManServicePropertyEthernetMethodKey[]                  = "Method";
+
+static constexpr char kConnManServicePropertyFavoriteKey[]                        = "Favorite";
+static constexpr char kConnManServicePropertyIPv4Key[]                            = "IPv4";
+static constexpr char kConnManServicePropertyIPv4ConfigurationKey[]               = "IPv4.Configuration";
+static constexpr char kConnManServicePropertyIPv6Key[]                            = "IPv6";
+static constexpr char kConnManServicePropertyIPv6ConfigurationKey[]               = "IPv6.Configuration";
+
+static constexpr char kConnManServicePropertyIPAddressKey[]                       = "Address";
+
+static constexpr char kConnManServicePropertymDNSKey[]                            = "mDNS";
+static constexpr char kConnManServicePropertymDNSConfigurationKey[]               = "mDNS.Configuration";
+static constexpr char kConnManServicePropertyNameKey[]                            = kConnManObjectPropertyNameKey;
+static constexpr char kConnManServicePropertyNameserversKey[]                     = "Nameservers";
+static constexpr char kConnManServicePropertyNameserversConfigurationKey[]        = "Nameservers.Configuration";
+static constexpr char kConnManServicePropertyProviderKey[]                        = "Provider";
+static constexpr char kConnManServicePropertyProxyConfigurationKey[]              = "Proxy.Configuration";
+static constexpr char kConnManServicePropertyProxyKey[]                           = "Proxy";
+
+static constexpr char kConnManServicePropertyRoamingKey[]                         = "Roaming";
+
+static constexpr char kConnManServicePropertySecurityKey[]                        = "Security";
+
+static constexpr char kConnManServicePropertySecurity8021XValue[]                 = "ieee8021x";
+static constexpr char kConnManServicePropertySecurityNoneValue[]                  = "none";
+static constexpr char kConnManServicePropertySecurityPSKValue[]                   = "psk";
+static constexpr char kConnManServicePropertySecurityRSNValue[]                   = "rsn";
+static constexpr char kConnManServicePropertySecurityWEPValue[]                   = "wep";
+static constexpr char kConnManServicePropertySecurityWPAValue[]                   = "wpa";
+static constexpr char kConnManServicePropertySecurityWPSAdvertisingValue[]        = "wps_advertising";
+static constexpr char kConnManServicePropertySecurityWPSValue[]                   = "wps";
+
+static constexpr char kConnManServicePropertyStateKey[]                           = "State";
+
+static constexpr char kConnManServicePropertyStateAssociationValue[]              = "association";
+static constexpr char kConnManServicePropertyStateConfigurationValue[]            = "configuration";
+static constexpr char kConnManServicePropertyStateDisconnectValue[]               = "disconnect";
+static constexpr char kConnManServicePropertyStateFailureValue[]                  = "failure";
+static constexpr char kConnManServicePropertyStateIdleValue[]                     = kConnManObjectPropertyStateIdleValue;
+static constexpr char kConnManServicePropertyStateOfflineValue[]                  = kConnManObjectPropertyStateOfflineValue;
+static constexpr char kConnManServicePropertyStateOnlineValue[]                   = kConnManObjectPropertyStateOnlineValue;
+static constexpr char kConnManServicePropertyStateReadyValue[]                    = kConnManObjectPropertyStateReadyValue;
+
+static constexpr char kConnManServicePropertyStrengthKey[]                        = "Strength";
+static constexpr char kConnManServicePropertyTimeserversKey[]                     = "Timeservers";
+static constexpr char kConnManServicePropertyTimeserversConfigurationKey[]        = "Timeservers.Configuration";
+
+static constexpr char kConnManServicePropertyTypeKey[]                            = kConnManObjectPropertyTypeKey;
+
+static constexpr char kConnManServicePropertyTypeEthernetValue[]                  = kConnManObjectPropertyTypeEthernetValue;
+static constexpr char kConnManServicePropertyTypeWiFiValue[]                      = kConnManObjectPropertyTypeWiFiValue;
+
+// Technology Object Property Keys and Values
+
+static constexpr char kConnManTechnologyPropertyConnectedKey[]                    = "Connected";
+static constexpr char kConnManTechnologyPropertyNameKey[]                         = kConnManObjectPropertyNameKey;
+static constexpr char kConnManTechnologyPropertyPoweredKey[]                      = "Powered";
+static constexpr char kConnManTechnologyPropertyTypeKey[]                         = kConnManObjectPropertyTypeKey;
+
+static constexpr char kConnManTechnologyPropertyTypeEthernetValue[]               = kConnManObjectPropertyTypeEthernetValue;
+static constexpr char kConnManTechnologyPropertyTypeWiFiValue[]                   = kConnManObjectPropertyTypeWiFiValue;
+
+// Network Name and Passphrase Validate Check Failure Reason Strings
+
+static constexpr char kNetworkNameIsTooShort[]                                    = "name is too short";
+static constexpr char kNetworkNameIsTooLong[]                                     = "name is too long";
+static constexpr char kNetworkPassphraseIsTooShort[]                              = "passphrase is too short";
+static constexpr char kNetworkPassphraseIsTooLong[]                               = "passphrase is too long";
+static constexpr char kNetworkPassphraseHasInvalidCharacters[]                    = "passphrase contains an invalid character";
+// clang-format on
+
+/**
+ *  The maximum number of "active" (connman does not actually do
+ *  active, directed scans) scans for a particular SSID before
+ *  failing.
+ */
+static constexpr size_t kWiFiActiveScanLimit = 4;
+
+/**
+ *  The maximum number of scans for connecting to a particular SSID
+ *  before failing.
+ */
+static constexpr size_t kWiFiConnectScanLimit = 4;
+
+/**
+ *  Trailing-edge debounce interval applied between an observed change
+ *  in a tracked network service's IPv4/IPv6 configuration and the
+ *  posting of a kInternetConnectivityChange device event, so that
+ *  connman property storms at interface bring-up coalesce into a
+ *  single event.
+ */
+static constexpr System::Clock::Milliseconds32 kNetworkServiceConnectivityDebounce = System::Clock::Milliseconds32(1000);
+
+static constexpr std::array sNetworkServiceTypeDescriptors = {
+    NetworkServiceTypeDescriptor
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    { kConnManObjectPropertyTypeEthernetValue, "Ethernet" },
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    NetworkServiceTypeDescriptor{ kConnManObjectPropertyTypeWiFiValue, "Wi-Fi" },
+#endif
+};
+
+// Function and Method Implementation
+
+// Unboxed Variant
+
+// Construction
+
+UnboxedVariant::UnboxedVariant(GVariant * inMaybeVariant) noexcept : mValue(inMaybeVariant)
+{
+    if (mValue != nullptr && g_variant_is_of_type(mValue, G_VARIANT_TYPE_VARIANT))
+    {
+        mOwned.reset(g_variant_get_variant(mValue));
+
+        mValue = mOwned.get();
+    }
+}
+
+GVariant * UnboxedVariant::get() const noexcept
+{
+    return mValue;
+}
+
+UnboxedVariant::operator bool() const noexcept
+{
+    return mValue != nullptr;
+}
+
+static CHIP_ERROR RemoveObjectLocked(GHashTable * inObjectTable, const char * inObjectPath, GHashTable * inObjectProxies) noexcept
+{
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectProxies != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_hash_table_remove(inObjectTable, inObjectPath);
+    g_hash_table_remove(inObjectProxies, inObjectPath);
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectPropertiesFromPathLocked(GHashTable * inObjectTable, const char * inObjectPath,
+                                                    GVariant *& outProperties) noexcept
+{
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GVariant * props = static_cast<GVariant *>(g_hash_table_lookup(inObjectTable, inObjectPath));
+    VerifyOrReturnError(props != nullptr, ChipError(ChipError::Range::kPOSIX, ENOENT));
+
+    outProperties = props;
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectByteValueFromPropertiesLocked(GVariant * inProperties, const char * inKey, uint8_t & outValue) noexcept
+{
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    GAutoPtr<GVariant> boxed(g_variant_lookup_value(inProperties, inKey, nullptr));
+    VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    UnboxedVariant value(boxed.get());
+    VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(g_variant_is_of_type(value.get(), G_VARIANT_TYPE_BYTE), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    outValue = g_variant_get_byte(value.get());
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectStringValueFromPropertiesLocked(GVariant * inProperties, const char * inKey,
+                                                           const char *& outValue) noexcept
+{
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    GAutoPtr<GVariant> boxed(g_variant_lookup_value(inProperties, inKey, nullptr));
+    VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    UnboxedVariant value(boxed.get());
+    VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(g_variant_is_of_type(value.get(), G_VARIANT_TYPE_STRING), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    outValue = g_variant_get_string(value.get(), nullptr);
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectNameFromPropertiesLocked(GVariant * inProperties, const char *& outName) noexcept
+{
+    return GetObjectStringValueFromPropertiesLocked(inProperties, kConnManObjectPropertyNameKey, outName);
+}
+
+static CHIP_ERROR GetObjectStateFromPropertiesLocked(GVariant * inProperties, const char *& outState) noexcept
+{
+    return GetObjectStringValueFromPropertiesLocked(inProperties, kConnManObjectPropertyStateKey, outState);
+}
+
+static CHIP_ERROR GetObjectTypeFromPropertiesLocked(GVariant * inProperties, const char *& outType) noexcept
+{
+    return GetObjectStringValueFromPropertiesLocked(inProperties, kConnManObjectPropertyTypeKey, outType);
+}
+
+static CHIP_ERROR GetObjectStringValueFromPathLocked(GHashTable * inObjectTable, const char * inObjectPath, const char * inKey,
+                                                     const char *& outValue) noexcept
+{
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GVariant * props = static_cast<GVariant *>(g_hash_table_lookup(inObjectTable, inObjectPath));
+    VerifyOrReturnError(props != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    ReturnErrorOnFailure(GetObjectStringValueFromPropertiesLocked(props, inKey, outValue));
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectTypeFromPathLocked(GHashTable * inObjectTable, const char * inObjectPath, const char *& outType) noexcept
+{
+    return GetObjectStringValueFromPathLocked(inObjectTable, inObjectPath, kConnManObjectPropertyTypeKey, outType);
+}
+
+static CHIP_ERROR GetObjectPathFromProxyLocked(GDBusProxy * inProxy, const char *& outPath) noexcept
+{
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const char * path = g_dbus_proxy_get_object_path(inProxy);
+    VerifyOrReturnError(path != nullptr, CHIP_ERROR_INTERNAL);
+
+    outPath = path;
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetObjectTypeFromProxyLocked(GDBusProxy * inProxy, GHashTable * inObjectTable, const char *& outType) noexcept
+{
+    const char * path;
+
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ReturnErrorOnFailure(GetObjectPathFromProxyLocked(inProxy, path));
+
+    ReturnErrorOnFailure(GetObjectTypeFromPathLocked(inObjectTable, path, outType));
+
+    return CHIP_NO_ERROR;
+}
+
+static bool HasTechnologyLocked(GHashTable * inTechnologies, const char * inType) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    VerifyOrReturnValue(inTechnologies != nullptr, false);
+    VerifyOrReturnValue(inType != nullptr, false);
+
+    g_hash_table_iter_init(&iter, inTechnologies);
+
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        GVariant * const props = static_cast<GVariant *>(value);
+        if (props == nullptr || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+
+        if ((GetObjectTypeFromPropertiesLocked(props, type) == CHIP_NO_ERROR) && (type != nullptr) && strcmp(type, inType) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void LogProperty(const char * inDescription, const char * inPath, const char * inKey, GVariant * inValue) noexcept
+{
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s: %s: key '%s' value type '%s'", inDescription, inPath,
+                  inKey, g_variant_get_type_string(inValue));
+}
+
+static void LogProperties(const char * inDescription, const char * inPath, GVariant * inDictionary) noexcept
+{
+    GVariantIter it;
+    const char * key = nullptr;
+    GVariant * value = nullptr;
+
+    if (inDictionary == nullptr || !g_variant_is_of_type(inDictionary, G_VARIANT_TYPE_VARDICT))
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s: %s: not a{sv} (type=%s)", inDescription, inPath,
+                     inDictionary ? g_variant_get_type_string(inDictionary) : "(null)");
+    }
+    else
+    {
+        g_variant_iter_init(&it, inDictionary);
+        while (g_variant_iter_next(&it, "{&sv}", &key, &value))
+        {
+            LogProperty(inDescription, inPath, key, value);
+
+            g_variant_unref(value);
+        }
+    }
+}
+
+static CHIP_ERROR Merge(GVariant * inBase, GVariant * inDelta, GAutoPtr<GVariant> & outResult) noexcept
+{
+    VerifyOrReturnError(inDelta != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inDelta, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // If there is no base variant, then just take a reference to the
+    // delta variant. Otherwise, proceed merging base and delta.
+
+    if (inBase == nullptr)
+    {
+        outResult.reset(g_variant_ref(inDelta));
+    }
+    else
+    {
+        GVariantIter delta_iter;
+        const char * delta_key = nullptr;
+        GVariant * delta_value = nullptr;
+        GVariantIter base_iter;
+        const char * base_key = nullptr;
+        GVariant * base_value = nullptr;
+        GVariantBuilder builder;
+
+        VerifyOrReturnError(g_variant_is_of_type(inBase, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+
+        // GLib does not have a container with set semantics, so we use a
+        // hash table to uniquely contain all of the keys in the delta
+        // variant.
+
+        GAutoPtr<GHashTable> delta_keys(g_hash_table_new_full(g_str_hash, g_str_equal, g_free, nullptr));
+        VerifyOrReturnError(delta_keys.get() != nullptr, CHIP_ERROR_INTERNAL);
+
+        // Get all of the delta keys into the newly-created hash table.
+
+        g_variant_iter_init(&delta_iter, inDelta);
+
+        while (g_variant_iter_next(&delta_iter, "{&sv}", &delta_key, &delta_value))
+        {
+            g_hash_table_replace(delta_keys.get(), g_strdup(delta_key), GINT_TO_POINTER(1));
+
+            g_variant_unref(delta_value);
+        }
+
+        // Initialize the result variant builder and add all base entries
+        // that are not otherwise overwritten by the delta.
+
+        g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+
+        g_variant_iter_init(&base_iter, inBase);
+
+        while (g_variant_iter_next(&base_iter, "{&sv}", &base_key, &base_value))
+        {
+            if (!g_hash_table_contains(delta_keys.get(), base_key))
+            {
+                g_variant_builder_add(&builder, "{sv}", base_key, base_value);
+            }
+
+            g_variant_unref(base_value);
+        }
+
+        // Finally, add with delta entries.
+
+        g_variant_iter_init(&delta_iter, inDelta);
+
+        while (g_variant_iter_next(&delta_iter, "{&sv}", &delta_key, &delta_value))
+        {
+            g_variant_builder_add(&builder, "{sv}", delta_key, delta_value);
+
+            g_variant_unref(delta_value);
+        }
+
+        outResult.reset(g_variant_builder_end(&builder));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR MergeObjectPropertiesLocked(const char * inDescription, GHashTable * inObjectTable, const char * inObjectPath,
+                                              GVariant * inObjectProperties) noexcept
+{
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(g_variant_is_of_type(inObjectProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // If the specified object properties are empty, then there is
+    // nothing to merge; otherwise, merge the properties key/value
+    // pairs.
+
+    LogProperties(inDescription, inObjectPath, inObjectProperties);
+
+    if (g_variant_n_children(inObjectProperties) == 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    GVariant * current = nullptr;
+    ReturnErrorOnFailure(GetObjectPropertiesFromPathLocked(inObjectTable, inObjectPath, current)
+                             .NoErrorIf(ChipError(ChipError::Range::kPOSIX, ENOENT)));
+
+    GAutoPtr<GVariant> merged;
+    ReturnErrorOnFailure(Merge(current, inObjectProperties, merged));
+
+    g_hash_table_replace(inObjectTable, g_strdup(inObjectPath), merged.release());
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR MergeObjectPropertiesLocked(const char * inDescription, GHashTable * inObjectTable, const char * inObjectPath,
+                                              const char * inKey, GVariant * inValue) noexcept
+{
+    GVariantBuilder builder;
+
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inValue != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+
+    g_variant_builder_add(&builder, "{sv}", inKey, inValue);
+
+    GAutoPtr<GVariant> property(g_variant_builder_end(&builder));
+
+    ReturnErrorOnFailure(MergeObjectPropertiesLocked(inDescription, inObjectTable, inObjectPath, property.get()));
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR MergeObjectPropertiesLocked(const char * inDescription, GHashTable * inObjectTable, GVariant * inObjects) noexcept
+{
+    GVariantIter iter;
+    const char * path = nullptr;
+    GVariant * props  = nullptr;
+
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjects != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inObjects, G_VARIANT_TYPE("a(oa{sv})")), CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_variant_iter_init(&iter, inObjects);
+
+    while (g_variant_iter_next(&iter, "(&o@a{sv})", &path, &props))
+    {
+        ReturnErrorOnFailure(MergeObjectPropertiesLocked(inDescription, inObjectTable, path, props));
+
+        props = nullptr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+static bool ByteSpanEqualsString(const ByteSpan & inSpan, const char * inString) noexcept
+{
+    VerifyOrReturnError(inString != nullptr, false);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s: comparing '%.*s' v. '%s'...", __func__,
+                  static_cast<int>(inSpan.size()), inSpan.data(), inString);
+
+    const size_t length = strlen(inString);
+
+    return ((inSpan.size() == length) && (memcmp(inSpan.data(), inString, length) == 0));
+}
+
+static ConnManService * GetWiFiServiceProxyFromSsidLocked(const ByteSpan & inSsid, GHashTable * inProxies,
+                                                          GHashTable * inServices) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    VerifyOrReturnValue(inSsid.size() > 0, nullptr);
+    VerifyOrReturnValue(inProxies != nullptr, nullptr);
+    VerifyOrReturnValue(inServices != nullptr, nullptr);
+
+    g_hash_table_iter_init(&iter, inServices);
+
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        const char * const path = static_cast<const char *>(key);
+        GVariant * const props  = static_cast<GVariant *>(value);
+        if ((path == nullptr) || (props == nullptr) || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if ((GetObjectTypeFromPropertiesLocked(props, type) != CHIP_NO_ERROR) || (type == nullptr) ||
+            strcmp(type, kConnManServicePropertyTypeWiFiValue) != 0)
+        {
+            continue;
+        }
+
+        const char * name = nullptr;
+        if ((GetObjectNameFromPropertiesLocked(props, name) == CHIP_NO_ERROR) && (name != nullptr) &&
+            ByteSpanEqualsString(inSsid, name))
+        {
+            return static_cast<ConnManService *>(g_hash_table_lookup(inProxies, path));
+        }
+    }
+
+    return nullptr;
+}
+
+static ConnManTechnology * GetTechnologyProxyFromTypeLocked(const char * inType, GHashTable * inProxies,
+                                                            GHashTable * inTechnologies) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    VerifyOrReturnValue(inType != nullptr, nullptr);
+    VerifyOrReturnValue(inProxies != nullptr, nullptr);
+    VerifyOrReturnValue(inTechnologies != nullptr, nullptr);
+
+    g_hash_table_iter_init(&iter, inTechnologies);
+
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        const char * const path = static_cast<const char *>(key);
+        GVariant * const props  = static_cast<GVariant *>(value);
+        if ((path == nullptr) || (props == nullptr) || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if ((GetObjectTypeFromPropertiesLocked(props, type) == CHIP_NO_ERROR) && (type != nullptr) && strcmp(type, inType) == 0)
+        {
+            return static_cast<ConnManTechnology *>(g_hash_table_lookup(inProxies, path));
+        }
+    }
+
+    return nullptr;
+}
+
+static CHIP_ERROR GetServiceInterfaceFromEthernetLocked(GVariant * inEthernet, GAutoPtr<gchar> & outInterface) noexcept
+{
+    const char * interface;
+
+    VerifyOrReturnError(inEthernet != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(g_variant_is_of_type(inEthernet, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    const gboolean status = g_variant_lookup(inEthernet, kConnManServicePropertyEthernetInterfaceKey, "&s", &interface);
+    VerifyOrReturnError(status && interface, CHIP_ERROR_KEY_NOT_FOUND);
+
+    outInterface.reset(g_strdup(interface));
+    VerifyOrReturnError(outInterface.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetServiceInterfaceFromPropertiesLocked(GVariant * inProperties, GAutoPtr<gchar> & outInterface) noexcept
+{
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    GAutoPtr<GVariant> variant(g_variant_lookup_value(inProperties, kConnManServicePropertyEthernetKey, nullptr));
+    VerifyOrReturnError(variant.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    ReturnErrorOnFailure(GetServiceInterfaceFromEthernetLocked(variant.get(), outInterface));
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetServiceInterfaceFromPathLocked(GHashTable * inObjectTable, const char * inObjectPath,
+                                                    GAutoPtr<gchar> & outInterface) noexcept
+{
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GVariant * const props = static_cast<GVariant *>(g_hash_table_lookup(inObjectTable, inObjectPath));
+    VerifyOrReturnError(props != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    ReturnErrorOnFailure(GetServiceInterfaceFromPropertiesLocked(props, outInterface));
+
+    return CHIP_NO_ERROR;
+}
+
+static int GetServiceStateScore(const char * inState) noexcept
+{
+    VerifyOrReturnValue(inState != nullptr, 0);
+
+    if (strcmp(inState, kConnManServicePropertyStateOnlineValue) == 0)
+    {
+        return 7;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateReadyValue) == 0)
+    {
+        return 6;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateConfigurationValue) == 0)
+    {
+        return 5;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateAssociationValue) == 0)
+    {
+        return 4;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateIdleValue) == 0)
+    {
+        return 3;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateDisconnectValue) == 0)
+    {
+        return 2;
+    }
+    else if (strcmp(inState, kConnManServicePropertyStateOfflineValue) == 0)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+static CHIP_ERROR GetBestServicePathForTypeLocked(const char * inType, GHashTable * inServices, GAutoPtr<gchar> & outPath) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+    int best_score = -1;
+    GAutoPtr<gchar> best_path;
+
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inServices != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_hash_table_iter_init(&iter, inServices);
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        const char * const current_path = static_cast<const char *>(key);
+        GVariant * const props          = static_cast<GVariant *>(value);
+        if (props == nullptr || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if (GetObjectTypeFromPropertiesLocked(props, type) != CHIP_NO_ERROR || type == nullptr || strcmp(type, inType) != 0)
+        {
+            continue;
+        }
+
+        const char * state = nullptr;
+        if (GetObjectStateFromPropertiesLocked(props, state) != CHIP_NO_ERROR)
+        {
+            continue;
+        }
+
+        const int current_score = GetServiceStateScore(state);
+        if (current_score > best_score)
+        {
+            best_score = current_score;
+            best_path.reset(g_strdup(current_path));
+        }
+    }
+
+    VerifyOrReturnError(best_path.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    outPath.reset(best_path.release());
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetBestServiceInterfaceForTypeLocked(const char * inType, GHashTable * inServices,
+                                                       GAutoPtr<gchar> & outInterface) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+    int best_score = -1;
+    GAutoPtr<gchar> best_interface;
+
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inServices != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_hash_table_iter_init(&iter, inServices);
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        GVariant * const props = static_cast<GVariant *>(value);
+        if (props == nullptr || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if (GetObjectTypeFromPropertiesLocked(props, type) != CHIP_NO_ERROR || type == nullptr || strcmp(type, inType) != 0)
+        {
+            continue;
+        }
+
+        // At this point of execution, retrieval of the state property
+        // may fail; proceed with scoring anyway. A null state will be
+        // factored into scoring accordingly.
+
+        const char * state = nullptr;
+        RETURN_SAFELY_IGNORED GetObjectStringValueFromPropertiesLocked(props, kConnManServicePropertyStateKey, state);
+
+        const int current_score = GetServiceStateScore(state);
+
+        GAutoPtr<gchar> current_interface;
+        if (GetServiceInterfaceFromPropertiesLocked(props, current_interface) != CHIP_NO_ERROR ||
+            current_interface.get() == nullptr)
+        {
+            continue;
+        }
+
+        if (current_score > best_score)
+        {
+            best_score = current_score;
+            best_interface.reset(current_interface.release());
+        }
+    }
+
+    VerifyOrReturnError(best_interface.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    outInterface.reset(best_interface.release());
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetWiFiServicePropertiesFromSsidLocked(const ByteSpan & inSsid, GHashTable * inObjectTable,
+                                                         GAutoPtr<GVariant> & outProperties) noexcept
+{
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    VerifyOrReturnError(inSsid.size() > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    outProperties.reset();
+
+    g_hash_table_iter_init(&iter, inObjectTable);
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        const char * const path = static_cast<const char *>(key);
+        GVariant * const props  = static_cast<GVariant *>(value);
+        if ((path == nullptr) || (props == nullptr) || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if ((GetObjectTypeFromPropertiesLocked(props, type) != CHIP_NO_ERROR) || (type == nullptr) ||
+            (strcmp(type, kConnManServicePropertyTypeWiFiValue) != 0))
+        {
+            continue;
+        }
+
+        // ConnMan's "Name" for Wi-Fi services is the SSID string.
+        const char * name = nullptr;
+        if ((GetObjectNameFromPropertiesLocked(props, name) == CHIP_NO_ERROR) && (name != nullptr) &&
+            ByteSpanEqualsString(inSsid, name))
+        {
+            outProperties.reset(g_variant_ref(props));
+            VerifyOrReturnError(outProperties.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_KEY_NOT_FOUND;
+}
+
+static CHIP_ERROR GetWiFiServiceSecurityLocked(GVariant * inProperties, chip::BitFlags<WiFiSecurityBitmap> & outSecurity) noexcept
+{
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GAutoPtr<GVariant> boxed(g_variant_lookup_value(inProperties, kConnManServicePropertySecurityKey, nullptr));
+    VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_KEY_NOT_FOUND);
+
+    UnboxedVariant value(boxed.get());
+    VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(g_variant_is_of_type(value.get(), G_VARIANT_TYPE_STRING_ARRAY), CHIP_ERROR_WRONG_KEY_TYPE);
+
+    chip::BitFlags<WiFiSecurityBitmap> security;
+    GVariantIter it;
+    const char * s = nullptr;
+
+    g_variant_iter_init(&it, value.get());
+
+    while (g_variant_iter_next(&it, "&s", &s))
+    {
+        if (s == nullptr)
+        {
+            continue;
+        }
+
+        // Attempt to map connman's notion of Wi-Fi security as best
+        // we are able.
+        //
+        // At this time, IEEE 802.1x and WPS are intentionally
+        // unmapped.
+
+        if (strcmp(s, kConnManServicePropertySecurityNoneValue) == 0)
+        {
+            security.Set(WiFiSecurityBitmap::kUnencrypted);
+        }
+        else if (strcmp(s, kConnManServicePropertySecurityWEPValue) == 0)
+        {
+            security.Set(WiFiSecurityBitmap::kWep);
+        }
+        else if ((strcmp(s, kConnManServicePropertySecurityPSKValue) == 0) ||
+                 (strcmp(s, kConnManServicePropertySecurityRSNValue) == 0) ||
+                 (strcmp(s, kConnManServicePropertySecurityWPAValue) == 0))
+        {
+            security.Set(WiFiSecurityBitmap::kWpa2Personal);
+        }
+    }
+
+    outSecurity = security;
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR GetWiFiServiceStrengthLocked(GVariant * inProperties, int8_t & outStrength) noexcept
+{
+    uint8_t value;
+
+    ReturnErrorOnFailure(GetObjectByteValueFromPropertiesLocked(inProperties, kConnManServicePropertyStrengthKey, value));
+
+    outStrength = std::clamp(static_cast<int8_t>(value), static_cast<int8_t>(0), static_cast<int8_t>(100));
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Validate the Wi-Fi network name.
+ *
+ *  This validates that the specified Wi-Fi network name is valid
+ *  which means that the specified string is non-null and is between 1
+ *  and 32, inclusive ASCII characters or UTF-8 bytes.
+ *
+ *  @param[in]   inNetworkName  An immutable reference to the network
+ *                              name to validate.
+ *  @param[out]  outReason
+ *
+ *  @retval  CHIP_NO_ERROR  If @a inNetworkName is valid.
+ *  @retval  -EINVAL        If @a inNetworkName is invalid.
+ *
+ */
+static CHIP_ERROR ValidateWiFiServiceSsid(const ByteSpan & inSsid, const char *& outReason) noexcept
+{
+    static constexpr size_t kMinLength = 1;
+    static constexpr size_t kMaxLength = 32;
+
+    const size_t lLength = inSsid.size();
+    VerifyOrReturnError(lLength >= kMinLength, CHIP_ERROR_INVALID_ARGUMENT, outReason = kNetworkNameIsTooShort);
+    VerifyOrReturnError(lLength <= kMaxLength, CHIP_ERROR_INVALID_ARGUMENT, outReason = kNetworkNameIsTooLong);
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Validate the Wi-Fi network passphrase.
+ *
+ *  This validates that the specified Wi-Fi network passphrase is valid,
+ *  which means that the specified string is non-null and is either exactly 64
+ *  hexadecimal ASCII characters (that is, of the [[:xdigit:]] character class)
+ *  or is between 8 and 63, inclusive ASCII characters.
+ *
+ *  @param[in]   inPassphrase
+ *    An immutable reference to the network passphrase to validate.
+ *
+ *  @param[out]  outReason
+ *    A reference to a pointer to an immutable null-terminated C
+ *    string containing the human-readable reason @a inPassphrase was
+ *    invalid if the returned value is not @c CHIP_NO_ERROR.
+ *
+ *  @retval  CHIP_NO_ERROR
+ *    If @a inPassphrase is valid.
+ *
+ *  @retval  CHIP_ERROR_INVALID_ARGUMENT
+ *    If @a inPassphrase is either too short or too long.
+ *
+ *  @retval  -EILSEQ
+ *    If @a inPassphrase contains invalid characters.
+ *
+ */
+static CHIP_ERROR ValidateWiFiServicePassphrase(const ByteSpan & inPassphrase, const char *& outReason) noexcept
+{
+    static constexpr size_t kMinLength = 8;
+    static constexpr size_t kMaxLength = Internal::kMaxWiFiKeyLength;
+
+    // Do a quick character range sanity check.
+
+    const size_t lLength = inPassphrase.size();
+    VerifyOrReturnError(lLength >= kMinLength, CHIP_ERROR_INVALID_ARGUMENT, outReason = kNetworkPassphraseIsTooShort);
+    VerifyOrReturnError(lLength <= kMaxLength, CHIP_ERROR_INVALID_ARGUMENT, outReason = kNetworkPassphraseIsTooLong);
+
+    return CHIP_NO_ERROR;
+}
+
+static void _MaybeClearInterfaceName(const char * inInterfaceName, char * inOutInterfaceName) noexcept
+{
+    VerifyOrReturn(inInterfaceName != nullptr);
+    VerifyOrReturn(inOutInterfaceName != nullptr);
+
+    if (strncmp(inInterfaceName, inOutInterfaceName, Inet::InterfaceId::kMaxIfNameLength) == 0)
+    {
+        inOutInterfaceName[0] = '\0';
+    }
+}
+
+static void _MaybeSetInterfaceName(const char * inDescription, const char * inInterfaceName, char * inOutInterfaceName) noexcept
+{
+    VerifyOrReturn(inDescription != nullptr);
+    VerifyOrReturn(inInterfaceName != nullptr);
+    VerifyOrReturn(inOutInterfaceName != nullptr);
+
+    if (strncmp(inOutInterfaceName, inInterfaceName, Inet::InterfaceId::kMaxIfNameLength) != 0)
+    {
+        strncpy(inOutInterfaceName, inInterfaceName, Inet::InterfaceId::kMaxIfNameLength);
+        inOutInterfaceName[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
+
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Got %s interface: %s", inDescription,
+                        inOutInterfaceName);
+    }
+}
+
+template <typename Callable>
+static CHIP_ERROR InvokeOnGLibContextSyncTrampoline(GLibInvokeContext<Callable> * inContext) noexcept
+{
+    VerifyOrReturnError(inContext != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    inContext->mStatus = inContext->mCallable();
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename Callable>
+static CHIP_ERROR InvokeOnGLibContextSync(Callable && inCallable) noexcept
+{
+    // Callable must be invocable and return CHIP_ERROR.
+    using DecayedCallable = std::decay_t<Callable>;
+
+    static_assert(std::is_same_v<std::invoke_result_t<DecayedCallable &>, CHIP_ERROR>,
+                  "InvokeOnGLibMainLoopSync callable must return CHIP_ERROR");
+
+    DecayedCallable callable(std::forward<Callable>(inCallable));
+    GLibInvokeContext<DecayedCallable> context{ callable };
+
+    ReturnErrorOnFailure(
+        PlatformMgrImpl().GLibMatterContextInvokeSync(&InvokeOnGLibContextSyncTrampoline<DecayedCallable>, &context));
+
+    return context.mStatus;
+}
+
+template <typename LockT, typename Callable>
+auto UnlockAndInvoke(LockT & inOutLock, Callable && inCallable) noexcept -> decltype(inCallable())
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    inOutLock.unlock();
+
+    auto retval = inCallable();
+
+    inOutLock.lock();
+
+    return retval;
+}
+
+template <typename LockT, typename Callable>
+static CHIP_ERROR UnlockAndInvokeOnGLibContextSync(LockT & inOutLock, Callable && inCallable) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    return UnlockAndInvoke(inOutLock, [&]() { return InvokeOnGLibContextSync(std::forward<Callable>(inCallable)); });
+}
+
+} // namespace
+
+// Matter Linux Connectivity Manager Implementation for connman
+
+// Family Connectivity Aggregate
+
+ConnectivityManagerImpl_NetworkManagementConnMan::FamilyConnectivityAggregate::FamilyConnectivityAggregate() noexcept :
+    mReportable(false), mAnyEstablished(false), mAddress(Inet::IPAddress::Any)
+{
+    return;
+}
+
+// Network Service Family Connectivity State
+
+ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceFamilyConnectivityState::
+    NetworkServiceFamilyConnectivityState() noexcept :
+    mConnectivity(NetworkServiceConnectivity::kUnknown),
+    mAddress(Inet::IPAddress::Any)
+{
+    return;
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceFamilyConnectivityState::operator==(
+    const NetworkServiceFamilyConnectivityState & inOther) const noexcept
+{
+    return ((mConnectivity == inOther.mConnectivity) && (mAddress == inOther.mAddress));
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceFamilyConnectivityState::operator!=(
+    const NetworkServiceFamilyConnectivityState & inOther) const noexcept
+{
+    return !(*this == inOther);
+}
+
+// Network Service Family Connectivity State
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceConnectivityState::operator==(
+    const NetworkServiceConnectivityState & inOther) const noexcept
+{
+    return ((mIPv4 == inOther.mIPv4) && (mIPv6 == inOther.mIPv6));
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceConnectivityState::operator!=(
+    const NetworkServiceConnectivityState & inOther) const noexcept
+{
+    return !(*this == inOther);
+}
+
+// Network Service State
+
+ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceState::NetworkServiceState() noexcept :
+    mType(nullptr), mDescription(nullptr), mIfName{}, mPendingConnectivity(), mReportedConnectivity()
+{
+    return;
+}
+
+// Wi-Fi Scan State
+
+ConnectivityManagerImpl_NetworkManagementConnMan::WiFiScanState::WiFiScanState() noexcept : mSsid(), mCount(0)
+{
+    return;
+}
+
+// Introspection
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::WiFiScanState::IsActive() const noexcept
+{
+    return (mCount != 0);
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::WiFiScanState::IsDirected() const noexcept
+{
+    return !mSsid.empty();
+}
+
+// Mutation
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::WiFiScanState::Reset() noexcept
+{
+    mSsid.reset();
+
+    mCount = 0;
+}
+
+// Initialization
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::Init(ConnectivityManagerImpl & inConnectivityManagerImpl)
+{
+    // Initialize the base network management class.
+
+    ReturnErrorOnFailure(NetworkManagementBasis::Init());
+
+    mConnectivityManagerImpl = &inConnectivityManagerImpl;
+
+    static_assert(sNetworkServiceTypeDescriptors.size() ==
+                      ConnectivityManagerImpl_NetworkManagementConnMan::kNetworkServiceStateCount,
+                  "network service descriptor/state table size mismatch");
+
+    for (size_t i = 0; i < kNetworkServiceStateCount; i++)
+    {
+        mNetworkServiceStates[i]              = NetworkServiceState{};
+        mNetworkServiceStates[i].mType        = sNetworkServiceTypeDescriptors[i].mType;
+        mNetworkServiceStates[i].mDescription = sNetworkServiceTypeDescriptors[i].mDescription;
+    }
+
+    mWiFiActiveScanState.Reset();
+    mWiFiConnectPassphrase.reset();
+    mWiFiConnectScanState.Reset();
+    mWiFiStationConnected         = false;
+    mWiFiStationMode              = ConnectivityManager::kWiFiStationMode_NotSupported;
+    mWiFiStationReconnectInterval = {};
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::InitAgentOnGLib(ConnectivityManagerImpl_NetworkManagementConnMan * inSelf,
+                                                                  GDBusConnection * inConnection, const char * inPath,
+                                                                  ConnManAgent *& outSkeleton, GError ** outError) noexcept
+{
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    VerifyOrReturnError(inSelf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inConnection != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GAutoPtr<ConnManAgent> skeleton(conn_man_agent_skeleton_new());
+    VerifyOrReturnError(skeleton.get() != nullptr, CHIP_ERROR_INTERNAL);
+
+    // Register for the agent server methods: cancel, release, request
+    // input, and report error.
+
+    // Cancel
+
+    g_signal_connect(skeleton.get(), "handle-cancel",
+                     G_CALLBACK(+[](ConnManAgent * inAgent_, GDBusMethodInvocation * inInvocation_,
+                                    ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) -> gboolean {
+                         return inSelf_->OnAgentCancel(inAgent_, inInvocation_);
+                     }),
+                     inSelf);
+
+    // Release
+
+    g_signal_connect(skeleton.get(), "handle-release",
+                     G_CALLBACK(+[](ConnManAgent * inAgent_, GDBusMethodInvocation * inInvocation_,
+                                    ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) -> gboolean {
+                         return inSelf_->OnAgentRelease(inAgent_, inInvocation_);
+                     }),
+                     inSelf);
+
+    // Request Input
+
+    g_signal_connect(
+        skeleton.get(), "handle-request-input",
+        G_CALLBACK(+[](ConnManAgent * inAgent_, GDBusMethodInvocation * inInvocation_, const gchar * inPath_,
+                       GVariant * inProperties_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) -> gboolean {
+            return inSelf_->OnAgentRequestInput(inAgent_, inInvocation_, inPath_, inProperties_);
+        }),
+        inSelf);
+
+    // Report Error
+
+    g_signal_connect(
+        skeleton.get(), "handle-report-error",
+        G_CALLBACK(+[](ConnManAgent * inAgent_, GDBusMethodInvocation * inInvocation_, const gchar * inPath_,
+                       const gchar * inError_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) -> gboolean {
+            return inSelf_->OnAgentReportError(inAgent_, inInvocation_, inPath_, inError_);
+        }),
+        inSelf);
+
+    GAutoPtr<GError> err;
+    const gboolean exported =
+        g_dbus_interface_skeleton_export(G_DBUS_INTERFACE_SKELETON(skeleton.get()), inConnection, inPath, &err.GetReceiver());
+    if (!exported || err.get() != nullptr)
+    {
+        if (outError != nullptr)
+        {
+            *outError = err.get() ? g_error_copy(err.get()) : nullptr;
+        }
+
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    outSkeleton = CONN_MAN_AGENT(g_object_ref(skeleton.get()));
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::ShutdownAgentLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                           const char * inPath) noexcept
+{
+    GAutoPtr<GDBusConnection> connection;
+    GAutoPtr<ConnManAgent> skeleton;
+
+    VerifyOrDie(inOutLock.owns_lock());
+
+    if (mConnManAgentServer.mConnection)
+    {
+        connection.reset(static_cast<GDBusConnection *>(g_object_ref(mConnManAgentServer.mConnection.get())));
+    }
+
+    if (mConnManAgentServer.mSkeleton)
+    {
+        skeleton.reset(CONN_MAN_AGENT(g_object_ref(mConnManAgentServer.mSkeleton.get())));
+    }
+
+    mConnManAgentServer.mRegistered = false;
+    mConnManAgentServer.mExported   = false;
+    mConnManAgentServer.mSkeleton.reset();
+    mConnManAgentServer.mConnection.reset();
+
+    if (connection && skeleton)
+    {
+        LogErrorOnFailure(UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+            ShutdownAgentOnGLib(this, connection.get(), inPath, skeleton.get());
+
+            return CHIP_NO_ERROR;
+        }));
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::ShutdownAgentOnGLib(
+    ConnectivityManagerImpl_NetworkManagementConnMan * inSelf, GDBusConnection * inConnection, const char * inPath,
+    ConnManAgent * inSkeleton) noexcept
+{
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    (void) inSelf;
+    (void) inPath;
+
+    if (inConnection != nullptr && inSkeleton != nullptr)
+    {
+        g_dbus_interface_skeleton_unexport_from_connection(G_DBUS_INTERFACE_SKELETON(inSkeleton), inConnection);
+    }
+}
+
+// Observation
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    GAutoPtr<gchar> path;
+    GVariant * props  = nullptr;
+    const char * name = nullptr;
+
+    // Iterate over all Wi-Fi networks and get the best connected
+    // network. From that network, copy its SSID.
+
+    ReturnErrorOnFailure(
+        GetBestServicePathForTypeLocked(kConnManServicePropertyTypeWiFiValue, mConnManClient.mServices.get(), path));
+
+    ReturnErrorOnFailure(GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path.get(), props));
+
+    ReturnErrorOnFailure(GetObjectNameFromPropertiesLocked(props, name));
+
+    const size_t length = std::min(sizeof(outNetwork.networkID), strlen(name));
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Current connected network: %.*s",
+                    static_cast<int>(length), name);
+
+    memcpy(outNetwork.networkID, name, length);
+    outNetwork.networkIDLen = length;
+
+    return CHIP_NO_ERROR;
+}
+
+// Event Handling
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) {}
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+// Ethernet Control Plane Management
+
+const char * ConnectivityManagerImpl_NetworkManagementConnMan::GetEthernetIfName()
+{
+    return GetInterfaceName(kConnManObjectPropertyTypeEthernetValue);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::UpdateEthernetNetworkingStatus()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // TBD
+}
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+// Wi-Fi Control Plane Management
+
+// Observation
+
+const char * ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiIfName()
+{
+    return GetInterfaceName(kConnManObjectPropertyTypeWiFiValue);
+}
+
+// Control
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::StartNetworkManagementOnGLib() noexcept
+{
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Start network management");
+
+    // Initiate an asynchronous request to establish
+
+    conn_man_manager_proxy_new_for_bus(
+        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kConnManServiceName, kConnManManagerPath, nullptr,
+        reinterpret_cast<GAsyncReadyCallback>(
+            +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                inSelf_->OnManagerReady(sourceObject_, res_);
+            }),
+        this);
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::StartNonConcurrentWiFiManagement()
+{
+    StartWiFiManagement();
+
+    for (size_t cnt = 0; cnt < WIFI_START_CHECK_ATTEMPTS; cnt++)
+    {
+        if (IsWiFiManagementStarted())
+        {
+            LogErrorOnFailure(DeviceControlServer::DeviceControlSvr().PostOperationalNetworkStartedEvent());
+
+            ChipLogProgress(DeviceLayer, "Non-concurrent mode Wi-Fi Management Started.");
+
+            return;
+        }
+
+        usleep(WIFI_START_CHECK_TIME_USEC);
+    }
+
+    ChipLogError(Ble, "Non-concurrent mode Wi-Fi Management taking too long to start.");
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::StartWiFiManagement()
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    mConnManClient = GDBusConnManClient{};
+
+    // IMPORTANT: Do not synchronously wait on the GLib thread while
+    //            holding mConnManMutex.
+    //
+    // Use the explicit unlock/invoke/relock primitive to avoid
+    // deadlock when GLib callbacks re-enter and attempt to take
+    // mConnManMutex.
+
+    CHIP_ERROR err = UnlockAndInvokeOnGLibContextSync(lock, [this]() -> CHIP_ERROR { return StartNetworkManagementOnGLib(); });
+
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start Wi-Fi management"));
+}
+
+// Introspection
+
+/**
+ *  @brief
+ *    Determine whether a per-family connectivity transition warrants
+ *    a device event.
+ *
+ *  A family transition is reportable on a connectivity state change
+ *  or, while established, on an address change (the latter because
+ *  any one-shot consumer state (for example, published DNS-SD
+ *  address records) derived from the previous address is now
+ *  stale). The kUnknown -> kLost transition is deliberately absorbed
+ *  without an event: reporting "lost" connectivity that was never
+ *  established is startup noise.
+ *
+ */
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsFamilyConnectivityChangeReportable(
+    const NetworkServiceFamilyConnectivityState & inPending, const NetworkServiceFamilyConnectivityState & inReported) noexcept
+{
+    const bool absorbed     = ((inReported.mConnectivity == NetworkServiceConnectivity::kUnknown) &&
+                           (inPending.mConnectivity == NetworkServiceConnectivity::kLost));
+    const bool stateChanged = (inPending.mConnectivity != inReported.mConnectivity);
+    const bool addressChanged =
+        ((inPending.mConnectivity == NetworkServiceConnectivity::kEstablished) && (inPending.mAddress != inReported.mAddress));
+
+    return ((stateChanged && !absorbed) || addressChanged);
+}
+
+// Wi-Fi Station Control Plane Management
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiManagementStarted()
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    return !!mConnManClient.mManagerProxy;
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiStationApplicationControlled()
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    return (mWiFiStationMode == ConnectivityManager::kWiFiStationMode_ApplicationControlled);
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiStationConnected()
+{
+    // Get the Wi-Fi technology and return the value of the Connected property.
+    //
+    // We should possibly also consider the State property of the
+    // currently-connected Wi-Fi network service.
+
+    return mWiFiStationConnected;
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiStationEnabled()
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    return (mWiFiStationMode == ConnectivityManager::kWiFiStationMode_Enabled);
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiStationProvisioned()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // TBD
+
+    return false;
+}
+
+// Observation
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiBssId(MutableByteSpan & outBssId)
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Use the nl80211 API to retrieve this, similar to 'iw dev wlan0
+    // link', where "wlan0" is the network interface name of the
+    // currently-connected Wi-Fi network service. Failing that, the
+    // Wi-Fi backend could be used.
+
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiSecurityType(
+    app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outSecurityType)
+{
+    // ConnMan only distinguishes between "psk" and "rsn" security
+    // types, lumping all of WPA-, WPA-2-, and WPA-3-Personal under
+    // "psk". For now, just use 'kUnspecified' for now. We may be able
+    // to get this through nl80211 or the Wi-Fi backend in the future.
+
+    outSecurityType = SecurityTypeEnum::kUnspecified;
+
+    return CHIP_NO_ERROR;
+}
+
+ConnectivityManager::WiFiStationMode ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiStationMode()
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    return mWiFiStationMode;
+}
+
+System::Clock::Timeout ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiStationReconnectInterval()
+{
+    return mWiFiStationReconnectInterval;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiVersion(
+    app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outVersion)
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+// Mutation
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::SetWiFiStationMode(const ConnectivityManager::WiFiStationMode & inWiFiStationMode)
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturnError(inWiFiStationMode != ConnectivityManager::kWiFiStationMode_NotSupported, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (mWiFiStationMode != inWiFiStationMode)
+    {
+        ChipLogProgress(DeviceLayer, "Wi-Fi station mode change: %s -> %s",
+                        ConnectivityManager::WiFiStationModeToStr(mWiFiStationMode),
+                        ConnectivityManager::WiFiStationModeToStr(inWiFiStationMode));
+
+        switch (inWiFiStationMode)
+        {
+
+            // If the mode is enabled/disabled, then set the Wi-Fi
+            // technology "Powered" property to true/false.
+
+        case ConnectivityManager::kWiFiStationMode_Disabled:
+        case ConnectivityManager::kWiFiStationMode_Enabled: {
+            const bool powered = (inWiFiStationMode == ConnectivityManager::kWiFiStationMode_Enabled);
+
+            ConnManTechnology * const technology =
+                GetTechnologyProxyFromTypeLocked(kConnManTechnologyPropertyTypeWiFiValue, mConnManClient.mTechnologyProxies.get(),
+                                                 mConnManClient.mTechnologies.get());
+            VerifyOrReturnError(technology != nullptr, ChipError(ChipError::Range::kPOSIX, ENOENT));
+
+            ReturnErrorOnFailure(TechnologySetPoweredLocked(lock, technology, powered));
+            break;
+        }
+
+        default:
+            break;
+        }
+
+        mWiFiStationMode = inWiFiStationMode;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::SetWiFiStationReconnectInterval(const System::Clock::Timeout & inInterval)
+{
+    mWiFiStationReconnectInterval = inInterval;
+
+    return CHIP_NO_ERROR;
+}
+
+// Worker
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::ClearWiFiStationProvision()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // TBD but probably remove all favorited networks.
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::CommitConfig()
+{
+    // As presently implemented, there is nothing to do for this with
+    // connman. On successful connection to a Wi-Fi (or other) network
+    // services, the necessary credentials are serialized to
+    // non-volatile storage.
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConnectWiFiNetworkAsync(
+    ByteSpan inSsid, ByteSpan inCredentials, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback)
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+    const char * reason = nullptr;
+
+    // Ensure that we have an initialized Connectivity Manager
+    // implementation pointer.
+
+    VerifyOrReturnError(mConnectivityManagerImpl != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    // Verify that there is not another Wi-Fi station connection in-flight.
+
+    VerifyOrReturnError(!mConnectivityManagerImpl->IsWiFiStationConnecting(), CHIP_ERROR_BUSY);
+
+    // Sanity check the SSID.
+
+    ReturnErrorAndLogOnFailure(ValidateWiFiServiceSsid(inSsid, reason), DeviceLayer, "invalid Wi-Fi SSID '%.*s': %s",
+                               static_cast<int>(inSsid.size()), inSsid.data(), reason);
+
+    // Sanity check the credentials.
+
+    ReturnErrorAndLogOnFailure(ValidateWiFiServicePassphrase(inCredentials, reason), DeviceLayer, "invalid Wi-Fi passphrase: %s",
+                               reason);
+
+    // Set the connection completion callback.
+
+    mConnectivityManagerImpl->SetOneShotConnectCallback(inConnectCallback);
+
+    // There will be one of two cases here given that connman cannot
+    // connect to a service it does not know about or has not seen.
+    //
+    // The first, easiest, case is that connman does know about and
+    // has seen the network service associated with the SSID. In that
+    // case, 'GetWiFiServiceProxyFromSsidLocked' will succeed and the
+    // network service connect will proceed normally.
+    //
+    // The second, more difficult, case is that connman does NOT know
+    // about and has NOT seen the network service associated with the
+    // SSID. In that case, 'GetWiFiServiceProxyFromSsidLocked' will
+    // fail. As a result, we will need to initiate a Wi-Fi scan and
+    // then attempt to proceed with the connect once the network
+    // service has appeared in scan results.
+
+    // Find a matching W-Fi network service proxy to the SSID.
+
+    ConnManService * const service =
+        GetWiFiServiceProxyFromSsidLocked(inSsid, mConnManClient.mServiceProxies.get(), mConnManClient.mServices.get());
+    if (service != nullptr)
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to '%.*s'...",
+                        static_cast<int>(inSsid.size()), inSsid.data());
+
+        // Cache the provided credentials.
+
+        mWiFiConnectPassphrase = inCredentials;
+
+        ReturnErrorOnFailure(HandleServiceConnectRequestLocked(lock, service));
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "scanning for '%.*s'...",
+                        static_cast<int>(inSsid.size()), inSsid.data());
+
+        ConnManTechnology * const technology = GetTechnologyProxyFromTypeLocked(
+            kConnManTechnologyPropertyTypeWiFiValue, mConnManClient.mTechnologyProxies.get(), mConnManClient.mTechnologies.get());
+        VerifyOrReturnError(technology != nullptr, ChipError(ChipError::Range::kPOSIX, ENOENT));
+
+        // Cache the provided SSID.
+
+        mWiFiConnectScanState.mSsid = inSsid;
+
+        // Cache the provided credentials.
+
+        mWiFiConnectPassphrase = inCredentials;
+
+        // Initialize the connect scan count.
+
+        mWiFiConnectScanState.mCount = 1;
+
+        // Attempt to scan for the desired network service.
+
+        ReturnErrorOnFailure(TechnologyScanLocked(lock, technology));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConnectWiFiNetworkWithPDCAsync(
+    ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity, const Crypto::P256Keypair & inClientIdentityKeypair,
+    NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback)
+{
+    // ConnMan fully supports connecting Wi-Fi stations and access
+    // points using certificate-based security; this implementation
+    // would simply have to cache the input parameters to satisfy the
+    // requisite agent input request from those cached input
+    // parameters.
+
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::StartWiFiScan(ByteSpan inSsid,
+                                                                NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback)
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    // Ensure that we have an initialized Connectivity Manager
+    // implementation pointer.
+
+    VerifyOrReturnError(mConnectivityManagerImpl != nullptr, CHIP_ERROR_UNINITIALIZED);
+
+    // If there is another ongoing scan request, reject the new one.
+
+    VerifyOrReturnError(!mConnectivityManagerImpl->IsWiFiStationScanning(), CHIP_ERROR_INCORRECT_STATE);
+
+    // If Wi-Fi is not among the supported technologies, there is
+    // nothing further to do.
+
+    const bool has_technology = HasTechnologyLocked(mConnManClient.mTechnologies.get(), kConnManTechnologyPropertyTypeWiFiValue);
+    VerifyOrReturnError(has_technology, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+
+    // ConnMan does not support active, directed scans. Consequently,
+    // all we can reasonably do here is set a cache of the desired
+    // SSID, do a Wi-Fi passive, broadcast scan, and then see if the
+    // desired SSID is among the known Wi-Fi network services at the
+    // completion of the scan.
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "scanning for '%.*s'...", static_cast<int>(inSsid.size()),
+                    inSsid.data());
+
+    // Cache the provided SSID.
+
+    mWiFiActiveScanState.mSsid = inSsid;
+
+    // Initialize the "active" scan count.
+
+    mWiFiActiveScanState.mCount = 1;
+
+    mConnectivityManagerImpl->SetOneShotScanCallback(inScanCallback);
+
+    auto scanGuard = ScopeExit([&]() {
+        mConnectivityManagerImpl->SetOneShotScanCallback(nullptr);
+
+        mWiFiActiveScanState.Reset();
+    });
+
+    ReturnErrorOnFailure(TechnologyScanLocked(lock,
+                                              GetTechnologyProxyFromTypeLocked(kConnManTechnologyPropertyTypeWiFiValue,
+                                                                               mConnManClient.mTechnologyProxies.get(),
+                                                                               mConnManClient.mTechnologies.get())));
+
+    // Success; disarm the scoped clean-up.
+
+    scanGuard.release();
+
+    return CHIP_NO_ERROR;
+}
+
+// Wi-Fi Soft Access Point (AP) Control Plane Management
+
+// Observation
+
+ConnectivityManager::WiFiAPMode ConnectivityManagerImpl_NetworkManagementConnMan::GetWiFiApMode()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+
+    return ConnectivityManager::kWiFiAPMode_NotSupported;
+}
+
+// Mutation
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::SetWiFiApMode(const ConnectivityManager::WiFiAPMode & inWiFiApMode)
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::SetWiFiApIdleTimeout(const System::Clock::Timeout & inTimeout)
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+}
+
+// Control
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::DemandStartWiFiAp()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::StopOnDemandWiFiAp()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::MaintainOnDemandWiFiAp()
+{
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s", __func__);
+
+    // Were this supported, this would use the ConnMan technology tethering API.
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+// Mutation
+
+const char * ConnectivityManagerImpl_NetworkManagementConnMan::GetConnectivityChangeString(ConnectivityChange inChange) noexcept
+{
+    return ((inChange == kConnectivity_Established) ? "established" : (inChange == kConnectivity_Lost) ? "lost" : "no change");
+}
+
+const char * ConnectivityManagerImpl_NetworkManagementConnMan::GetNetworkServiceConnectivityString(
+    NetworkServiceConnectivity inNetworkServiceConnectivity) noexcept
+{
+    return ((inNetworkServiceConnectivity == NetworkServiceConnectivity::kEstablished) ? "established"
+                : (inNetworkServiceConnectivity == NetworkServiceConnectivity::kLost)  ? "lost"
+                                                                                       : "unknown");
+}
+
+// Mutation
+
+/**
+ *  @brief
+ *    Project a per-family connectivity aggregate onto the event's
+ *    `ConnectivityChange` field.
+ *
+ *  Maps the reduced aggregate for one IP family onto the tri-state
+ *  verdict carried by `OnInternetConnectivityChange`:
+ *  `kConnectivity_NoChange` when nothing is reportable, otherwise
+ *  `kConnectivity_Established` or `kConnectivity_Lost` according to
+ *  whether the family is established on any tracked service. The
+ *  return value lets the caller gate address population and event
+ *  emission on the same reportability test.
+ *
+ *  @param[in]   inAggregate
+ *    The per-family aggregate produced by folding every tracked
+ *    service's (pending, reported) pair via
+ *    `AccumulateFamilyConnectivity`.
+ *
+ *  @param[out]  outChange
+ *    On return, the `ConnectivityChange` verdict for the family:
+ *    `kConnectivity_NoChange`, `kConnectivity_Established`, or
+ *    `kConnectivity_Lost`.
+ *
+ *  @returns
+ *    True if the family had a reportable change (equivalently,
+ *    `outChange` is not `kConnectivity_NoChange`); false otherwise.
+ *
+ *  @sa AccumulateFamilyConnectivity
+ *
+ *  @private
+ *
+ */
+bool ConnectivityManagerImpl_NetworkManagementConnMan::SetConnectivityChangeFromAggregate(
+    const FamilyConnectivityAggregate & inAggregate, ConnectivityChange & outChange) noexcept
+{
+    outChange = kConnectivity_NoChange;
+
+    if (inAggregate.mReportable)
+    {
+        outChange = (inAggregate.mAnyEstablished ? kConnectivity_Established : kConnectivity_Lost);
+    }
+
+    return inAggregate.mReportable;
+}
+
+// Helper Methods
+
+/**
+ *  @brief
+ *    Fold one service type's (pending, reported) family pair into the
+ *    running per-family aggregate.
+ *
+ *  The fold step invoked once per tracked service type, per family,
+ *  while building the `FamilyConnectivityAggregate` for an
+ *  `OnInternetConnectivityChange` event. It raises `mReportable` when
+ *  this service's pending-versus-reported transition is surfaceable
+ *  (per `IsFamilyConnectivityChangeReportable`), records the family
+ *  as established when this service's pending state is established,
+ *  and--on the first established entry in table (declaration)
+ *  order--captures that service's address as the aggregate's
+ *  representative address.
+ *
+ *  @param[in]      inPending
+ *    This service's freshly recomputed family connectivity.
+ *
+ *  @param[in]      inReported
+ *    This service's family connectivity as last reported (the
+ *    debounce baseline), against which reportability is judged.
+ *
+ *  @param[in,out]  inOutAggregate
+ *    The per-family aggregate updated in place; must be
+ *    default-constructed before the first fold.
+ *
+ *  @sa SetConnectivityChangeFromAggregate
+ *  @sa IsFamilyConnectivityChangeReportable
+ *
+ *  @private
+ *
+ */
+void ConnectivityManagerImpl_NetworkManagementConnMan::AccumulateFamilyConnectivity(
+    const NetworkServiceFamilyConnectivityState & inPending, const NetworkServiceFamilyConnectivityState & inReported,
+    FamilyConnectivityAggregate & inOutAggregate) noexcept
+{
+    if (IsFamilyConnectivityChangeReportable(inPending, inReported))
+    {
+        inOutAggregate.mReportable = true;
+    }
+
+    if (inPending.mConnectivity == NetworkServiceConnectivity::kEstablished)
+    {
+        // The first-established entry in table (declaration) order
+        // supplies the cosmetic single address carried by the event.
+
+        if (!inOutAggregate.mAnyEstablished)
+        {
+            inOutAggregate.mAddress = inPending.mAddress;
+        }
+
+        inOutAggregate.mAnyEstablished = true;
+    }
+}
+
+/**
+ *  @brief
+ *    Populate a Matter Wi-Fi scan response from a connman service
+ *    property dictionary.
+ *
+ *  Translates one connman Wi-Fi service's cached properties into a
+ *  single `WiFiScanResponse`. The service "Name" is the SSID; a
+ *  hidden network surfaces with an empty Name and is rejected here,
+ *  which is precisely the non-hidden filter a broadcast scan
+ *  requires. Security is mapped from connman's "Security" array via
+ *  #GetWiFiServiceSecurityLocked, falling back to `kWpa2Personal`
+ *  when connman reports nothing recognizable so that the bitmap is
+ *  never empty. BSSID, channel, and band are proxy values: connman
+ *  exposes no introspectable equivalents, and signal strength is
+ *  reported qualitatively (0-100) rather than in dBm. A failed
+ *  strength read is non-fatal and leaves the zero default.
+ *
+ *  @param[in]   inProperties
+ *    A pointer to the connman service property dictionary (a{sv}).
+ *
+ *  @param[out]  outResponse
+ *    On `#CHIP_NO_ERROR`, the populated scan response. Left
+ *    unmodified on failure.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    If a response was built.
+ *
+ *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
+ *    If `inProperties` is null, or the service Name is absent, empty
+ *    (hidden), or longer than #Internal::kMaxWiFiSSIDLength.
+ *
+ *  @retval  *
+ *    Otherwise, any error returned while reading the service Name.
+ *
+ *  @sa GetWiFiServiceSecurityLocked
+ *  @sa HandleWiFiBroadcastScanCompleteLocked
+ *  @sa HandleWiFiPendingScanLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::BuildWiFiScanResponseFromServicePropertiesLocked(
+    GVariant * inProperties, WiFiScanResponse & outResponse) noexcept
+{
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // ConnMan's "Name" for a Wi-Fi service is its SSID string. A hidden
+    // network surfaces with an empty Name; rejecting those here is exactly
+    // the "non-hidden" filter the broadcast scan requires.
+
+    const char * name = nullptr;
+    ReturnErrorOnFailure(GetObjectNameFromPropertiesLocked(inProperties, name));
+    VerifyOrReturnError(name != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const size_t nameLen = strlen(name);
+    VerifyOrReturnError(nameLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(nameLen <= Internal::kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
+
+    WiFiScanResponse response{};
+
+    // Prefer connman's actual Security array (notably so open
+    // networks report kUnencrypted rather than mis-prompting a
+    // commissioner for a passphrase).  On absence or an
+    // all-unrecognized array, fall back to the prior kWpa2Personal
+    // proxy so behavior never regresses to an empty bitmap.
+
+    chip::BitFlags<WiFiSecurityBitmap> security;
+    if (GetWiFiServiceSecurityLocked(inProperties, security) != CHIP_NO_ERROR || !security.HasAny())
+    {
+        security = chip::BitFlags<WiFiSecurityBitmap>();
+        security.Set(WiFiSecurityBitmap::kWpa2Personal);
+    }
+
+    response.security = security;
+
+    memcpy(response.ssid, name, nameLen);
+    response.ssidLen = static_cast<uint8_t>(nameLen);
+
+    memset(&response.bssid, 0, sizeof(response.bssid));
+
+    // ConnMan does not expose an introspectable channel, band, or
+    // frequency for wireless networks. For now, set proxy
+    // values. In the future, we may be able to get this through
+    // nl80211 or the Wi-Fi backend.
+
+    response.channel  = 0;
+    response.wiFiBand = WiFiBandEnum::k5g;
+
+    // By default, ConnMan virtualizes all wireless signal strength in
+    // the qualitative range 0-100; indicate and set the value as
+    // such. In the future, we may be able to return dBm quantiatively
+    // via nl80211 or the Wi-Fi backend. Alternatively, in the future,
+    // the specification and the Network Commissioning Cluster would
+    // support and pass through a qualitative wireless signal
+    // assessment.
+    //
+    // Strength is best-effort and cosmetic; a failed read leaves the
+    // zero-initialized default. It must not gate the scan result, which
+    // has already been assembled and is about to be reported successful.
+
+    int8_t strength = 0;
+    RETURN_SAFELY_IGNORED GetWiFiServiceStrengthLocked(inProperties, strength);
+
+    response.signal.type     = WirelessSignalType::kQualitative;
+    response.signal.strength = strength;
+
+    outResponse = response;
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Complete a Wi-Fi connect operation exactly once, deferring off
+ *    the class lock.
+ *
+ *  Drives the Connectivity Manager `OnConnectResult` terminal for a
+ *  connect, preferring to defer it onto a fresh Matter event-loop
+ *  iteration (via `ScheduleLambda`) so that it runs after the caller
+ *  releases `mConnManMutex` and may therefore re-enter this object
+ *  safely. Should that deferral fail to allocate, the completion is
+ *  instead run synchronously with the lock temporarily released via
+ *  #UnlockAndInvoke, so that the Network Commissioning command is
+ *  always completed rather than left wedged. The debug text is copied
+ *  by value up front because its backing store (a connman service
+ *  "Name") may be mutated or removed before a deferred callback runs.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion. On the
+ *    fallback path the lock is released and reacquired around the
+ *    synchronous completion.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock, which may be
+ *    temporarily released on the synchronous fallback path.
+ *
+ *  @param[in]      inStatus
+ *    The Network Commissioning status to report.
+ *
+ *  @param[in]      inDebugText
+ *    The debug text (typically the target SSID) to report; copied by
+ *    value and truncated to #Internal::kMaxWiFiSSIDLength.
+ *
+ *  @param[in]      inReason
+ *    The association/connect reason code to report.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    Always; the completion is dispatched on either the deferred or
+ *    the synchronous fallback path.
+ *
+ *  @sa DispatchWiFiScanFinishedLocked
+ *  @sa HandleServiceConnectComplete
+ *  @sa HandleWiFiUnresolvedAfterScanLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::DispatchWiFiConnectFinishedLocked(
+    std::unique_lock<std::mutex> & inOutLock, Status inStatus, const CharSpan & inDebugText, int32_t inReason) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    // Deferred execution must capture the debug bytes by value; inDebugText's
+    // backing store (a connman service "Name" in the properties hash table)
+    // may be mutated or removed before the callback runs.
+    std::array<uint8_t, Internal::kMaxWiFiSSIDLength> debugBytes{};
+    const size_t debugLen = std::min<size_t>(inDebugText.size(), debugBytes.size());
+    if (debugLen > 0)
+    {
+        memcpy(debugBytes.data(), inDebugText.data(), debugLen);
+    }
+
+    // Preferred path: defer onto a fresh Matter event-loop iteration so the
+    // caller's scope releases mConnManMutex before OnConnectResult runs.
+    const CHIP_ERROR scheduled = DeviceLayer::SystemLayer().ScheduleLambda([this, inStatus, debugBytes, debugLen, inReason]() {
+        VerifyOrReturn(mConnectivityManagerImpl != nullptr);
+
+        const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
+        mConnectivityManagerImpl->OnConnectResult(inStatus, debug, inReason);
+    });
+
+    if (scheduled != CHIP_NO_ERROR)
+    {
+        LogErrorOnFailure(scheduled);
+
+        // Fallback: the deferral could not be allocated. Complete the
+        // command synchronously with the lock temporarily released,
+        // so OnConnectResult may re-enter safely, rather than leaving
+        // the command handle wedged.
+
+        UnlockAndInvoke(inOutLock, [&]() -> CHIP_ERROR {
+            const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
+
+            mConnectivityManagerImpl->OnConnectResult(inStatus, debug, inReason);
+
+            return CHIP_NO_ERROR;
+        });
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Complete a Wi-Fi scan operation exactly once, deferring off the
+ *    class lock.
+ *
+ *  Drives the Connectivity Manager `OnScanFinished` terminal for a
+ *  scan, preferring to defer it onto a fresh Matter event-loop
+ *  iteration (via `ScheduleLambda`) so that it runs after the caller
+ *  releases `mConnManMutex` and may therefore re-enter this object
+ *  safely. Should that deferral fail to allocate, the completion is
+ *  instead run synchronously with the lock temporarily released via
+ *  #UnlockAndInvoke, so that the Network Commissioning command is
+ *  always completed rather than left wedged. Ownership of
+ *  `inResponses` transfers into the deferred task on the preferred
+ *  path and is released in place on the fallback path. A null
+ *  `inResponses` encodes not-found (a null result iterator); a
+ *  non-null but empty vector encodes a successful scan that matched
+ *  nothing. The debug text is copied by value because its backing
+ *  store may not outlive this frame.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion. On the
+ *    fallback path the lock is released and reacquired around the
+ *    synchronous completion.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock, which may be
+ *    temporarily released on the synchronous fallback path.
+ *
+ *  @param[in]      inStatus
+ *    The Network Commissioning status to report.
+ *
+ *  @param[in]      inDebugText
+ *    The debug text (typically the target SSID) to report; copied by
+ *    value and truncated to #Internal::kMaxWiFiSSIDLength.
+ *
+ *  @param[in]      inResponses
+ *    The scan results to report, ownership of which is consumed by
+ *    this call. Null encodes not-found; non-null-but-empty encodes a
+ *    successful empty result.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    Always; the completion is dispatched on either the deferred or
+ *    the synchronous fallback path.
+ *
+ *  @sa DispatchWiFiConnectFinishedLocked
+ *  @sa HandleWiFiBroadcastScanCompleteLocked
+ *  @sa HandleWiFiPendingScanLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::DispatchWiFiScanFinishedLocked(
+    std::unique_lock<std::mutex> & inOutLock, Status inStatus, const CharSpan & inDebugText,
+    std::unique_ptr<std::vector<WiFiScanResponse>> inResponses) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    // Deferred execution must capture debug bytes by value;
+    // inDebugText's backing store may not outlive this frame.
+
+    std::array<uint8_t, Internal::kMaxWiFiSSIDLength> debugBytes{};
+    const size_t debugLen = std::min<size_t>(inDebugText.size(), debugBytes.size());
+    if (debugLen > 0)
+    {
+        memcpy(debugBytes.data(), inDebugText.data(), debugLen);
+    }
+
+    // A null vector encodes not-found (nullptr iterator); a non-null
+    // but empty vector encodes a successful scan that found nothing.
+
+    std::vector<WiFiScanResponse> * const raw = inResponses.get();
+
+    // Preferred path: defer onto a fresh Matter event-loop iteration
+    // so the caller's scope releases mConnManMutex before
+    // OnScanFinished runs.
+
+    const CHIP_ERROR scheduled = DeviceLayer::SystemLayer().ScheduleLambda([this, inStatus, debugBytes, debugLen, raw]() {
+        std::unique_ptr<std::vector<WiFiScanResponse>> owned(raw);
+
+        VerifyOrReturn(mConnectivityManagerImpl != nullptr);
+
+        const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
+        LinuxScanResponseIterator<WiFiScanResponse> iter(owned.get());
+
+        mConnectivityManagerImpl->OnScanFinished(inStatus, debug, (owned != nullptr) ? &iter : nullptr);
+    });
+
+    if (scheduled == CHIP_NO_ERROR)
+    {
+        RETURN_SAFELY_IGNORED inResponses.release();
+    }
+    else
+    {
+        LogErrorOnFailure(scheduled);
+
+        // Fallback: the deferral could not be allocated. Complete the
+        // command synchronously with the lock temporarily released, so
+        // OnScanFinished may safely re-enter, rather than leaving the
+        // command handle wedged. Nothing below aliases inResponses after
+        // this returns; it is freed here.
+
+        UnlockAndInvoke(inOutLock, [&]() -> CHIP_ERROR {
+            LinuxScanResponseIterator<WiFiScanResponse> iter(inResponses.get());
+            const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
+
+            mConnectivityManagerImpl->OnScanFinished(inStatus, debug, (inResponses != nullptr) ? &iter : nullptr);
+
+            return CHIP_NO_ERROR;
+        });
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Look up the tracked-state entry for a connman service type.
+ *
+ *  Performs a linear search of the tracked-state table for the entry
+ *  whose `mType` matches `inType` by string value. The `Locked`
+ *  suffix denotes the precondition that the caller holds
+ *  `mConnManMutex`; the returned pointer aliases table storage and is
+ *  valid only while that lock is held. Note that an ineligible type
+ *  (for example, cellular or VPN, deliberately absent from the table)
+ *  is indistinguishable here from an unknown one: both yield
+ *  `nullptr`.
+ *
+ *  @param[in]  inType
+ *    The connman service "Type" value to match (for example,
+ *    "ethernet"); may be `nullptr`.
+ *
+ *  @returns
+ *    A pointer to the matching `NetworkServiceState`, or `nullptr` if
+ *    `inType` is @c `nullptr` or no tracked entry matches.
+ *
+ *  @private
+ *
+ */
+ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceState *
+ConnectivityManagerImpl_NetworkManagementConnMan::FindNetworkServiceStateLocked(const char * inType) noexcept
+{
+    VerifyOrReturnValue(inType != nullptr, nullptr);
+
+    const auto it =
+        std::find_if(mNetworkServiceStates.begin(), mNetworkServiceStates.end(), [inType](const NetworkServiceState & inState) {
+            return ((inState.mType != nullptr) && (strcmp(inState.mType, inType) == 0));
+        });
+
+    return ((it != mNetworkServiceStates.end()) ? &(*it) : nullptr);
+}
+
+const char * ConnectivityManagerImpl_NetworkManagementConnMan::GetInterfaceName(const char * inType) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    NetworkServiceState * const state = FindNetworkServiceStateLocked(inType);
+    VerifyOrReturnValue(state != nullptr, nullptr);
+
+    // If we have a valid interface name, return it. Otherwise,
+    // perform a lazy update of the interface name based on the best
+    // network service of the specified type.
+
+    if (state->mIfName[0] != '\0')
+    {
+        return &state->mIfName[0];
+    }
+    else if (mConnManClient.mServices)
+    {
+        GAutoPtr<gchar> interface;
+
+        CHIP_ERROR status = GetBestServiceInterfaceForTypeLocked(inType, mConnManClient.mServices.get(), interface);
+        VerifyOrReturnValue(status == CHIP_NO_ERROR, nullptr);
+
+        if (interface.get() != nullptr)
+        {
+            _MaybeSetInterfaceName(state->mDescription, interface.get(), &state->mIfName[0]);
+
+            return &state->mIfName[0];
+        }
+    }
+
+    return nullptr;
+}
+
+/**
+ *  @brief
+ *    Derive one IP address family's connectivity disposition from a
+ *    connman service property dictionary.
+ *
+ *  Established-detection deliberately keys off the presence of a
+ *  parseable "Address" member within the family's ("IPv4" / "IPv6")
+ *  sub-dictionary rather than off the service "State": connman
+ *  reaches "ready" when *either* family completes configuration, so
+ *  "State" alone cannot distinguish per-family establishment.
+ *
+ *  @param[in]   inProperties
+ *    A pointer to the service property dictionary (a{sv}).
+ *
+ *  @param[in]   inFamilyKey
+ *    The family sub-dictionary key, one of "IPv4" or "IPv6".
+ *
+ *  @returns
+ *    The derived connectivity disposition.
+ *
+ */
+ConnectivityManagerImpl_NetworkManagementConnMan::NetworkServiceFamilyConnectivityState
+ConnectivityManagerImpl_NetworkManagementConnMan::GetServiceFamilyConnectivityStateLocked(GVariant * inProperties,
+                                                                                          const char * inFamilyKey) noexcept
+{
+    NetworkServiceFamilyConnectivityState retval;
+
+    // A missing or malformed dictionary results in state connectivity
+    // NetworkServiceConnectivity::kUnknown, from default
+    // construction.
+
+    VerifyOrReturnValue(inProperties != nullptr, retval);
+    VerifyOrReturnValue(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), retval);
+
+    // A structurally valid dictionary but without a parseable family
+    // address results in state connectivity
+    // NetworkServiceConnectivity::kLost.
+
+    retval.mConnectivity = NetworkServiceConnectivity::kLost;
+
+    GAutoPtr<GVariant> boxed(g_variant_lookup_value(inProperties, inFamilyKey, nullptr));
+    VerifyOrReturnValue(boxed.get() != nullptr, retval);
+
+    UnboxedVariant family(boxed.get());
+    VerifyOrReturnValue(family, retval);
+    VerifyOrReturnValue(g_variant_is_of_type(family.get(), G_VARIANT_TYPE_VARDICT), retval);
+
+    const char * address = nullptr;
+    const gboolean found = g_variant_lookup(family.get(), kConnManServicePropertyIPAddressKey, "&s", &address);
+    VerifyOrReturnValue(found && (address != nullptr) && address[0] != '\0', retval);
+
+    // Parse into a local so a partial write from a failed parse can't
+    // escape.
+
+    Inet::IPAddress parsed;
+    VerifyOrReturnValue(Inet::IPAddress::FromString(address, parsed), retval);
+
+    retval.mConnectivity = NetworkServiceConnectivity::kEstablished;
+    retval.mAddress      = parsed;
+
+    return retval;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetProperties(ConnManManager * inManager,
+                                                                                  GVariant * inProperties,
+                                                                                  const GError * inError) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturn(inProperties != nullptr);
+
+    if (inError == nullptr)
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "got %zu manager property/ies",
+                        g_variant_n_children(inProperties));
+
+        ReturnOnFailure(UpdateManagerPropertiesLocked(inProperties));
+
+        ReturnOnFailure(HandleManagerPropertiesChangedLocked(inManager, inProperties));
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to get manager properties: %s",
+                     inError ? inError->message : "unknown error");
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetServices(ConnManManager * inManager, GVariant * inServices,
+                                                                                const GError * inError) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturn(inServices != nullptr);
+
+    if (inError == nullptr)
+    {
+        GHashTableIter iter;
+        gpointer key   = nullptr;
+        gpointer value = nullptr;
+
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "got %zu manager service(s)",
+                        g_variant_n_children(inServices));
+
+        ReturnOnFailure(UpdateServicesLocked(inServices));
+
+        g_hash_table_iter_init(&iter, mConnManClient.mServices.get());
+
+        while (g_hash_table_iter_next(&iter, &key, &value))
+        {
+            const char * const path  = static_cast<const char *>(key);
+            GVariant * const props   = static_cast<GVariant *>(value);
+            const char * type        = nullptr;
+            ConnManService * service = nullptr;
+
+            ReturnOnFailure(UpdateServiceProxyLocked(lock, path, service));
+
+            // Prime service-derived state (for example, interface
+            // name) from the initial service enumeration (that is,
+            // "big get").
+
+            ReturnOnFailure(GetObjectTypeFromPropertiesLocked(props, type));
+
+            ReturnOnFailure(HandleServicePropertiesChangedLocked(G_DBUS_PROXY(service), path, type, props));
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to get manager services: %s",
+                     inError ? inError->message : "unknown error");
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetTechnologies(ConnManManager * inManager,
+                                                                                    GVariant * inTechnologies,
+                                                                                    const GError * inError) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturn(inTechnologies != nullptr);
+
+    if (inError == nullptr)
+    {
+        GHashTableIter iter;
+        gpointer key   = nullptr;
+        gpointer value = nullptr;
+
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "got %zu manager technology/ies",
+                        g_variant_n_children(inTechnologies));
+
+        ReturnOnFailure(UpdateTechnologiesLocked(inTechnologies));
+
+        g_hash_table_iter_init(&iter, mConnManClient.mTechnologies.get());
+
+        while (g_hash_table_iter_next(&iter, &key, &value))
+        {
+            const char * const path        = static_cast<const char *>(key);
+            GVariant * const props         = static_cast<GVariant *>(value);
+            const char * type              = nullptr;
+            ConnManTechnology * technology = nullptr;
+
+            ReturnOnFailure(UpdateTechnologyProxyLocked(lock, path, technology));
+
+            ReturnOnFailure(GetObjectTypeFromPropertiesLocked(props, type));
+
+            ReturnOnFailure(HandleTechnologyPropertiesChangedLocked(G_DBUS_PROXY(technology), path, type, props));
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to get manager technologies: %s",
+                     inError ? inError->message : "unknown error");
+    }
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerPropertiesChangedLocked(ConnManManager * inManager,
+                                                                                                  GVariant * inProperties) noexcept
+{
+    static const char * const kDescription = "manager";
+
+    return HandleObjectPropertiesChangedLocked(
+        kDescription, G_DBUS_PROXY(inManager), inProperties,
+        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerPropertyChangedAnyLocked);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerPropertyChanged(ConnManManager * inManager, const char * inKey,
+                                                                                    GVariant * inValue) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    CHIP_ERROR status;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "manager property changed");
+
+    // First, merge the changed property back into the local cache
+    // such that any subsequent gets in reaction to the changed
+    // property correctly reflect the current, rather than previous,
+    // state.
+
+    status = MergeObjectPropertiesLocked("manager (property changed)", mConnManClient.mProperties.get(), CONNMAN_MANAGER_PATH,
+                                         inKey, inValue);
+    ReturnOnFailure(status);
+
+    status = HandleManagerPropertyChangedAnyLocked(G_DBUS_PROXY(inManager), inKey, inValue);
+    ReturnOnFailure(status);
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerPropertyChangedAnyLocked(GDBusProxy * inManager, const char * inKey,
+                                                                                        GVariant * inMaybeVariant) noexcept
+{
+    VerifyOrReturnError(inManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inMaybeVariant != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    UnboxedVariant value(inMaybeVariant);
+    VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
+
+    ReturnErrorOnFailure(HandleManagerPropertyChangedLocked(CONN_MAN_MANAGER(inManager), inKey, value.get()));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerPropertyChangedLocked(ConnManManager * inManager,
+                                                                                                const char * inKey,
+                                                                                                GVariant * inValue) noexcept
+{
+    VerifyOrReturnError(inManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inValue != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "manager \"%s\" property changed", inKey);
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerServicesChanged(ConnManManager * inManager,
+                                                                                    GVariant * inServicesChanged,
+                                                                                    const char * const * inServicesRemoved) noexcept
+
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inServicesChanged != nullptr);
+
+    // Handle removed service paths.
+
+    HandleManagerServicesRemovedLocked(lock, inManager, inServicesRemoved);
+
+    // Handle changed service objects.
+
+    HandleManagerServicesChangedLocked(lock, inManager, inServicesChanged);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerServicesChangedLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                          ConnManManager * inManager,
+                                                                                          GVariant * inServicesChanged) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    CHIP_ERROR status   = CHIP_NO_ERROR;
+    const auto logGuard = ScopeExit([&status]() {
+        if (status != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer,
+                         CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to handle changed services:%" CHIP_ERROR_FORMAT,
+                         status.Format());
+        }
+    });
+
+    VerifyOrReturn(inManager != nullptr, status = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturn(inServicesChanged != nullptr, status = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturn(g_variant_is_of_type(inServicesChanged, G_VARIANT_TYPE("a(oa{sv})")), status = CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Add or update any changed services to the hash table.
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%zu manager services changed",
+                    g_variant_n_children(inServicesChanged));
+
+    // Per the connman manager interface documentation:
+    //
+    //    "This signal indicates a change in the services. List of all
+    //     services currently registered is passed. The list of all
+    //     services is sorted. The dictionary with the properties
+    //     might be empty in case none of the properties have
+    //     changed. Or only contains the properties that have changed.
+    //
+    //    "For newly added services the whole set of properties will
+    //     be present.
+    //
+    // With that in mind, we need to carefully merge the received
+    // property changes, if any, against the base set of properties
+    // from the initial "big get" or a first-time appearance of a
+    // service via this handler.
+
+    status = MergeObjectPropertiesLocked("services (changed)", mConnManClient.mServices.get(), inServicesChanged);
+    VerifyOrReturn(status == CHIP_NO_ERROR);
+
+    GVariantIter iter;
+    const char * path = nullptr;
+    GVariant * props  = nullptr;
+    g_variant_iter_init(&iter, inServicesChanged);
+    while (g_variant_iter_next(&iter, "(&o@a{sv})", &path, &props))
+    {
+        ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s: %s has %zu properties", __func__, path,
+                      g_variant_n_children(props));
+
+        ConnManService * service = nullptr;
+        status                   = UpdateServiceProxyLocked(inOutLock, path, service);
+        VerifyOrReturn(status == CHIP_NO_ERROR);
+
+        // Result intentionally ignored; a null `current` is caught by
+        // the type lookup below.
+
+        GVariant * current = nullptr;
+        RETURN_SAFELY_IGNORED GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path, current);
+
+        // Funnel the changed service properties through the same
+        // handler used for per-service property changed signals.
+
+        const char * type = nullptr;
+        status            = GetObjectTypeFromPropertiesLocked(current, type);
+        VerifyOrReturn(status == CHIP_NO_ERROR);
+
+        status = HandleServicePropertiesChangedLocked(G_DBUS_PROXY(service), path, type, props);
+        VerifyOrReturn(status == CHIP_NO_ERROR);
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerServicesRemovedLocked(
+    std::unique_lock<std::mutex> & inOutLock, ConnManManager * inManager, const char * const * inServicesRemoved) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturn(inManager != nullptr);
+
+    // Drop any removed services from the hash table.
+
+    if (inServicesRemoved != nullptr)
+    {
+        size_t removed = 0;
+
+        for (const char * const * ppath = inServicesRemoved; *ppath != nullptr; ++ppath, ++removed)
+        {
+            MaybeClearInterfaceNameLocked(*ppath);
+
+            RemoveServiceLocked(*ppath);
+        }
+
+        if (removed > 0)
+        {
+            RETURN_SAFELY_IGNORED UpdateNetworkServiceConnectivityLocked();
+        }
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerTechnologyAdded(ConnManManager * inManager, const char * inPath,
+                                                                                    GVariant * inProperties) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+    const char * type              = nullptr;
+    ConnManTechnology * technology = nullptr;
+    CHIP_ERROR status;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inPath != nullptr);
+    VerifyOrReturn(inProperties != nullptr);
+
+    VerifyOrReturn(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT));
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "manager technology added");
+
+    g_hash_table_replace(mConnManClient.mTechnologies.get(), g_strdup(inPath), g_variant_ref(inProperties));
+
+    status = UpdateTechnologyProxyLocked(lock, inPath, technology);
+    ReturnOnFailure(status);
+
+    status = GetObjectTypeFromPathLocked(mConnManClient.mTechnologies.get(), inPath, type);
+    ReturnOnFailure(status);
+
+    status = HandleTechnologyPropertiesChangedLocked(G_DBUS_PROXY(technology), inPath, type, inProperties);
+    ReturnOnFailure(status);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerTechnologyRemoved(ConnManManager * inManager,
+                                                                                      const char * inPath) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    const char * type = nullptr;
+    CHIP_ERROR status;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inPath != nullptr);
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "manager technology removed");
+
+    // If the Wi-Fi technology type has been removed, update the Wi-Fi
+    // station connected state and mode accordingly.
+
+    status = GetObjectTypeFromPathLocked(mConnManClient.mTechnologies.get(), inPath, type);
+    if ((status == CHIP_NO_ERROR))
+    {
+        if (strcmp(type, kConnManTechnologyPropertyTypeWiFiValue) == 0)
+        {
+            const auto newMode = ConnectivityManager::kWiFiStationMode_NotSupported;
+
+            if (mWiFiStationMode != newMode)
+            {
+                ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Wi-Fi station mode: %s -> %s",
+                                ConnectivityManager::WiFiStationModeToStr(mWiFiStationMode),
+                                ConnectivityManager::WiFiStationModeToStr(newMode));
+
+                mWiFiStationMode = newMode;
+            }
+
+            mWiFiStationConnected = false;
+        }
+    }
+
+    RemoveTechnologyLocked(inPath);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropertiesChangedLocked(
+    const char * inDescription, GDBusProxy * inProxy, GVariant * inProperties,
+    ObjectPropertiesChangedAnyLockedMethod inObjectPropertiesChangedAnyLockedMethod) noexcept
+{
+    VerifyOrReturnError(inDescription != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inObjectPropertiesChangedAnyLockedMethod != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const size_t count = g_variant_n_children(inProperties);
+    if (count > 0)
+    {
+        GVariantIter iter;
+        const char * key = nullptr;
+        GAutoPtr<GVariant> boxed;
+
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%zu %s property/ies changed", count, inDescription);
+
+        g_variant_iter_init(&iter, inProperties);
+
+        while (g_variant_iter_next(&iter, "{&s@v}", &key, &boxed.GetReceiver()))
+        {
+            VerifyOrReturnError(key != nullptr, CHIP_ERROR_INTERNAL);
+            VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_INTERNAL);
+
+            ReturnErrorOnFailure((this->*inObjectPropertiesChangedAnyLockedMethod)(inProxy, key, boxed.get()));
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropertiesChangedLocked(
+    const char * inDescription, GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties,
+    TypedObjectPropertiesChangedAnyLockedMethod inTypedObjectPropertiesChangedAnyLockedMethod) noexcept
+{
+    VerifyOrReturnError(inDescription != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inTypedObjectPropertiesChangedAnyLockedMethod != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const size_t count = g_variant_n_children(inProperties);
+    if (count > 0)
+    {
+        GVariantIter iter;
+        const char * key = nullptr;
+        GAutoPtr<GVariant> boxed;
+
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%zu %s %s property/ies changed", count, inType,
+                        inDescription);
+
+        g_variant_iter_init(&iter, inProperties);
+
+        while (g_variant_iter_next(&iter, "{&s@v}", &key, &boxed.GetReceiver()))
+        {
+            VerifyOrReturnError(key != nullptr, CHIP_ERROR_INTERNAL);
+            VerifyOrReturnError(boxed.get() != nullptr, CHIP_ERROR_INTERNAL);
+
+            ReturnErrorOnFailure((this->*inTypedObjectPropertiesChangedAnyLockedMethod)(inProxy, inPath, inType, key, boxed.get()));
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleObjectPropertyChangedAnyLocked(
+    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant,
+    TypedObjectPropertyChangedLockedMethod inTypedObjectPropertyChangedLockedMethod) noexcept
+{
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inMaybeVariant != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inTypedObjectPropertyChangedLockedMethod != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    UnboxedVariant value(inMaybeVariant);
+    VerifyOrReturnError(value, CHIP_ERROR_INTERNAL);
+
+    ReturnErrorOnFailure((this->*inTypedObjectPropertyChangedLockedMethod)(inProxy, inPath, inType, inKey, value.get()));
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectComplete(GDBusProxy * inService,
+                                                                                    const GError * inError) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    VerifyOrReturn(inService != nullptr);
+
+    auto teardown = ScopeExit([&]() {
+        mWiFiConnectScanState.Reset();
+
+        mConnManAgentServer.mPendingService.reset();
+
+        if (mConnManAgentServer.mRegistered)
+        {
+            const CHIP_ERROR status = ManagerUnregisterAgentLocked(lock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
+            if (status != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to unregister agent:%" CHIP_ERROR_FORMAT,
+                             status.Format());
+            }
+        }
+    });
+
+    const char * path = nullptr;
+    ReturnOnFailure(GetObjectPathFromProxyLocked(inService, path));
+
+    GVariant * props = nullptr;
+    ReturnOnFailure(GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path, props));
+
+    const char * type = nullptr;
+    ReturnOnFailure(GetObjectTypeFromPropertiesLocked(props, type));
+
+    CharSpan debug_text;
+    const char * name = nullptr;
+    if (GetObjectNameFromPropertiesLocked(props, name) == CHIP_NO_ERROR)
+    {
+        debug_text = CharSpan::fromCharString(name);
+    }
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s service %s connect done", type, path);
+
+    if (inError == nullptr)
+    {
+        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(lock, Status::kSuccess, debug_text, 0));
+    }
+    else
+    {
+        WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
+        constexpr int reason               = 0;
+
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to connect %s service: %s", type,
+                     inError->message);
+
+        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(lock, Status::kUnknownError, debug_text, reason));
+
+        if (delegate != nullptr)
+        {
+            constexpr uint8_t associationFailureCause   = static_cast<uint8_t>(AssociationFailureCauseEnum::kUnknown);
+            constexpr uint16_t associationFailureStatus = WLAN_STATUS_UNSPECIFIED_FAILURE;
+            LogErrorOnFailure(
+                DeviceLayer::SystemLayer().ScheduleLambda([delegate, associationFailureCause, associationFailureStatus]() {
+                    delegate->OnAssociationFailureDetected(associationFailureCause, associationFailureStatus);
+                }));
+        }
+    }
+}
+
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectRequestLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                    ConnManService * inService) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+    VerifyOrReturnError(inService != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    CharSpan debug_text; // best-effort, for OnConnectResult
+    {
+        const char * path = nullptr;
+        GVariant * props  = nullptr;
+        const char * name = nullptr;
+
+        if (GetObjectPathFromProxyLocked(G_DBUS_PROXY(inService), path) == CHIP_NO_ERROR &&
+            GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path, props) == CHIP_NO_ERROR &&
+            GetObjectNameFromPropertiesLocked(props, name) == CHIP_NO_ERROR)
+        {
+            debug_text = CharSpan::fromCharString(name);
+        }
+    }
+
+    // On any failure below, unwind the agent registration and surface
+    // an unknown-error connect result. Disarmed on success.
+
+    CHIP_ERROR result = CHIP_NO_ERROR;
+    auto cleanup      = ScopeExit([&]() {
+        if (mConnManAgentServer.mRegistered)
+        {
+            CHIP_ERROR status = ManagerUnregisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
+            if (status != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to unregister agent:%" CHIP_ERROR_FORMAT,
+                                  status.Format());
+            }
+        }
+
+        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(inOutLock, Status::kUnknownError, debug_text, result.GetValue()));
+    });
+
+    result = ManagerRegisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
+    ReturnErrorOnFailure(result);
+
+    mConnManAgentServer.mPendingService.reset(g_object_ref(inService));
+
+    result = ServiceConnectLocked(inOutLock, inService);
+    ReturnErrorOnFailure(result);
+
+    // Success; disarm the scoped clean-up.
+
+    cleanup.release();
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertiesChangedLocked(GDBusProxy * inProxy,
+                                                                                                  const char * inPath,
+                                                                                                  const char * inType,
+                                                                                                  GVariant * inProperties) noexcept
+{
+    static const char * const kDescription = "service";
+
+    return HandleObjectPropertiesChangedLocked(
+        kDescription, inProxy, inPath, inType, inProperties,
+        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedAnyLocked);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChanged(ConnManService * inService, const char * inKey,
+                                                                                    GVariant * inValue) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    const char * path = nullptr;
+    const char * type = nullptr;
+    CHIP_ERROR status;
+
+    VerifyOrReturn(inService != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    status = GetObjectPathFromProxyLocked(G_DBUS_PROXY(inService), path);
+    ReturnOnFailure(status);
+
+    // First, merge the changed property back into the local cache
+    // such that any subsequent gets in reaction to the changed
+    // property correctly reflect the current, rather than previous,
+    // state.
+
+    status = MergeObjectPropertiesLocked("service (property changed)", mConnManClient.mServices.get(), path, inKey, inValue);
+    ReturnOnFailure(status);
+
+    status = GetObjectTypeFromPathLocked(mConnManClient.mServices.get(), path, type);
+    ReturnOnFailure(status);
+
+    status = HandleServicePropertyChangedAnyLocked(G_DBUS_PROXY(inService), path, type, inKey, inValue);
+    ReturnOnFailure(status);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedLocked(
+    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept
+{
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inValue != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s service \"%s\" property changed", inType, inKey);
+
+    if (strcmp(inKey, kConnManServicePropertyEthernetKey) == 0)
+    {
+        GAutoPtr<gchar> interface;
+
+        ReturnErrorOnFailure(GetServiceInterfaceFromEthernetLocked(inValue, interface));
+
+        ReturnErrorOnFailure(MaybeSetInterfaceNameLocked(inType, interface.get()));
+    }
+    else if ((FindNetworkServiceStateLocked(inType) != nullptr) &&
+             ((strcmp(inKey, kConnManServicePropertyIPv4Key) == 0) || (strcmp(inKey, kConnManServicePropertyIPv6Key) == 0) ||
+              (strcmp(inKey, kConnManServicePropertyStateKey) == 0)))
+    {
+        // Any change to a tracked service type's address
+        // configuration (or to its state, which gates best-of-type
+        // selection) may alter Internet connectivity; recompute and
+        // debounce.
+
+        ReturnErrorOnFailure(UpdateNetworkServiceConnectivityLocked());
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedAnyLocked(
+    GDBusProxy * inService, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept
+{
+    return HandleObjectPropertyChangedAnyLocked(
+        G_DBUS_PROXY(inService), inPath, inType, inKey, inMaybeVariant,
+        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleServicePropertyChangedLocked);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertiesChangedLocked(
+    GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties) noexcept
+{
+    static const char * const kDescription = "technology";
+
+    return HandleObjectPropertiesChangedLocked(
+        kDescription, inProxy, inPath, inType, inProperties,
+        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedAnyLocked);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChanged(ConnManTechnology * inTechnology,
+                                                                                       const char * inKey,
+                                                                                       GVariant * inValue) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    const char * path = nullptr;
+    const char * type = nullptr;
+    CHIP_ERROR status;
+
+    VerifyOrReturn(inTechnology != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    status = GetObjectPathFromProxyLocked(G_DBUS_PROXY(inTechnology), path);
+    ReturnOnFailure(status);
+
+    // First, merge the changed property back into the local cache
+    // such that any subsequent gets in reaction to the changed
+    // property correctly reflect the current, rather than previous,
+    // state.
+
+    status = MergeObjectPropertiesLocked("technology (property changed)", mConnManClient.mTechnologies.get(), path, inKey, inValue);
+    ReturnOnFailure(status);
+
+    status = GetObjectTypeFromPathLocked(mConnManClient.mTechnologies.get(), path, type);
+    ReturnOnFailure(status);
+
+    status = HandleTechnologyPropertyChangedAnyLocked(G_DBUS_PROXY(inTechnology), path, type, inKey, inValue);
+    ReturnOnFailure(status);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedLocked(
+    GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept
+{
+    VerifyOrReturnError(inProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inValue != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s technology \"%s\" property changed", inType, inKey);
+
+    if (strcmp(inKey, kConnManTechnologyPropertyConnectedKey) == 0)
+    {
+        VerifyOrReturnError(g_variant_is_of_type(inValue, G_VARIANT_TYPE_BOOLEAN), CHIP_ERROR_WRONG_KEY_TYPE);
+
+        const bool connected = g_variant_get_boolean(inValue);
+
+        if (strcmp(inType, kConnManTechnologyPropertyTypeWiFiValue) == 0)
+        {
+            if (mWiFiStationConnected != connected)
+            {
+                ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Wi-Fi station connected: %u -> %u",
+                                mWiFiStationConnected, connected);
+
+                mWiFiStationConnected = connected;
+            }
+        }
+    }
+    else if (strcmp(inKey, kConnManTechnologyPropertyPoweredKey) == 0)
+    {
+        VerifyOrReturnError(g_variant_is_of_type(inValue, G_VARIANT_TYPE_BOOLEAN), CHIP_ERROR_WRONG_KEY_TYPE);
+
+        const bool powered = g_variant_get_boolean(inValue);
+
+        ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s %s=%u", inType, kConnManTechnologyPropertyPoweredKey,
+                      powered);
+
+        if (strcmp(inType, kConnManTechnologyPropertyTypeWiFiValue) == 0)
+        {
+            const auto newMode =
+                (powered ? ConnectivityManager::kWiFiStationMode_Enabled : ConnectivityManager::kWiFiStationMode_Disabled);
+
+            if (mWiFiStationMode != newMode)
+            {
+                ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Wi-Fi station mode: %s -> %s",
+                                ConnectivityManager::WiFiStationModeToStr(mWiFiStationMode),
+                                ConnectivityManager::WiFiStationModeToStr(newMode));
+
+                mWiFiStationMode = newMode;
+            }
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedAnyLocked(
+    GDBusProxy * inTechnology, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept
+{
+    return HandleObjectPropertyChangedAnyLocked(
+        inTechnology, inPath, inType, inKey, inMaybeVariant,
+        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyPropertyChangedLocked);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyScanComplete(GDBusProxy * inTechnology,
+                                                                                    const GError * inError) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+    const char * type = nullptr;
+
+    VerifyOrReturn(inTechnology != nullptr);
+
+    ReturnOnFailure(GetObjectTypeFromProxyLocked(G_DBUS_PROXY(inTechnology), mConnManClient.mTechnologies.get(), type));
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s technology scan done", type);
+
+    if (inError == nullptr)
+    {
+        if (strcmp(type, kConnManTechnologyPropertyTypeWiFiValue) == 0)
+        {
+            ReturnOnFailure(HandleWiFiScanCompleteLocked(lock, CONN_MAN_TECHNOLOGY(inTechnology)));
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to scan %s technology: %s", type,
+                     inError->message);
+    }
+}
+
+/**
+ *  @brief
+ *    Complete a broadcast (non-directed) Wi-Fi scan from the current
+ *    service set.
+ *
+ *  Reached from #HandleWiFiScanCompleteLocked when the active scan is
+ *  live but carries no target SSID. Enumerates every currently-known
+ *  connman Wi-Fi service and accumulates one `WiFiScanResponse` per
+ *  non-hidden entry via
+ *  #BuildWiFiScanResponseFromServicePropertiesLocked.  Unlike the
+ *  directed path, an empty result set is reported as success rather
+ *  than not-found, and there is no rescan or retry: the scan has
+ *  already run, and this reports whatever connman presently
+ *  knows. De-duplication is implicit, since connman collapses the
+ *  BSSIDs of a shared SSID/security into one service.  The
+ *  active-scan state is reset before dispatch to restore the idle
+ *  invariant (`mCount == 0`) across the possible lock release inside
+ *  #DispatchWiFiScanFinishedLocked.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock, passed through to
+ *    #DispatchWiFiScanFinishedLocked.
+ *
+ *  @param[in]      inTechnology
+ *    A pointer to the completed connman Wi-Fi technology. Validated
+ *    but otherwise unused, since a broadcast scan never rescans.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    If the results were assembled and dispatched.
+ *
+ *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
+ *    If `inTechnology` is null.
+ *
+ *  @retval  #CHIP_ERROR_NO_MEMORY
+ *    If the result vector could not be allocated.
+ *
+ *  @sa BuildWiFiScanResponseFromServicePropertiesLocked
+ *  @sa DispatchWiFiScanFinishedLocked
+ *  @sa HandleWiFiScanCompleteLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiBroadcastScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                        ConnManTechnology * inTechnology) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Enumerate every currently-known Wi-Fi service and accumulate a
+    // scan response for each non-hidden one. A broadcast scan reports
+    // whatever connman knows after the just-completed technology
+    // scan; unlike the directed path, an empty result set is a
+    // success, not a not-found, and there is no rescan or
+    // retry. De-duplication is implicit: connman collapses BSSIDs of
+    // a common SSID/security into one service, so at most one
+    // response per (SSID, security) is produced.
+
+    std::unique_ptr<std::vector<WiFiScanResponse>> responses(new (std::nothrow) std::vector<WiFiScanResponse>());
+    VerifyOrReturnError(responses != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    GHashTableIter iter;
+    gpointer key   = nullptr;
+    gpointer value = nullptr;
+
+    g_hash_table_iter_init(&iter, mConnManClient.mServices.get());
+    while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+        GVariant * const props = static_cast<GVariant *>(value);
+        if ((props == nullptr) || !g_variant_is_of_type(props, G_VARIANT_TYPE_VARDICT))
+        {
+            continue;
+        }
+
+        const char * type = nullptr;
+        if ((GetObjectTypeFromPropertiesLocked(props, type) != CHIP_NO_ERROR) || (type == nullptr) ||
+            (strcmp(type, kConnManServicePropertyTypeWiFiValue) != 0))
+        {
+            continue;
+        }
+
+        WiFiScanResponse response;
+        if (BuildWiFiScanResponseFromServicePropertiesLocked(props, response) != CHIP_NO_ERROR)
+        {
+            // Skips hidden (empty-Name), oversized, and malformed services.
+
+            continue;
+        }
+
+        responses->push_back(response);
+    }
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "broadcast scan found %zu Wi-Fi network(s)",
+                    responses->size());
+
+    // Restore the idle invariant before dispatching: a broadcast scan is
+    // single-shot, so clear the count (the liveness sentinel). The SSID is
+    // already empty.
+
+    mWiFiActiveScanState.Reset();
+
+    return DispatchWiFiScanFinishedLocked(inOutLock, NetworkCommissioning::Status::kSuccess, CharSpan(), std::move(responses));
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingConnectLocked(
+    std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology, WiFiScanState & inOutScanState) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ConnManService * const service = GetWiFiServiceProxyFromSsidLocked(
+        inOutScanState.mSsid.span(), mConnManClient.mServiceProxies.get(), mConnManClient.mServices.get());
+    if (service != nullptr)
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to '%.*s' after %zu scan(s)...",
+                        static_cast<int>(inOutScanState.mSsid.size()), inOutScanState.mSsid.data(), inOutScanState.mCount);
+
+        return HandleServiceConnectRequestLocked(inOutLock, service);
+    }
+
+    return HandleWiFiUnresolvedAfterScanLocked(inOutLock, inTechnology, inOutScanState, kWiFiConnectScanLimit,
+                                               "could not connect to", WiFiScanTerminalKind::kConnect);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingScanLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                         ConnManTechnology * inTechnology,
+                                                                                         WiFiScanState & inOutScanState) noexcept
+{
+    GAutoPtr<GVariant> properties;
+    CHIP_ERROR retval = CHIP_NO_ERROR;
+
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Directed scan: resolve the target SSID against the current service set.
+
+    retval = GetWiFiServicePropertiesFromSsidLocked(inOutScanState.mSsid.span(), mConnManClient.mServices.get(), properties);
+
+    if (retval == CHIP_NO_ERROR)
+    {
+        std::unique_ptr<std::vector<WiFiScanResponse>> services(new (std::nothrow) std::vector<WiFiScanResponse>());
+        VerifyOrReturnError(services != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        WiFiScanResponse response;
+        ReturnErrorOnFailure(BuildWiFiScanResponseFromServicePropertiesLocked(properties.get(), response));
+        services->push_back(response);
+
+        // Snapshot the SSID for debug text BEFORE Reset(); the dispatch helper
+        // copies these bytes by value, so the reset cannot race the deferred
+        // callback.
+
+        const CharSpan debug(reinterpret_cast<const char *>(inOutScanState.mSsid.data()), inOutScanState.mSsid.size());
+
+        // Directed scan resolved: clear scan state so mCount == 0 restores the
+        // idle invariant. Ordering matters -- capture `debug` above first.
+
+        inOutScanState.Reset();
+
+        return DispatchWiFiScanFinishedLocked(inOutLock, Status::kSuccess, debug, std::move(services));
+    }
+
+    // Not found: hand off to the shared give-up-versus-retry arbiter.
+
+    return HandleWiFiUnresolvedAfterScanLocked(inOutLock, inTechnology, inOutScanState, kWiFiActiveScanLimit,
+                                               "no Wi-Fi network found matching", WiFiScanTerminalKind::kScan);
+}
+
+/**
+ *  @brief
+ *    Dispatch a completed Wi-Fi technology scan to its pending
+ *    connect and/or scan handlers.
+ *
+ *  Reached from #HandleTechnologyScanComplete once a connman Wi-Fi
+ *  technology scan finishes. A single scan may satisfy an in-flight
+ *  connect, an in-flight `ScanNetworks`, or neither (an unsolicited
+ *  background scan); the first two are handled independently and in
+ *  order, and the third is a no-op. Liveness is keyed off each
+ *  operation's nonzero scan count, *not* off SSID emptiness: a
+ *  broadcast scan legitimately carries an empty SSID and must still
+ *  be completed, or the Network Commissioning command handle wedges.
+ *  For a live active scan, SSID emptiness then selects between the
+ *  directed (#HandleWiFiPendingScanLocked) and broadcast
+ *  (#HandleWiFiBroadcastScanCompleteLocked) completion paths.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion. The lock
+ *    is passed through to the pending-operation handlers, which may
+ *    temporarily release it.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock guarding the scan
+ *    state machine.
+ *
+ *  @param[in]      inTechnology
+ *    A pointer to the completed connman Wi-Fi network technology.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    If any pending operations were dispatched, or none were pending.
+ *
+ *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
+ *    If `inTechnology` is null.
+ *
+ *  @retval  *
+ *    Otherwise, any error returned by a pending-operation handler.
+ *
+ *  @sa HandleWiFiPendingConnectLocked
+ *  @sa HandleWiFiPendingScanLocked
+ *  @sa HandleWiFiBroadcastScanCompleteLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                          ConnManTechnology * inTechnology) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // A Wi-Fi scan may have been initiated due to an active, directed
+    // scan for a specific SSID, from a service connect for a specific
+    // SSID, or as just a general passive, broadcast background
+    // scan. We handle those first two cases independently and in
+    // parallel. There is nothing to do for the third case.
+    //
+    // A nonzero active-scan count (not the emptiness of
+    // mWiFiActiveScanState.mSsid) is the liveness sentinel for an
+    // outstanding StartWiFiScan. The SSID's emptiness is instead the
+    // (correct) directed-versus-broadcast selector: a broadcast scan
+    // legitimately carries an empty SSID and must still be completed,
+    // or the Network Commissioning command initiator handle wedges.
+
+    // If there is a pending asynchronous connect that required a
+    // scan, handle it.
+
+    if (mWiFiConnectScanState.IsActive())
+    {
+        ReturnErrorOnFailure(HandleWiFiPendingConnectLocked(inOutLock, inTechnology, mWiFiConnectScanState));
+    }
+
+    // If there is a pending asynchronous scan, handle it.
+
+    if (mWiFiActiveScanState.IsActive())
+    {
+        if (mWiFiActiveScanState.IsDirected())
+        {
+            ReturnErrorOnFailure(HandleWiFiPendingScanLocked(inOutLock, inTechnology, mWiFiActiveScanState));
+        }
+        else
+        {
+            ReturnErrorOnFailure(HandleWiFiBroadcastScanCompleteLocked(inOutLock, inTechnology));
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanRetryLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                       ConnManTechnology * inTechnology,
+                                                                                       const char * inReason,
+                                                                                       WiFiScanState & inOutScanState) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inReason != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s SSID '%.*s' after %zu scan(s): retrying...", inReason,
+                    static_cast<int>(inOutScanState.mSsid.size()), inOutScanState.mSsid.data(), inOutScanState.mCount);
+
+    // Increment the scan count.
+
+    inOutScanState.mCount++;
+
+    // Attempt to scan, again, for the desired network service.
+
+    ReturnErrorOnFailure(TechnologyScanLocked(inOutLock, inTechnology));
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
+ *    Arbitrate between retrying a Wi-Fi scan and terminally reporting
+ *    an unresolved SSID.
+ *
+ *  Invoked from a pending connect or active-scan completion once the
+ *  target SSID remains absent from the connman service set after a
+ *  scan. This is the shared give-up-versus-retry policy for both
+ *  callers: if the scan budget is exhausted (`inOutScanState.mCount`
+ *  has reached `inScanLimit`), the SSID is snapshotted for the debug
+ *  text, the scan state is reset, and the caller-specific terminal is
+ *  completed exactly once through the corresponding dispatch
+ *  primitive; otherwise, another scan is armed via
+ *  #HandleWiFiScanRetryLocked and its status is returned.
+ *
+ *  The terminal disposition is selected by an `inKind` tag rather
+ *  than a caller-supplied callback so that the give-up bookkeeping
+ *  (logging, scan-state reset) and the terminal dispatch both live
+ *  here once, and so that dispatch routes through
+ *  #DispatchWiFiScanFinishedLocked or #DispatchWiFiConnectFinishedLocked,
+ *  which guarantee exactly-once completion even under scheduler
+ *  allocation failure. The two callers differ only in which delegate
+ *  they ultimately drive (`OnScanFinished` versus `OnConnectResult`)
+ *  and in the advisory error they propagate upward; the `OnScan`/
+ *  `OnConnect` completion is authoritative, and the returned error is
+ *  logged, not acted upon, by #HandleTechnologyScanComplete. The SSID
+ *  is snapshotted before the reset because the dispatch primitives
+ *  copy the debug bytes by value into a deferred task that must not
+ *  alias `inOutScanState.mSsid`.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion. The lock
+ *    is passed through to #HandleWiFiScanRetryLocked and the dispatch
+ *    primitives, which may temporarily release it.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock guarding the
+ *    critical members touched by the scan state machine.
+ *
+ *  @param[in]      inTechnology
+ *    A pointer to the connman Wi-Fi network technology to rescan on
+ *    the non-terminal path.
+ *
+ *  @param[in,out]  inOutScanState
+ *    A reference to the mutable scan operation state (target SSID and
+ *    scan count). On the terminal path its SSID is snapshotted and
+ *    the state is reset; on the retry path #HandleWiFiScanRetryLocked
+ *    increments its count.
+ *
+ *  @param[in]      inScanLimit
+ *    The maximum number of Wi-Fi scans permitted before the operation
+ *    is abandoned and its terminal is reported.
+ *
+ *  @param[in]      inReason
+ *    A pointer to an immutable null-terminated C string describing
+ *    why the SSID is unresolved, used both in the terminal error log
+ *    and as the retry log reason.
+ *
+ *  @param[in]      inKind
+ *    Selects the terminal disposition: `#WiFiScanTerminalKind::kScan`
+ *    completes `OnScanFinished`; `#WiFiScanTerminalKind::kConnect`
+ *    completes `OnConnectResult`.
+ *
+ *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
+ *    If `inTechnology` or `inReason` is null.
+ *
+ *  @retval  #CHIP_ERROR_KEY_NOT_FOUND
+ *    If the scan budget is exhausted for `#WiFiScanTerminalKind::kScan`
+ *    (advisory; `OnScanFinished` is the authoritative completion).
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    If a further scan was successfully armed.
+ *
+ *  @retval  *
+ *    Otherwise, a POSIX ENOENT #CHIP_ERROR for an exhausted
+ *    `#WiFiScanTerminalKind::kConnect` budget (advisory), or any error
+ *    returned by #HandleWiFiScanRetryLocked in arming a further scan.
+ *
+ *  @sa HandleWiFiScanRetryLocked
+ *  @sa HandleWiFiPendingConnectLocked
+ *  @sa HandleWiFiPendingScanLocked
+ *  @sa DispatchWiFiScanFinishedLocked
+ *  @sa DispatchWiFiConnectFinishedLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiUnresolvedAfterScanLocked(
+    std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology, WiFiScanState & inOutScanState,
+    const size_t & inScanLimit, const char * inReason, WiFiScanTerminalKind inKind) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inReason != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (inOutScanState.mCount >= inScanLimit)
+    {
+        // Snapshot the SSID for the debug text before the reset; the dispatch
+        // helpers copy these bytes by value, so the reset cannot race the
+        // deferred callback.
+        const Internal::WiFiSSIDFixedBuffer ssid = inOutScanState.mSsid;
+        const CharSpan debug(reinterpret_cast<const char *>(ssid.data()), ssid.size());
+
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s SSID '%.*s' after %zu scan(s)", inReason,
+                     static_cast<int>(ssid.size()), reinterpret_cast<const char *>(ssid.data()), inOutScanState.mCount);
+
+        // Reset the SSID and scan count.
+        //
+        // Clear the operation's scan state BEFORE dispatching the
+        // terminal result; the snapshot above keeps the reported SSID
+        // stable across the reset.
+
+        inOutScanState.Reset();
+
+        switch (inKind)
+        {
+
+        case WiFiScanTerminalKind::kScan:
+            ReturnErrorOnFailure(DispatchWiFiScanFinishedLocked(inOutLock, Status::kNetworkNotFound, debug, nullptr));
+
+            return CHIP_ERROR_KEY_NOT_FOUND;
+
+        case WiFiScanTerminalKind::kConnect:
+            ReturnErrorOnFailure(DispatchWiFiConnectFinishedLocked(inOutLock, Status::kNetworkNotFound, debug, 0));
+
+            return ChipError(ChipError::Range::kPOSIX, ENOENT);
+        }
+
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    return HandleWiFiScanRetryLocked(inOutLock, inTechnology, inReason, inOutScanState);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerAgentOpLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                  const char * inPath,
+                                                                                  ManagerAgentOpFunc inManagerAgentOpFunc,
+                                                                                  const char * inAction,
+                                                                                  const bool & inRegister) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inManagerAgentOpFunc != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inAction != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(mConnManClient.mManagerProxy, CHIP_ERROR_UNINITIALIZED);
+
+    VerifyOrReturnError(mConnManAgentServer.mRegistered != inRegister, CHIP_ERROR_INCORRECT_STATE);
+
+    // Hold a reference to the manager proxy across the unlock boundary.
+
+    GAutoPtr<ConnManManager> manager(static_cast<ConnManManager *>(g_object_ref(mConnManClient.mManagerProxy.get())));
+
+    // Unlock and synchronously invoke the manager agent operation
+    // function on the GLib context.
+
+    ReturnErrorOnFailure(UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        GAutoPtr<GError> err;
+        if (!inManagerAgentOpFunc(manager.get(), inPath, nullptr, &err.GetReceiver()))
+        {
+            ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "could not %s manager agent %s: %s", inAction, inPath,
+                         (err.get() && err->message) ? err->message : "unknown error");
+
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        return CHIP_NO_ERROR;
+    }));
+
+    mConnManAgentServer.mRegistered = inRegister;
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::MaybeClearInterfaceNameLocked(const char * inPath) noexcept
+{
+    const char * type = nullptr;
+    GAutoPtr<gchar> interface;
+
+    VerifyOrReturn(inPath != nullptr);
+
+    ReturnOnFailure(GetObjectTypeFromPathLocked(mConnManClient.mServices.get(), inPath, type));
+
+    ReturnOnFailure(GetServiceInterfaceFromPathLocked(mConnManClient.mServices.get(), inPath, interface));
+
+    NetworkServiceState * const state = FindNetworkServiceStateLocked(type);
+    if (state != nullptr)
+    {
+        _MaybeClearInterfaceName(interface.get(), &state->mIfName[0]);
+    }
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::MaybeSetInterfaceNameLocked(const char * inType,
+                                                                                         const char * inInterface) noexcept
+{
+    VerifyOrReturnError(inType != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inInterface != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Untracked Matter network service types (for example, cellular or VPN) are
+    // silently ignored.
+
+    NetworkServiceState * const state = FindNetworkServiceStateLocked(inType);
+    if (state != nullptr)
+    {
+        _MaybeSetInterfaceName(state->mDescription, inInterface, &state->mIfName[0]);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::RemoveServiceLocked(const char * inPath) noexcept
+{
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    return RemoveObjectLocked(mConnManClient.mServices.get(), inPath, mConnManClient.mServiceProxies.get());
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::RemoveTechnologyLocked(const char * inPath) noexcept
+{
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    return RemoveObjectLocked(mConnManClient.mTechnologies.get(), inPath, mConnManClient.mTechnologyProxies.get());
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateManagerPropertiesLocked(GVariant * inProperties) noexcept
+{
+    GHashTable * const table = mConnManClient.mProperties.get();
+
+    VerifyOrReturnError(inProperties != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(table, CHIP_ERROR_INCORRECT_STATE);
+
+    g_hash_table_remove(table, CONNMAN_MANAGER_PATH);
+
+    return MergeObjectPropertiesLocked("manager properties (update)", table, CONNMAN_MANAGER_PATH, inProperties);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateNetworkServiceConnectivityLocked() noexcept
+{
+    bool changed = false;
+
+    // This method, like all *Locked methods reached via
+    // ScheduleLambda-marshaled handlers, runs on the Matter thread;
+    // the System layer timer APIs below require it.
+
+    VerifyOrDie(PlatformMgr().IsChipStackLockedByCurrentThread());
+
+    // Recompute the pending per-family connectivity state for each
+    // tracked network service type from the cached properties of the
+    // best service of that type. Absence of any service of the type
+    // means both families are lost.
+
+    for (auto & state : mNetworkServiceStates)
+    {
+        NetworkServiceConnectivityState pending;
+        GAutoPtr<gchar> path;
+        GVariant * props = nullptr;
+        CHIP_ERROR status;
+
+        status = GetBestServicePathForTypeLocked(state.mType, mConnManClient.mServices.get(), path);
+
+        if (status == CHIP_NO_ERROR)
+        {
+            status = GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path.get(), props);
+        }
+
+        if ((status == CHIP_NO_ERROR) && (props != nullptr))
+        {
+            pending.mIPv4 = GetServiceFamilyConnectivityStateLocked(props, kConnManServicePropertyIPv4Key);
+            pending.mIPv6 = GetServiceFamilyConnectivityStateLocked(props, kConnManServicePropertyIPv6Key);
+        }
+        else
+        {
+            pending.mIPv4.mConnectivity = NetworkServiceConnectivity::kLost;
+            pending.mIPv6.mConnectivity = NetworkServiceConnectivity::kLost;
+        }
+
+        if (pending != state.mPendingConnectivity)
+        {
+            state.mPendingConnectivity = pending;
+            changed                    = true;
+
+            ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s connectivity pending: IPv4 %s IPv6 %s",
+                          state.mDescription, GetNetworkServiceConnectivityString(pending.mIPv4.mConnectivity),
+                          GetNetworkServiceConnectivityString(pending.mIPv6.mConnectivity));
+        }
+    }
+
+    // If any tracked type's pending state changed, (re)arm the
+    // trailing-edge debounce timer. Storms that settle back to the
+    // previously-reported state result in a timer expiration that
+    // reports nothing.
+
+    if (changed)
+    {
+        DeviceLayer::SystemLayer().CancelTimer(HandleNetworkServiceConnectivityDebounce, this);
+
+        ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(kNetworkServiceConnectivityDebounce,
+                                                                   HandleNetworkServiceConnectivityDebounce, this));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateServicesLocked(GVariant * inServices) noexcept
+{
+    VerifyOrReturnError(inServices != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mConnManClient.mServices, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(g_variant_is_of_type(inServices, G_VARIANT_TYPE("a(oa{sv})")), CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_hash_table_remove_all(mConnManClient.mServices.get());
+
+    ReturnErrorOnFailure(MergeObjectPropertiesLocked("services (update)", mConnManClient.mServices.get(), inServices));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateServiceProxyLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                      const char * inPath,
+                                                                                      ConnManService *& outService) noexcept
+{
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mConnManClient.mServiceProxies, CHIP_ERROR_INCORRECT_STATE);
+
+    ConnManService * proxy = static_cast<ConnManService *>(g_hash_table_lookup(mConnManClient.mServiceProxies.get(), inPath));
+    if (proxy == nullptr)
+    {
+        ReturnErrorOnFailure(UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+            GAutoPtr<GError> err;
+            ConnManService * service = conn_man_service_proxy_new_for_bus_sync(
+                G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kConnManServiceName, inPath, nullptr, &err.GetReceiver());
+
+            if (!service || err)
+            {
+                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to create service proxy for %s: %s",
+                             inPath, err ? err->message : "unknown");
+
+                return CHIP_ERROR_INTERNAL;
+            }
+
+            ServiceRegisterPropertyChangedOnGLib(service);
+
+            proxy = service;
+
+            return CHIP_NO_ERROR;
+        }));
+
+        g_hash_table_insert(mConnManClient.mServiceProxies.get(), g_strdup(inPath), proxy);
+    }
+
+    outService = proxy;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateTechnologiesLocked(GVariant * inTechnologies) noexcept
+{
+    VerifyOrReturnError(inTechnologies != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mConnManClient.mTechnologies, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(g_variant_is_of_type(inTechnologies, G_VARIANT_TYPE("a(oa{sv})")), CHIP_ERROR_INVALID_ARGUMENT);
+
+    g_hash_table_remove_all(mConnManClient.mTechnologies.get());
+
+    return MergeObjectPropertiesLocked("technologies (update)", mConnManClient.mTechnologies.get(), inTechnologies);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateTechnologyProxyLocked(
+    std::unique_lock<std::mutex> & inOutLock, const char * inPath, ConnManTechnology *& outTechnology) noexcept
+{
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mConnManClient.mTechnologyProxies, CHIP_ERROR_INCORRECT_STATE);
+
+    ConnManTechnology * proxy =
+        static_cast<ConnManTechnology *>(g_hash_table_lookup(mConnManClient.mTechnologyProxies.get(), inPath));
+    if (proxy == nullptr)
+    {
+        ReturnErrorOnFailure(UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+            GAutoPtr<GError> err;
+            ConnManTechnology * technology = conn_man_technology_proxy_new_for_bus_sync(
+                G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kConnManServiceName, inPath, nullptr, &err.GetReceiver());
+
+            if (!technology || err)
+            {
+                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to create technology proxy for %s: %s",
+                             inPath, err ? err->message : "unknown");
+
+                return CHIP_ERROR_INTERNAL;
+            }
+
+            TechnologyRegisterPropertyChangedOnGLib(technology);
+
+            proxy = technology;
+
+            return CHIP_NO_ERROR;
+        }));
+
+        g_hash_table_insert(mConnManClient.mTechnologyProxies.get(), g_strdup(inPath), proxy);
+    }
+
+    outTechnology = proxy;
+
+    return CHIP_NO_ERROR;
+}
+
+// Worker Methods
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerRegisterAgent(const char * inPath) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    return ManagerRegisterAgentLocked(lock, inPath);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerRegisterAgentLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                        const char * inPath) noexcept
+{
+    GAutoPtr<gchar> path;
+    GAutoPtr<GDBusConnection> connection;
+    ConnManAgent * skeleton = nullptr;
+    GAutoPtr<GError> exportError;
+    CHIP_ERROR status;
+
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrReturnError(mConnManClient.mManagerProxy, CHIP_ERROR_UNINITIALIZED);
+
+    VerifyOrReturnError(!mConnManAgentServer.mExported, CHIP_ERROR_ALREADY_INITIALIZED);
+
+    path.reset(g_strdup(inPath));
+    VerifyOrReturnError(path.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    // Hold a reference to the manager client proxy connection across
+    // the unlock boundary.
+
+    {
+        GDBusConnection * c = g_dbus_proxy_get_connection(G_DBUS_PROXY(mConnManClient.mManagerProxy.get()));
+        VerifyOrReturnError(c != nullptr, CHIP_ERROR_INTERNAL);
+        connection.reset(static_cast<GDBusConnection *>(g_object_ref(c)));
+    }
+
+    ReturnErrorOnFailure(UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        return InitAgentOnGLib(this, connection.get(), path.get(), skeleton, &exportError.GetReceiver());
+    }));
+
+    if (skeleton == nullptr)
+    {
+        if (exportError.get() != nullptr)
+        {
+            ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "could not export agent server skeleton: %s",
+                         exportError->message);
+        }
+
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    // Commit exported objects under lock.
+
+    mConnManAgentServer.mConnection.reset(static_cast<GDBusConnection *>(g_object_ref(connection.get())));
+    mConnManAgentServer.mSkeleton.reset(skeleton);
+    mConnManAgentServer.mExported = true;
+
+    status = ManagerAgentOpLocked(inOutLock, path.get(), conn_man_manager_call_register_agent_sync, "register", true);
+    if ((status != CHIP_NO_ERROR))
+    {
+        ShutdownAgentLocked(inOutLock, inPath);
+
+        return status;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerUnregisterAgent(const char * inPath) noexcept
+{
+    std::unique_lock<std::mutex> lock(mConnManMutex);
+
+    return ManagerUnregisterAgentLocked(lock, inPath);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ManagerUnregisterAgentLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                          const char * inPath) noexcept
+{
+    GAutoPtr<gchar> path;
+    CHIP_ERROR retval = CHIP_NO_ERROR;
+
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    path.reset(g_strdup(inPath));
+    VerifyOrReturnError(path.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    retval = ManagerAgentOpLocked(inOutLock, path.get(), conn_man_manager_call_unregister_agent_sync, "unregister", false);
+
+    ShutdownAgentLocked(inOutLock, inPath);
+
+    return retval;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ServiceConnectLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                  ConnManService * inService) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inService != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Initiate the asynchronous D-Bus call on the GLib context while *not* holding the class lock.
+    // This is a synchronous cross-thread invoke to *schedule* the asynchronous operation; it does
+    // not wait for the D-Bus operation to complete--service connect is inherently asynchronous.
+
+    return UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        GAutoPtr<ConnManService> service(static_cast<ConnManService *>(g_object_ref(inService)));
+        VerifyOrReturnError(service.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        conn_man_service_call_connect(
+            service.get(), nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                    inSelf_->OnServiceConnectReady(sourceObject_, res_);
+                }),
+            this);
+
+        return CHIP_NO_ERROR;
+    });
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::ServiceRegisterPropertyChangedOnGLib(ConnManService * inService) noexcept
+{
+    VerifyOrReturn(inService != nullptr);
+
+    g_signal_connect(inService, "property-changed",
+                     G_CALLBACK(+[](ConnManService * inService_, const char * inKey_, GVariant * inValue_,
+                                    ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                         inSelf_->OnServicePropertyChanged(inService_, inKey_, inValue_);
+                     }),
+                     this);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::TechnologyRegisterPropertyChangedOnGLib(
+    ConnManTechnology * inTechnology) noexcept
+{
+    VerifyOrReturn(inTechnology != nullptr);
+
+    g_signal_connect(inTechnology, "property-changed",
+                     G_CALLBACK(+[](ConnManTechnology * inTechnology_, const char * inKey_, GVariant * inValue_,
+                                    ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                         inSelf_->OnTechnologyPropertyChanged(inTechnology_, inKey_, inValue_);
+                     }),
+                     this);
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::TechnologyScanLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                  ConnManTechnology * inTechnology) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Initiate the asynchronous D-Bus call on the GLib context while *not* holding the class lock.
+    // This is a synchronous cross-thread invoke to *schedule* the asynchronous operation; it does
+    // not wait for the D-Bus operation to complete--technology scan is inherently asynchronous.
+
+    return UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        GAutoPtr<ConnManTechnology> technology(static_cast<ConnManTechnology *>(g_object_ref(inTechnology)));
+        VerifyOrReturnError(technology.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        conn_man_technology_call_scan(
+            technology.get(), nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                    inSelf_->OnTechnologyScanReady(sourceObject_, res_);
+                }),
+            this);
+
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::TechnologySetPropertyLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                         ConnManTechnology * inTechnology,
+                                                                                         const char * inKey,
+                                                                                         GVariant * inValue) noexcept
+{
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(inValue != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GAutoPtr<ConnManTechnology> technology(static_cast<ConnManTechnology *>(g_object_ref(inTechnology)));
+
+    GAutoPtr<gchar> key(g_strdup(inKey));
+    VerifyOrReturnError(key.get() != nullptr, CHIP_ERROR_NO_MEMORY); // technology released here on the OOM path
+
+    GAutoPtr<GVariant> value(g_variant_ref(inValue));
+
+    return UnlockAndInvokeOnGLibContextSync(inOutLock, [&]() -> CHIP_ERROR {
+        GAutoPtr<GError> err;
+        gboolean status =
+            conn_man_technology_call_set_property_sync(technology.get(), key.get(), value.get(), nullptr, &err.GetReceiver());
+        if (!status || err)
+        {
+            ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to set technology %s property %s: %s",
+                         g_dbus_proxy_get_object_path(G_DBUS_PROXY(technology.get())), key.get(), err ? err->message : "unknown");
+
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::TechnologySetPoweredLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                        ConnManTechnology * inTechnology,
+                                                                                        const bool & inPowered) noexcept
+{
+    VerifyOrReturnError(inTechnology != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GAutoPtr<GVariant> value(g_variant_new_boolean(inPowered));
+    VerifyOrReturnError(value.get() != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return TechnologySetPropertyLocked(inOutLock, inTechnology, kConnManTechnologyPropertyPoweredKey, value.get());
+}
+
+// System Layer Timer Completion Methods
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::HandleNetworkServiceConnectivityDebounce(System::Layer * inSystemLayer,
+                                                                                                void * inAppState)
+{
+    auto * lSelf = static_cast<ConnectivityManagerImpl_NetworkManagementConnMan *>(inAppState);
+
+    VerifyOrReturn(lSelf != nullptr);
+
+    lSelf->ReportNetworkServiceConnectivity();
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::ReportNetworkServiceConnectivity() noexcept
+{
+    ChipDeviceEvent event{};
+    bool report = false;
+    CHIP_ERROR status;
+
+    // Gather and diff under lock; post outside it.
+
+    {
+        std::lock_guard<std::mutex> lock(mConnManMutex);
+
+        FamilyConnectivityAggregate v4;
+        FamilyConnectivityAggregate v6;
+
+        for (auto & state : mNetworkServiceStates)
+        {
+            AccumulateFamilyConnectivity(state.mPendingConnectivity.mIPv4, state.mReportedConnectivity.mIPv4, v4);
+            AccumulateFamilyConnectivity(state.mPendingConnectivity.mIPv6, state.mReportedConnectivity.mIPv6, v6);
+
+            // Reported state adopts pending state regardless of
+            // whether an event posts, so that absorbed transitions
+            // establish the baseline.
+
+            state.mReportedConnectivity = state.mPendingConnectivity;
+        }
+
+        event.Type = DeviceEventType::kInternetConnectivityChange;
+
+        report |= SetConnectivityChangeFromAggregate(v4, event.InternetConnectivityChange.IPv4);
+        report |= SetConnectivityChangeFromAggregate(v6, event.InternetConnectivityChange.IPv6);
+
+        if (v4.mReportable && v4.mAnyEstablished)
+        {
+            event.InternetConnectivityChange.ipAddress = v4.mAddress;
+        }
+        else if (v6.mReportable && v6.mAnyEstablished)
+        {
+            event.InternetConnectivityChange.ipAddress = v6.mAddress;
+        }
+    }
+
+    if (report)
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "Internet connectivity change: IPv4 %s IPv6 %s",
+                        GetConnectivityChangeString(event.InternetConnectivityChange.IPv4),
+                        GetConnectivityChangeString(event.InternetConnectivityChange.IPv6));
+
+        status = PlatformMgr().PostEvent(&event);
+        if (status != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer,
+                         CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX
+                         "failed to post Internet connectivity change event: %" CHIP_ERROR_FORMAT,
+                         status.Format());
+        }
+    }
+}
+
+// D-Bus / glib Asynchronous Completion Methods
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerReady(GObject * inObject, GAsyncResult * inResult)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManManager * manager;
+    GAutoPtr<GError> err;
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to manager");
+
+    VerifyOrReturn(inObject != nullptr);
+    VerifyOrReturn(inResult != nullptr);
+
+    // When creating D-Bus manager object, the thread default context
+    // must be initialized. Otherwise, all D-Bus signals will be
+    // delivered to the GLib global default main context.
+
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    manager = conn_man_manager_proxy_new_for_bus_finish(inResult, &err.GetReceiver());
+
+    if (manager && err.get() == nullptr)
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connected to manager");
+
+        mConnManClient.mManagerProxy.reset(manager);
+
+        // Establish manager signal handlers.
+
+        // Property Changed
+
+        g_signal_connect(mConnManClient.mManagerProxy.get(), "property-changed",
+                         G_CALLBACK(+[](ConnManManager * inManager_, const char * inKey, GVariant * inValue,
+                                        ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                             inSelf_->OnManagerPropertyChanged(inManager_, inKey, inValue);
+                         }),
+                         this);
+
+        // Technology Added
+
+        g_signal_connect(mConnManClient.mManagerProxy.get(), "technology-added",
+                         G_CALLBACK(+[](ConnManManager * inManager_, const char * inPath, GVariant * inProperties,
+                                        ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                             inSelf_->OnManagerTechnologyAdded(inManager_, inPath, inProperties);
+                         }),
+                         this);
+
+        // Technology Removed
+
+        g_signal_connect(mConnManClient.mManagerProxy.get(), "technology-removed",
+                         G_CALLBACK(+[](ConnManManager * inManager_, const char * inPath,
+                                        ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                             inSelf_->OnManagerTechnologyRemoved(inManager_, inPath);
+                         }),
+                         this);
+
+        // Services Changed
+
+        g_signal_connect(
+            mConnManClient.mManagerProxy.get(), "services-changed",
+            G_CALLBACK(+[](ConnManManager * inManager_, GVariant * inServicesChanged, const char * const * inServicesRemoved,
+                           ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                inSelf_->OnManagerServicesChanged(inManager_, inServicesChanged, inServicesRemoved);
+            }),
+            this);
+
+        // Prime the manager properties, services, and technologies.
+
+        mConnManClient.mProperties.reset(
+            g_hash_table_new_full(g_str_hash, g_str_equal, g_free, reinterpret_cast<GDestroyNotify>(g_variant_unref)));
+
+        conn_man_manager_call_get_properties(
+            mConnManClient.mManagerProxy.get(), nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                    inSelf_->OnManagerGetPropertiesReady(sourceObject_, res_);
+                }),
+            this);
+
+        mConnManClient.mServiceProxies.reset(g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_object_unref));
+        mConnManClient.mServices.reset(
+            g_hash_table_new_full(g_str_hash, g_str_equal, g_free, reinterpret_cast<GDestroyNotify>(g_variant_unref)));
+
+        conn_man_manager_call_get_services(
+            mConnManClient.mManagerProxy.get(), nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                    inSelf_->OnManagerGetServicesReady(sourceObject_, res_);
+                }),
+            this);
+
+        mConnManClient.mTechnologyProxies.reset(g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_object_unref));
+        mConnManClient.mTechnologies.reset(
+            g_hash_table_new_full(g_str_hash, g_str_equal, g_free, reinterpret_cast<GDestroyNotify>(g_variant_unref)));
+
+        conn_man_manager_call_get_technologies(
+            mConnManClient.mManagerProxy.get(), nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl_NetworkManagementConnMan * inSelf_) {
+                    inSelf_->OnManagerGetTechnologiesReady(sourceObject_, res_);
+                }),
+            this);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to create manager: %s",
+                        err ? err->message : "unknown error");
+    }
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerGetObjectsReady(
+    GObject * inObject, GAsyncResult * inResult, ManagerGetObjectsFinishFunc inManagerGetObjectsFinishFunc,
+    HandleManagerGetObjectsMethod inHandleManagerGetObjectsMethod) noexcept
+{
+    GAutoPtr<GVariant> objects_pointer;
+    GAutoPtr<GError> err_pointer;
+    GObject * object   = nullptr;
+    GVariant * objects = nullptr;
+    GError * err       = nullptr;
+
+    VerifyOrReturn(inObject != nullptr);
+    VerifyOrReturn(inResult != nullptr);
+    VerifyOrReturn(inManagerGetObjectsFinishFunc != nullptr);
+    VerifyOrReturn(inHandleManagerGetObjectsMethod != nullptr);
+
+    // Complete the asynchronous objects "big get" with the lock and
+    // then release it.
+
+    {
+        std::lock_guard<std::mutex> lock(mConnManMutex);
+
+        inManagerGetObjectsFinishFunc(CONN_MAN_MANAGER(inObject), &objects_pointer.GetReceiver(), inResult,
+                                      &err_pointer.GetReceiver());
+    }
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+    //
+    // IMPORTANT: GAutoPtr is not safely copyable to another thread /
+    //            deferred context by capture.  We explicitly retain
+    //            (ref/copy) the underlying GLib objects and then
+    //            release them in the lambda.
+
+    object = g_object_ref(inObject);
+
+    if (objects_pointer.get() != nullptr)
+    {
+        // Retained: released in lambda
+
+        objects = g_variant_ref(objects_pointer.get());
+    }
+
+    if (err_pointer.get() != nullptr)
+    {
+        // Deep Copy: released in lambda
+
+        err = g_error_copy(err_pointer.get());
+    }
+
+    LogErrorOnFailure(
+        DeviceLayer::SystemLayer().ScheduleLambda([this, object, objects, err, inHandleManagerGetObjectsMethod]() -> void {
+            GAutoPtr<GObject> retained_object(object);
+            GAutoPtr<GVariant> retained_objects(objects);
+            GAutoPtr<GError> retained_err(err);
+
+            (this->*inHandleManagerGetObjectsMethod)(CONN_MAN_MANAGER(retained_object.get()), retained_objects.get(),
+                                                     retained_err.get());
+        }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerGetPropertiesReady(GObject * inObject, GAsyncResult * inResult)
+{
+    OnManagerGetObjectsReady(inObject, inResult, conn_man_manager_call_get_properties_finish,
+                             &ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetProperties);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerGetServicesReady(GObject * inObject, GAsyncResult * inResult)
+{
+    OnManagerGetObjectsReady(inObject, inResult, conn_man_manager_call_get_services_finish,
+                             &ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetServices);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerGetTechnologiesReady(GObject * inObject, GAsyncResult * inResult)
+{
+    OnManagerGetObjectsReady(inObject, inResult, conn_man_manager_call_get_technologies_finish,
+                             &ConnectivityManagerImpl_NetworkManagementConnMan::HandleManagerGetTechnologies);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnObjectActionReady(
+    GObject * inObject, GAsyncResult * inResult, ObjectActionFinishFunc inObjectActionFinishFunc,
+    HandleObjectActionCompleteMethod inHandleObjectActionCompleteMethod) noexcept
+{
+    GAutoPtr<GError> err_pointer;
+    GObject * object = nullptr;
+    GError * err     = nullptr;
+
+    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+
+    VerifyOrReturn(inObject != nullptr);
+    VerifyOrReturn(inResult != nullptr);
+    VerifyOrReturn(inObjectActionFinishFunc != nullptr);
+    VerifyOrReturn(inHandleObjectActionCompleteMethod != nullptr);
+
+    // Complete the asynchronous objects "big get" with the lock and
+    // then release it.
+
+    {
+        std::lock_guard<std::mutex> lock(mConnManMutex);
+
+        inObjectActionFinishFunc(inObject, inResult, &err_pointer.GetReceiver());
+    }
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+    //
+    // IMPORTANT: GAutoPtr is not safely copyable to another thread /
+    //            deferred context by capture.  We explicitly retain
+    //            (ref/copy) the underlying GLib object and then
+    //            release it in the lambda.
+
+    // Retained: released in lambda
+
+    object = g_object_ref(inObject);
+
+    if (err_pointer.get() != nullptr)
+    {
+        // Deep Copy: released in lambda
+
+        err = g_error_copy(err_pointer.get());
+    }
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, object, err, inHandleObjectActionCompleteMethod]() -> void {
+        GAutoPtr<GObject> retained_object(object);
+        GAutoPtr<GError> retained_err(err);
+
+        (this->*inHandleObjectActionCompleteMethod)(G_DBUS_PROXY(retained_object.get()), retained_err.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnServiceConnectReady(GObject * inObject, GAsyncResult * inResult)
+{
+    OnObjectActionReady(inObject, inResult, reinterpret_cast<ObjectActionFinishFunc>(conn_man_service_call_connect_finish),
+                        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectComplete);
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnTechnologyScanReady(GObject * inObject, GAsyncResult * inResult)
+{
+    OnObjectActionReady(inObject, inResult, reinterpret_cast<ObjectActionFinishFunc>(conn_man_technology_call_scan_finish),
+                        &ConnectivityManagerImpl_NetworkManagementConnMan::HandleTechnologyScanComplete);
+}
+
+// D-Bus / glib Signal Callback Methods
+
+gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentCancel(ConnManAgent * inAgent,
+                                                                         GDBusMethodInvocation * inInvocation) noexcept
+{
+    VerifyOrReturnValue(inAgent != nullptr, TRUE);
+    VerifyOrReturnValue(inInvocation != nullptr, TRUE);
+
+    conn_man_agent_complete_cancel(inAgent, inInvocation);
+
+    // The connman agent contract requires the handler to report the
+    // invocation as handled; there is no path on which we decline it.
+
+    return TRUE;
+}
+
+gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRelease(ConnManAgent * inAgent,
+                                                                          GDBusMethodInvocation * inInvocation) noexcept
+{
+    VerifyOrReturnValue(inAgent != nullptr, TRUE);
+    VerifyOrReturnValue(inInvocation != nullptr, TRUE);
+
+    conn_man_agent_complete_release(inAgent, inInvocation);
+
+    // The connman agent contract requires the handler to report the
+    // invocation as handled; there is no path on which we decline it.
+
+    return TRUE;
+}
+
+gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRequestInput(ConnManAgent * inAgent,
+                                                                               GDBusMethodInvocation * inInvocation,
+                                                                               const gchar * inPath,
+                                                                               GVariant * inProperties) noexcept
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+
+    // Any cached passphrase is scrubbed on every return path.
+
+    auto passphraseGuard = ScopeExit([this]() {
+        if (!mWiFiConnectPassphrase.empty())
+        {
+            Crypto::DRBG_get_bytes(mWiFiConnectPassphrase.data(), mWiFiConnectPassphrase.capacity());
+
+            mWiFiConnectPassphrase.clear();
+        }
+    });
+
+    // Answer the invocation with a G_IO_ERROR and yield the TRUE the
+    // agent contract mandates. Safe when there is no invocation to
+    // answer.
+
+    const auto fail = [&](gint inCode_, const char * inMessage_) -> gboolean {
+        if (inInvocation != nullptr)
+        {
+            g_dbus_method_invocation_return_error(inInvocation, G_IO_ERROR, inCode_, "%s", inMessage_);
+        }
+
+        return TRUE;
+    };
+
+    // Sanity check the input parameters.
+
+    VerifyOrReturnValue(inAgent != nullptr, fail(G_IO_ERROR_INVALID_ARGUMENT, "inAgent == nullptr"));
+    VerifyOrReturnValue(inInvocation != nullptr, TRUE);
+    VerifyOrReturnValue(inPath != nullptr, fail(G_IO_ERROR_INVALID_ARGUMENT, "inPath == nullptr"));
+    VerifyOrReturnValue(inProperties != nullptr, fail(G_IO_ERROR_INVALID_ARGUMENT, "inProperties == nullptr"));
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "agent service %s request input", inPath);
+
+    // First, ensure there is a pending service we are currently connecting.
+
+    VerifyOrReturnValue(mConnManAgentServer.mPendingService, fail(G_IO_ERROR_FAILED, "No pending service for RequestInput"));
+
+    // Second, ensure the pending service matches the one requesting input.
+
+    const char * pending_path = g_dbus_proxy_get_object_path(G_DBUS_PROXY(mConnManAgentServer.mPendingService.get()));
+    VerifyOrReturnValue(pending_path != nullptr, fail(G_IO_ERROR_FAILED, "No path for pending service"));
+
+    const bool paths_match = (strcmp(pending_path, inPath) == 0);
+    VerifyOrReturnValue(paths_match, fail(G_IO_ERROR_FAILED, "Input requested for unexpected service"));
+
+    // Third, validate the request type.
+
+    VerifyOrReturnValue(g_variant_is_of_type(inProperties, G_VARIANT_TYPE_VARDICT),
+                        fail(G_IO_ERROR_INVALID_ARGUMENT, "properties are not 'a{sv}' type"));
+
+    bool want_passphrase = false;
+    {
+        GVariantIter iter;
+        const char * key = nullptr;
+        GVariant * boxed = nullptr;
+        g_variant_iter_init(&iter, inProperties);
+
+        // Fourth, iterate over the requested property keys and decide
+        // what we can satisfy relative to what is requested.
+
+        while (g_variant_iter_next(&iter, "{&s@v}", &key, &boxed))
+        {
+            UnboxedVariant variant(boxed);
+            g_variant_unref(boxed);
+
+            if (!variant || !g_variant_is_of_type(variant.get(), G_VARIANT_TYPE_VARDICT))
+            {
+                continue;
+            }
+
+            if (strcmp(key, kConnManServiceAgentPropertyPassphraseKey) == 0)
+            {
+                ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s: wants %s", __func__, key);
+
+                // Optional: check "Type" == "passphrase" and/or Requirement.
+
+                want_passphrase = true;
+            }
+        }
+    }
+
+    // Fifth and finally, build the reply with only the requested keys.
+
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+    if (want_passphrase)
+    {
+        VerifyOrReturnValue(!mWiFiConnectPassphrase.empty(), fail(G_IO_ERROR_FAILED, "Passphrase requested but not available"));
+
+        char passphrase[Internal::kMaxWiFiKeyLength + 1];
+        const size_t n = std::min<size_t>(mWiFiConnectPassphrase.size(), Internal::kMaxWiFiKeyLength);
+        memcpy(passphrase, mWiFiConnectPassphrase.data(), n);
+        passphrase[n] = '\0';
+
+        g_variant_builder_add(&builder, "{sv}", kConnManServiceAgentPropertyPassphraseKey, g_variant_new_string(passphrase));
+
+        // g_variant_new_string copied the passphrase bytes; wipe the stack copy.
+
+        Crypto::DRBG_get_bytes(reinterpret_cast<uint8_t *>(passphrase), sizeof(passphrase));
+    }
+
+    conn_man_agent_complete_request_input(inAgent, inInvocation, g_variant_builder_end(&builder));
+
+    // The connman agent contract requires the handler to report the
+    // invocation as handled; there is no path on which we decline it.
+
+    return TRUE;
+}
+
+gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentReportError(ConnManAgent * inAgent,
+                                                                              GDBusMethodInvocation * inInvocation,
+                                                                              const gchar * inPath, const gchar * inError) noexcept
+{
+    VerifyOrReturnValue(inAgent != nullptr, TRUE);
+    VerifyOrReturnValue(inInvocation != nullptr, TRUE);
+
+    ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "service %s had error %s", inPath ? inPath : "(null)",
+                 inError ? inError : "(null)");
+
+    conn_man_agent_complete_report_error(inAgent, inInvocation);
+
+    // The connman agent contract requires the handler to report the
+    // invocation as handled; there is no path on which we decline it.
+
+    return TRUE;
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerPropertyChanged(ConnManManager * inManager, const char * inKey,
+                                                                                GVariant * inValue)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManManager * manager = nullptr;
+    const char * key         = nullptr;
+    GVariant * value         = nullptr;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    manager = g_object_ref(inManager);
+
+    key = g_strdup(inKey);
+    VerifyOrReturn(key != nullptr);
+
+    value = g_variant_ref(inValue);
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, manager, key, value]() -> void {
+        GAutoPtr<ConnManManager> retained_manager(manager);
+        GAutoPtr<gchar> retained_key(const_cast<gchar *>(key));
+        GAutoPtr<GVariant> retained_value(value);
+
+        HandleManagerPropertyChanged(retained_manager.get(), retained_key.get(), retained_value.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerServicesChanged(ConnManManager * inManager,
+                                                                                GVariant * inServicesChanged,
+                                                                                const char * const * inServicesRemoved)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManManager * manager = nullptr;
+    GVariant * changed       = nullptr;
+    gchar ** removed         = nullptr;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inServicesChanged != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    manager = g_object_ref(inManager);
+    changed = g_variant_ref(inServicesChanged);
+
+    if (inServicesRemoved != nullptr)
+    {
+        removed = g_strdupv(const_cast<gchar **>(inServicesRemoved));
+        VerifyOrReturn(removed != nullptr);
+    }
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, manager, changed, removed]() -> void {
+        GAutoPtr<ConnManManager> retained_manager(manager);
+        GAutoPtr<GVariant> retained_changed(changed);
+        GAutoPtr<gchar *> retained_removed(removed);
+
+        HandleManagerServicesChanged(retained_manager.get(), retained_changed.get(), retained_removed.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerTechnologyAdded(ConnManManager * inManager, const char * inPath,
+                                                                                GVariant * inProperties)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManManager * manager = nullptr;
+    char * path              = nullptr;
+    GVariant * properties    = nullptr;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inPath != nullptr);
+    VerifyOrReturn(inProperties != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    manager = g_object_ref(inManager);
+
+    path = g_strdup(inPath);
+    VerifyOrReturn(path != nullptr);
+
+    properties = g_variant_ref(inProperties);
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, manager, path, properties]() -> void {
+        GAutoPtr<ConnManManager> retained_manager(manager);
+        GAutoPtr<gchar> retained_path(const_cast<gchar *>(path));
+        GAutoPtr<GVariant> retained_properties(properties);
+
+        HandleManagerTechnologyAdded(retained_manager.get(), retained_path.get(), retained_properties.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnManagerTechnologyRemoved(ConnManManager * inManager, const char * inPath)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManManager * manager = nullptr;
+    const char * path        = nullptr;
+
+    VerifyOrReturn(inManager != nullptr);
+    VerifyOrReturn(inPath != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    manager = g_object_ref(inManager);
+
+    path = g_strdup(inPath);
+    VerifyOrReturn(path != nullptr);
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, manager, path]() -> void {
+        GAutoPtr<ConnManManager> retained_manager(manager);
+        GAutoPtr<gchar> retained_path(const_cast<gchar *>(path));
+
+        HandleManagerTechnologyRemoved(retained_manager.get(), retained_path.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnServicePropertyChanged(ConnManService * inService, const char * inKey,
+                                                                                GVariant * inValue)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManService * service = nullptr;
+    const char * key         = nullptr;
+    GVariant * value         = nullptr;
+
+    VerifyOrReturn(inService != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    service = g_object_ref(inService);
+
+    key = g_strdup(inKey);
+    VerifyOrReturn(key != nullptr);
+
+    value = g_variant_ref(inValue);
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, service, key, value]() -> void {
+        GAutoPtr<ConnManService> retained_service(service);
+        GAutoPtr<gchar> retained_key(const_cast<gchar *>(key));
+        GAutoPtr<GVariant> retained_value(value);
+
+        HandleServicePropertyChanged(retained_service.get(), retained_key.get(), retained_value.get());
+    }));
+}
+
+void ConnectivityManagerImpl_NetworkManagementConnMan::OnTechnologyPropertyChanged(ConnManTechnology * inTechnology,
+                                                                                   const char * inKey, GVariant * inValue)
+{
+    std::lock_guard<std::mutex> lock(mConnManMutex);
+    ConnManTechnology * technology = nullptr;
+    const char * key               = nullptr;
+    GVariant * value               = nullptr;
+
+    VerifyOrReturn(inTechnology != nullptr);
+    VerifyOrReturn(inKey != nullptr);
+    VerifyOrReturn(inValue != nullptr);
+
+    // Defer the actual work to the main thread, outside the lock, via
+    // a lambda. The lock will be reacquired in the method called by
+    // the lambda.
+
+    technology = g_object_ref(inTechnology);
+
+    key = g_strdup(inKey);
+    VerifyOrReturn(key != nullptr);
+
+    value = g_variant_ref(inValue);
+
+    LogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda([this, technology, key, value]() -> void {
+        GAutoPtr<ConnManTechnology> retained_technology(technology);
+        GAutoPtr<gchar> retained_key(const_cast<gchar *>(key));
+        GAutoPtr<GVariant> retained_value(value);
+
+        HandleTechnologyPropertyChanged(retained_technology.get(), retained_key.get(), retained_value.get());
+    }));
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -164,6 +164,14 @@ struct ClientErrorTableEntry
     int mErrno;
 };
 
+using ServiceError = Platform::Linux::Detail::ConnManServiceError;
+
+struct ServiceErrorTableEntry
+{
+    const char * mName;
+    ServiceError mError;
+};
+
 // Global Variables
 
 // clang-format off
@@ -311,14 +319,20 @@ static constexpr char kNetworkPassphraseHasInvalidCharacters[]                  
  *  The maximum number of "active" (connman does not actually do
  *  active, directed scans) scans for a particular SSID before
  *  failing.
+ *
+ *  'chip-tool' and most app-based commissioners will timeout with
+ *  anything longer than this.
  */
-static constexpr size_t kWiFiActiveScanLimit = 4;
+static constexpr size_t kWiFiActiveScanLimit = 2;
 
 /**
  *  The maximum number of scans for connecting to a particular SSID
  *  before failing.
+ *
+ *  'chip-tool' and most app-based commissioners will timeout with
+ *  anything longer than this.
  */
-static constexpr size_t kWiFiConnectScanLimit = 4;
+static constexpr size_t kWiFiConnectScanLimit = 2;
 
 /**
  *  Trailing-edge debounce interval applied between an observed change
@@ -383,6 +397,220 @@ static constexpr std::array<ClientErrorTableEntry, 25> kClientErrorTable =
     // net.connman.Error.Failed is deliberately absent: it is
     // connman's catch-all and carries no information beyond the caller's
     // default.
+}};
+// clang-format on
+
+/**
+ *  connman surfaces neither the IEEE 802.11 status code nor the
+ *  disconnect reason code from wpa_supplicant anywhere on D-Bus (it
+ *  collapses both into the closed "Error" vocabulary above). The
+ *  wpa_supplicant-backed peer implementation reads them directly from
+ *  the supplicant D-Bus interface; we have no equivalent here. Rather
+ *  than fabricate a specific code we do not have, report the generic
+ *  one and let the `AssociationFailureCauseEnum` carry what signal we
+ *  do possess.
+ */
+static constexpr uint16_t kWlanStatusSuccess            = 0;
+static constexpr uint16_t kWlanStatusUnspecifiedFailure = 1;
+
+// clang-format off
+static constexpr ServiceError kServiceErrorNone =
+{
+    Status::kSuccess,
+    AssociationFailureCauseEnum::kUnknown,
+    kWlanStatusSuccess,
+    false,
+    false
+};
+
+static constexpr ServiceError kServiceErrorUnknown =
+{
+    Status::kUnknownError,
+    AssociationFailureCauseEnum::kUnknown,
+    kWlanStatusUnspecifiedFailure,
+    true,
+    true
+};
+
+static constexpr std::array<ServiceErrorTableEntry, 9> kServiceErrorTable =
+{{
+    /**
+     *  The WPA 4-way handshake rejected the pre-shared key: the
+     *  passphrase is wrong. This is the canonical Wi-Fi commissioning
+     *  failure and the one a commissioner most needs rendered
+     *  faithfully, since it is the only one an installer can act on
+     *  directly. Association succeeded; authentication did not.
+     *  Terminal, and a true association failure.
+     */
+    { "invalid-key", {
+            Status::kAuthFailure,
+            AssociationFailureCauseEnum::kAuthenticationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  IEEE 802.11 authentication failed ahead of, or independently
+     *  of, the 4-way handshake. connman does not distinguish this
+     *  from "invalid-key" in any way Matter can exploit, so it maps
+     *  identically; the distinction survives only in the log.
+     *  Terminal, and a true association failure.
+     */
+    { "auth-failed", {
+            Status::kAuthFailure,
+            AssociationFailureCauseEnum::kAuthenticationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  Credential rejection above the link layer: EAP for
+     *  WPA-Enterprise, or PPP for cellular. Not reachable for the
+     *  WPA2-PSK networks this implementation presently commissions,
+     *  but it is a credential failure in every sense that matters to
+     *  the commissioner, and it becomes live the moment
+     *  `ConnectWiFiNetworkWithPDCAsync` is implemented. Terminal, and
+     *  a true association failure.
+     */
+    { "login-failed", {
+            Status::kAuthFailure,
+            AssociationFailureCauseEnum::kAuthenticationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  connman's generic link-establishment failure: the association
+     *  itself did not complete. The credential was never exercised,
+     *  so reporting an authentication failure would be a lie; the
+     *  cause is almost always RF (the AP moved out of range mid-
+     *  connect, refused the association, or is at capacity). Terminal,
+     *  and a true association failure, but of the association rather
+     *  than the authentication.
+     */
+    { "connect-failed", {
+            Status::kOtherConnectionFailure,
+            AssociationFailureCauseEnum::kAssociationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  The AP refused the station outright, typically by MAC
+     *  filtering or an access control list. Indistinguishable from
+     *  "connect-failed" from the station's perspective, and mapped
+     *  the same way: the association was refused, not the
+     *  credential. Terminal, and a true association failure.
+     */
+    { "blocked", {
+            Status::kOtherConnectionFailure,
+            AssociationFailureCauseEnum::kAssociationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  The network service vanished between the scan that resolved it
+     *  and the connect that targeted it. Semantically this is
+     *  "the SSID is not there", which is precisely
+     *  `kNetworkNotFound` / `kSsidNotFound` -- and, unlike a generic
+     *  connection failure, it is actionable for an installer, who can
+     *  move the controller closer to the access point. Terminal, and
+     *  a true association failure.
+     */
+    { "out-of-range", {
+            Status::kNetworkNotFound,
+            AssociationFailureCauseEnum::kSsidNotFound,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    },
+
+    /**
+     *  DHCP (or DHCPv6) did not yield an address. By the time connman
+     *  runs its DHCP client, association *and* the 4-way handshake
+     *  have both demonstrably succeeded: L2 is up and the credential
+     *  was accepted. The failure is strictly at L3 -- an exhausted
+     *  pool, an absent or unreachable server, or a lease timeout --
+     *  which is exactly `kIPBindFailed`.
+     *
+     *  Deliberately **not** an association failure. The
+     *  `AssociationFailure` event is diagnostic telemetry a fabric
+     *  administrator reads to separate "wrong password" from "bad RF";
+     *  raising one here, where the handshake demonstrably succeeded,
+     *  would corrupt that stream and actively mislead. `OnConnectResult`
+     *  alone tells the true story. Terminal, but not an association
+     *  failure.
+     */
+    { "dhcp-failed", {
+            Status::kIPBindFailed,
+            AssociationFailureCauseEnum::kUnknown,
+            kWlanStatusSuccess,
+            false,
+            true
+        }
+    },
+
+    /**
+     *  connman's Internet reachability probe (WISPr / `online-check`)
+     *  failed. The service has nonetheless reached at least "ready":
+     *  IPv4 and/or IPv6 is configured, which is precisely and
+     *  entirely what Matter's `ConnectNetwork` contract requires.
+     *
+     *  connman's notion of "online" is strictly stronger than
+     *  Matter's, and the gap is not hypothetical: a captive portal,
+     *  an egress-filtered enterprise network, or an air-gapped
+     *  installation will all fail this probe on a network that is
+     *  perfectly commissionable. Letting it veto a connect would hard-
+     *  fail commissioning on networks that work -- and the commissioner
+     *  proves end-to-end reachability itself, via operational discovery
+     *  and CASE, so the device has no business second-guessing it.
+     *
+     *  Hence: neither terminal nor an association failure. Should this
+     *  arrive as a *failure* state at all -- it should not, given the
+     *  service has already reached "ready" -- the state handler
+     *  tolerates it and leaves the connect in flight rather than
+     *  fabricating a terminal error.
+     */
+    { "online-check-failed", {
+            Status::kSuccess,
+            AssociationFailureCauseEnum::kUnknown,
+            kWlanStatusSuccess,
+            false,
+            false
+        }
+    },
+
+    /**
+     *  A cellular SIM PIN is required and was not supplied.
+     *  Unreachable for Wi-Fi, and mapped only so that the table
+     *  covers connman's error vocabulary exhaustively (see connman
+     *  `service.c:error2string()`); an unrecognized value would
+     *  otherwise fall through to `kServiceErrorUnknown` and log.
+     *  Treated as a credential failure, which is what it
+     *  is. Terminal, and nominally an association failure (though on
+     *  Wi-Fi, where the association-started latch will never have
+     *  been set, the event is suppressed regardless).
+     */
+    { "pin-missing", {
+            Status::kAuthFailure,
+            AssociationFailureCauseEnum::kAuthenticationFailed,
+            kWlanStatusUnspecifiedFailure,
+            true,
+            true
+        }
+    }
 }};
 // clang-format on
 
@@ -1302,6 +1530,27 @@ static CHIP_ERROR MapClientError(const GError * inError) noexcept
     return MapClientError(inError, CHIP_ERROR_INTERNAL);
 }
 
+static ServiceError MapServiceError(const char * inServiceError) noexcept
+{
+    // A cleared or absent "Error" is not a failure; callers gate on
+    // mIsTerminal, so return the benign mapping rather than "unknown".
+
+    VerifyOrReturnValue(inServiceError != nullptr, kServiceErrorNone);
+
+    for (const auto & entry : kServiceErrorTable)
+    {
+        if (strcmp(entry.mName, inServiceError) == 0)
+        {
+            return entry.mError;
+        }
+    }
+
+    ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "unrecognized service error '%s'; reporting as unknown",
+                 inServiceError);
+
+    return kServiceErrorUnknown;
+}
+
 } // namespace
 
 // Matter Linux Connectivity Manager Implementation for connman
@@ -1408,8 +1657,11 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::Init(ConnectivityMa
     }
 
     mWiFiActiveScanState.Reset();
-    mWiFiConnectPassphrase.reset();
-    mWiFiConnectScanState.Reset();
+    mWiFiClientConnectPassphrase.reset();
+    mWiFiClusterConnectAssociationStarted = false;
+    mWiFiClusterConnectPending            = false;
+    mWiFiClusterConnectScanState.Reset();
+    mWiFiClusterConnectServiceError.reset();
     mWiFiStationConnected         = false;
     mWiFiStationMode              = ConnectivityManager::kWiFiStationMode_NotSupported;
     mWiFiStationReconnectInterval = {};
@@ -1661,6 +1913,11 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::StartWiFiManagement()
 
 // Introspection
 
+bool ConnectivityManagerImpl_NetworkManagementConnMan::HasWiFiClusterConnectPendingLocked() const noexcept
+{
+    return mWiFiClusterConnectPending;
+}
+
 /**
  *  @brief
  *    Determine whether a per-family connectivity transition warrants
@@ -1685,6 +1942,17 @@ bool ConnectivityManagerImpl_NetworkManagementConnMan::IsFamilyConnectivityChang
         ((inPending.mConnectivity == NetworkServiceConnectivity::kEstablished) && (inPending.mAddress != inReported.mAddress));
 
     return ((stateChanged && !absorbed) || addressChanged);
+}
+
+bool ConnectivityManagerImpl_NetworkManagementConnMan::IsWiFiPendingConnectServicePathLocked(const char * inPath) const noexcept
+{
+    VerifyOrReturnValue(inPath != nullptr, false);
+    VerifyOrReturnValue(mConnManAgentServer.mPendingService, false);
+
+    const char * const pending = g_dbus_proxy_get_object_path(G_DBUS_PROXY(mConnManAgentServer.mPendingService.get()));
+    VerifyOrReturnValue(pending != nullptr, false);
+
+    return (strcmp(pending, inPath) == 0);
 }
 
 // Wi-Fi Station Control Plane Management
@@ -1876,6 +2144,36 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConnectWiFiNetworkA
 
     mConnectivityManagerImpl->SetOneShotConnectCallback(inConnectCallback);
 
+    // Mark the connect in flight. This is the sole gate on the
+    // service state machine driving the Matter completion, and it is
+    // retired by ConcludeWiFiClusterConnectLocked.
+
+    mWiFiClusterConnectPending = true;
+
+    // Unconditionally cache the provided SSID.
+
+    mWiFiClusterConnectScanState.mSsid = inSsid;
+
+    // Unconditionally cache the provided credentials.
+
+    mWiFiClientConnectPassphrase = inCredentials;
+
+    // On any synchronous failure below, `Service.Connect()` was never
+    // issued: connman will never request the credential, and
+    // HandleServiceConnectComplete will never run. Retire the connect
+    // *without* dispatching a Matter completion, since
+    // LinuxWiFiDriver::ConnectNetwork completes the command from the
+    // CHIP_ERROR we return, and drop the one-shot callback that will
+    // now never fire. Disarmed on success.
+
+    auto connectGuard = ScopeExit([&]() {
+        ScrubWiFiClientConnectPassphraseLocked();
+
+        mConnectivityManagerImpl->SetOneShotConnectCallback(nullptr);
+
+        LogErrorOnFailure(ConcludeWiFiClusterConnectLocked());
+    });
+
     // There will be one of two cases here given that connman cannot
     // connect to a service it does not know about or has not seen.
     //
@@ -1900,10 +2198,6 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConnectWiFiNetworkA
         ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to '%.*s'...",
                         static_cast<int>(inSsid.size()), inSsid.data());
 
-        // Cache the provided credentials.
-
-        mWiFiConnectPassphrase = inCredentials;
-
         ReturnErrorOnFailure(HandleServiceConnectRequestLocked(lock, service));
     }
     else
@@ -1915,22 +2209,18 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConnectWiFiNetworkA
             kConnManTechnologyPropertyTypeWiFiValue, mConnManClient.mTechnologyProxies.get(), mConnManClient.mTechnologies.get());
         VerifyOrReturnError(technology != nullptr, ChipError(ChipError::Range::kPOSIX, ENOENT));
 
-        // Cache the provided SSID.
-
-        mWiFiConnectScanState.mSsid = inSsid;
-
-        // Cache the provided credentials.
-
-        mWiFiConnectPassphrase = inCredentials;
-
         // Initialize the connect scan count.
 
-        mWiFiConnectScanState.mCount = 1;
+        mWiFiClusterConnectScanState.mCount = 1;
 
         // Attempt to scan for the desired network service.
 
         ReturnErrorOnFailure(TechnologyScanLocked(lock, technology));
     }
+
+    // Success; disarm the scoped clean-up.
+
+    connectGuard.release();
 
     return CHIP_NO_ERROR;
 }
@@ -2293,10 +2583,122 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::BuildWiFiScanRespon
 
 /**
  *  @brief
+ *    Retire an in-flight Wi-Fi connect and dispatch its Matter
+ *    completion, exactly once.
+ *
+ *  The sole completion for `ConnectWiFiNetworkAsync`. Three steps, in
+ *  an order that is not negotiable and is therefore enforced here
+ *  rather than at the multiple call sites in which it is used:
+ *
+ *    1. Snapshot the debug text. `inDebugText` frequently aliases
+ *       `mWiFiClusterConnectScanState.mSsid`, which step 2 clears.
+ *
+ *    2. Retire the connect state, so that any further connman signal for this
+ *       service (the `failure` -> `idle` transition, a late `Agent.ReportError`,
+ *       the `Service.Connect()` reply itself) finds no pending connect and
+ *       drives no second, contradictory result.
+ *
+ *    3. Dispatch `OnConnectResult`, which may temporarily release the
+ *       class lock on its fallback path and therefore must observe
+ *       fully-retired state.
+ *
+ *  Deliberately *not* folded into #DispatchWiFiConnectFinishedLocked: the
+ *  synchronous failure paths out of `ConnectWiFiNetworkAsync` must retire the
+ *  connect via #ConcludeWiFiClusterConnectLocked *without* completing it,
+ *  since `LinuxWiFiDriver::ConnectNetwork` completes those from the returned
+ *  CHIP_ERROR.
+ *
+ *  @sa ConcludeWiFiClusterConnectLocked
+ *  @sa DispatchWiFiConnectFinishedLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::CompleteWiFiConnectLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                                                       Status inStatus,
+                                                                                       const CharSpan & inDebugText,
+                                                                                       int32_t inReason) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "completing connect: pending=%u status=%u debug='%.*s'",
+                  HasWiFiClusterConnectPendingLocked(), static_cast<unsigned>(inStatus), static_cast<int>(inDebugText.size()),
+                  inDebugText.data());
+
+    // Exactly-once, structurally. Every completion now funnels through here, so
+    // the guard lives here rather than being re-derived by each caller.
+
+    VerifyOrReturnError(HasWiFiClusterConnectPendingLocked(), CHIP_NO_ERROR);
+
+    // 1. Snapshot before retiring: inDebugText may alias mWiFiClusterConnectScanState.mSsid.
+
+    Internal::WiFiSSIDFixedBuffer debug;
+    debug = ByteSpan(reinterpret_cast<const uint8_t *>(inDebugText.data()), inDebugText.size());
+
+    // 2. Retire.
+
+    ReturnErrorOnFailure(ConcludeWiFiClusterConnectLocked());
+
+    // 3. Complete.
+
+    return DispatchWiFiConnectFinishedLocked(inOutLock, inStatus,
+                                             CharSpan(reinterpret_cast<const char *>(debug.data()), debug.size()), inReason);
+}
+
+/**
+ *  @brief
+ *    Conclude the Matter Network Commissioning Cluster connect: the
+ *    state whose lifetime is that of the Network Commissioning
+ *    Cluster `ConnectNetwork` command.
+ *
+ *  The peer of #ShutdownClientConnectSessionLocked. Retires only the
+ *  state that the Matter Cluster completion renders meaningless (the
+ *  pending gate, the association latch, the latched service error,
+ *  and the connect scan state) so that any further connman signal for
+ *  this service (the `failure` -> `idle` transition, a late
+ *  `Agent.ReportError`, the `Service.Connect()` reply itself) finds
+ *  no pending connect and drives no second, contradictory result.
+ *
+ *  @note
+ *    Which to call: *"has the Network Commissioning Cluster been
+ *    answered?"* -- if it has, this runs. Contrast
+ *    #ShutdownClientConnectSessionLocked, whose test is *"can connman
+ *    still call my agent?"*. The agent, pending service proxy, and
+ *    credential belong to that longer-lived D-Bus scope and are
+ *    deliberately *not* touched here.
+ *
+ *  @note
+ *    Does not clear the one-shot connect callback: that is consumed by
+ *    `OnConnectResult`, which #CompleteWiFiConnectLocked dispatches
+ *    *after* this returns. Clearing it here would wedge the command
+ *    handle.
+ *
+ *  @retval  #CHIP_NO_ERROR  Always.
+ *
+ *  @sa CompleteWiFiConnectLocked
+ *  @sa ShutdownClientConnectSessionLocked
+ *
+ *  @private
+ *
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::ConcludeWiFiClusterConnectLocked() noexcept
+{
+    mWiFiClusterConnectPending            = false;
+    mWiFiClusterConnectAssociationStarted = false;
+
+    mWiFiClusterConnectServiceError.reset();
+
+    mWiFiClusterConnectScanState.Reset();
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  @brief
  *    Complete a Wi-Fi connect operation exactly once, deferring off
  *    the class lock.
  *
- *  Drives the Connectivity Manager `OnConnectResult` terminal for a
+ *  Drives the Connectivity Manager `OnConnectResult` completion for a
  *  connect, preferring to defer it onto a fresh Matter event-loop
  *  iteration (via `ScheduleLambda`) so that it runs after the caller
  *  releases `mConnManMutex` and may therefore re-enter this object
@@ -2359,6 +2761,11 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::DispatchWiFiConnect
         VerifyOrReturn(mConnectivityManagerImpl != nullptr);
 
         const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
+
+        ChipLogDetail(
+            DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "dispatching connect result: pending=%u status=%u debug='%.*s'",
+            HasWiFiClusterConnectPendingLocked(), static_cast<unsigned>(inStatus), static_cast<int>(debug.size()), debug.data());
+
         mConnectivityManagerImpl->OnConnectResult(inStatus, debug, inReason);
     });
 
@@ -2388,7 +2795,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::DispatchWiFiConnect
  *    Complete a Wi-Fi scan operation exactly once, deferring off the
  *    class lock.
  *
- *  Drives the Connectivity Manager `OnScanFinished` terminal for a
+ *  Drives the Connectivity Manager `OnScanFinished` completion for a
  *  scan, preferring to defer it onto a fresh Matter event-loop
  *  iteration (via `ScheduleLambda`) so that it runs after the caller
  *  releases `mConnManMutex` and may therefore re-enter this object
@@ -2468,6 +2875,11 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::DispatchWiFiScanFin
 
         const CharSpan debug(reinterpret_cast<const char *>(debugBytes.data()), debugLen);
         LinuxScanResponseIterator<WiFiScanResponse> iter(owned.get());
+
+        ChipLogDetail(DeviceLayer,
+                      CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "dispatching scan result: status=%u count=%zu debug='%.*s' owned=%u",
+                      static_cast<unsigned>(inStatus), (raw != nullptr) ? raw->size() : 0, static_cast<int>(debug.size()),
+                      debug.data(), owned != nullptr);
 
         mConnectivityManagerImpl->OnScanFinished(inStatus, debug, (owned != nullptr) ? &iter : nullptr);
     });
@@ -3092,21 +3504,11 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectCompl
 
     VerifyOrReturn(inService != nullptr);
 
-    auto teardown = ScopeExit([&]() {
-        mWiFiConnectScanState.Reset();
+    // connman has replied to Service.Connect() and will request nothing
+    // further for it; retire the D-Bus-call-scoped state unconditionally,
+    // irrespective of which path drove the Matter completion.
 
-        mConnManAgentServer.mPendingService.reset();
-
-        if (mConnManAgentServer.mRegistered)
-        {
-            const CHIP_ERROR status = ManagerUnregisterAgentLocked(lock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
-            if (status != CHIP_NO_ERROR)
-            {
-                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to unregister agent:%" CHIP_ERROR_FORMAT,
-                             status.Format());
-            }
-        }
-    });
+    auto teardown = ScopeExit([&]() { ShutdownClientConnectSessionLocked(lock); });
 
     const char * path = nullptr;
     ReturnOnFailure(GetObjectPathFromProxyLocked(inService, path));
@@ -3124,34 +3526,55 @@ void ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectCompl
         debug_text = CharSpan::fromCharString(name);
     }
 
+    // If the service state machine already concluded this connect (at "ready"
+    // or at "failure") the Matter completion has been dispatched with a
+    // *specific* status and the connect state retired. connman emits those
+    // PropertyChanged signals ahead of replying to Connect(), so this is the
+    // ordinary path. Do not dispatch a second, less specific result -- and do
+    // not log a misleading failure for a connect that already succeeded.
+
+    VerifyOrReturn(HasWiFiClusterConnectPendingLocked(),
+                   ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s service %s connect already concluded",
+                                   type, path));
+
     ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "%s service %s connect done", type, path);
 
-    if (inError == nullptr)
+    // Fallback: Connect() completed without the service ever reaching a
+    // terminal state. This is a synchronous rejection (invalid arguments,
+    // already connected, unsupported) or a D-Bus transport failure: not an
+    // association failure, and connman told us nothing more specific.
+
+    if (inError != nullptr)
     {
-        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(lock, Status::kSuccess, debug_text, 0));
+        ChipLogError(DeviceLayer,
+                     CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to connect %s service: %s (%" CHIP_ERROR_FORMAT ")", type,
+                     inError->message, MapClientError(inError).Format());
     }
-    else
-    {
-        WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
-        constexpr int reason               = 0;
 
-        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to connect %s service: %s", type,
-                     inError->message);
-
-        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(lock, Status::kUnknownError, debug_text, reason));
-
-        if (delegate != nullptr)
-        {
-            constexpr uint8_t associationFailureCause   = static_cast<uint8_t>(AssociationFailureCauseEnum::kUnknown);
-            constexpr uint16_t associationFailureStatus = WLAN_STATUS_UNSPECIFIED_FAILURE;
-            LogErrorOnFailure(
-                DeviceLayer::SystemLayer().ScheduleLambda([delegate, associationFailureCause, associationFailureStatus]() {
-                    delegate->OnAssociationFailureDetected(associationFailureCause, associationFailureStatus);
-                }));
-        }
-    }
+    LogErrorOnFailure(
+        CompleteWiFiConnectLocked(lock, (inError == nullptr) ? Status::kSuccess : Status::kUnknownError, debug_text, 0));
 }
 
+/**
+ *  @brief
+ *    Register the connman agent and issue an asynchronous
+ *    `Service.Connect()` for a Wi-Fi network service.
+ *
+ *  @note
+ *    Deliberately does *not* dispatch a Matter completion on failure.
+ *    Its two callers have opposite completion contracts:
+ *    `ConnectWiFiNetworkAsync`'s failure is completed by
+ *    `LinuxWiFiDriver::ConnectNetwork` from the returned CHIP_ERROR,
+ *    whereas #HandleWiFiPendingConnectLocked is reached from
+ *    #HandleTechnologyScanComplete, which only logs, and so must
+ *    complete the command itself.
+ *
+ *  @sa ShutdownClientConnectSessionLocked
+ *  @sa HandleWiFiPendingConnectLocked
+ *
+ *  @private
+ *
+ */
 CHIP_ERROR
 ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectRequestLocked(std::unique_lock<std::mutex> & inOutLock,
                                                                                     ConnManService * inService) noexcept
@@ -3159,45 +3582,17 @@ ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceConnectRequestLoc
     VerifyOrDie(inOutLock.owns_lock());
     VerifyOrReturnError(inService != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    CharSpan debug_text; // best-effort, for OnConnectResult
-    {
-        const char * path = nullptr;
-        GVariant * props  = nullptr;
-        const char * name = nullptr;
+    // On any failure below, `Service.Connect()` either was not issued or will
+    // not complete; unwind the D-Bus-call-scoped state. Disarmed on success,
+    // where HandleServiceConnectComplete assumes that responsibility.
 
-        if (GetObjectPathFromProxyLocked(G_DBUS_PROXY(inService), path) == CHIP_NO_ERROR &&
-            GetObjectPropertiesFromPathLocked(mConnManClient.mServices.get(), path, props) == CHIP_NO_ERROR &&
-            GetObjectNameFromPropertiesLocked(props, name) == CHIP_NO_ERROR)
-        {
-            debug_text = CharSpan::fromCharString(name);
-        }
-    }
+    auto cleanup = ScopeExit([&]() { ShutdownClientConnectSessionLocked(inOutLock); });
 
-    // On any failure below, unwind the agent registration and surface
-    // an unknown-error connect result. Disarmed on success.
-
-    CHIP_ERROR result = CHIP_NO_ERROR;
-    auto cleanup      = ScopeExit([&]() {
-        if (mConnManAgentServer.mRegistered)
-        {
-            CHIP_ERROR status = ManagerUnregisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
-            if (status != CHIP_NO_ERROR)
-            {
-                ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "failed to unregister agent:%" CHIP_ERROR_FORMAT,
-                                  status.Format());
-            }
-        }
-
-        LogErrorOnFailure(DispatchWiFiConnectFinishedLocked(inOutLock, Status::kUnknownError, debug_text, result.GetValue()));
-    });
-
-    result = ManagerRegisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH);
-    ReturnErrorOnFailure(result);
+    ReturnErrorOnFailure(ManagerRegisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH));
 
     mConnManAgentServer.mPendingService.reset(g_object_ref(inService));
 
-    result = ServiceConnectLocked(inOutLock, inService);
-    ReturnErrorOnFailure(result);
+    ReturnErrorOnFailure(ServiceConnectLocked(inOutLock, inService));
 
     // Success; disarm the scoped clean-up.
 
@@ -3279,6 +3674,23 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleServiceProper
         // debounce.
 
         ReturnErrorOnFailure(UpdateNetworkServiceConnectivityLocked());
+    }
+
+    // Independently of, and in addition to, the connectivity
+    // recomputation above, "Error" and "State" changes on the service
+    // backing an in-flight Network Commissioning connect drive that
+    // connect's Matter completion. These are deliberately NOT chained
+    // onto the preceding 'else if': the connectivity concern is about
+    // *any* tracked service type, whereas this is about *the* pending
+    // service, and both must run.
+
+    if (strcmp(inKey, kConnManServicePropertyErrorKey) == 0)
+    {
+        ReturnErrorOnFailure(HandleWiFiPendingConnectServiceErrorChangedLocked(inPath, inType, inValue));
+    }
+    else if (strcmp(inKey, kConnManServicePropertyStateKey) == 0)
+    {
+        ReturnErrorOnFailure(HandleWiFiPendingConnectServiceStateChangedLocked(inOutLock, inPath, inType, inValue));
     }
 
     return CHIP_NO_ERROR;
@@ -3552,11 +3964,238 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingCo
         ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting to '%.*s' after %zu scan(s)...",
                         static_cast<int>(inOutScanState.mSsid.size()), inOutScanState.mSsid.data(), inOutScanState.mCount);
 
-        return HandleServiceConnectRequestLocked(inOutLock, service);
+        const CHIP_ERROR status = HandleServiceConnectRequestLocked(inOutLock, service);
+        if (status == CHIP_NO_ERROR)
+        {
+            // The scan that this connect was waiting on has served
+            // its purpose; clear the liveness sentinel so a
+            // subsequent technology scan completion does not re-enter
+            // and issue a second Service.Connect() (and a second
+            // agent registration) atop the live one. The SSID is
+            // retained: it is still the completion's debug text.
+
+            inOutScanState.mCount = 0;
+        }
+        else
+        {
+            // This path is reached from HandleTechnologyScanComplete, which
+            // merely logs the returned error. No caller will complete the
+            // Network Commissioning command, so complete it here or the
+            // commissioner waits out the fail-safe.
+
+            const CharSpan debug(reinterpret_cast<const char *>(inOutScanState.mSsid.data()), inOutScanState.mSsid.size());
+
+            LogErrorOnFailure(CompleteWiFiConnectLocked(inOutLock, Status::kUnknownError, debug, status.GetValue()));
+        }
+
+        return status;
     }
 
     return HandleWiFiUnresolvedAfterScanLocked(inOutLock, inTechnology, inOutScanState, kWiFiConnectScanLimit,
-                                               "could not connect to", WiFiScanTerminalKind::kConnect);
+                                               "could not connect to", WiFiScanCompletionKind::kConnect);
+}
+
+/**
+ *  @brief
+ *    Latch a connman network service "Error" property change for the
+ *    service backing an in-flight Wi-Fi connect.
+ *
+ *  connman emits `PropertyChanged("Error")` before it emits
+ *  `PropertyChanged("State" = "failure")`, and invokes
+ *  `Agent.ReportError()` only after both. This handler is therefore
+ *  the authoritative, race-free point at which the failure cause
+ *  becomes known; the failure state transition merely consumes what
+ *  is latched here.
+ *
+ *  @note
+ *    connman signals a *cleared* error as the empty string rather than
+ *    by omitting the property; that is handled as a latch reset.
+ *
+ *  @param[in]  inPath
+ *    The service object path whose property changed.
+ *
+ *  @param[in]  inType
+ *    The service type; only Wi-Fi participates.
+ *
+ *  @param[in]  inValue
+ *    The new "Error" property value, of type 's'.
+ *
+ *  @retval  #CHIP_NO_ERROR
+ *    On success, or when the change is not for the pending service.
+ *
+ *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
+ *    If @a inValue is not a string.
+ *
+ *  @sa HandleWiFiPendingConnectServiceStateChangedLocked
+ *  @sa MapServiceError
+ *
+ *  @private
+ */
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingConnectServiceErrorChangedLocked(
+    const char * inPath, const char * inType, GVariant * inValue) noexcept
+{
+    // If the network service type is not Wi-Fi, ignore it.
+
+    VerifyOrReturnError(strcmp(inType, kConnManServicePropertyTypeWiFiValue) == 0, CHIP_NO_ERROR);
+
+    // If the change is not for a Wi-Fi service we are attempting to
+    // connect to, ignore it.
+
+    VerifyOrReturnError(IsWiFiPendingConnectServicePathLocked(inPath), CHIP_NO_ERROR);
+
+    // If the variant is of the wrong type (not 's'), it's an invalid
+    // argument.
+
+    VerifyOrReturnError(g_variant_is_of_type(inValue, G_VARIANT_TYPE_STRING), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const char * const error = g_variant_get_string(inValue, nullptr);
+
+    if ((error == nullptr) || (*error == '\0'))
+    {
+        mWiFiClusterConnectServiceError.reset();
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting service \"%s\" error is now \"%s\"", inPath,
+                     error);
+
+        mWiFiClusterConnectServiceError = MapServiceError(error);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingConnectServiceStateChangedLocked(
+    std::unique_lock<std::mutex> & inOutLock, const char * inPath, const char * inType, GVariant * inValue) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    // If the network service type is not Wi-Fi, ignore it.
+
+    VerifyOrReturnError(strcmp(inType, kConnManServicePropertyTypeWiFiValue) == 0, CHIP_NO_ERROR);
+
+    // Ensure that the Wi-Fi network service is one we are actually
+    // connecting to. Only the service backing the pending connect
+    // drives the completion. connman multiplexes PropertyChanged
+    // across every service it knows about; a neighboring AP drifting
+    // out of range must not complete our `ConnectWiFiNetwork*Async`
+    // command.
+
+    VerifyOrReturnError(IsWiFiPendingConnectServicePathLocked(inPath), CHIP_NO_ERROR);
+
+    // Absent an in-flight connect there is no completion to drive. This is
+    // what makes the handler idempotent across the ready -> online
+    // transition and immune to the failure -> idle transition that connman
+    // induces once the error is retired.
+
+    VerifyOrReturnError(HasWiFiClusterConnectPendingLocked(), CHIP_NO_ERROR);
+
+    // If the variant is of the wrong type (not 's'), it's an invalid
+    // argument.
+
+    VerifyOrReturnError(g_variant_is_of_type(inValue, G_VARIANT_TYPE_STRING), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const char * const state = g_variant_get_string(inValue, nullptr);
+    VerifyOrReturnError(state != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogProgress(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "connecting service \"%s\" state is now \"%s\"", inPath,
+                    state);
+
+    WiFiDiagnosticsDelegate * const delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
+
+    if (strcmp(state, kConnManServicePropertyStateAssociationValue) == 0)
+    {
+        mWiFiClusterConnectAssociationStarted = true;
+    }
+    else if (strcmp(state, kConnManServicePropertyStateConfigurationValue) == 0)
+    {
+        // Association and the 4-way handshake have both succeeded; L2 is up
+        // and DHCP/SLAAC is running. Report the link, but do not conclude:
+        // dhcp-failed is still reachable from here.
+
+        if (delegate != nullptr)
+        {
+            ReturnLogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda(
+                [delegate]() { delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected)); }));
+        }
+    }
+    else if ((strcmp(state, kConnManServicePropertyStateReadyValue) == 0) ||
+             (strcmp(state, kConnManServicePropertyStateOnlineValue) == 0))
+    {
+        // "ready" means IPv4 and/or IPv6 is configured, which is precisely
+        // Matter's ConnectNetwork contract. Deliberately do NOT hold out for
+        // "online": connman's Internet reachability probe is strictly
+        // stronger than Matter requires and will not fire on an
+        // egress-filtered or captive-portal network that is nonetheless
+        // perfectly commissionable. Note also that when a higher-priority
+        // service is already the default, this service never transitions
+        // ready -> online at all.
+        //
+        // The HasWiFiClusterConnectPendingLocked() gate above makes
+        // the subsequent "online" a no-op on the networks where it
+        // does arrive.
+
+        const CharSpan debug(reinterpret_cast<const char *>(mWiFiClusterConnectScanState.mSsid.data()),
+                             mWiFiClusterConnectScanState.mSsid.size());
+        ReturnErrorOnFailure(CompleteWiFiConnectLocked(inOutLock, Status::kSuccess, debug, 0));
+
+        NotifyWiFiConnectivityChange(kConnectivity_Established);
+    }
+    else if (strcmp(state, kConnManServicePropertyStateFailureValue) == 0)
+    {
+        // The cause was latched by
+        // `HandleWiFiPendingConnectServiceErrorChangedLocked` from
+        // the PropertyChanged("Error") that connman emits ahead of
+        // this transition. A failure state with no latched error
+        // should not happen; report it honestly rather than silently
+        // succeeding.
+
+        const ServiceError mapped = mWiFiClusterConnectServiceError.value_or(kServiceErrorUnknown);
+
+        if (!mapped.mIsTerminal)
+        {
+            // online-check-failed: the service reached at least "ready", so
+            // Matter's contract is already satisfied and this is not a
+            // connect failure. It should not arrive as a *failure* state,
+            // but tolerate it rather than fabricating a terminal error.
+
+            ChipLogProgress(DeviceLayer,
+                            CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "non-terminal service error; ignoring failure state");
+
+            return CHIP_NO_ERROR;
+        }
+
+        if (mapped.mIsAssociationFailure && mWiFiClusterConnectAssociationStarted && (delegate != nullptr))
+        {
+            const uint8_t cause   = static_cast<uint8_t>(mapped.mCause);
+            const uint16_t status = mapped.mAssociationStatus;
+
+            ReturnLogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda(
+                [delegate, cause, status]() { delegate->OnAssociationFailureDetected(cause, status); }));
+        }
+
+        if (delegate != nullptr)
+        {
+            ReturnLogErrorOnFailure(DeviceLayer::SystemLayer().ScheduleLambda(
+                [delegate]() { delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kNotConnected)); }));
+        }
+
+        const CharSpan debug(reinterpret_cast<const char *>(mWiFiClusterConnectScanState.mSsid.data()),
+                             mWiFiClusterConnectScanState.mSsid.size());
+        ReturnErrorOnFailure(CompleteWiFiConnectLocked(inOutLock, mapped.mStatus, debug, 0));
+
+        NotifyWiFiConnectivityChange(kConnectivity_Lost);
+    }
+
+    // "idle" and "disconnect" are intentionally unhandled
+    // here. connman reaches them both on the way *into* a connect and
+    // on the way out of a retired failure; neither is a completion for
+    // an in-flight connect, and treating them as one would deliver a
+    // second, contradictory result to the Network Commissioning
+    // cluster. A connect that stalls short of a completion is the job
+    // of the connect timeout, not of this handler.
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingScanLocked(std::unique_lock<std::mutex> & inOutLock,
@@ -3573,6 +4212,10 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingSc
     // Directed scan: resolve the target SSID against the current service set.
 
     retval = GetWiFiServicePropertiesFromSsidLocked(inOutScanState.mSsid.span(), mConnManClient.mServices.get(), properties);
+
+    ChipLogDetail(DeviceLayer, CONNECTIVITY_MANAGER_CONNMAN_LOG_PREFIX "directed scan for '%.*s': %s",
+                  static_cast<int>(inOutScanState.mSsid.size()), inOutScanState.mSsid.data(),
+                  (retval == CHIP_NO_ERROR) ? "resolved" : "unresolved");
 
     if (retval == CHIP_NO_ERROR)
     {
@@ -3600,7 +4243,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiPendingSc
     // Not found: hand off to the shared give-up-versus-retry arbiter.
 
     return HandleWiFiUnresolvedAfterScanLocked(inOutLock, inTechnology, inOutScanState, kWiFiActiveScanLimit,
-                                               "no Wi-Fi network found matching", WiFiScanTerminalKind::kScan);
+                                               "no Wi-Fi network found matching", WiFiScanCompletionKind::kScan);
 }
 
 /**
@@ -3672,9 +4315,9 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanCompl
     // If there is a pending asynchronous connect that required a
     // scan, handle it.
 
-    if (mWiFiConnectScanState.IsActive())
+    if (mWiFiClusterConnectScanState.IsActive())
     {
-        ReturnErrorOnFailure(HandleWiFiPendingConnectLocked(inOutLock, inTechnology, mWiFiConnectScanState));
+        ReturnErrorOnFailure(HandleWiFiPendingConnectLocked(inOutLock, inTechnology, mWiFiClusterConnectScanState));
     }
 
     // If there is a pending asynchronous scan, handle it.
@@ -3727,14 +4370,14 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanRetry
  *  scan. This is the shared give-up-versus-retry policy for both
  *  callers: if the scan budget is exhausted (`inOutScanState.mCount`
  *  has reached `inScanLimit`), the SSID is snapshotted for the debug
- *  text, the scan state is reset, and the caller-specific terminal is
+ *  text, the scan state is reset, and the caller-specific completion is
  *  completed exactly once through the corresponding dispatch
  *  primitive; otherwise, another scan is armed via
  *  #HandleWiFiScanRetryLocked and its status is returned.
  *
- *  The terminal disposition is selected by an `inKind` tag rather
+ *  The completion disposition is selected by an `inKind` tag rather
  *  than a caller-supplied callback so that the give-up bookkeeping
- *  (logging, scan-state reset) and the terminal dispatch both live
+ *  (logging, scan-state reset) and the completion dispatch both live
  *  here once, and so that dispatch routes through
  *  #DispatchWiFiScanFinishedLocked or #DispatchWiFiConnectFinishedLocked,
  *  which guarantee exactly-once completion even under scheduler
@@ -3769,23 +4412,23 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanRetry
  *
  *  @param[in]      inScanLimit
  *    The maximum number of Wi-Fi scans permitted before the operation
- *    is abandoned and its terminal is reported.
+ *    is abandoned and its completion is reported.
  *
  *  @param[in]      inReason
  *    A pointer to an immutable null-terminated C string describing
- *    why the SSID is unresolved, used both in the terminal error log
+ *    why the SSID is unresolved, used both in the completion error log
  *    and as the retry log reason.
  *
  *  @param[in]      inKind
- *    Selects the terminal disposition: `#WiFiScanTerminalKind::kScan`
- *    completes `OnScanFinished`; `#WiFiScanTerminalKind::kConnect`
+ *    Selects the completion disposition: `#WiFiScanCompletionKind::kScan`
+ *    completes `OnScanFinished`; `#WiFiScanCompletionKind::kConnect`
  *    completes `OnConnectResult`.
  *
  *  @retval  #CHIP_ERROR_INVALID_ARGUMENT
  *    If `inTechnology` or `inReason` is null.
  *
  *  @retval  #CHIP_ERROR_KEY_NOT_FOUND
- *    If the scan budget is exhausted for `#WiFiScanTerminalKind::kScan`
+ *    If the scan budget is exhausted for `#WiFiScanCompletionKind::kScan`
  *    (advisory; `OnScanFinished` is the authoritative completion).
  *
  *  @retval  #CHIP_NO_ERROR
@@ -3793,7 +4436,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanRetry
  *
  *  @retval  *
  *    Otherwise, a POSIX ENOENT #CHIP_ERROR for an exhausted
- *    `#WiFiScanTerminalKind::kConnect` budget (advisory), or any error
+ *    `#WiFiScanCompletionKind::kConnect` budget (advisory), or any error
  *    returned by #HandleWiFiScanRetryLocked in arming a further scan.
  *
  *  @sa HandleWiFiScanRetryLocked
@@ -3807,7 +4450,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiScanRetry
  */
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiUnresolvedAfterScanLocked(
     std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology, WiFiScanState & inOutScanState,
-    const size_t & inScanLimit, const char * inReason, WiFiScanTerminalKind inKind) noexcept
+    const size_t & inScanLimit, const char * inReason, WiFiScanCompletionKind inKind) noexcept
 {
     VerifyOrDie(inOutLock.owns_lock());
 
@@ -3819,6 +4462,7 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiUnresolve
         // Snapshot the SSID for the debug text before the reset; the dispatch
         // helpers copy these bytes by value, so the reset cannot race the
         // deferred callback.
+
         const Internal::WiFiSSIDFixedBuffer ssid = inOutScanState.mSsid;
         const CharSpan debug(reinterpret_cast<const char *>(ssid.data()), ssid.size());
 
@@ -3836,13 +4480,13 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::HandleWiFiUnresolve
         switch (inKind)
         {
 
-        case WiFiScanTerminalKind::kScan:
+        case WiFiScanCompletionKind::kScan:
             ReturnErrorOnFailure(DispatchWiFiScanFinishedLocked(inOutLock, Status::kNetworkNotFound, debug, nullptr));
 
             return CHIP_ERROR_KEY_NOT_FOUND;
 
-        case WiFiScanTerminalKind::kConnect:
-            ReturnErrorOnFailure(DispatchWiFiConnectFinishedLocked(inOutLock, Status::kNetworkNotFound, debug, 0));
+        case WiFiScanCompletionKind::kConnect:
+            ReturnErrorOnFailure(CompleteWiFiConnectLocked(inOutLock, Status::kNetworkNotFound, debug, 0));
 
             return ChipError(ChipError::Range::kPOSIX, ENOENT);
         }
@@ -3930,6 +4574,14 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::MaybeSetInterfaceNa
     return CHIP_NO_ERROR;
 }
 
+void ConnectivityManagerImpl_NetworkManagementConnMan::NotifyWiFiConnectivityChange(ConnectivityChange inChange) noexcept
+{
+    const ChipDeviceEvent event{ .Type                   = DeviceEventType::kWiFiConnectivityChange,
+                                 .WiFiConnectivityChange = { .Result = inChange } };
+
+    PlatformMgr().PostEventOrDie(&event);
+}
+
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::RemoveServiceLocked(const char * inPath) noexcept
 {
     VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -3942,6 +4594,90 @@ CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::RemoveTechnologyLoc
     VerifyOrReturnError(inPath != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     return RemoveObjectLocked(mConnManClient.mTechnologies.get(), inPath, mConnManClient.mTechnologyProxies.get());
+}
+
+/**
+ *  @brief
+ *    Scrub and clear the cached Wi-Fi connect credential.
+ *
+ *  The credential's lifetime is that of the D-Bus `Service.Connect()`
+ *  call, not that of any single `Agent.RequestInput`: connman may
+ *  legitimately request input more than once within one connect
+ *  (hidden networks, WPS, and any future `Agent.Error.Retry` reply).
+ *  It is therefore scrubbed by whichever of the two scope terminators
+ *  runs: #ShutdownClientConnectSessionLocked, when `Connect()` was
+ *  issued and has replied; or the abort guard in
+ *  `ConnectWiFiNetworkAsync`, when `Connect()` was never issued at
+ *  all.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`.
+ *
+ *  @sa ShutdownClientConnectSessionLocked
+ *
+ *  @private
+ *
+ */
+void ConnectivityManagerImpl_NetworkManagementConnMan::ScrubWiFiClientConnectPassphraseLocked() noexcept
+{
+    if (!mWiFiClientConnectPassphrase.empty())
+    {
+        Crypto::DRBG_get_bytes(mWiFiClientConnectPassphrase.data(), mWiFiClientConnectPassphrase.size());
+
+        mWiFiClientConnectPassphrase.clear();
+    }
+}
+
+/**
+ *  @brief
+ *    Shut down the connman connect session: the state whose lifetime
+ *    is that of the D-Bus `Service.Connect()` call.
+ *
+ *  The peer of #ConcludeWiFiClusterConnectLocked. Retires everything
+ *  connman may still reach into while a connect request is
+ *  outstanding: the registered agent, the pending service proxy
+ *  against which agent requests are path-matched, and the cached
+ *  credential from which `Agent.RequestInput` is answered.
+ *
+ *  @note
+ *    Which to call: *"can connman still call my agent?"* -- if it can,
+ *    the session is live and this must not run. Contrast
+ *    #ConcludeWiFiClusterConnectLocked, whose test is *"has the Network
+ *    Commissioning cluster been answered?"*. The two scopes do not
+ *    nest and do not end together: connman drives the service to
+ *    "ready" or "failure" -- concluding the *Matter* connect -- before
+ *    it replies to `Connect()`, and may request agent input at any
+ *    point until it does.
+ *
+ *  @note
+ *    The `Locked` suffix denotes the precondition that the caller
+ *    holds `mConnManMutex`; this is verified by assertion. The lock
+ *    may be temporarily released by the agent unregistration, which is
+ *    why this takes the lock and #ConcludeWiFiClusterConnectLocked does not.
+ *
+ *  @param[in,out]  inOutLock
+ *    A reference to the mutable, held class lock.
+ *
+ *  @sa ConcludeWiFiClusterConnectLocked
+ *  @sa ScrubWiFiClientConnectPassphraseLocked
+ *
+ *  @private
+ *
+ */
+void ConnectivityManagerImpl_NetworkManagementConnMan::ShutdownClientConnectSessionLocked(
+    std::unique_lock<std::mutex> & inOutLock) noexcept
+{
+    VerifyOrDie(inOutLock.owns_lock());
+
+    if (mConnManAgentServer.mRegistered)
+    {
+        LogErrorOnFailure(ManagerUnregisterAgentLocked(inOutLock, MATTER_CONNECTIVITY_MANAGER_CONNMAN_AGENT_PATH));
+    }
+
+    mConnManAgentServer.mPendingService.reset();
+
+    ScrubWiFiClientConnectPassphraseLocked();
 }
 
 CHIP_ERROR ConnectivityManagerImpl_NetworkManagementConnMan::UpdateManagerPropertiesLocked(GVariant * inProperties) noexcept
@@ -4741,16 +5477,11 @@ gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRequestInput(C
 {
     std::lock_guard<std::mutex> lock(mConnManMutex);
 
-    // Any cached passphrase is scrubbed on every return path.
-
-    auto passphraseGuard = ScopeExit([this]() {
-        if (!mWiFiConnectPassphrase.empty())
-        {
-            Crypto::DRBG_get_bytes(mWiFiConnectPassphrase.data(), mWiFiConnectPassphrase.capacity());
-
-            mWiFiConnectPassphrase.clear();
-        }
-    });
+    // The cached credential is deliberately NOT scrubbed here. Its lifetime is
+    // the D-Bus Service.Connect() call, not this single request: connman may
+    // legitimately call Agent.RequestInput more than once within one connect,
+    // and scrubbing here would fail the second with a misleading "not
+    // available". ShutdownClientConnectSessionLocked owns the scrub.
 
     // Answer the invocation with a G_IO_ERROR and yield the TRUE the
     // agent contract mandates. Safe when there is no invocation to
@@ -4828,11 +5559,12 @@ gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRequestInput(C
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
     if (want_passphrase)
     {
-        VerifyOrReturnValue(!mWiFiConnectPassphrase.empty(), fail(G_IO_ERROR_FAILED, "Passphrase requested but not available"));
+        VerifyOrReturnValue(!mWiFiClientConnectPassphrase.empty(),
+                            fail(G_IO_ERROR_FAILED, "Passphrase requested but not available"));
 
         char passphrase[Internal::kMaxWiFiKeyLength + 1];
-        const size_t n = std::min<size_t>(mWiFiConnectPassphrase.size(), Internal::kMaxWiFiKeyLength);
-        memcpy(passphrase, mWiFiConnectPassphrase.data(), n);
+        const size_t n = std::min<size_t>(mWiFiClientConnectPassphrase.size(), Internal::kMaxWiFiKeyLength);
+        memcpy(passphrase, mWiFiClientConnectPassphrase.data(), n);
         passphrase[n] = '\0';
 
         g_variant_builder_add(&builder, "{sv}", kConnManServiceAgentPropertyPassphraseKey, g_variant_new_string(passphrase));
@@ -4901,6 +5633,27 @@ gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentReportError(Co
                  inError ? inError : "(null)");
 
     conn_man_agent_complete_report_error(inAgent, inInvocation);
+
+    // Secondary latch only, and deliberately handled inline on the GLib thread
+    // rather than marshaled to the Matter thread: connman emits
+    // PropertyChanged("Error") and PropertyChanged("State" = "failure") ahead of
+    // this call, and those are *already* deferred via ScheduleLambda. Deferring
+    // this as well would queue it strictly behind them -- that is, behind the
+    // ConcludeWiFiClusterConnectLocked that the failure transition performs --
+    // and every guard below would reject it, making the latch dead code.
+    // Handled inline, it can still win that race and serve as the fallback it
+    // is meant to be.
+    //
+    // Never overwrite a latched cause, and never latch for a connect that is no
+    // longer in flight or for a service that is not ours: connman calls
+    // ReportError *after* the failure transition in the ordinary case, and an
+    // unguarded write would arm a stale error for the *next* connect.
+
+    if ((inError != nullptr) && HasWiFiClusterConnectPendingLocked() && IsWiFiPendingConnectServicePathLocked(inPath) &&
+        !mWiFiClusterConnectServiceError.has_value())
+    {
+        mWiFiClusterConnectServiceError = MapServiceError(inError);
+    }
 
     // The connman agent contract requires the handler to report the
     // invocation as handled; there is no path on which we decline it.

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.cpp
@@ -4601,6 +4601,37 @@ gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRelease(ConnMa
     return TRUE;
 }
 
+/**
+ *  @brief
+ *    Answer connman's `Agent.RequestInput` with the cached Wi-Fi
+ *    credential.
+ *
+ *  @note
+ *    **Runs on the GLib thread and takes `mConnManMutex` directly.**
+ *    Unlike the connman signal handlers (`OnServicePropertyChanged`
+ *    and friends), which marshal to the Matter thread via
+ *    `ScheduleLambda`, this *cannot*: it must answer the D-Bus method
+ *    invocation synchronously, with the passphrase, before returning.
+ *
+ *    There is no deferral that preserves that contract. This is the
+ *    precedent that also licenses the same treatment in
+ *    #OnAgentReportError.
+ *
+ *  @note
+ *    The cached credential is deliberately **not** scrubbed here.
+ *    connman may legitimately call `RequestInput` more than once
+ *    within a single `Service.Connect()` (hidden networks, WPS, and
+ *    any future `Agent.Error.Retry` reply) and scrubbing on the first
+ *    would fail the second with a misleading "not available".
+ *    #ShutdownClientConnectSessionLocked owns the scrub, at the
+ *    close of the D-Bus call that is the credential's true scope.
+ *
+ *  @sa OnAgentReportError
+ *  @sa ShutdownClientConnectSessionLocked
+ *
+ *  @private
+ *
+ */
 gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRequestInput(ConnManAgent * inAgent,
                                                                                GDBusMethodInvocation * inInvocation,
                                                                                const gchar * inPath,
@@ -4717,6 +4748,46 @@ gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentRequestInput(C
     return TRUE;
 }
 
+/**
+ *  @brief
+ *    Latch the cause of a connman network service failure reported
+ *    via `Agent.ReportError`, as a fallback to the "Error" property.
+ *
+ *  @note
+ *    **Runs on the GLib thread and takes `mConnManMutex` directly,
+ *    and must not be marshaled to the Matter thread.** This is subtle
+ *    and load-bearing. connman emits, in order:
+ *
+ *      1. `PropertyChanged("Error")`
+ *      2. `PropertyChanged("State" = "failure")`
+ *      3. `Agent.ReportError()`
+ *
+ *    Signals (1) and (2) are *already* deferred onto the Matter
+ *    thread by `OnServicePropertyChanged`, and (2) concludes the
+ *    Matter connect via #ConcludeWiFiClusterConnectLocked, which clears
+ *    the latch and the pending gate. Marshaling this handler as well
+ *    would queue it strictly *behind* both (that is, behind the very
+ *    conclusion that clears what it is trying to set) so its
+ *    `HasWiFiClusterConnectPendingLocked()` guard below would reject it on
+ *    every single connect, rendering the fallback dead code. Handled
+ *    inline on the GLib thread, it can still win that race and serve
+ *    as the fallback it is meant to be.
+ *
+ *  @note
+ *    Secondary latch only;
+ *    #HandleWiFiPendingConnectServiceErrorChangedLocked, driven from
+ *    signal (1), is the primary and normally wins. Hence the
+ *    never-overwrite guard: in the ordinary case this handler arrives
+ *    *after* the failure has already been mapped, dispatched, and
+ *    concluded, and an unguarded write would arm a stale error for
+ *    the *next* connect.
+ *
+ *  @sa HandleWiFiPendingConnectServiceErrorChangedLocked
+ *  @sa OnAgentRequestInput
+ *
+ *  @private
+ *
+ */
 gboolean ConnectivityManagerImpl_NetworkManagementConnMan::OnAgentReportError(ConnManAgent * inAgent,
                                                                               GDBusMethodInvocation * inInvocation,
                                                                               const gchar * inPath, const gchar * inError) noexcept

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
@@ -463,9 +463,11 @@ private:
     using ObjectPropertiesChangedLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
         GDBusProxy * inProxy, const char * inKey, GVariant * inValue) noexcept;
     using TypedObjectPropertiesChangedAnyLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
-        GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept;
+        std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType,
+        const char * inKey, GVariant * inMaybeVariant) noexcept;
     using TypedObjectPropertyChangedLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
-        GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept;
+        std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath, const char * inType,
+        const char * inKey, GVariant * inValue) noexcept;
 
     void AccumulateFamilyConnectivity(const NetworkServiceFamilyConnectivityState & inPending,
                                       const NetworkServiceFamilyConnectivityState & inReported,
@@ -503,28 +505,33 @@ private:
     HandleObjectPropertiesChangedLocked(const char * inDescription, GDBusProxy * inProxy, GVariant * inProperties,
                                         ObjectPropertiesChangedAnyLockedMethod inObjectPropertiesChangedAnyLockedMethod) noexcept;
     CHIP_ERROR HandleObjectPropertiesChangedLocked(
-        const char * inDescription, GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties,
+        std::unique_lock<std::mutex> & inOutLock, const char * inDescription, GDBusProxy * inProxy, const char * inPath,
+        const char * inType, GVariant * inProperties,
         TypedObjectPropertiesChangedAnyLockedMethod inTypedObjectPropertiesChangedAnyLockedMethod) noexcept;
     CHIP_ERROR
-    HandleObjectPropertyChangedAnyLocked(GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey,
-                                         GVariant * inMaybeVariant,
+    HandleObjectPropertyChangedAnyLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy, const char * inPath,
+                                         const char * inType, const char * inKey, GVariant * inMaybeVariant,
                                          TypedObjectPropertyChangedLockedMethod inTypedObjectPropertyChangedLockedMethod) noexcept;
     void HandleServiceConnectComplete(GDBusProxy * inService, const GError * inError) noexcept;
     CHIP_ERROR HandleServiceConnectRequestLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
-    CHIP_ERROR HandleServicePropertiesChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
-                                                    GVariant * inProperties) noexcept;
+    CHIP_ERROR HandleServicePropertiesChangedLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy,
+                                                    const char * inPath, const char * inType, GVariant * inProperties) noexcept;
     void HandleServicePropertyChanged(ConnManService * inService, const char * inKey, GVariant * inValue) noexcept;
-    CHIP_ERROR HandleServicePropertyChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
-                                                  const char * inKey, GVariant * inValue) noexcept;
-    CHIP_ERROR HandleServicePropertyChangedAnyLocked(GDBusProxy * inService, const char * inPath, const char * inType,
-                                                     const char * inKey, GVariant * inMaybeVariant) noexcept;
-    CHIP_ERROR HandleTechnologyPropertiesChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
-                                                       GVariant * inProperties) noexcept;
+    CHIP_ERROR HandleServicePropertyChangedLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy,
+                                                  const char * inPath, const char * inType, const char * inKey,
+                                                  GVariant * inValue) noexcept;
+    CHIP_ERROR HandleServicePropertyChangedAnyLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inService,
+                                                     const char * inPath, const char * inType, const char * inKey,
+                                                     GVariant * inMaybeVariant) noexcept;
+    CHIP_ERROR HandleTechnologyPropertiesChangedLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy,
+                                                       const char * inPath, const char * inType, GVariant * inProperties) noexcept;
     void HandleTechnologyPropertyChanged(ConnManTechnology * inTechnology, const char * inKey, GVariant * inValue) noexcept;
-    CHIP_ERROR HandleTechnologyPropertyChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
-                                                     const char * inKey, GVariant * inValue) noexcept;
-    CHIP_ERROR HandleTechnologyPropertyChangedAnyLocked(GDBusProxy * inTechnology, const char * inPath, const char * inType,
-                                                        const char * inKey, GVariant * inMaybeVariant) noexcept;
+    CHIP_ERROR HandleTechnologyPropertyChangedLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inProxy,
+                                                     const char * inPath, const char * inType, const char * inKey,
+                                                     GVariant * inValue) noexcept;
+    CHIP_ERROR HandleTechnologyPropertyChangedAnyLocked(std::unique_lock<std::mutex> & inOutLock, GDBusProxy * inTechnology,
+                                                        const char * inPath, const char * inType, const char * inKey,
+                                                        GVariant * inMaybeVariant) noexcept;
     void HandleTechnologyScanComplete(GDBusProxy * inTechnology, const GError * inError) noexcept;
     CHIP_ERROR HandleWiFiBroadcastScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock,
                                                      ConnManTechnology * inTechnology) noexcept;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
@@ -631,6 +631,7 @@ private:
     CHIP_ERROR ManagerUnregisterAgent(const char * inPath) noexcept;
     CHIP_ERROR ManagerUnregisterAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
     CHIP_ERROR ServiceConnectLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
+    CHIP_ERROR ServiceRemoveLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
     void ServiceRegisterPropertyChangedOnGLib(ConnManService * inService) noexcept;
     void TechnologyRegisterPropertyChangedOnGLib(ConnManTechnology * inTechnology) noexcept;
     CHIP_ERROR TechnologyScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology) noexcept;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
@@ -167,6 +167,7 @@ public:
 
     void StartNonConcurrentWiFiManagement() override final;
     void StartWiFiManagement() override final;
+    void StopWiFiManagement() override final;
 
     // Wi-Fi Station Control Plane Management
 
@@ -615,6 +616,7 @@ private:
     void ScrubWiFiClientConnectPassphraseLocked() noexcept;
     void ShutdownClientConnectSessionLocked(std::unique_lock<std::mutex> & inOutLock) noexcept;
     CHIP_ERROR StartNetworkManagementOnGLib() noexcept;
+    CHIP_ERROR StopNetworkManagementOnGLib(GDBusConnManClient & inOutClient) noexcept;
     CHIP_ERROR UpdateManagerPropertiesLocked(GVariant * inProperties) noexcept;
     CHIP_ERROR UpdateNetworkServiceConnectivityLocked() noexcept;
     CHIP_ERROR UpdateServicesLocked(GVariant * inServices) noexcept;
@@ -630,6 +632,7 @@ private:
     CHIP_ERROR ManagerRegisterAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
     CHIP_ERROR ManagerUnregisterAgent(const char * inPath) noexcept;
     CHIP_ERROR ManagerUnregisterAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
+    void ObjectsUnregisterPropertyChangedOnGLib(GHashTable * inProxies) noexcept;
     CHIP_ERROR ServiceConnectLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
     CHIP_ERROR ServiceRemoveLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
     void ServiceRegisterPropertyChangedOnGLib(ConnManService * inService) noexcept;
@@ -718,6 +721,14 @@ private:
 
     // clang-format off
     std::mutex                           mConnManMutex;
+
+    /**
+     *  Indicates whether a start has been requested and not yet
+     *  stopped. Distinct from IsWiFiManagementStarted(), which
+     *  reports whether the manager proxy is live; between the two, a
+     *  start is in flight.
+     */
+    bool                                 mConnManStarted;
     GDBusConnManClient                   mConnManClient CHIP_GUARDED_BY(mConnManMutex);
     GDBusConnManAgent                    mConnManAgentServer CHIP_GUARDED_BY(mConnManMutex);
     ConnectivityManagerImpl *            mConnectivityManagerImpl;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
@@ -1,0 +1,665 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <mutex>
+#include <utility>
+
+#include <gio/gio.h>
+
+#include <lib/core/Optional.h>
+#include <lib/support/FixedBuffer.h>
+#include <lib/support/Span.h>
+#include <platform/Linux/dbus/connman/DBusConnManAgent.h>
+#include <platform/Linux/dbus/connman/DBusConnManManager.h>
+#include <platform/Linux/dbus/connman/DBusConnManService.h>
+#include <platform/Linux/dbus/connman/DBusConnManTechnology.h>
+#include <platform/NetworkCommissioning.h>
+#include <system/SystemMutex.h>
+
+#include "ConnectivityManagerImpl_NetworkManagementBasis.h"
+#include "ConnectivityManagerImpl_NetworkManagementInterface.h"
+
+namespace chip {
+
+template <>
+struct GAutoPtrDeleter<ConnManAgent>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<ConnManManager>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<ConnManService>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<ConnManTechnology>
+{
+    using deleter = GObjectDeleter;
+};
+
+namespace DeviceLayer {
+
+// Forward Declarations
+
+struct ChipDeviceEvent;
+
+/**
+ *  Provides an implementation of the ConnectionManager object
+ *  for Linux platforms where Connection Manager (aka connman)
+ *  is the high-level network manager, that owns network
+ *  policy and state and orchestrates connectivity decisions
+ *  and cross-interface policy.
+ *
+ */
+class ConnectivityManagerImpl_NetworkManagementConnMan final : public Internal::NetworkManagementBasis,
+                                                               public Internal::NetworkManagementInterface
+{
+public:
+    // Construction
+
+    ConnectivityManagerImpl_NetworkManagementConnMan() = default;
+
+    // Destruction
+
+    virtual ~ConnectivityManagerImpl_NetworkManagementConnMan() = default;
+
+    // Initialization
+
+    CHIP_ERROR Init(ConnectivityManagerImpl & inConnectivityManagerImpl) override final;
+
+    // Observation
+
+    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork) override final;
+
+    // Event Handling
+
+    void OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) override final;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    // Ethernet Control Plane Management
+
+    const char * GetEthernetIfName() override final;
+    void UpdateEthernetNetworkingStatus() override final;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Wi-Fi Control Plane Management
+
+    // Observation
+
+    const char * GetWiFiIfName() override final;
+
+    // Control
+
+    void StartNonConcurrentWiFiManagement() override final;
+    void StartWiFiManagement() override final;
+
+    // Wi-Fi Station Control Plane Management
+
+    // Introspection
+
+    bool IsWiFiManagementStarted() override final;
+    bool IsWiFiStationApplicationControlled() override final;
+    bool IsWiFiStationConnected() override final;
+    bool IsWiFiStationEnabled() override final;
+    bool IsWiFiStationProvisioned() override final;
+
+    // Observation
+
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & outBssId) override final;
+    CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outSecurityType) override final;
+    ConnectivityManager::WiFiStationMode GetWiFiStationMode() override final;
+    System::Clock::Timeout GetWiFiStationReconnectInterval() override final;
+    CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outVersion) override final;
+
+    // Mutation
+
+    CHIP_ERROR SetWiFiStationMode(const ConnectivityManager::WiFiStationMode & inWiFiStationMode) override final;
+    CHIP_ERROR SetWiFiStationReconnectInterval(const System::Clock::Timeout & inInterval) override final;
+
+    // Worker
+
+    void ClearWiFiStationProvision() override final;
+    CHIP_ERROR CommitConfig() override final;
+    CHIP_ERROR
+    ConnectWiFiNetworkAsync(ByteSpan inSsid, ByteSpan inCredentials,
+                            NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) override final;
+    CHIP_ERROR ConnectWiFiNetworkWithPDCAsync(
+        ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity, const Crypto::P256Keypair & inClientIdentityKeypair,
+        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) override final;
+    CHIP_ERROR StartWiFiScan(ByteSpan inSsid, NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback) override final;
+
+    // Wi-Fi Soft Access Point (AP) Control Plane Management
+
+    // Observation
+
+    ConnectivityManager::WiFiAPMode GetWiFiApMode() override final;
+
+    // Mutation
+
+    CHIP_ERROR SetWiFiApMode(const ConnectivityManager::WiFiAPMode & inWiFiApMode) override final;
+    void SetWiFiApIdleTimeout(const System::Clock::Timeout & inTimeout) override final;
+
+    // Control
+
+    void DemandStartWiFiAp() override final;
+    void StopOnDemandWiFiAp() override final;
+    void MaintainOnDemandWiFiAp() override final;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+private:
+    // Network Service Internet-Connectivity Tracking
+    //
+    // Producer for DeviceEventType::kInternetConnectivityChange,
+    // derived from the cached connman network service "IPv4" / "IPv6"
+    // properties and debounced against connman property storms.
+
+    /**
+     *  Per-IP-address-family Internet connectivity disposition for a
+     *  tracked connman network service type.
+     */
+    enum class NetworkServiceConnectivity : uint8_t
+    {
+        /**
+         *  The connectivity disposition has not yet been observed;
+         *  this is the initial state and, uniquely, transitions out
+         *  of it to #kLost are absorbed without generating a device
+         *  event.
+         */
+        kUnknown = 0,
+
+        /**
+         *  The address family has no completed configuration (no
+         *  "Address" member in the service "IPv4"/"IPv6" property
+         *  dictionary) on any service of the tracked type.
+         */
+        kLost = 1,
+
+        /**
+         *  The address family has a completed configuration with a
+         *  parseable address on the best service of the tracked
+         *  type.
+         */
+        kEstablished = 2,
+    };
+
+    /**
+     *  @brief
+     *    Per-IP-family reduction of tracked connectivity across every
+     *    eligible network service type.
+     *
+     *  One instance accumulates, for a single IP family, the fold
+     *  over all `NetworkServiceState` entries performed when the
+     *  debounce timer expires: whether any tracked service's family
+     *  transition is worth surfacing (`mReportable`), whether the
+     *  family is currently established on any tracked service (
+     *  `mAnyEstablished`), and the representative address carried by
+     *  the resulting event (`mAddress`). Two of these (one for IPv4
+     *  and one for IPv6) drive a single
+     *  `OnInternetConnectivityChange` notification, whose data model
+     *  expresses only a per-family `ConnectivityChange` verdict and
+     *  one address per family.
+     *
+     *  @sa AccumulateFamilyConnectivity
+     *  @sa SetConnectivityChangeFromAggregate
+     *
+     *  @private
+     *
+     */
+    struct FamilyConnectivityAggregate
+    {
+        FamilyConnectivityAggregate() noexcept;
+
+        /**
+         *  True once at least one tracked service type exhibits a
+         *  family connectivity change (per
+         *  `IsFamilyConnectivityChangeReportable`) that the event
+         *  model can express; the sole gate on whether a
+         *  `ConnectivityChange` other than `kConnectivity_NoChange`
+         *  is emitted for this family.
+         */
+        bool mReportable;
+
+        /**
+         *  True if this IP family is established on any tracked
+         *  service type. Selects `kConnectivity_Established` versus
+         *  `kConnectivity_Lost` when `mReportable` holds, and gates
+         *  capture of `mAddress` to the first-established entry in
+         *  table order.
+         */
+        bool mAnyEstablished;
+
+        /**
+         *  Representative address for this family, taken from the
+         *  first-established tracked service in table (declaration)
+         *  order. Cosmetic: the event data model carries a single
+         *  address per family even though several services may be
+         *  established at once. Remains `Inet::IPAddress::Any` until
+         *  a first established entry supplies it.
+         */
+        Inet::IPAddress mAddress;
+    };
+
+    /**
+     *  @brief
+     *    Snapshot of one IP family's connectivity on one network service
+     *    type.
+     *
+     *  The per-family unit of the tracked-state table: the
+     *  reachability verdict for a single family (IPv4 or IPv6) on a
+     *  single service, paired with the address observed for that
+     *  family. A `NetworkServiceConnectivityState` holds one of these
+     *  per family, and `AccumulateFamilyConnectivity` folds a
+     *  (pending, reported) pair of them into a
+     *  `FamilyConnectivityAggregate`.
+     *
+     *  @private
+     *
+     */
+    struct NetworkServiceFamilyConnectivityState
+    {
+        NetworkServiceFamilyConnectivityState() noexcept;
+
+        /**
+         *  Reachability verdict for this family on this service:
+         *  established or lost.
+         */
+        NetworkServiceConnectivity mConnectivity;
+
+        /**
+         *  Address observed for this family on this service;
+         *  meaningful when `mConnectivity` is `kEstablished`, and the
+         *  source of the aggregate's representative address.
+         */
+        Inet::IPAddress mAddress;
+
+        bool operator==(const NetworkServiceFamilyConnectivityState & inOther) const noexcept;
+        bool operator!=(const NetworkServiceFamilyConnectivityState & inOther) const noexcept;
+    };
+
+    /**
+     *  Per-IP-address-family Internet connectivity state, with the
+     *  established address retained so that address *changes* while
+     *  established are themselves detectable and reportable (a
+     *  consumer such as the DNS-SD advertiser derives one-shot state
+     *  from the address and must be re-driven when it changes).
+     */
+    struct NetworkServiceConnectivityState
+    {
+        NetworkServiceFamilyConnectivityState mIPv4;
+        NetworkServiceFamilyConnectivityState mIPv6;
+
+        bool operator==(const NetworkServiceConnectivityState & inOther) const noexcept;
+        bool operator!=(const NetworkServiceConnectivityState & inOther) const noexcept;
+    };
+
+    /**
+     *  Aggregate tracked state for one eligible connman network
+     *  service type. Membership in the tracked-state table *is* the
+     *  eligibility policy: only service types on which Matter can
+     *  meaningfully advertise and operate (that is, link-local
+     *  mDNS-reachable interfaces--Ethernet and Wi-Fi) have entries.
+     *  Cellular and VPN services are deliberately excluded, since
+     *  their addresses are not valid DNS-SD advertisement targets;
+     *  do not conflate this eligibility set with connman's
+     *  connection *preference* policy, which lives in connman.conf.
+     */
+    struct NetworkServiceState
+    {
+        NetworkServiceState() noexcept;
+
+        /**
+         *  connman service "Type" value (for example, "ethernet")
+         */
+        const char * mType;
+
+        /**
+         *  Human-readable description of the service (for example,
+         *  "Ethernet").
+         */
+        const char * mDescription;
+
+        /**
+         *  The network interface name underlying the service.
+         */
+        char mIfName[Inet::InterfaceId::kMaxIfNameLength];
+
+        /**
+         *  Most recently computed per-family connectivity for this
+         *  service, recomputed from the cached best-service properties on
+         *  each connman event. Compared against `mReportedConnectivity`
+         *  to decide whether to (re)arm the debounce timer, and adopted as
+         *  the new baseline when the timer expires.
+         */
+        NetworkServiceConnectivityState mPendingConnectivity;
+
+        /**
+         *  Per-family connectivity last reflected into a posted
+         *  `OnInternetConnectivityChange` event: the debounce baseline.
+         *  A pending state that settles back to this value across a storm
+         *  expires the timer with nothing to report.
+         */
+        NetworkServiceConnectivityState mReportedConnectivity;
+    };
+
+    /**
+     *  Tracks one in-flight, SSID-oriented Wi-Fi scan operation with
+     *  its retry budget.
+     *
+     *  A nonzero `mCount` is the sole liveness sentinel (a scan is
+     *  outstanding); `mSsid`'s emptiness is orthogonally the
+     *  directed-versus-broadcast selector, meaningful only while
+     *  active.
+     */
+    struct WiFiScanState
+    {
+        WiFiScanState() noexcept;
+
+        // Introspection
+
+        bool IsActive() const noexcept;
+        bool IsDirected() const noexcept;
+
+        // Mutation
+
+        void Reset() noexcept;
+
+        /**
+         *  The fixed buffer for the Service Set Identifier (SSID) of
+         *  the Wi-Fi remote access point to scan for when the scan is
+         *  directed. Otherwise, empty when the scan is non-directed
+         *  (that is, broadcast).
+         *
+         *  Here, the empty state of the member is load-bearing: it
+         *  reflects the optional and nullable state of the upstream,
+         *  over-the-wire scan networks command SSID parameter, where
+         *  both absence and null translate to an empty buffer.
+         */
+        Internal::WiFiSSIDFixedBuffer mSsid;
+
+        /**
+         *  The number of scans performed.
+         */
+        size_t mCount;
+    };
+
+    enum class WiFiScanTerminalKind : uint8_t
+    {
+        /**
+         *  A Wi-Fi scan was for a connect and is terminating
+         *  with `OnConnectResult`.
+         */
+        kConnect,
+
+        /**
+         *  A Wi-Fi scan was for an actual scan and is terminating
+         *  with `OnScanFinished`.
+         */
+        kScan
+    };
+
+    // Initialization
+
+    static CHIP_ERROR InitAgentOnGLib(ConnectivityManagerImpl_NetworkManagementConnMan * inSelf, GDBusConnection * inConnection,
+                                      const char * inPath, ConnManAgent *& outSkeleton, GError ** outError) noexcept;
+    void ShutdownAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
+    static void ShutdownAgentOnGLib(ConnectivityManagerImpl_NetworkManagementConnMan * inSelf, GDBusConnection * inConnection,
+                                    const char * inPath, ConnManAgent * inSkeleton) noexcept;
+
+    // Introspection
+
+    static bool IsFamilyConnectivityChangeReportable(const NetworkServiceFamilyConnectivityState & inPending,
+                                                     const NetworkServiceFamilyConnectivityState & inReported) noexcept;
+
+    // Observation
+
+    static const char * GetConnectivityChangeString(ConnectivityChange inChange) noexcept;
+    static const char * GetNetworkServiceConnectivityString(NetworkServiceConnectivity inNetworkServiceConnectivity) noexcept;
+
+    // Mutation
+
+    static bool SetConnectivityChangeFromAggregate(const FamilyConnectivityAggregate & inAggregate,
+                                                   ConnectivityChange & outChange) noexcept;
+
+    // Helper Methods
+
+    using ManagerAgentOpFunc          = gboolean (*)(ConnManManager * inManager, const gchar * inPath, GCancellable * inCancellable,
+                                            GError ** inOutError);
+    using ManagerGetObjectsFinishFunc = gboolean (*)(ConnManManager * inManager, GVariant ** outObjects,
+                                                     GAsyncResult * inAsyncResult, GError ** outError);
+    using ObjectActionFinishFunc      = gboolean (*)(GObject * inObject, GAsyncResult * inAsyncResult, GError ** outError);
+
+    using HandleManagerGetObjectsMethod = void (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
+        ConnManManager * inManager, GVariant * inObjects, const GError * inError) noexcept;
+    using HandleObjectActionCompleteMethod =
+        void (ConnectivityManagerImpl_NetworkManagementConnMan::*)(GDBusProxy * inProxy, const GError * inError) noexcept;
+    using ObjectPropertiesChangedAnyLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
+        GDBusProxy * inProxy, const char * inKey, GVariant * inMaybeVariant) noexcept;
+    using ObjectPropertiesChangedLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
+        GDBusProxy * inProxy, const char * inKey, GVariant * inValue) noexcept;
+    using TypedObjectPropertiesChangedAnyLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
+        GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inMaybeVariant) noexcept;
+    using TypedObjectPropertyChangedLockedMethod = CHIP_ERROR (ConnectivityManagerImpl_NetworkManagementConnMan::*)(
+        GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey, GVariant * inValue) noexcept;
+
+    void AccumulateFamilyConnectivity(const NetworkServiceFamilyConnectivityState & inPending,
+                                      const NetworkServiceFamilyConnectivityState & inReported,
+                                      FamilyConnectivityAggregate & inOutAggregate) noexcept;
+    static CHIP_ERROR
+    BuildWiFiScanResponseFromServicePropertiesLocked(GVariant * inProperties,
+                                                     DeviceLayer::NetworkCommissioning::WiFiScanResponse & outResponse) noexcept;
+    CHIP_ERROR DispatchWiFiConnectFinishedLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                 DeviceLayer::NetworkCommissioning::Status inStatus, const CharSpan & inDebugText,
+                                                 int32_t inReason) noexcept;
+    CHIP_ERROR DispatchWiFiScanFinishedLocked(
+        std::unique_lock<std::mutex> & inOutLock, DeviceLayer::NetworkCommissioning::Status inStatus, const CharSpan & inDebugText,
+        std::unique_ptr<std::vector<DeviceLayer::NetworkCommissioning::WiFiScanResponse>> inResponses) noexcept;
+    NetworkServiceState * FindNetworkServiceStateLocked(const char * inType) noexcept;
+    const char * GetInterfaceName(const char * inType) noexcept;
+    static NetworkServiceFamilyConnectivityState GetServiceFamilyConnectivityStateLocked(GVariant * inProperties,
+                                                                                         const char * inFamilyKey) noexcept;
+    void HandleManagerGetProperties(ConnManManager * inManager, GVariant * inProperties, const GError * inError) noexcept;
+    void HandleManagerGetServices(ConnManManager * inManager, GVariant * inServices, const GError * inError) noexcept;
+    void HandleManagerGetTechnologies(ConnManManager * inManager, GVariant * inTechnologies, const GError * inError) noexcept;
+    CHIP_ERROR HandleManagerPropertiesChangedLocked(ConnManManager * inManager, GVariant * inProperties) noexcept;
+    void HandleManagerPropertyChanged(ConnManManager * inManager, const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleManagerPropertyChangedLocked(ConnManManager * inManager, const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleManagerPropertyChangedAnyLocked(GDBusProxy * inManager, const char * inKey,
+                                                     GVariant * inMaybeVariant) noexcept;
+    void HandleManagerServicesChanged(ConnManManager * inManager, GVariant * inServicesChanged,
+                                      const char * const * inServicesRemoved) noexcept;
+    void HandleManagerServicesChangedLocked(std::unique_lock<std::mutex> & inOutLock, ConnManManager * inManager,
+                                            GVariant * inServicesChanged) noexcept;
+    void HandleManagerServicesRemovedLocked(std::unique_lock<std::mutex> & inOutLock, ConnManManager * inManager,
+                                            const char * const * inServicesRemoved) noexcept;
+    void HandleManagerTechnologyAdded(ConnManManager * inManager, const char * inPath, GVariant * inProperties) noexcept;
+    void HandleManagerTechnologyRemoved(ConnManManager * inManager, const char * inPath) noexcept;
+    CHIP_ERROR
+    HandleObjectPropertiesChangedLocked(const char * inDescription, GDBusProxy * inProxy, GVariant * inProperties,
+                                        ObjectPropertiesChangedAnyLockedMethod inObjectPropertiesChangedAnyLockedMethod) noexcept;
+    CHIP_ERROR HandleObjectPropertiesChangedLocked(
+        const char * inDescription, GDBusProxy * inProxy, const char * inPath, const char * inType, GVariant * inProperties,
+        TypedObjectPropertiesChangedAnyLockedMethod inTypedObjectPropertiesChangedAnyLockedMethod) noexcept;
+    CHIP_ERROR
+    HandleObjectPropertyChangedAnyLocked(GDBusProxy * inProxy, const char * inPath, const char * inType, const char * inKey,
+                                         GVariant * inMaybeVariant,
+                                         TypedObjectPropertyChangedLockedMethod inTypedObjectPropertyChangedLockedMethod) noexcept;
+    void HandleServiceConnectComplete(GDBusProxy * inService, const GError * inError) noexcept;
+    CHIP_ERROR HandleServiceConnectRequestLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
+    CHIP_ERROR HandleServicePropertiesChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
+                                                    GVariant * inProperties) noexcept;
+    void HandleServicePropertyChanged(ConnManService * inService, const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleServicePropertyChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
+                                                  const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleServicePropertyChangedAnyLocked(GDBusProxy * inService, const char * inPath, const char * inType,
+                                                     const char * inKey, GVariant * inMaybeVariant) noexcept;
+    CHIP_ERROR HandleTechnologyPropertiesChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
+                                                       GVariant * inProperties) noexcept;
+    void HandleTechnologyPropertyChanged(ConnManTechnology * inTechnology, const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleTechnologyPropertyChangedLocked(GDBusProxy * inProxy, const char * inPath, const char * inType,
+                                                     const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR HandleTechnologyPropertyChangedAnyLocked(GDBusProxy * inTechnology, const char * inPath, const char * inType,
+                                                        const char * inKey, GVariant * inMaybeVariant) noexcept;
+    void HandleTechnologyScanComplete(GDBusProxy * inTechnology, const GError * inError) noexcept;
+    CHIP_ERROR HandleWiFiBroadcastScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock,
+                                                     ConnManTechnology * inTechnology) noexcept;
+    CHIP_ERROR HandleWiFiPendingConnectLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                              WiFiScanState & inOutScanState) noexcept;
+    CHIP_ERROR HandleWiFiPendingScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                           WiFiScanState & inOutScanState) noexcept;
+    CHIP_ERROR HandleWiFiScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology) noexcept;
+    CHIP_ERROR HandleWiFiScanRetryLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                         const char * inReason, WiFiScanState & inOutScanState) noexcept;
+    CHIP_ERROR HandleWiFiUnresolvedAfterScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                                   WiFiScanState & inOutScanState, const size_t & inScanLimit,
+                                                   const char * inReason, WiFiScanTerminalKind inKind) noexcept;
+    CHIP_ERROR ManagerAgentOpLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath,
+                                    ManagerAgentOpFunc inManagerAgentOpFunc, const char * inAction,
+                                    const bool & inRegister) noexcept;
+    void MaybeClearInterfaceNameLocked(const char * inPath) noexcept;
+    CHIP_ERROR MaybeSetInterfaceNameLocked(const char * inType, const char * inInterface) noexcept;
+    CHIP_ERROR RemoveServiceLocked(const char * inPath) noexcept;
+    CHIP_ERROR RemoveTechnologyLocked(const char * inPath) noexcept;
+    CHIP_ERROR StartNetworkManagementOnGLib() noexcept;
+    CHIP_ERROR UpdateManagerPropertiesLocked(GVariant * inProperties) noexcept;
+    CHIP_ERROR UpdateNetworkServiceConnectivityLocked() noexcept;
+    CHIP_ERROR UpdateServicesLocked(GVariant * inServices) noexcept;
+    CHIP_ERROR UpdateServiceProxyLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath,
+                                        ConnManService *& outService) noexcept;
+    CHIP_ERROR UpdateTechnologiesLocked(GVariant * inTechnologies) noexcept;
+    CHIP_ERROR UpdateTechnologyProxyLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath,
+                                           ConnManTechnology *& outTechnology) noexcept;
+
+    // Worker Methods
+
+    CHIP_ERROR ManagerRegisterAgent(const char * inPath) noexcept;
+    CHIP_ERROR ManagerRegisterAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
+    CHIP_ERROR ManagerUnregisterAgent(const char * inPath) noexcept;
+    CHIP_ERROR ManagerUnregisterAgentLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath) noexcept;
+    CHIP_ERROR ServiceConnectLocked(std::unique_lock<std::mutex> & inOutLock, ConnManService * inService) noexcept;
+    void ServiceRegisterPropertyChangedOnGLib(ConnManService * inService) noexcept;
+    void TechnologyRegisterPropertyChangedOnGLib(ConnManTechnology * inTechnology) noexcept;
+    CHIP_ERROR TechnologyScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology) noexcept;
+    CHIP_ERROR TechnologySetPropertyLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                           const char * inKey, GVariant * inValue) noexcept;
+    CHIP_ERROR TechnologySetPoweredLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
+                                          const bool & inPowered) noexcept;
+
+    // System Layer Timer Completion Methods
+
+    static void HandleNetworkServiceConnectivityDebounce(System::Layer * inSystemLayer, void * inAppState);
+    void ReportNetworkServiceConnectivity(void) noexcept;
+
+    // D-Bus / glib Asynchronous Completion Methods
+
+    void OnManagerReady(GObject * inObject, GAsyncResult * inResult);
+    void OnManagerGetObjectsReady(GObject * inObject, GAsyncResult * inResult,
+                                  ManagerGetObjectsFinishFunc inManagerGetObjectsFinishFunc,
+                                  HandleManagerGetObjectsMethod inHandleManagerGetObjectsMethod) noexcept;
+    void OnManagerGetPropertiesReady(GObject * inObject, GAsyncResult * inResult);
+    void OnManagerGetServicesReady(GObject * inObject, GAsyncResult * inResult);
+    void OnManagerGetTechnologiesReady(GObject * inObject, GAsyncResult * inResult);
+    void OnObjectActionReady(GObject * inObject, GAsyncResult * inResult, ObjectActionFinishFunc inObjectActionFinishFunc,
+                             HandleObjectActionCompleteMethod inHandleObjectActionCompleteMethod) noexcept;
+    void OnServiceConnectReady(GObject * inObject, GAsyncResult * inResult);
+    void OnTechnologyScanReady(GObject * inObject, GAsyncResult * inResult);
+
+    // D-Bus / glib Signal Callback Methods
+
+    gboolean OnAgentCancel(ConnManAgent * inAgent, GDBusMethodInvocation * inInvocation) noexcept;
+    gboolean OnAgentRelease(ConnManAgent * inAgent, GDBusMethodInvocation * inInvocation) noexcept;
+    gboolean OnAgentRequestInput(ConnManAgent * inAgent, GDBusMethodInvocation * inInvocation, const gchar * inPath,
+                                 GVariant * inProperties) noexcept;
+    gboolean OnAgentReportError(ConnManAgent * inAgent, GDBusMethodInvocation * inInvocation, const gchar * inPath,
+                                const gchar * inError) noexcept;
+    void OnManagerPropertyChanged(ConnManManager * inManager, const char * inKey, GVariant * inValue);
+    void OnManagerTechnologyAdded(ConnManManager * inManager, const char * inPath, GVariant * inProperties);
+    void OnManagerTechnologyRemoved(ConnManManager * inManager, const char * inPath);
+    void OnManagerServicesChanged(ConnManManager * inManager, GVariant * inServicesChanged, const char * const * inServicesRemoved);
+    void OnServicePropertyChanged(ConnManService * inService, const char * inKey, GVariant * inValue);
+    void OnTechnologyPropertyChanged(ConnManTechnology * inTechnology, const char * inKey, GVariant * inValue);
+
+private:
+    /**
+     *  The number of tracked network service types, sized by build
+     *  configuration.
+     */
+    static constexpr size_t kNetworkServiceEthernetCount = CHIP_DEVICE_CONFIG_ENABLE_ETHERNET;
+    static constexpr size_t kNetworkServiceWiFiCount     = CHIP_DEVICE_CONFIG_ENABLE_WIFI;
+    static constexpr size_t kNetworkServiceStateCount    = (kNetworkServiceEthernetCount + kNetworkServiceWiFiCount);
+
+    struct GDBusConnManClient
+    {
+        // clang-format off
+        GAutoPtr<ConnManManager>  mManagerProxy;
+        GAutoPtr<GHashTable>      mServiceProxies;
+        GAutoPtr<GHashTable>      mTechnologyProxies;
+        GAutoPtr<GHashTable>      mProperties;
+        GAutoPtr<GHashTable>      mServices;
+        GAutoPtr<GHashTable>      mTechnologies;
+        // clang-format on
+    };
+
+    struct GDBusConnManAgent
+    {
+        using ConnectCallback = NetworkCommissioning::Internal::WirelessDriver::ConnectCallback *;
+
+        // clang-format off
+        GAutoPtr<GDBusConnection> mConnection;
+        GAutoPtr<ConnManAgent>    mSkeleton;
+        bool                      mExported = false;
+        bool                      mRegistered = false;
+        GAutoPtr<ConnManService>  mPendingService;
+        ConnectCallback           mConnectCallback = nullptr;
+        // clang-format on
+    };
+
+    using NetworkServiceStateStorage = std::array<NetworkServiceState, kNetworkServiceStateCount>;
+
+    // Access to mConnManClient and mConnManAgentServer have to be
+    // protected by a mutex because they are accessed from both the
+    // Matter event loop thread (down calls) and dedicated GLib D-Bus thread
+    // started by Platform Manager (up calls).
+
+    // clang-format off
+    std::mutex                           mConnManMutex;
+    GDBusConnManClient                   mConnManClient CHIP_GUARDED_BY(mConnManMutex);
+    GDBusConnManAgent                    mConnManAgentServer CHIP_GUARDED_BY(mConnManMutex);
+    ConnectivityManagerImpl *            mConnectivityManagerImpl;
+    NetworkServiceStateStorage           mNetworkServiceStates CHIP_GUARDED_BY(mConnManMutex);
+    WiFiScanState                        mWiFiActiveScanState CHIP_GUARDED_BY(mConnManMutex);
+    Internal::WiFiKeyFixedBuffer         mWiFiConnectPassphrase;
+    WiFiScanState                        mWiFiConnectScanState CHIP_GUARDED_BY(mConnManMutex);
+    bool                                 mWiFiStationConnected;
+    ConnectivityManager::WiFiStationMode mWiFiStationMode;
+    System::Clock::Timeout               mWiFiStationReconnectInterval;
+    // clang-format on
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementConnMan.h
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <mutex>
+#include <optional>
 #include <utility>
 
 #include <gio/gio.h>
@@ -26,6 +27,7 @@
 #include <lib/core/Optional.h>
 #include <lib/support/FixedBuffer.h>
 #include <lib/support/Span.h>
+#include <platform/CHIPDeviceEvent.h>
 #include <platform/Linux/dbus/connman/DBusConnManAgent.h>
 #include <platform/Linux/dbus/connman/DBusConnManManager.h>
 #include <platform/Linux/dbus/connman/DBusConnManService.h>
@@ -64,9 +66,56 @@ struct GAutoPtrDeleter<ConnManTechnology>
 
 namespace DeviceLayer {
 
-// Forward Declarations
+namespace Platform {
 
-struct ChipDeviceEvent;
+namespace Linux {
+
+namespace Detail {
+
+/**
+ *  @brief
+ *    A connman network service failure, expressed in Matter terms.
+ *
+ *  connman's service "Error" property is a small, closed vocabulary
+ *  (see connman `service.c:error2string()`). Each value carries an
+ *  implicit claim about *how far* a connect request got, which
+ *  determines not merely which status to report but whether an
+ *  association failure occurred at all.
+ *
+ */
+struct ConnManServiceError
+{
+    /**
+     *  Status for `OnConnectResult`.
+     */
+    DeviceLayer::NetworkCommissioning::Status mStatus;
+
+    /**
+     *  Cause for `OnAssociationFailureDetected`.
+     */
+    app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCauseEnum mCause;
+
+    /**
+     *  IEEE 802.11 status code, or zero.
+     */
+    uint16_t mAssociationStatus;
+
+    /**
+     *  Whether to delegate to `OnAssociationFailureDetected` at all.
+     */
+    bool mIsAssociationFailure;
+
+    /**
+     *  Whether the connect operation has actually failed.
+     */
+    bool mIsTerminal;
+};
+
+} // namespace Detail
+
+} // namespace Linux
+
+} // namespace Platform
 
 /**
  *  Provides an implementation of the ConnectionManager object
@@ -408,7 +457,7 @@ private:
         size_t mCount;
     };
 
-    enum class WiFiScanTerminalKind : uint8_t
+    enum class WiFiScanCompletionKind : uint8_t
     {
         /**
          *  A Wi-Fi scan was for a connect and is terminating
@@ -433,8 +482,10 @@ private:
 
     // Introspection
 
+    bool HasWiFiClusterConnectPendingLocked() const noexcept;
     static bool IsFamilyConnectivityChangeReportable(const NetworkServiceFamilyConnectivityState & inPending,
                                                      const NetworkServiceFamilyConnectivityState & inReported) noexcept;
+    bool IsWiFiPendingConnectServicePathLocked(const char * inPath) const noexcept;
 
     // Observation
 
@@ -475,6 +526,10 @@ private:
     static CHIP_ERROR
     BuildWiFiScanResponseFromServicePropertiesLocked(GVariant * inProperties,
                                                      DeviceLayer::NetworkCommissioning::WiFiScanResponse & outResponse) noexcept;
+    CHIP_ERROR CompleteWiFiConnectLocked(std::unique_lock<std::mutex> & inOutLock,
+                                         DeviceLayer::NetworkCommissioning::Status inStatus, const CharSpan & inDebugText,
+                                         int32_t inReason) noexcept;
+    CHIP_ERROR ConcludeWiFiClusterConnectLocked() noexcept;
     CHIP_ERROR DispatchWiFiConnectFinishedLocked(std::unique_lock<std::mutex> & inOutLock,
                                                  DeviceLayer::NetworkCommissioning::Status inStatus, const CharSpan & inDebugText,
                                                  int32_t inReason) noexcept;
@@ -537,6 +592,10 @@ private:
                                                      ConnManTechnology * inTechnology) noexcept;
     CHIP_ERROR HandleWiFiPendingConnectLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
                                               WiFiScanState & inOutScanState) noexcept;
+    CHIP_ERROR HandleWiFiPendingConnectServiceErrorChangedLocked(const char * inPath, const char * inType,
+                                                                 GVariant * inValue) noexcept;
+    CHIP_ERROR HandleWiFiPendingConnectServiceStateChangedLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath,
+                                                                 const char * inType, GVariant * inValue) noexcept;
     CHIP_ERROR HandleWiFiPendingScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
                                            WiFiScanState & inOutScanState) noexcept;
     CHIP_ERROR HandleWiFiScanCompleteLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology) noexcept;
@@ -544,14 +603,17 @@ private:
                                          const char * inReason, WiFiScanState & inOutScanState) noexcept;
     CHIP_ERROR HandleWiFiUnresolvedAfterScanLocked(std::unique_lock<std::mutex> & inOutLock, ConnManTechnology * inTechnology,
                                                    WiFiScanState & inOutScanState, const size_t & inScanLimit,
-                                                   const char * inReason, WiFiScanTerminalKind inKind) noexcept;
+                                                   const char * inReason, WiFiScanCompletionKind inKind) noexcept;
     CHIP_ERROR ManagerAgentOpLocked(std::unique_lock<std::mutex> & inOutLock, const char * inPath,
                                     ManagerAgentOpFunc inManagerAgentOpFunc, const char * inAction,
                                     const bool & inRegister) noexcept;
     void MaybeClearInterfaceNameLocked(const char * inPath) noexcept;
     CHIP_ERROR MaybeSetInterfaceNameLocked(const char * inType, const char * inInterface) noexcept;
+    void NotifyWiFiConnectivityChange(ConnectivityChange inChange) noexcept;
     CHIP_ERROR RemoveServiceLocked(const char * inPath) noexcept;
     CHIP_ERROR RemoveTechnologyLocked(const char * inPath) noexcept;
+    void ScrubWiFiClientConnectPassphraseLocked() noexcept;
+    void ShutdownClientConnectSessionLocked(std::unique_lock<std::mutex> & inOutLock) noexcept;
     CHIP_ERROR StartNetworkManagementOnGLib() noexcept;
     CHIP_ERROR UpdateManagerPropertiesLocked(GVariant * inProperties) noexcept;
     CHIP_ERROR UpdateNetworkServiceConnectivityLocked() noexcept;
@@ -659,11 +721,29 @@ private:
     GDBusConnManAgent                    mConnManAgentServer CHIP_GUARDED_BY(mConnManMutex);
     ConnectivityManagerImpl *            mConnectivityManagerImpl;
     NetworkServiceStateStorage           mNetworkServiceStates CHIP_GUARDED_BY(mConnManMutex);
+
+    using ServiceError = Platform::Linux::Detail::ConnManServiceError;
+
     WiFiScanState                        mWiFiActiveScanState CHIP_GUARDED_BY(mConnManMutex);
-    Internal::WiFiKeyFixedBuffer         mWiFiConnectPassphrase;
-    WiFiScanState                        mWiFiConnectScanState CHIP_GUARDED_BY(mConnManMutex);
+    Internal::WiFiKeyFixedBuffer         mWiFiClientConnectPassphrase CHIP_GUARDED_BY(mConnManMutex);
+
+    /**
+     *  Whether the pending connect reached "association". Gates
+     *  `OnAssociationFailureDetected`.
+     */
+    bool                                 mWiFiClusterConnectAssociationStarted CHIP_GUARDED_BY(mConnManMutex);
+    bool                                 mWiFiClusterConnectPending CHIP_GUARDED_BY(mConnManMutex);
+    WiFiScanState                        mWiFiClusterConnectScanState CHIP_GUARDED_BY(mConnManMutex);
+    /**
+     *  Cause of the most recent failure on the pending connect's
+     *  service, latched from PropertyChanged("Error") (which connman
+     *  emits ahead of both PropertyChanged("State" = "failure") and
+     *  Agent.ReportError()). Cleared at the start of every connect
+     *  and by `ConcludeWiFiClusterConnectLocked`.
+     */
+    std::optional<ServiceError>          mWiFiClusterConnectServiceError CHIP_GUARDED_BY(mConnManMutex);
     bool                                 mWiFiStationConnected;
-    ConnectivityManager::WiFiStationMode mWiFiStationMode;
+    ConnectivityManager::WiFiStationMode mWiFiStationMode CHIP_GUARDED_BY(mConnManMutex);
     System::Clock::Timeout               mWiFiStationReconnectInterval;
     // clang-format on
 };

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementInterface.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementInterface.h
@@ -221,6 +221,21 @@ public:
      */
     virtual void StartWiFiManagement(void) = 0;
 
+    /**
+     *  @brief
+     *    Stop Wi-Fi management.
+     *
+     *  Stop the Wi-Fi management infrastructure for the device. This
+     *  may include terminating any event subscriptions, detaching
+     *  from or stopping an external network manager, and releasing
+     *  associated resources.
+     *
+     *  @sa IsWiFiManagementStarted
+     *  @sa StartWiFiManagement
+     *
+     */
+    virtual void StopWiFiManagement(void) = 0;
+
     // Wi-Fi Station Control Plane Management
 
     // Introspection

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -17,6 +17,8 @@
  *    limitations under the License.
  */
 
+#include "ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h"
+
 #include <mutex>
 
 #include <ifaddrs.h>
@@ -37,7 +39,6 @@
 #include "ConnectivityUtils.h"
 #include "NetworkCommissioningDriver.h"
 #include "WirelessDefs.h"
-#include "WpaSupplicantClient.h"
 
 using namespace ::chip;
 using namespace ::chip::Credentials;
@@ -51,71 +52,152 @@ namespace chip {
 namespace DeviceLayer {
 namespace {
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-/*
-During stress tests  we observed a maximum of 5 retries to be enough for successful
-connection in all cases outside of a few outliers. Adding +50% more retries for headroom
-we set the number to 8.
-*/
-constexpr unsigned int kWpaAssocMaxRetries = 8;
+// Global Variables
 
-static constexpr char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
-static constexpr char kWpaSupplicantObjectPath[]  = "/fi/w1/wpa_supplicant1";
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 static constexpr char kWpaSupplicantBlobUnknown[] = "fi.w1.wpa_supplicant1.BlobUnknown";
+
+// Note: Static blob names assume we're only supporting a single network configuration.
+static constexpr char kNetworkIdentityBlobRef[]   = "blob://pdc-ni";
+static constexpr char kClientIdentityBlobRef[]    = "blob://pdc-ci";
+static constexpr char kClientIdentityKeyBlobRef[] = "blob://pdc-cik";
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+
+// Function and Method Implementation
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+static CHIP_ERROR AddOrReplaceBlob(WpaSupplicant1Interface * iface, const char * nameOrRef, ByteSpan data) noexcept
+{
+    // Strip the blob:// prefix off the name (if present), so we don't need as many string constants.
+    constexpr auto refPrefix = "blob://"_span;
+    const char * name = (strncmp(nameOrRef, refPrefix.data(), refPrefix.size()) == 0) ? nameOrRef + refPrefix.size() : nameOrRef;
+
+    GAutoPtr<GError> err;
+    if (!wpa_supplicant_1_interface_call_remove_blob_sync(iface, name, nullptr, &err.GetReceiver()))
+    {
+        GCharPtr remoteError(g_dbus_error_get_remote_error(err.get()));
+        if (!(remoteError && strcmp(remoteError.get(), kWpaSupplicantBlobUnknown) == 0))
+        {
+            ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to remove blob: %s",
+                         err ? err->message : "unknown error");
+            return CHIP_ERROR_INTERNAL;
+        }
+        err.reset();
+    }
+    if (!wpa_supplicant_1_interface_call_add_blob_sync(
+            iface, name, g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, data.data(), data.size(), 1), nullptr, &err.GetReceiver()))
+    {
+        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to add blob: %s", err ? err->message : "unknown error");
+        return CHIP_ERROR_INTERNAL;
+    }
+    return CHIP_NO_ERROR;
+}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 
 } // namespace
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+// Function and Method Implementation
 
-ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
+// Matter Linux Connectivity Manager Implementation for wpa_supplicant
+
+// Intialization
+
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::Init(ConnectivityManagerImpl & inConnectivityManagerImpl)
 {
-    if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
+    char wifi_ifname[Inet::InterfaceId::kMaxIfNameLength];
+
+    VerifyOrReturnError(mConnectivityManagerImpl == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
+
+    // Initialize the base network management class.
+
+    ReturnErrorOnFailure(NetworkManagementBasis::Init());
+
+    // Initialize the base wpa_supplicant class.
+
+    ReturnErrorOnFailure(WpaSupplicantClient::Init(inConnectivityManagerImpl));
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    if (ConnectivityUtils::GetEthInterfaceName(mEthernetIfName, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(DeviceLayer, "Got Ethernet interface: %s", mEthernetIfName);
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get Ethernet interface");
+        mEthernetIfName[0] = '\0';
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    if (ConnectivityUtils::GetWiFiInterfaceName(wifi_ifname, Inet::InterfaceId::kMaxIfNameLength) == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(DeviceLayer, "Got WiFi interface: %s", wifi_ifname);
+
+        ReturnErrorOnFailure(WpaSupplicantClient::SetIfName(CharSpan(&wifi_ifname[0], strlen(wifi_ifname))));
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get WiFi interface");
+    }
+#endif
+
+    mConnectivityManagerImpl = &inConnectivityManagerImpl;
+
+    return CHIP_NO_ERROR;
+}
+
+// Event Handling
+
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) {}
+
+ConnectivityManager::WiFiStationMode ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiStationMode()
+{
+    if (mWiFiStationMode != ConnectivityManager::kWiFiStationMode_ApplicationControlled)
     {
         std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-        mWiFiStationMode = mWpaSupplicant.iface ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
+        mWiFiStationMode = IsWiFiManagementStarted() ? ConnectivityManager::kWiFiStationMode_Enabled
+                                                     : ConnectivityManager::kWiFiStationMode_Disabled;
     }
 
     return mWiFiStationMode;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(ConnectivityManager::WiFiStationMode val)
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::SetWiFiStationMode(
+    const ConnectivityManager::WiFiStationMode & inWiFiStationMode)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrReturnError(inWiFiStationMode != ConnectivityManager::kWiFiStationMode_NotSupported, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(val != ConnectivityManager::kWiFiStationMode_NotSupported, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    if (mWiFiStationMode != val)
+    if (mWiFiStationMode != inWiFiStationMode)
     {
-        ChipLogProgress(DeviceLayer, "WiFi station mode change: %s -> %s", WiFiStationModeToStr(mWiFiStationMode),
-                        WiFiStationModeToStr(val));
+        ChipLogProgress(DeviceLayer, "WiFi station mode change: %s -> %s",
+                        ConnectivityManager::WiFiStationModeToStr(mWiFiStationMode),
+                        ConnectivityManager::WiFiStationModeToStr(inWiFiStationMode));
     }
 
-    mWiFiStationMode = val;
-exit:
-    return err;
-}
-
-System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectInterval()
-{
-    return mWiFiStationReconnectInterval;
-}
-
-CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationReconnectInterval(System::Clock::Timeout val)
-{
-    mWiFiStationReconnectInterval = val;
+    mWiFiStationMode = inWiFiStationMode;
 
     return CHIP_NO_ERROR;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationEnabled()
+System::Clock::Timeout ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiStationReconnectInterval()
 {
-    return GetWiFiStationMode() == kWiFiStationMode_Enabled;
+    return mWiFiStationReconnectInterval;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationConnected()
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementWpaSupplicant::SetWiFiStationReconnectInterval(const System::Clock::Timeout & inInterval)
+{
+    mWiFiStationReconnectInterval = inInterval;
+
+    return CHIP_NO_ERROR;
+}
+
+bool ConnectivityManagerImpl_NetworkManagementWpaSupplicant::IsWiFiStationEnabled()
+{
+    return GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Enabled;
+}
+
+bool ConnectivityManagerImpl_NetworkManagementWpaSupplicant::IsWiFiStationConnected()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -125,12 +207,12 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
     return g_strcmp0(state.get(), "completed") == 0;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
+bool ConnectivityManagerImpl_NetworkManagementWpaSupplicant::IsWiFiStationApplicationControlled()
 {
     return mWiFiStationMode == ConnectivityManager::kWiFiStationMode_ApplicationControlled;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
+bool ConnectivityManagerImpl_NetworkManagementWpaSupplicant::IsWiFiStationProvisioned()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -153,12 +235,12 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
     return g_variant_n_children(networks.get()) > 0;
 }
 
-void ConnectivityManagerImpl::_ClearWiFiStationProvision()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ClearWiFiStationProvision()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     VerifyOrReturn(mWpaSupplicant.iface);
-    VerifyOrReturn(mWiFiStationMode != kWiFiStationMode_ApplicationControlled);
+    VerifyOrReturn(mWiFiStationMode != ConnectivityManager::kWiFiStationMode_ApplicationControlled);
 
     GAutoPtr<GError> err;
     if (!wpa_supplicant_1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface.get(), nullptr, &err.GetReceiver()))
@@ -167,480 +249,139 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
-bool ConnectivityManagerImpl::_IsWiFiAPActive()
-{
-    return mWiFiAPState == kWiFiAPState_Active;
-}
-
-bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
-{
-    return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
-}
-
-System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
-{
-    return mWiFiAPIdleTimeout;
-}
-
-ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
+ConnectivityManager::WiFiAPMode ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiApMode()
 {
     return mWiFiAPMode;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
+CHIP_ERROR
+ConnectivityManagerImpl_NetworkManagementWpaSupplicant::SetWiFiApMode(const ConnectivityManager::WiFiAPMode & inWiFiApMode)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrReturnError(inWiFiApMode != ConnectivityManager::kWiFiAPMode_NotSupported, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(val != kWiFiAPMode_NotSupported, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    if (mWiFiAPMode != val)
+    if (mWiFiAPMode != inWiFiApMode)
     {
-        ChipLogProgress(DeviceLayer, "WiFi AP mode change: %s -> %s", WiFiAPModeToStr(mWiFiAPMode), WiFiAPModeToStr(val));
-        mWiFiAPMode = val;
+        ChipLogProgress(DeviceLayer, "WiFi AP mode change: %s -> %s", ConnectivityManager::WiFiAPModeToStr(mWiFiAPMode),
+                        ConnectivityManager::WiFiAPModeToStr(inWiFiApMode));
 
-        return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
+        mWiFiAPMode = inWiFiApMode;
+
+        return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveApState(); });
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
-void ConnectivityManagerImpl::_DemandStartWiFiAP()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::DemandStartWiFiAp()
 {
-    if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
+    if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand ||
+        mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision)
     {
         ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Demand start WiFi AP");
         mLastAPDemandTime = System::SystemClock().GetMonotonicTimestamp();
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveApState(); });
     }
     else
     {
         ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Demand start WiFi AP ignored, mode: %s",
-                        WiFiAPModeToStr(mWiFiAPMode));
+                        ConnectivityManager::WiFiAPModeToStr(mWiFiAPMode));
     }
 }
 
-void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::StopOnDemandWiFiAp()
 {
-    if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
+    if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand ||
+        mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision)
     {
         ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Demand stop WiFi AP");
         mLastAPDemandTime = System::Clock::kZero;
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
+        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveApState(); });
     }
     else
     {
         ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Demand stop WiFi AP ignored, mode: %s",
-                        WiFiAPModeToStr(mWiFiAPMode));
+                        ConnectivityManager::WiFiAPModeToStr(mWiFiAPMode));
     }
 }
 
-void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::MaintainOnDemandWiFiAp()
 {
-    if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
+    if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand ||
+        mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        if (mWiFiAPState == kWiFiAPState_Active)
+        if (mWiFiAPState == ConnectivityManager::kWiFiAPState_Active)
         {
             mLastAPDemandTime = System::SystemClock().GetMonotonicTimestamp();
         }
     }
 }
 
-void ConnectivityManagerImpl::_SetWiFiAPIdleTimeout(System::Clock::Timeout val)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::SetWiFiApIdleTimeout(const System::Clock::Timeout & inTimeout)
 {
-    mWiFiAPIdleTimeout = val;
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
+    mWiFiAPIdleTimeout = inTimeout;
+    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveApState(); });
 }
 
-void ConnectivityManagerImpl::NotifyWiFiConnectivityChange(ConnectivityChange change)
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+// Ethernet Control Plane Management
+
+const char * ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetEthernetIfName()
 {
-    ChipDeviceEvent event{ .Type = DeviceEventType::kWiFiConnectivityChange, .WiFiConnectivityChange = { .Result = change } };
-    PlatformMgr().PostEventOrDie(&event);
+    return (mEthernetIfName[0] == '\0') ? nullptr : mEthernetIfName;
 }
 
-void ConnectivityManagerImpl::UpdateNetworkStatus()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::UpdateEthernetNetworkingStatus()
 {
-    Network configuredNetwork;
+    VerifyOrReturn(mConnectivityManagerImpl != nullptr);
 
-    VerifyOrReturn(IsWiFiStationEnabled());
-
-    CHIP_ERROR err = WpaSupplicantClient::GetConfiguredNetwork(configuredNetwork);
-    if (err != CHIP_NO_ERROR)
+    if (mEthernetIfName[0] != '\0')
     {
-        ChipLogError(DeviceLayer, "Failed to get configured network when updating network status: %s", err.AsString());
-        return;
-    }
-
-    // If we have already connected to the WiFi AP, then return null to indicate a success state.
-    if (IsWiFiStationConnected())
-    {
-        OnStatusChange(Status::kSuccess, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
-                       NullOptional);
-        return;
-    }
-
-    OnStatusChange(Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
-                   MakeOptional(GetDisconnectReason()));
-}
-
-void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaSupplicant1Interface * iface, GVariant * changedProperties)
-{
-    const char * state = nullptr;
-    // We are only interested in the "State" property changes.
-    VerifyOrReturn(g_variant_lookup(changedProperties, "State", "&s", &state));
-
-    WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
-
-    ChipLogDetail(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Interface properties changed, state is '%s'", state);
-
-    if (g_strcmp0(state, "associating") == 0)
-    {
-        mAssociationStarted = true;
-    }
-    else if (g_strcmp0(state, "disconnected") == 0)
-    {
-        int reason = wpa_supplicant_1_interface_get_disconnect_reason(iface);
-
-        ChipLogDetail(DeviceLayer,
-                      WPA_SUPPLICANT_CLIENT_LOG_PREFIX
-                      "Disconnected with reason code=%d, assoc status code=%d, auth status code=%d (associationStarted=%d)",
-                      reason, wpa_supplicant_1_interface_get_assoc_status_code(iface),
-                      wpa_supplicant_1_interface_get_auth_status_code(iface), mAssociationStarted);
-
-        if (delegate != nullptr)
-        {
-            TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([delegate, reason]() {
-                delegate->OnDisconnectionDetected(reason);
-                delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kNotConnected));
-            });
-        }
-
-        if (mAssociationStarted)
-        {
-            uint8_t associationFailureCause = static_cast<uint8_t>(AssociationFailureCauseEnum::kUnknown);
-            uint16_t status                 = WLAN_STATUS_UNSPECIFIED_FAILURE;
-
-            if (wpa_supplicant_1_interface_get_assoc_status_code(iface) == WLAN_STATUS_AUTH_TIMEOUT)
-            {
-                std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-                /* Handle intermittent association failures */
-                if (mAssociationRetriesLeft > 0)
-                {
-                    mAssociationRetriesLeft--;
-                    ChipLogDetail(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Association timeout, %u retries left",
-                                  mAssociationRetriesLeft);
-
-                    mAssociationStarted = false;
-
-                    GAutoPtr<GError> err;
-                    if (!wpa_supplicant_1_interface_call_select_network_sync(
-                            mWpaSupplicant.iface.get(), mWpaSupplicant.networkPath.get(), nullptr, &err.GetReceiver()))
-                    {
-                        // Fallthrough to existing error handling code as we could not retry.
-                        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to select network: '%s'", err->message);
-                    }
-                    else
-                    {
-                        // Skip existing error handling code to not report error too early to the network commissioning cluster.
-                        return;
-                    }
-                }
-            }
-
-            switch (abs(reason))
-            {
-            case WLAN_REASON_DISASSOC_DUE_TO_INACTIVITY:
-            case WLAN_REASON_DISASSOC_AP_BUSY:
-            case WLAN_REASON_DISASSOC_STA_HAS_LEFT:
-            case WLAN_REASON_DISASSOC_LOW_ACK:
-            case WLAN_REASON_BSS_TRANSITION_DISASSOC:
-                associationFailureCause = static_cast<uint8_t>(AssociationFailureCauseEnum::kAssociationFailed);
-                status                  = wpa_supplicant_1_interface_get_assoc_status_code(iface);
-                break;
-            case WLAN_REASON_PREV_AUTH_NOT_VALID:
-            case WLAN_REASON_DEAUTH_LEAVING:
-            case WLAN_REASON_IEEE_802_1X_AUTH_FAILED:
-                associationFailureCause = static_cast<uint8_t>(AssociationFailureCauseEnum::kAuthenticationFailed);
-                status                  = wpa_supplicant_1_interface_get_auth_status_code(iface);
-                break;
-            default:
-                break;
-            }
-
-            TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda(
-                [this, reason]() { OnConnectResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), reason); });
-            if (delegate != nullptr)
-            {
-                TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([delegate, associationFailureCause, status]() {
-                    delegate->OnAssociationFailureDetected(associationFailureCause, status);
-                });
-            }
-        }
-
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
-        NotifyWiFiConnectivityChange(kConnectivity_Lost);
-
-        mAssociationStarted = false;
-    }
-    else if (g_strcmp0(state, "associated") == 0)
-    {
-        if (delegate != nullptr)
-        {
-            TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda(
-                [delegate]() { delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected)); });
-        }
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
-    }
-    else if (g_strcmp0(state, "completed") == 0)
-    {
-        if (mAssociationStarted)
-        {
-            TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this]() {
-                OnConnectResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
-                ConnectivityMgrImpl().PostNetworkConnect();
-            });
-        }
-        NotifyWiFiConnectivityChange(kConnectivity_Established);
-        mAssociationStarted = false;
+        ByteSpan ifNameSpan(reinterpret_cast<unsigned char *>(mEthernetIfName),
+                            strnlen(mEthernetIfName, Inet::InterfaceId::kMaxIfNameLength));
+        mConnectivityManagerImpl->OnStatusChange(Status::kSuccess, MakeOptional(ifNameSpan), NullOptional);
     }
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
 
-void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res)
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+// Wi-Fi Control Plane Management
+
+// Observation
+
+const char * ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiIfName()
 {
-    // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
-    // all D-Bus signals will be delivered to the GLib global default main context.
-    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+    CharSpan ifname;
+    CHIP_ERROR status;
+    const char * retval = nullptr;
 
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    status = WpaSupplicantClient::GetIfName(ifname);
+    SuccessOrExit(status);
 
-    GAutoPtr<GError> err;
-    mWpaSupplicant.iface.reset(wpa_supplicant_1_interface_proxy_new_for_bus_finish(res, &err.GetReceiver()));
-    if (mWpaSupplicant.iface && err == nullptr)
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "connected to interface proxy");
+    retval = ifname.data();
 
-        g_signal_connect(
-            mWpaSupplicant.iface.get(), "g-properties-changed",
-            G_CALLBACK(+[](WpaSupplicant1Interface * iface, GVariant * properties, const char * const * invalidatedProps,
-                           ConnectivityManagerImpl * self) { return self->_OnWpaPropertiesChanged(iface, properties); }),
-            this);
+exit:
+    return retval;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-        g_signal_connect(mWpaSupplicant.iface.get(), "scan-done",
-                         G_CALLBACK(+[](WpaSupplicant1Interface * iface, gboolean success, ConnectivityManagerImpl * self) {
-                             return self->_OnWpaInterfaceScanDone(iface, success);
-                         }),
-                         this);
-        PostWpaInterfaceProxyReady();
-    }
-    else
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to create interface proxy %s: %s",
-                        mWpaSupplicant.interfacePath.get(), err ? err->message : "unknown error");
-    }
+// Observation
 
-    // We need to stop auto scan or it will block our network scan.
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this]() {
-        CHIP_ERROR errInner = StopAutoScan();
-        if (errInner != CHIP_NO_ERROR)
-        {
-            ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to stop auto scan: %" CHIP_ERROR_FORMAT,
-                         errInner.Format());
-        }
-    });
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::StartWiFiManagement()
+{
+    WpaSupplicantClient::Start();
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::StopWiFiManagement()
 {
-    // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
-    // all D-Bus signals will be delivered to the GLib global default main context.
-    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
-
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    GAutoPtr<GError> err;
-    if (wpa_supplicant_1_call_get_interface_finish(mWpaSupplicant.proxy.get(), &mWpaSupplicant.interfacePath.GetReceiver(), res,
-                                                   &err.GetReceiver()))
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "WiFi interface: %s", mWpaSupplicant.interfacePath.get());
-
-        wpa_supplicant_1_interface_proxy_new_for_bus(
-            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath.get(), nullptr,
-            reinterpret_cast<GAsyncReadyCallback>(
-                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
-                    return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
-                }),
-            this);
-    }
-    else
-    {
-        GVariant * args = nullptr;
-        GVariantBuilder builder;
-
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "can't find interface %s: %s", sWiFiIfName,
-                        err ? err->message : "unknown error");
-
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "try to create interface %s",
-                        CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
-
-        g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
-        g_variant_builder_add(&builder, "{sv}", "Ifname", g_variant_new_string(CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME));
-        args = g_variant_builder_end(&builder);
-
-        err.reset();
-        if (wpa_supplicant_1_call_create_interface_sync(mWpaSupplicant.proxy.get(), args,
-                                                        &mWpaSupplicant.interfacePath.GetReceiver(), nullptr, &err.GetReceiver()))
-        {
-            ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "WiFi interface: %s", mWpaSupplicant.interfacePath.get());
-
-            Platform::CopyString(sWiFiIfName, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
-
-            wpa_supplicant_1_interface_proxy_new_for_bus(
-                G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath.get(), nullptr,
-                reinterpret_cast<GAsyncReadyCallback>(
-                    +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
-                        return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
-                    }),
-                this);
-        }
-        else
-        {
-            ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to create interface %s: %s",
-                            CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, err ? err->message : "unknown error");
-            mWpaSupplicant.interfacePath.reset();
-        }
-    }
+    WpaSupplicantClient::Reset();
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const char * path, GVariant * properties)
-{
-    // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
-    // all D-Bus signals will be delivered to the GLib global default main context.
-    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
-
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    if (mWpaSupplicant.interfacePath)
-    {
-        return;
-    }
-
-    mWpaSupplicant.interfacePath.reset(g_strdup(path));
-    if (mWpaSupplicant.interfacePath)
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "WiFi interface added: %s",
-                        mWpaSupplicant.interfacePath.get());
-        wpa_supplicant_1_interface_proxy_new_for_bus(
-            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath.get(), nullptr,
-            reinterpret_cast<GAsyncReadyCallback>(
-                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
-                    return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
-                }),
-            this);
-    }
-}
-
-void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path)
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    if (g_strcmp0(mWpaSupplicant.interfacePath.get(), path) == 0)
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "WiFi interface removed: %s", StringOrNullMarker(path));
-        mWpaSupplicant.interfacePath.reset();
-        mWpaSupplicant.iface.reset();
-    }
-}
-
-void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res)
-{
-    // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
-    // all D-Bus signals will be delivered to the GLib global default main context.
-    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
-
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    GAutoPtr<GError> err;
-    mWpaSupplicant.proxy.reset(wpa_supplicant_1_proxy_new_for_bus_finish(res, &err.GetReceiver()));
-    if (mWpaSupplicant.proxy && err.get() == nullptr)
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "connected to proxy");
-
-        g_signal_connect(
-            mWpaSupplicant.proxy.get(), "interface-added",
-            G_CALLBACK(+[](WpaSupplicant1 * proxy, const char * path, GVariant * properties, ConnectivityManagerImpl * self) {
-                return self->_OnWpaInterfaceAdded(proxy, path, properties);
-            }),
-            this);
-        g_signal_connect(mWpaSupplicant.proxy.get(), "interface-removed",
-                         G_CALLBACK(+[](WpaSupplicant1 * proxy, const char * path, ConnectivityManagerImpl * self) {
-                             return self->_OnWpaInterfaceRemoved(proxy, path);
-                         }),
-                         this);
-
-        wpa_supplicant_1_call_get_interface(mWpaSupplicant.proxy.get(), sWiFiIfName, nullptr,
-                                            reinterpret_cast<GAsyncReadyCallback>(
-                                                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
-                                                    return self->_OnWpaInterfaceReady(sourceObject_, res_);
-                                                }),
-                                            this);
-    }
-    else
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to create proxy %s",
-                        err ? err->message : "unknown error");
-    }
-}
-
-void ConnectivityManagerImpl::StartWiFiManagement()
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    mWpaSupplicant = GDBusWpaSupplicant{};
-
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ConnectivityManagerImpl * self) { return self->_StartWiFiManagement(); }, this);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start WiFi management"));
-}
-
-void ConnectivityManagerImpl::StopWiFiManagement()
-{
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ConnectivityManagerImpl * self) { return self->_StopWiFiManagement(); }, this);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to stop WiFi management"));
-}
-
-CHIP_ERROR ConnectivityManagerImpl::StartWiFiManagementSync()
-{
-    if (IsWiFiManagementStarted())
-    {
-        return CHIP_NO_ERROR;
-    }
-    ChipLogProgress(DeviceLayer, "Start and sync Wi-Fi Management.");
-    static constexpr useconds_t kWiFiStartCheckTimeUsec = WIFI_START_CHECK_TIME_USEC;
-    static constexpr uint8_t kWiFiStartCheckAttempts    = WIFI_START_CHECK_ATTEMPTS;
-    StartWiFiManagement();
-    for (int cnt = 0; cnt < kWiFiStartCheckAttempts; cnt++)
-    {
-        if (IsWiFiManagementStarted())
-        {
-            break;
-        }
-        usleep(kWiFiStartCheckTimeUsec);
-    }
-    if (!IsWiFiManagementStarted())
-    {
-        ChipLogError(DeviceLayer, "Wi-Fi Management can't be started.");
-        return CHIP_ERROR_INTERNAL;
-    }
-    ChipLogProgress(DeviceLayer, "Wi-Fi Management is started");
-    return CHIP_NO_ERROR;
-}
-
-bool ConnectivityManagerImpl::IsWiFiManagementStarted()
+bool ConnectivityManagerImpl_NetworkManagementWpaSupplicant::IsWiFiManagementStarted()
 {
     return WpaSupplicantClient::IsStarted();
 }
 
-void ConnectivityManagerImpl::StartNonConcurrentWiFiManagement()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::StartNonConcurrentWiFiManagement()
 {
     StartWiFiManagement();
 
@@ -657,78 +398,79 @@ void ConnectivityManagerImpl::StartNonConcurrentWiFiManagement()
     ChipLogError(Ble, "Non-concurrent mode Wi-Fi Management taking too long to start.");
 }
 
-void ConnectivityManagerImpl::DriveAPState()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::DriveApState()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    WiFiAPState targetState;
+    ConnectivityManager::WiFiAPState targetState;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     // If the AP interface is not under application control...
-    if (mWiFiAPMode != kWiFiAPMode_ApplicationControlled)
+    if (mWiFiAPMode != ConnectivityManager::kWiFiAPMode_ApplicationControlled)
     {
         // Determine the target (desired) state for AP interface...
 
         // The target state is 'NotActive' if the application has expressly disabled the AP interface.
-        if (mWiFiAPMode == kWiFiAPMode_Disabled)
+        if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_Disabled)
         {
-            targetState = kWiFiAPState_NotActive;
+            targetState = ConnectivityManager::kWiFiAPState_NotActive;
         }
 
         // The target state is 'Active' if the application has expressly enabled the AP interface.
-        else if (mWiFiAPMode == kWiFiAPMode_Enabled)
+        else if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_Enabled)
         {
-            targetState = kWiFiAPState_Active;
+            targetState = ConnectivityManager::kWiFiAPState_Active;
         }
 
         // The target state is 'Active' if the AP mode is 'On demand, when no station is available'
         // and the station interface is not provisioned or the application has disabled the station
         // interface.
-        else if (mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision &&
-                 (!IsWiFiStationProvisioned() || GetWiFiStationMode() == kWiFiStationMode_Disabled))
+        else if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision &&
+                 (!IsWiFiStationProvisioned() || GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Disabled))
         {
-            targetState = kWiFiAPState_Active;
+            targetState = ConnectivityManager::kWiFiAPState_Active;
         }
 
         // The target state is 'Active' if the AP mode is one of the 'On demand' modes and there
         // has been demand for the AP within the idle timeout period.
-        else if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
+        else if (mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand ||
+                 mWiFiAPMode == ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision)
         {
             System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
             if (mLastAPDemandTime != System::Clock::kZero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
             {
-                targetState = kWiFiAPState_Active;
+                targetState = ConnectivityManager::kWiFiAPState_Active;
 
                 // Compute the amount of idle time before the AP should be deactivated and
                 // arm a timer to fire at that time.
                 System::Clock::Timeout apTimeout = (mLastAPDemandTime + mWiFiAPIdleTimeout) - now;
-                err                              = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, this);
+                err                              = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveApState, this);
                 SuccessOrExit(err);
                 ChipLogProgress(DeviceLayer, "Next WiFi AP timeout in %" PRIu32 " s",
                                 std::chrono::duration_cast<System::Clock::Seconds32>(apTimeout).count());
             }
             else
             {
-                targetState = kWiFiAPState_NotActive;
+                targetState = ConnectivityManager::kWiFiAPState_NotActive;
             }
         }
 
         // Otherwise the target state is 'NotActive'.
         else
         {
-            targetState = kWiFiAPState_NotActive;
+            targetState = ConnectivityManager::kWiFiAPState_NotActive;
         }
 
         // If the current AP state does not match the target state...
         if (mWiFiAPState != targetState)
         {
-            if (targetState == kWiFiAPState_Active)
+            if (targetState == ConnectivityManager::kWiFiAPState_Active)
             {
-                err = ConfigureWiFiAP();
+                err = ConfigureWiFiAp();
                 SuccessOrExit(err);
 
-                ChangeWiFiAPState(kWiFiAPState_Active);
+                ChangeWiFiApState(ConnectivityManager::kWiFiAPState_Active);
             }
             else
             {
@@ -740,7 +482,7 @@ void ConnectivityManagerImpl::DriveAPState()
                     {
                         ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "removed network: %s",
                                         mWpaSupplicant.networkPath.get());
-                        ChangeWiFiAPState(kWiFiAPState_NotActive);
+                        ChangeWiFiApState(ConnectivityManager::kWiFiAPState_NotActive);
                         mWpaSupplicant.networkPath.reset();
                     }
                     else
@@ -757,12 +499,12 @@ void ConnectivityManagerImpl::DriveAPState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        TEMPORARY_RETURN_IGNORED SetWiFiAPMode(kWiFiAPMode_Disabled);
+        TEMPORARY_RETURN_IGNORED SetWiFiApMode(ConnectivityManager::kWiFiAPMode_Disabled);
         ChipLogError(DeviceLayer, "Drive AP state failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
-CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ConfigureWiFiAp()
 {
     CHIP_ERROR ret = CHIP_NO_ERROR;
     GAutoPtr<GError> err;
@@ -821,25 +563,25 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     return ret;
 }
 
-void ConnectivityManagerImpl::ChangeWiFiAPState(WiFiAPState newState)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ChangeWiFiApState(const ConnectivityManager::WiFiAPState & newState)
 {
     if (mWiFiAPState != newState)
     {
-        ChipLogProgress(DeviceLayer, "WiFi AP state change: %s -> %s", WiFiAPStateToStr(mWiFiAPState), WiFiAPStateToStr(newState));
+        ChipLogProgress(DeviceLayer, "WiFi AP state change: %s -> %s", ConnectivityManager::WiFiAPStateToStr(mWiFiAPState),
+                        ConnectivityManager::WiFiAPStateToStr(newState));
         mWiFiAPState = newState;
     }
 }
 
-void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::DriveApState(::chip::System::Layer * aLayer, void * aAppState)
 {
-    reinterpret_cast<ConnectivityManagerImpl *>(aAppState)->DriveAPState();
+    reinterpret_cast<ConnectivityManagerImpl_NetworkManagementWpaSupplicant *>(aAppState)->DriveApState();
 }
 
-CHIP_ERROR
-ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
-                                                  NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback)
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ConnectWiFiNetworkAsyncLocked(
+    GVariant * inArguments, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) noexcept
 {
-    GAutoPtr<GVariant> argsDeleter(g_variant_ref_sink(args)); // args may be floating, ensure we don't leak it
+    GAutoPtr<GVariant> argsDeleter(g_variant_ref_sink(inArguments)); // args may be floating, ensure we don't leak it
     GAutoPtr<GError> err;
 
     VerifyOrReturnError(WpaSupplicantClient::IsWiFiInterfaceEnabled(), CHIP_ERROR_INCORRECT_STATE,
@@ -863,18 +605,14 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
         }
     }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mPafChannelAvailable = false;
-#endif
+    OnWiFiMediumAvailable(*this, false);
 
-    if (!wpa_supplicant_1_interface_call_add_network_sync(mWpaSupplicant.iface.get(), args,
+    if (!wpa_supplicant_1_interface_call_add_network_sync(mWpaSupplicant.iface.get(), inArguments,
                                                           &mWpaSupplicant.networkPath.GetReceiver(), nullptr, &err.GetReceiver()))
     {
         ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to add network: %s", err->message);
         mWpaSupplicant.networkPath.reset();
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        mPafChannelAvailable = true;
-#endif
+        OnWiFiMediumAvailable(*this, true);
         return CHIP_ERROR_INTERNAL;
     }
 
@@ -894,15 +632,15 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
     }
 
     // Network was provisioned successfully - emit a connectivity change event so the application can update its state.
-    NotifyWiFiConnectivityChange(kConnectivity_NoChange);
+    WpaSupplicantClient::NotifyWiFiConnectivityChange(kConnectivity_NoChange);
 
-    SetOneShotConnectCallback(apCallback);
+    mConnectivityManagerImpl->SetOneShotConnectCallback(inConnectCallback);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR
-ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credentials,
-                                                 NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
+ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ConnectWiFiNetworkAsync(
+    ByteSpan ssid, ByteSpan credentials, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
 {
     char ssidStr[kMaxWiFiSSIDLength + 1] = { 0 };
     char keyStr[kMaxWiFiKeyLength + 1]   = { 0 };
@@ -914,7 +652,7 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
 
     // There is another ongoing connect request, reject the new one.
-    VerifyOrReturnError(!IsWiFiStationConnecting(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(!mConnectivityManagerImpl->IsWiFiStationConnecting(), CHIP_ERROR_INCORRECT_STATE);
 
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
@@ -924,53 +662,23 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     g_variant_builder_add(&builder, "{sv}", "psk", g_variant_new_string(keyStr));
     g_variant_builder_add(&builder, "{sv}", "key_mgmt", g_variant_new_string("SAE WPA-PSK"));
     GVariant * args = g_variant_builder_end(&builder);
-    return _ConnectWiFiNetworkAsync(args, connectCallback);
+    return ConnectWiFiNetworkAsyncLocked(args, connectCallback);
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
-static CHIP_ERROR AddOrReplaceBlob(WpaSupplicant1Interface * iface, const char * nameOrRef, ByteSpan data)
-{
-    // Strip the blob:// prefix off the name (if present), so we don't need as many string constants.
-    constexpr auto refPrefix = "blob://"_span;
-    const char * name = (strncmp(nameOrRef, refPrefix.data(), refPrefix.size()) == 0) ? nameOrRef + refPrefix.size() : nameOrRef;
-
-    GAutoPtr<GError> err;
-    if (!wpa_supplicant_1_interface_call_remove_blob_sync(iface, name, nullptr, &err.GetReceiver()))
-    {
-        GCharPtr remoteError(g_dbus_error_get_remote_error(err.get()));
-        if (!(remoteError && strcmp(remoteError.get(), kWpaSupplicantBlobUnknown) == 0))
-        {
-            ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to remove blob: %s",
-                         err ? err->message : "unknown error");
-            return CHIP_ERROR_INTERNAL;
-        }
-        err.reset();
-    }
-    if (!wpa_supplicant_1_interface_call_add_blob_sync(
-            iface, name, g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, data.data(), data.size(), 1), nullptr, &err.GetReceiver()))
-    {
-        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to add blob: %s", err ? err->message : "unknown error");
-        return CHIP_ERROR_INTERNAL;
-    }
-    return CHIP_NO_ERROR;
-}
-
-// Note: Static blob names assume we're only supporting a single network configuration.
-static constexpr char kNetworkIdentityBlobRef[]   = "blob://pdc-ni";
-static constexpr char kClientIdentityBlobRef[]    = "blob://pdc-ci";
-static constexpr char kClientIdentityKeyBlobRef[] = "blob://pdc-cik";
-
-CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkWithPDCAsync(
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::ConnectWiFiNetworkWithPDCAsync(
     ByteSpan ssid, ByteSpan networkIdentity, ByteSpan clientIdentity, const Crypto::P256Keypair & clientIdentityKeypair,
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+    VerifyOrReturnError(mConnectivityManagerImpl != nullptr, CHIP_ERROR_UNINITIALIZED);
+
     VerifyOrReturnError(ssid.size() <= kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
     VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
 
     // There is another ongoing connect request, reject the new one.
-    VerifyOrReturnError(!IsWiFiStationConnecting(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(!mConnectivityManagerImpl->IsWiFiStationConnecting(), CHIP_ERROR_INCORRECT_STATE);
 
     // Convert identities and our key pair to DER and add them to wpa_supplicant as blobs
     {
@@ -1036,12 +744,20 @@ CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkWithPDCAsync(
     g_variant_builder_add(&builder, "{sv}", "client_cert", g_variant_new_string(kClientIdentityBlobRef));
     g_variant_builder_add(&builder, "{sv}", "private_key", g_variant_new_string(kClientIdentityKeyBlobRef));
     GVariant * args = g_variant_builder_end(&builder);
-    return _ConnectWiFiNetworkAsync(args, connectCallback);
-}
+    return ConnectWiFiNetworkAsyncLocked(args, connectCallback);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+}
 
-void ConnectivityManagerImpl::PostNetworkConnect()
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::PostNetworkConnect()
 {
+    CharSpan wiFiIfName;
+    CHIP_ERROR status;
+
+    status = WpaSupplicantClient::GetIfName(wiFiIfName);
+    ReturnOnFailure(status);
+
     // Iterate on the network interface to see if we already have beed assigned addresses.
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we deprecate the rendezvous session.
@@ -1049,7 +765,7 @@ void ConnectivityManagerImpl::PostNetworkConnect()
     {
         char ifName[Inet::InterfaceId::kMaxIfNameLength];
         if (it.IsUp() && CHIP_NO_ERROR == it.GetInterfaceName(ifName, sizeof(ifName)) &&
-            strncmp(ifName, sWiFiIfName, sizeof(ifName)) == 0)
+            strncmp(ifName, wiFiIfName.data(), sizeof(ifName)) == 0)
         {
             chip::Inet::IPAddress addr;
             if (it.GetAddress(addr) != CHIP_NO_ERROR)
@@ -1098,7 +814,7 @@ void ConnectivityManagerImpl::PostNetworkConnect()
 #endif // defined(CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD)
 }
 
-CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::CommitConfig()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -1139,7 +855,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & securityType)
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiSecurityType(SecurityTypeEnum & outSecurityType)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -1151,52 +867,49 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
 
     if (strncmp(mode, "WPA-PSK", 7) == 0)
     {
-        securityType = SecurityTypeEnum::kWpa;
+        outSecurityType = SecurityTypeEnum::kWpa;
     }
     else if (strncmp(mode, "WPA2-PSK", 8) == 0)
     {
-        securityType = SecurityTypeEnum::kWpa2;
+        outSecurityType = SecurityTypeEnum::kWpa2;
     }
     else if (strncmp(mode, "WPA2-EAP", 8) == 0)
     {
-        securityType = SecurityTypeEnum::kWpa2;
+        outSecurityType = SecurityTypeEnum::kWpa2;
     }
     else if (strncmp(mode, "WPA3-PSK", 8) == 0)
     {
-        securityType = SecurityTypeEnum::kWpa3;
+        outSecurityType = SecurityTypeEnum::kWpa3;
     }
     else if (strncmp(mode, "WEP", 3) == 0)
     {
-        securityType = SecurityTypeEnum::kWep;
+        outSecurityType = SecurityTypeEnum::kWep;
     }
     else if (strncmp(mode, "NONE", 4) == 0)
     {
-        securityType = SecurityTypeEnum::kNone;
+        outSecurityType = SecurityTypeEnum::kNone;
     }
     else if (strncmp(mode, "WPA-NONE", 8) == 0)
     {
-        securityType = SecurityTypeEnum::kNone;
+        outSecurityType = SecurityTypeEnum::kNone;
     }
     else
     {
-        securityType = SecurityTypeEnum::kUnspecified;
+        outSecurityType = SecurityTypeEnum::kUnspecified;
     }
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::GetWiFiVersion(WiFiVersionEnum & wiFiVersion)
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetWiFiVersion(WiFiVersionEnum & wiFiVersion)
 {
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
-
     // We don't have direct API to get the WiFi version yet, return 802.11n on Linux simulation.
     wiFiVersion = WiFiVersionEnum::kN;
 
     return CHIP_NO_ERROR;
 }
 
-int32_t ConnectivityManagerImpl::GetDisconnectReason()
+int32_t ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetDisconnectReason()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
     GAutoPtr<GError> err;
@@ -1207,404 +920,66 @@ int32_t ConnectivityManagerImpl::GetDisconnectReason()
     return errorValue;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::Network & network)
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork)
 {
-    return WpaSupplicantClient::GetConfiguredNetwork(network);
+    return WpaSupplicantClient::GetConfiguredNetwork(outNetwork);
 }
 
-CHIP_ERROR ConnectivityManagerImpl::StopAutoScan()
+CHIP_ERROR ConnectivityManagerImpl_NetworkManagementWpaSupplicant::StartWiFiScan(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
 {
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
+    CHIP_ERROR retval = CHIP_NO_ERROR;
 
-    ChipLogDetail(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "disabling auto scan");
-
-    GAutoPtr<GError> err;
-    if (!wpa_supplicant_1_interface_call_auto_scan_sync(mWpaSupplicant.iface.get(), "" /* empty string means disabling auto scan */,
-                                                        nullptr, &err.GetReceiver()))
-    {
-        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to stop auto network scan: %s",
-                     err ? err->message : "unknown");
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mConnectivityManagerImpl != nullptr, CHIP_ERROR_UNINITIALIZED);
     // There is another ongoing scan request, reject the new one.
-    VerifyOrReturnError(!IsWiFiStationScanning(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(ssid.size() <= mInterestedSSID.capacity(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!mConnectivityManagerImpl->IsWiFiStationScanning(), CHIP_ERROR_INCORRECT_STATE);
 
-    GAutoPtr<GError> err;
-    GVariant * args = nullptr;
-    GVariantBuilder builder;
+    mConnectivityManagerImpl->SetOneShotScanCallback(callback);
 
-    mInterestedSSID = ssid;
-
-    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&builder, "{sv}", "Type", g_variant_new_string("active"));
-    args = g_variant_builder_end(&builder);
-
-    SetOneShotScanCallback(callback);
-    if (!wpa_supplicant_1_interface_call_scan_sync(mWpaSupplicant.iface.get(), args, nullptr, &err.GetReceiver()))
+    retval = WpaSupplicantClient::ScanNetwork(ssid);
+    if (retval != CHIP_NO_ERROR)
     {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to start network scan: %s",
-                        err ? err->message : "unknown error");
-        SetOneShotScanCallback(nullptr);
-        return CHIP_ERROR_INTERNAL;
+        mConnectivityManagerImpl->SetOneShotScanCallback(nullptr);
+        return retval;
     }
 
-    ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "initialized network scan");
-    return CHIP_NO_ERROR;
+    return retval;
 }
 
-namespace {
+// wpa_supplicant Base Class Method Overrides
 
-// wpa_supplicant's scan results don't contains the channel infomation, so we need this lookup table for resolving the band and
-// channel infomation.
-std::pair<WiFiBand, uint16_t> GetBandAndChannelFromFrequency(uint32_t freq)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::OnWiFiMediumAvailable(WpaSupplicantClient & inOutWpaSupplicantClient,
+                                                                                   bool inAvailable)
 {
-    std::pair<WiFiBand, uint16_t> ret = std::make_pair(WiFiBand::k2g4, 0);
-    if (freq <= 931)
-    {
-        ret.first = WiFiBand::k1g;
-        if (freq >= 916)
-        {
-            ret.second = ((freq - 916) * 2) - 1;
-        }
-        else if (freq >= 902)
-        {
-            ret.second = (freq - 902) * 2;
-        }
-        else if (freq >= 863)
-        {
-            ret.second = (freq - 863) * 2;
-        }
-        else
-        {
-            ret.second = 1;
-        }
-    }
-    else if (freq <= 2472)
-    {
-        ret.second = static_cast<uint16_t>((freq - 2412) / 5 + 1);
-    }
-    else if (freq == 2484)
-    {
-        ret.second = 14;
-    }
-    else if (freq >= 3600 && freq <= 3700)
-    {
-        // Note: There are not many devices supports this band, and this band contains rational frequency in MHz, need to figure out
-        // the behavior of wpa_supplicant in this case.
-        ret.first = WiFiBand::k3g65;
-    }
-    else if (freq >= 5035 && freq <= 5945)
-    {
-        ret.first  = WiFiBand::k5g;
-        ret.second = static_cast<uint16_t>((freq - 5000) / 5);
-    }
-    else if (freq == 5960 || freq == 5980)
-    {
-        ret.first  = WiFiBand::k5g;
-        ret.second = static_cast<uint16_t>((freq - 5000) / 5);
-    }
-    else if (freq >= 5955)
-    {
-        ret.first  = WiFiBand::k6g;
-        ret.second = static_cast<uint16_t>((freq - 5950) / 5);
-    }
-    else if (freq >= 58000)
-    {
-        ret.first = WiFiBand::k60g;
-        // Note: Some channel has the same center frequency but different bandwidth. Should figure out wpa_supplicant's behavior in
-        // this case. Also, wpa_supplicant's frequency property is uint16 infact.
-        switch (freq)
-        {
-        case 58'320:
-            ret.second = 1;
-            break;
-        case 60'480:
-            ret.second = 2;
-            break;
-        case 62'640:
-            ret.second = 3;
-            break;
-        case 64'800:
-            ret.second = 4;
-            break;
-        case 66'960:
-            ret.second = 5;
-            break;
-        case 69'120:
-            ret.second = 6;
-            break;
-        case 59'400:
-            ret.second = 9;
-            break;
-        case 61'560:
-            ret.second = 10;
-            break;
-        case 63'720:
-            ret.second = 11;
-            break;
-        case 65'880:
-            ret.second = 12;
-            break;
-        case 68'040:
-            ret.second = 13;
-            break;
-        }
-    }
-    return ret;
+    NetworkManagementBasis::OnWiFiMediumAvailable(inAvailable);
 }
 
-} // namespace
-
-CHIP_ERROR ConnectivityManagerImpl::_GetBssInfo(const char * bssPath, NetworkCommissioning::WiFiScanResponse & result)
+void ConnectivityManagerImpl_NetworkManagementWpaSupplicant::UpdateWiFiNetworkStatus()
 {
-    // This function can be called without g_main_context_get_thread_default() being set.
-    // The BSS proxy object is created in a synchronous manner, so the D-Bus call will be
-    // completed before this function returns. Also, no external callbacks are registered
-    // with the proxy object.
+    Network configuredNetwork;
 
-    GAutoPtr<GError> err;
-    GAutoPtr<WpaSupplicant1BSS> bss(wpa_supplicant_1_bss_proxy_new_for_bus_sync(
-        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, bssPath, nullptr, &err.GetReceiver()));
-    VerifyOrReturnError(bss != nullptr, CHIP_ERROR_INCORRECT_STATE,
-                        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Failed to create BSS proxy: %s", err->message));
+    VerifyOrReturn(mConnectivityManagerImpl != nullptr);
+    VerifyOrReturn(IsWiFiStationEnabled());
 
-    GVariant * ssid  = wpa_supplicant_1_bss_get_ssid(bss.get());
-    GVariant * bssid = wpa_supplicant_1_bss_get_bssid(bss.get());
-
-    // Network scan is performed in the background, so the BSS
-    // may be gone when we try to get the properties.
-    if (ssid == nullptr || bssid == nullptr)
+    CHIP_ERROR err = GetConfiguredNetwork(configuredNetwork);
+    if (err != CHIP_NO_ERROR)
     {
-        ChipLogDetail(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "BSS not found: %s", StringOrNullMarker(bssPath));
-        return CHIP_ERROR_NOT_FOUND;
-    }
-
-    gsize ssidLen                = 0;
-    gsize bssidLen               = 0;
-    char bssidStr[2 * 6 + 5 + 1] = { 0 };
-    auto ssidStr                 = reinterpret_cast<const uint8_t *>(g_variant_get_fixed_array(ssid, &ssidLen, sizeof(uint8_t)));
-    auto bssidBuf                = reinterpret_cast<const uint8_t *>(g_variant_get_fixed_array(bssid, &bssidLen, sizeof(uint8_t)));
-    int16_t signal               = wpa_supplicant_1_bss_get_signal(bss.get());
-    uint16_t frequency           = wpa_supplicant_1_bss_get_frequency(bss.get());
-
-    if (bssidLen == 6)
-    {
-        snprintf(bssidStr, sizeof(bssidStr), "%02x:%02x:%02x:%02x:%02x:%02x", bssidBuf[0], bssidBuf[1], bssidBuf[2], bssidBuf[3],
-                 bssidBuf[4], bssidBuf[5]);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer,
-                     WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Got a network with incorrect BSSID len: %" G_GSIZE_FORMAT " != 6", bssidLen);
-        bssidLen = 0;
-    }
-
-    // Internal sentinel (bit 7). Not a real WiFiSecurityBitmap value; keeps an EAP-only
-    // network from being reported as Open. Masked off before the result is returned.
-
-    // TODO: The following code will mistakenly recognize WEP encryption as OPEN network, this should be fixed by reading
-    // IEs (information elements) field instead of reading cooked data.
-
-    static constexpr chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> kEAP{ static_cast<uint8_t>(1 << 7) };
-
-    auto IsNetworkWPAPSK = [](GVariant * wpa) -> chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> {
-        chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> res;
-
-        if (wpa == nullptr)
-        {
-            return res;
-        }
-
-        GAutoPtr<GVariant> keyMgmt(g_variant_lookup_value(wpa, "KeyMgmt", nullptr));
-        if (keyMgmt == nullptr)
-        {
-            return res;
-        }
-        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
-        const gchar ** keyMgmtsHandle = keyMgmts.get();
-
-        VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
-
-        for (auto keyMgmtVal = *keyMgmtsHandle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHandle))
-        {
-            if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-none") == 0)
-            {
-                res.Set(app::Clusters::NetworkCommissioning::WiFiSecurityBitmap::kWpaPersonal);
-            }
-            else if (g_strcasecmp(keyMgmtVal, "wpa-eap") == 0)
-            {
-                res.Set(kEAP);
-            }
-        }
-
-        return res;
-    };
-    auto IsNetworkWPA2PSK = [](GVariant * rsn) -> chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> {
-        chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> res;
-
-        if (rsn == nullptr)
-        {
-            return res;
-        }
-        GAutoPtr<GVariant> keyMgmt(g_variant_lookup_value(rsn, "KeyMgmt", nullptr));
-        if (keyMgmt == nullptr)
-        {
-            return res;
-        }
-        GBorrowedStrvPtr keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
-        const gchar ** keyMgmtsHandle = keyMgmts.get();
-
-        VerifyOrReturnError(keyMgmtsHandle != nullptr, res);
-
-        for (auto keyMgmtVal = *keyMgmtsHandle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHandle))
-        {
-            if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-psk-sha256") == 0 ||
-                g_strcasecmp(keyMgmtVal, "wpa-ft-psk") == 0)
-            {
-                res.Set(app::Clusters::NetworkCommissioning::WiFiSecurityBitmap::kWpa2Personal);
-            }
-            else if (g_strcasecmp(keyMgmtVal, "wpa-eap") == 0 || g_strcasecmp(keyMgmtVal, "wpa-eap-sha256") == 0 ||
-                     g_strcasecmp(keyMgmtVal, "wpa-ft-eap") == 0)
-            {
-                res.Set(kEAP);
-            }
-            else if (g_strcasecmp(keyMgmtVal, "sae") == 0)
-            {
-                // wpa_supplicant will include "sae" in KeyMgmt field for WPA3 WiFi, this is not included in the wpa_supplicant
-                // document.
-                res.Set(app::Clusters::NetworkCommissioning::WiFiSecurityBitmap::kWpa3Personal);
-            }
-        }
-
-        return res;
-    };
-
-    // Drop the network if its SSID or BSSID is illegal.
-    VerifyOrReturnError(ssidLen <= kMaxWiFiSSIDLength, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(bssidLen == kWiFiBSSIDLength, CHIP_ERROR_INTERNAL);
-    memcpy(result.ssid, ssidStr, ssidLen);
-    memcpy(result.bssid, bssidBuf, bssidLen);
-    result.ssidLen     = ssidLen;
-    result.signal.type = NetworkCommissioning::WirelessSignalType::kdBm;
-    if (signal < INT8_MIN)
-    {
-        result.signal.strength = INT8_MIN;
-    }
-    else if (signal > INT8_MAX)
-    {
-        result.signal.strength = INT8_MAX;
-    }
-    else
-    {
-        result.signal.strength = static_cast<uint8_t>(signal);
-    }
-
-    auto bandInfo   = GetBandAndChannelFromFrequency(frequency);
-    result.wiFiBand = bandInfo.first;
-    result.channel  = bandInfo.second;
-
-    chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> networkSecurityType(
-        IsNetworkWPAPSK(wpa_supplicant_1_bss_get_wpa(bss.get())), IsNetworkWPA2PSK(wpa_supplicant_1_bss_get_rsn(bss.get())));
-    if (!networkSecurityType.HasAny())
-    {
-        networkSecurityType.Set(app::Clusters::NetworkCommissioning::WiFiSecurityBitmap::kUnencrypted);
-    }
-    networkSecurityType.Clear(kEAP);
-    result.security = networkSecurityType;
-
-    return CHIP_NO_ERROR;
-}
-
-void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * iface, gboolean success)
-{
-    ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "network scan done");
-
-    const char * const * bsss = wpa_supplicant_1_interface_get_bsss(iface);
-    if (bsss == nullptr)
-    {
-        ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "no network found");
-        TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda(
-            [this]() { OnScanFinished(Status::kSuccess, CharSpan(), nullptr); });
+        ChipLogError(DeviceLayer, "Failed to get configured network when updating network status: %s", err.AsString());
         return;
     }
 
-    auto networkScanned = std::make_unique<std::vector<WiFiScanResponse>>();
-    for (const char * bssPath = (bsss != nullptr ? *bsss : nullptr); bssPath != nullptr; bssPath = *(++bsss))
+    // If we have already connected to the WiFi AP, then return null to indicate a success state.
+    if (IsWiFiStationConnected())
     {
-        WiFiScanResponse network;
-        if (_GetBssInfo(bssPath, network) == CHIP_NO_ERROR)
-        {
-            ChipLogDetail(DeviceLayer, "Network Found: %s (%02x:%02x:%02x:%02x:%02x:%02x) Signal: %d",
-                          NullTerminated(StringOrNullMarker((const char *) network.ssid), network.ssidLen).c_str(),
-                          network.bssid[0], network.bssid[1], network.bssid[2], network.bssid[3], network.bssid[4],
-                          network.bssid[5], network.signal.strength);
-            if (mInterestedSSID.empty() ||
-                (network.ssidLen == mInterestedSSID.size() &&
-                 memcmp(network.ssid, mInterestedSSID.data(), mInterestedSSID.size()) == 0))
-            {
-                networkScanned->push_back(network);
-            }
-        }
-    }
-
-    CHIP_ERROR err = DeviceLayer::SystemLayer().ScheduleLambda([this, scanned = networkScanned.get()]() {
-        // Note: We cannot post an event in ScheduleLambda since std::vector is not trivial copyable.
-        LinuxScanResponseIterator<WiFiScanResponse> iter(scanned);
-
-        OnScanFinished(Status::kSuccess, CharSpan(), &iter);
-
-        delete scanned;
-    });
-
-    if (err == CHIP_NO_ERROR)
-    {
-        networkScanned.release();
+        mConnectivityManagerImpl->OnStatusChange(
+            Status::kSuccess, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)), NullOptional);
     }
     else
     {
-        ChipLogError(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "failed to schedule scan completion: %" CHIP_ERROR_FORMAT,
-                     err.Format());
+        mConnectivityManagerImpl->OnStatusChange(
+            Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
+            MakeOptional(GetDisconnectReason()));
     }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mPafChannelAvailable = true;
-#endif
 }
-
-CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement()
-{
-    // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
-    // all D-Bus signals will be delivered to the GLib global default main context.
-    VerifyOrDie(g_main_context_get_thread_default() != nullptr);
-
-    ChipLogProgress(DeviceLayer, WPA_SUPPLICANT_CLIENT_LOG_PREFIX "Start WiFi management");
-    wpa_supplicant_1_proxy_new_for_bus(
-        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, kWpaSupplicantObjectPath, nullptr,
-        reinterpret_cast<GAsyncReadyCallback>(+[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
-            return self->_OnWpaProxyReady(sourceObject_, res_);
-        }),
-        this);
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ConnectivityManagerImpl::_StopWiFiManagement()
-{
-    WpaSupplicantClient::Reset();
-
-    return CHIP_NO_ERROR;
-}
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h
@@ -1,0 +1,168 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "ConnectivityManagerImpl_NetworkManagementBasis.h"
+#include "ConnectivityManagerImpl_NetworkManagementInterface.h"
+#include "WpaSupplicantClient.h"
+
+namespace chip {
+namespace DeviceLayer {
+
+// Forward Declarations
+
+struct ChipDeviceEvent;
+
+/**
+ *  Provides an implementation of the ConnectionManager object
+ *  for Linux platforms where wpa_supplicant is both the
+ *  high-level network manager, that owns Wi-Fi network policy
+ *  and state and is the low-level Wi-Fi control plane manager
+ *  that drives the Wi-Fi MAC and PHY through the Linux
+ *  nl80211 driver.
+ *
+ */
+class ConnectivityManagerImpl_NetworkManagementWpaSupplicant final : public Internal::NetworkManagementBasis,
+                                                                     public Internal::NetworkManagementInterface,
+                                                                     public Internal::WpaSupplicantClient
+{
+public:
+    // Construction
+
+    ConnectivityManagerImpl_NetworkManagementWpaSupplicant() = default;
+
+    // Destruction
+
+    virtual ~ConnectivityManagerImpl_NetworkManagementWpaSupplicant() = default;
+
+    // Initialization
+
+    CHIP_ERROR Init(ConnectivityManagerImpl & inConnectivityManagerImpl) override final;
+
+    // Observation
+
+    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork) override final;
+
+    // Event Handling
+
+    void OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) override final;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    // Ethernet Control Plane Management
+
+    const char * GetEthernetIfName() override final;
+    void UpdateEthernetNetworkingStatus() override final;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Wi-Fi Control Plane Management
+
+    // Observation
+
+    const char * GetWiFiIfName() override final;
+
+    // Control
+
+    void StartNonConcurrentWiFiManagement() override final;
+    void StartWiFiManagement() override final;
+    void StopWiFiManagement() override final;
+
+    // Wi-Fi Station Control Plane Management
+
+    // Introspection
+
+    bool IsWiFiManagementStarted() override final;
+    bool IsWiFiStationApplicationControlled() override final;
+    bool IsWiFiStationConnected() override final;
+    bool IsWiFiStationEnabled() override final;
+    bool IsWiFiStationProvisioned() override final;
+
+    // Observation
+
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & outBssId) override final;
+    CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outSecurityType) override final;
+    ConnectivityManager::WiFiStationMode GetWiFiStationMode() override final;
+    System::Clock::Timeout GetWiFiStationReconnectInterval() override final;
+    CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outVersion) override final;
+
+    // Mutation
+
+    CHIP_ERROR SetWiFiStationMode(const ConnectivityManager::WiFiStationMode & inWiFiStationMode) override final;
+    CHIP_ERROR SetWiFiStationReconnectInterval(const System::Clock::Timeout & inInterval) override final;
+
+    // Worker
+
+    void ClearWiFiStationProvision() override final;
+    CHIP_ERROR CommitConfig() override final;
+    CHIP_ERROR
+    ConnectWiFiNetworkAsync(ByteSpan inSsid, ByteSpan inCredentials,
+                            NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) override final;
+    CHIP_ERROR ConnectWiFiNetworkWithPDCAsync(
+        ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity, const Crypto::P256Keypair & inClientIdentityKeypair,
+        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) override final;
+    CHIP_ERROR StartWiFiScan(ByteSpan inSsid, NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback) override final;
+
+    // Wi-Fi Soft Access Point (AP) Control Plane Management
+
+    // Observation
+
+    ConnectivityManager::WiFiAPMode GetWiFiApMode() override final;
+
+    // Mutation
+
+    CHIP_ERROR SetWiFiApMode(const ConnectivityManager::WiFiAPMode & inWiFiApMode) override final;
+    void SetWiFiApIdleTimeout(const System::Clock::Timeout & inTimeout) override final;
+
+    // Control
+
+    void DemandStartWiFiAp() override final;
+    void StopOnDemandWiFiAp() override final;
+    void MaintainOnDemandWiFiAp() override final;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+private:
+    // Helper Methods
+
+    void ChangeWiFiApState(const ConnectivityManager::WiFiAPState & newState);
+    CHIP_ERROR ConfigureWiFiAp();
+    CHIP_ERROR ConnectWiFiNetworkAsyncLocked(GVariant * args,
+                                             NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback) noexcept;
+    void DriveApState();
+    static void DriveApState(::chip::System::Layer * aSystemLayer, void * aAppState);
+    int32_t GetDisconnectReason();
+
+    // wpa_supplicant Base Class Method Overrides
+
+    void OnWiFiMediumAvailable(WpaSupplicantClient & inOutWpaSupplicantClient, bool inAvailable) override final;
+    void PostNetworkConnect() override final;
+    void UpdateWiFiNetworkStatus() override final;
+
+private:
+    ConnectivityManagerImpl * mConnectivityManagerImpl;
+    ConnectivityManager::WiFiStationMode mWiFiStationMode;
+    System::Clock::Timeout mWiFiStationReconnectInterval;
+    ConnectivityManager::WiFiAPMode mWiFiAPMode;
+    ConnectivityManager::WiFiAPState mWiFiAPState;
+    System::Clock::Timestamp mLastAPDemandTime;
+    System::Clock::Timeout mWiFiAPIdleTimeout;
+    bool mAssociationStarted = false;
+    char mEthernetIfName[Inet::InterfaceId::kMaxIfNameLength];
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
@@ -137,6 +137,47 @@ public:
 
     /**
      *  @brief
+     *    Enable or disable Wi-Fi NAN USD PAF Commissioning Transport
+     *    advertising.
+     *
+     *  @note
+     *    Enabling establishes a publish using the advertising
+     *    parameters most-recently set with `WiFiPafSetParam`.
+     *    Consequently, those parameters **must** have been set, with
+     *    a non-empty frequency list, before advertising is enabled.
+     *
+     *  @note
+     *    Disabling cancels the publish identified by
+     *    `inOutPublishId`, which **must** be a valid, defined
+     *    identifier previously returned by this method. The value is
+     *    left unmodified on return; the caller is responsible for
+     *    invalidating its copy.
+     *
+     *  @param[in]      inEnabled
+     *    A Boolean indicating whether Wi-Fi NAN USD PAF Commissioning
+     *    Transport advertising should be enabled (`true`) or disabled
+     *    (`false`).
+     *
+     *  @param[in,out]  inOutPublishId
+     *    A reference to mutable storage for the publish identifier.
+     *    On input, when `inEnabled` is deasserted, the identifier of
+     *    the publish to cancel. On output, when `inEnabled` is
+     *    asserted and the underlying implementation assigned a
+     *    defined identifier, the identifier of the newly-established
+     *    publish; otherwise, left unmodified.
+     *
+     *  @retval  CHIP_ERROR_INCORRECT_STATE
+     *    If `inEnabled` is asserted and no advertising frequency list
+     *    has been set; or if `inEnabled` is deasserted and
+     *    `inOutPublishId` is not a valid, defined publish identifier.
+     *
+     *  @sa WiFiPafSetParam
+     *
+     */
+    virtual CHIP_ERROR WiFiPafSetAdvertisingEnabled(bool inEnabled, uint32_t & inOutPublishId) = 0;
+
+    /**
+     *  @brief
      *    Set the Wi-Fi NAN USD PAF Commissioning Transport resource
      *    availability.
      *

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
@@ -178,6 +178,31 @@ public:
 
     /**
      *  @brief
+     *    Set the Wi-Fi NAN USD PAF Commissioning Transport
+     *    advertising parameters.
+     *
+     *  @note
+     *    Only the advertising frequency list is retained, and it is
+     *    deep copied. The caller retains ownership of
+     *    `inWiFiPAFAdvertiseParams` and of any storage associated with
+     *    it. Any previously-set parameters are replaced.
+     *
+     *  @note
+     *    The parameters are latched for use by a subsequent call to
+     *    `WiFiPafSetAdvertisingEnabled` and have no effect on a
+     *    publish that is already active.
+     *
+     *  @param[in]  inWiFiPAFAdvertiseParams
+     *    A reference to the immutable Wi-Fi NAN USD PAF Commissioning
+     *    Transport advertising parameters to set.
+     *
+     *  @sa WiFiPafSetAdvertisingEnabled
+     *
+     */
+    virtual void WiFiPafSetParam(const ConnectivityManager::WiFiPAFAdvertiseParam & inWiFiPafAdvertiseParams) = 0;
+
+    /**
+     *  @brief
      *    Set the Wi-Fi NAN USD PAF Commissioning Transport resource
      *    availability.
      *

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
@@ -17,22 +17,14 @@
  *    limitations under the License.
  */
 
-#include <mutex>
-
-#include <stdint.h>
-
-#include <glib.h>
+#include "ConnectivityManagerImpl_WiFiPafWpaSupplicant.h"
 
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CommissionableDataProvider.h>
-#include <platform/ConnectivityManager.h>
 #include <platform/DeviceInstanceInfoProvider.h>
-#include <platform/GLibTypeDeleter.h>
+#include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
 #include <platform/PlatformManager.h>
-
-#include "ConnectivityManagerImpl.h"
-#include "WpaSupplicantClient.h"
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 using namespace ::chip::WiFiPAF;
@@ -42,6 +34,11 @@ namespace chip {
 namespace DeviceLayer {
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+namespace {
+
+// Global Variables
+
 static const char srv_name[] = "_matterc._udp";
 /*
     NAN-USD Service Protocol Type: ref: Table 58 of Wi-Fi Aware Specificaiton
@@ -65,9 +62,138 @@ enum nan_service_protocol_type
 };
 #pragma pack(pop)
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFPublish(ConnectivityManager::WiFiPAFAdvertiseParam & InArgs)
+} // namespace
+
+// MARK: Function and Method Implementation
+
+// MARK: Matter Linux Connectivity Manager Implementation Wi-Fi
+//       Neighbor Awareness Networking (NAN) Unsynchronized Service
+//       Discovery (USD) / Public Action Frame (PAF) for wpa_supplicant
+
+// MARK: Initialization
+
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::Init(ConnectivityManagerImpl & inConnectivityManagerImpl)
 {
-    CHIP_ERROR result = StartWiFiManagementSync();
+    VerifyOrReturnError(mConnectivityManagerImpl == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
+
+    // Initialize the base wpa_supplicant class.
+
+    ReturnErrorOnFailure(WpaSupplicantClient::Init(inConnectivityManagerImpl));
+
+    mConnectivityManagerImpl = &inConnectivityManagerImpl;
+
+    mPafChannelAvailable = true;
+
+    return CHIP_NO_ERROR;
+}
+
+// MARK: Introspection
+
+bool ConnectivityManagerImpl_WiFiPafWpaSupplicant::IsWiFiPafResourceAvailable(void) const
+{
+    return mPafChannelAvailable;
+}
+
+// MARK: Mutation
+
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSetAdvertisingEnabled(bool inEnabled, uint32_t & inOutPublishId)
+{
+    if (inEnabled)
+    {
+        VerifyOrReturnError(mPafAdvertiseParams.freq_list_len > 0, CHIP_ERROR_INCORRECT_STATE);
+
+        auto res = WiFiPafPublish(mPafAdvertiseParams);
+        if ((res == CHIP_NO_ERROR) && (mPafAdvertiseParams.publish_id != WiFiPAF::kUndefinedWiFiPafSessionId))
+        {
+            inOutPublishId = mPafAdvertiseParams.publish_id;
+        }
+
+        return res;
+    }
+
+    // Cancel paf_publish, publish_id should be valid
+
+    VerifyOrReturnError((inOutPublishId != 0) && (inOutPublishId != WiFiPAF::kUndefinedWiFiPafSessionId),
+                        CHIP_ERROR_INCORRECT_STATE);
+
+    return WiFiPafCancelPublish(inOutPublishId);
+}
+
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSetParam(
+    const ConnectivityManager::WiFiPAFAdvertiseParam & inWiFiPafAdvertiseParams)
+{
+    mPafAdvertiseParams.freq_list_len = inWiFiPAFAdvertiseParam.freq_list_len;
+    mPafAdvertiseParams.freq_list     = std::make_unique<uint16_t[]>(mPafAdvertiseParam.freq_list_len);
+    for (size_t i = 0; i < mPafAdvertiseParams.freq_list_len; i++)
+    {
+        mPafAdvertiseParams.freq_list[i] = inWiFiPAFAdvertiseParam.freq_list[i];
+    }
+}
+
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSetResourceAvailable(const bool & inAvailable)
+{
+    mPafChannelAvailable = inAvailable;
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSetSubscribeFreq(const uint16_t & inFrequency)
+{
+    mSubscribeFreq = inFrequency;
+}
+
+// MARK: Event Handling
+
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent)
+{
+    WiFiPAFLayer & WiFiPafLayer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+
+    switch (inDeviceEvent.Type)
+    {
+
+    case DeviceEventType::kCHIPoWiFiPAFReceived: {
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFReceived");
+        WiFiPAFSession RxInfo;
+        memcpy(&RxInfo, &inDeviceEvent.CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
+        WiFiPafLayer.OnWiFiPAFMessageReceived(RxInfo, System::PacketBufferHandle::Adopt(inDeviceEvent.CHIPoWiFiPAFReceived.Data));
+        break;
+    }
+
+    case DeviceEventType::kCHIPoWiFiPAFConnected: {
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFConnected");
+        WiFiPAF::WiFiPAFSession SessionInfo;
+        memcpy(&SessionInfo, &inDeviceEvent.CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
+        WiFiPafLayer.HandleTransportConnectionInitiated(SessionInfo, mOnPafSubscribeComplete, mAppState, mOnPafSubscribeError);
+        break;
+    }
+
+    case DeviceEventType::kCHIPoWiFiPAFCancelConnect: {
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFCancelConnect");
+        if (mOnPafSubscribeError != nullptr)
+        {
+            mOnPafSubscribeError(mAppState, CHIP_ERROR_CANCELLED);
+            mOnPafSubscribeError = nullptr;
+        }
+        break;
+    }
+
+    case DeviceEventType::kCHIPoWiFiPAFWriteDone: {
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFWriteDone");
+        WiFiPAF::WiFiPAFSession TxInfo;
+        memcpy(&TxInfo, &inDeviceEvent.CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
+        WiFiPafLayer.HandleWriteConfirmed(TxInfo, inDeviceEvent.CHIPoWiFiPAFReceived.result);
+        break;
+    }
+    }
+}
+
+// MARK: Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+//       Service Discovery (USD) / Public Action Frame (PAF)
+//       Commissioning Transport
+
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafPublish(ConnectivityManager::WiFiPAFAdvertiseParam & InArgs)
+{
+    CHIP_ERROR result = WpaSupplicantClient::StartSync();
     VerifyOrReturnError(result == CHIP_NO_ERROR, result);
 
     GAutoPtr<GError> err;
@@ -127,18 +253,18 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFPublish(ConnectivityManager::WiFiPAF
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelPublish(uint32_t PublishId)
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafCancelPublish(const uint32_t & inPublishId)
 {
     GAutoPtr<GError> err;
 
-    ChipLogProgress(DeviceLayer, "WiFi-PAF: cancel publish_id: %d ! ", PublishId);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: cancel publish_id: %d ! ", inPublishId);
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "WiFi-PAF: Skip D-Bus 'cancel publish' call since wpa_supplicant is not ready"));
 
-    gboolean result =
-        wpa_supplicant_1_interface_call_nancancel_publish_sync(mWpaSupplicant.iface.get(), PublishId, nullptr, &err.GetReceiver());
+    gboolean result = wpa_supplicant_1_interface_call_nancancel_publish_sync(mWpaSupplicant.iface.get(), inPublishId, nullptr,
+                                                                             &err.GetReceiver());
 
     // TODO #40814: make sure that the callers do check the return values. This doesn't seem to be happening now.
     VerifyOrReturnError(
@@ -151,7 +277,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelPublish(uint32_t PublishId)
 /*
     NAN-USD Service Protocol Type: ref: Table 58 of Wi-Fi Aware Specificaiton
 */
-void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnDiscoveryResult(GVariant * discov_info)
 {
     ChipLogProgress(Controller, "WiFi-PAF: OnDiscoveryResult");
     uint32_t subscribe_id;
@@ -198,7 +324,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     auto ssibuf = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
     VerifyOrReturn(bufferLen >= sizeof(PAFPublishSSI), ChipLogError(DeviceLayer, "WiFi-PAF: DiscoveryResult SSI too short"));
     auto pPublishSSI = reinterpret_cast<const PAFPublishSSI *>(ssibuf);
-    GetWiFiPAF()->SetWiFiPAFState(WiFiPAF::State::kConnected);
+    mConnectivityManagerImpl->GetWiFiPAF()->SetWiFiPAFState(WiFiPAF::State::kConnected);
 
     /*
         Error Checking
@@ -250,7 +376,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnReplied(GVariant * reply_info)
 {
     ChipLogProgress(Controller, "WiFi-PAF: OnReplied");
     uint32_t publish_id;
@@ -347,7 +473,7 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     LogErrorOnFailure(PlatformMgr().ScheduleWork(handleInitiated, reinterpret_cast<intptr_t>(pPafInfo)));
 }
 
-void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnNanReceive(GVariant * obj)
 {
     if (g_variant_n_children(obj) == 0)
     {
@@ -392,7 +518,7 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void ConnectivityManagerImpl::OnNanPublishTerminated(guint public_id, gchar * reason)
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnNanPublishTerminated(guint public_id, gchar * reason)
 {
     ChipLogProgress(Controller, "WiFi-PAF: Publish terminated (%u, %s)", public_id, reason);
     WiFiPAFSession sessionInfo  = { .id = public_id };
@@ -411,7 +537,7 @@ void ConnectivityManagerImpl::OnNanPublishTerminated(guint public_id, gchar * re
     TEMPORARY_RETURN_IGNORED WiFiPafLayer.RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
 }
 
-void ConnectivityManagerImpl::OnNanSubscribeTerminated(guint subscribe_id, gchar * reason)
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnNanSubscribeTerminated(guint subscribe_id, gchar * reason)
 {
     ChipLogProgress(Controller, "WiFi-PAF: Subscription terminated (%u, %s)", subscribe_id, reason);
     WiFiPAFSession sessionInfo  = { .id = subscribe_id };
@@ -435,37 +561,11 @@ void ConnectivityManagerImpl::OnNanSubscribeTerminated(guint subscribe_id, gchar
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void ConnectivityManagerImpl::_WiFiPAFSetParam(const WiFiPAFAdvertiseParam & pafAdvParam)
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSubscribe(const uint16_t & connDiscriminator, void * appState,
+                                                                          ConnectivityManager::OnConnectionCompleteFunct onSuccess,
+                                                                          ConnectivityManager::OnConnectionErrorFunct onError)
 {
-    mPafAdvParam.freq_list_len = pafAdvParam.freq_list_len;
-    mPafAdvParam.freq_list     = std::make_unique<uint16_t[]>(mPafAdvParam.freq_list_len);
-    for (size_t i = 0; i < mPafAdvParam.freq_list_len; i++)
-    {
-        mPafAdvParam.freq_list[i] = pafAdvParam.freq_list[i];
-    }
-}
-
-CHIP_ERROR ConnectivityManagerImpl::_SetWiFiPAFAdvertisingEnabled(bool enabled, uint32_t & publishId)
-{
-    if (enabled)
-    {
-        VerifyOrReturnError(mPafAdvParam.freq_list_len > 0, CHIP_ERROR_INCORRECT_STATE);
-        auto res = WiFiPAFPublish(mPafAdvParam);
-        if ((res == CHIP_NO_ERROR) && (mPafAdvParam.publish_id != kUndefinedWiFiPafSessionId))
-        {
-            publishId = mPafAdvParam.publish_id;
-        }
-        return res;
-    }
-    // Cancel paf_publish, publish_id should be valid
-    VerifyOrReturnError((publishId != 0) && (publishId != WiFiPAF::kUndefinedWiFiPafSessionId), CHIP_ERROR_INCORRECT_STATE);
-    return WiFiPAFCancelPublish(publishId);
-}
-
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & connDiscriminator, void * appState,
-                                                      OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError)
-{
-    CHIP_ERROR result = StartWiFiManagementSync();
+    CHIP_ERROR result = WpaSupplicantClient::StartSync();
     VerifyOrReturnError(result == CHIP_NO_ERROR, result);
 
     ChipLogProgress(Controller, "WiFi-PAF: Try to subscribe the NAN-USD devices");
@@ -475,8 +575,8 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & connDiscr
     enum nan_service_protocol_type srv_proto_type = nan_service_protocol_type::NAN_SRV_PROTO_CSA_MATTER;
     uint8_t is_active                             = 1;
     unsigned int ttl                              = CHIP_DEVICE_CONFIG_WIFIPAF_DISCOVERY_TIMEOUT_SECS;
-    unsigned int freq                             = (mApFreq == 0) ? CHIP_DEVICE_CONFIG_WIFIPAF_24G_DEFAUTL_CHNL : mApFreq;
-    unsigned int ssi_len                          = sizeof(struct PAFPublishSSI);
+    unsigned int freq    = (mSubscribeFreq == 0) ? CHIP_DEVICE_CONFIG_WIFIPAF_24G_DEFAUTL_CHNL : mSubscribeFreq;
+    unsigned int ssi_len = sizeof(struct PAFPublishSSI);
     struct PAFPublishSSI PafPublish_ssi;
 
     mAppState                = appState;
@@ -527,24 +627,26 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & connDiscr
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelSubscribe(uint32_t SubscribeId)
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafCancelSubscribe(const uint32_t & inSubscribeId)
 {
     GAutoPtr<GError> err;
 
-    ChipLogProgress(DeviceLayer, "WiFi-PAF: cancel subscribe_id: %d ! ", SubscribeId);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: cancel subscribe_id: %d ! ", inSubscribeId);
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-    wpa_supplicant_1_interface_call_nancancel_subscribe_sync(mWpaSupplicant.iface.get(), SubscribeId, nullptr, &err.GetReceiver());
+    wpa_supplicant_1_interface_call_nancancel_subscribe_sync(mWpaSupplicant.iface.get(), inSubscribeId, nullptr,
+                                                             &err.GetReceiver());
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelIncompleteSubscribe()
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafCancelIncompleteSubscribe(void)
 {
     mOnPafSubscribeComplete = nullptr;
     mOnPafSubscribeError    = nullptr;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession & TxInfo, System::PacketBufferHandle && msgBuf)
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafSend(const WiFiPAF::WiFiPAFSession & TxInfo,
+                                                                     System::PacketBufferHandle && msgBuf)
 {
     ChipLogProgress(Controller, "WiFi-PAF: sending PAF Follow-up packets, (%zu)", msgBuf->DataLength());
     CHIP_ERROR ret = CHIP_NO_ERROR;
@@ -608,50 +710,32 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession &
     return ret;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role)
+CHIP_ERROR ConnectivityManagerImpl_WiFiPafWpaSupplicant::WiFiPafShutdown(const uint32_t & inId,
+                                                                         const WiFiPAF::WiFiPafRole & inWiFiPafRole)
 {
-    VerifyOrReturnError(((id != kUndefinedWiFiPafSessionId) && (id != 0)), CHIP_ERROR_INTERNAL);
-    switch (role)
+    VerifyOrReturnError(((inId != kUndefinedWiFiPafSessionId) && (inId != 0)), CHIP_ERROR_INTERNAL);
+
+    switch (inWiFiPafRole)
     {
     case WiFiPAF::WiFiPafRole::kWiFiPafRole_Publisher:
-        return _WiFiPAFCancelPublish(id);
+        return WiFiPafCancelPublish(inId);
     case WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber:
-        return _WiFiPAFCancelSubscribe(id);
+        return WiFiPafCancelSubscribe(inId);
     }
     return CHIP_ERROR_INTERNAL;
 }
 
-void ConnectivityManagerImpl::PostWpaInterfaceProxyReady()
+// wpa_supplicant Base Class Method Overrides
+
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::OnWiFiMediumAvailable(WpaSupplicantClient & inOutWpaSupplicantClient,
+                                                                         bool inAvailable)
 {
-    g_signal_connect(mWpaSupplicant.iface.get(), "nanreplied",
-                     G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * obj, ConnectivityManagerImpl * self) {
-                         return self->OnReplied(obj);
-                     }),
-                     this);
-    g_signal_connect(mWpaSupplicant.iface.get(), "nanreceive",
-                     G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * obj, ConnectivityManagerImpl * self) {
-                         return self->OnNanReceive(obj);
-                     }),
-                     this);
-    g_signal_connect(
-        mWpaSupplicant.iface.get(), "nanpublish-terminated",
-        G_CALLBACK(+[](WpaSupplicant1Interface * proxy, guint term_publish_id, gchar * reason, ConnectivityManagerImpl * self) {
-            return self->OnNanPublishTerminated(term_publish_id, reason);
-        }),
-        this);
-    g_signal_connect(mWpaSupplicant.iface.get(), "nandiscovery-result",
-                     G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * obj, ConnectivityManagerImpl * self) {
-                         return self->OnDiscoveryResult(obj);
-                     }),
-                     this);
-    g_signal_connect(
-        mWpaSupplicant.iface.get(), "nansubscribe-terminated",
-        G_CALLBACK(+[](WpaSupplicant1Interface * proxy, guint term_subscribe_id, gchar * reason, ConnectivityManagerImpl * self) {
-            return self->OnNanSubscribeTerminated(term_subscribe_id, reason);
-        }),
-        this);
+    RETURN_SAFELY_IGNORED WiFiPafSetResourceAvailable(inAvailable);
 }
 
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::PostNetworkConnect(void) {}
+
+void ConnectivityManagerImpl_WiFiPafWpaSupplicant::UpdateWiFiNetworkStatus(void) {}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.h
@@ -1,0 +1,113 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "ConnectivityManagerImpl_WiFiPafInterface.h"
+#include "WpaSupplicantClient.h"
+
+namespace chip {
+namespace DeviceLayer {
+
+// Forward Declarations
+
+struct ChipDeviceEvent;
+
+/**
+ *  Provides an implementation of the ConnectionManager object
+ *  for Linux platforms where wpa_supplicant provides the
+ *  Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+ *  Service Discovery (USD) / Public Action Frame (PAF)
+ *  commissioning transport.
+ *
+ */
+class ConnectivityManagerImpl_WiFiPafWpaSupplicant final : public Internal::WiFiPafInterface, public Internal::WpaSupplicantClient
+{
+public:
+    // Destruction
+
+    virtual ~ConnectivityManagerImpl_WiFiPafWpaSupplicant() = default;
+
+    // Initialization
+
+    CHIP_ERROR Init(ConnectivityManagerImpl & inConnectivityManagerImpl) override final;
+
+    // Event Handling
+
+    void OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) override final;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    // Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+    // Service Discovery (USD) / Public Action Frame (PAF)
+    // Commissioning Transport
+
+    // Initialization
+
+    CHIP_ERROR WiFiPafShutdown(const uint32_t & inId, const WiFiPAF::WiFiPafRole & inWiFiPafRole) override final;
+
+    // Introspection
+
+    bool IsWiFiPafResourceAvailable() const override final;
+
+    // Mutation
+
+    CHIP_ERROR WiFiPafSetAdvertisingEnabled(bool inEnabled, uint32_t & inOutPublishId) override final;
+    void WiFiPafSetParam(const ConnectivityManager::WiFiPAFAdvertiseParam & inWiFiPafAdvertiseParams) override final;
+    CHIP_ERROR WiFiPafSetResourceAvailable(const bool & inAvailable) override final;
+    void WiFiPafSetSubscribeFreq(const uint16_t & inFrequency) override final;
+
+    // Publish-and-subscribe
+
+    CHIP_ERROR WiFiPafPublish(ConnectivityManager::WiFiPAFAdvertiseParam & inOutWiFiPafAdvertiseParams) override final;
+    CHIP_ERROR WiFiPafCancelPublish(const uint32_t & inPublishId) override final;
+    CHIP_ERROR WiFiPafSubscribe(const uint16_t & inConnectionDiscriminator, void * inContext,
+                                ConnectivityManager::OnConnectionCompleteFunct onSuccessFunc,
+                                ConnectivityManager::OnConnectionErrorFunct onErrorFunc) override final;
+    CHIP_ERROR WiFiPafCancelSubscribe(const uint32_t & inSubscribeId) override final;
+    CHIP_ERROR WiFiPafCancelIncompleteSubscribe() override final;
+
+    // Data Transmission
+
+    CHIP_ERROR WiFiPafSend(const WiFiPAF::WiFiPAFSession & inWiFiPafSession,
+                           chip::System::PacketBufferHandle && inOutMessageBuffer) override final;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+private:
+    void OnDiscoveryResult(GVariant * obj);
+    void OnReplied(GVariant * obj);
+    void OnNanReceive(GVariant * obj);
+    void OnNanPublishTerminated(guint public_id, gchar * reason);
+    void OnNanSubscribeTerminated(guint subscribe_id, gchar * reason);
+
+    // wpa_supplicant Base Class Method Overrides
+
+    void OnWiFiMediumAvailable(WpaSupplicantClient & inOutWpaSupplicantClient, bool inAvailable) override final;
+    void PostNetworkConnect() override final;
+    void UpdateWiFiNetworkStatus() override final;
+
+private:
+    ConnectivityManagerImpl * mConnectivityManagerImpl;
+    bool mPafChannelAvailable;
+    ConnectivityManager::WiFiPAFAdvertiseParam mPafAdvertiseParams;
+    ConnectivityManager::OnConnectionCompleteFunct mOnPafSubscribeComplete;
+    ConnectivityManager::OnConnectionErrorFunct mOnPafSubscribeError;
+    void * mAppState;
+    uint16_t mSubscribeFreq;
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/WpaSupplicantClient.cpp
+++ b/src/platform/Linux/WpaSupplicantClient.cpp
@@ -192,11 +192,20 @@ void WpaSupplicantClient::Shutdown() noexcept
     mConnectivityManagerImpl = nullptr;
 }
 
-void WpaSupplicantClient::Reset() noexcept
+CHIP_ERROR WpaSupplicantClient::ResetOnGLib(void)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
     mWpaSupplicant.Reset();
+
+    return CHIP_NO_ERROR;
+}
+
+void WpaSupplicantClient::Reset() noexcept
+{
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](WpaSupplicantClient * self) { return self->ResetOnGLib(); }, this);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to stop Wi-Fi management"));
 }
 
 bool WpaSupplicantClient::IsStarted() const noexcept

--- a/src/platform/Linux/WpaSupplicantClient.h
+++ b/src/platform/Linux/WpaSupplicantClient.h
@@ -250,6 +250,7 @@ private:
     void OnWpaInterfaceScanDone(WpaSupplicant1Interface * iface, gboolean success);
     void OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
     CHIP_ERROR StartOnGLib();
+    CHIP_ERROR ResetOnGLib();
 
 protected:
     struct GDBusWpaSupplicant


### PR DESCRIPTION
### Summary

Per #42516, this enables conman as a concrete Linux platform Connectivity Management network management implementation.

In the course of doing so, three additional refactors occur:

1. _ConfigurationManagerImpl.{h,cpp}_
    * This refactors the Linux platform Connectivity Manager implementation by continuing to use CRTP for the public-facing "front end". However, it now delegates those methods to one of two new Linux platform-only abstract interfaces:
        1. `chip::DeviceLayer::Internal::NetworkManagementInterface`
            * An abstract interface for controlling and interacting with network management infrastructure on a Linux platform.
            * Concrete implementations are expected to provide the platform-and driver-specific integration required to manage one or more IP-bearing network interfaces, especially Wi-Fi but also Ethernet. Thread, however, is excluded as it is managed through an independent, parallel stack interface.
            * Implementations may include full-featured network management software such as GNOME Network Manager or Connection Manager (also known as connman) or may be Wi-Fi-specific backends such as iwd or wpa_supplicant with adjunct handling for Ethernet, if any.
        2. `chip::DeviceLayer::Internal::WiFiPafInterface`
            * An abstract interface for controlling and interacting with a Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized Service Discovery (USD) / Public Action Frame (PAF) Commissioning Transport on a Linux platform.
            * Concrete implementations are expected to provide the platform- and driver-specific integration required to publish and subscribe to commissioning services and to exchange commissioning data over the Wi-Fi NAN USD PAF transport.
    * Initial instantiation support is available for the following network and Wi-Fi PAF commissioning transport mangement combinations, respectively:
        * "connman" and "" (none)
        * "wpa_supplicant" and "" (none)
        * "wpa_supplicant" and "wpa_supplicant"
2. _ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp_
    * Refactored to use abstract virtual network management interface described above.
3. _ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp_
    * Refactored to use abstract virtual Wi-Fi USD NAN / PAF management interface described above.

Finally, _BUILD.gn_ is modified to handle the different combinations described above.

### Related issues

Fixes #42516.

### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with **both** a Connectivity Manager implementation **and** a wpa_supplicant implementation using this infrastructure.