### PR TITLE
[v1.6][backport] fix(thermostat-server): notify subscribers when ActivePresetHandle changes

### DIFF
--- a/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
+++ b/examples/thermostat/thermostat-common/include/thermostat-delegate-impl.h
@@ -150,6 +150,7 @@ private:
 
     uint8_t mActivePresetHandleData[kPresetHandleSize];
     size_t mActivePresetHandleDataSize;
+    bool mActivePresetHandleIsNull = true;
 
     uint8_t mMaxThermostatSuggestions;
     ThermostatSuggestionStructWithOwnedMembers mThermostatSuggestions[kMaxNumberOfThermostatSuggestions];

--- a/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp
@@ -132,7 +132,7 @@ CHIP_ERROR ThermostatDelegate::GetPresetAtIndex(size_t index, PresetStructWithOw
 
 CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<MutableByteSpan> & activePresetHandle)
 {
-    if (mActivePresetHandleDataSize != 0)
+    if (!mActivePresetHandleIsNull)
     {
         ReturnErrorOnFailure(
             CopySpanToMutableSpan(ByteSpan(mActivePresetHandleData, mActivePresetHandleDataSize), activePresetHandle.Value()));
@@ -147,7 +147,15 @@ CHIP_ERROR ThermostatDelegate::GetActivePresetHandle(DataModel::Nullable<Mutable
 
 CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<ByteSpan> & newActivePresetHandle)
 {
-    if (!newActivePresetHandle.IsNull())
+    bool newIsNull = newActivePresetHandle.IsNull();
+    ByteSpan oldHandle(mActivePresetHandleData, mActivePresetHandleDataSize);
+
+    if (mActivePresetHandleIsNull == newIsNull && (newIsNull || oldHandle.data_equal(newActivePresetHandle.Value())))
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (!newIsNull)
     {
         size_t newActivePresetHandleSize = newActivePresetHandle.Value().size();
         if (newActivePresetHandleSize > sizeof(mActivePresetHandleData))
@@ -168,6 +176,10 @@ CHIP_ERROR ThermostatDelegate::SetActivePresetHandle(const DataModel::Nullable<B
         mActivePresetHandleDataSize = 0;
         ChipLogDetail(NotSpecified, "Clear ActivePresetHandle");
     }
+
+    mActivePresetHandleIsNull = newIsNull;
+    MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
+
     return CHIP_NO_ERROR;
 }
 
@@ -449,7 +461,6 @@ CHIP_ERROR ThermostatDelegate::ReEvaluateCurrentSuggestion()
         // ActivePresetHandle. Otherwise set the ActivePresetHandle to the preset handle in the suggestion and set
         // ThermostatSuggestionNotFollowingReason to null.
         TEMPORARY_RETURN_IGNORED SetActivePresetHandle(currentThermostatSuggestion.GetPresetHandle());
-        MatterReportingAttributeChangeCallback(mEndpointId, Thermostat::Id, Attributes::ActivePresetHandle::Id);
         TEMPORARY_RETURN_IGNORED SetThermostatSuggestionNotFollowingReason(DataModel::NullNullable);
 
         // Start a timer from the timestamp in currentMatterEpochTimestamp to the timestamp in the expiration time.


### PR DESCRIPTION
### Summary

Backport of #72769 to v1.6-branch.

`SetActivePreset()` was updating the `ActivePresetHandle` attribute via the delegate but not calling `MatterReportingAttributeChangeCallback()` afterwards. As a result, active subscriptions never received a Report Data message when the active preset changed via `SetActivePresetRequest` — the new value was silently applied on the device side but never pushed to subscribers.

Additionally, `ActivePresetHandle` is a nullable `octstr` with no `minLength` constraint. The previous implementation used `mActivePresetHandleDataSize == 0` to represent both the null state and a non-null empty octet string, making them indistinguishable.

Fix:
- Centralize `MatterReportingAttributeChangeCallback` inside `SetActivePresetHandle` so both the command path (`SetActivePresetRequest`) and the suggestion path (`ReEvaluateCurrentSuggestion`) emit consistent subscription reports.
- Add an explicit `mActivePresetHandleIsNull` boolean flag to correctly distinguish null from a non-null empty `octstr`.
- Only emit a subscription report when the value has actually changed.

Cherry-picked cleanly from ff311154bf71f18bb02c0f655f8be75ee94bd586 (merge commit of #72769) onto v1.6-branch, no conflicts.

### Related issues

Fixes: #43582

### Testing

Same fix already validated and merged on v1.5-branch (#73358, merged). Tested with thermostat/linux example in the original PR #72769:
1. `ActivePresetHandle` is updated correctly
2. Attribute `0x4E` is marked dirty, dirty generation incremented
3. A `ReportData` message is sent to the subscriber
4. Subscriber acknowledges with SUCCESS
5. When the same value is set again, no spurious report is emitted