### PR TITLE
Fix stale CurrentLevel read on FreeRTOS for immediate LevelControl tr…

### DIFF
--- a/src/app/clusters/level-control/codegen/level-control.cpp
+++ b/src/app/clusters/level-control/codegen/level-control.cpp
@@ -993,7 +993,16 @@ static Status moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
     // The setup was successful, so mark the new state as active and return.
-    scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+
+    // Execute immediate transitions synchronously instead of scheduling a 0ms timer.
+    if (state->transitionTimeMs == 0)
+    {
+        emberAfLevelControlClusterServerTickCallback(endpoint);
+    }
+    else
+    {
+        scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+    }
 
 #ifdef MATTER_DM_PLUGIN_ON_OFF
     // Check that the received MoveToLevelWithOnOff produces a On action and that the onoff support the lighting featuremap
@@ -1143,7 +1152,16 @@ static void moveHandler(CommandHandler * commandObj, const ConcreteCommandPath &
     state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
     // The setup was successful, so mark the new state as active and return.
-    scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+
+    // Execute immediate transitions synchronously instead of scheduling a 0ms timer.
+    if (state->transitionTimeMs == 0)
+    {
+        emberAfLevelControlClusterServerTickCallback(endpoint);
+    }
+    else
+    {
+        scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+    }
     status = Status::Success;
 
 send_default_response:
@@ -1290,7 +1308,16 @@ static void stepHandler(CommandHandler * commandObj, const ConcreteCommandPath &
     state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
     // The setup was successful, so mark the new state as active and return.
-    scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+
+    // Execute immediate transitions synchronously instead of scheduling a 0ms timer.
+    if (state->transitionTimeMs == 0)
+    {
+        emberAfLevelControlClusterServerTickCallback(endpoint);
+    }
+    else
+    {
+        scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
+    }
     status = Status::Success;
 
 send_default_response:


### PR DESCRIPTION
…ansitions

MoveToLevel/Move/Step with TransitionTime=0 schedules a 0ms timer via scheduleTimerCallbackMs() to write CurrentLevel. StartTimer(0ms) posts to the event queue rather than executing inline. The event loop's inner drain loop processes all queued messages, including a subsequent ReadAttribute, before checking timers — so the Read returns stale CurrentLevel.

Call emberAfLevelControlClusterServerTickCallback() synchronously for immediate transitions instead of scheduling a 0ms timer.

Fixes #73306

### Related issues

Issue: #73306


### Testing

- TC-LVL-3.1 passes every time.