### PR TITLE
Disabled some NFC traces

### DIFF
--- a/src/platform/Linux/NFCCommissioningManagerImpl.cpp
+++ b/src/platform/Linux/NFCCommissioningManagerImpl.cpp
@@ -745,7 +745,7 @@ bool NFCCommissioningManagerImpl::CanSendToPeer(const Transport::PeerAddress & a
 
     // nfcShortId is used to find the peer device
     uint16_t nfcShortId = address.GetNFCShortId();
-    ChipLogProgress(DeviceLayer, "CanSendToPeer? nfcShortId = %d", nfcShortId);
+    ChipLogProgressNfcDebug(DeviceLayer, "CanSendToPeer? nfcShortId = %d", nfcShortId);
 
     {
         std::lock_guard<std::mutex> lock(mStateMutex);

--- a/src/transport/raw/NFC.cpp
+++ b/src/transport/raw/NFC.cpp
@@ -86,8 +86,6 @@ bool NFCBase::CanSendToPeer(const Transport::PeerAddress & address)
 
 void NFCBase::OnNfcTagResponse(const Transport::PeerAddress & address, System::PacketBufferHandle && buffer)
 {
-    ChipLogProgress(Controller, "NFCBase::OnNfcTagResponse");
-
     HandleMessageReceived(address, std::move(buffer));
 }
 


### PR DESCRIPTION
Disabled some NFC traces not useful.

OnNfcTagResponse is not needed because there is already a Rx trace:

[MatterTest] 07-30 15:14:22.803 INFO NFCBase::OnNfcTagResponse 

[MatterTest] 07-30 15:14:22.804 INFO >>> [E:10436i S:0 M:225716277] (U) Msg RX from 0:0000000000000000 [0000] to B20B42CB2318DDC8 --- Type 0000:23 (SecureChannel:PASE_Pake2) (B:127)

### Testing

Tested NFC commissioning