### PR TITLE
[Silabs] Bugfix posix_spawn argument list too long

### DIFF
--- a/src/lib/BUILD.gn
+++ b/src/lib/BUILD.gn
@@ -82,7 +82,12 @@ static_library("lib") {
 
   output_dir = "${root_out_dir}/lib"
 
-  complete_static_lib = true
+  # TODO: Remove the condition once pigweed fix is upstreamed https://github.com/project-chip/connectedhomeip/issues/73278
+  if(chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
+    complete_static_lib = true
+  } else {
+    complete_static_lib = false
+  }
 }
 
 # This version of libCHIP is only meant for internal use by some test drivers
@@ -96,5 +101,10 @@ static_library("with-stdio-logging") {
 
   output_dir = "${root_out_dir}/lib"
 
-  complete_static_lib = true
+  # TODO: Remove the condition once pigweed fix is upstreamed https://github.com/project-chip/connectedhomeip/issues/73278
+  if(chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
+    complete_static_lib = true
+  } else {
+    complete_static_lib = false
+  }
 }

--- a/src/lib/BUILD.gn
+++ b/src/lib/BUILD.gn
@@ -83,10 +83,10 @@ static_library("lib") {
   output_dir = "${root_out_dir}/lib"
 
   # TODO: Remove the condition once pigweed fix is upstreamed https://github.com/project-chip/connectedhomeip/issues/73278
-  if(chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
-    complete_static_lib = true
-  } else {
+  if (chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
     complete_static_lib = false
+  } else {
+    complete_static_lib = true
   }
 }
 
@@ -102,9 +102,9 @@ static_library("with-stdio-logging") {
   output_dir = "${root_out_dir}/lib"
 
   # TODO: Remove the condition once pigweed fix is upstreamed https://github.com/project-chip/connectedhomeip/issues/73278
-  if(chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
-    complete_static_lib = true
-  } else {
+  if (chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
     complete_static_lib = false
+  } else {
+    complete_static_lib = true
   }
 }


### PR DESCRIPTION


### Summary

Added a workaround to prevent failure to build libCHIP.a on Silabs platforms.

Essentially, we do not build the lib anymore for Silabs.

### Related issues
Workaround for: 
https://github.com/project-chip/connectedhomeip/issues/73278

Not quite a fix.
### Testing

Local build of examples failing with the:
`ar libCHIP.aninja: fatal: posix_spawn: Argument list too long`

Error, hopefully nothing in CI uses that lib.