### PR TITLE
[Zephyr][WiFi] Report IPv6 internet connectivity changes from WiFiManager

### DIFF
--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    Copyright (c) 2024-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -194,6 +194,11 @@ void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mg
 void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
 #endif
 {
+    if (iface != Instance().mNetIf)
+    {
+        return; // should only handle events originating from Wi-Fi interface if there are multiple interfaces available
+    }
+
     if (((mgmtEvent == NET_EVENT_IPV6_ADDR_ADD) || (mgmtEvent == NET_EVENT_IPV6_ADDR_DEL)) && cb->info)
     {
         IPv6AddressChangeHandler(cb->info);
@@ -646,7 +651,38 @@ void WiFiManager::IPv6AddressChangeHandler(const void * data)
         {
             ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
         }
+
+        UpdateIpv6InternetConnectivityState();
     }
+}
+
+void WiFiManager::UpdateIpv6InternetConnectivityState()
+{
+    net_if * iface = Instance().mNetIf;
+    VerifyOrReturn(iface != nullptr);
+
+    struct net_if * found = iface;
+    const bool hasGlobal  = (net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &found) != nullptr);
+
+    // Report only on transition so we emit Established/Lost exactly once.
+    if (hasGlobal == Instance().mHasGlobalIPv6Address)
+    {
+        return;
+    }
+
+    ChipDeviceEvent event{};
+    event.Type                            = DeviceEventType::kInternetConnectivityChange;
+    event.InternetConnectivityChange.IPv4 = kConnectivity_NoChange;
+    event.InternetConnectivityChange.IPv6 = hasGlobal ? kConnectivity_Established : kConnectivity_Lost;
+
+    CHIP_ERROR error = PlatformMgr().PostEvent(&event);
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
+        return; // next event will re-attempt the transition
+    }
+
+    Instance().mHasGlobalIPv6Address = hasGlobal;
 }
 
 WiFiManager::StationStatus WiFiManager::GetStationStatus() const

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -194,6 +194,11 @@ void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mg
 void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
 #endif
 {
+    if (iface != Instance().mNetIf)
+    {
+        return; // should only handle events originating from Wi-Fi interface if there are multiple interfaces available
+    }
+
     if (((mgmtEvent == NET_EVENT_IPV6_ADDR_ADD) || (mgmtEvent == NET_EVENT_IPV6_ADDR_DEL)) && cb->info)
     {
         IPv6AddressChangeHandler(cb->info);
@@ -646,6 +651,35 @@ void WiFiManager::IPv6AddressChangeHandler(const void * data)
         {
             ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
         }
+
+        UpdateIpv6InternetConnectivityState();
+    }
+}
+
+void WiFiManager::UpdateIpv6InternetConnectivityState()
+{
+    net_if * iface = Instance().mNetIf;
+    VerifyOrReturn(iface != nullptr);
+
+    struct net_if * found  = iface;
+    const bool hasRoutable = (net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &found) != nullptr);
+
+    // Report only on transition so we emit Established/Lost exactly once.
+    if (hasRoutable == Instance().mHasRoutableIPv6Address)
+    {
+        return;
+    }
+    Instance().mHasRoutableIPv6Address = hasRoutable;
+
+    ChipDeviceEvent event{};
+    event.Type                            = DeviceEventType::kInternetConnectivityChange;
+    event.InternetConnectivityChange.IPv4 = kConnectivity_NoChange;
+    event.InternetConnectivityChange.IPv6 = hasRoutable ? kConnectivity_Established : kConnectivity_Lost;
+
+    CHIP_ERROR err = PlatformMgr().PostEvent(&event);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/Zephyr/wifi/WiFiManager.h
+++ b/src/platform/Zephyr/wifi/WiFiManager.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2024, 2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -229,6 +229,7 @@ private:
     static void PostConnectivityStatusChange(ConnectivityChange changeType);
     static void SendRouterSolicitation(System::Layer * layer, void * param);
     static void IPv6AddressChangeHandler(const void * data);
+    static void UpdateIpv6InternetConnectivityState();
 
     // Connection Recovery feature
     // This feature allows re-scanning and re-connecting the connection to the known network after
@@ -262,6 +263,7 @@ private:
     uint32_t mConnectionRecoveryTimeMs{ kConnectionRecoveryMinIntervalMs };
     bool mApplicationDisconnectRequested{ false };
     uint16_t mLastDisconnectedReason;
+    bool mHasGlobalIPv6Address{ false };
 
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
 };

--- a/src/platform/Zephyr/wifi/WiFiManager.h
+++ b/src/platform/Zephyr/wifi/WiFiManager.h
@@ -229,6 +229,7 @@ private:
     static void PostConnectivityStatusChange(ConnectivityChange changeType);
     static void SendRouterSolicitation(System::Layer * layer, void * param);
     static void IPv6AddressChangeHandler(const void * data);
+    static void UpdateIpv6InternetConnectivityState(void);
 
     // Connection Recovery feature
     // This feature allows re-scanning and re-connecting the connection to the known network after
@@ -262,6 +263,7 @@ private:
     uint32_t mConnectionRecoveryTimeMs{ kConnectionRecoveryMinIntervalMs };
     bool mApplicationDisconnectRequested{ false };
     uint16_t mLastDisconnectedReason;
+    bool mHasRoutableIPv6Address{ false };
 
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
 };


### PR DESCRIPTION
### Summary

Adds `WiFiManager::UpdateIpv6InternetConnectivityState()` to the Zephyr Wi-Fi platform layer so the device emits Matter internet-connectivity events when its IPv6 reachability changes.

On an IPv6 address change, the handler now checks for a routable (non-link-local) global IPv6 address via `net_if_ipv6_get_global_addr()`.
Tracks the current routable state in `mHasRoutableIPv6Address` and posts a `kInternetConnectivityChange` event only on transitions, so `Established` / `Lost` is reported exactly once (no duplicate events).

### Testing

Verified on Zephyr Wi-Fi application: connecting/disconnecting and gaining/losing a global IPv6 address produces a single `Established`/`Lost` event per transition.
