### PR TITLE
[Scenes] Scenable Current Hue

### DIFF
--- a/src/app/clusters/color-control-server/codegen/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/codegen/color-control-server.cpp
@@ -43,9 +43,9 @@ using chip::Protocols::InteractionModel::Status;
 class DefaultColorControlSceneHandler : public scenes::DefaultSceneHandlerImpl
 {
 public:
-    // As per spec, 9 attributes are scenable in the color control cluster, if new scenables attributes are added, this value should
-    // be updated.
-    static constexpr uint8_t kColorControlScenableAttributesCount = 9;
+    // As per spec, 10 attributes are scenable in the color control cluster, if new scenables attributes are added, this value
+    // should be updated.
+    static constexpr uint8_t kColorControlScenableAttributesCount = 10; // XY + EnhancedHue + HS + Loop + Temp + Mode
 
     DefaultColorControlSceneHandler() : scenes::DefaultSceneHandlerImpl(scenes::CodegenAttributeValuePairValidator::Instance()) {}
     ~DefaultColorControlSceneHandler() override = default;
@@ -76,21 +76,21 @@ public:
             {
                 xValue = 0x616B; // Default X value according to spec
             }
-            AddAttributeValuePair<uint16_t>(pairs, Attributes::CurrentX::Id, xValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::CurrentX::Id, xValue, attributeCount));
 
             uint16_t yValue;
             if (Status::Success != Attributes::CurrentY::Get(endpoint, &yValue))
             {
                 yValue = 0x607D; // Default Y value according to spec
             }
-            AddAttributeValuePair<uint16_t>(pairs, Attributes::CurrentY::Id, yValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::CurrentY::Id, yValue, attributeCount));
         }
 
         if (ColorControlServer::Instance().HasFeature(endpoint, ColorControlServer::Feature::kEnhancedHue))
         {
             uint16_t hueValue = 0x0000;
             Attributes::EnhancedCurrentHue::Get(endpoint, &hueValue);
-            AddAttributeValuePair<uint16_t>(pairs, Attributes::EnhancedCurrentHue::Id, hueValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::EnhancedCurrentHue::Id, hueValue, attributeCount));
         }
 
         if (ColorControlServer::Instance().HasFeature(endpoint, ColorControlServer::Feature::kHueAndSaturation))
@@ -100,14 +100,14 @@ public:
             {
                 saturationValue = 0x00;
             }
-            AddAttributeValuePair<uint8_t>(pairs, Attributes::CurrentSaturation::Id, saturationValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::CurrentSaturation::Id, saturationValue, attributeCount));
 
             uint8_t hueValue;
             if (Status::Success != Attributes::CurrentHue::Get(endpoint, &hueValue))
             {
                 hueValue = 0x00;
             }
-            AddAttributeValuePair<uint8_t>(pairs, Attributes::CurrentHue::Id, hueValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::CurrentHue::Id, hueValue, attributeCount));
         }
 
         if (ColorControlServer::Instance().HasFeature(endpoint, ColorControlServer::Feature::kColorLoop))
@@ -117,21 +117,22 @@ public:
             {
                 loopActiveValue = 0x00;
             }
-            AddAttributeValuePair<uint8_t>(pairs, Attributes::ColorLoopActive::Id, loopActiveValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::ColorLoopActive::Id, loopActiveValue, attributeCount));
 
             uint8_t loopDirectionValue;
             if (Status::Success != Attributes::ColorLoopDirection::Get(endpoint, &loopDirectionValue))
             {
                 loopDirectionValue = 0x00;
             }
-            AddAttributeValuePair<uint8_t>(pairs, Attributes::ColorLoopDirection::Id, loopDirectionValue, attributeCount);
+            ReturnErrorOnFailure(
+                AddAttributeValuePair(pairs, Attributes::ColorLoopDirection::Id, loopDirectionValue, attributeCount));
 
             uint16_t loopTimeValue;
             if (Status::Success != Attributes::ColorLoopTime::Get(endpoint, &loopTimeValue))
             {
                 loopTimeValue = 0x0019; // Default loop time value according to spec
             }
-            AddAttributeValuePair<uint16_t>(pairs, Attributes::ColorLoopTime::Id, loopTimeValue, attributeCount);
+            ReturnErrorOnFailure(AddAttributeValuePair(pairs, Attributes::ColorLoopTime::Id, loopTimeValue, attributeCount));
         }
 
         if (ColorControlServer::Instance().HasFeature(endpoint, ColorControlServer::Feature::kColorTemperature))
@@ -141,7 +142,8 @@ public:
             {
                 temperatureValue = 0x00FA; // Default temperature value according to spec
             }
-            AddAttributeValuePair<uint16_t>(pairs, Attributes::ColorTemperatureMireds::Id, temperatureValue, attributeCount);
+            ReturnErrorOnFailure(
+                AddAttributeValuePair(pairs, Attributes::ColorTemperatureMireds::Id, temperatureValue, attributeCount));
         }
 
         EnhancedColorMode modeValue;
@@ -149,7 +151,8 @@ public:
         {
             modeValue = EnhancedColorMode::kCurrentXAndCurrentY; // Default mode value according to spec
         }
-        AddAttributeValuePair(pairs, Attributes::EnhancedColorMode::Id, to_underlying(modeValue), attributeCount);
+        ReturnErrorOnFailure(
+            AddAttributeValuePair(pairs, Attributes::EnhancedColorMode::Id, to_underlying(modeValue), attributeCount));
 
         app::DataModel::List<AttributeValuePair> attributeValueList(pairs, attributeCount);
 
@@ -172,7 +175,7 @@ public:
         size_t attributeCount = 0;
         auto pair_iterator    = attributeValueList.begin();
 
-        // The color control cluster should have a maximum of 9 scenable attributes
+        // The color control cluster should have a maximum of kColorControlScenableAttributesCount scenable attributes
         ReturnErrorOnFailure(attributeValueList.ComputeSize(&attributeCount));
         VerifyOrReturnError(attributeCount <= kColorControlScenableAttributesCount, CHIP_ERROR_BUFFER_TOO_SMALL);
 
@@ -366,11 +369,13 @@ private:
     /// @param value attribute value
     /// @param attributeCount number of attributes in the list, incremented by this function, used to keep track of how many
     /// attributes from the array are being used for the list to encode
-    template <typename Type>
-    void AddAttributeValuePair(ScenesManagement::Structs::AttributeValuePairStruct::Type * pairs, AttributeId id, Type value,
-                               size_t & attributeCount)
+    /// @return CHIP_NO_ERROR no errors, CHIP_ERROR_BUFFER_TOO_SMALL if we are trying to serialize past the array size
+    template <size_t N, typename Type>
+    CHIP_ERROR AddAttributeValuePair(ScenesManagement::Structs::AttributeValuePairStruct::Type (&pairs)[N], AttributeId id,
+                                     Type value, size_t & attributeCount)
     {
         static_assert((std::is_same_v<Type, uint8_t>) || (std::is_same_v<Type, uint16_t>), "Type must be uint8_t or uint16_t");
+        VerifyOrReturnError(attributeCount < N, CHIP_ERROR_BUFFER_TOO_SMALL);
 
         pairs[attributeCount].attributeID = id;
         if constexpr ((std::is_same_v<Type, uint8_t>) )
@@ -382,6 +387,7 @@ private:
             pairs[attributeCount].valueUnsigned16.SetValue(value);
         }
         attributeCount++;
+        return CHIP_NO_ERROR;
     }
 };
 static DefaultColorControlSceneHandler sColorControlSceneHandler;

--- a/src/app/clusters/color-control-server/codegen/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/codegen/color-control-server.cpp
@@ -101,6 +101,13 @@ public:
                 saturationValue = 0x00;
             }
             AddAttributeValuePair<uint8_t>(pairs, Attributes::CurrentSaturation::Id, saturationValue, attributeCount);
+
+            uint8_t hueValue;
+            if (Status::Success != Attributes::CurrentHue::Get(endpoint, &hueValue))
+            {
+                hueValue = 0x00;
+            }
+            AddAttributeValuePair<uint8_t>(pairs, Attributes::CurrentHue::Id, hueValue, attributeCount);
         }
 
         if (ColorControlServer::Instance().HasFeature(endpoint, ColorControlServer::Feature::kColorLoop))
@@ -231,6 +238,13 @@ public:
                                                                           colorSaturationTransitionState->highLimit);
                 }
                 break;
+            case Attributes::CurrentHue::Id:
+                if (SupportsColorMode(endpoint, EnhancedColorMode::kCurrentHueAndCurrentSaturation))
+                {
+                    VerifyOrReturnError(decodePair.valueUnsigned8.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
+                    colorHueTransitionState->finalHue = decodePair.valueUnsigned8.Value();
+                }
+                break;
             case Attributes::ColorLoopActive::Id:
                 VerifyOrReturnError(decodePair.valueUnsigned8.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
                 loopActiveValue = decodePair.valueUnsigned8.Value();
@@ -292,8 +306,7 @@ public:
             {
             case EnhancedColorMode::kCurrentHueAndCurrentSaturation:
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-                ColorControlServer::Instance().moveToSaturation(
-                    endpoint, static_cast<uint8_t>(colorSaturationTransitionState->finalValue), transitionTime10th);
+                ColorControlServer::Instance().moveToHueAndSaturation(endpoint, colorHueTransitionState->finalHue, static_cast<uint8_t>(colorSaturationTransitionState->finalValue), transitionTime10th, false);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
                 break;
             case EnhancedColorMode::kCurrentXAndCurrentY:

--- a/src/app/clusters/color-control-server/codegen/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/codegen/color-control-server.cpp
@@ -306,7 +306,9 @@ public:
             {
             case EnhancedColorMode::kCurrentHueAndCurrentSaturation:
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-                ColorControlServer::Instance().moveToHueAndSaturation(endpoint, colorHueTransitionState->finalHue, static_cast<uint8_t>(colorSaturationTransitionState->finalValue), transitionTime10th, false);
+                ColorControlServer::Instance().moveToHueAndSaturation(
+                    endpoint, colorHueTransitionState->finalHue, static_cast<uint8_t>(colorSaturationTransitionState->finalValue),
+                    transitionTime10th, false);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
                 break;
             case EnhancedColorMode::kCurrentXAndCurrentY:

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -107,7 +107,7 @@ class TC_CC_10_1(MatterBaseTest):
             TestStep(
                 "6a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x00 }, { AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
             TestStep("6b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02 and the _TransitionTime_ omitted."),
-            TestStep("6c", "TH reads the _CurrentSaturation attribute_ from DUT."),
+            TestStep("6c", "TH reads the _CurrentHue and _CurrentSaturation attribute_ from DUT."),
             TestStep(
                 "7a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x01 }, { AttributeID: 0x0003, ValueUnsigned16: 16334 },{ AttributeID: 0x0004, ValueUnsigned16: 13067 }]}]'"),
             TestStep("7b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03 and the _TransitionTime_ omitted."),
@@ -254,6 +254,11 @@ class TC_CC_10_1(MatterBaseTest):
                     continue
 
                 for AV in EFS.attributeValueList:
+                    if AV.attributeID == 0x0000:
+                        asserts.assert_less_equal(AV.valueUnsigned8, 230, "View Scene failed on Hue above limit")
+                        asserts.assert_greater_equal(AV.valueUnsigned8, 170, "View Scene failed on Hue below limit")
+
+                for AV in EFS.attributeValueList:
                     if AV.attributeID == 0x0001:
                         asserts.assert_less_equal(AV.valueUnsigned8, 58, "View Scene failed on Saturation above limit")
                         asserts.assert_greater_equal(AV.valueUnsigned8, 42, "View Scene failed on Saturation below limit")
@@ -367,11 +372,12 @@ class TC_CC_10_1(MatterBaseTest):
                     self.kGroup1,
                     0x02,
                     0,
-                    "Sat Scene",
+                    "HueSat Scene",
                     [
                         self._prepare_cc_extension_field_set(
                             [
                                 Clusters.ScenesManagement.Structs.AttributeValuePairStruct(attributeID=0x4001, valueUnsigned8=0x00),
+                                Clusters.ScenesManagement.Structs.AttributeValuePairStruct(attributeID=0x0000, valueUnsigned8=0xE0),
                                 Clusters.ScenesManagement.Structs.AttributeValuePairStruct(attributeID=0x0001, valueUnsigned8=0xE0)
                             ]
                         )
@@ -388,7 +394,7 @@ class TC_CC_10_1(MatterBaseTest):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
         self.step("6c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
-            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8)])
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8), (attributes.CurrentHue, 0xD8, 0xE8)])
 
         self.step("7a")
         if self.pics_guard(self.check_pics("CC.S.F03")):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -46,7 +46,7 @@ from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
-kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
+kCCAttributeValueIDs = [0x0000, 0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
 kTempTolerance = 0.15
 
 
@@ -105,9 +105,9 @@ class TC_CC_10_1(MatterBaseTest):
             TestStep("5c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
             TestStep("5d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
             TestStep(
-                "6a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x00 }, { AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
+                "6a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0xE0 }, { AttributeID: 0x4001, ValueUnsigned8: 0xE0 }, { AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
             TestStep("6b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02 and the _TransitionTime_ omitted."),
-            TestStep("6c", "TH reads the _CurrentHue and _CurrentSaturation attribute_ from DUT."),
+            TestStep("6c", "TH reads the _CurrentHue attribute_ and _CurrentSaturation attribute_ from DUT."),
             TestStep(
                 "7a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x01 }, { AttributeID: 0x0003, ValueUnsigned16: 16334 },{ AttributeID: 0x0004, ValueUnsigned16: 13067 }]}]'"),
             TestStep("7b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03 and the _TransitionTime_ omitted."),
@@ -258,7 +258,6 @@ class TC_CC_10_1(MatterBaseTest):
                         asserts.assert_less_equal(AV.valueUnsigned8, 230, "View Scene failed on Hue above limit")
                         asserts.assert_greater_equal(AV.valueUnsigned8, 170, "View Scene failed on Hue below limit")
 
-                for AV in EFS.attributeValueList:
                     if AV.attributeID == 0x0001:
                         asserts.assert_less_equal(AV.valueUnsigned8, 58, "View Scene failed on Saturation above limit")
                         asserts.assert_greater_equal(AV.valueUnsigned8, 42, "View Scene failed on Saturation below limit")


### PR DESCRIPTION


### Summary

Making Color Hue Scenable and adding checks in the test plan to validate it can be included in colour control scenes.

This applies the changes from https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12948.

### Related issues

fixes: https://github.com/project-chip/connectedhomeip/issues/73330

### Testing

Local tests on device and Ran TC_CC_10_1.py on all-clusters-app
