### PR TITLE
[Telink] Fix IPV6_RECVPKTINFO socket option.

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -529,6 +529,10 @@ config TELINK_TLX_SHA_HW_SLOTS
     default 2 if BOARD_TL3218X_RETENTION
     default 8 if SOC_RISCV_TELINK_TLX
 
+config NET_CONTEXT_RECV_PKTINFO
+    bool
+    default y
+
 endif # !ZEPHYR_VERSION_3_3
 
 config GETOPT_LONG


### PR DESCRIPTION
### Summary
During Matter Telink devices starting up observed an error:
`E: 5075 [IN]IPV6_PKTINFO failed: 109`
The socket option _IPV6_RECVPKTINFO_ tells the operating system to give an application extra packet details, including the destination IP address and the network interface index, for every incoming IPv6 packet.
The error comes from here: _src/inet/UDPEndPointImplSockets.cpp_
```
#ifdef IPV6_RECVPKTINFO
        if (addressType == IPAddressType::kIPv6)
        {
            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one));
            if (res != 0)
            {
                ChipLogError(Inet, "IPV6_PKTINFO failed: %d", errno);
            }
        }
#endif // defined(IPV6_RECVPKTINFO)
```
_IPV6_RECVPKTINFO_ unconditionally defined in zephyr 4.1 see: _include/zephyr/net/socket.h_
but implementation _subsys/net/lib/sockets/sockets_inet.c_ closed by macro:
```
		case IPV6_RECVPKTINFO:
			if (IS_ENABLED(CONFIG_NET_IPV6) &&
			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_PKTINFO)) {
```
So enabling implementation by enabling _CONFIG_NET_CONTEXT_RECV_PKTINFO_

### Related issues
N/A

### Testing
Manually using chip-tool by following commissioning procedure. 
