### PR TITLE
Update of runner.py for NFC commissioning

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -757,14 +757,29 @@ def convert_args_to_matter_config(args: argparse.Namespace):
     if "nfc" in (args.commissioning_method or []):
 
         if "NFC_Reader_index" not in config.global_test_params:
-            LOGGER.error("Error: Missing required argument --int-arg NFC_Reader_index:<int-value> for "
-                         "NFC commissioning tests")
-            sys.exit(1)
+            LOGGER.warning("WARNING: NFC_Reader_index not found in global_test_params; "
+                           "defaulting to 0.")
+            config.global_test_params["NFC_Reader_index"] = 0
 
-        if any([args.passcodes, args.discriminators, args.manual_code, args.qr_code]):
-            LOGGER.error("Error: Do not provide discriminator, passcode, manual code or qr-code for NFC commissioning. "
+        if args.passcodes:
+            LOGGER.warning("WARNING: Provided passcode is ignored for NFC commissioning. "
                          "The onboarding data is read directly from the NFC tag.")
-            sys.exit(1)
+            args.passcodes.clear()
+
+        if args.discriminators:
+            LOGGER.warning("WARNING: Provided discriminator is ignored for NFC commissioning. "
+                         "The onboarding data is read directly from the NFC tag.")
+            args.discriminators.clear()
+
+        if args.manual_code:
+            LOGGER.warning("WARNING: Provided manual code is ignored for NFC commissioning. "
+                         "The onboarding data is read directly from the NFC tag.")
+            args.manual_code.clear()
+
+        if args.qr_code:
+            LOGGER.warning("WARNING: Provided qr-code is ignored for NFC commissioning. "
+                         "The onboarding data is read directly from the NFC tag.")
+            args.qr_code.clear()
 
         from matter.testing.nfc import NFCReader
         nfc_reader_index = config.global_test_params.get("NFC_Reader_index", 0)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -760,26 +760,25 @@ def convert_args_to_matter_config(args: argparse.Namespace):
             LOGGER.warning("WARNING: NFC_Reader_index not found in global_test_params; "
                            "defaulting to 0.")
             config.global_test_params["NFC_Reader_index"] = 0
-
         if args.passcodes:
             LOGGER.warning("WARNING: Provided passcode is ignored for NFC commissioning. "
                            "The onboarding data is read directly from the NFC tag.")
-            args.passcodes.clear()
+            args.passcodes = []
 
         if args.discriminators:
             LOGGER.warning("WARNING: Provided discriminator is ignored for NFC commissioning. "
                            "The onboarding data is read directly from the NFC tag.")
-            args.discriminators.clear()
+            args.discriminators = []
 
         if args.manual_code:
             LOGGER.warning("WARNING: Provided manual code is ignored for NFC commissioning. "
                            "The onboarding data is read directly from the NFC tag.")
-            args.manual_code.clear()
+            args.manual_code = None
 
         if args.qr_code:
             LOGGER.warning("WARNING: Provided qr-code is ignored for NFC commissioning. "
                            "The onboarding data is read directly from the NFC tag.")
-            args.qr_code.clear()
+            args.qr_code = None
 
         from matter.testing.nfc import NFCReader
         nfc_reader_index = config.global_test_params.get("NFC_Reader_index", 0)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -773,7 +773,7 @@ def convert_args_to_matter_config(args: argparse.Namespace):
         if args.manual_code:
             LOGGER.warning("WARNING: Provided manual code is ignored for NFC commissioning. "
                            "The onboarding data is read directly from the NFC tag.")
-            args.manual_code = None
+            args.manual_code = []
 
         if args.qr_code:
             LOGGER.warning("WARNING: Provided qr-code is ignored for NFC commissioning. "

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -763,22 +763,22 @@ def convert_args_to_matter_config(args: argparse.Namespace):
 
         if args.passcodes:
             LOGGER.warning("WARNING: Provided passcode is ignored for NFC commissioning. "
-                         "The onboarding data is read directly from the NFC tag.")
+                           "The onboarding data is read directly from the NFC tag.")
             args.passcodes.clear()
 
         if args.discriminators:
             LOGGER.warning("WARNING: Provided discriminator is ignored for NFC commissioning. "
-                         "The onboarding data is read directly from the NFC tag.")
+                           "The onboarding data is read directly from the NFC tag.")
             args.discriminators.clear()
 
         if args.manual_code:
             LOGGER.warning("WARNING: Provided manual code is ignored for NFC commissioning. "
-                         "The onboarding data is read directly from the NFC tag.")
+                           "The onboarding data is read directly from the NFC tag.")
             args.manual_code.clear()
 
         if args.qr_code:
             LOGGER.warning("WARNING: Provided qr-code is ignored for NFC commissioning. "
-                         "The onboarding data is read directly from the NFC tag.")
+                           "The onboarding data is read directly from the NFC tag.")
             args.qr_code.clear()
 
         from matter.testing.nfc import NFCReader


### PR DESCRIPTION
### Summary

Changed runner.py:
- If NFC_Reader_index is not present, it is now default to 0.
- It is no more an error if passcodes, discriminators, manual_code or qr_code is present in the command. They will be ignored.

### Testing

Tested that it works:

```
python3 src/python_testing/TC_ACE_1_5.py --discriminator 888 --passcode 55556666 --commissioning-method nfc-thread --thread-dataset-hex $DataSet --tests test_TC_ACE_1_5
WARNING: NFC_Reader_index not found in global_test_params; defaulting to 0.
WARNING: Provided passcode is ignored for NFC commissioning. The onboarding data is read directly from the NFC tag.
WARNING: Provided discriminator is ignored for NFC commissioning. The onboarding data is read directly from the NFC tag.
[1785326986.245] [2490509:2490509] [CTL] Setting attestation nonce to random value
[1785326986.246] [2490509:2490509] [CTL] Setting CSR nonce to random value
...
```



