### PR TITLE
[Silabs][Docker]Update silabs docker image to add S3 libraries

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-207 : [Silabs] Keep generative_ai; JDK 21; Bake SLT python/apack registry + slt CLI
+208 : [Silabs] Add Libs for series3

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -57,6 +57,7 @@ bluetooth_le_controller/build/gcc/xg27/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg28/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg29/release/liblinklayer.a
 bluetooth_le_controller/build/llvm/xg24/release/liblinklayer.a
+bluetooth_le_controller/build/llvm/x301/release/liblinklayer.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/rpa_resolution/release/libble_host_rpa_resolution_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/resolving_list/release/libble_host_resolving_list_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/local_privacy/release/libble_host_local_privacy_stub.a
@@ -74,6 +75,7 @@ bluetooth_le_host/build/gcc/cortex-m33/ble_system/release/libble_system.a
 bluetooth_le_host/build/gcc/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/core/release/libble_host_core.a
 bluetooth_le_host/build/gcc/cortex-m33/hal/release/libble_host_hal_series2.a
+bluetooth_le_host/build/gcc/cortex-m33/hal/release/libble_host_hal_series3.a
 bluetooth_le_host/build/gcc/cortex-m33/hci/release/libble_host_hci.a
 bluetooth_le_host/build/gcc/cortex-m33/system/release/libble_host_system.a
 bluetooth_le_host/build/llvm/cortex-m33/privacy/rpa_resolution/release/libble_host_rpa_resolution_stub.a
@@ -93,6 +95,7 @@ bluetooth_le_host/build/llvm/cortex-m33/ble_system/release/libble_system.a
 bluetooth_le_host/build/llvm/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
 bluetooth_le_host/build/llvm/cortex-m33/core/release/libble_host_core.a
 bluetooth_le_host/build/llvm/cortex-m33/hal/release/libble_host_hal_series2.a
+bluetooth_le_host/build/llvm/cortex-m33/hal/release/libble_host_hal_series3.a
 bluetooth_le_host/build/llvm/cortex-m33/hci/release/libble_host_hci.a
 bluetooth_le_host/build/llvm/cortex-m33/system/release/libble_host_system.a
 openthread/libs/build/gcc/cortex-m33/sl-openthread-library/Release/libsl_openthread.a
@@ -163,6 +166,8 @@ rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release
 rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_llvm_release.a
 rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_gcc_release.a
 rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_llvm_release.a
+rail_library/autogen/librail_release/librail_multiprotocol_sixg301_gcc_release.a
+rail_library/autogen/librail_release/librail_multiprotocol_sixg301_llvm_release.a
 
 # all (combined unique, alphabetical)
 bgapi_protocol

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -50,12 +50,8 @@ bluetooth_common/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a
 bluetooth_common/lib/build/llvm/cortex-m33/bgcommon/release/libbgcommon.a
 bluetooth_le_controller/build/gcc/x301/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg21/release/liblinklayer.a
-bluetooth_le_controller/build/gcc/xg22/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg24/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg26/release/liblinklayer.a
-bluetooth_le_controller/build/gcc/xg27/release/liblinklayer.a
-bluetooth_le_controller/build/gcc/xg28/release/liblinklayer.a
-bluetooth_le_controller/build/gcc/xg29/release/liblinklayer.a
 bluetooth_le_controller/build/llvm/xg24/release/liblinklayer.a
 bluetooth_le_controller/build/llvm/x301/release/liblinklayer.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/rpa_resolution/release/libble_host_rpa_resolution_stub.a


### PR DESCRIPTION
### Summary
This PR adds a few librairies to our docker image so it can build/compile Series 3 boards. 

Follow-up pr to add GN build support for a board of this new MCU series, BRD4407A ( SiMG301)

### Related issues
n/a

### Testing
Tested the image locally and through our (silabs) internal ci
