### PR TITLE
[v1.5][backport] fix(thermostat-server): notify subscribers when ActivePresetHandle changes

### DIFF
--- a/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
+++ b/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
@@ -150,6 +150,7 @@ private:
 
     uint8_t mActivePresetHandleData[kPresetHandleSize];
     size_t mActivePresetHandleDataSize;
+    bool mActivePresetHandleIsNull = true;
 
     uint8_t mMaxThermostatSuggestions;
     ThermostatSuggestionStructWithOwnedMembers mThermostatSuggestions[kMaxNumberOfThermostatSuggestions];

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -132,7 +132,7 @@ CHIP_ERROR ThermostatDelegate::GetPresetAtIndex(size_t index, PresetStructWithOw
 
 CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<MutableByteSpan> & activePresetHandle)
 {
-    if (mActivePresetHandleDataSize != 0)
+    if (!mActivePresetHandleIsNull)
     {
         ReturnErrorOnFailure(
             CopySpanToMutableSpan(ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize), activePresetHandle.Value()));
@@ -147,7 +147,15 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
-    if (!newActivePresetHandle.IsNull())
+    bool newIsNull = newActivePresetHandle.IsNull();
+    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
+
+    if (mActivePresetHandleIsNull == newIsNull && (newIsNull || oldHandle.data_equal(newActivePresetHandle.Value())))
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (!newIsNull)
     {
         size_t newActivePresetHandleSize = newActivePresetHandle.Value().size();
         if (newActivePresetHandleSize > sizeof(mActivePresetHandleData))
@@ -168,6 +176,10 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
         mActivePresetHandleDataSize = 0;
         ChipLogDetail(NotSpecified, "Clear ActivePresetHandle");
     }
+
+    mActivePresetHandleIsNull = newIsNull;
+    MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
+
     return CHIP_NO_ERROR;
 }
 
@@ -447,9 +459,8 @@ CHIP_ERROR ThermostatDelegate::ReEvaluateCurrentSuggestion()
         // TODO: Check if a hold is set and set the ThermostatSuggestionNotFollowingReason to OngoingHold and do not update
         // ActivePresetHandle. Otherwise set the ActivePresetHandle to the preset handle in the suggestion and set
         // ThermostatSuggestionNotFollowingReason to null.
-        SetActivePresetHandle(currentThermostatSuggestion.GetPresetHandle());
-        MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
-        SetThermostatSuggestionNotFollowingReason(DataModel::NullNullable);
+        TEMPORARY_RETURN_IGNORED SetActivePresetHandle(currentThermostatSuggestion.GetPresetHandle());
+        TEMPORARY_RETURN_IGNORED SetThermostatSuggestionNotFollowingReason(DataModel::NullNullable);
 
         // Start a timer from the timestamp in currentMatterEpochTimestamp to the timestamp in the expiration time.
         if (currentThermostatSuggestion.GetExpirationTime() > currentMatterEpochTimestamp)


### PR DESCRIPTION
#### Summary

Manual backport of #72769 to `v1.5-branch`.

`SetActivePreset()` was updating the `ActivePresetHandle` attribute via the delegate but not calling `MatterReportingAttributeChangeCallback()` afterwards. As a result, active subscriptions never received a Report Data message when the active preset changed via `SetActivePresetRequest` — the new value was silently applied on the device side but never pushed to subscribers.

Fix:
- Centralize `MatterReportingAttributeChangeCallback` inside `SetActivePresetHandle` so both the command path (`SetActivePresetRequest`) and the suggestion path (`ReEvaluateCurrentSuggestion`) emit consistent subscription reports.
- Add an explicit `mActivePresetHandleIsNull` boolean flag to correctly distinguish null from a non-null empty `octstr`.
- Only emit a subscription report when the value has actually changed: null-to-null and same-value comparisons both short-circuit without reporting.

**Conflict resolution note:** `ReEvaluateCurrentSuggestion()` on `v1.5-branch` already wraps the `SetActivePresetHandle`/`SetThermostatSuggestionNotFollowingReason` calls with `TEMPORARY_RETURN_IGNORED` (a `v1.5-branch`-only convention, unrelated to this fix). That wrapping was preserved during the cherry-pick; the now-redundant explicit `MatterReportingAttributeChangeCallback()` call was removed, matching the intent of the original PR.

This is a manual backport (cherry-pick with conflict resolution) of #72769, squash-merged as `ff311154bf71f18bb02c0f655f8be75ee94bd586` on master.

#### Related issues

Fixes: #43582

#### Testing

Tested with thermostat/linux example on master (see #72769). Cherry-picked cleanly onto `v1.5-branch` aside from the noted conflict; local build not re-run for this backport due to submodule pinning differences between `master` and `v1.5-branch`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)