### PR TITLE
fix leak in HeapObjectPool::CreateObject when node allocation fails

### DIFF
--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -496,18 +496,19 @@ public:
     T * CreateObject(Args &&... args)
     {
         T * object = Platform::New<T>(std::forward<Args>(args)...);
-        if (object != nullptr)
+        VerifyOrReturnValue(object != nullptr, nullptr);
+
+        auto node = Platform::New<internal::HeapObjectListNode>();
+        if (node == nullptr)
         {
-            auto node = Platform::New<internal::HeapObjectListNode>();
-            if (node != nullptr)
-            {
-                node->mObject = object;
-                mObjects.Append(node);
-                IncreaseUsage();
-                return object;
-            }
+            Platform::Delete(object);
+            return nullptr;
         }
-        return nullptr;
+
+        node->mObject = object;
+        mObjects.Append(node);
+        IncreaseUsage();
+        return object;
     }
 
     /*


### PR DESCRIPTION
### Summary

HeapObjectPool::CreateObject allocates the pooled object first and its list node second, and when the node allocation fails it returns nullptr without freeing the object it just built. the object is unreachable at that point, since it was never appended to mObjects, so neither ReleaseObject nor the pool destructor's leak check can ever see it, and ~T() never runs so whatever the object owned leaks with it. this is the pool backing ReadHandler, WriteHandler, CommandHandlerImpl and ExchangeContext when CHIP_SYSTEM_CONFIG_POOL_USE_HEAP is set. delete the object on that path; the success path and the object-allocation-failure path are unchanged.

### Related issues

None.

### Testing

built darwin-arm64-tests-clang and ran the unit test suite, all green including TestPool. the failure window needs an allocation failure between the two Platform::New calls and there is no hook for that in-tree, so i checked it out of tree: linking Pool.cpp against a chip::Platform allocator that fails the Nth allocation, the pre-patch build leaves the object block live with ~T() never called, and the patched build frees it and runs the destructor. glad to fold that into the support tests as a MemoryAlloc failure hook if you would rather have it covered there.
