### PR TITLE
[Tizen] Increase QEMU VM memory to 1GB to prevent flaky timeouts

### DIFF
--- a/src/test_driver/tizen/chip_tests/BUILD.gn
+++ b/src/test_driver/tizen/chip_tests/BUILD.gn
@@ -26,6 +26,10 @@ tizen_qemu_run("chip-tests") {
   # Share tests directory.
   share = "${root_out_dir}"
 
+  # Increase memory to 1GB to prevent guest OS swapping and VM freezes under
+  # memory pressure, which negatively impacts test execution and causes flaky timeouts.
+  memory = 1024
+
   # Runner script file name.
   runner = "runner-${target_name}.sh"
 

--- a/third_party/tizen/tizen_sdk.gni
+++ b/third_party/tizen/tizen_sdk.gni
@@ -193,6 +193,12 @@ template("tizen_qemu_run") {
     if (defined(invoker.virtio_net) && invoker.virtio_net) {
       args += [ "--virtio-net" ]
     }
+    if (defined(invoker.memory)) {
+      args += [
+        "--memory",
+        "${invoker.memory}",
+      ]
+    }
 
     # Use console pool to print QEMU output in real-time.
     pool = "//:console"


### PR DESCRIPTION
#### Summary

Increase the memory allocated to the Tizen QEMU emulator to 1GB to prevent flakiness in unit tests.

##### Problem

-   Tizen unit tests running in QEMU (specifically `TestRead` tests) suffer from intermittent timeouts (`CHIP_ERROR_TIMEOUT` instead of expected errors, or failing to establish subscriptions in time).
-   This flakiness is caused by **guest-level memory pressure and swapping**:
    -   The emulator is configured with a default of **512MB** of RAM.
    -   During test execution, memory usage exceeds this limit, triggering aggressive kernel memory reclamation (`mem_cgroup_force_reclaim`) and swapping.
    -   These reclamation cycles freeze the VM event loop for seconds at a time.
    -   Because the test timeout check (`DriveIOUntil`) uses real time (which continues to progress during the freeze), the test prematurely times out before the subscription handshake can complete.

##### Solution

-   Updated the `tizen_qemu_run` GN template in `third_party/tizen/tizen_sdk.gni` to support a `memory` parameter and forward it to the QEMU launch script (`tizen_qemu.py`).
-   Increased the memory allocation for the Tizen unit tests target (`chip-tests` in `src/test_driver/tizen/chip_tests/BUILD.gn`) from the default 512MB to **1024MB (1GB)**.
-   Added a detailed comment in the build file explaining the rationale (swapping/freezes causing flaky timeouts).

#### Testing

-   Verified that the modified GN files (`third_party/tizen/tizen_sdk.gni` and `src/test_driver/tizen/chip_tests/BUILD.gn`) format and parse correctly using `gn format`.
