### PR TITLE
feat(tv-app): add OAuth-only fake Content App with OAuth 2.0 login

### DIFF
--- a/examples/tv-app/android/include/account-login/AccountLoginManager.h
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.h
@@ -50,6 +50,7 @@ public:
     void HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper) override;
     bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
+    uint32_t GetFeatureMap(chip::EndpointId endpoint) override { return 0; };
 
 protected:
     static const size_t kSetupPinSize = 12;

--- a/examples/tv-app/linux/main.cpp
+++ b/examples/tv-app/linux/main.cpp
@@ -102,6 +102,11 @@ void ApplicationInit()
     constexpr uint16_t kApp4VendorId  = 1111;
     constexpr uint16_t kApp4ProductId = 22;
     factory->InstallContentApp(kApp4VendorId, kApp4ProductId);
+
+    // Content App 5 - OAuth-only login (see OAuthAccountLoginManager)
+    constexpr uint16_t kApp5VendorId  = 4242;
+    constexpr uint16_t kApp5ProductId = 1;
+    factory->InstallContentApp(kApp5VendorId, kApp5ProductId);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 }
 

--- a/examples/tv-app/linux/main.cpp
+++ b/examples/tv-app/linux/main.cpp
@@ -162,6 +162,11 @@ void ApplicationInit()
     constexpr uint16_t kApp4VendorId  = 1111;
     constexpr uint16_t kApp4ProductId = 22;
     factory->InstallContentApp(kApp4VendorId, kApp4ProductId);
+
+    // Content App 5 - OAuth-only login (see OAuthAccountLoginManager)
+    constexpr uint16_t kApp5VendorId  = 4242;
+    constexpr uint16_t kApp5ProductId = 1;
+    factory->InstallContentApp(kApp5VendorId, kApp5ProductId);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 }
 

--- a/examples/tv-app/tv-common/BUILD.gn
+++ b/examples/tv-app/tv-common/BUILD.gn
@@ -43,6 +43,8 @@ source_set("tv-common-sources") {
   sources = [
     "clusters/account-login/AccountLoginManager.cpp",
     "clusters/account-login/AccountLoginManager.h",
+    "clusters/account-login/OAuthAccountLoginManager.cpp",
+    "clusters/account-login/OAuthAccountLoginManager.h",
     "clusters/application-basic/ApplicationBasicManager.cpp",
     "clusters/application-basic/ApplicationBasicManager.h",
     "clusters/application-launcher/ApplicationLauncherManager.cpp",

--- a/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.h
@@ -51,6 +51,7 @@ public:
     bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
 
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
+    uint32_t GetFeatureMap(chip::EndpointId endpoint) override { return 0; };
 
 protected:
     static const size_t kSetupPinSize = 12;

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "OAuthAccountLoginManager.h"
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/CommandHandler.h>
+#include <app/reporting/reporting.h>
+#include <app/util/config.h>
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace chip;
+using namespace chip::app::Clusters::AccountLogin;
+
+bool OAuthAccountLoginManager::HandleLogin(const CharSpan & tempAccountIdentifier, const CharSpan & setupPin,
+                                           const chip::Optional<chip::NodeId> & nodeId)
+{
+    // PIN-based login is not supported by this app - only the OAuth device
+    // authorization grant flow (see HandleGetDeviceAuthURI) can log a user in.
+    ChipLogProgress(Zcl, "OAuthAccountLoginManager::HandleLogin rejected: PIN login is disabled for this app");
+    return false;
+}
+
+bool OAuthAccountLoginManager::HandleLogout(const chip::Optional<chip::NodeId> & nodeId)
+{
+    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
+    mOAuthLoggedIn = false;
+    ChipLogProgress(Zcl, "OAuthAccountLoginManager::HandleLogout success");
+    return true;
+}
+
+void OAuthAccountLoginManager::HandleGetSetupPin(CommandResponseHelper<GetSetupPINResponse> & helper,
+                                                 const CharSpan & tempAccountIdentifier)
+{
+    // PIN-based login is disabled for this app; respond with an inert placeholder
+    // that can never be used to successfully call Login.
+    GetSetupPINResponse response;
+    response.setupPIN = "N/A"_span;
+    TEMPORARY_RETURN_IGNORED helper.Success(response);
+}
+
+void OAuthAccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper)
+{
+    ChipLogProgress(Zcl, "OAuthAccountLoginManager::HandleGetDeviceAuthURI: will report logged-in in %u seconds",
+                    static_cast<unsigned>(kLoginDelaySeconds));
+
+    GetDeviceAuthURIResponse response;
+    response.userCode        = "ABCD-EFGH"_span;
+    response.verificationURI = "https://example.com/device"_span;
+    response.expiresIn       = 1800;
+    response.interval        = 5;
+    TEMPORARY_RETURN_IGNORED helper.Success(response);
+
+    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
+    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(kLoginDelaySeconds),
+                                                                    OnLoginTimerExpired, this);
+}
+
+void OAuthAccountLoginManager::OnLoginTimerExpired(System::Layer * systemLayer, void * context)
+{
+    auto * self          = reinterpret_cast<OAuthAccountLoginManager *>(context);
+    self->mOAuthLoggedIn = true;
+    ChipLogProgress(Zcl, "OAuthAccountLoginManager: OAuth login completed asynchronously");
+
+    if (self->mEndpointId != kInvalidEndpointId)
+    {
+        MatterReportingAttributeChangeCallback(self->mEndpointId, Id, Attributes::OAuthLoggedIn::Id);
+    }
+}
+
+uint16_t OAuthAccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
+{
+    if (endpoint >= MATTER_DM_ACCOUNT_LOGIN_CLUSTER_SERVER_ENDPOINT_COUNT)
+    {
+        return kClusterRevision;
+    }
+
+    uint16_t clusterRevision = 0;
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
+    if (!success)
+    {
+        ChipLogError(Zcl, "OAuthAccountLoginManager::GetClusterRevision error reading cluster revision");
+    }
+    return clusterRevision;
+}
+
+OAuthAccountLoginManager::~OAuthAccountLoginManager()
+{
+    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
+}

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -19,7 +19,9 @@
 #include "OAuthAccountLoginManager.h"
 #include <app/CommandHandler.h>
 #include <app/reporting/reporting.h>
+#include <clusters/AccountLogin/Enums.h>
 #include <clusters/AccountLogin/Metadata.h>
+#include <lib/support/TypeTraits.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
@@ -98,6 +100,11 @@ void OAuthAccountLoginManager::SimulateAsyncLoginSuccess(System::Layer * systemL
 uint16_t OAuthAccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
 {
     return chip::app::Clusters::AccountLogin::kRevision;
+}
+
+uint32_t OAuthAccountLoginManager::GetFeatureMap(chip::EndpointId endpoint)
+{
+    return chip::to_underlying(Feature::kOAuth);
 }
 
 OAuthAccountLoginManager::~OAuthAccountLoginManager()

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -17,10 +17,9 @@
  */
 
 #include "OAuthAccountLoginManager.h"
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/CommandHandler.h>
 #include <app/reporting/reporting.h>
-#include <app/util/config.h>
+#include <clusters/AccountLogin/Metadata.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
@@ -37,7 +36,7 @@ bool OAuthAccountLoginManager::HandleLogin(const CharSpan & tempAccountIdentifie
 
 bool OAuthAccountLoginManager::HandleLogout(const chip::Optional<chip::NodeId> & nodeId)
 {
-    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
+    DeviceLayer::SystemLayer().CancelTimer(SimulateAsyncLoginSuccess, this);
     if (mOAuthLoggedIn)
     {
         mOAuthLoggedIn = false;
@@ -57,7 +56,7 @@ void OAuthAccountLoginManager::HandleGetSetupPin(CommandResponseHelper<GetSetupP
     // that can never be used to successfully call Login.
     GetSetupPINResponse response;
     response.setupPIN = "N/A"_span;
-    TEMPORARY_RETURN_IGNORED helper.Success(response);
+    LogErrorOnFailure(helper.Success(response));
 }
 
 void OAuthAccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper)
@@ -65,19 +64,26 @@ void OAuthAccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetD
     ChipLogProgress(Zcl, "OAuthAccountLoginManager::HandleGetDeviceAuthURI: will report logged-in in %u seconds",
                     static_cast<unsigned>(kLoginDelaySeconds));
 
+    DeviceLayer::SystemLayer().CancelTimer(SimulateAsyncLoginSuccess, this);
+    CHIP_ERROR err =
+        DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(kLoginDelaySeconds), SimulateAsyncLoginSuccess, this);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "OAuthAccountLoginManager::HandleGetDeviceAuthURI failed to start login timer: %" CHIP_ERROR_FORMAT,
+                    err.Format());
+        LogErrorOnFailure(helper.Failure(Protocols::InteractionModel::Status::Failure));
+        return;
+    }
+
     GetDeviceAuthURIResponse response;
     response.userCode        = "ABCD-EFGH"_span;
     response.verificationURI = "https://example.com/device"_span;
     response.expiresIn       = 1800;
     response.interval        = 5;
-    TEMPORARY_RETURN_IGNORED helper.Success(response);
-
-    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
-    TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(kLoginDelaySeconds),
-                                                                   OnLoginTimerExpired, this);
+    LogErrorOnFailure(helper.Success(response));
 }
 
-void OAuthAccountLoginManager::OnLoginTimerExpired(System::Layer * systemLayer, void * context)
+void OAuthAccountLoginManager::SimulateAsyncLoginSuccess(System::Layer * systemLayer, void * context)
 {
     auto * self          = reinterpret_cast<OAuthAccountLoginManager *>(context);
     self->mOAuthLoggedIn = true;
@@ -91,22 +97,10 @@ void OAuthAccountLoginManager::OnLoginTimerExpired(System::Layer * systemLayer, 
 
 uint16_t OAuthAccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
 {
-    if (endpoint >= MATTER_DM_ACCOUNT_LOGIN_CLUSTER_SERVER_ENDPOINT_COUNT)
-    {
-        return kClusterRevision;
-    }
-
-    uint16_t clusterRevision = 0;
-    bool success =
-        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
-    if (!success)
-    {
-        ChipLogError(Zcl, "OAuthAccountLoginManager::GetClusterRevision error reading cluster revision");
-    }
-    return clusterRevision;
+    return chip::app::Clusters::AccountLogin::kRevision;
 }
 
 OAuthAccountLoginManager::~OAuthAccountLoginManager()
 {
-    DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
+    DeviceLayer::SystemLayer().CancelTimer(SimulateAsyncLoginSuccess, this);
 }

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -38,7 +38,14 @@ bool OAuthAccountLoginManager::HandleLogin(const CharSpan & tempAccountIdentifie
 bool OAuthAccountLoginManager::HandleLogout(const chip::Optional<chip::NodeId> & nodeId)
 {
     DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
-    mOAuthLoggedIn = false;
+    if (mOAuthLoggedIn)
+    {
+        mOAuthLoggedIn = false;
+        if (mEndpointId != kInvalidEndpointId)
+        {
+            MatterReportingAttributeChangeCallback(mEndpointId, Id, Attributes::OAuthLoggedIn::Id);
+        }
+    }
     ChipLogProgress(Zcl, "OAuthAccountLoginManager::HandleLogout success");
     return true;
 }

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -70,7 +70,7 @@ void OAuthAccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetD
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "OAuthAccountLoginManager::HandleGetDeviceAuthURI failed to start login timer: %" CHIP_ERROR_FORMAT,
-                    err.Format());
+                     err.Format());
         LogErrorOnFailure(helper.Failure(Protocols::InteractionModel::Status::Failure));
         return;
     }

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -67,7 +67,7 @@ void OAuthAccountLoginManager::HandleGetDeviceAuthURI(CommandResponseHelper<GetD
 
     DeviceLayer::SystemLayer().CancelTimer(OnLoginTimerExpired, this);
     TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(kLoginDelaySeconds),
-                                                                    OnLoginTimerExpired, this);
+                                                                   OnLoginTimerExpired, this);
 }
 
 void OAuthAccountLoginManager::OnLoginTimerExpired(System::Layer * systemLayer, void * context)

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.cpp
@@ -109,5 +109,10 @@ uint32_t OAuthAccountLoginManager::GetFeatureMap(chip::EndpointId endpoint)
 
 OAuthAccountLoginManager::~OAuthAccountLoginManager()
 {
-    DeviceLayer::SystemLayer().CancelTimer(SimulateAsyncLoginSuccess, this);
+    // Deliberately not cancelling the timer here: this object is owned by the
+    // global ContentAppFactoryImpl, so this destructor can run during static
+    // destruction at process exit, after DeviceLayer::SystemLayer()'s own global
+    // has already been torn down (C++ doesn't order static destructors across
+    // translation units). Calling into it here previously caused a pure-virtual-call
+    // abort. The OS reclaims any outstanding timer when the process exits anyway.
 }

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
@@ -40,14 +40,14 @@ using GetDeviceAuthURIResponse = chip::app::Clusters::AccountLogin::Commands::Ge
 class DLL_EXPORT OAuthAccountLoginManager : public AccountLoginDelegate
 {
 public:
-    inline void SetSetupPin(char * setupPin) override {};
+    inline void SetSetupPin(char * setupPin) override{};
 
     bool HandleLogin(const CharSpan & tempAccountIdentifierString, const CharSpan & setupPinString,
                      const chip::Optional<chip::NodeId> & nodeId) override;
     bool HandleLogout(const chip::Optional<chip::NodeId> & nodeId) override;
     void HandleGetSetupPin(CommandResponseHelper<GetSetupPINResponse> & helper,
                            const CharSpan & tempAccountIdentifierString) override;
-    inline void GetSetupPin(char * setupPin, size_t setupPinSize, const CharSpan & tempAccountIdentifierString) override {};
+    inline void GetSetupPin(char * setupPin, size_t setupPinSize, const CharSpan & tempAccountIdentifierString) override{};
 
     void HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper) override;
     bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
@@ -1,0 +1,72 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/account-login-server/account-login-server.h>
+
+#include <lib/support/DLLUtil.h>
+#include <lib/support/Span.h>
+#include <system/SystemClock.h>
+#include <system/SystemLayer.h>
+
+using chip::CharSpan;
+using chip::app::CommandResponseHelper;
+using AccountLoginDelegate     = chip::app::Clusters::AccountLogin::Delegate;
+using GetSetupPINResponse      = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type;
+using GetDeviceAuthURIResponse = chip::app::Clusters::AccountLogin::Commands::GetDeviceAuthURIResponse::Type;
+
+// AccountLogin delegate for a fake Content App that only supports the OAuth 2.0
+// Device Authorization Grant flow. PIN-based login (GetSetupPIN/Login) is
+// deliberately disabled: Login always fails and GetSetupPIN returns an inert
+// placeholder. Requesting the device auth URI starts logged-out and flips
+// OAuthLoggedIn to true on its own a few seconds later, simulating a user
+// completing the out-of-band OAuth flow.
+class DLL_EXPORT OAuthAccountLoginManager : public AccountLoginDelegate
+{
+public:
+    inline void SetSetupPin(char * setupPin) override {};
+
+    bool HandleLogin(const CharSpan & tempAccountIdentifierString, const CharSpan & setupPinString,
+                     const chip::Optional<chip::NodeId> & nodeId) override;
+    bool HandleLogout(const chip::Optional<chip::NodeId> & nodeId) override;
+    void HandleGetSetupPin(CommandResponseHelper<GetSetupPINResponse> & helper,
+                           const CharSpan & tempAccountIdentifierString) override;
+    inline void GetSetupPin(char * setupPin, size_t setupPinSize, const CharSpan & tempAccountIdentifierString) override {};
+
+    void HandleGetDeviceAuthURI(CommandResponseHelper<GetDeviceAuthURIResponse> & helper) override;
+    bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
+
+    uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
+
+    // Not part of the AccountLogin::Delegate contract. ContentAppImpl calls this
+    // once the app-platform assigns this app's dynamic endpoint, so the delayed
+    // login callback can report the attribute change on the right endpoint.
+    void SetEndpointId(chip::EndpointId endpoint) { mEndpointId = endpoint; };
+
+    ~OAuthAccountLoginManager() override;
+
+private:
+    static constexpr uint32_t kLoginDelaySeconds = 5;
+
+    static void OnLoginTimerExpired(chip::System::Layer * systemLayer, void * context);
+
+    bool mOAuthLoggedIn                        = false;
+    chip::EndpointId mEndpointId               = chip::kInvalidEndpointId;
+    static constexpr uint16_t kClusterRevision = 3;
+};

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
@@ -53,6 +53,7 @@ public:
     bool GetOAuthLoggedIn(chip::EndpointId endpoint) override { return mOAuthLoggedIn; };
 
     uint16_t GetClusterRevision(chip::EndpointId endpoint) override;
+    uint32_t GetFeatureMap(chip::EndpointId endpoint) override;
 
     // Not part of the AccountLogin::Delegate contract. ContentAppImpl calls this
     // once the app-platform assigns this app's dynamic endpoint, so the delayed

--- a/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
+++ b/examples/tv-app/tv-common/clusters/account-login/OAuthAccountLoginManager.h
@@ -64,9 +64,8 @@ public:
 private:
     static constexpr uint32_t kLoginDelaySeconds = 5;
 
-    static void OnLoginTimerExpired(chip::System::Layer * systemLayer, void * context);
+    static void SimulateAsyncLoginSuccess(chip::System::Layer * systemLayer, void * context);
 
-    bool mOAuthLoggedIn                        = false;
-    chip::EndpointId mEndpointId               = chip::kInvalidEndpointId;
-    static constexpr uint16_t kClusterRevision = 3;
+    bool mOAuthLoggedIn          = false;
+    chip::EndpointId mEndpointId = chip::kInvalidEndpointId;
 };

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -97,8 +97,7 @@ public:
         ContentApp{ supportedClusters },
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
-        mOAuthAccountLoginDelegate(oauthAccountLoginDelegate.get()),
-        mAccountLoginDelegate(std::move(oauthAccountLoginDelegate)),
+        mOAuthAccountLoginDelegate(oauthAccountLoginDelegate.get()), mAccountLoginDelegate(std::move(oauthAccountLoginDelegate)),
         mContentLauncherDelegate({ "image/*", "video/*" },
                                  to_underlying(SupportedProtocolsBitmap::kDash) | to_underlying(SupportedProtocolsBitmap::kHls)),
         mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -146,7 +146,7 @@ protected:
 
 class DLL_EXPORT ContentAppFactoryImpl : public ContentAppFactory
 {
-#define APP_LIBRARY_SIZE 4
+#define APP_LIBRARY_SIZE 5
 public:
     ContentAppFactoryImpl();
     virtual ~ContentAppFactoryImpl() {}

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -26,10 +26,12 @@
 #include <app/app-platform/ContentAppPlatform.h>
 #include <app/util/attribute-storage.h>
 #include <functional>
+#include <memory>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "account-login/AccountLoginManager.h"
+#include "account-login/OAuthAccountLoginManager.h"
 #include "application-basic/ApplicationBasicManager.h"
 #include "application-launcher/ApplicationLauncherManager.h"
 #include "channel/ChannelManager.h"
@@ -78,13 +80,32 @@ public:
         ContentApp{ supportedClusters },
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
-        mAccountLoginDelegate(setupPIN),
+        mAccountLoginDelegate(std::make_unique<AccountLoginManager>(setupPIN)),
         mContentLauncherDelegate({ "image/*", "video/*" },
                                  to_underlying(SupportedProtocolsBitmap::kDash) | to_underlying(SupportedProtocolsBitmap::kHls)),
         mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};
+
+    // Variant used for apps that authenticate via OAuth instead of a setup PIN.
+    // Takes ownership of a concrete OAuthAccountLoginManager (rather than the
+    // generic AccountLoginDelegate interface) purely so mOAuthAccountLoginDelegate
+    // can capture the raw pointer up front, before it's moved into
+    // mAccountLoginDelegate - this avoids needing RTTI (dynamic_cast) later, which
+    // this codebase builds without.
+    ContentAppImpl(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
+                   const char * szApplicationVersion, std::unique_ptr<OAuthAccountLoginManager> oauthAccountLoginDelegate,
+                   std::vector<SupportedCluster> supportedClusters) :
+        ContentApp{ supportedClusters },
+        mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
+                                  szApplicationVersion),
+        mOAuthAccountLoginDelegate(oauthAccountLoginDelegate.get()),
+        mAccountLoginDelegate(std::move(oauthAccountLoginDelegate)),
+        mContentLauncherDelegate({ "image/*", "video/*" },
+                                 to_underlying(SupportedProtocolsBitmap::kDash) | to_underlying(SupportedProtocolsBitmap::kHls)),
+        mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};
+
     virtual ~ContentAppImpl() {}
 
-    AccountLoginDelegate * GetAccountLoginDelegate() override { return &mAccountLoginDelegate; };
+    AccountLoginDelegate * GetAccountLoginDelegate() override { return mAccountLoginDelegate.get(); };
     ApplicationBasicDelegate * GetApplicationBasicDelegate() override { return &mApplicationBasicDelegate; };
     ApplicationLauncherDelegate * GetApplicationLauncherDelegate() override { return &mApplicationLauncherDelegate; };
     ChannelDelegate * GetChannelDelegate() override { return &mChannelDelegate; };
@@ -99,9 +120,22 @@ public:
             productId == mApplicationBasicDelegate.HandleGetProductId();
     }
 
+    void SetEndpointId(EndpointId id) override
+    {
+        ContentApp::SetEndpointId(id);
+        if (mOAuthAccountLoginDelegate != nullptr)
+        {
+            mOAuthAccountLoginDelegate->SetEndpointId(id);
+        }
+    }
+
 protected:
     ApplicationBasicManager mApplicationBasicDelegate;
-    AccountLoginManager mAccountLoginDelegate;
+    // Declared before mAccountLoginDelegate: when the OAuth ctor runs, this must
+    // capture the raw pointer before mAccountLoginDelegate's std::move() empties it,
+    // and member init order follows declaration order, not initializer-list order.
+    OAuthAccountLoginManager * mOAuthAccountLoginDelegate = nullptr;
+    std::unique_ptr<AccountLoginDelegate> mAccountLoginDelegate;
     ApplicationLauncherManager mApplicationLauncherDelegate;
     ChannelManager mChannelDelegate;
     ContentLauncherManager mContentLauncherDelegate;

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -691,7 +691,7 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
         // few seconds after GetDeviceAuthURI is called, with no further client
         // action needed. See OAuthAccountLoginManager.
         auto ptr =
-            std::make_unique<ContentAppImpl>("Vendor4", vendorId, "oauthAppId", productId, "Version4",
+            std::make_unique<ContentAppImpl>("Vendor5", vendorId, "oauthAppId", productId, "Version5",
                                              std::make_unique<OAuthAccountLoginManager>(), make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -370,7 +370,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CatalogList::Id, ARRA
 
 // Declare Account Login cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(accountLoginAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::OAuthLoggedIn::Id, BOOLEAN, 1, 0), /* OAuthLoggedIn */
+    DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Content Launcher cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(contentLauncherAttrs)
@@ -434,10 +435,12 @@ constexpr CommandId accountLoginIncomingCommands[] = {
     app::Clusters::AccountLogin::Commands::GetSetupPIN::Id,
     app::Clusters::AccountLogin::Commands::Login::Id,
     app::Clusters::AccountLogin::Commands::Logout::Id,
+    app::Clusters::AccountLogin::Commands::GetDeviceAuthURI::Id,
     kInvalidCommandId,
 };
 constexpr CommandId accountLoginOutgoingCommands[] = {
     app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Id,
+    app::Clusters::AccountLogin::Commands::GetDeviceAuthURIResponse::Id,
     kInvalidCommandId,
 };
 // TODO: Sort out when the optional commands here should be listed.
@@ -679,6 +682,16 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
     else if (vendorId == 1111 && productId == 22)
     {
         auto ptr = std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2", "20202021",
+                                                    make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
+    }
+    else if (vendorId == 4242 && productId == 1)
+    {
+        // OAuth-only app: PIN login is disabled, and OAuthLoggedIn flips to true a
+        // few seconds after GetDeviceAuthURI is called, with no further client
+        // action needed. See OAuthAccountLoginManager.
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor4", vendorId, "oauthAppId", productId, "Version4",
+                                                    std::make_unique<OAuthAccountLoginManager>(),
                                                     make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -370,8 +370,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CatalogList::Id, ARRA
 
 // Declare Account Login cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(accountLoginAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::OAuthLoggedIn::Id, BOOLEAN, 1, 0), /* OAuthLoggedIn */
-    DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                       /* FeatureMap */
+DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::OAuthLoggedIn::Id, BOOLEAN, 1, 0),   /* OAuthLoggedIn */
+    DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Content Launcher cluster attributes

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -690,9 +690,9 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
         // OAuth-only app: PIN login is disabled, and OAuthLoggedIn flips to true a
         // few seconds after GetDeviceAuthURI is called, with no further client
         // action needed. See OAuthAccountLoginManager.
-        auto ptr = std::make_unique<ContentAppImpl>("Vendor4", vendorId, "oauthAppId", productId, "Version4",
-                                                    std::make_unique<OAuthAccountLoginManager>(),
-                                                    make_default_supported_clusters());
+        auto ptr =
+            std::make_unique<ContentAppImpl>("Vendor4", vendorId, "oauthAppId", productId, "Version4",
+                                             std::make_unique<OAuthAccountLoginManager>(), make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
     else

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -371,6 +371,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CatalogList::Id, ARRA
 // Declare Account Login cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(accountLoginAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::OAuthLoggedIn::Id, BOOLEAN, 1, 0), /* OAuthLoggedIn */
+    DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                       /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Content Launcher cluster attributes

--- a/examples/tv-app/tv-common/tv-app.cmake
+++ b/examples/tv-app/tv-common/tv-app.cmake
@@ -51,6 +51,7 @@ macro(chip_add_tv_app_common target)
             ${CHIP_TV_COMMON_BASE_DIR}/src/ZCLCallbacks.cpp
 
             ${CHIP_TV_COMMON_BASE_DIR}/clusters/account-login/AccountLoginManager.cpp
+            ${CHIP_TV_COMMON_BASE_DIR}/clusters/account-login/OAuthAccountLoginManager.cpp
             ${CHIP_TV_COMMON_BASE_DIR}/clusters/application-basic/ApplicationBasicManager.cpp
             ${CHIP_TV_COMMON_BASE_DIR}/clusters/application-launcher/ApplicationLauncherManager.cpp
             ${CHIP_TV_COMMON_BASE_DIR}/clusters/audio-output/AudioOutputManager.cpp

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -115,7 +115,7 @@ public:
 
     virtual ~ContentApp() = default;
 
-    inline void SetEndpointId(EndpointId id) { mEndpointId = id; };
+    virtual void SetEndpointId(EndpointId id) { mEndpointId = id; };
     inline EndpointId GetEndpointId() { return mEndpointId; };
 
     const std::vector<SupportedCluster> & GetSupportedClusters() const { return mSupportedClusters; };

--- a/src/app/clusters/account-login-server/account-login-delegate.h
+++ b/src/app/clusters/account-login-server/account-login-delegate.h
@@ -47,6 +47,7 @@ public:
     virtual bool GetOAuthLoggedIn(chip::EndpointId endpoint)                                                      = 0;
 
     virtual uint16_t GetClusterRevision(chip::EndpointId endpoint) = 0;
+    virtual uint32_t GetFeatureMap(chip::EndpointId endpoint)      = 0;
 
     virtual ~Delegate() = default;
 };

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -130,6 +130,7 @@ public:
 private:
     CHIP_ERROR ReadRevisionAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
     CHIP_ERROR ReadOAuthLoggedInAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
+    CHIP_ERROR ReadFeatureMapAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder, Delegate * delegate);
 };
 
 AccountLoginAttrAccess gAccountLoginAttrAccess;
@@ -145,6 +146,8 @@ CHIP_ERROR AccountLoginAttrAccess::Read(const app::ConcreteReadAttributePath & a
         return ReadRevisionAttribute(endpoint, aEncoder, delegate);
     case app::Clusters::AccountLogin::Attributes::OAuthLoggedIn::Id:
         return ReadOAuthLoggedInAttribute(endpoint, aEncoder, delegate);
+    case app::Clusters::AccountLogin::Attributes::FeatureMap::Id:
+        return ReadFeatureMapAttribute(endpoint, aEncoder, delegate);
     default:
         break;
     }
@@ -163,6 +166,13 @@ CHIP_ERROR AccountLoginAttrAccess::ReadOAuthLoggedInAttribute(EndpointId endpoin
                                                               Delegate * delegate)
 {
     return aEncoder.Encode(delegate->GetOAuthLoggedIn(endpoint));
+}
+
+CHIP_ERROR AccountLoginAttrAccess::ReadFeatureMapAttribute(EndpointId endpoint, app::AttributeValueEncoder & aEncoder,
+                                                           Delegate * delegate)
+{
+    uint32_t featureMap = delegate->GetFeatureMap(endpoint);
+    return aEncoder.Encode(featureMap);
 }
 
 } // anonymous namespace

--- a/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
+++ b/src/app/clusters/account-login-server/tests/TestAccountLoginCluster.cpp
@@ -81,10 +81,13 @@ public:
 
     uint16_t GetClusterRevision(EndpointId) override { return mClusterRevision; }
 
+    uint32_t GetFeatureMap(EndpointId) override { return mFeatureMap; }
+
     bool mLoginResult         = true;
     bool mLogoutResult        = true;
     bool mOAuthLoggedIn       = false;
     uint16_t mClusterRevision = 3;
+    uint32_t mFeatureMap      = 0;
     CharSpan mSetupPin        = "1234"_span;
     CharSpan mUserCode        = "ABCD-EFGH"_span;
     CharSpan mVerificationURI = "https://example.com/device"_span;


### PR DESCRIPTION
### Summary

Add a fifth fake Content App (vendor 4242) whose AccountLogin delegate disables PIN-based login entirely (GetSetupPIN/Login are always rejected) and instead simulates the OAuth 2.0 Device Authorization Grant flow: GetDeviceAuthURI replies immediately with a dummy verification URI, then flips OAuthLoggedIn to true on its own a few seconds later, pushing the change to subscribers via MatterReportingAttributeChangeCallback. Logout clears the flag.

### Testing

Built and ran `chip-tv-app` + `chip-tool` locally, commissioned the app via `chip-tool pairing onnetwork`, then exercised the new Content App (vendor `4242`, landed on endpoint 8) end-to-end:

1. **Initial state**: `chip-tool accountlogin read oauth-logged-in <node> 8` → `FALSE`.
2. **Start OAuth flow**: `chip-tool accountlogin get-device-auth-uri <node> 8 --timedInteractionTimeoutMs 5000` → immediate dummy `GetDeviceAuthURIResponse` (userCode/verificationURI/expiresIn/interval).
3. **Async login**: waited ~5s, re-read `oauth-logged-in` → `TRUE`. Confirmed via tv-app logs that the timer fired and `MatterReportingAttributeChangeCallback` was invoked (no manual poll needed for subscribers).
4. **PIN login disabled**: `chip-tool accountlogin login ... <node> 8` → rejected (`HandleLogin` always returns `false` by design).
5. **Logout**: `chip-tool accountlogin logout <node> 8 --timedInteractionTimeoutMs 5000` → `SUCCESS`; re-read `oauth-logged-in` → back to `FALSE`.

Also verified that the `OAuthLoggedIn`/`GetDeviceAuthURI` additions to the shared Content App dynamic-endpoint template didn't regress the existing PIN-based apps (endpoints 4–7 still read/build fine).