### PR TITLE
[Docker] Fix argument forwarding in build.sh to support --build-arg

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -73,44 +73,91 @@ if [ -f "$DOCKER_VOLUME_PATH" ]; then
     mb_space_before=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
 fi
 
+# Save original arguments for recursive calls before parsing
+ORIG_ARGS=("$@")
+
+BUILD_ARGS=()
+LATEST=false
+PUSH=false
+SKIP_BUILD=false
+SQUASH=false
+CLEAR=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-cache)
+            BUILD_ARGS+=("$1")
+            shift
+            ;;
+        --latest)
+            LATEST=true
+            shift
+            ;;
+        --push)
+            PUSH=true
+            shift
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --squash)
+            SQUASH=true
+            shift
+            ;;
+        --clear)
+            CLEAR=true
+            shift
+            ;;
+        --build-arg)
+            BUILD_ARGS+=("$1" "$2")
+            shift 2
+            ;;
+        --build-arg=*)
+            BUILD_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            # Forward any other arguments to docker build
+            BUILD_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 # go find and build any CHIP images this image is "FROM"
 awk -F/ '/^FROM project-chip/ {print $2}' Dockerfile | while read -r dep; do
     dep=${dep%:*}
-    (cd "../$dep" && ./build.sh "$@")
+    (cd "../$dep" && ./build.sh "${ORIG_ARGS[@]}")
 done
 
-BUILD_ARGS=()
-if [[ ${*/--no-cache//} != "${*}" ]]; then
-    BUILD_ARGS+=(--no-cache)
-fi
-
-[[ ${*/--skip-build//} != "${*}" ]] || {
+if [ "$SKIP_BUILD" = false ]; then
     docker build "${BUILD_ARGS[@]}" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$GHCR_ORG/$ORG/$IMAGE:$VERSION" .
     docker image prune --force
-}
+fi
 
-[[ ${*/--latest//} != "${*}" ]] && {
+if [ "$LATEST" = true ]; then
     docker tag "$GHCR_ORG"/"$ORG"/"$IMAGE":"$VERSION" "$GHCR_ORG"/"$ORG"/"$IMAGE":latest
-}
+fi
 
-[[ ${*/--squash//} != "${*}" ]] && {
+if [ "$SQUASH" = true ]; then
     command -v docker-squash >/dev/null &&
         docker-squash "$GHCR_ORG"/"$ORG"/"$IMAGE":"$VERSION" -t "$GHCR_ORG"/"$ORG"/"$IMAGE":latest
-}
+fi
 
-[[ ${*/--push//} != "${*}" ]] && {
+if [ "$PUSH" = true ]; then
     docker push "$GHCR_ORG"/"$ORG"/"$IMAGE":"$VERSION"
-    [[ ${*/--latest//} != "${*}" ]] && {
+    if [ "$LATEST" = true ]; then
         docker push "$GHCR_ORG"/"$ORG"/"$IMAGE":latest
-    }
-}
+    fi
+fi
 
-[[ ${*/--clear//} != "${*}" ]] && {
+if [ "$CLEAR" = true ]; then
     docker rmi -f "$GHCR_ORG"/"$ORG"/"$IMAGE":"$VERSION"
-    [[ ${*/--latest//} != "${*}" ]] && {
+    if [ "$LATEST" = true ]; then
         docker rmi -f "$GHCR_ORG"/"$ORG"/"$IMAGE":latest
-    }
-}
+    fi
+fi
 
 docker images --filter=reference="$GHCR_ORG/$ORG/*"
 


### PR DESCRIPTION
#### Summary

Fixes Cirque test failures caused by incompatibility between `otbr-agent` and `ot-rcp` due to unpinned `ot-br-posix` version in docker builds.

##### Problem

-   The docker build script `integrations/docker/build.sh` (shared by all docker images, including `chip-cirque-device-base`) ignored extra arguments like `--build-arg`.
-   As a result, `chip-cirque-device-base` was always built using `ot-br-posix` `main` branch instead of the pinned version (`d8800de`).
-   When `ot-br-posix` `main` was bumped to a newer OpenThread version (on Aug 5th), it introduced a runtime compatibility issue with the pinned `ot-rcp` (built with older OpenThread), causing `otbr-agent` to fail to start in Cirque tests.

**Argument Handling Before:**
Only detected hardcoded flags (`--no-cache`, `--latest`, etc.) via substring matching. All other arguments were discarded.
*   *Input:* `build.sh --build-arg OT_BR_POSIX_CHECKOUT=foo`
*   *Resulting Docker command:* `docker build --build-arg TARGETPLATFORM=...` (argument lost)

##### Solution

-   Refactored argument parsing in `integrations/docker/build.sh` to use a standard `while` loop, allowing it to correctly capture and forward `--build-arg` (and other unrecognized arguments) to `docker build`.
-   This ensures that the pinned `OT_BR_POSIX_CHECKOUT` version is respected during the docker build.

**Argument Handling After:**
Uses a loop to parse arguments, explicitly capturing `--build-arg` and forwarding unknown options.
*   *Input:* `build.sh --build-arg OT_BR_POSIX_CHECKOUT=foo`
*   *Resulting Docker command:* `docker build --build-arg OT_BR_POSIX_CHECKOUT=foo --build-arg TARGETPLATFORM=...` (argument preserved)

#### Testing

-   This change fixes the build pipeline argument forwarding.
-   Verification will be performed via GHA CI once the PR is created and runs.
