### PR TITLE
De-inline-ify VA_ARGS macros in CodeUtils.h

### DIFF
--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -104,6 +104,7 @@
  *
  *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
  */
+#if CHIP_CONFIG_ERROR_SOURCE
 #define ReturnLogErrorOnFailure(expr)                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
@@ -114,6 +115,18 @@
             return __err;                                                                                                          \
         }                                                                                                                          \
     } while (false)
+#else
+#define ReturnLogErrorOnFailure(expr)                                                                                              \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (__err != CHIP_NO_ERROR)                                                                                                \
+        {                                                                                                                          \
+            ::chip::Logging::LogFailure(::chip::Logging::kLogModule_NotSpecified, __err);                                          \
+            return __err;                                                                                                          \
+        }                                                                                                                          \
+    } while (false)
+#endif
 
 /**
  *  @def SuccessOrLog(expr, MOD, MSG, ...)
@@ -308,7 +321,7 @@
         if (!(expr))                                                                                                               \
         {                                                                                                                          \
             auto __code = (code);                                                                                                  \
-            ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(__code), __FILE__, __LINE__);                                       \
+            ::chip::Logging::LogVerifyOrReturnErrorWithSource(__code, __FILE__, __LINE__);                                         \
             return __code;                                                                                                         \
         }                                                                                                                          \
     } while (false)
@@ -319,7 +332,7 @@
         if (!(expr))                                                                                                               \
         {                                                                                                                          \
             auto __code = (code);                                                                                                  \
-            ChipLogError(NotSpecified, "%s:%d false: %" CHIP_ERROR_FORMAT, #expr, __LINE__, __code.Format());                      \
+            ::chip::Logging::LogVerifyOrReturnError(#expr, __LINE__, __code);                                                      \
             return __code;                                                                                                         \
         }                                                                                                                          \
     } while (false)
@@ -430,10 +443,10 @@ inline void chipDie(void)
  */
 #if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE && CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE_NO_COND
 #define VerifyOrDie(aCondition)                                                                                                    \
-    VerifyOrDo(aCondition, ChipLogError(Support, "VerifyOrDie failure at %s:%d", __FILE__, __LINE__); chipAbort())
+    VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__))
 #elif CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDie(aCondition)                                                                                                    \
-    VerifyOrDo(aCondition, ChipLogError(Support, "VerifyOrDie failure at %s:%d: %s", __FILE__, __LINE__, #aCondition); chipAbort())
+    VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
 #else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDie(aCondition) VerifyOrDieWithoutLogging(aCondition)
 #endif // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
@@ -466,18 +479,14 @@ inline void chipDie(void)
     do                                                                                                                             \
     {                                                                                                                              \
         auto __err = (error);                                                                                                      \
-        VerifyOrDo(::chip::ChipError::IsSuccess(__err),                                                                            \
-                   ChipLogError(Support, "SuccessOrDie failure %s at %s:%d", ErrorStr(__err), __FILE__, __LINE__);                 \
-                   chipAbort());                                                                                                   \
+        VerifyOrDo(::chip::ChipError::IsSuccess(__err), ::chip::Logging::LogSuccessOrDie(__FILE__, __LINE__, __err));              \
     } while (false)
 #elif CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define SuccessOrDie(error)                                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
         auto __err = (error);                                                                                                      \
-        VerifyOrDo(::chip::ChipError::IsSuccess(__err),                                                                            \
-                   ChipLogError(Support, "SuccessOrDie failure %s at %s:%d: %s", ErrorStr(__err), __FILE__, __LINE__, #error);     \
-                   chipAbort());                                                                                                   \
+        VerifyOrDo(::chip::ChipError::IsSuccess(__err), ::chip::Logging::LogSuccessOrDie(__FILE__, __LINE__, __err, #error));      \
     } while (false)
 #else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define SuccessOrDie(error) VerifyOrDieWithoutLogging(::chip::ChipError::IsSuccess((error)))
@@ -493,7 +502,7 @@ inline void chipDie(void)
 #if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDieWithObject(aCondition, aObject)                                                                                 \
     VerifyOrDo(aCondition, ::chip::DumpObjectToLog(aObject);                                                                       \
-               ChipLogError(Support, "VerifyOrDie failure at %s:%d: %s", __FILE__, __LINE__, #aCondition); chipAbort())
+               ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
 #else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDieWithObject(aCondition, aObject) VerifyOrDieWithoutLogging(aCondition)
 #endif // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
@@ -532,8 +541,19 @@ inline void chipDie(void)
  *  @sa #chipDie
  *
  */
-#define VerifyOrDieWithMsg(aCondition, aModule, aMessage, ...)                                                                     \
+#define CHIP_VERIFY_OR_DIE_WITH_MSG_SELECT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+
+#define VerifyOrDieWithMsg_NO_VA_ARGS(aCondition, aModule, aMessage)                                                               \
+    VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDieWithMsg(::chip::Logging::kLogModule_##aModule, aMessage))
+
+#define VerifyOrDieWithMsg_VA_ARGS(aCondition, aModule, aMessage, ...)                                                             \
     VerifyOrDo(aCondition, ChipLogError(aModule, aMessage, ##__VA_ARGS__); chipAbort())
+
+#define VerifyOrDieWithMsg(...)                                                                                                    \
+    CHIP_VERIFY_OR_DIE_WITH_MSG_SELECT(__VA_ARGS__, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS,                        \
+                                       VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS,         \
+                                       VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_NO_VA_ARGS)(     \
+        __VA_ARGS__)
 
 /**
  *  @def LogErrorOnFailure(expr)
@@ -549,6 +569,7 @@ inline void chipDie(void)
  *
  *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
  */
+#if CHIP_CONFIG_ERROR_SOURCE
 #define LogErrorOnFailure(expr)                                                                                                    \
     do                                                                                                                             \
     {                                                                                                                              \
@@ -558,6 +579,17 @@ inline void chipDie(void)
             ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(__err), __FILE__, __LINE__);                                        \
         }                                                                                                                          \
     } while (false)
+#else
+#define LogErrorOnFailure(expr)                                                                                                    \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (__err != CHIP_NO_ERROR)                                                                                                \
+        {                                                                                                                          \
+            ::chip::Logging::LogFailure(::chip::Logging::kLogModule_NotSpecified, __err);                                          \
+        }                                                                                                                          \
+    } while (false)
+#endif
 
 #if (__cplusplus >= 201103L)
 

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -442,11 +442,9 @@ inline void chipDie(void)
  *
  */
 #if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE && CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE_NO_COND
-#define VerifyOrDie(aCondition)                                                                                                    \
-    VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__))
+#define VerifyOrDie(aCondition) VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__))
 #elif CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
-#define VerifyOrDie(aCondition)                                                                                                    \
-    VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
+#define VerifyOrDie(aCondition) VerifyOrDo(aCondition, ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
 #else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDie(aCondition) VerifyOrDieWithoutLogging(aCondition)
 #endif // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
@@ -501,8 +499,7 @@ inline void chipDie(void)
  */
 #if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDieWithObject(aCondition, aObject)                                                                                 \
-    VerifyOrDo(aCondition, ::chip::DumpObjectToLog(aObject);                                                                       \
-               ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
+    VerifyOrDo(aCondition, ::chip::DumpObjectToLog(aObject); ::chip::Logging::LogVerifyOrDie(__FILE__, __LINE__, #aCondition))
 #else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDieWithObject(aCondition, aObject) VerifyOrDieWithoutLogging(aCondition)
 #endif // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
@@ -552,8 +549,8 @@ inline void chipDie(void)
 #define VerifyOrDieWithMsg(...)                                                                                                    \
     CHIP_VERIFY_OR_DIE_WITH_MSG_SELECT(__VA_ARGS__, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS,                        \
                                        VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS,         \
-                                       VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_NO_VA_ARGS)(     \
-        __VA_ARGS__)
+                                       VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_VA_ARGS, VerifyOrDieWithMsg_NO_VA_ARGS)      \
+    (__VA_ARGS__)
 
 /**
  *  @def LogErrorOnFailure(expr)

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -108,8 +108,8 @@
 #define ReturnLogErrorOnFailure(expr)                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
-        CHIP_ERROR __err = (expr);                                                                                                 \
-        if (__err != CHIP_NO_ERROR)                                                                                                \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
             ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(__err), __FILE__, __LINE__);                                        \
             return __err;                                                                                                          \
@@ -119,8 +119,8 @@
 #define ReturnLogErrorOnFailure(expr)                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
-        CHIP_ERROR __err = (expr);                                                                                                 \
-        if (__err != CHIP_NO_ERROR)                                                                                                \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
             ::chip::Logging::LogFailure(::chip::Logging::kLogModule_NotSpecified, __err);                                          \
             return __err;                                                                                                          \
@@ -573,8 +573,8 @@ inline void chipDie(void)
 #define LogErrorOnFailure(expr)                                                                                                    \
     do                                                                                                                             \
     {                                                                                                                              \
-        CHIP_ERROR __err = (expr);                                                                                                 \
-        if (__err != CHIP_NO_ERROR)                                                                                                \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
             ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(__err), __FILE__, __LINE__);                                        \
         }                                                                                                                          \
@@ -583,8 +583,8 @@ inline void chipDie(void)
 #define LogErrorOnFailure(expr)                                                                                                    \
     do                                                                                                                             \
     {                                                                                                                              \
-        CHIP_ERROR __err = (expr);                                                                                                 \
-        if (__err != CHIP_NO_ERROR)                                                                                                \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
             ::chip::Logging::LogFailure(::chip::Logging::kLogModule_NotSpecified, __err);                                          \
         }                                                                                                                          \

--- a/src/lib/support/logging/TextOnlyLogging.cpp
+++ b/src/lib/support/logging/TextOnlyLogging.cpp
@@ -25,6 +25,7 @@
 #include "TextOnlyLogging.h"
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
 
 #include <platform/logging/LogV.h>
@@ -167,6 +168,69 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list args)
         Platform::LogV(moduleName, category, msg, args);
     }
 }
+
+void LogFailure(uint8_t module, CHIP_ERROR err, const char * msg)
+{
+    if (err != CHIP_NO_ERROR)
+    {
+        Log(module, kLogCategory_Error, "%s: %" CHIP_ERROR_FORMAT, msg, err.Format());
+    }
+}
+
+void LogFailure(uint8_t module, CHIP_ERROR err)
+{
+    if (err != CHIP_NO_ERROR)
+    {
+        Log(module, kLogCategory_Error, "Error %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+void LogVerifyOrReturnError(const char * expr, int line, CHIP_ERROR code)
+{
+    Log(kLogModule_NotSpecified, kLogCategory_Error, "%s:%d false: %" CHIP_ERROR_FORMAT, expr, line, code.Format());
+}
+
+#if CHIP_CONFIG_ERROR_SOURCE
+void LogVerifyOrReturnErrorWithSource(CHIP_ERROR code, const char * file, int line)
+{
+    Log(kLogModule_NotSpecified, kLogCategory_Error, "%s at %s:%d", ErrorStr(code), file, line);
+}
+#endif
+
+#if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+void LogVerifyOrDie(const char * file, int line, const char * condition)
+{
+    if (condition != nullptr)
+    {
+        Log(kLogModule_Support, kLogCategory_Error, "VerifyOrDie failure at %s:%d: %s", file, line, condition);
+    }
+    else
+    {
+        Log(kLogModule_Support, kLogCategory_Error, "VerifyOrDie failure at %s:%d", file, line);
+    }
+    chipAbort();
+}
+
+void LogSuccessOrDie(const char * file, int line, CHIP_ERROR err, const char * expr)
+{
+    if (expr != nullptr)
+    {
+        Log(kLogModule_Support, kLogCategory_Error, "SuccessOrDie failure %s at %s:%d: %s", ErrorStr(err), file, line, expr);
+    }
+    else
+    {
+        Log(kLogModule_Support, kLogCategory_Error, "SuccessOrDie failure %s at %s:%d", ErrorStr(err), file, line);
+    }
+    chipAbort();
+}
+#endif
+
+void LogVerifyOrDieWithMsg(uint8_t module, const char * msg)
+{
+    Log(module, kLogCategory_Error, "%s", msg);
+    chipAbort();
+}
+
 
 #if CHIP_LOG_FILTERING
 std::atomic<uint8_t> gLogFilter(kLogCategory_Max);

--- a/src/lib/support/logging/TextOnlyLogging.cpp
+++ b/src/lib/support/logging/TextOnlyLogging.cpp
@@ -231,7 +231,6 @@ void LogVerifyOrDieWithMsg(uint8_t module, const char * msg)
     chipAbort();
 }
 
-
 #if CHIP_LOG_FILTERING
 std::atomic<uint8_t> gLogFilter(kLogCategory_Max);
 

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -95,16 +95,13 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  *
  */
 #define ChipLogError(MOD, MSG, ...) ChipInternalLog(MOD, ERROR, MSG, ##__VA_ARGS__)
-#else // CHIP_ERROR_LOGGING
-#define ChipLogError(MOD, MSG, ...) ((void) 0)
-#endif // CHIP_ERROR_LOGGING
 
 /**
  * @def ChipLogFailure(err, MOD, MSG, ...)
  *
  * @brief
  *   Log a chip message with a formatted ChipError for the specified module in the 'Error'
- *   category.
+ *   category if and only if ERROR_CODE is not CHIP_NO_ERROR.
  *
  *  Example usage:
  *
@@ -112,7 +109,7 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  *    ChipLogFailure(errCode, Module, "Failure message: %s", param);
  *  @endcode
  *
- *  @param[in]  ERROR_CODE  A CHIP_ERROR to log.
+ *  @param[in]  ERROR_CODE  A CHIP_ERROR to log if failure.
  *  @param[in]  MOD         The log module to use.
  *  @param[in]  MSG         The log message format string.
  *  @param[in]  ...         Optional arguments for the log message.
@@ -123,12 +120,23 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
     ::chip::Logging::LogFailure(::chip::Logging::kLogModule_##MOD, ERROR_CODE, MSG)
 
 #define ChipLogFailure_VA_ARGS(ERROR_CODE, MOD, MSG, ...)                                                                          \
-    ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, (ERROR_CODE).Format())
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!::chip::ChipError::IsSuccess(ERROR_CODE))                                                                             \
+        {                                                                                                                          \
+            ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, (ERROR_CODE).Format());                                  \
+        }                                                                                                                          \
+    } while (false)
 
 #define ChipLogFailure(...)                                                                                                        \
-    CHIP_LOG_FAILURE_SELECT(__VA_ARGS__, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,                  \
+    CHIP_LOG_FAILURE_SELECT(__VA_ARGS__, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,                   \
                             ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,        \
                             ChipLogFailure_NO_VA_ARGS)(__VA_ARGS__)
+
+#else // CHIP_ERROR_LOGGING
+#define ChipLogError(MOD, MSG, ...) ((void) 0)
+#define ChipLogFailure(...) ((void) 0)
+#endif // CHIP_ERROR_LOGGING
 
 #if CHIP_PROGRESS_LOGGING
 /**
@@ -464,6 +472,10 @@ static constexpr uint16_t kMaxModuleNameLen = 3;
 
 void Log(uint8_t module, uint8_t category, const char * msg, ...) ENFORCE_FORMAT(3, 4);
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args) ENFORCE_FORMAT(3, 0);
+
+/**
+ * Log a failure message with error code if err != CHIP_NO_ERROR.
+ */
 void LogFailure(uint8_t module, CHIP_ERROR err, const char * msg);
 void LogFailure(uint8_t module, CHIP_ERROR err);
 void LogVerifyOrReturnError(const char * expr, int line, CHIP_ERROR code);

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -126,9 +126,10 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
     ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, (ERROR_CODE).Format())
 
 #define ChipLogFailure(...)                                                                                                        \
-    CHIP_LOG_FAILURE_SELECT(__VA_ARGS__, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,                  \
+    CHIP_LOG_FAILURE_SELECT(__VA_ARGS__, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,                   \
                             ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,        \
-                            ChipLogFailure_NO_VA_ARGS)(__VA_ARGS__)
+                            ChipLogFailure_NO_VA_ARGS)                                                                             \
+    (__VA_ARGS__)
 
 #if CHIP_PROGRESS_LOGGING
 /**

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPError.h>
 
 #include <lib/support/Assertions.h>
 #include <lib/support/Compiler.h>
@@ -116,8 +117,18 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  *  @param[in]  MSG         The log message format string.
  *  @param[in]  ...         Optional arguments for the log message.
  */
-#define ChipLogFailure(ERROR_CODE, MOD, MSG, ...)                                                                                  \
-    ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, ERROR_CODE.Format());
+#define CHIP_LOG_FAILURE_SELECT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+
+#define ChipLogFailure_NO_VA_ARGS(ERROR_CODE, MOD, MSG)                                                                            \
+    ::chip::Logging::LogFailure(::chip::Logging::kLogModule_##MOD, ERROR_CODE, MSG)
+
+#define ChipLogFailure_VA_ARGS(ERROR_CODE, MOD, MSG, ...)                                                                          \
+    ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, (ERROR_CODE).Format())
+
+#define ChipLogFailure(...)                                                                                                        \
+    CHIP_LOG_FAILURE_SELECT(__VA_ARGS__, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,                  \
+                            ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS, ChipLogFailure_VA_ARGS,        \
+                            ChipLogFailure_NO_VA_ARGS)(__VA_ARGS__)
 
 #if CHIP_PROGRESS_LOGGING
 /**
@@ -453,6 +464,17 @@ static constexpr uint16_t kMaxModuleNameLen = 3;
 
 void Log(uint8_t module, uint8_t category, const char * msg, ...) ENFORCE_FORMAT(3, 4);
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args) ENFORCE_FORMAT(3, 0);
+void LogFailure(uint8_t module, CHIP_ERROR err, const char * msg);
+void LogFailure(uint8_t module, CHIP_ERROR err);
+void LogVerifyOrReturnError(const char * expr, int line, CHIP_ERROR code);
+#if CHIP_CONFIG_ERROR_SOURCE
+void LogVerifyOrReturnErrorWithSource(CHIP_ERROR code, const char * file, int line);
+#endif
+#if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+[[noreturn]] void LogVerifyOrDie(const char * file, int line, const char * condition = nullptr);
+[[noreturn]] void LogSuccessOrDie(const char * file, int line, CHIP_ERROR err, const char * expr = nullptr);
+#endif
+[[noreturn]] void LogVerifyOrDieWithMsg(uint8_t module, const char * msg);
 
 #if CHIP_SYSTEM_CONFIG_PLATFORM_LOG
 #ifndef ChipPlatformLog
@@ -496,6 +518,26 @@ void HandleTokenizedLog(uint32_t levels, pw_tokenizer_Token token, pw_tokenizer_
 #else // _CHIP_USE_LOGGING
 
 inline void SetLogRedirectCallback(LogRedirectCallback_t callback) {}
+inline void LogFailure(uint8_t, CHIP_ERROR, const char *) {}
+inline void LogFailure(uint8_t, CHIP_ERROR) {}
+inline void LogVerifyOrReturnError(const char *, int, CHIP_ERROR) {}
+#if CHIP_CONFIG_ERROR_SOURCE
+inline void LogVerifyOrReturnErrorWithSource(CHIP_ERROR, const char *, int) {}
+#endif
+#if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+[[noreturn]] inline void LogVerifyOrDie(const char *, int, const char * = nullptr)
+{
+    chipAbort();
+}
+[[noreturn]] inline void LogSuccessOrDie(const char *, int, CHIP_ERROR, const char * = nullptr)
+{
+    chipAbort();
+}
+#endif
+[[noreturn]] inline void LogVerifyOrDieWithMsg(uint8_t, const char *)
+{
+    chipAbort();
+}
 
 #endif // _CHIP_USE_LOGGING
 


### PR DESCRIPTION
### Summary
- Reduce inline calls to varargs vnprintf-like functions which have heavy call sites.
- Remove many embeddings of __LINE__ and __FILE__ for situations where not relevant (and it's bad practice)

### Testing

- All unit tests and python tests still pass, logs still look the same except where it's intended that they lose FILE/LINE.
