### PR TITLE
[TC-DD-3.5, 3.6, 3.7, 3.8] Yaml Manual script have been updated as per the Test plan by removing the  "MCORE.COM.WIRELESS" PICS

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DD_3_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_5.yaml
@@ -133,7 +133,6 @@ tests:
     - label:
           "Step 5: Commissioner SHALL configure regulatory information in the
           Commissionee."
-      PICS: MCORE.COM.WIRELESS
       verification: |
           Verify in TH (ALL-CLUSTER-APP)
            NVS set: chip-config/regulatory-location = 0 (0x0)

--- a/src/app/tests/suites/certification/Test_TC_DD_3_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_6.yaml
@@ -104,7 +104,6 @@ tests:
     - label:
           "Step 5: Commissioner SHALL configure regulatory information in the
           Commissionee."
-      PICS: MCORE.COM.WIRELESS
       verification: |
           Verify in DUT as commissioner side
 

--- a/src/app/tests/suites/certification/Test_TC_DD_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_7.yaml
@@ -316,7 +316,6 @@ tests:
     - label:
           "Step 9: Commissioner SHALL configure regulatory information in the
           Commissionee."
-      PICS: MCORE.COM.WIRELESS
       verification: |
           Verify in DUT as client side
 

--- a/src/app/tests/suites/certification/Test_TC_DD_3_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_8.yaml
@@ -103,7 +103,6 @@ tests:
     - label:
           "Step 5: Commissioner SHALL configure regulatory information in the
           Commissionee."
-      PICS: MCORE.COM.WIRELESS
       verification: |
           Verify in DUT as client side
 
@@ -433,7 +432,6 @@ tests:
     - label:
           "Step 15: Commissioner SHALL configure regulatory information in the
           Commissionee."
-      PICS: MCORE.COM.WIRELESS
       verification: |
           Verify in DUT as client side
 


### PR DESCRIPTION
### Summary

In following DD test cases **MCORE.COM.WIRELESS** PICS have been removed from few steps as per the Test plan.

TC-DD-3.5 - In Step 5 MCORE.COM.WIRELESS PICS have been removed.
TC-DD-3.6 - In Step 5 MCORE.COM.WIRELESS PICS have been removed.
TC-DD-3.7 - In Step 9 MCORE.COM.WIRELESS PICS have been removed.
TC-DD-3.8 - In Step 5, 15 MCORE.COM.WIRELESS PICS have been removed.

### Related issues
https://github.com/project-chip/matter-test-scripts/issues/796


### Testing


