### PR TITLE
[Telink] reduce TL7218X retention RAM usage

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -233,14 +233,14 @@ config CHIP_USE_MARS_SENSOR
 	default n
 
 config CHIP_PERSISTENT_SUBSCRIPTIONS
-	default n if BOARD_TL3218X_RETENTION
+	default n if BOARD_TL3218X_RETENTION || BOARD_TL7218X_RETENTION
 	default y
 	# selecting experimental for this feature since there is an issue with multiple controllers.
 	select EXPERIMENTAL
 
 config CHIP_MAX_FABRICS
 	int "Maximum number of Matter fabrics"
-	default 3 if BOARD_TL3218X_RETENTION
+	default 3 if BOARD_TL3218X_RETENTION || BOARD_TL7218X_RETENTION
 	default 5
 	help
 	  The maximum number of Matter fabrics that device can be joined to.


### PR DESCRIPTION
#### Summary

- disable CHIP_PERSISTENT_SUBSCRIPTIONS for BOARD_TL7218X_RETENTION
- reduce CHIP_MAX_FABRICS for BOARD_TL7218X_RETENTION

#### Testing

- Verified by GitHub CI jobs.