### PR TITLE
[Silabs] MATTER-6215: Refactor EVSE app (#1011)

### DIFF
--- a/examples/evse-app/esp32/main/main.cpp
+++ b/examples/evse-app/esp32/main/main.cpp
@@ -122,7 +122,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kS
 static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment);
 #endif
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -214,7 +214,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
 {
     if (!gCommonClustersInitialized)
     {
-        chip::BitMask<DeviceEnergyManagement::Feature> featureMap = GetFeatureMapFromCmdLine();
+        chip::BitMask<DeviceEnergyManagement::Feature> featureMap = GetFeatureMap();
         ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, featureMap));
 
         // Initialize ElectricalSensorManager (owns both EPM and EEM)

--- a/examples/evse-app/linux/main.cpp
+++ b/examples/evse-app/linux/main.cpp
@@ -61,7 +61,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kP
                                           Feature::kStartTimeAdjustment, Feature::kPausable, Feature::kForecastAdjustment,
                                           Feature::kConstraintBasedAdjustment);
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }

--- a/examples/evse-app/silabs/BUILD.gn
+++ b/examples/evse-app/silabs/BUILD.gn
@@ -83,6 +83,7 @@ if (wifi_soc) {
       "${examples_plat_dir}",
       "${chip_root}/src/lib",
       "${examples_common_plat_dir}",
+      "${examples_common_plat_dir}/customer",
       "${examples_common_plat_dir}/freertos_config",
     ]
 
@@ -107,6 +108,7 @@ if (wifi_soc) {
       "${examples_plat_dir}",
       "${chip_root}/src/lib",
       "${examples_common_plat_dir}",
+      "${examples_common_plat_dir}/customer",
       "${examples_common_plat_dir}/freertos_config",
     ]
 
@@ -133,6 +135,7 @@ silabs_executable("evse-app") {
 
   sources = [
     # Actual application code
+    "${examples_common_plat_dir}/customer/CustomerAppTask.cpp",
     "src/AppTask.cpp",
 
     # EVSE Common, will be moved to evse-common when we have code driven clusters for evse

--- a/examples/evse-app/silabs/README.md
+++ b/examples/evse-app/silabs/README.md
@@ -4,27 +4,33 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 EVSE Example](#matter-efr32-evse-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SEGGER RTT](#segger-rtt)
-        -   [Console Log](#console-log)
-            -   [Configuring the VCOM](#configuring-the-vcom)
-        -   [Using the console](#using-the-console)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Group Communication (Multicast)](#group-communication-multicast)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 EVSE Example](#matter-efr32-evse-example)
+  - [Introduction](#introduction)
+  - [Extending Base App Implementation](#extending-base-app-implementation)
+    -   [CustomerAppTask](#customerapptask)
+    -   [How to Override APIs](#how-to-override-apis)
+    -   [DataModelCallbacks and CustomerAppTask](#datamodelcallbacks-and-customerapptask)
+    -   [Sample Implementation](#sample-implementation)
+    -   [Override API Reference](#override-api-reference)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Running RPC console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Group Communication (Multicast)](#group-communication-multicast)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -52,6 +58,170 @@ Rendez-vous procedure.
 The EVSE examples is intended to serve both as a means to explore the workings
 of Matter EVSE as well as a template for creating real products based on the
 Silicon Labs platform.
+
+## Extending Base App Implementation
+
+### CustomerAppTask
+
+To implement custom app behavior you can override any Silicon Labs implemented
+API in the CustomerAppTask file. This example provides
+[`CustomerAppTask.h`](../../platform/silabs/customer/CustomerAppTask.h) and
+[`CustomerAppTask.cpp`](../../platform/silabs/customer/CustomerAppTask.cpp) for
+that purpose. The base implementation and the full set of overridable `*Impl()`
+APIs live in this example's source tree under
+[`include/AppTaskImpl.h`](include/AppTaskImpl.h) and
+[`src/AppTask.cpp`](src/AppTask.cpp). Any `*Impl()` you do not override keeps
+the Silicon Labs default behavior. To customize behavior, copy
+[`CustomerAppTask.h`](../../platform/silabs/customer/CustomerAppTask.h) and
+[`CustomerAppTask.cpp`](../../platform/silabs/customer/CustomerAppTask.cpp) from
+`examples/platform/silabs/customer/` into this app's `include/` and `src/`
+folders, then update the corresponding paths in `BUILD.gn`.
+
+### How to Override APIs
+
+`CustomerAppTask` derives from the base AppTask through the Curiously Recurring
+Template Pattern (CRTP). You override only the `*Impl()` methods you need, the
+base declares one `*Impl()` per overridable API. Steps:
+
+1. Find the method to override in the base API (see
+   [Override API reference](#override-api-reference) below).
+2. Declare the same method signature in `CustomerAppTask` in your
+   `CustomerAppTask.h` under `private:`. Match the base `*Impl()` signature
+   exactly — note that `*Impl()` overrides are **non-static instance methods**
+   even when the public dispatcher (e.g. `ButtonEventHandler`) is `static`.
+3. Implement the method in `CustomerAppTask.cpp`.
+4. Build. The CRTP layer automatically routes each call to your `*Impl()` if
+   present, otherwise to the Silicon Labs default.
+
+### DataModelCallbacks and CustomerAppTask
+
+What used to live in `DataModelCallbacks.cpp` now lives in `AppTask.cpp`. The
+Matter SDK's `MatterPostAttributeChangeCallback` is implemented in
+`examples/platform/silabs/BaseApplication.cpp` and forwards to
+`AppTask::DMPostAttributeChangeCallback` (defined in `AppTask.cpp`), which you
+can customize via `DMPostAttributeChangeCallbackImpl()` in `CustomerAppTask`.
+
+Forwarding into `AppTask` still goes through CRTP as in
+[How to Override APIs](#how-to-override-apis).
+
+-   **Methods that already exist in the AppTask** — Customize them by overriding
+    the matching `*Impl()` method in `CustomerAppTask`. Do not edit the
+    `AppTask.cpp` for app-specific behavior.
+
+-   **New custom data model methods** — Add them in `CustomerAppTask` directly.
+    Do not add new application logic in autogenerated sources; those edits will
+    not survive regeneration or project upgrades.
+
+### Sample Implementation
+
+The following shows a minimal example `CustomerAppTask` that overrides
+`AppInitImpl()` and `ButtonEventHandlerImpl()`.
+
+**CustomerAppTask.h**
+
+```cpp
+#pragma once
+#include "AppTaskImpl.h"
+
+/** Minimal AppTaskImpl-derived class. Override only the *Impl() methods you need **/
+class CustomerAppTask : public AppTaskImpl<CustomerAppTask>
+{
+public:
+    static CustomerAppTask & GetAppTask() { return sAppTask; }
+
+private:
+    friend class AppTaskImpl<CustomerAppTask>;
+    CHIP_ERROR AppInitImpl();
+    void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction);
+    static CustomerAppTask sAppTask;
+};
+```
+
+**CustomerAppTask.cpp**
+
+```cpp
+#include "CustomerAppTask.h"
+#include "AppTask.h"
+#include "AppEvent.h"
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+
+#define APP_FUNCTION_BUTTON 0
+#define APP_CONTROL_BUTTON 1
+
+CustomerAppTask CustomerAppTask::sAppTask;
+
+AppTask & AppTask::GetAppTask()
+{
+    return CustomerAppTask::GetAppTask();
+}
+
+CHIP_ERROR CustomerAppTask::AppInitImpl()
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (AppInitImpl)");
+    CHIP_ERROR err = AppTask::AppInit();
+    if (err == CHIP_NO_ERROR)
+    {
+        // Override the SDK default button handler registered in AppTask::AppInit().
+        chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(CustomerAppTask::ButtonEventHandler);
+    }
+    return err;
+}
+
+void CustomerAppTask::ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction)
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (ButtonEventHandlerImpl)");
+    AppEvent aEvent           = {};
+    aEvent.Type               = AppEvent::kEventType_Button;
+    aEvent.ButtonEvent.Action = btnAction;
+
+    if (button == APP_CONTROL_BUTTON && btnAction == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonPressed))
+    {
+        aEvent.Handler = &CustomerAppTask::EnergyManagementActionEventHandler;
+        AppTask::GetAppTask().PostEvent(&aEvent);
+    }
+    else if (button == APP_FUNCTION_BUTTON)
+    {
+        aEvent.Handler = BaseApplication::ButtonHandler;
+        AppTask::GetAppTask().PostEvent(&aEvent);
+    }
+}
+```
+
+### Override API Reference
+
+`CHIP_ERROR StartAppTask()` is declared on `AppTask` only. It is not an
+`*Impl()` hook: platform code (for example `MatterConfig`) calls
+`AppTask::GetAppTask().StartAppTask()` with static type `AppTask &`, which runs
+the implementation in `AppTask.cpp` (creating the FreeRTOS app task via
+`BaseApplication::StartAppTask(...)`). To change startup behavior, edit
+`AppTask::StartAppTask()` or `BaseApplication::StartAppTask` in your product
+sources.
+
+The base API and default AppTask behavior for this example are maintained under
+[`include/`](include/AppTaskImpl.h) and [`src/`](src/AppTask.cpp). Use them as
+the reference for overridable methods and app configuration.
+
+| File                                             | Purpose                                                                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`include/AppTaskImpl.h`](include/AppTaskImpl.h) | Declarations of every overridable `*Impl()` method. Copy the signatures you need from here into `CustomerAppTask.h`.                                 |
+| [`src/AppTask.cpp`](src/AppTask.cpp)             | Silicon Labs default implementation of AppTask. This is what runs for any `*Impl()` you do not override. Use as reference when customizing behavior. |
+
+### Energy Management Hardware Integration
+
+The CRTP `CustomerAppTask` pattern covers AppTask behavior. Energy management hardware
+integration (Power and Energy Measurement, Power Topology, and
+activating/deactivating the charging hardware in response to cluster commands) is not 
+currently routed through CRTP. Work is planned to route this functionality through the
+CRTP `CustomerAppTask` interface in the future.
+
+Until that follow up work is complete, manufacturers who need to connect real
+energy management hardware must edit the following shared delegate implementations
+directly:
+
+- [`examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp) 
+- [`examples/energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp)
+- [`examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp)
 
 ## Building
 

--- a/examples/evse-app/silabs/README.md
+++ b/examples/evse-app/silabs/README.md
@@ -4,33 +4,33 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 EVSE Example](#matter-efr32-evse-example)
-  - [Introduction](#introduction)
-  - [Extending Base App Implementation](#extending-base-app-implementation)
-    -   [CustomerAppTask](#customerapptask)
-    -   [How to Override APIs](#how-to-override-apis)
-    -   [DataModelCallbacks and CustomerAppTask](#datamodelcallbacks-and-customerapptask)
-    -   [Sample Implementation](#sample-implementation)
-    -   [Override API Reference](#override-api-reference)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Running RPC console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Group Communication (Multicast)](#group-communication-multicast)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 EVSE Example](#matter-efr32-evse-example)
+    -   [Introduction](#introduction)
+    -   [Extending Base App Implementation](#extending-base-app-implementation)
+        -   [CustomerAppTask](#customerapptask)
+        -   [How to Override APIs](#how-to-override-apis)
+        -   [DataModelCallbacks and CustomerAppTask](#datamodelcallbacks-and-customerapptask)
+        -   [Sample Implementation](#sample-implementation)
+        -   [Override API Reference](#override-api-reference)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Group Communication (Multicast)](#group-communication-multicast)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -209,19 +209,19 @@ the reference for overridable methods and app configuration.
 
 ### Energy Management Hardware Integration
 
-The CRTP `CustomerAppTask` pattern covers AppTask behavior. Energy management hardware
-integration (Power and Energy Measurement, Power Topology, and
-activating/deactivating the charging hardware in response to cluster commands) is not 
-currently routed through CRTP. Work is planned to route this functionality through the
-CRTP `CustomerAppTask` interface in the future.
+The CRTP `CustomerAppTask` pattern covers AppTask behavior. Energy management
+hardware integration (Power and Energy Measurement, Power Topology, and
+activating/deactivating the charging hardware in response to cluster commands)
+is not currently routed through CRTP. Work is planned to route this
+functionality through the CRTP `CustomerAppTask` interface in the future.
 
 Until that follow up work is complete, manufacturers who need to connect real
-energy management hardware must edit the following shared delegate implementations
-directly:
+energy management hardware must edit the following shared delegate
+implementations directly:
 
-- [`examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp) 
-- [`examples/energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp)
-- [`examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp)
+-   [`examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp)
+-   [`examples/energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp)
+-   [`examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp`](../../energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp)
 
 ## Building
 

--- a/examples/evse-app/silabs/include/AppTask.h
+++ b/examples/evse-app/silabs/include/AppTask.h
@@ -68,12 +68,12 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-        /**
+    /**
      * @brief Processes energy management button actions posted from ButtonEventHandler.
      *
      * @param aEvent button event being processed
      */
-     static void EnergyManagementActionEventHandler(AppEvent * aEvent);
+    static void EnergyManagementActionEventHandler(AppEvent * aEvent);
 
 protected:
     /**

--- a/examples/evse-app/silabs/include/AppTask.h
+++ b/examples/evse-app/silabs/include/AppTask.h
@@ -45,7 +45,8 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    static AppTask & GetAppTask() { return sAppTask; }
+    /** @brief Returns the active app instance */
+    static AppTask & GetAppTask();
 
     /**
      * @brief AppTask task main loop function
@@ -54,6 +55,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -66,12 +68,14 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-private:
-    static AppTask sAppTask;
-    static void EnergyManagementActionEventHandler(AppEvent * aEvent);
+        /**
+     * @brief Processes energy management button actions posted from ButtonEventHandler.
+     *
+     * @param aEvent button event being processed
+     */
+     static void EnergyManagementActionEventHandler(AppEvent * aEvent);
 
-    static void UpdateClusterState(intptr_t context);
-
+protected:
     /**
      * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
@@ -79,20 +83,6 @@ private:
      */
     CHIP_ERROR AppInit() override;
 
-    /**
-     * @brief PB0 Button event processing function
-     *        Press and hold will trigger a factory reset timer start
-     *        Press and release will restart BLEAdvertising if not commisionned
-     *
-     * @param aEvent button event being processed
-     */
-    static void ButtonHandler(AppEvent * aEvent);
-
-    /**
-     * @brief PB1 Button event processing function
-     *        Function triggers a switch action sent to the CHIP task
-     *
-     * @param aEvent button event being processed
-     */
-    static void SwitchActionEventHandler(AppEvent * aEvent);
+    /** @brief Application bring up. Locks the stack and calls EvseApplicationInit(). */
+    void ApplicationInit();
 };

--- a/examples/evse-app/silabs/include/AppTaskImpl.h
+++ b/examples/evse-app/silabs/include/AppTaskImpl.h
@@ -1,0 +1,74 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "AppEvent.h"
+#include "AppTask.h"
+#include "CRTPHelpers.h"
+
+/**
+ * @brief CRTP override layer for `AppTask`.
+ *
+ * Each public entry point dispatches to a corresponding `Derived::*Impl()` hook.
+ * The default `*Impl()` (declared private below) forwards to `AppTask`, so
+ * `Derived` only needs to override the hooks whose behavior it wants to
+ * customize.
+ *
+ * Customer code overrides these hooks in `CustomerAppTask`; see the app README
+ * ("How to Override APIs").
+ *
+ * @tparam Derived The CRTP derived class (`CustomerAppTask`).
+ */
+template <typename Derived>
+class AppTaskImpl : public AppTask
+{
+public:
+    // Common AppTask bring up
+    CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
+
+    // Application bring up, invoked from AppInit
+    void ApplicationInit() { CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, ApplicationInitImpl); }
+
+    // Handle button press
+    static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+    {
+        CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
+    }
+
+    // AppTask thread event handler for energy management button actions
+    static void EnergyManagementActionEventHandler(AppEvent * aEvent)
+    {
+        CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, EnergyManagementActionEventHandlerImpl, aEvent);
+    }
+
+private:
+    friend Derived;
+
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
+
+    CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
+
+    void ApplicationInitImpl() { AppTask::ApplicationInit(); }
+
+    void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction) { AppTask::ButtonEventHandler(button, btnAction); }
+
+    void EnergyManagementActionEventHandlerImpl(AppEvent * aEvent) { AppTask::EnergyManagementActionEventHandler(aEvent); }
+};

--- a/examples/evse-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/evse-app/silabs/include/CHIPProjectConfig.h
@@ -100,3 +100,9 @@
  *
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
+
+// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+#define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+
+// Setting to prevent required Data Model implementation in AppTask
+#define CHIP_SILABS_APP_NO_DM_IMPLEMENTATION

--- a/examples/evse-app/silabs/include/EvseConfig.h
+++ b/examples/evse-app/silabs/include/EvseConfig.h
@@ -1,6 +1,7 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +17,20 @@
  *    limitations under the License.
  */
 
-#pragma once
+#ifndef SL_MATTER_EVSE_CONFIG_H
+#define SL_MATTER_EVSE_CONFIG_H
 
-#include <app-common/zap-generated/cluster-objects.h>
-#include <lib/support/BitMask.h>
+// <<< Use Configuration Wizard in Context Menu >>>
 
-namespace chip {
-namespace app {
-namespace Clusters {
-namespace DeviceEnergyManagement {
+// EvseConfig.h
+// Preprocessor knobs for the silabs EVSE example. Edit these #define
+// statements to customize the endpoint hosting the EnergyEvse /
+// DeviceEnergyManagement clusters.
 
-chip::BitMask<Feature> GetFeatureMap();
+// <o EVSE_ENDPOINT> EnergyEvse / DeviceEnergyManagement cluster endpoint
+// <i> Default: 1
+#define EVSE_ENDPOINT 1
 
-} // namespace DeviceEnergyManagement
-} // namespace Clusters
-} // namespace app
-} // namespace chip
+// <<< end of configuration section >>>
+
+#endif // SL_MATTER_EVSE_CONFIG_H

--- a/examples/evse-app/silabs/src/AppTask.cpp
+++ b/examples/evse-app/silabs/src/AppTask.cpp
@@ -20,6 +20,8 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "CustomerAppTask.h"
+#include "EvseConfig.h"
 #include <EnergyEvseMain.h>
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app-common/zap-generated/cluster-objects.h>
@@ -72,8 +74,13 @@ using namespace chip::TLV;
 
 namespace {
 
+CustomerAppTask & AppInstance()
+{
+    return CustomerAppTask::GetAppTask();
+}
+
 LEDWidget sEnergyManagementLED;
-constexpr chip::EndpointId kEvseEndpoint = 1;
+constexpr chip::EndpointId kEvseEndpoint = EVSE_ENDPOINT;
 
 #ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 EnergyEvseTestEventTriggerHandler sEnergyEvseTestEventTriggerHandler;
@@ -105,7 +112,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kS
 static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment);
 #endif
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }
@@ -115,14 +122,12 @@ chip::BitMask<Feature> GetFeatureMapFromCmdLine()
 } // namespace app
 } // namespace chip
 
-AppTask AppTask::sAppTask;
-
 EndpointId GetEnergyDeviceEndpointId()
 {
     return kEvseEndpoint;
 }
 
-void ApplicationInit()
+void AppTask::ApplicationInit()
 {
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     SILABS_LOG("==================================================");
@@ -133,18 +138,12 @@ void ApplicationInit()
     sEnergyManagementLED.Init(EVSE_LED);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 }
-void ApplicationShutdown()
-{
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
-    EvseApplicationShutdown();
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-}
 
 CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
-    ApplicationInit();
+    chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(&CustomerAppTask::ButtonEventHandler);
+    AppInstance().ApplicationInit();
 
 #ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
     TestEventTriggerDelegate * pTestEventDelegate = Server::GetInstance().GetTestEventTriggerDelegate();
@@ -195,7 +194,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     AppEvent event;
     osMessageQueueId_t sAppEventQueue = *(static_cast<osMessageQueueId_t *>(pvParameter));
 
-    CHIP_ERROR err = sAppTask.Init();
+    CHIP_ERROR err = AppInstance().Init();
     if (err != CHIP_NO_ERROR)
     {
         SILABS_LOG("AppTask.Init() failed");
@@ -209,7 +208,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         osStatus_t eventReceived = osMessageQueueGet(sAppEventQueue, &event, NULL, osWaitForever);
         while (eventReceived == osOK)
         {
-            sAppTask.DispatchEvent(&event);
+            AppInstance().DispatchEvent(&event);
             eventReceived = osMessageQueueGet(sAppEventQueue, &event, NULL, 0);
         }
     }
@@ -241,12 +240,12 @@ void AppTask::ButtonEventHandler(uint8_t button, uint8_t btnAction)
 
     if (button == APP_CONTROL_BUTTON && btnAction == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonPressed))
     {
-        button_event.Handler = EnergyManagementActionEventHandler;
-        AppTask::GetAppTask().PostEvent(&button_event);
+        button_event.Handler = &CustomerAppTask::EnergyManagementActionEventHandler;
+        AppInstance().PostEvent(&button_event);
     }
     else if (button == APP_FUNCTION_BUTTON)
     {
         button_event.Handler = BaseApplication::ButtonHandler;
-        AppTask::GetAppTask().PostEvent(&button_event);
+        AppInstance().PostEvent(&button_event);
     }
 }

--- a/examples/water-heater-app/esp32/main/main.cpp
+++ b/examples/water-heater-app/esp32/main/main.cpp
@@ -123,7 +123,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kS
 static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment);
 #endif
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }

--- a/examples/water-heater-app/linux/main.cpp
+++ b/examples/water-heater-app/linux/main.cpp
@@ -62,7 +62,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kP
                                           Feature::kStartTimeAdjustment, Feature::kPausable, Feature::kForecastAdjustment,
                                           Feature::kConstraintBasedAdjustment);
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }

--- a/examples/water-heater-app/silabs/src/AppTask.cpp
+++ b/examples/water-heater-app/silabs/src/AppTask.cpp
@@ -105,7 +105,7 @@ static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment, Feature::kS
 static chip::BitMask<Feature> sFeatureMap(Feature::kPowerAdjustment);
 #endif
 
-chip::BitMask<Feature> GetFeatureMapFromCmdLine()
+chip::BitMask<Feature> GetFeatureMap()
 {
     return sFeatureMap;
 }

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -202,7 +202,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
 {
     if (!gCommonClustersInitialized)
     {
-        ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMapFromCmdLine()));
+        ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMap()));
 
         // Initialize ElectricalSensorManager (owns both EPM and EEM)
         gESManager = std::make_unique<ElectricalSensorManager>();


### PR DESCRIPTION
### Summary
cherry-pick of https://github.com/SiliconLabsSoftware/matter_sdk/pull/1011

- Create AppTaskImpl as CRTP base
- Streamline APIs per class diagram from design doc 
- Add EvseConfig.h for user configurable endpoint
- Rename `GetFeatureMapFromCmdLine` -> `GetFeatureMap`
   - Isn't truly a shell method
   - Touches common code to fix all instances

### Related issues
MATTER-6216

### Testing
CI
Local testing of overrides
