### PR TITLE
[ConnectivityManager] Add accessors for Thread and external network interfaces

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include <app/icd/server/ICDServerConfig.h>
+#include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>
@@ -222,6 +223,10 @@ public:
     bool IsThreadProvisioned();
     void ErasePersistentInfo();
     void ResetThreadNetworkDiagnosticsCounts();
+
+    // Network interface accessors (primarily meaningful on LwIP platforms).
+    Inet::InterfaceId GetThreadInterface();
+    Inet::InterfaceId GetExternalInterface();
 
     CHIP_ERROR SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 
@@ -544,6 +549,15 @@ inline void ConnectivityManager::ErasePersistentInfo()
 inline void ConnectivityManager::ResetThreadNetworkDiagnosticsCounts()
 {
     static_cast<ImplClass *>(this)->_ResetThreadNetworkDiagnosticsCounts();
+}
+
+inline Inet::InterfaceId ConnectivityManager::GetThreadInterface()
+{
+    return Inet::InterfaceId::Null();
+}
+inline Inet::InterfaceId ConnectivityManager::GetExternalInterface()
+{
+    return Inet::InterfaceId::Null();
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include <app/icd/server/ICDServerConfig.h>
+#include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>
@@ -222,6 +223,10 @@ public:
     bool IsThreadProvisioned();
     void ErasePersistentInfo();
     void ResetThreadNetworkDiagnosticsCounts();
+
+    // Network interface accessors (primarily meaningful on LwIP platforms).
+    Inet::InterfaceId GetThreadInterface();
+    Inet::InterfaceId GetExternalInterface();
 
     CHIP_ERROR SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 
@@ -544,6 +549,15 @@ inline void ConnectivityManager::ErasePersistentInfo()
 inline void ConnectivityManager::ResetThreadNetworkDiagnosticsCounts()
 {
     static_cast<ImplClass *>(this)->_ResetThreadNetworkDiagnosticsCounts();
+}
+
+inline Inet::InterfaceId ConnectivityManager::GetThreadInterface()
+{
+    return static_cast<ImplClass *>(this)->_GetThreadInterface();
+}
+inline Inet::InterfaceId ConnectivityManager::GetExternalInterface()
+{
+    return static_cast<ImplClass *>(this)->_GetExternalInterface();
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF

--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <inet/InetInterface.h>
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -47,6 +49,8 @@ public:
     uint16_t _GetUserSelectedModeTimeout();
     void _SetUserSelectedModeTimeout(uint16_t val);
     CHIP_ERROR _DisconnectNetwork();
+    Inet::InterfaceId _GetThreadInterface();
+    Inet::InterfaceId _GetExternalInterface();
 
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -76,6 +80,18 @@ template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_DisconnectNetwork()
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline Inet::InterfaceId GenericConnectivityManagerImpl<ImplClass>::_GetThreadInterface()
+{
+    return Inet::InterfaceId::Null();
+}
+
+template <class ImplClass>
+inline Inet::InterfaceId GenericConnectivityManagerImpl<ImplClass>::_GetExternalInterface()
+{
+    return Inet::InterfaceId::Null();
 }
 
 } // namespace Internal


### PR DESCRIPTION
### Summary

On LwIP-based platforms, network interfaces are commonly identified by their netif name. Name-based lookup is fragile, as interfaces are usually named by vendor specific implementation.
These new accessors let a platform report its Thread and external interfaces explicitly, avoiding name comparisons and the need for a possible lookup update when interface names change.

These accessors have also a default implementation, so platforms that do not override them are unaffected.

### Testing
Verified on a FreeRTOS application, NXP border router application that runs on RW612 and has both Wi-Fi and Thread interfaces enabled.

From NXP's ConnectivityManagerImpl.cpp file, both external and internal interfaces have been set, and those are retrieved using the following commands (DnssdImplBr.cpp file). There is also a draft PR under work which implements this: https://github.com/project-chip/connectedhomeip/pull/73447
 ```
 mExternalNetIf = ConnectivityMgr().GetExternalInterface();
 mThreadNetIf   = ConnectivityMgr().GetThreadInterface();
 ```

In the test setup, there are two RW612 devices that run Matter OTBR application.
On one device, this matter service is registered and available:
```
Service D7F36BEEFC89B9BE-0000000000000002 for _matter._tcp
    host: 96E2AD50E1669444
    1 sub-type:
        _ID7F36BEEFC89B9BE
    port: 5540
    priority: 0
    weight: 0
    ttl: 120
    txt-data: 085349493d32303030085341493d32303030085341543d34303030
    state: registered
```
and it has the following addresses:
```
otcli mdns localhostaddrs
fe80:0:0:0:c295:daff:fe01:24a8
fd11:1111:1122:2222:c295:daff:fe01:24a8
```

From the second device, on which this new implementation is tested, the following command is issued:
`dns resolve 15560899811678468542 2`
having the following outcome:
```
dns resolve 15560899811678468542 2
Resolving ...
Done
> DNS resolve for D7F36BEEFC89B9BE-0000000000000002 succeeded:
Resolve completed: UDP:[fe80::c295:daff:fe01:24a8%ml2]:5540
   Supports TCP Client:  NO
   Supports TCP Server:  NO
   MRP IDLE retransmit timeout:   2000 ms
   MRP ACTIVE retransmit timeout: 2000 ms
   MRP ACTIVE Threshold time:     4000 ms
   ICD is operating as a:         SIT
  ```
  
  NXP's border router implementation makes use of OpenThread's native mDNS module.
When a response is received, ```mInterface``` field from ```struct DnssdService``` is populated with the incoming interface, `external` if response came from mDNS, `internal` if response was received from SRP cache.
  
 Resolve completed shows the correct device IPv6 address and interface.
 
 Adding lwIP's global variable ```netif_list``` to watch, we can see that interface name is ```ml``` and num is ```2```, same as reported on CLI.
 
<img width="718" height="662" alt="image" src="https://github.com/user-attachments/assets/b30bcaea-a2fd-4af3-93f8-b54775119916" />

Build command:
```
west build -d build_matter_otbr -b frdmrw612 examples/thermostat/nxp   --   -DCONF_FILE_NAME=prj_thread_ftd_wifi_br_ota.conf   -DCONFIG_DEBUG=y
```

flashing using j-link:
```
exec EnableEraseAllFlashBanks
erase 0x8020000, 0x88a0000
loadfile "mcuboot_opensource.elf"
loadfile "app_SIGNED.bin" 0x8020000
```
