### PR TITLE
GroupKeyManagement: fix EndpointIterator leak in GroupTableCodec::Encode

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2025 Project CHIP Authors
+ *    Copyright (c) 2020-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,19 +82,24 @@ struct GroupTableCodec
         auto iter = mProvider->IterateEndpoints(mFabric, std::make_optional(mInfo.group_id));
         if (nullptr != iter)
         {
+            CHIP_ERROR endpointEncodeErr = CHIP_NO_ERROR;
             while (iter->Next(mapping))
             {
-                ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id)));
+                endpointEncodeErr = writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id));
+                if (endpointEncodeErr != CHIP_NO_ERROR)
+                {
+                    break;
+                }
             }
             iter->Release();
+            ReturnErrorOnFailure(endpointEncodeErr);
         }
         ReturnErrorOnFailure(writer.EndContainer(inner));
         // GroupName
         uint32_t name_size = static_cast<uint32_t>(strnlen(mInfo.name, GroupDataProvider::GroupInfo::kGroupNameMax));
         ReturnErrorOnFailure(writer.PutString(TagGroupName(), mInfo.name, name_size));
 
-        ReturnErrorOnFailure(writer.EndContainer(outer));
-        return CHIP_NO_ERROR;
+        return writer.EndContainer(outer);
     }
 };
 

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -426,4 +426,107 @@ TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttributeIteratorExhau
     EXPECT_EQ(err, CHIP_ERROR_NO_MEMORY);
 }
 
+// Provider that drives the GroupTable read into the endpoint-encoding failure path and makes a
+// leaked EndpointIterator observable on any pool backend (the host build uses the heap pool, which
+// never exhausts, so the leak cannot be detected by watching IterateEndpoints return nullptr).
+class LeakDetectingGroupDataProvider : public Credentials::GroupDataProviderImpl
+{
+public:
+    int liveEndpointIterators = 0;
+
+    // The GroupTable read loops over groups; without at least one group it never builds a
+    // GroupTableCodec and the endpoint-encoding path under test is never reached. Yield exactly one.
+    GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override { return new SingleGroupInfoIterator(); }
+
+    // Return the counting/flooding iterator instead of the real pool-backed one. This is the hook
+    // that both forces the failure (flood) and observes the leak (counter).
+    EndpointIterator * IterateEndpoints(FabricIndex fabric_index, std::optional<GroupId> group_id = std::nullopt) override
+    {
+        return new FloodEndpointIterator(*this);
+    }
+
+private:
+    // Minimal GroupInfoIterator that yields a single group then stops.
+    class SingleGroupInfoIterator : public GroupInfoIterator
+    {
+    public:
+        size_t Count() override { return 1; }
+        bool Next(GroupInfo & item) override
+        {
+            if (mDone)
+            {
+                return false;
+            }
+            mDone         = true;
+            item.group_id = 0x0001;
+            item.SetName("G"_span);
+            return true;
+        }
+        void Release() override { delete this; }
+
+    private:
+        bool mDone = false;
+    };
+
+    // EndpointIterator that (a) emits far more endpoints than fit in the encode buffer, so
+    // writer.Put() fails partway through the endpoints array, and (b) bumps the provider's live
+    // counter on construction / down on Release so a skipped Release is observable.
+    class FloodEndpointIterator : public EndpointIterator
+    {
+    public:
+        explicit FloodEndpointIterator(LeakDetectingGroupDataProvider & provider) : mProvider(provider)
+        {
+            ++mProvider.liveEndpointIterators;
+        }
+        size_t Count() override { return kFloodCount; }
+        bool Next(GroupEndpoint & item) override
+        {
+            if (mEmitted >= kFloodCount)
+            {
+                return false;
+            }
+            item.group_id    = 0x0001;
+            item.endpoint_id = static_cast<EndpointId>(mEmitted++);
+            return true;
+        }
+        void Release() override
+        {
+            --mProvider.liveEndpointIterators;
+            delete this;
+        }
+
+    private:
+        // Far exceeds the encoder buffer so writer.Put() is guaranteed to fail inside the endpoints array.
+        static constexpr size_t kFloodCount = 1000;
+        LeakDetectingGroupDataProvider & mProvider;
+        size_t mEmitted = 0;
+    };
+};
+
+TEST_F(TestGroupKeyManagementCluster, TestGroupTableReadReleasesEndpointIteratorOnEncodeFailure)
+{
+    LeakDetectingGroupDataProvider leakProvider;
+
+    auto * storage = &mTestContext.StorageDelegate();
+    leakProvider.SetStorageDelegate(storage);
+    leakProvider.SetSessionKeystore(&mMockKeystore);
+    ASSERT_EQ(leakProvider.Init(), CHIP_NO_ERROR);
+    Credentials::SetGroupDataProvider(&leakProvider);
+
+    GroupKeyManagementCluster leakCluster{ { fabricHelper.GetFabricTable(), leakProvider } };
+    ASSERT_EQ(leakCluster.Startup(mTestContext.Get()), CHIP_NO_ERROR);
+
+    ClusterTester leakTester{ leakCluster };
+    leakTester.SetFabricIndex(kTestFabricIndex);
+
+    uint32_t sink = 0;
+    (void) leakTester.ReadAttribute(GroupKeyManagement::Attributes::GroupTable::Id, sink);
+
+    // The endpoint iterator was released despite the encode failing.
+    // Fails (==1) without the fix, passes (==0) with it.
+    EXPECT_EQ(leakProvider.liveEndpointIterators, 0);
+
+    leakCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 } // namespace


### PR DESCRIPTION
#### Problem

TC-G-2.2 was failing on a device (Matter v1.4.2) where Groups server was present on EP1 and EP4 but absent on EP2 and EP3.

`GroupTableCodec::Encode` leaks an `EndpointIterator` on its error path. When `writer.Put()` fails  inside the endpoint-iteration loop it returned immediately via `ReturnErrorOnFailure`, skipping `iter->Release()`.

GroupTable is a list attribute, so its reads are chunked. A chunk boundary that lands inside the endpoints array makes `writer.Put()` return an out-of-memory error as part of normal chunking leaking one iterator each time as it happens.

#### Change Overview

Capture the `writer.Put()` result, break out of the loop on error, release the iterator, then propagate the error.

### Testing
- Had the same patch for v1.4.2 and ATL reported the test case as a success
- Added unit test for the same. Unit test passed with the current patch. On reverting the current patch unit test fails.