### PR TITLE
[inet] Add GetInterfaceIndex accessor

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -83,6 +83,12 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
 
     return CHIP_NO_ERROR;
 }
+
+uint32_t InterfaceId::GetInterfaceIndex() const
+{
+    return static_cast<uint32_t>(mPlatformInterface);
+}
+
 CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
 {
     if (strlen(intfName) < 3)
@@ -227,6 +233,11 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
     }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
+}
+
+uint32_t InterfaceId::GetInterfaceIndex() const
+{
+    return mPlatformInterface ? netif_get_index(mPlatformInterface) : 0;
 }
 
 CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
@@ -480,6 +491,11 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
     }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
+}
+
+uint32_t InterfaceId::GetInterfaceIndex() const
+{
+    return static_cast<uint32_t>(mPlatformInterface);
 }
 
 CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
@@ -837,6 +853,11 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
     }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
+}
+
+uint32_t InterfaceId::GetInterfaceIndex() const
+{
+    return static_cast<uint32_t>(mPlatformInterface);
 }
 
 CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -143,6 +143,12 @@ public:
     CHIP_ERROR GetInterfaceName(char * nameBuf, size_t nameBufSize) const;
 
     /**
+     * Get the numeric platform interface index (e.g. for APIs that require an
+     * interface/scope index). Returns 0 for the null interface.
+     */
+    uint32_t GetInterfaceIndex() const;
+
+    /**
      * Search the list of network interfaces for the indicated name.
      *
      * @param[in]   intfName    Name of the network interface to find.

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -142,6 +142,7 @@ TEST_F(TestInetEndPoint, TestInetInterface)
     InterfaceId intId;
     IPAddress addr{};
     InterfaceType intType;
+    uint32_t intIndex;
     // 64 bit IEEE MAC address
     const uint8_t kMaxHardwareAddressSize = 8;
     uint8_t intHwAddress[kMaxHardwareAddressSize];
@@ -161,6 +162,9 @@ TEST_F(TestInetEndPoint, TestInetInterface)
     err = InterfaceId::Null().GetInterfaceName(intName, sizeof(intName));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(intName[0], '\0');
+
+    // A Null interface must always report index 0.
+    EXPECT_EQ(InterfaceId::Null().GetInterfaceIndex(), 0u);
 
     intId = InterfaceId::FromIPAddress(addr);
     EXPECT_FALSE(intId.IsPresent());
@@ -188,6 +192,9 @@ TEST_F(TestInetEndPoint, TestInetInterface)
         err = intId.GetLinkLocalAddr(&addr);
         EXPECT_TRUE(err == CHIP_NO_ERROR || err == INET_ERROR_ADDRESS_NOT_FOUND);
         InterfaceId::MatchLocalIPv6Subnet(addr);
+
+        intIndex = intId.GetInterfaceIndex();
+        EXPECT_NE(intIndex, 0u);
 
         // Not all platforms support getting interface type and hardware address
         err = intIterator.GetInterfaceType(intType);


### PR DESCRIPTION
### Summary

Add a portable GetInterfaceIndex() accessor to InterfaceId that returns the numeric platform interface/scope index as a uint32_t (0 for the null interface). Implemented for all platform variants; the LwIP variant maps the underlying struct netif* to an index via netif_get_index().


### Testing
Verified on both FreeRTOS and Zephyr applications.
