### PR TITLE
Make MaxGroupsPerFabric 0 w/ Groupcast, Fix IsGroupcastEnabled() 

### DIFF
--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -323,20 +323,21 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 
     // SetGroupcastEnabled() is called both here and in Server.cpp. It is called in Server.cpp so there is a general sdk-wide
     // location where the value is set, no matter which app is being run. It must be called here because this value
-    // must be set in order to properly startup the devices (with devices.Startup()) further down in this function. 
-    // This is because this value indicidating if groupcast is enabled at run time (based on the all devices app 
-    // --groupcast argument) must be correct in scenarios such as to correctly instantiate (or not instantiate) 
-    // the groupcast cluster, which happens before Server initialization. Server init (with Server::GetInstance().Init(initParams)) 
-    // cannot be moved to be before devices.Startup() either, as server is dependednt on the DataModelProvider devices.Startup() creates.
+    // must be set in order to properly startup the devices (with devices.Startup()) further down in this function.
+    // This is because this value indicidating if groupcast is enabled at run time (based on the all devices app
+    // --groupcast argument) must be correct in scenarios such as to correctly instantiate (or not instantiate)
+    // the groupcast cluster, which happens before Server initialization. Server init (with Server::GetInstance().Init(initParams))
+    // cannot be moved to be before devices.Startup() either, as server is dependednt on the DataModelProvider devices.Startup()
+    // creates.
     gGroupDataProvider.SetGroupcastEnabled(enableGroupcast);
 
     // This groupcastEnabledOverride is set here so that the app argument of --groupcast is respected when SetGroupcastEnabled()
     // is called in Server.cpp. In this case, the override is required so that the default value of CHIP_CONFIG_ENABLE_GROUPCAST
-    // is not used. CHIP_CONFIG_ENABLE_GROUPCAST is always set to true for the all devices app so that use of groupcast can be 
-    // configured at run-time, in contrast to many apps which can just configure this at compile time. This exists in order to 
+    // is not used. CHIP_CONFIG_ENABLE_GROUPCAST is always set to true for the all devices app so that use of groupcast can be
+    // configured at run-time, in contrast to many apps which can just configure this at compile time. This exists in order to
     // enable both legacy groups and the newer groupcast paths easily in various scenarios (like testing). This override ensures
-    // the value from IsGroupcastEnabled() remains consistent for the app's entire run-time (from the previous line setting the value,
-    // and Server.cpp doing the same).
+    // the value from IsGroupcastEnabled() remains consistent for the app's entire run-time (from the previous line setting the
+    // value, and Server.cpp doing the same).
     initParams.groupcastEnabledOverride = enableGroupcast;
 
     if (enableGroupcast)

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -318,20 +318,38 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
     RegisterDeviceFactoryOverrides(gTimerDelegate, initParams.persistentStorageDelegate, gAudioManager);
 
 #if CHIP_CONFIG_ENABLE_GROUPCAST
-    // TODO(#72056): Once groupcast is enabled by default, this should not be dependent on the app argument.
-    if (AppOptions::GetConfig().enableGroupcast)
+    // TODO(#72056): Once groupcast is enabled by default, this block of code should not be dependent on the app argument.
+    bool enableGroupcast = AppOptions::GetConfig().enableGroupcast;
+
+    // SetGroupcastEnabled() is called both here and in Server.cpp. It is called in Server.cpp so there is a general sdk-wide
+    // location where the value is set, no matter which app is being run. It must be called here because this value
+    // must be set in order to properly startup the devices (with devices.Startup()) further down in this function. 
+    // This is because this value indicidating if groupcast is enabled at run time (based on the all devices app 
+    // --groupcast argument) must be correct in scenarios such as to correctly instantiate (or not instantiate) 
+    // the groupcast cluster, which happens before Server initialization. Server init (with Server::GetInstance().Init(initParams)) 
+    // cannot be moved to be before devices.Startup() either, as server is dependednt on the DataModelProvider devices.Startup() creates.
+    gGroupDataProvider.SetGroupcastEnabled(enableGroupcast);
+
+    // This groupcastEnabledOverride is set here so that the app argument of --groupcast is respected when SetGroupcastEnabled()
+    // is called in Server.cpp. In this case, the override is required so that the default value of CHIP_CONFIG_ENABLE_GROUPCAST
+    // is not used. CHIP_CONFIG_ENABLE_GROUPCAST is always set to true for the all devices app so that use of groupcast can be 
+    // configured at run-time, in contrast to many apps which can just configure this at compile time. This exists in order to 
+    // enable both legacy groups and the newer groupcast paths easily in various scenarios (like testing). This override ensures
+    // the value from IsGroupcastEnabled() remains consistent for the app's entire run-time (from the previous line setting the value,
+    // and Server.cpp doing the same).
+    initParams.groupcastEnabledOverride = enableGroupcast;
+
+    if (enableGroupcast)
     {
         static chip::Access::Examples::GroupAuxiliaryAccessControlDelegateImpl groupAuxDelegate;
         SuccessOrDie(groupAuxDelegate.Initialize(&gGroupDataProvider, &Server::GetInstance().GetFabricTable()));
         initParams.groupAuxiliaryAccessControlDelegate = &groupAuxDelegate;
-        gGroupDataProvider.SetGroupcastEnabled(true);
     }
 #endif // CHIP_CONFIG_ENABLE_GROUPCAST
 
     gGroupDataProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     gGroupDataProvider.SetSessionKeystore(initParams.sessionKeystore);
     SuccessOrDie(gGroupDataProvider.Init());
-    Credentials::SetGroupDataProvider(&gGroupDataProvider);
 
     DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
     if (provider == nullptr)

--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -262,6 +262,10 @@ CHIP_ERROR ReadGroupTable(FabricTable & fabricTable, GroupDataProvider & provide
 
 CHIP_ERROR ReadMaxGroupsPerFabric(GroupDataProvider & provider, AttributeValueEncoder & aEncoder)
 {
+    if (provider.IsGroupcastEnabled())
+    {
+        return aEncoder.Encode(static_cast<uint16_t>(0));
+    }
     return aEncoder.Encode(provider.GetMaxGroupsPerFabric());
 }
 

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -182,6 +182,21 @@ TEST_F(TestGroupKeyManagementCluster, AttributesTest)
     ASSERT_TRUE(chip::Testing::IsAttributesListEqualTo(mCluster, expectedAttributes));
 }
 
+TEST_F(TestGroupKeyManagementCluster, TestMaxGroupsPerFabricAttribute)
+{
+    uint16_t maxGroups = 0;
+    // When Groupcast is disabled, MaxGroupsPerFabric returns provider's non-zero value
+    mRealProvider.SetGroupcastEnabled(false);
+    EXPECT_TRUE(tester.ReadAttribute(GroupKeyManagement::Attributes::MaxGroupsPerFabric::Id, maxGroups).IsSuccess());
+    EXPECT_EQ(maxGroups, mRealProvider.GetMaxGroupsPerFabric());
+    EXPECT_NE(maxGroups, 0);
+
+    // When Groupcast is enabled, MaxGroupsPerFabric must return 0 per spec
+    mRealProvider.SetGroupcastEnabled(true);
+    EXPECT_TRUE(tester.ReadAttribute(GroupKeyManagement::Attributes::MaxGroupsPerFabric::Id, maxGroups).IsSuccess());
+    EXPECT_EQ(maxGroups, 0);
+}
+
 // Cluster should accept writing multiple group keys with the same KeySetID but different Group IDs
 TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttributeSameKeySetDifferentGroup)
 {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -312,7 +312,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 
     mGroupsProvider = initParams.groupDataProvider;
     SetGroupDataProvider(mGroupsProvider);
-    mGroupsProvider->SetGroupcastEnabled(CHIP_CONFIG_ENABLE_GROUPCAST);
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    mGroupsProvider->SetGroupcastEnabled(initParams.groupcastEnabledOverride.value_or(CHIP_CONFIG_ENABLE_GROUPCAST));
+#endif
 
     SuccessOrExit(err = mAccessControl.Init(initParams.accessDelegate, sDeviceTypeResolver));
     if (initParams.groupAuxiliaryAccessControlDelegate != nullptr)

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <app/AppConfig.h>
 #include <app/icd/server/ICDServerConfig.h>
 
@@ -186,6 +188,10 @@ struct ServerInitParams
     // Group data provider: MUST be injected. Used to maintain critical keys such as the Identity
     // Protection Key (IPK) for CASE. Must be initialized before being provided.
     Credentials::GroupDataProvider * groupDataProvider = nullptr;
+#if CHIP_CONFIG_ENABLE_GROUPCAST
+    // Groupcast enabled override: Optional. If set, overrides default CHIP_CONFIG_ENABLE_GROUPCAST setting in Server::Init.
+    std::optional<bool> groupcastEnabledOverride;
+#endif // CHIP_CONFIG_ENABLE_GROUPCAST
     // Session keystore: MUST be injected. Used to derive and manage lifecycle of symmetric keys.
     Crypto::SessionKeystore * sessionKeystore = nullptr;
     // Access control delegate: MUST be injected. Used to look up access control rules. Must be


### PR DESCRIPTION
### Summary

This PR ensures that the `MaxGroupsPerFabric` attribute in the group key management cluster returns a value of 0 when groupcast is enabled. This is to align with the expected behaviour in spec to represent deprecation of the old method of group mapping.

In making this change, it was also discovered the `IsGroupcastEnabled()` function for the posix version of the all devices app was not always returning the correct value. It was set in `main.cpp`, but also overridden in `Server.cpp`. This was unique to the posix all devices app as it has a `--groupcast` command line argument to enable groupcast at run-time. When this argument is not present on app startup, groupcast should be disabled. While this was true to an extent as the groupcast cluster was not being registered with the app argument not being present, since Server.cpp would override this value with the value of `CHIP_CONFIG_ENABLE_GROUPCAST`, the value of `IsGroupcastEnabled()` would change mid-way through the app's lifetime. This would result in a mixed state of the app initially correctly thinking that groupcast was not enabled, but then later thinking that it was. While the majority of groupcast functionality was still correctly disabled here, some things like values reported in the group data provider (and the newly added update to `MaxGroupsPerFabric`) were wrong. This should fix that.

### Testing

- CI should still pass
- Added unit test to check the `MaxGroupsPerFabric` value based on `IsGroupcastEnabled()`
- Ran posix all devices app locally both with and without the `--groupcast` app argument, and `MaxGroupsPerFabric` was reported correctly when testing with chip-tool. This also verified the fix for `IsGroupcastEnabled()`, as previously this function would always return true from the application layer, and `MaxGroupsPerFabric` would always report 0. This no longer happens, and a correct non-zero value will be reported when groupcast is disabled.
