### PR TITLE
[infra]Add a timeout/ignore stale mergify check

### DIFF
--- a/scripts/tools/pr_checker_bot.py
+++ b/scripts/tools/pr_checker_bot.py
@@ -400,8 +400,9 @@ class PRContext:
                     created_at = created_at.replace(tzinfo=UTC)
 
                 age = now - created_at
-                # Some external integrations automatically create a CheckSuite on every commit but never trigger or complete
-                # builds for PRs. To prevent PRs from hanging, we ignore uncompleted check suites ONLY IF:
+                # Some external integrations automatically create a CheckSuite for every commit but never start or complete it
+                # on certain PRs. For example, Mergify can registers a check that remains queued indefinitely without ever running.
+                # To prevent otherwise merge-ready PRs from requiring manual intervention, we ignore incomplete check suites only if:
                 # 1. The check suite belongs to a known external app in `IGNORED_STALE_SUITE_APPS`.
                 # 2. The check suite has been queued/pending for longer than `STALE_SUITE_TIMEOUT`.
                 if (

--- a/scripts/tools/pr_checker_bot.py
+++ b/scripts/tools/pr_checker_bot.py
@@ -44,9 +44,9 @@ DEFAULT_CONFIG_PATH = ".github/platform_maintainers.yaml"
 
 ELIGIBILITY_COMMENT_MARKER = "<!-- pr-checker-bot-eligibility-marker -->"
 
-# Timeout after which uncompleted check suites from known non-critical external apps
-# on Dependabot PRs are considered stale/indefinitely queued.
-DEPENDABOT_STALE_SUITE_TIMEOUT = timedelta(hours=6)
+# Timeout after which uncompleted check suites from known non-critical external apps (IGNORED_STALE_SUITE_APPS)
+# on PRs are considered stale/indefinitely queued.
+STALE_SUITE_TIMEOUT = timedelta(hours=6)
 
 # Third-party integrations / GitHub apps that register check suites on all PRs but
 # never complete or execute builds for Dependabot PRs
@@ -56,6 +56,7 @@ IGNORED_STALE_SUITE_APPS = {
     "Testspace.com",
     "SonarQubeCloud",
     "BuildJet",
+    "Mergify",
 }
 
 
@@ -400,14 +401,12 @@ class PRContext:
 
                 age = now - created_at
                 # Some external integrations automatically create a CheckSuite on every commit but never trigger or complete
-                # builds for Dependabot PRs. To prevent Dependabot PRs from hanging, we ignore uncompleted check suites ONLY IF:
-                # 1. The PR is authored by Dependabot
-                # 2. The check suite belongs to a known external app in `IGNORED_STALE_SUITE_APPS`.
-                # 3. The check suite has been queued/pending for longer than `DEPENDABOT_STALE_SUITE_TIMEOUT`.
+                # builds for PRs. To prevent PRs from hanging, we ignore uncompleted check suites ONLY IF:
+                # 1. The check suite belongs to a known external app in `IGNORED_STALE_SUITE_APPS`.
+                # 2. The check suite has been queued/pending for longer than `STALE_SUITE_TIMEOUT`.
                 if (
-                    self.is_dependabot
-                    and app_name in IGNORED_STALE_SUITE_APPS
-                    and age > DEPENDABOT_STALE_SUITE_TIMEOUT
+                    app_name in IGNORED_STALE_SUITE_APPS
+                     and age > STALE_SUITE_TIMEOUT
                 ):
                     log.info(
                         "PR #%d HEAD commit %s check suite '%s' (%s) is pending but ignored (queued for %s > %s threshold)",
@@ -416,7 +415,7 @@ class PRContext:
                         suite.id,
                         app_name,
                         age,
-                        DEPENDABOT_STALE_SUITE_TIMEOUT,
+                        STALE_SUITE_TIMEOUT,
                     )
                     continue
 

--- a/scripts/tools/pr_checker_bot.py
+++ b/scripts/tools/pr_checker_bot.py
@@ -406,7 +406,7 @@ class PRContext:
                 # 2. The check suite has been queued/pending for longer than `STALE_SUITE_TIMEOUT`.
                 if (
                     app_name in IGNORED_STALE_SUITE_APPS
-                     and age > STALE_SUITE_TIMEOUT
+                    and age > STALE_SUITE_TIMEOUT
                 ):
                     log.info(
                         "PR #%d HEAD commit %s check suite '%s' (%s) is pending but ignored (queued for %s > %s threshold)",

--- a/scripts/tools/tests/test_pr_checker_bot.py
+++ b/scripts/tools/tests/test_pr_checker_bot.py
@@ -1127,7 +1127,7 @@ esp32:
         mock_pr.create_issue_comment.assert_not_called()
 
     def test_check_ci_ignores_old_non_critical_pending_suites(self) -> None:
-        """Tests that _check_ci_passed ignores pending non-critical suites older than 6 hours for Dependabot."""
+        """Tests that _check_ci_passed ignores pending non-critical suites older than 6 hours for any PR."""
         files = [self.create_mock_file("some/random/file.txt")]
         mock_pr = self.create_mock_pr(
             1, "Bump dependency", "dependabot[bot]", files, []
@@ -1184,6 +1184,13 @@ esp32:
         mock_buildjet_old_pending.conclusion = None
         mock_buildjet_old_pending.created_at = now - timedelta(hours=7)
 
+        # 8. Allowed non-critical suite (Mergify) - pending - old (7h > 6h) - should be ignored
+        mock_mergify_old_pending = MagicMock()
+        mock_mergify_old_pending.app.name = "Mergify"
+        mock_mergify_old_pending.status = "queued"
+        mock_mergify_old_pending.conclusion = None
+        mock_mergify_old_pending.created_at = now - timedelta(hours=7)
+
         # Test Case A: Only old non-critical pending suites present (and some passing suites to meet min 10 checks)
         # Should MERGE (ignore the old pending non-critical suites)
         mock_success_suite = MagicMock()
@@ -1195,7 +1202,8 @@ esp32:
             mock_testspace_old_pending,
             mock_sonarqube_old_pending,
             mock_buildjet_old_pending,
-        ] + [mock_success_suite] * 6
+            mock_mergify_old_pending,
+        ] + [mock_success_suite] * 5
 
         self.bot.check_and_process_pr(mock_pr)
         mock_pr.merge.assert_called_once()
@@ -1219,20 +1227,24 @@ esp32:
         mock_pr.merge.assert_not_called()
         mock_pr.reset_mock()
 
-        # Test Case D: Same old pending suite but PR is NOT from dependabot (e.g. platform merge)
-        # Should NOT merge (blocks because ignore is dependabot-specific)
+        # Test Case D: Same old pending suite but PR is non-Dependabot platform specific approved PR
+        # Should MERGE (stale-suite ignore applies to all PRs)
+        platform_files = [
+            self.create_mock_file("src/platform/nxp/SystemTimeSupport.cpp")
+        ]
         mock_human_pr = self.create_mock_pr(
             2,
             "Platform changes",
             "doru91",
-            files,
+            platform_files,
             [self.create_mock_review("nxpdev", "APPROVED")],
         )
         self.mock_commit.get_check_suites.return_value = [
-            mock_non_critical_old_pending
-        ] + [mock_success_suite] * 9
+            mock_mergify_old_pending,
+            mock_non_critical_old_pending,
+        ] + [mock_success_suite] * 8
         self.bot.check_and_process_pr(mock_human_pr)
-        mock_human_pr.merge.assert_not_called()
+        mock_human_pr.merge.assert_called_once()
         mock_human_pr.reset_mock()
 
         # Test Case E: Old pending suite from unallowed app


### PR DESCRIPTION
### Summary

Fixes platform auto-merge being blocked by indefinitely queued Mergify check suites even when CI is green.

#### Problem

- The PR checker bot treats any non-completed GitHub **check suite** as failed CI.
- Mergify registers a check suite on commits that often stays in `queued` forever.
  - In the Checks UI this commonly appears as **Mergify Merge Protections → skipping**.
  - Via the Check Suites API it remains `status: queued` / never `completed`.
- Stale-suite ignoring previously applied **only to Dependabot PRs**, and **Mergify was not allowlisted**.
- Result for otherwise eligible platform PRs (path-scoped + maintainer approval + green Actions):
  - Bot posted/updated eligibility comments with **CI checks are pending or failed**.
  - Auto-merge never ran (e.g. [#73223](https://github.com/project-chip/connectedhomeip/pull/73223)).

#### Solution
- Added `Mergify` to `IGNORED_STALE_SUITE_APPS`.
- Applied the stale-suite timeout (`STALE_SUITE_TIMEOUT`, 6h) to **all** PRs, not only Dependabot.
- Real CI/actions still blocks merge if not completed / not successful.

### Testing
- Updated `test_check_ci_ignores_old_non_critical_pending_suites` in `scripts/tools/tests/test_pr_checker_bot.py`:
- Covers stale Mergify suites.
- Asserts a non-Dependabot platform PR merges when only stale allowlisted suites are pending.