### PR TITLE
[Silabs] [Zephyr] 4118a bootloader configs for OTA

### DIFF
--- a/examples/lighting-app/silabs/zephyr/boards/xg26_rb4118a.conf
+++ b/examples/lighting-app/silabs/zephyr/boards/xg26_rb4118a.conf
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Bootloader overwrite-only mode for computing image padding/overflow.
+CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY=y
+CONFIG_MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY=y

--- a/examples/lighting-app/silabs/zephyr/boards/xg26_rb4118a_bootloader.conf
+++ b/examples/lighting-app/silabs/zephyr/boards/xg26_rb4118a_bootloader.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_BOOT_UPGRADE_ONLY=y


### PR DESCRIPTION
### Summary

Adds the overwrite only configs to MCUBoot for the 4118a to be able to OTA

### Related issues
Dependant on:
#73282 

### Testing

On a 4118a, flash v1, commission, read software-version-string, ota v2, read software-version-string