### PR TITLE
Turn off wildcard subscriptions for BasicCompositionTests

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -142,6 +142,7 @@ def JsonToMatterTlv(json_filename: str) -> AttributeCache:
 
 
 class BasicCompositionTests(MatterBaseTest):
+    # Disabled because these tests can run over PASE
     disable_wildcard_subscription = True
     # These attributes are initialized/provided by the inheriting test class (MatterBaseTest)
     # or its setup process. Providing type hints here for mypy.

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -142,6 +142,7 @@ def JsonToMatterTlv(json_filename: str) -> AttributeCache:
 
 
 class BasicCompositionTests(MatterBaseTest):
+    disable_wildcard_subscription = True
     # These attributes are initialized/provided by the inheriting test class (MatterBaseTest)
     # or its setup process. Providing type hints here for mypy.
     default_controller: ChipDeviceController


### PR DESCRIPTION
### Summary
This lets us run against PASE and file (both of which are permitted for this type) without waiting for the wildcard to time out.

### Related issues


### Testing
Ran against file locally, it's faster. Also runs in the CI, but CI doesn't capture "faster" very easily.
