### PR TITLE
[v1.5][backport][ESP32]remove duplicate Thread stack lock

### DIFF
--- a/src/platform/ESP32/ThreadStackManagerImpl.cpp
+++ b/src/platform/ESP32/ThreadStackManagerImpl.cpp
@@ -54,9 +54,7 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     openthread_init_stack();
-    _LockThreadStack();
     err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(esp_openthread_get_instance());
-    _UnlockThreadStack();
     return err;
 }
 


### PR DESCRIPTION
### Summary

GenericThreadStackManagerImpl_OpenThread::DoInit(esp_openthread_get_instance()); is now thread-safe, so no additional lock is needed externally. backport from https://github.com/project-chip/connectedhomeip/pull/73311

### Related issues

None

### Testing

