### PR TITLE
[network-manager] Don't re-register the ubus watch while shutting down

### DIFF
--- a/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
+++ b/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
@@ -39,6 +39,13 @@ CHIP_ERROR OpenThreadUbusBorderRouterDelegate::Init(AttributeChangeCallback * at
 {
     mAttributeChangeCallback = attributeChangeCallback;
 
+    // The cluster uses Init() for two opposite things: Startup() passes the
+    // callback, and Shutdown() passes nullptr to detach it. The second runs on
+    // the way down, by which point ApplicationShutdown() has already stopped
+    // the ubus manager -- and registering a watch on a stopped manager is a
+    // VerifyOrDie. Detaching is not a fresh initialisation, so stop here.
+    VerifyOrReturnValue(attributeChangeCallback != nullptr, CHIP_NO_ERROR);
+
     mOtbr.SetResolvedCallback([](UbusWatch & watch, void * appState) {
         auto * self = static_cast<decltype(this)>(appState);
         ubus_invoke(&self->mUbusManager.Context(), watch.ObjectID(), "status", nullptr,


### PR DESCRIPTION
### Summary

`examples/network-manager-app/linux` aborts on every clean shutdown when built with ubus support:

```
SPT: VerifyOrDie failure at examples/network-manager-app/linux/UbusManager.cpp:163: mInitialized
```

`ThreadBorderRouterManagementCluster` calls the delegate's `Init()` for two opposite purposes:
`Startup()` passes the attribute-change callback, `Shutdown()` passes `nullptr` to detach it.
`OpenThreadUbusBorderRouterDelegate::Init()` treats both as a fresh initialisation and registers its
ubus watch either way. The detach call arrives after `ChipLinuxAppMainLoop()` has run
`ApplicationShutdown()`, which stops the `UbusManager` — so `Register()` asserts on a manager that is
already down.

Return early when there is no callback: detaching is not an initialisation and has nothing to
register.

### Related issues

None found.

### Testing

- Cross-compiled for arm with this as the only change.
- On a Turris Omnia commissioned into a Matter fabric, `/etc/init.d/matter stop` previously aborted
  every time. It now shuts down cleanly and the daemon restarts with its fabric intact.
