### PR TITLE
Use the DUT's ScanMaxTimeSeconds value as the interation timeout of ScanNetworks in TC_CNET_4_4

### DIFF
--- a/src/controller/python/matter/clusters/Command.py
+++ b/src/controller/python/matter/clusters/Command.py
@@ -264,7 +264,7 @@ def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(future: Future, eventLo
         lambda: handle.pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke(
             ctypes.py_object(transaction), device,
             commandPath.EndpointId, commandPath.ClusterId, commandPath.CommandId, payloadTLV, len(payloadTLV),
-            ctypes.c_uint16(0),  # interactionTimeoutMs
+            ctypes.c_uint32(0),  # interactionTimeoutMs
             ctypes.c_uint16(0),  # busyWaitMs
             ctypes.c_bool(False)  # suppressResponse
         ))
@@ -301,7 +301,7 @@ async def SendCommand(future: Future, eventLoop, responseType: type[ClusterComma
             ctypes.py_object(transaction), device,
             c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), commandPath.EndpointId,
             commandPath.ClusterId, commandPath.CommandId, payloadTLV, len(payloadTLV),
-            ctypes.c_uint16(0 if interactionTimeoutMs is None else interactionTimeoutMs),
+            ctypes.c_uint32(0 if interactionTimeoutMs is None else interactionTimeoutMs),
             ctypes.c_uint16(0 if busyWaitMs is None else busyWaitMs),
             ctypes.c_bool(False if suppressResponse is None else suppressResponse),
             ctypes.c_bool(False if allowLargePayload is None else allowLargePayload)
@@ -374,7 +374,7 @@ async def SendBatchCommands(future: Future, eventLoop, device, commands: list[In
         lambda: handle.pychip_CommandSender_SendBatchCommands(
             py_object(transaction), device,
             c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
-            c_uint16(0 if interactionTimeoutMs is None else interactionTimeoutMs),
+            c_uint32(0 if interactionTimeoutMs is None else interactionTimeoutMs),
             c_uint16(0 if busyWaitMs is None else busyWaitMs),
             c_bool(False if suppressResponse is None else suppressResponse),
             pyBatchCommandsData, c_size_t(len(pyBatchCommandsData)))
@@ -416,7 +416,7 @@ def TestOnlySendBatchCommands(future: Future, eventLoop, device, commands: list[
         lambda: handle.pychip_CommandSender_TestOnlySendBatchCommands(
             py_object(transaction), device,
             c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
-            c_uint16(0 if interactionTimeoutMs is None else interactionTimeoutMs),
+            c_uint32(0 if interactionTimeoutMs is None else interactionTimeoutMs),
             c_uint16(0 if busyWaitMs is None else busyWaitMs),
             c_bool(False if suppressResponse is None else suppressResponse),
             testOnlyOverrides,
@@ -449,13 +449,13 @@ def Init():
         setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_CommandSender_SendCommand',
-                   PyChipError, [py_object, c_void_p, c_uint16, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16, c_uint16, c_bool, c_bool])
+                   PyChipError, [py_object, c_void_p, c_uint16, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint32, c_uint16, c_bool, c_bool])
         setter.Set('pychip_CommandSender_SendBatchCommands',
-                   PyChipError, [py_object, c_void_p, c_uint16, c_uint16, c_uint16, c_bool, POINTER(PyInvokeRequestData), c_size_t])
+                   PyChipError, [py_object, c_void_p, c_uint16, c_uint32, c_uint16, c_bool, POINTER(PyInvokeRequestData), c_size_t])
         setter.Set('pychip_CommandSender_TestOnlySendBatchCommands',
-                   PyChipError, [py_object, c_void_p, c_uint16, c_uint16, c_uint16, c_bool, TestOnlyPyBatchCommandsOverrides, POINTER(PyInvokeRequestData), c_size_t])
+                   PyChipError, [py_object, c_void_p, c_uint16, c_uint32, c_uint16, c_bool, TestOnlyPyBatchCommandsOverrides, POINTER(PyInvokeRequestData), c_size_t])
         setter.Set('pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke',
-                   PyChipError, [py_object, c_void_p, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16, c_uint16, c_bool])
+                   PyChipError, [py_object, c_void_p, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint32, c_uint16, c_bool])
         setter.Set('pychip_CommandSender_SendGroupCommand',
                    PyChipError, [c_uint16, c_void_p, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16])
         setter.Set('pychip_CommandSender_InitCallbacks', None, [

--- a/src/controller/python/matter/clusters/command.cpp
+++ b/src/controller/python/matter/clusters/command.cpp
@@ -36,16 +36,16 @@ using PyObject = void *;
 extern "C" {
 PyChipError pychip_CommandSender_SendCommand(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
                                              chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
-                                             const uint8_t * payload, size_t length, uint16_t interactionTimeoutMs,
+                                             const uint8_t * payload, size_t length, uint32_t interactionTimeoutMs,
                                              uint16_t busyWaitMs, bool suppressResponse, bool allowLargePayload);
 
 PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                                   uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                                   uint32_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
                                                    chip::python::PyInvokeRequestData * batchCommandData, size_t length);
 
 PyChipError pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke(
     void * appContext, DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
-    const uint8_t * payload, size_t length, uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse);
+    const uint8_t * payload, size_t length, uint32_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse);
 
 PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId, chip::Controller::DeviceCommissioner * devCtrl,
                                                   chip::ClusterId clusterId, chip::CommandId commandId, const uint8_t * payload,
@@ -194,7 +194,7 @@ private:
 };
 
 PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                      uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                      uint32_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
                                       python::TestOnlyPyBatchCommandsOverrides * testOnlyOverrides,
                                       python::PyInvokeRequestData * batchCommandData, size_t length)
 {
@@ -351,7 +351,7 @@ void pychip_CommandSender_InitCallbacks(OnCommandSenderResponseCallback onComman
 
 PyChipError pychip_CommandSender_SendCommand(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
                                              chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
-                                             const uint8_t * payload, size_t length, uint16_t interactionTimeoutMs,
+                                             const uint8_t * payload, size_t length, uint32_t interactionTimeoutMs,
                                              uint16_t busyWaitMs, bool suppressResponse, bool allowLargePayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -403,7 +403,7 @@ exit:
 }
 
 PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                                   uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                                   uint32_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
                                                    python::PyInvokeRequestData * batchCommandData, size_t length)
 {
     python::TestOnlyPyBatchCommandsOverrides * testOnlyOverrides = nullptr;
@@ -412,7 +412,7 @@ PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProx
 }
 
 PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                                           uint16_t interactionTimeoutMs, uint16_t busyWaitMs,
+                                                           uint32_t interactionTimeoutMs, uint16_t busyWaitMs,
                                                            bool suppressResponse,
                                                            python::TestOnlyPyBatchCommandsOverrides testOnlyOverrides,
                                                            python::PyInvokeRequestData * batchCommandData, size_t length)
@@ -427,7 +427,7 @@ PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, De
 
 PyChipError pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke(
     void * appContext, DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
-    const uint8_t * payload, size_t length, uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse)
+    const uint8_t * payload, size_t length, uint32_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse)
 {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
 

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -68,7 +68,7 @@ class TC_CNET_4_4(MatterBaseTest):
         connected = [network for network in networks if network.connected is True]
         asserts.assert_greater_equal(len(connected), 1, "Did not find any connected networks on a commissioned device")
         known_ssid = connected[0].networkID
-         # Dynamically compute the interaction timeout based on the DUT's reported max scan time
+        # Dynamically compute the interaction timeout based on the DUT's reported max scan time
         scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
         scan_interaction_timeout_ms = self.default_controller.ComputeRoundTripTimeout(
             self.dut_node_id, upperLayerProcessingTimeoutMs=scan_max_time_s * 1000)

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -69,6 +69,8 @@ class TC_CNET_4_4(MatterBaseTest):
         asserts.assert_greater_equal(len(connected), 1, "Did not find any connected networks on a commissioned device")
         known_ssid = connected[0].networkID
         scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
+        scan_interaction_timeout_ms = self.default_controller.ComputeRoundTripTimeout(
+            self.dut_node_id, upperLayerProcessingTimeoutMs=scan_max_time_s * 1000)
 
         async def scan_and_check(ssid_to_scan: bytes | None, breadcrumb: int, expect_results: bool = True):
             all_security = 0
@@ -77,7 +79,7 @@ class TC_CNET_4_4(MatterBaseTest):
 
             ssid = ssid_to_scan if ssid_to_scan is not None else NullValue
             cmd = cnet.Commands.ScanNetworks(ssid=ssid, breadcrumb=breadcrumb)
-            scan_results = await self.send_single_cmd(cmd=cmd, interactionTimeoutMs=scan_max_time_s * 1000)
+            scan_results = await self.send_single_cmd(cmd=cmd, interactionTimeoutMs=scan_interaction_timeout_ms)
             asserts.assert_true(matchers.is_type(scan_results, cnet.Commands.ScanNetworksResponse),
                                 "Unexpected value returned from scan network")
             log.info("Scan results: %s", scan_results)

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -68,10 +68,10 @@ class TC_CNET_4_4(MatterBaseTest):
         connected = [network for network in networks if network.connected is True]
         asserts.assert_greater_equal(len(connected), 1, "Did not find any connected networks on a commissioned device")
         known_ssid = connected[0].networkID
+        scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
 
         async def scan_and_check(ssid_to_scan: bytes | None, breadcrumb: int, expect_results: bool = True):
             all_security = 0
-            scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
             for security_bitmask in cnet.Bitmaps.WiFiSecurityBitmap:
                 all_security |= security_bitmask
 

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -71,12 +71,13 @@ class TC_CNET_4_4(MatterBaseTest):
 
         async def scan_and_check(ssid_to_scan: bytes | None, breadcrumb: int, expect_results: bool = True):
             all_security = 0
+            scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
             for security_bitmask in cnet.Bitmaps.WiFiSecurityBitmap:
                 all_security |= security_bitmask
 
             ssid = ssid_to_scan if ssid_to_scan is not None else NullValue
             cmd = cnet.Commands.ScanNetworks(ssid=ssid, breadcrumb=breadcrumb)
-            scan_results = await self.send_single_cmd(cmd=cmd)
+            scan_results = await self.send_single_cmd(cmd=cmd, interactionTimeoutMs=scan_max_time_s * 1000)
             asserts.assert_true(matchers.is_type(scan_results, cnet.Commands.ScanNetworksResponse),
                                 "Unexpected value returned from scan network")
             log.info("Scan results: %s", scan_results)

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -68,6 +68,7 @@ class TC_CNET_4_4(MatterBaseTest):
         connected = [network for network in networks if network.connected is True]
         asserts.assert_greater_equal(len(connected), 1, "Did not find any connected networks on a commissioned device")
         known_ssid = connected[0].networkID
+         # Dynamically compute the interaction timeout based on the DUT's reported max scan time
         scan_max_time_s = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.ScanMaxTimeSeconds)
         scan_interaction_timeout_ms = self.default_controller.ComputeRoundTripTimeout(
             self.dut_node_id, upperLayerProcessingTimeoutMs=scan_max_time_s * 1000)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -2951,6 +2951,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             node_id: Target node ID, defaults to dut_node_id.
             endpoint: Target endpoint, defaults to configured endpoint.
             timedRequestTimeoutMs: Timeout for timed requests in milliseconds.
+            interactionTimeoutMs: Overall interaction timeout in milliseconds. Defaults to an SDK-computed timeout.
             payloadCapability: Transport payload capability setting.
 
         Returns:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -2941,6 +2941,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             self, cmd: Clusters.ClusterObjects.ClusterCommand,
             dev_ctrl: ChipDeviceCtrl.ChipDeviceController | None = None, node_id: int | None = None, endpoint: int | None = None,
             timedRequestTimeoutMs: OptionalTimeout = None,
+            interactionTimeoutMs: OptionalTimeout = None,
             payloadCapability: int = ChipDeviceCtrl.TransportPayloadCapability.MRP_PAYLOAD) -> object:
         """Send a single command to a Matter device.
 
@@ -2963,7 +2964,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             endpoint = self.get_endpoint()
 
         return await dev_ctrl.SendCommand(nodeId=node_id, endpoint=endpoint, payload=cmd, timedRequestTimeoutMs=timedRequestTimeoutMs,
-                                          payloadCapability=payloadCapability)
+                                          interactionTimeoutMs=interactionTimeoutMs, payloadCapability=payloadCapability)
 
     async def send_test_event_triggers(self, eventTrigger: int, enableKey: bytes | None = None):
         """This helper function sends a test event trigger to the General Diagnostics cluster on endpoint 0


### PR DESCRIPTION
#### Summary

  Extends Python command interaction timeouts and applies the DUT-reported scan timeout in
  `TC_CNET_4_4`.

  ##### Problem

  - Python command bindings represent interaction timeouts as 16-bit milliseconds.
  - `TC_CNET_4_4` did not use the DUT's `ScanMaxTimeSeconds` value when sending`ScanNetworks`, while the SPEC says `The client SHALL NOT expect the server to be done scanning and have responded with ScanNetworksResponse before ScanMaxTimeSeconds have elapsed.`

  ##### Changes

  - Widened command interaction timeout bindings from 16 to 32 bits.
  - Added interaction-timeout forwarding to `send_single_cmd`.
  - Configured `TC_CNET_4_4` scan commands using the DUT's `ScanMaxTimeSeconds` value.

  #### Testing

  - Run the TC_CNET_4_4 manually