### PR TITLE
[Silabs]Add support for BRD4407a, a series 3 board within silabs gn build system

### DIFF
--- a/examples/platform/silabs/ldscripts/simg301.ld
+++ b/examples/platform/silabs/ldscripts/simg301.ld
@@ -1,0 +1,518 @@
+/***************************************************************************//**
+ * GCC Linker script for Silicon Labs devices
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+
+ MEMORY
+ {
+   FLASH      (rx)  : ORIGIN = 0x1008000, LENGTH = 0x389000
+   RAM        (rwx) : ORIGIN = 0x20000100, LENGTH = 0x7ff00
+   RAM_ALIAS  (x)   : ORIGIN = 0x800100, LENGTH = 0x7ff00
+   BOOTLOADER_RESET_REGION (rwx) : ORIGIN = 0x20000000, LENGTH = 0x100
+   /* Dummy region is used for the dummy segment, which in turn never gets data
+    * loaded, but is only used to calculate the size of objects placed in it. */
+   DUMMY      (!ax) : ORIGIN = 0xffc77000, LENGTH = 0x389000
+ }
+__flash_size__ = 0x391000;
+__flash_page_size__ = 0x1000;
+__mspu_region_size__ = 0x8000;
+
+/*******************************************************************************
+ * Due to an issue in GNU LD, which results in wrongly applying the writeable
+ * flag to a text section (thereby triggering an error since the memory block is
+ * declared rx), we need to define our segments manually.
+ *
+ * Typical Silicon Labs program layout:
+ *
+ * ----- START OF APPLICATION FLASH -----
+ * R X - TrustZone Secure-to-Nonsecure trampoline app.
+ * R   - Vector table
+ * R X - RAM functions (copied to RAM at startup)
+ * R   - Read-only data
+ * R X - Code
+ * R X - Secure Gateways (Trustzone S only)
+ * R X - extab
+ * R X - exidx
+ * R   - startup copy table
+ * R   - startup zeroization table
+ * RW  - Initialised RAM data (copied to RAM at startup)
+ *     - [unallocated space]
+ *     - NVM (defined using linker symbols only, not an ELF section)
+ * ----- END OF APPLICATION FLASH -----
+ *
+ * ----- START OF APPLICATION RAM -----
+ * RW  - Bootloader reset reason (if present)
+ * RW  - stack
+ * RW  - stack sealing
+ * RW  - BSS (zero-init RAM)
+ * RW  - uninitialised RAM
+ * R X - RAM functions
+ * RW  - Initialised RAM
+ * RW  - Heap (automatically expanded to end of RAM)
+ * ----- END OF APPLICATION RAM -----
+ *
+ * ----- START OF DUMMY REGION -----
+ * RW  - NVM sections (not loadable, only collected such that the linker can
+ *         calculate the size of the symbols placed inside it, to subtract that
+ *         size from the end of the available flash space)
+ * ----- END OF DUMMY REGION -----
+ *
+ * For the purpose of defining segments, we need a new segment whenever the
+ * data loaded changes type. That means e.g. we need three segments for all RAM
+ * content: the initial RW segment, the RX segment, and the final RW segment.
+ ******************************************************************************/
+
+PHDRS
+{
+  text_s PT_LOAD FLAGS(5);        /* Executable S code (if present) */
+  vectors PT_LOAD FLAGS(4);       /* Flash content before RAM functions is R */
+  readonly PT_LOAD FLAGS(4);      /* Readonly content after RAM functions */
+  text PT_LOAD FLAGS(5);          /* Executable flash content after readonly */
+  tables PT_LOAD FLAGS(4);        /* Tables supporting startup copying are R */
+  empty PT_LOAD FLAGS(4);         /* Empty area is R */
+
+  ram_pre_code PT_LOAD FLAGS(6);  /* All RAM content before RAMfuncs is RW */
+  ram_code PT_LOAD FLAGS(5);      /* RAMfuncs need to be RX */
+  ram_data PT_LOAD FLAGS(6);      /* Relocatable RAM data needs own segment */
+  ram_post_data PT_LOAD FLAGS(6); /* All RAM content after data is RW */
+  btl_data PT_LOAD FLAGS(6);      /* Bootloader data is in a separate region */
+
+  dummy_seg PT_NULL FLAGS(6);     /* Dummy segment for dummy sections */
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .secure_app :
+  {
+    __Secure_Vectors = .;
+    KEEP(*(.secure_vectors))
+    KEEP(*(.secure_config_data))
+    __Secure_Reset_Handler = .;
+    KEEP(*(.secure_reset_handler))
+    KEEP(*(.secure_fault_handler))
+    . = ALIGN(__mspu_region_size__);
+  } > FLASH :text_s
+
+  .vectors :
+  {
+    linker_vectors_begin = .;
+    KEEP(*(.vectors))
+    linker_vectors_end = .;
+
+    __Vectors_End = .;
+    __Vectors_Size = __Vectors_End - __Vectors;
+  } > FLASH :vectors
+  text_ram :
+  {
+    . = ALIGN(32);
+    __vma_ramfuncs_start__ = .;
+
+    /* text_application_ram */
+    *(text_application_ram)
+
+    . = ALIGN(4);
+
+    /* text_<component>_ram */
+    __text_system_ram_start__ = .;
+    *(text_system_*timecritical*)
+
+    . = ALIGN(4);
+    __text_system_ram_end__ = .;
+    __text_aes_ccm_ram_start__ = .;
+    *(text_aes_ccm_*security*)
+    *(text_aes_ccm_*timecritical*)
+
+    . = ALIGN(4);
+    __text_aes_ccm_ram_end__ = .;
+    __text_aes_common_ram_start__ = .;
+    *(text_aes_common_*security*)
+    *(text_aes_common_*timecritical*)
+
+    . = ALIGN(4);
+    __text_aes_common_ram_end__ = .;
+    __text_clock_manager_ram_start__ = .;
+    *(text_clock_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_clock_manager_ram_end__ = .;
+    __text_device_peripheral_ram_start__ = .;
+    *(text_device_peripheral_*timecritical*)
+
+    . = ALIGN(4);
+    __text_device_peripheral_ram_end__ = .;
+    __text_dma_channel_ram_start__ = .;
+    *(text_dma_channel_*timecritical*)
+
+    . = ALIGN(4);
+    __text_dma_channel_ram_end__ = .;
+    __text_dma_manager_ram_start__ = .;
+    *(text_dma_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_dma_manager_ram_end__ = .;
+    __text_dmadrv_ram_start__ = .;
+    *(text_dmadrv_*timecritical*)
+
+    . = ALIGN(4);
+    __text_dmadrv_ram_end__ = .;
+    __text_gpio_ram_start__ = .;
+    *(text_gpio_*timecritical*)
+
+    . = ALIGN(4);
+    __text_gpio_ram_end__ = .;
+    __text_hal_common_ram_start__ = .;
+    *(text_hal_common_*timecritical*)
+
+    . = ALIGN(4);
+    __text_hal_common_ram_end__ = .;
+    __text_hal_gpio_ram_start__ = .;
+    *(text_hal_gpio_*timecritical*)
+
+    . = ALIGN(4);
+    __text_hal_gpio_ram_end__ = .;
+    __text_hal_ldma_ram_start__ = .;
+    *(text_hal_ldma_*timecritical*)
+
+    . = ALIGN(4);
+    __text_hal_ldma_ram_end__ = .;
+    __text_hal_sysrtc_ram_start__ = .;
+    *(text_hal_sysrtc_*timecritical*)
+
+    . = ALIGN(4);
+    __text_hal_sysrtc_ram_end__ = .;
+    __text_interrupt_manager_ram_start__ = .;
+    *(text_interrupt_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_interrupt_manager_ram_end__ = .;
+    __text_memlcd_ram_start__ = .;
+    *(text_memlcd_*timecritical*)
+
+    . = ALIGN(4);
+    __text_memlcd_ram_end__ = .;
+    __text_memory_manager_ram_start__ = .;
+    *(text_memory_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_memory_manager_ram_end__ = .;
+    __text_ot_platform_abstraction_ram_start__ = .;
+    *(text_ot_platform_abstraction_*timecritical*)
+
+    . = ALIGN(4);
+    __text_ot_platform_abstraction_ram_end__ = .;
+    __text_power_manager_ram_start__ = .;
+    *(text_power_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_power_manager_ram_end__ = .;
+    __text_rail_lib_ram_start__ = .;
+    *(text_rail_lib_*timecritical*)
+
+    . = ALIGN(4);
+    __text_rail_lib_ram_end__ = .;
+    __text_se_manager_ram_start__ = .;
+    *(text_se_manager_*timecritical*)
+
+    . = ALIGN(4);
+    __text_se_manager_ram_end__ = .;
+    __text_core_ram_start__ = .;
+    *(text_core_*timecritical*)
+
+    . = ALIGN(4);
+    __text_core_ram_end__ = .;
+    __text_sleeptimer_ram_start__ = .;
+    *(text_sleeptimer_*timecritical*)
+
+    . = ALIGN(4);
+    __text_sleeptimer_ram_end__ = .;
+    __text_sli_crypto_ram_start__ = .;
+    *(text_sli_crypto_*timecritical*)
+
+    . = ALIGN(4);
+    __text_sli_crypto_ram_end__ = .;
+    __text_psec_osal_ram_start__ = .;
+    *(text_psec_osal_*timecritical*)
+
+    . = ALIGN(4);
+    __text_psec_osal_ram_end__ = .;
+    __text_sxsymcrypt_ram_start__ = .;
+    *(text_sxsymcrypt_*timecritical*)
+
+    . = ALIGN(4);
+    __text_sxsymcrypt_ram_end__ = .;
+    __text_uartdrv_ram_start__ = .;
+    *(text_uartdrv_*timecritical*)
+
+    . = ALIGN(4);
+    __text_uartdrv_ram_end__ = .;
+    *libgcc.a:_*.*(.text*)
+    *libgcc.a:_*.*(.rodata*)
+    *memset.*(.text*)
+    *memset.*(.rodata*)
+    */link_raw_api.*(.text*)
+    */link_raw_api.*(.rodata*)
+    */sub_mac.*(.text*)
+    */sub_mac.*(.rodata*)
+    */factory_diags.*(.text*)
+    */factory_diags.*(.rodata*)
+    */link_metrics.*(.text*)
+    */link_metrics.*(.rodata*)
+    */mac.*(.text*)
+    */mac.*(.rodata*)
+    *(text_freertos_kernel_*timecritical*)
+
+    . = ALIGN(32);
+    __vma_ramfuncs_end__ = .;
+  } > RAM_ALIAS AT > FLASH :ram_code
+
+  __lma_ramfuncs_start__ = LOADADDR(text_ram);
+  __lma_ramfuncs_end__ = LOADADDR(text_ram) + SIZEOF(text_ram);
+
+  .rodata :
+  {
+  } > FLASH :readonly
+
+  .text :
+  {
+    linker_code_begin = .;
+    *(SORT_BY_ALIGNMENT(.text*))
+    *(SORT_BY_ALIGNMENT(text_*))
+    . = ALIGN(32);
+    linker_code_end = .;
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+    *(.rodata*)
+    *(.eh_frame*)
+  } > FLASH :text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH :text
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH :text
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+    /*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+    */
+    __copy_table_end__ = .;
+  } > FLASH :tables
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    /* Add each additional bss section here */
+    /*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+    */
+    __zero_table_end__ = .;
+  } > FLASH :tables
+  .bootloader_reset_section (NOLOAD):
+  {
+    __ResetReasonStart__ = .;
+    KEEP(*(.bootloader_reset_section))
+  } > BOOTLOADER_RESET_REGION :btl_data
+  text_ram_vma (NOLOAD):
+  {
+    /* Offset the location counter to account for RAM code that was placed in
+       the aliased RAM region.
+     */
+    . += (__vma_ramfuncs_end__ - __vma_ramfuncs_start__);
+  } > RAM :ram_pre_code
+
+  .stack (NOLOAD):
+  {
+    . = ALIGN(8);
+    __stack_limit = .;
+    __StackLimit = .;
+    KEEP(*(.stack*))
+    . = ALIGN(4);
+    __stack = .;
+    __StackTop = .;
+  } > RAM :ram_pre_code
+
+  .noinit (NOLOAD):
+  {
+    __noinit_start__ = .;
+    *(.noinit*);
+    __noinit_end__ = .;
+  } > RAM :ram_pre_code
+  vector_table_ram (NOLOAD):
+  {
+    linker_vectors_ram_begin = .;
+    KEEP(*(.vector_table_ram))
+    linker_vectors_ram_end = .;
+  } > RAM :ram_pre_code
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(SORT_BY_ALIGNMENT(.bss*))
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM :ram_pre_code
+
+  .data :
+  {
+    *(vtable)
+    *(SORT_BY_ALIGNMENT(.data*))
+    . = ALIGN(4);
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    . = ALIGN(4);
+    /* Shareable data sections here */
+    __start_shareable = .;
+    *(.rail_shareable)
+    /* Add each additional shareable sections here */
+    __stop_shareable = .;
+    . = ALIGN(4);
+    *(SEGGER_RTT)
+
+    . = ALIGN(4);
+    /* All data end */
+
+  } > RAM AT > FLASH :ram_data
+
+  /* Values to support copying initialised values at startup */
+  __etext = LOADADDR(.data);
+  __data_start__ = ADDR(.data);
+  __data_end__ = ADDR(.data) + SIZEOF(.data);
+
+  ASSERT((__etext % 4) == 0, "Data section needs to be word-aligned in LMA")
+  ASSERT((__data_start__ % 4) == 0, "Data section needs to be word-aligned in VMA")
+  ASSERT((__data_end__ % 4) == 0, "Data section needs to be word-multiple sized")
+.code_flash_end : {
+  code_flash_end = .;
+} > FLASH :empty
+
+/* Calculate heap size based on RAM limits. */
+heap_limit = ORIGIN(RAM) + LENGTH(RAM);  /* End of RAM */
+heap_size = heap_limit - __HeapBase;
+  .memory_manager_heap (NOLOAD):
+  {
+    . = ALIGN(8);
+    __HeapBase = .;
+    . += heap_size;
+    __end__ = .;
+    _end = __end__;
+    KEEP(*(.memory_manager_heap*))
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+  } > RAM :ram_post_data
+
+  __ram_end__ = 0x20000100 + 0x7ff00;
+  __main_flash_end__ = 0x1008000 + 0x389000;
+
+   /* This is where we handle flash storage blocks. We use dummy sections for finding the configured
+   * block sizes and then "place" them at the end of flash when the size is known. */
+  .internal_storage (NOLOAD) : {
+    KEEP(*(.internal_storage*))
+  } > DUMMY :dummy_seg
+
+
+  .nvm (NOLOAD) : {
+    KEEP(*(.simee*))
+  } > DUMMY :dummy_seg
+  __ramfuncs_start__ = ORIGIN(RAM) + (__vma_ramfuncs_start__ - ORIGIN(RAM_ALIAS));
+  __ramfuncs_end__ = ORIGIN(RAM) + (__vma_ramfuncs_end__ - ORIGIN(RAM_ALIAS));
+
+  /* Static secure tokens reserve flash memory at the end of the flash */
+  linker_static_secure_tokens_end = __main_flash_end__;
+  linker_static_secure_tokens_begin = linker_static_secure_tokens_end - 0x2000;
+
+  linker_nvm_end = linker_static_secure_tokens_begin;
+  linker_nvm_begin = linker_nvm_end - SIZEOF(.nvm);
+  linker_storage_end = linker_nvm_begin;
+  __nvm3Base = linker_nvm_begin;
+
+  linker_storage_begin = linker_storage_end - SIZEOF(.internal_storage);
+  ASSERT((linker_storage_begin >= (__etext + SIZEOF(.data))), "FLASH memory overflowed !")
+
+  HIDDEN(app_flash_end = 0x1008000 + 0x389000);
+  ASSERT( (linker_nvm_begin + SIZEOF(.nvm)) <= linker_static_secure_tokens_begin, "NVM3 is excessing the flash size !")
+  ASSERT( (linker_static_secure_tokens_begin + 0x2000) <= app_flash_end, "Static secure storage is exceeding the flash size !")
+  ASSERT( code_flash_end - 0x1008000 <= 0x1f0000, "Code size exceeds code region 1 capacity. Flash partitions can be reconfigured: https://docs.silabs.com/gecko-platform/latest/flash-partitions-series3/")
+
+}
+

--- a/examples/platform/silabs/matter-platform.slcp
+++ b/examples/platform/silabs/matter-platform.slcp
@@ -113,12 +113,12 @@ configuration:
 - condition: [uartdrv_usart]
   name: UARTDRV_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION
   value: '1'
-- condition: [iostream_usart]
-  name: SL_IOSTREAM_USART_VCOM_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION
-  value: '1'
-- condition: [iostream_usart]
-  name: SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE
-  value: '128'
+#- condition: [iostream_usart]
+#  name: SL_IOSTREAM_USART_VCOM_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION
+#  value: '1'
+#- condition: [iostream_usart]
+#  name: SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE
+#  value: '128'
 - {name: SL_HEAP_SIZE, value: '0'}
 - {name: SL_STACK_SIZE, value: '4608'}
 - {name: SL_BOARD_ENABLE_VCOM, value: '0'}
@@ -128,7 +128,12 @@ configuration:
 - {name: SL_CLOCK_MANAGER_HFRCO_DPLL_EN, value: 1}
 - {name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE, value: 1024}
 - {name: SL_BT_RTOS_HOST_STACK_TASK_STACK_SIZE, value: 2048}
-- {name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE, value: 1536}
+- name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
+  value: "1536"
+  condition: [device_series_2]
+- name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
+  value: "2000"
+  condition: [device_series_3]
 - {name: SL_MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS, value: 1}
 - {name: SL_OPENTHREAD_ENABLE_SERIAL_TASK, value: 0}
 - condition: [device_series_3]
@@ -137,6 +142,8 @@ configuration:
 
 requires:
 - condition: [device_series_2]
+  name: uartdrv_eusart
+- condition: [device_series_3]
   name: uartdrv_eusart
 - condition: [device_series_2]
   name: device_init_dpll

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -355,15 +355,9 @@ template("efr32_sdk") {
         ]
 
         if (is_series_2) {
-          libs += [
-            "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
-            "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series2.a",
-          ]
+          libs += [ "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series2.a" ]
         } else if (is_series_3) {
-          libs += [
-            "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/x301/release/liblinklayer.a",
-            "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series3.a",
-          ]
+          libs += [ "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series3.a" ]
         }
       }
     }
@@ -378,7 +372,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform_core/platform/emdrv/spidrv/config",
       ]
 
-      libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg24_${compiler}_release.a" ]
+      libs += [
+        "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg24_${compiler}_release.a"
+      ]
 
       defines += [ "EFR32MG24" ]
     } else if (silabs_family == "mgm24") {
@@ -389,7 +386,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/efr32xg24",
       ]
 
-      libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_${compiler}_release.a" ]
+      libs += [
+        "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_${compiler}_release.a"
+      ]
 
       if (silabs_mcu == "MGM240PB32VNA") {
         libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_config_mgm240pb32vna_gcc.a" ]
@@ -414,7 +414,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/efr32xg26",
       ]
 
-      libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_${compiler}_release.a" ]
+      libs += [
+        "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg26/release/liblinklayer.a",
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_${compiler}_release.a"
+      ]
 
       defines += [ "EFR32MG26" ]
     } else if (silabs_family == "simg301") {
@@ -426,7 +429,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_pa_tables/sixg301",
       ]
 
-      libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_sixg301_${compiler}_release.a" ]
+      libs += [
+        "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/x301/release/liblinklayer.a",
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_sixg301_${compiler}_release.a"
+      ]
 
       # Family-level Series 3 / HostCrypto defines required to build SDK sources.
       # Board-specific options (e.g. SL_TOKEN_MANAGER_BACKEND_EXT_FLASH, HFXO,

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -109,6 +109,7 @@ silabs_platform_dir = "${chip_root}/src/platform/silabs"
 
 is_series_2 = silabs_family == "mgm24" || silabs_family == "efr32mg24" ||
               silabs_family == "efr32mg26"
+is_series_3 = silabs_family == "simg301"
 
 declare_args() {
   sl_ot_libs_path = "${efr32_sdk_root}/openthread"
@@ -179,19 +180,14 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/boards/hardware/driver/memlcd/inc",
       "${efr32_sdk_root}/boards/hardware/driver/memlcd/src/ls013b7dh03",
       "${efr32_sdk_root}/platform_core/hardware/driver/configuration_over_swo/inc",
-      "${efr32_sdk_root}/bootloader/platform/bootloader",
       "${efr32_sdk_root}/bootloader/platform/bootloader/config",
       "${efr32_sdk_root}/bootloader/platform/bootloader/config/btl_interface",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/core/flash",
       "${efr32_sdk_root}/bootloader/platform/bootloader/common/api",
       "${efr32_sdk_root}/bootloader/platform/bootloader/common",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/api",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/core/flash",
       "${efr32_sdk_root}/bgapi_protocol/rtos_adaptation/inc",
       "${efr32_sdk_root}/bgapi_protocol/bgapi_trace/inc",
       "${efr32_sdk_root}/bgapi_protocol/config",
       "${efr32_sdk_root}/bgapi_protocol/protocol/inc",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/config",
       "${efr32_sdk_root}/cmsis/Core/Include",
       "${efr32_sdk_root}/cmsis/RTOS2/Include",
       "${efr32_sdk_root}/openthread_stack/util/third_party/openthread/include",
@@ -199,11 +195,9 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/driver/debug/inc",
       "${efr32_sdk_root}/platform_core/platform/driver/gpio/inc",
       "${efr32_sdk_root}/platform_core/platform/emdrv/common/inc",
-      "${efr32_sdk_root}/platform_core/platform/emdrv/gpiointerrupt/inc",
       "${efr32_sdk_root}/platform_core/platform/emdrv/dmadrv/inc",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/config",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/inc",
-      "${efr32_sdk_root}/platform_core/platform/emlib/inc",
       "${efr32_sdk_root}/platform_core/platform/peripheral/inc",
       "${efr32_sdk_root}/rail_library/common",
       "${efr32_sdk_root}/rail_library/chip/efr32",
@@ -219,7 +213,6 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/config",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/config/preset",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/inc",
-      "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/inc",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sli_crypto/inc",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sli_psec_osal/inc",
@@ -227,10 +220,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/driver/dma_channel/inc",
       "${efr32_sdk_root}/platform_core/platform/common/inc/",
       "${efr32_sdk_root}/platform_core/platform/service/clock_manager/inc",
-      "${efr32_sdk_root}/platform_core/platform/service/device_init/inc",
       "${efr32_sdk_root}/platform_core/platform/service/device_manager/inc",
-      "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/inc",
-      "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/src",
       "${efr32_sdk_root}/platform_core/platform/service/interrupt_manager/inc",
       "${efr32_sdk_root}/platform_core/platform/service/interrupt_manager/inc/arm",
       "${efr32_sdk_root}/platform_core/platform/service/interrupt_manager/src",
@@ -287,21 +277,57 @@ template("efr32_sdk") {
 
     if (is_series_2) {
       _include_dirs += [
+        "${efr32_sdk_root}/bootloader/platform/bootloader",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/api",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/core/flash",
         "${efr32_sdk_root}/platform_core/platform/emdrv/dmadrv/inc/s2_signals",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/gpiointerrupt/inc",
+        "${efr32_sdk_root}/platform_core/platform/emlib/inc",
         "${efr32_sdk_root}/platform_core/platform/driver/debug/inc/",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src",
+        "${efr32_sdk_root}/platform_core/platform/service/device_init/inc",
+        "${efr32_sdk_root}/platform_core/platform/service/device_init/config/s2/",
+        "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/inc",
         "${efr32_sdk_root}/rail_library/chip/efr32/efr32xg2x",
         "${efr32_sdk_root}/rail_library/plugin/fem_util/",
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_rssi/",
-        "${efr32_sdk_root}/platform_core/platform/service/device_init/config/s2/",
         "${efr32_sdk_root}/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
       ]
+    }
 
+    if (is_series_3) {
+      _include_dirs += [
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/api",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/core",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/parser",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/storage/bootloadinfo",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/storage/ext_mem",
+        "${efr32_sdk_root}/bootloader/platform/bootloader",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/dmadrv/inc/s3_signals",
+        "${efr32_sdk_root}/platform_core/platform/driver/debug/inc/",
+        "${efr32_sdk_root}/platform_core/platform/service/mpa_manager/inc",
+        "${efr32_sdk_root}/platform_core/platform/service/mpa_manager/src",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/inc",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/legacy/inc",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src",
+        "${efr32_sdk_root}/rail_library/chip/efr32/sixg3xx",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_rssi/",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_load_devinfo",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_mp_transition_time",
+        "${efr32_sdk_root}/security_sxsymcrypt/include",
+        "${efr32_sdk_root}/security_sxsymcrypt/src",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/platform/silicon_labs",
+        "${efr32_sdk_root}/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
+      ]
+    }
+
+    if (is_series_2 || is_series_3) {
       libs += [ "${efr32_sdk_root}/openthread/libs/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
 
       if (!sl_matter_enable_siwx_ble) {
         libs += [
           "${efr32_sdk_root}/bluetooth_common/lib/build/${compiler}/cortex-m33/bgcommon/release/libbgcommon.a",
-          "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
           "${efr32_sdk_root}/bgapi_protocol/build/${compiler}/cortex-m33/protocol/core/release/libbgapi_core.a",
           "${efr32_sdk_root}/bgapi_protocol/build/${compiler}/cortex-m33/protocol/command/release/libbgapi_command.a",
           "${efr32_sdk_root}/bgapi_protocol/build/${compiler}/cortex-m33/protocol/device/release/libbgapi_device.a",
@@ -319,7 +345,6 @@ template("efr32_sdk") {
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/core/release/libble_host_core.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/crypto/release/libble_host_crypto_stub.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/crypto/crypto_lib/crypto_lib_psa/release/libble_host_crypto_lib_psa.a",
-          "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series2.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hci/release/libble_host_hci.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/advertiser/periodic_advertiser/release/libble_host_periodic_advertiser_stub.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/privacy/local_privacy/release/libble_host_local_privacy_stub.a",
@@ -328,6 +353,18 @@ template("efr32_sdk") {
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/system/release/libble_host_system.a",
           "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/crypto/release/libble_host_crypto_stub.a",
         ]
+
+        if (is_series_2) {
+          libs += [
+            "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
+            "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series2.a",
+          ]
+        } else if (is_series_3) {
+          libs += [
+            "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/x301/release/liblinklayer.a",
+            "${efr32_sdk_root}/bluetooth_le_host/build/${compiler}/cortex-m33/hal/release/libble_host_hal_series3.a",
+          ]
+        }
       }
     }
 
@@ -380,6 +417,41 @@ template("efr32_sdk") {
       libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_${compiler}_release.a" ]
 
       defines += [ "EFR32MG26" ]
+    } else if (silabs_family == "simg301") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform_core/platform/Device/SiliconLabs/SIMG301/Include",
+        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/sixg301",
+        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/sixg301/config",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/sixg301",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_pa_tables/sixg301",
+      ]
+
+      libs += [ "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_sixg301_${compiler}_release.a" ]
+
+      # Family-level Series 3 / HostCrypto defines required to build SDK sources.
+      # Board-specific options (e.g. SL_TOKEN_MANAGER_BACKEND_EXT_FLASH, HFXO,
+      # NVM3 sizing) belong in board config or invoker.defines.
+      defines += [
+        "SIMG301",
+        "CUSTOM_TOKEN_HEADER=\"sl_token_manager_af_token_header.h\"",
+        "SL_COMMON_TOKEN_MANAGER_ENABLE_DYNAMIC_TOKENS=1",
+        "SL_COMMON_TOKEN_MANAGER_ENABLE_STATIC_TOKENS=1",
+        "SL_TOKEN_MANAGER_BACKEND_EXT_FLASH=1",
+        "SL_TOKEN_MANAGER_SECURITY=1",
+        "NVM3_OPTIMIZATION=1",
+        "NVM3_SECURITY=1",
+        "SL_CODE_CLASS_SECURITY=security",
+        "SL_CODE_COMPONENT_AES_CCM=aes_ccm",
+        "SL_CODE_COMPONENT_AES_COMMON=aes_common",
+        "SL_CODE_COMPONENT_SXSYMCRYPT=sxsymcrypt",
+        "SX_HASH_BLOCKSZ_MAX=0",
+        "SX_HASH_DIGESTSZ_MAX=0",
+        "SX_KEYREF_MAX_ID=32",
+        "_SILICON_LABS_DEFEATURE_SHA3=1",
+        "SL_TZ_NON_SECURE_EXECUTION=1",
+        "configENABLE_TRUSTZONE=0",
+        "configRUN_FREERTOS_SECURE_ONLY=0",
+      ]
     }
 
     if (use_SiWx917) {
@@ -650,14 +722,26 @@ template("efr32_sdk") {
       if (use_external_flash) {
         defines += [ "CONFIG_USE_EXTERNAL_FLASH" ]
 
-        _include_dirs += [ "${efr32_sdk_root}/boards/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart" ]
+        if (!is_series_3) {
+          _include_dirs += [ "${efr32_sdk_root}/boards/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart" ]
+        }
       }
 
       _include_dirs += [
         "${efr32_sdk_root}/platform_core/platform/emdrv/uartdrv/inc",
         "${efr32_sdk_root}/platform_core/platform/emdrv/uartdrv/config",
-        "${efr32_sdk_root}/boards/hardware/driver/memlcd/inc/memlcd_usart",
       ]
+
+      # memlcd SPI backend differs by series (USART on S2, EUSART on S3).
+      if (is_series_3) {
+        _include_dirs += [
+          "${efr32_sdk_root}/boards/hardware/driver/memlcd/inc/memlcd_eusart",
+        ]
+      } else {
+        _include_dirs += [
+          "${efr32_sdk_root}/boards/hardware/driver/memlcd/inc/memlcd_usart",
+        ]
+      }
     }
 
     if (sl_verbose_mode) {
@@ -681,7 +765,7 @@ template("efr32_sdk") {
 
     cflags += [ "-Wno-shadow" ]
 
-    if (is_series_2) {
+    if (is_series_2 || is_series_3) {
       cflags += [ "-mcmse" ]
     }
 
@@ -715,12 +799,7 @@ template("efr32_sdk") {
     sources = [
       "${efr32_sdk_root}/boards/hardware/board/src/sl_board_control_gpio.c",
       "${efr32_sdk_root}/boards/hardware/board/src/sl_board_init.c",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/api/btl_interface.c",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/api/btl_interface_storage.c",
       "${efr32_sdk_root}/bootloader/platform/bootloader/app_properties/app_properties.c",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/core/flash/btl_internal_flash.c",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/security/sha/crypto_sha.c",
-      "${efr32_sdk_root}/bootloader/platform/bootloader/storage/internal_flash/btl_storage_internal_flash_raw.c",
       "${efr32_sdk_root}/cmsis/RTOS2/Source/os_systick.c",
       "${efr32_sdk_root}/common_15_4/plugin/security_manager/security_manager.c",
       "${efr32_sdk_root}/freertos/cmsis/Source/cmsis_os2.c",
@@ -794,33 +873,19 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/driver/dma_channel/src/sl_dma_descriptor_allocator.c",
       "${efr32_sdk_root}/platform_core/platform/driver/gpio/src/sl_gpio.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/dmadrv/src/dmadrv.c",
-      "${efr32_sdk_root}/platform_core/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_cache.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_default_common_linker.c",
-      "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_hal_flash.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_lock.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_object.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_page.c",
       "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_utils.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_burtc.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_cmu.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_emu.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_gpio.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_ldma.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_msc.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_prs.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_rmu.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_system.c",
-      "${efr32_sdk_root}/platform_core/platform/emlib/src/em_timer.c",
-      "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_emu.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_gpio.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_ldma.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_prs.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_sysrtc.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_sysrtc_subsystem.c",
       "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_system.c",
-      "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_usart.c",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/error.c",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ccm.c",
       "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_cmac.c",
@@ -844,7 +909,6 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/service/device_manager/src/sl_device_peripheral.c",
       "${efr32_sdk_root}/platform_core/platform/service/dma_manager/src/sl_dma_manager.c",
       "${efr32_sdk_root}/platform_core/platform/service/dma_manager/src/sl_dma_manager_hal_ldma.c",
-      "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/src/sl_hfxo_manager.c",
       "${efr32_sdk_root}/platform_core/platform/service/interrupt_manager/src/sl_interrupt_manager_cortexm.c",
       "${efr32_sdk_root}/platform_core/platform/service/iostream/src/sl_iostream.c",
       "${efr32_sdk_root}/platform_core/platform/service/iostream/src/sl_iostream_rtt.c",
@@ -866,7 +930,6 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform_core/platform/service/sl_main/src/sl_main_init_memory.c",
       "${efr32_sdk_root}/platform_core/platform/service/sl_main/src/sl_main_kernel.c",
       "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer.c",
-      "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c",
       "${efr32_sdk_root}/platform_core/platform/service/udelay/src/sl_udelay.c",
       "${efr32_sdk_root}/platform_core/platform/service/udelay/src/sl_udelay_armv6m_gcc.S",
       "${efr32_sdk_root}/platform_core/util/silicon_labs/silabs_core/queue/circular_queue.c",
@@ -992,14 +1055,21 @@ template("efr32_sdk") {
         (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) ||
         show_qr_code || !disable_lcd || use_external_flash) {
       sources += [
-        "${efr32_sdk_root}/boards/hardware/driver/memlcd/src/memlcd_usart/sl_memlcd_spi.c",
         "${efr32_sdk_root}/platform_core/platform/emdrv/uartdrv/src/uartdrv.c",
-        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_eusart.c",
-        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_usart.c",
         "${silabs_gen_folder}/autogen/sl_uartdrv_init.c",
       ]
 
-      if (use_external_flash) {
+      if (is_series_3) {
+        sources += [ "${efr32_sdk_root}/boards/hardware/driver/memlcd/src/memlcd_eusart/sl_memlcd_spi.c" ]
+      } else {
+        sources += [
+          "${efr32_sdk_root}/boards/hardware/driver/memlcd/src/memlcd_usart/sl_memlcd_spi.c",
+          "${efr32_sdk_root}/platform_core/platform/emlib/src/em_eusart.c",
+          "${efr32_sdk_root}/platform_core/platform/emlib/src/em_usart.c",
+        ]
+      }
+
+      if (use_external_flash && !is_series_3) {
         sources += [ "${efr32_sdk_root}/boards/hardware/driver/mx25_flash_shutdown/src/sl_mx25_flash_shutdown_usart/sl_mx25_flash_shutdown.c" ]
       }
     }
@@ -1066,9 +1136,21 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/efr32xg26/sl_rail_ble_config_39MHz.c",
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/efr32xg26/sl_rail_ieee802154_config_39MHz.c",
       ]
+    } else if (silabs_family == "simg301") {
+      sources += [
+        "${efr32_sdk_root}/platform_core/platform/Device/SiliconLabs/SIMG301/Source/startup_simg301.c",
+        "${efr32_sdk_root}/platform_core/platform/Device/SiliconLabs/SIMG301/Source/system_simg301.c",
+        "${efr32_sdk_root}/platform_core/platform/service/device_manager/clocks/sl_device_clock_sixx301.c",
+        "${efr32_sdk_root}/platform_core/platform/service/device_manager/devices/sl_device_peripheral_hal_sixx301.c",
+        "${efr32_sdk_root}/rail_library/plugin/pa-conversions/pa_curves_efr32.c",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/sixg301/sl_rail_ble_config_38M4Hz.c",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_built_in_phys/sixg301/sl_rail_ieee802154_config_38M4Hz.c",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_load_devinfo/sl_rail_util_load_devinfo.c",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_mp_transition_time/sl_rail_util_mp_transition_time.c",
+      ]
     }
 
-    if (is_series_2) {
+    if (is_series_2 || is_series_3) {
       sources += [
         "${efr32_sdk_root}/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure/mpu_wrappers_v2_asm.c",
         "${efr32_sdk_root}/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure/port.c",
@@ -1084,9 +1166,6 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/se_manager/src/sl_se_manager_util.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/se_manager/src/sli_se_manager_mailbox.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c",
-        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c",
-        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c",
-        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c",
@@ -1101,17 +1180,116 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c",
+        "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c",
+        "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_sysrtc.c",
+        "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c",
+        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_rssi/sl_rail_util_rssi.c",
+      ]
+    }
+
+    if (is_series_2) {
+      sources += [
+        "${efr32_sdk_root}/bootloader/platform/bootloader/api/btl_interface.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/api/btl_interface_storage.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/core/flash/btl_internal_flash.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/security/sha/crypto_sha.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/storage/internal_flash/btl_storage_internal_flash_raw.c",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_hal_flash.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_burtc.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_cmu.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_emu.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_gpio.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_ldma.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_msc.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_prs.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_rmu.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_system.c",
+        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_timer.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_emu.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_usart.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c",
         "${efr32_sdk_root}/platform_core/platform/security/sl_component/sli_crypto/src/sl_crypto_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/clock_manager/src/sl_clock_manager_hal_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/clock_manager/src/sl_clock_manager_init_hal_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_init/src/sl_device_init_dcdc_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/device_manager/dma/sl_device_dma_s2.c",
+        "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/src/sl_hfxo_manager.c",
         "${efr32_sdk_root}/platform_core/platform/service/hfxo_manager/src/sl_hfxo_manager_hal_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/mpu/src/sl_mpu_s2.c",
         "${efr32_sdk_root}/platform_core/platform/service/power_manager/src/sleep_loop/sl_power_manager_hal_s2.c",
-        "${efr32_sdk_root}/platform_core/platform/service/sleeptimer/src/sl_sleeptimer_hal_sysrtc.c",
-        "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_rssi/sl_rail_util_rssi.c",
         "${efr32_sdk_root}/rail_library/plugin/sl_rail_util_sequencer/sl_rail_util_sequencer.c",
+      ]
+    }
+
+    if (is_series_3) {
+      sources += [
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/api/btl_interface.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/api/btl_interface_lock.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/api/btl_interface_storage.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/core/btl_bootload.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/core/btl_parse.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/parser/gbl/btl_gbl_custom_tags.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/parser/gbl/btl_gbl_parser.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/security/btl_crc16.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/security/btl_crc32.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/security/btl_security_aes.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/security/btl_security_ecdsa.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/security/btl_security_sha256.c",
+        "${efr32_sdk_root}/bootloader/platform/bootloader/series3/storage/bootloadinfo/btl_storage_bootloadinfo.c",
+        "${efr32_sdk_root}/platform_core/platform/common/src/sl_tz_non_secure_execution.c",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_hal_crypto_host.c",
+        "${efr32_sdk_root}/platform_core/platform/emdrv/nvm3/src/nvm3_hal_flash_ext.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_burtc.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_emu.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_eusart.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_gpcrc.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_syscfg.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_timer.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/se_manager/src/sl_se_manager_extmem.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/se_manager/src/sli_se_manager_device_data.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_driver_key_management.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_opaque_driver.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_transparent_driver_aead.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_transparent_driver_cipher.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_transparent_driver_hash.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sl_psa_driver/src/sli_hostcrypto_transparent_driver_mac.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sli_crypto/src/sl_crypto_s3.c",
+        "${efr32_sdk_root}/platform_core/platform/security/sl_component/sli_crypto/src/sli_crypto_ksu_manager.c",
+        "${efr32_sdk_root}/platform_core/platform/service/clock_manager/src/sl_clock_manager_hal_s3.c",
+        "${efr32_sdk_root}/platform_core/platform/service/clock_manager/src/sl_clock_manager_init_hal_s3.c",
+        "${efr32_sdk_root}/platform_core/platform/service/device_manager/dma/sl_device_dma_s3.c",
+        "${efr32_sdk_root}/platform_core/platform/service/mpa_manager/src/sl_mpa_manager.c",
+        "${efr32_sdk_root}/platform_core/platform/service/mpa_manager/src/sl_mpa_manager_armv8m.c",
+        "${efr32_sdk_root}/platform_core/platform/service/mpu/src/sl_mpu_s3.c",
+        "${efr32_sdk_root}/platform_core/platform/service/power_manager/src/common/sl_power_manager_execution_modes_hal_sixg301.c",
+        "${efr32_sdk_root}/platform_core/platform/service/power_manager/src/sleep_loop/sl_power_manager_hal_sixg301.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sl_token_manager_api.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sl_token_manager_lock.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_backend_nvm.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_backend_ram.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_dynamic.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_format_klv.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_hal_crypto_se.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_hal_ext_flash.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_hal_se_mtp.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_internal.c",
+        "${efr32_sdk_root}/platform_core/platform/service/token_manager/src/sli_token_manager_manufacturing.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/aead.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/blkcipher.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/channel.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/cmac.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/cmdma.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/cmmask.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/hash.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/hmac.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/interrupts.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/keyref.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/mac.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/platform/silicon_labs/sli_sxsymcrypt_engine_management.c",
+        "${efr32_sdk_root}/security_sxsymcrypt/src/platform/silicon_labs/sli_sxsymcrypt_hardware_interaction.c",
       ]
     }
 
@@ -1120,9 +1298,13 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/boards/hardware/driver/si70xx/src/sl_si70xx.c",
         "${efr32_sdk_root}/platform_core/platform/common/src/sl_status.c",
         "${efr32_sdk_root}/platform_core/platform/driver/i2cspm/src/sl_i2cspm.c",
-        "${efr32_sdk_root}/platform_core/platform/emlib/src/em_i2c.c",
         "${matter_support_root}/board-support/efr32/${silabs_family}/${silabs_board}/autogen/sl_i2cspm_init.c",
       ]
+
+      if (is_series_2) {
+        sources +=
+            [ "${efr32_sdk_root}/platform_core/platform/emlib/src/em_i2c.c" ]
+      }
     }
 
     public_deps = [

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -374,7 +374,7 @@ template("efr32_sdk") {
 
       libs += [
         "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
-        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg24_${compiler}_release.a"
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg24_${compiler}_release.a",
       ]
 
       defines += [ "EFR32MG24" ]
@@ -388,7 +388,7 @@ template("efr32_sdk") {
 
       libs += [
         "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg24/release/liblinklayer.a",
-        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_${compiler}_release.a"
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_${compiler}_release.a",
       ]
 
       if (silabs_mcu == "MGM240PB32VNA") {
@@ -416,7 +416,7 @@ template("efr32_sdk") {
 
       libs += [
         "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/xg26/release/liblinklayer.a",
-        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_${compiler}_release.a"
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_${compiler}_release.a",
       ]
 
       defines += [ "EFR32MG26" ]
@@ -431,7 +431,7 @@ template("efr32_sdk") {
 
       libs += [
         "${efr32_sdk_root}/bluetooth_le_controller/build/${compiler}/x301/release/liblinklayer.a",
-        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_sixg301_${compiler}_release.a"
+        "${efr32_sdk_root}/rail_library/autogen/librail_release/librail_multiprotocol_sixg301_${compiler}_release.a",
       ]
 
       # Family-level Series 3 / HostCrypto defines required to build SDK sources.

--- a/third_party/silabs/silabs_arm.gni
+++ b/third_party/silabs/silabs_arm.gni
@@ -21,7 +21,7 @@ if (silabs_family == "SiWx917-common") {
   arm_float_abi = "softfp"
   arm_fpu = "fpv4-sp-d16"
 } else if (silabs_family == "efr32mg24" || silabs_family == "mgm24" ||
-           silabs_family == "efr32mg26") {
+           silabs_family == "efr32mg26" || silabs_family == "simg301") {
   arm_arch = "armv8-m.main+dsp"
   arm_abi = "aapcs"
   arm_cpu = "cortex-m33"

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -215,6 +215,11 @@ if (is_si917_board) {
   disable_lcd = true
   sl_enable_rgb_led = true
 
+  # Series 3 ----------
+} else if (silabs_board == "BRD4407A") {
+  silabs_family = "simg301"
+  silabs_mcu = "SIMG301M104LIL"
+
   # Custom Board ----------
 } else if (silabs_board == "CUSTOM") {
   print("Using custom board configuration")


### PR DESCRIPTION
### Summary
Add support for BRD4407a, to support on new series 3 on CSA/within the GN build system
- New silabs_family -> simg301
- New devkit radio board -> BRD4407A
- Add linkerfile for simg301
- Update efr32_sdk.gni to add the required files and libs for this new board from our SimplicitySDK
- Update conditions for shared files between new MCU family vs older.
- Bump matter_support submodule to bring generated config/support files for this board.

### Related issues
N/A

### Testing
- Manually build SL Lock-app and Lighting-app on the new board and validate devices runs and commisions.
- SL internal CI built all ours app on this new board ([examples Build jobs](https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/30586495898/job/91018988992?pr=1110))
