### PR TITLE
esp32: remove pigweed-app build steps

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -240,9 +240,6 @@ jobs:
             - name: Build example LIT ICD App (Target:ESP32H2)
               run: scripts/examples/esp_example.sh lit-icd-app sdkconfig.defaults esp32h2
 
-            - name: Build example Pigweed App
-              run: scripts/examples/esp_example.sh pigweed-app sdkconfig.defaults
-
             - name: Build example Lock App (Target:ESP32C6)
               run: scripts/examples/esp_example.sh lock-app sdkconfig.defaults esp32c6
 


### PR DESCRIPTION
### Summary
pigweed-app was removed in #72251. For esp32 that runs in `ESP32_1` job which gets skipped on the PRs to reduce the CI time and runs on the espressif's fork of repository hence wasn't caught on that PR.

### Related issues
PR - #72251
failed job - https://github.com/espressif/connectedhomeip/actions/runs/29649776479/job/88094003349

### Testing
- None, removes the unsupported app from the ci