### PR TITLE
[Ameba] Added ICD support for Ameba platform

### DIFF
--- a/examples/air-purifier-app/ameba/main/chipinterface.cpp
+++ b/examples/air-purifier-app/ameba/main/chipinterface.cpp
@@ -30,6 +30,7 @@
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
 #include <app/server/TermsAndConditionsManager.h>
 #endif
+#include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
@@ -165,6 +166,9 @@ static void InitServer(intptr_t context)
     }
 
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
     InitAirPurifierManager();
 }
 

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -178,6 +178,9 @@ static void InitServer(intptr_t context)
 #endif
 
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
@@ -179,6 +179,9 @@ static void InitServer(intptr_t context)
     Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/chef/ameba/main/chipinterface.cpp
+++ b/examples/chef/ameba/main/chipinterface.cpp
@@ -112,6 +112,9 @@ static void InitServer(intptr_t context)
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -134,6 +134,9 @@ static void InitServer(intptr_t context)
 #endif
 
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -157,6 +157,9 @@ static void InitServer(intptr_t context)
     }
 
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -88,6 +88,9 @@ static void InitServer(intptr_t context)
 
     NetWorkCommissioningInstInit();
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAmebaObserver);
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/platform/ameba/observer/AmebaObserver.h
+++ b/examples/platform/ameba/observer/AmebaObserver.h
@@ -21,10 +21,18 @@
 #include <app/server/AppDelegate.h>
 #include <app/server/Server.h>
 #include <credentials/FabricTable.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/server/ICDStateObserver.h>
+#endif
 
 namespace chip {
 
-class AmebaObserver : public AppDelegate, public FabricTable::Delegate
+class AmebaObserver : public AppDelegate,
+                      public FabricTable::Delegate
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    ,
+                      public chip::app::ICDStateObserver
+#endif
 {
 public:
     // Commissioning Observer
@@ -42,6 +50,30 @@ public:
             // Customer code
         }
     }
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    void OnEnterActiveMode() override
+    {
+        // Request high-performance WiFi mode (disable power-save)
+        matter_wifi_set_powersave_mode(0, 0);
+        ChipLogProgress(DeviceLayer, "ICD: Entering Active Mode");
+    }
+    void OnEnterIdleMode() override
+    {
+        // Allow WiFi to use DTIM-based sleep
+        matter_wifi_set_powersave_mode(1, 1);
+        ChipLogProgress(DeviceLayer, "ICD: Entering Idle Mode");
+    }
+    void OnTransitionToIdle() override
+    {
+        // Called before the transition to idle; can be used to flush pending operations
+        ChipLogProgress(DeviceLayer, "ICD: Transitioning to Idle");
+    }
+    void OnICDModeChange() override
+    {
+        // Called when the ICD mode changes (SIT <-> LIT)
+        ChipLogProgress(DeviceLayer, "ICD: Mode Changed");
+    }
+#endif
 };
 
 } // namespace chip

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -466,6 +466,28 @@ void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
     TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
+{
+    // Listen Interval is expressed in beacon intervals.
+    // Assuming a default beacon interval of 100 TU = 102.4 ms.
+    constexpr uint32_t kBeaconIntervalMs_x10 = 1024; // 102.4 ms x 10
+
+    ChipLogProgress(DeviceLayer, "Set Polling Interval = %lu ms", static_cast<unsigned long>(pollingInterval.count()));
+
+    // Round to the nearest beacon interval.
+    uint32_t listenInterval = (pollingInterval.count() * 10 + kBeaconIntervalMs_x10 / 2) / kBeaconIntervalMs_x10;
+    // Listen interval can only be set between 1 to 255
+    listenInterval = std::clamp<uint32_t>(listenInterval, 1, 255);
+
+    ChipLogProgress(DeviceLayer, "Listen Interval = %lu", static_cast<unsigned long>(listenInterval));
+
+    int ret = matter_wifi_set_lps_listen_interval(listenInterval);
+
+    return (ret == RTW_SUCCESS) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+}
+#endif
+
 // ==================== ConnectivityManager Private Methods ====================
 
 void ConnectivityManagerImpl::DriveStationState()

--- a/src/platform/Ameba/ConnectivityManagerImpl.h
+++ b/src/platform/Ameba/ConnectivityManagerImpl.h
@@ -116,6 +116,9 @@ private:
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
+#endif
 
     // ===== Private members reserved for use by this class only.
 


### PR DESCRIPTION
### Summary

* Cherry picked from 6e617c8f6946c93b1d6a543f1835cc41d823c736
* Set _SetPollingInterval at src/platform/Ameba/ConnectivityManagerImpl.* if ICD server is enabled
* Add ICD State Observer to AmebaObserver.h if ICD server is enabled
* Register AmebaObserver to observe ICD state changes at **/ameba/main/chipinterface.cpp if ICD server is enabled

### Related issues

N.A.

### Testing

* Enabled ICD server during build.
* DUT commissioned by chip-tool, wait for ICD state changes between Idle and Active.
* AmebaObserver printed "ICD: ..." correctly when ICD state changes.
* Ameba enable/disable the WiFi power save mode successfully
