### PR TITLE
[docs] Note that example apps are not production-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ show simple interactions, and are supported on multiple transports -- Wi-Fi and
 Thread -- starting with resource-constrained (i.e., memory, processing) silicon
 platforms to help ensure Matter’s scalability.
 
+> **Note:** The applications under `examples/` are reference implementations
+> intended for development and testing. They are not production-ready and are
+> not intended to be shipped as-is in a commercial product.
+
 # How to Contribute
 
 We welcome your contributions to Matter. Read our contribution guidelines
@@ -214,7 +218,7 @@ The Matter repository is structured as follows:
 | config             | Project configurations                                                                                                                                |
 | credentials        | Development and test credentials                                                                                                                      |
 | docs               | Documentation, including guides. Visit the [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html) to read it. |
-| examples           | Example firmware applications that demonstrate use of Matter                                                                                          |
+| examples           | Example firmware applications that demonstrate use of Matter (not production-ready)                                                                   |
 | integrations       | 3rd party integrations                                                                                                                                |
 | scripts            | Scripts needed to work with the Matter repository                                                                                                     |
 | src                | Implementation of Matter                                                                                                                              |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Matter Example Applications
+
+> **Note:** The applications in this directory are reference implementations
+> intended for development and testing. They are not production-ready and are
+> not intended to be shipped as-is in a commercial product.


### PR DESCRIPTION
#### Summary

Clarifies that the applications under `examples/` are reference implementations intended for development and testing not a starting point for a shipping product. The note is added to the "Current Status of Matter" section of the README (which the documentation homepage includes), to the directory-structure table, and to a new `examples/README.md`.

#### Testing

Documentation-only change; no code, build, or test behavior is affected. The `docbuild` job covers the new `examples/README.md`.
