### PR TITLE
[Zephyr] Minor build/portability fixes for Zephyr and newer mbedTLS

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLSCert.cpp
@@ -28,9 +28,16 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
+#include <mbedtls/version.h>
+
+// mbedtls/ecp.h (mbedtls_ecp_* symbols) is only used by the legacy non-PSA path
+// and became private in mbedTLS 4.1.0, so include it only before 4.1.0.
+#if (MBEDTLS_VERSION_NUMBER < 0x04010000)
+#include <mbedtls/ecp.h>
+#endif // (MBEDTLS_VERSION_NUMBER < 0x04010000)
+
 #include <mbedtls/oid.h>
 #include <mbedtls/pk.h>
-#include <mbedtls/version.h>
 #include <mbedtls/x509.h>
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x04000000)

--- a/src/platform/Zephyr/CHIPDevicePlatformConfig.h
+++ b/src/platform/Zephyr/CHIPDevicePlatformConfig.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "autoconf.h"
+#include <zephyr/autoconf.h>
 
 // ==================== Platform Adaptations ====================
 
@@ -87,13 +87,13 @@
 #define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER CONFIG_CHIP_DEVICE_SPAKE2_TEST_VERIFIER
 #endif
 
-// Check if Zephyr app use NET_L2_OPENTHREAD
+// Check if Zephyr app uses OpenThread
 #ifndef CHIP_DEVICE_CONFIG_ENABLE_THREAD
-#ifdef CONFIG_NET_L2_OPENTHREAD
+#ifdef CONFIG_OPENTHREAD
 #define CHIP_DEVICE_CONFIG_ENABLE_THREAD 1
 #else
 #define CHIP_DEVICE_CONFIG_ENABLE_THREAD 0
-#endif // CONFIG_NET_L2_OPENTHREAD
+#endif // CONFIG_OPENTHREAD
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 // Check if Zephyr app use BT

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -60,6 +60,7 @@ namespace DeviceLayer {
 
 namespace {
 
+#if defined(CONFIG_THREAD_MONITOR)
 static void GetThreadInfo(const struct k_thread * thread, void * user_data)
 {
     size_t unusedStackSize;
@@ -91,6 +92,7 @@ static void GetThreadInfo(const struct k_thread * thread, void * user_data)
     threadMetrics->Next    = *threadMetricsListHead;
     *threadMetricsListHead = threadMetrics;
 }
+#endif // CONFIG_THREAD_MONITOR
 
 BootReasonType DetermineBootReason()
 {

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -83,7 +83,9 @@ public:
 };
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
+// Zephyr uses LayerImplZephyr (not LayerImplFreeRTOS), so exclude it here to
+// avoid referencing the undeclared FreeRTOS type on Thread-only Zephyr targets.
+#if (CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT) && !defined(__ZEPHYR__)
 
 template <class LayerImpl>
 class LayerEvents<LayerImpl, typename std::enable_if<std::is_base_of<LayerImplFreeRTOS, LayerImpl>::value>::type>
@@ -100,7 +102,7 @@ public:
     }
 };
 
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
+#endif // (CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT) && !defined(__ZEPHYR__)
 
 // Test input vector format.
 static const uint32_t MAX_NUM_TIMERS = 1000;


### PR DESCRIPTION
### Summary

Small, platform-independent build and portability fixes for the Zephyr
platform and newer mbedTLS versions. No functional/runtime behavior change;
each fix only affects compilation under specific configs.

### Changes

- **crypto (mbedTLS 4.1.0+):** `mbedtls/ecp.h` (the `mbedtls_ecp_*` symbols)
  became private in mbedTLS 4.1.0 and is only used by the legacy non-PSA path,
  so it is now included only for `MBEDTLS_VERSION_NUMBER < 0x04010000`.

- **Zephyr platform config:**
  - Include `<zephyr/autoconf.h>` instead of the bare `"autoconf.h"` to match
    the modern Zephyr include layout.
  - Derive `CHIP_DEVICE_CONFIG_ENABLE_THREAD` from `CONFIG_OPENTHREAD` rather
    than `CONFIG_NET_L2_OPENTHREAD`, so Thread is detected correctly on targets
    that use OpenThread without the L2 layer.

- **Zephyr DiagnosticDataProvider:** Guard the file-local `GetThreadInfo()`
  with `CONFIG_THREAD_MONITOR` (its only caller was already guarded). This
  avoids a `-Wunused-function` / `-Werror` build failure when the kernel shell
  (and therefore `THREAD_MONITOR`) is disabled.

- **TestSystemTimer:** The `LayerImplFreeRTOS` `LayerEvents` specialization is
  selected via `CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT`.
  On Zephyr the system layer is `LayerImplZephyr` and `LayerImplFreeRTOS` is
  never declared, so the specialization is now excluded with `!defined(__ZEPHYR__)`
  to fix the Thread-only Zephyr unit-test build.

### Testing

- Builds cleanly on existing Zephyr targets (Wi-Fi and Thread).
- No change to non-Zephyr builds or to runtime behavior.
