### PR TITLE
[crypto] Align PSA P256Keypair::Serialize buffer cleanup with the mbedTLS backend

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -882,6 +882,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     error = output.SetLength(bbuf.Needed());
 
 exit:
+    ClearSecretData(privateKey, sizeof(privateKey));
     LogPsaError(status);
 
     return error;

--- a/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
@@ -849,6 +849,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     error = output.SetLength(bbuf.Needed());
 
 exit:
+    ClearSecretData(privateKey, sizeof(privateKey));
     LogPsaError(status);
 
     return error;


### PR DESCRIPTION
### Summary

Aligns the two PSA implementations of `P256Keypair::Serialize` with the mbedTLS one, which calls `ClearSecretData` on its temporary buffer before returning:

- `src/crypto/CHIPCryptoPALPSA.cpp`
- `src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp` — a copy of the same function used by the EFR32 platform backend

Placed before `LogPsaError` so it runs on the success path and on both `VerifyOrExit` error paths, matching the ordering in `CHIPCryptoPALmbedTLS.cpp`.

### Testing

Two added lines, no behavioural change, so no new test. Existing crypto unit tests cover `Serialize` / `Deserialize` round-tripping on the PSA backend.