### PR TITLE
[Scenes] SceneValid Deprecation

### DIFF
--- a/src/app/clusters/color-control-server/codegen/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/codegen/color-control-server.cpp
@@ -1623,9 +1623,6 @@ Status ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, ui
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
     Status status = moveToHueAndSaturation(endpoint, hue, saturation, transitionTime, isEnhanced);
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     return status;
 }
 
@@ -1804,9 +1801,6 @@ Status ColorControlServer::moveToSaturationCommand(EndpointId endpoint,
 
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
     Status status = moveToSaturation(endpoint, commandData.saturation, commandData.transitionTime);
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     return status;
 }
 
@@ -1972,9 +1966,6 @@ Status ColorControlServer::colorLoopCommand(EndpointId endpoint, const Commands:
         }
     }
 
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     return Status::Success;
 }
 
@@ -2227,9 +2218,6 @@ Status ColorControlServer::moveToColorCommand(EndpointId endpoint, const Command
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
 
     Status status = moveToColor(endpoint, commandData.colorX, commandData.colorY, commandData.transitionTime);
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     return status;
 }
 
@@ -2779,9 +2767,6 @@ Status ColorControlServer::moveToColorTempCommand(EndpointId endpoint,
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
 
     Status status = moveToColorTemp(endpoint, commandData.colorTemperatureMireds, commandData.transitionTime);
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     return status;
 }
 

--- a/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
+++ b/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
@@ -99,7 +99,7 @@ public:
     void SetUp() override
     {
         mCluster       = std::make_unique<GroupsCluster>(kTestEndpointId,
-                                                         GroupsCluster::Context{
+                                                   GroupsCluster::Context{
                                                              .groupDataProvider   = mGroupDataProvider,
                                                              .scenesIntegration   = &mScenesDelegate,
                                                              .identifyIntegration = &mIdentifyDelegate,

--- a/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
+++ b/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
@@ -85,8 +85,6 @@ public:
 
     CHIP_ERROR RecallGlobalScene(FabricIndex fabricIndex) override { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR MakeSceneInvalidForAllFabrics() override { return CHIP_NO_ERROR; }
-
     uint32_t mGroupWillBeRemovedCallCount = 0;
     FabricIndex mLastFabricIndex          = kUndefinedFabricIndex;
     GroupId mLastGroupId                  = kUndefinedGroupId;
@@ -101,7 +99,7 @@ public:
     void SetUp() override
     {
         mCluster       = std::make_unique<GroupsCluster>(kTestEndpointId,
-                                                   GroupsCluster::Context{
+                                                         GroupsCluster::Context{
                                                              .groupDataProvider   = mGroupDataProvider,
                                                              .scenesIntegration   = &mScenesDelegate,
                                                              .identifyIntegration = &mIdentifyDelegate,

--- a/src/app/clusters/level-control/codegen/level-control.cpp
+++ b/src/app/clusters/level-control/codegen/level-control.cpp
@@ -984,14 +984,6 @@ static Status moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8
     state->storedLevel              = storedLevel;
     state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    // The level has changed, the scene is no longer valid.
-    if (emberAfContainsServer(endpoint, ScenesManagement::Id))
-    {
-        ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-    }
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-
     // The setup was successful, so mark the new state as active and return.
     scheduleTimerCallbackMs(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
 

--- a/src/app/clusters/mode-select-server/ModeSelectCluster.cpp
+++ b/src/app/clusters/mode-select-server/ModeSelectCluster.cpp
@@ -272,14 +272,6 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
 
     uint8_t currentMode = 0;
     ModeSelect::Attributes::CurrentMode::Get(commandPath.mEndpointId, &currentMode);
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    if (currentMode != commandData.newMode)
-    {
-        //  the scene has been changed (the value of CurrentMode has changed) so
-        //  the current scene as described in the scene table is invalid
-        ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(commandPath.mEndpointId);
-    }
-#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
     Status status = ChangeToMode(commandPath.mEndpointId, commandData.newMode);
 

--- a/src/app/clusters/on-off-server/OnOffLightingCluster.cpp
+++ b/src/app/clusters/on-off-server/OnOffLightingCluster.cpp
@@ -335,13 +335,7 @@ void OnOffLightingCluster::UpdateTimer()
 
 DataModel::ActionReturnStatus OnOffLightingCluster::HandleOff()
 {
-    bool wasOn = GetOnOff();
     ReturnErrorOnFailure(SetOnOffFromCommand(false));
-
-    if (wasOn && mScenesIntegrationDelegate != nullptr)
-    {
-        LogErrorOnFailure(mScenesIntegrationDelegate->MakeSceneInvalidForAllFabrics());
-    }
 
     SetAttributeValue<uint16_t, uint16_t>(mOnTime, 0, Attributes::OnTime::Id);
     UpdateTimer();
@@ -350,18 +344,12 @@ DataModel::ActionReturnStatus OnOffLightingCluster::HandleOff()
 
 DataModel::ActionReturnStatus OnOffLightingCluster::HandleOn()
 {
-    bool wasOff = !GetOnOff();
     ReturnErrorOnFailure(SetOnOffFromCommand(true));
 
     // Spec requirement:
     //   This attribute SHALL be set to TRUE after the reception of a command which
     //   causes the OnOff attribute to be set to TRUE;
     SetAttributeValue(mGlobalSceneControl, true, Attributes::GlobalSceneControl::Id);
-
-    if (wasOff && mScenesIntegrationDelegate != nullptr)
-    {
-        LogErrorOnFailure(mScenesIntegrationDelegate->MakeSceneInvalidForAllFabrics());
-    }
 
     if (mOnTime == 0)
     {

--- a/src/app/clusters/on-off-server/codegen/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/codegen/on-off-server.cpp
@@ -267,11 +267,6 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
         }
     }
 
-    //  the scene has been changed (the value of on/off has changed) so
-    //  the current scene as described in the attribute table is invalid,
-    //  so mark it as invalid (just writes the valid/invalid attribute)
-    Internal::Scenes::MarkInvalid(endpoint);
-
     // The returned status is based solely on the On/Off cluster.  Errors in the
     // Level Control and/or Scenes cluster are ignored.
     return Status::Success;
@@ -734,8 +729,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint),
-    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
+    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
+    mEffectVariant(effectVariant)
 {
     reg(this);
 };

--- a/src/app/clusters/on-off-server/codegen/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/codegen/on-off-server.cpp
@@ -729,8 +729,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
-    mEffectVariant(effectVariant)
+    mEndpoint(endpoint),
+    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
 {
     reg(this);
 };

--- a/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
@@ -169,11 +169,6 @@ void Recall(FabricIndex fabricIndex, EndpointId endpoint)
         fabricIndex, endpoint, ScenesManagement::ScenesServer::kGlobalSceneGroupId, ScenesManagement::ScenesServer::kGlobalSceneId);
 }
 
-void MarkInvalid(EndpointId endpoint)
-{
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
-}
-
 } // namespace chip::app::Clusters::OnOff::Internal::Scenes
 
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT

--- a/src/app/clusters/on-off-server/codegen/scenes-integration.h
+++ b/src/app/clusters/on-off-server/codegen/scenes-integration.h
@@ -36,7 +36,6 @@ inline void RegisterGlobalHandler(EndpointId endpoint) {}
 
 void Store(FabricIndex fabricIndex, EndpointId endpoint);
 void Recall(FabricIndex fabricIndex, EndpointId endpoint);
-void MarkInvalid(EndpointId endpoint);
 
 } // namespace chip::app::Clusters::OnOff::Internal::Scenes
 
@@ -51,7 +50,6 @@ inline chip::scenes::SceneHandler * GlobalHandler()
 inline void RegisterGlobalHandler(EndpointId endpoint) {}
 inline void Store(FabricIndex fabricIndex, EndpointId endpoint) {}
 inline void Recall(FabricIndex fabricIndex, EndpointId endpoint) {}
-inline void MarkInvalid(EndpointId endpoint) {}
 
 } // namespace chip::app::Clusters::OnOff::Internal::Scenes
 

--- a/src/app/clusters/on-off-server/tests/TestOnOffLightingCluster.cpp
+++ b/src/app/clusters/on-off-server/tests/TestOnOffLightingCluster.cpp
@@ -76,18 +76,11 @@ public:
     };
     std::vector<Call> storeCalls;
     std::vector<Call> recallCalls;
-    int markInvalidCalls        = 0;
     int groupWillBeRemovedCalls = 0;
 
     CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) override
     {
         groupWillBeRemovedCalls++;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR MakeSceneInvalidForAllFabrics() override
-    {
-        markInvalidCalls++;
         return CHIP_NO_ERROR;
     }
 
@@ -453,7 +446,6 @@ TEST_F(TestOnOffLightingCluster, TestOffWithEffect)
     EXPECT_TRUE(mMockEffectDelegate.mCalled);
     EXPECT_EQ(mMockEffectDelegate.mEffectId, EffectIdentifierEnum::kDyingLight);
     EXPECT_FALSE(mMockDelegate.mOnOff);
-    EXPECT_EQ(mMockScenesIntegrationDelegate.markInvalidCalls, 1);
 }
 
 TEST_F(TestOnOffLightingCluster, TestOffWithEffect_DelegateFails)

--- a/src/app/clusters/scenes-server/CodegenIntegration.cpp
+++ b/src/app/clusters/scenes-server/CodegenIntegration.cpp
@@ -170,21 +170,6 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     LogErrorOnFailure(cluster->GroupWillBeRemoved(aFabricIx, aGroupId));
 }
 
-void ScenesServer::MakeSceneInvalid(EndpointId aEndpointId, FabricIndex aFabricIx)
-{
-    ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
-    VerifyOrReturn(cluster != nullptr);
-
-    LogErrorOnFailure(cluster->MakeSceneInvalid(aFabricIx));
-}
-
-void ScenesServer::MakeSceneInvalidForAllFabrics(EndpointId aEndpointId)
-{
-    ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
-    VerifyOrReturn(cluster != nullptr);
-    LogErrorOnFailure(cluster->MakeSceneInvalidForAllFabrics());
-}
-
 void ScenesServer::StoreCurrentScene(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId, SceneId aSceneId)
 {
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);

--- a/src/app/clusters/scenes-server/CodegenIntegration.h
+++ b/src/app/clusters/scenes-server/CodegenIntegration.h
@@ -36,8 +36,6 @@ public:
 
     // Callbacks
     void GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId);
-    void MakeSceneInvalid(EndpointId aEndpointId, FabricIndex aFabricIx);
-    void MakeSceneInvalidForAllFabrics(EndpointId aEndpointId);
     void StoreCurrentScene(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId, SceneId aSceneId);
     void RecallScene(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId, SceneId aSceneId);
 

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -45,9 +45,6 @@ public:
     ///
     /// This can be used to invalidate scenes that reference the given group.
     virtual CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) = 0;
-
-    /// Marks all scenes on the associated endpoint as invalid for all fabrics.
-    virtual CHIP_ERROR MakeSceneInvalidForAllFabrics() = 0;
 };
 
 } // namespace chip::scenes

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
@@ -90,8 +90,7 @@ CHIP_ERROR ScenesManagementCluster::RecallGlobalScene(FabricIndex fabricIndex)
     return RecallScene(fabricIndex, scenes::kGlobalSceneGroupId, scenes::kGlobalSceneId);
 }
 
-CHIP_ERROR ScenesManagementCluster::UpdateFabricSceneInfo(FabricIndex fabric, Optional<GroupId> group, Optional<SceneId> scene,
-                                                          Optional<bool> sceneValid)
+CHIP_ERROR ScenesManagementCluster::UpdateFabricSceneInfo(FabricIndex fabric)
 {
     VerifyOrReturnError(kUndefinedFabricIndex != fabric, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -100,20 +99,9 @@ CHIP_ERROR ScenesManagementCluster::UpdateFabricSceneInfo(FabricIndex fabric, Op
     SceneInfoStruct::Type * sceneInfo = GetSceneInfoStruct(fabric);
     if (nullptr != sceneInfo)
     {
-        if (group.HasValue())
-        {
-            sceneInfo->currentGroup = group.Value();
-        }
-
-        if (scene.HasValue())
-        {
-            sceneInfo->currentScene = scene.Value();
-        }
-
-        if (sceneValid.HasValue())
-        {
-            sceneInfo->sceneValid = sceneValid.Value();
-        }
+        sceneInfo->currentGroup = 0;
+        sceneInfo->currentScene = 0xFF;
+        sceneInfo->sceneValid   = false;
 
         ReturnErrorOnFailure(sceneTable->GetFabricSceneCount(fabric, sceneInfo->sceneCount));
         ReturnErrorOnFailure(sceneTable->GetRemainingCapacity(fabric, sceneInfo->remainingCapacity));
@@ -124,9 +112,9 @@ CHIP_ERROR ScenesManagementCluster::UpdateFabricSceneInfo(FabricIndex fabric, Op
         SceneInfoStruct::Type newSceneInfo;
         newSceneInfo.fabricIndex = fabric;
 
-        newSceneInfo.currentGroup = group.ValueOr(0);
-        newSceneInfo.currentScene = scene.ValueOr(0);
-        newSceneInfo.sceneValid   = sceneValid.ValueOr(false);
+        newSceneInfo.currentGroup = 0;
+        newSceneInfo.currentScene = 0xFF;
+        newSceneInfo.sceneValid   = false;
 
         ReturnErrorOnFailure(sceneTable->GetFabricSceneCount(fabric, newSceneInfo.sceneCount));
         ReturnErrorOnFailure(sceneTable->GetRemainingCapacity(fabric, newSceneInfo.remainingCapacity));
@@ -189,8 +177,6 @@ void ScenesManagementCluster::FabricSceneInfo::ClearSceneInfoStruct(FabricIndex 
     // Clear the last populated SceneInfoStruct
     mSceneInfoStructs[mSceneInfoStructsCount].fabricIndex       = kUndefinedFabricIndex;
     mSceneInfoStructs[mSceneInfoStructsCount].sceneCount        = 0;
-    mSceneInfoStructs[mSceneInfoStructsCount].currentScene      = 0;
-    mSceneInfoStructs[mSceneInfoStructsCount].currentGroup      = 0;
     mSceneInfoStructs[mSceneInfoStructsCount].remainingCapacity = 0;
 }
 
@@ -272,9 +258,6 @@ void ScenesManagementCluster::OnFabricRemoved(const FabricTable & fabricTable, F
 
 CHIP_ERROR ScenesManagementCluster::StoreSceneParse(const FabricIndex & fabricIdx, const GroupId & groupID, const SceneId & sceneID)
 {
-    // Make the current fabric's SceneValid false before storing a scene
-    ReturnErrorOnFailure(MakeSceneInvalid(fabricIdx));
-
     ScopedSceneTable sceneTable(mSceneTableProvider);
 
     // Verify Endpoint in group
@@ -315,25 +298,13 @@ CHIP_ERROR ScenesManagementCluster::StoreSceneParse(const FabricIndex & fabricId
     ReturnErrorOnFailure(sceneTable->SetSceneTableEntry(fabricIdx, scene));
 
     // Update SceneInfo Attribute
-    return UpdateFabricSceneInfo(fabricIdx, MakeOptional(groupID), MakeOptional(sceneID), MakeOptional(static_cast<bool>(true)));
-}
-
-CHIP_ERROR ScenesManagementCluster::MakeSceneInvalidForAllFabrics()
-{
-    for (auto & info : *mFabricTable)
-    {
-        ReturnErrorOnFailure(MakeSceneInvalid(info.GetFabricIndex()));
-    }
-    return CHIP_NO_ERROR;
+    return UpdateFabricSceneInfo(fabricIdx);
 }
 
 CHIP_ERROR ScenesManagementCluster::RecallSceneParse(const FabricIndex & fabricIdx, const GroupId & groupID,
                                                      const SceneId & sceneID,
                                                      const Optional<DataModel::Nullable<uint32_t>> & transitionTime)
 {
-    // Make SceneValid false for all fabrics before recalling a scene
-    ReturnErrorOnFailure(MakeSceneInvalidForAllFabrics());
-
     // Get Scene Table Instance
     ScopedSceneTable sceneTable(mSceneTableProvider);
 
@@ -363,7 +334,7 @@ CHIP_ERROR ScenesManagementCluster::RecallSceneParse(const FabricIndex & fabricI
     ReturnErrorOnFailure(sceneTable->SceneApplyEFS(scene));
 
     // Update FabricSceneInfo, at this point the scene is considered valid
-    return UpdateFabricSceneInfo(fabricIdx, Optional<GroupId>(groupID), Optional<SceneId>(sceneID), Optional<bool>(true));
+    return UpdateFabricSceneInfo(fabricIdx);
 }
 
 std::optional<DataModel::ActionReturnStatus> ScenesManagementCluster::InvokeCommand(const DataModel::InvokeRequest & request,
@@ -476,7 +447,7 @@ CHIP_ERROR ScenesManagementCluster::Startup(ServerClusterContext & context)
     for (const FabricInfo & info : *mFabricTable)
     {
         FabricIndex fabric = info.GetFabricIndex();
-        LogErrorOnFailure(UpdateFabricSceneInfo(fabric, Optional<GroupId>(), Optional<SceneId>(), Optional<bool>()));
+        LogErrorOnFailure(UpdateFabricSceneInfo(fabric));
     }
 
     return DefaultServerCluster::Startup(context);
@@ -509,17 +480,6 @@ CHIP_ERROR ScenesManagementCluster::GroupWillBeRemoved(FabricIndex aFabricIdx, G
     // Get Scene Table Instance
     ScopedSceneTable sceneTable(mSceneTableProvider);
     VerifyOrReturnError(sceneTable, CHIP_ERROR_INTERNAL);
-
-    SceneInfoStruct::Type * sceneInfo = mFabricSceneInfo.GetSceneInfoStruct(aFabricIdx);
-    chip::GroupId currentGroup        = (nullptr != sceneInfo) ? sceneInfo->currentGroup : 0x0000;
-
-    // If currentGroup is what is being removed, we can't possibly still have a valid scene,
-    // because the scene we have (if any) will also be removed.
-    if (aGroupId == currentGroup)
-    {
-        ReturnErrorOnFailure(MakeSceneInvalid(aFabricIdx));
-    }
-
     VerifyOrReturnError(nullptr != mGroupProvider, CHIP_ERROR_INCORRECT_STATE);
 
     if (0 != aGroupId && !mGroupProvider->HasEndpoint(aFabricIdx, aGroupId, mPath.mEndpointId))
@@ -528,11 +488,6 @@ CHIP_ERROR ScenesManagementCluster::GroupWillBeRemoved(FabricIndex aFabricIdx, G
     }
 
     return sceneTable->DeleteAllScenesInGroup(aFabricIdx, aGroupId);
-}
-
-CHIP_ERROR ScenesManagementCluster::MakeSceneInvalid(FabricIndex aFabricIdx)
-{
-    return UpdateFabricSceneInfo(aFabricIdx, Optional<GroupId>(), Optional<SceneId>(), Optional<bool>(false));
 }
 
 CHIP_ERROR ScenesManagementCluster::StoreCurrentScene(FabricIndex aFabricIx, GroupId aGroupId, SceneId aSceneId)
@@ -646,8 +601,7 @@ AddSceneResponse::Type ScenesManagementCluster::HandleAddScene(FabricIndex fabri
     SuccessOrReturnWithFailureStatus(sceneTable->SetSceneTableEntry(fabricIndex, scene), response);
 
     // Update FabricSceneInfo
-    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex, Optional<GroupId>(), Optional<SceneId>(), Optional<bool>()),
-                                     response);
+    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex), response);
 
     // Write response
     response.status = to_underlying(Status::Success);
@@ -776,15 +730,7 @@ ScenesManagementCluster::HandleRemoveScene(FabricIndex fabricIndex,
     SuccessOrReturnWithFailureStatus(sceneTable->RemoveSceneTableEntry(fabricIndex, scene.mStorageId), response);
 
     // Update SceneInfoStruct Attributes
-    SceneInfoStruct::Type * sceneInfo = GetSceneInfoStruct(fabricIndex);
-    Optional<bool> sceneValid;
-    if (nullptr != sceneInfo && req.groupID == sceneInfo->currentGroup && req.sceneID == sceneInfo->currentScene)
-    {
-        sceneValid.Emplace(false);
-    }
-
-    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex, Optional<GroupId>(), Optional<SceneId>(), sceneValid),
-                                     response);
+    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex), response);
 
     response.status = to_underlying(Status::Success);
     return response;
@@ -822,16 +768,7 @@ ScenesManagementCluster::HandleRemoveAllScenes(FabricIndex fabricIndex,
     SuccessOrReturnWithFailureStatus(sceneTable->DeleteAllScenesInGroup(fabricIndex, req.groupID), response);
 
     // Update Attributes
-    SceneInfoStruct::Type * sceneInfo = GetSceneInfoStruct(fabricIndex);
-
-    Optional<bool> sceneValid;
-    if (nullptr != sceneInfo && req.groupID == sceneInfo->currentGroup)
-    {
-        sceneValid.Emplace(false);
-    }
-
-    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex, Optional<GroupId>(), Optional<SceneId>(), sceneValid),
-                                     response);
+    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex), response);
 
     response.status = to_underlying(Status::Success);
     return response;
@@ -1013,9 +950,7 @@ ScenesManagementCluster::HandleCopyScene(FabricIndex fabricIndex, const ScenesMa
             SuccessOrReturnWithFailureStatus(sceneTable->SetSceneTableEntry(fabricIndex, scene), response);
 
             // Update SceneInfoStruct Attributes after each insert in case we hit max capacity in the middle of the loop
-            SuccessOrReturnWithFailureStatus(
-                UpdateFabricSceneInfo(fabricIndex, Optional<GroupId>(), Optional<SceneId>(), Optional<bool>() /* = sceneValid*/),
-                response);
+            SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex), response);
         }
 
         response.status = to_underlying(Status::Success);
@@ -1029,8 +964,7 @@ ScenesManagementCluster::HandleCopyScene(FabricIndex fabricIndex, const ScenesMa
     SuccessOrReturnWithFailureStatus(sceneTable->SetSceneTableEntry(fabricIndex, scene), response);
 
     // Update Attributes
-    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex, Optional<GroupId>(), Optional<SceneId>(), Optional<bool>()),
-                                     response);
+    SuccessOrReturnWithFailureStatus(UpdateFabricSceneInfo(fabricIndex), response);
     response.status = to_underlying(Status::Success);
     return response;
 }

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
@@ -256,6 +256,12 @@ void ScenesManagementCluster::OnFabricRemoved(const FabricTable & fabricTable, F
     mFabricSceneInfo.ClearSceneInfoStruct(fabricIndex);
 }
 
+void ScenesManagementCluster::OnFabricCommitted(const FabricTable & fabricTable, FabricIndex fabricIndex)
+{
+    // Update FabricSceneInfo for the committed fabric
+    LogErrorOnFailure(UpdateFabricSceneInfo(fabricIndex));
+}
+
 CHIP_ERROR ScenesManagementCluster::StoreSceneParse(const FabricIndex & fabricIdx, const GroupId & groupID, const SceneId & sceneID)
 {
     ScopedSceneTable sceneTable(mSceneTableProvider);

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -160,6 +160,7 @@ public:
 
     // FabricTable::Delegate implementation
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
+    void OnFabricCommitted(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
 
     /// Removes the data persisted for this cluster
     ///

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -170,10 +170,8 @@ public:
     CHIP_ERROR StoreCurrentGlobalScene(FabricIndex fabricIndex) override;
     CHIP_ERROR RecallGlobalScene(FabricIndex fabricIndex) override;
     CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) override;
-    CHIP_ERROR MakeSceneInvalidForAllFabrics() override;
 
     // Integration methods for other cluster integrations
-    CHIP_ERROR MakeSceneInvalid(FabricIndex aFabricIdx);
     CHIP_ERROR StoreCurrentScene(FabricIndex aFabricIx, GroupId aGroupId, SceneId aSceneId);
     CHIP_ERROR RecallScene(FabricIndex aFabricIx, GroupId aGroupId, SceneId aSceneId);
     CHIP_ERROR RemoveFabric(FabricIndex aFabricIndex);
@@ -193,8 +191,7 @@ private:
         return mFabricSceneInfo.SetSceneInfoStruct(fabric, sceneInfoStruct);
     }
 
-    CHIP_ERROR UpdateFabricSceneInfo(FabricIndex fabric, Optional<GroupId> group, Optional<SceneId> scene,
-                                     Optional<bool> sceneValid);
+    CHIP_ERROR UpdateFabricSceneInfo(FabricIndex fabric);
 
     CHIP_ERROR StoreSceneParse(const FabricIndex & fabricIdx, const GroupId & groupID, const SceneId & sceneID);
 

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -1473,6 +1473,10 @@ TEST_F(TestScenesManagementCluster, PersistenceAfterPowerCycle)
 
 TEST_F(TestScenesManagementCluster, RecallSceneInvalidatesOtherFabrics)
 {
+    // NOTE: This test is testing a deprecated feature, we only use it to confirm that
+    // the new behavior (CurrentScene = 0xFF, CurrentGroup = 0x00, SceneValid = FALSE) 
+    // remains true when recalling a scene and there are no remnants of the old behavior.
+    
     // Pretend that we have some fabrics since this is what our tests expect
     // Note I could only find mock data for 2 fabrics even though fabric index 3 is defined.
     // This is just sufficient here for our own tests (adding fabric entries is rough!)
@@ -1507,10 +1511,12 @@ TEST_F(TestScenesManagementCluster, RecallSceneInvalidatesOtherFabrics)
     while (it.Next())
     {
         auto val = it.GetValue();
-
-        EXPECT_EQ(val.currentScene, 0xFF);
-        EXPECT_EQ(val.currentGroup, 0x00);
-        EXPECT_FALSE(val.sceneValid);
+        if (val.fabricIndex == kFabricIndex)
+        {
+            EXPECT_EQ(val.currentScene, 0xFF);
+            EXPECT_EQ(val.currentGroup, 0x00);
+            EXPECT_FALSE(val.sceneValid);
+        }
     }
 
     // 4. Recall Scene on Fabric 2
@@ -1518,20 +1524,17 @@ TEST_F(TestScenesManagementCluster, RecallSceneInvalidatesOtherFabrics)
     auto recall_response2 = tester.Invoke<RecallScene::Type, NullObjectType>(RecallScene::Id, recall_request);
     ASSERT_TRUE(recall_response2.IsSuccess());
 
-    // 5. Verify SceneValid is TRUE for Fabric 2 and FALSE for Fabric 1
+    // 5. Verify SceneValid is FALSE for Fabric 2 and FALSE for Fabric 1
     ASSERT_EQ(tester.ReadAttribute(Attributes::FabricSceneInfo::Id, sceneInfoList), CHIP_NO_ERROR);
     auto it2 = sceneInfoList.begin();
     while (it2.Next())
     {
         auto val = it2.GetValue();
-        if (val.fabricIndex == kFabricIndex)
+        if (val.fabricIndex == kFabricIndex2)
         {
-            // Fabric 1 should now be invalid
+            EXPECT_EQ(val.currentScene, 0xFF);
+            EXPECT_EQ(val.currentGroup, 0x00);
             EXPECT_FALSE(val.sceneValid);
-        }
-        else if (val.fabricIndex == kFabricIndex2)
-        {
-            EXPECT_TRUE(val.sceneValid);
         }
     }
 }

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -1507,17 +1507,10 @@ TEST_F(TestScenesManagementCluster, RecallSceneInvalidatesOtherFabrics)
     while (it.Next())
     {
         auto val = it.GetValue();
-        if (val.fabricIndex == kFabricIndex)
-        {
-            EXPECT_EQ(val.currentScene, kTestSceneId);
-            EXPECT_EQ(val.currentGroup, kTestGroupId);
-            EXPECT_TRUE(val.sceneValid);
-        }
-        else if (val.fabricIndex == kFabricIndex2)
-        {
-            // For Fabric 2, if sceneValid is initialized, it should be false (or effectively treated as invalid)
-            EXPECT_FALSE(val.sceneValid);
-        }
+
+        EXPECT_EQ(val.currentScene, 0xFF);
+        EXPECT_EQ(val.currentGroup, 0x00);
+        EXPECT_FALSE(val.sceneValid);
     }
 
     // 4. Recall Scene on Fabric 2

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -1474,9 +1474,9 @@ TEST_F(TestScenesManagementCluster, PersistenceAfterPowerCycle)
 TEST_F(TestScenesManagementCluster, RecallSceneInvalidatesOtherFabrics)
 {
     // NOTE: This test is testing a deprecated feature, we only use it to confirm that
-    // the new behavior (CurrentScene = 0xFF, CurrentGroup = 0x00, SceneValid = FALSE) 
+    // the new behavior (CurrentScene = 0xFF, CurrentGroup = 0x00, SceneValid = FALSE)
     // remains true when recalling a scene and there are no remnants of the old behavior.
-    
+
     // Pretend that we have some fabrics since this is what our tests expect
     // Note I could only find mock data for 2 fabrics even though fabric index 3 is defined.
     // This is just sufficient here for our own tests (adding fabric entries is rough!)

--- a/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
@@ -458,9 +458,9 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
-                      SceneValid: true,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]


### PR DESCRIPTION


### Summary

Removed SceneValid, CurrentScene, CurrentGroup and methods relying on their presence

Spec PR: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/13268
Test plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6271/changes

### Related issues

fixes: https://github.com/project-chip/connectedhomeip/issues/73124
fixes: https://github.com/project-chip/connectedhomeip/issues/73329

### Testing

Local test on device read and ran the yaml test with the changes.
