### PR TITLE
[v1.5] bound TargetAppList parse loop by element count in ReadPayload

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -313,7 +313,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
                 chip::TLV::TLVType listContainerType = chip::TLV::kTLVType_List;
                 ReturnErrorOnFailure(reader.EnterContainer(listContainerType));
 
-                while ((err = reader.Next()) == CHIP_NO_ERROR && mNumTargetAppInfos < sizeof(mTargetAppInfos))
+                while ((err = reader.Next()) == CHIP_NO_ERROR && mNumTargetAppInfos < kMaxTargetAppInfos)
                 {
                     containerTag = reader.GetTag();
                     if (!TLV::IsContextTag(containerTag))

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -492,6 +492,9 @@ constexpr uint8_t kTestTargetAppListTag = 9;
 constexpr uint8_t kTestTargetAppTag     = 10;
 constexpr uint8_t kTestAppVendorIdTag   = 11;
 constexpr uint8_t kTestAppProductIdTag  = 12;
+
+// Mirrors IdentificationDeclaration::kMaxTargetAppInfos, which is also private.
+constexpr uint8_t kTestMaxTargetAppInfos = 10;
 } // namespace
 
 // A TargetAppList carrying more entries than the fixed array holds must be capped by
@@ -532,8 +535,10 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
     IdentificationDeclaration idOut;
     idOut.ReadPayload(payload, kHeaderLen + writer.GetLengthWritten());
 
-    // The stored count must never exceed the array's element count.
-    EXPECT_LE(idOut.GetNumTargetAppInfos(), 10);
+    // The parser must fill the array to capacity and stop there. Asserting equality rather
+    // than an upper bound also fails if the list was not parsed at all, which would otherwise
+    // satisfy a bound check and skip the verification loop below.
+    EXPECT_EQ(idOut.GetNumTargetAppInfos(), kTestMaxTargetAppInfos);
 
     // Every entry the parser claims to have stored must be readable and correct.
     for (uint8_t i = 0; i < idOut.GetNumTargetAppInfos(); i++)

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -4,6 +4,7 @@
 
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/StringBuilderAdapters.h>
+#include <lib/core/TLV.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>
@@ -482,6 +483,60 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
 
     // TODO: remove following "force-fail" debug line
     // NL_TEST_ASSERT(inSuite, rotatingIdLen != id.GetRotatingIdLength());
+}
+
+// Mirrors IdentificationDeclaration::IdentificationDeclarationTLVTag, which is private.
+// Values are positional starting at 1; see UserDirectedCommissioning.h.
+namespace {
+constexpr uint8_t kTestTargetAppListTag = 9;
+constexpr uint8_t kTestTargetAppTag     = 10;
+constexpr uint8_t kTestAppVendorIdTag   = 11;
+constexpr uint8_t kTestAppProductIdTag  = 12;
+} // namespace
+
+// A TargetAppList carrying more entries than the fixed array holds must be capped by
+// ReadPayload rather than stored past the end of mTargetAppInfos.
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
+{
+    constexpr size_t kHeaderLen = Dnssd::Commission::kInstanceNameMaxLength + 1;
+    // Comfortably more entries than the array holds, while keeping any pre-fix write
+    // inside the object rather than off the end of the stack.
+    constexpr uint16_t kEntries = 14;
+
+    uint8_t payload[kHeaderLen + 512];
+    memset(payload, 0, sizeof(payload));
+    Platform::CopyString(reinterpret_cast<char *>(payload), kHeaderLen, "instance-name");
+
+    TLV::TLVWriter writer;
+    writer.Init(payload + kHeaderLen, sizeof(payload) - kHeaderLen);
+
+    TLV::TLVType listType;
+    ASSERT_EQ(writer.StartContainer(TLV::ContextTag(kTestTargetAppListTag), TLV::kTLVType_List, listType), CHIP_NO_ERROR);
+    for (uint16_t i = 0; i < kEntries; i++)
+    {
+        TLV::TLVType structType;
+        ASSERT_EQ(writer.StartContainer(TLV::ContextTag(kTestTargetAppTag), TLV::kTLVType_Structure, structType), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(kTestAppVendorIdTag), static_cast<uint16_t>(i + 1)), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(kTestAppProductIdTag), static_cast<uint16_t>(i + 100)), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.EndContainer(structType), CHIP_NO_ERROR);
+    }
+    ASSERT_EQ(writer.EndContainer(listType), CHIP_NO_ERROR);
+    ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+
+    IdentificationDeclaration idOut;
+    idOut.ReadPayload(payload, kHeaderLen + writer.GetLengthWritten());
+
+    // The stored count must never exceed the array's element count.
+    EXPECT_LE(idOut.GetNumTargetAppInfos(), 10);
+
+    // Every entry the parser claims to have stored must be readable and correct.
+    for (uint8_t i = 0; i < idOut.GetNumTargetAppInfos(); i++)
+    {
+        TargetAppInfo info;
+        EXPECT_TRUE(idOut.GetTargetAppInfo(i, info));
+        EXPECT_EQ(info.vendorId, static_cast<uint16_t>(i + 1));
+        EXPECT_EQ(info.productId, static_cast<uint16_t>(i + 100));
+    }
 }
 
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -510,6 +510,10 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
     TLV::TLVWriter writer;
     writer.Init(payload + kHeaderLen, sizeof(payload) - kHeaderLen);
 
+    // ReadPayload expects an anonymous structure envelope before any context-tagged element.
+    TLV::TLVType envelopeType;
+    ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, envelopeType), CHIP_NO_ERROR);
+
     TLV::TLVType listType;
     ASSERT_EQ(writer.StartContainer(TLV::ContextTag(kTestTargetAppListTag), TLV::kTLVType_List, listType), CHIP_NO_ERROR);
     for (uint16_t i = 0; i < kEntries; i++)
@@ -521,6 +525,8 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
         ASSERT_EQ(writer.EndContainer(structType), CHIP_NO_ERROR);
     }
     ASSERT_EQ(writer.EndContainer(listType), CHIP_NO_ERROR);
+
+    ASSERT_EQ(writer.EndContainer(envelopeType), CHIP_NO_ERROR);
     ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
 
     IdentificationDeclaration idOut;


### PR DESCRIPTION
### Problem

- `IdentificationDeclaration::ReadPayload` bounds its `TargetAppList` loop with `sizeof(mTargetAppInfos)` instead of the array's element count:

```cpp
while ((err = reader.Next()) == CHIP_NO_ERROR && mNumTargetAppInfos < sizeof(mTargetAppInfos))
```

- `mTargetAppInfos` holds `kMaxTargetAppInfos` = 10 entries of 16 bytes each, so `sizeof` is 160 and the loop can record up to 159 entries into a 10-element array. The loop stores into `mTargetAppInfos[mNumTargetAppInfos]` directly rather than calling `AddTargetAppInfo`, so that helper's own bound does not apply here.

- `master` bounds the same loop with `kMaxTargetAppInfos`. That form arrived there as part of #41870, a repo-wide `nodiscard` batch, so it is not a sensible cherry-pick candidate; raising it here as its own change instead.

### Change

One line at `UserDirectedCommissioningServer.cpp:326`, now byte-identical to master's equivalent line, plus a regression test.

### Testing

The test was pushed ahead of the bound change, so the failing run is in this PR's own CI history: before the change the parser records all 14 entries the payload carries, so `EXPECT_EQ(idOut.GetNumTargetAppInfos(), kTestMaxTargetAppInfos)` sees 14 against 10. Equality rather than an upper bound, so it also fails if the list is not parsed at all.

The TLV is written directly rather than via `AddTargetAppInfo`, which caps at the same limit.

### Related branches

- #73352 — same change for `v1.4.2-branch`. #73376 — same test for `master`, which already has the bound.
- `v1.6-branch` already carries the `kMaxTargetAppInfos` form.
- #73346 fixed the separate `AddTargetAppInfo` bound here; it does not touch this loop.
