### PR TITLE
[ESP32] fix build error when enable rotating device id

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1946,7 +1946,7 @@ int BLEManagerImpl::gatt_svr_chr_access_additional_data(uint16_t conn_handle, ui
         break;
     }
 
-    PlatformMgr().ScheduleWork(DriveBLEState, 0);
+    LogErrorOnFailure(PlatformMgr().ScheduleWork(DriveBLEState, 0));
 
     return err;
 }


### PR DESCRIPTION
### Summary

Fix build error when enable rotating device id with configuration option CONFIG_ENABLE_ROTATING_DEVICE_ID=y

Refer to PR: https://github.com/project-chip/connectedhomeip/pull/43280

### Testing
Manually built and ran lighting-app/esp32 
