### PR TITLE
[v1.4.2][backport] fix(thermostat-server): notify subscribers when ActivePresetHandle changes

### DIFF
--- a/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
+++ b/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
@@ -100,6 +100,7 @@ private:
 
     uint8_t mActivePresetHandleData[kPresetHandleSize];
     size_t mActivePresetHandleDataSize;
+    bool mActivePresetHandleIsNull = true;
 };
 
 } // namespace Thermostat

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -19,6 +19,7 @@
 #include <thermostat-delegate-impl.h>
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/reporting/reporting.h>
 #include <lib/support/Span.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -116,7 +116,7 @@ CHIP_ERROR ThermostatDelegate::GetPresetAtIndex(size_t index, PresetStructWithOw
 
 CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<MutableByteSpan> & activePresetHandle)
 {
-    if (mActivePresetHandleDataSize != 0)
+    if (!mActivePresetHandleIsNull)
     {
         ReturnErrorOnFailure(
             CopySpanToMutableSpan(ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize), activePresetHandle.Value()));
@@ -131,7 +131,15 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
-    if (!newActivePresetHandle.IsNull())
+    bool newIsNull = newActivePresetHandle.IsNull();
+    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
+
+    if (mActivePresetHandleIsNull == newIsNull && (newIsNull || oldHandle.data_equal(newActivePresetHandle.Value())))
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (!newIsNull)
     {
         size_t newActivePresetHandleSize = newActivePresetHandle.Value().size();
         if (newActivePresetHandleSize > sizeof(mActivePresetHandleData))
@@ -152,6 +160,10 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
         mActivePresetHandleDataSize = 0;
         ChipLogDetail(NotSpecified, "Clear ActivePresetHandle");
     }
+
+    mActivePresetHandleIsNull = newIsNull;
+    MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/clusters/thermostat-server/thermostat-delegate.h
+++ b/src/app/clusters/thermostat-server/thermostat-delegate.h
@@ -133,6 +133,12 @@ public:
      *
      */
     virtual void ClearPendingPresetList() = 0;
+
+    void SetEndpointId(EndpointId aEndpoint) { mEndpointId = aEndpoint; }
+
+    // This should be removed once #39949 is fixed.
+protected:
+    EndpointId mEndpointId = 0;
 };
 
 } // namespace Thermostat

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -521,6 +521,7 @@ void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate)
     if (ep < MATTER_ARRAY_SIZE(gDelegateTable))
     {
         gDelegateTable[ep] = delegate;
+        delegate->SetEndpointId(endpoint);
     }
 }
 


### PR DESCRIPTION
#### Summary

Manual backport of #72769 to `v1.4.2-branch`.

`SetActivePreset()` was updating the `ActivePresetHandle` attribute via the delegate but not calling `MatterReportingAttributeChangeCallback()` afterwards. As a result, active subscriptions never received a Report Data message when the active preset changed via `SetActivePresetRequest` — the new value was silently applied on the device side but never pushed to subscribers.

Fix:
- Add the `MatterReportingAttributeChangeCallback` call inside `SetActivePresetHandle` so the command path (`SetActivePresetRequest`) emits a subscription report.
- Add an explicit `mActivePresetHandleIsNull` boolean flag to correctly distinguish null from a non-null empty `octstr`.
- Only emit a subscription report when the value has actually changed: null-to-null and same-value comparisons both short-circuit without reporting.

**Note on this branch vs. v1.5/v1.6 backports:** `v1.4.2-branch` predates the Thermostat Suggestion feature — `ReEvaluateCurrentSuggestion()`, `SetThermostatSuggestionNotFollowingReason()`, and the `TEMPORARY_RETURN_IGNORED` wrapping around them don't exist here. `SetActivePresetHandle()` has a single call site on this branch ([thermostat-server-presets.cpp](https://github.com/project-chip/connectedhomeip/blob/v1.4.2-branch/src/app/clusters/thermostat-server/thermostat-server-presets.cpp#L310), the `SetActivePresetRequest` command path), so there is no duplicate reporting call to remove, unlike on master/v1.5/v1.6.

The actual conflict: `ThermostatDelegate` on this branch doesn't yet have `mEndpointId` / `SetEndpointId()` — that member was added later alongside the code-driven cluster migration (tracked by #39949). The second commit (`7099598c690`) backports just that minimal piece so `MatterReportingAttributeChangeCallback(mEndpointId, ...)` compiles; it carries no other behavioral change.

This is a manual backport of #72769, squash-merged as `ff311154bf71f18bb02c0f655f8be75ee94bd586` on master.

#### Related issues

Fixes: #43582

#### Testing

Tested with thermostat/linux example on master (see #72769). Cherry-picked onto `v1.4.2-branch` with the conflict noted above resolved manually; local build not re-run for this backport due to submodule pinning differences between `master` and `v1.4.2-branch`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
