### PR TITLE
[UDC] Add regression test for the TargetAppList parse loop bound

### DIFF
--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -579,6 +579,70 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppInfoOverflow)
     }
 }
 
+// Mirrors IdentificationDeclaration::IdentificationDeclarationTLVTag, which is private.
+// Values are positional starting at 1; see UserDirectedCommissioning.h.
+namespace {
+constexpr uint8_t kTestTargetAppListTag = 9;
+constexpr uint8_t kTestTargetAppTag     = 10;
+constexpr uint8_t kTestAppVendorIdTag   = 11;
+constexpr uint8_t kTestAppProductIdTag  = 12;
+} // namespace
+
+// A TargetAppList carrying more entries than the fixed array holds must be capped by
+// ReadPayload rather than stored past the end of mTargetAppInfos. The loop writes into
+// mTargetAppInfos directly instead of calling AddTargetAppInfo, so that helper's own
+// bound does not cover this path.
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
+{
+    constexpr size_t kHeaderLen = Dnssd::Commission::kInstanceNameMaxLength + 1;
+    // Comfortably more entries than the array holds.
+    constexpr uint16_t kEntries = 14;
+
+    uint8_t payload[kHeaderLen + 512];
+    memset(payload, 0, sizeof(payload));
+    Platform::CopyString(reinterpret_cast<char *>(payload), kHeaderLen, "instance-name");
+
+    TLV::TLVWriter writer;
+    writer.Init(payload + kHeaderLen, sizeof(payload) - kHeaderLen);
+
+    // ReadPayload expects an anonymous structure envelope before any context-tagged element.
+    TLV::TLVType envelopeType;
+    ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, envelopeType), CHIP_NO_ERROR);
+
+    TLV::TLVType listType;
+    ASSERT_EQ(writer.StartContainer(TLV::ContextTag(kTestTargetAppListTag), TLV::kTLVType_List, listType), CHIP_NO_ERROR);
+    for (uint16_t i = 0; i < kEntries; i++)
+    {
+        TLV::TLVType structType;
+        ASSERT_EQ(writer.StartContainer(TLV::ContextTag(kTestTargetAppTag), TLV::kTLVType_Structure, structType), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(kTestAppVendorIdTag), static_cast<uint16_t>(i + 1)), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(kTestAppProductIdTag), static_cast<uint16_t>(i + 100)), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.EndContainer(structType), CHIP_NO_ERROR);
+    }
+    ASSERT_EQ(writer.EndContainer(listType), CHIP_NO_ERROR);
+
+    ASSERT_EQ(writer.EndContainer(envelopeType), CHIP_NO_ERROR);
+    ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+
+    IdentificationDeclaration idOut;
+    // The parse loop stops consuming the list once the array is full, leaving the remaining
+    // entries to be reported as unrecognized tags. The returned status is therefore not the
+    // contract under test; the stored count is.
+    [[maybe_unused]] CHIP_ERROR err = idOut.ReadPayload(payload, kHeaderLen + writer.GetLengthWritten());
+
+    // The stored count must never exceed the array's element count.
+    EXPECT_LE(idOut.GetNumTargetAppInfos(), 10);
+
+    // Every entry the parser claims to have stored must be readable and correct.
+    for (uint8_t i = 0; i < idOut.GetNumTargetAppInfos(); i++)
+    {
+        TargetAppInfo info;
+        EXPECT_TRUE(idOut.GetTargetAppInfo(i, info));
+        EXPECT_EQ(info.vendorId, static_cast<uint16_t>(i + 1));
+        EXPECT_EQ(info.productId, static_cast<uint16_t>(i + 100));
+    }
+}
+
 TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -586,6 +586,9 @@ constexpr uint8_t kTestTargetAppListTag = 9;
 constexpr uint8_t kTestTargetAppTag     = 10;
 constexpr uint8_t kTestAppVendorIdTag   = 11;
 constexpr uint8_t kTestAppProductIdTag  = 12;
+
+// Mirrors IdentificationDeclaration::kMaxTargetAppInfos, which is also private.
+constexpr uint8_t kTestMaxTargetAppInfos = 10;
 } // namespace
 
 // A TargetAppList carrying more entries than the fixed array holds must be capped by
@@ -630,8 +633,10 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclarationTargetAppListOverflow)
     // contract under test; the stored count is.
     [[maybe_unused]] CHIP_ERROR err = idOut.ReadPayload(payload, kHeaderLen + writer.GetLengthWritten());
 
-    // The stored count must never exceed the array's element count.
-    EXPECT_LE(idOut.GetNumTargetAppInfos(), 10);
+    // The parser must fill the array to capacity and stop there. Asserting equality rather
+    // than an upper bound also fails if the list was not parsed at all, which would otherwise
+    // satisfy a bound check and skip the verification loop below.
+    EXPECT_EQ(idOut.GetNumTargetAppInfos(), kTestMaxTargetAppInfos);
 
     // Every entry the parser claims to have stored must be readable and correct.
     for (uint8_t i = 0; i < idOut.GetNumTargetAppInfos(); i++)


### PR DESCRIPTION
- `ReadPayload`'s `TargetAppList` loop is bounded by `kMaxTargetAppInfos` on master, but that form arrived incidentally in #41870, a repo-wide `nodiscard` batch, so no test came with it. The loop also stores into `mTargetAppInfos[mNumTargetAppInfos]` directly rather than via `AddTargetAppInfo`, so the existing `TestUDCIdentificationDeclarationTargetAppInfoOverflow` covers only that helper.

- Adds `TestUDCIdentificationDeclarationTargetAppListOverflow`: a `TargetAppList` of 14 entries against the 10-element array, asserting the stored count equals capacity and every stored entry is readable. The TLV is written directly, since `AddTargetAppInfo` caps at the same limit and cannot build a longer list.

### Testing

Test-only; runs in the existing `TestUdcMessages` suite:

```
ninja -C out/linux-x64-tests-clang src/protocols/user_directed_commissioning/tests:TestUdcMessages.run
```

Passes on master, which already has the bound. The same test fails on branches without it (#73352, #73351), so the assertion is not vacuous.

