### PR TITLE
[dnssd] Add typed record-data writers to wire::RecordWriter

### DIFF
--- a/src/lib/dnssd/minimal_mdns/records/IP.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/IP.cpp
@@ -22,17 +22,7 @@ namespace Minimal {
 
 bool IPResourceRecord::WriteData(RecordWriter & out) const
 {
-    // IP address is already stored in network byte order, hence raw bytes put
-    if (mIPAddress.IsIPv6())
-    {
-        out.Put(BytesRange::BufferWithSize(mIPAddress.Addr, 16));
-    }
-    else
-    {
-        out.Put(BytesRange::BufferWithSize(mIPAddress.Addr + 3, 4));
-    }
-
-    return out.Fit();
+    return out.PutIpAddress(mIPAddress).Fit();
 }
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/records/Ptr.h
+++ b/src/lib/dnssd/minimal_mdns/records/Ptr.h
@@ -30,7 +30,7 @@ public:
     const FullQName & GetPtr() const { return mPtrName; }
 
 protected:
-    bool WriteData(RecordWriter & out) const override { return out.WriteQName(mPtrName).Fit(); }
+    bool WriteData(RecordWriter & out) const override { return out.PutPtr(mPtrName).Fit(); }
 
 private:
     const FullQName mPtrName;

--- a/src/lib/dnssd/minimal_mdns/records/ResourceRecord.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/ResourceRecord.cpp
@@ -41,14 +41,13 @@ bool ResourceRecord::Append(HeaderRef & hdr, ResourceType asType, RecordWriter &
         .Put32(static_cast<uint32_t>(GetTtl()))   //
         ;
 
-    chip::Encoding::BigEndian::BufferWriter sizeOutput(out.Writer()); // copy to re-output size
-    out.Put16(0);                                                     // dummy, will be replaced later
+    chip::Encoding::BigEndian::BufferWriter sizeOutput = out.ReserveRdlength();
 
     if (!WriteData(out))
     {
         return false;
     }
-    sizeOutput.Put16(static_cast<uint16_t>(out.Writer().Needed() - sizeOutput.Needed() - 2));
+    out.FinishRdlength(sizeOutput);
 
     // This MUST be final and separated out: record count is only updated on success.
     if (out.Fit())

--- a/src/lib/dnssd/minimal_mdns/records/Srv.h
+++ b/src/lib/dnssd/minimal_mdns/records/Srv.h
@@ -40,10 +40,7 @@ public:
     void SetWeight(uint16_t value) { mWeight = value; }
 
 protected:
-    bool WriteData(RecordWriter & out) const override
-    {
-        return out.Put16(mPriority).Put16(mWeight).Put16(mPort).WriteQName(mServerName).Fit();
-    }
+    bool WriteData(RecordWriter & out) const override { return out.PutSrv(mPriority, mWeight, mPort, mServerName).Fit(); }
 
 private:
     FullQName mServerName;

--- a/src/lib/dnssd/minimal_mdns/records/Txt.h
+++ b/src/lib/dnssd/minimal_mdns/records/Txt.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include <string.h>
-
 #include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
+#include <lib/support/Span.h>
 
 namespace mdns {
 namespace Minimal {
@@ -52,26 +51,11 @@ public:
     const char * const * GetEntries() const { return mEntries; }
 
 protected:
-    bool WriteData(RecordWriter & out) const override
-    {
-        for (size_t i = 0; i < mEntryCount; i++)
-        {
-            size_t len = strlen(mEntries[i]);
-            if (len > kMaxTxtRecordLength)
-            {
-                return false;
-            }
-
-            out.Put8(static_cast<uint8_t>(len)).PutString(mEntries[i]);
-        }
-        return out.Fit();
-    }
+    bool WriteData(RecordWriter & out) const override { return out.PutTxt(chip::Span<const char * const>(mEntries, mEntryCount)); }
 
 private:
     const char * const * mEntries;
     const size_t mEntryCount;
-
-    static constexpr size_t kMaxTxtRecordLength = 63;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/wire/BUILD.gn
+++ b/src/lib/dnssd/wire/BUILD.gn
@@ -33,6 +33,5 @@ static_library("wire") {
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support:span",
-    "${chip_root}/src/platform",
   ]
 }

--- a/src/lib/dnssd/wire/RecordWriter.cpp
+++ b/src/lib/dnssd/wire/RecordWriter.cpp
@@ -16,6 +16,8 @@
  */
 #include "RecordWriter.h"
 
+#include <cstring>
+
 namespace mdns {
 namespace Minimal {
 
@@ -121,6 +123,55 @@ RecordWriter & RecordWriter::WriteQName(const SerializedQNameIterator & qname)
         RememberWrittenQnameOffset(qNameWriteStart);
     }
     return *this;
+}
+
+chip::Encoding::BigEndian::BufferWriter RecordWriter::ReserveRdlength()
+{
+    // Copy the current writer so its position marks where the length must go,
+    // then emit a placeholder that FinishRdlength() will overwrite.
+    chip::Encoding::BigEndian::BufferWriter rdlengthPosition(*mOutput);
+    mOutput->Put16(0);
+    return rdlengthPosition;
+}
+
+void RecordWriter::FinishRdlength(chip::Encoding::BigEndian::BufferWriter & rdlengthPosition)
+{
+    // Bytes written after the 2-byte length field are the record data length.
+    rdlengthPosition.Put16(static_cast<uint16_t>(mOutput->Needed() - rdlengthPosition.Needed() - 2));
+}
+
+RecordWriter & RecordWriter::PutSrv(uint16_t priority, uint16_t weight, uint16_t port, const FullQName & server)
+{
+    return Put16(priority).Put16(weight).Put16(port).WriteQName(server);
+}
+
+RecordWriter & RecordWriter::PutPtr(const FullQName & name)
+{
+    return WriteQName(name);
+}
+
+RecordWriter & RecordWriter::PutIpAddress(const chip::Inet::IPAddress & address)
+{
+    // Address bytes are already stored in network byte order.
+    if (address.IsIPv6())
+    {
+        return Put(BytesRange::BufferWithSize(address.Addr, 16));
+    }
+    return Put(BytesRange::BufferWithSize(address.Addr + 3, 4));
+}
+
+bool RecordWriter::PutTxt(chip::Span<const char * const> entries)
+{
+    for (const char * entry : entries)
+    {
+        size_t len = strlen(entry);
+        if (len > kMaxTxtRecordLength)
+        {
+            return false;
+        }
+        Put8(static_cast<uint8_t>(len)).PutString(entry);
+    }
+    return Fit();
 }
 
 void RecordWriter::RememberWrittenQnameOffset(size_t offset)

--- a/src/lib/dnssd/wire/RecordWriter.h
+++ b/src/lib/dnssd/wire/RecordWriter.h
@@ -88,7 +88,7 @@ public:
 
     // Maximum length of a single TXT character-string entry.
     // Per DNS-SD TXT Record Size (RFC 6763), it is suggested to keep the length of a single TXT entry small.
-    // While it can be larger than 63, this is the current value used in lib/dnssd/minimal_mdns/records/Txt.h.
+    // While it can be larger than 63, it was the value previously used in lib/dnssd/minimal_mdns/records/Txt.h.
     // TODO : I could not find any reference to why 63 is used. This shall be re-visited during ULD implementation.
     static constexpr size_t kMaxTxtRecordLength = 63;
 

--- a/src/lib/dnssd/wire/RecordWriter.h
+++ b/src/lib/dnssd/wire/RecordWriter.h
@@ -16,9 +16,11 @@
  */
 #pragma once
 
+#include <inet/IPAddress.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/dnssd/wire/QName.h>
 #include <lib/support/BufferWriter.h>
+#include <lib/support/Span.h>
 
 #include <optional>
 
@@ -83,6 +85,73 @@ public:
         mOutput->Put(range.Start(), range.Size());
         return *this;
     }
+
+    // Maximum length of a single TXT character-string entry.
+    // Per DNS-SD TXT Record Size (RFC 6763), it is suggested to keep the length of a single TXT entry small.
+    // While it can be larger than 63, this is the current value used in lib/dnssd/minimal_mdns/records/Txt.h.
+    // TODO : I could not find any reference to why 63 is used. This shall be re-visited during ULD implementation.
+    static constexpr size_t kMaxTxtRecordLength = 63;
+
+    /**
+     * @brief Writes a placeholder 16-bit RDLENGTH field.
+     *
+     * @return A BufferWriter positioned at the reserved RDLENGTH. After the record
+     *         data has been written, pass this value to FinishRdlength() to
+     *         backpatch the actual data length.
+     */
+    chip::Encoding::BigEndian::BufferWriter ReserveRdlength();
+
+    /**
+     * @brief Backpatches the RDLENGTH reserved by ReserveRdlength().
+     *
+     * Writes the number of bytes written to the underlying output since the
+     * reservation into the previously reserved 16-bit length field.
+     *
+     * @param[in,out] rdlengthPosition BufferWriter returned by ReserveRdlength().
+     */
+    void FinishRdlength(chip::Encoding::BigEndian::BufferWriter & rdlengthPosition);
+
+    /**
+     * @brief Writes SRV record data (priority, weight, port, target name).
+     *
+     * The target name is subject to qname compression.
+     *
+     * @param[in] priority SRV priority field.
+     * @param[in] weight   SRV weight field.
+     * @param[in] port     SRV port field.
+     * @param[in] server   Target host name.
+     *
+     * @return Reference to this writer for chaining.
+     */
+    RecordWriter & PutSrv(uint16_t priority, uint16_t weight, uint16_t port, const FullQName & server);
+
+    /**
+     * @brief Writes PTR record data (a single target name).
+     *
+     * The target name may be qname-compressed.
+     *
+     * @param[in] name Target name.
+     *
+     * @return Reference to this writer for chaining.
+     */
+    RecordWriter & PutPtr(const FullQName & name);
+
+    /**
+     * @brief Writes A or AAAA record data for the given address.
+     *
+     * Emits 4 (IPv4) or 16 (IPv6) address bytes in network byte order, selected
+     * by the address family.
+     *
+     * @param[in] address IP address to encode.
+     *
+     * @return Reference to this writer for chaining.
+     */
+    RecordWriter & PutIpAddress(const chip::Inet::IPAddress & address);
+
+    /// Writes TXT record data as a sequence of length-prefixed character-strings.
+    /// Returns false (writing nothing further) if any entry exceeds
+    /// kMaxTxtRecordLength.
+    bool PutTxt(chip::Span<const char * const> entries);
 
     inline bool Fit() const { return mOutput->Fit(); }
 

--- a/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
@@ -215,6 +215,7 @@ TEST(TestRecordWriter, PutPtr)
     EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
 
+#if INET_CONFIG_ENABLE_IPV4
 TEST(TestRecordWriter, PutIpAddressV4)
 {
     chip::Inet::IPAddress addr;
@@ -232,6 +233,7 @@ TEST(TestRecordWriter, PutIpAddressV4)
     EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
     EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
+#endif
 
 TEST(TestRecordWriter, PutIpAddressV6)
 {

--- a/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
@@ -18,6 +18,9 @@
 
 #include <pw_unit_test/framework.h>
 
+#include <cstring>
+
+#include <inet/IPAddress.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/wire/RecordWriter.h>
 
@@ -161,6 +164,169 @@ TEST(TestRecordWriter, TonsOfReferences)
 
     EXPECT_TRUE(output.Fit());
     EXPECT_EQ(output.Needed(), 423u);
+}
+
+TEST(TestRecordWriter, PutSrv)
+{
+    const QNamePart kTarget[] = { "myserver", "local" };
+
+    uint8_t dataBuffer[128];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.PutSrv(1, 2, 3, FullQName(kTarget));
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        0, 1,                                   // priority
+        0, 2,                                   // weight
+        0, 3,                                   // port
+        8, 'm', 'y', 's', 'e', 'r', 'v', 'e', 'r',
+        5, 'l', 'o', 'c', 'a', 'l',
+        0,
+    };
+    // clang-format on
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, PutPtr)
+{
+    const QNamePart kName[] = { "ptr", "target" };
+
+    uint8_t dataBuffer[128];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.PutPtr(FullQName(kName));
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        3, 'p', 't', 'r',
+        6, 't', 'a', 'r', 'g', 'e', 't',
+        0,
+    };
+    // clang-format on
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, PutIpAddressV4)
+{
+    chip::Inet::IPAddress addr;
+    ASSERT_TRUE(chip::Inet::IPAddress::FromString("10.20.30.40", addr));
+
+    uint8_t dataBuffer[32];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.PutIpAddress(addr);
+
+    const uint8_t expectedOutput[] = { 10, 20, 30, 40 };
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, PutIpAddressV6)
+{
+    chip::Inet::IPAddress addr;
+    ASSERT_TRUE(chip::Inet::IPAddress::FromString("fe80::1", addr));
+
+    uint8_t dataBuffer[32];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.PutIpAddress(addr);
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+        0,    0,    0, 0, 0, 0, 0, 1,
+    };
+    // clang-format on
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, PutTxt)
+{
+    const char * kEntries[] = { "a=b", "flag" };
+
+    uint8_t dataBuffer[128];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    EXPECT_TRUE(writer.PutTxt(chip::Span<const char * const>(kEntries)));
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        3, 'a', '=', 'b',
+        4, 'f', 'l', 'a', 'g',
+    };
+    // clang-format on
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, PutTxtRejectsOverlongEntry)
+{
+    // Try to write a TXT entry that is one octet over kMaxTxtRecordLength.
+    char kLong[RecordWriter::kMaxTxtRecordLength + 2];
+    memset(kLong, 'a', RecordWriter::kMaxTxtRecordLength + 1);
+    kLong[RecordWriter::kMaxTxtRecordLength + 1] = '\0';
+    ASSERT_EQ(strlen(kLong), RecordWriter::kMaxTxtRecordLength + 1);
+    const char * kEntries[] = { kLong };
+
+    uint8_t dataBuffer[128];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    EXPECT_FALSE(writer.PutTxt(chip::Span<const char * const>(kEntries)));
+}
+
+TEST(TestRecordWriter, ReserveAndFinishRdlength)
+{
+    uint8_t dataBuffer[64];
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    auto rdlength = writer.ReserveRdlength();
+    writer.Put16(0xABCD).Put8(0x42); // 3 bytes of record data
+    writer.FinishRdlength(rdlength);
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        0, 3,               // backpatched RDLENGTH == 3
+        0xAB, 0xCD, 0x42,   // record data
+    };
+    // clang-format on
+
+    EXPECT_TRUE(output.Fit());
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestRecordWriter, BufferTooSmall)
+{
+    const QNamePart kTarget[] = { "myserver", "local" };
+
+    uint8_t dataBuffer[4]; // far too small for an SRV record
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.PutSrv(1, 2, 3, FullQName(kTarget));
+
+    EXPECT_FALSE(output.Fit());
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

##### Problem
-`RecordWriter` only exposes low-level primitives (`WriteQName`, `Put8`/`Put16`/`Put32`).
- Typed record RDATA (SRV, PTR, A/AAAA, TXT) and RDLENGTH backpatching are duplicated in `minimal_mdns/records` (`ResourceRecord::Append` and each subclass `WriteData`), and would be re-duplicated by the upcoming Unicast Local Discovery (ULD / SRP-on-infrastructure) UPDATE writer.
- Without shared helpers, every consumer reimplements the same wire encoding and the same RDLENGTH placeholder/backpatch pattern.

##### Solution
- Extend `RecordWriter` with additive typed record-data helpers and an explicit RDLENGTH framing API:
  - `ReserveRdlength` / `FinishRdlength` for the placeholder + backpatch pattern.
  - `PutSrv`, `PutPtr`, `PutIpAddress` and `PutTxt`
- Reroute minimal DNS record serialization the new `RecordWriter` helpers
  - `ResourceRecord::Append`: `ReserveRdlength()` / `FinishRdlength()` replace the manual `BufferWriter` copy and length arithmetic.
  - `SrvResourceRecord::WriteData` -> `PutSrv()`
  - `PtrResourceRecord::WriteData` -> `PutPtr()`
  - `IPResourceRecord::WriteData` -> `PutIpAddress()`
  - `TxtResourceRecord::WriteData` -> `PutTxt()` 

#### Testing
- Extended `src/lib/dnssd/wire/tests/TestRecordWriter.cpp` with tests for `PutSrv`, `PutPtr`, `PutIpAddress` (v4 and v6), `PutTxt`, `ReserveRdlength`/`FinishRdlength`.
- Built and ran `src/lib/dnssd/minimal_mdns/records/tests`, `src/lib/dnssd/wire/tests`, `src/lib/dnssd/minimal_mdns/tests`, and `src/lib/dnssd/tests`. All pass.