### PR TITLE
[NXP] Improve portability of DnssdImplBr implementation

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -693,12 +693,12 @@ void ConnectivityManagerImpl::UnlockThreadStack()
     ThreadStackMgrImpl().UnlockThreadStack();
 }
 
-Inet::InterfaceId ConnectivityManagerImpl::GetThreadInterface()
+Inet::InterfaceId ConnectivityManagerImpl::_GetThreadInterface()
 {
     return sInstance.mThreadNetIf;
 }
 
-Inet::InterfaceId ConnectivityManagerImpl::GetExternalInterface()
+Inet::InterfaceId ConnectivityManagerImpl::_GetExternalInterface()
 {
     return sInstance.mExternalNetIf;
 }

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -93,8 +93,8 @@ public:
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #if CHIP_ENABLE_OPENTHREAD
-    Inet::InterfaceId GetExternalInterface();
-    Inet::InterfaceId GetThreadInterface();
+    Inet::InterfaceId _GetExternalInterface();
+    Inet::InterfaceId _GetThreadInterface();
     const char * GetHostName() { return sInstance.mHostname; }
 #endif
 

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -15,10 +15,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+/* this file behaves like a config.h, comes first */
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include "lib/dnssd/platform/Dnssd.h"
+#include <inet/InetInterface.h>
+#include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/FixedBufferAllocator.h>
+#include <lib/support/IntrusiveList.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 #include <platform/OpenThread/OpenThreadUtils.h>
@@ -28,8 +34,6 @@
 #include <openthread/mdns.h>
 #include <openthread/srp_server.h>
 
-#include "fsl_component_generic_list.h"
-
 #include <DnssdImplBr.h>
 
 using namespace ::chip::DeviceLayer;
@@ -37,8 +41,6 @@ using namespace chip::DeviceLayer::Internal;
 
 namespace chip {
 namespace Dnssd {
-
-#define USE_MDNS_NEXT_SERVICE_API 1
 
 // Support both operational and commissionable discovery, so buffers sizes must be worst case.
 static constexpr uint8_t kMaxMdnsServiceTxtEntriesNumber =
@@ -59,22 +61,36 @@ static const char * GetProtocolString(DnssdServiceProtocol protocol)
     return protocol == DnssdServiceProtocol::kDnssdProtocolUdp ? "_udp" : "_tcp";
 }
 
+enum ResolveStep : uint8_t
+{
+    kResolveStepSrv = 0,
+    kResolveStepTxt,
+    kResolveStepIpAddr,
+};
+
+enum NameType : uint8_t
+{
+    kNameTypeInstance = 0,
+    kNameTypeHost,
+    kNameTypeService,
+};
+
 struct DnsServiceTxtEntries
 {
     uint8_t mBuffer[kTotalMdnsServiceTxtBufferSize];
     Dnssd::TextEntry mTxtEntries[kMaxMdnsServiceTxtEntriesNumber];
 };
 
-struct mDnsQueryCtx
+struct mDnsQueryCtx : public IntrusiveListNodeBase<>
 {
-    list_element_t link;
-    void * matterCtx;
+    void * mMatterCtx;
     chip::Dnssd::DnssdService mMdnsService;
     DnsServiceTxtEntries mServiceTxtEntry;
     char mServiceType[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + 1];
     Inet::IPAddress mResolvedAddresses[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES];
     uint8_t mResolvedAddressCount;
-    CHIP_ERROR error;
+    ResolveStep mResolveStep;
+    CHIP_ERROR mError;
     union
     {
         otMdnsBrowser mBrowseInfo;
@@ -90,36 +106,20 @@ struct mDnsQueryCtx
 
     mDnsQueryCtx(void * context, DnsBrowseCallback aBrowseCallback)
     {
-        link.next             = nullptr;
-        link.list             = nullptr;
-        matterCtx             = context;
+        mMatterCtx            = context;
         mDnsBrowseCallback    = aBrowseCallback;
         mResolvedAddressCount = 0;
-        error                 = CHIP_NO_ERROR;
+        mResolveStep          = kResolveStepSrv;
+        mError                = CHIP_NO_ERROR;
     }
     mDnsQueryCtx(void * context, DnsResolveCallback aResolveCallback)
     {
-        link.next             = nullptr;
-        link.list             = nullptr;
-        matterCtx             = context;
+        mMatterCtx            = context;
         mDnsResolveCallback   = aResolveCallback;
         mResolvedAddressCount = 0;
-        error                 = CHIP_NO_ERROR;
+        mResolveStep          = kResolveStepSrv;
+        mError                = CHIP_NO_ERROR;
     }
-};
-
-enum ResolveStep : uint8_t
-{
-    kResolveStepSrv = 0,
-    kResolveStepTxt,
-    kResolveStepIpAddr,
-};
-
-enum NameType : uint8_t
-{
-    kNameTypeInstance = 0,
-    kNameTypeHost,
-    kNameTypeService,
 };
 
 static const char * GetProtocolString(DnssdServiceProtocol protocol);
@@ -138,7 +138,7 @@ static void DispatchResolve(intptr_t context);
 static void DispatchResolveSrp(intptr_t context);
 static void DispatchResolveError(intptr_t context);
 
-static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType);
+static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType, bool dispatchResolveError);
 
 static mDnsQueryCtx * GetResolveElement(const char * instanceName, NameType aType);
 static bool IsInResolveList(const mDnsQueryCtx * pResolveContext);
@@ -154,86 +154,116 @@ static CHIP_ERROR FromServiceTypeToMdnsData(chip::Dnssd::DnssdService & mdnsServ
 
 // ID 0 is reserved for host
 static uint32_t mRegisterServiceId = 1;
-static uint8_t mNetifIndex         = 0;
+static uint32_t mNetifIndex        = 0;
 
-static list_label_t mResolveList;
-static list_label_t mBrowseList;
-static bool mListIsInit = false;
+namespace {
 
-#if USE_MDNS_NEXT_SERVICE_API
-static otMdnsService * mServiceList[kServiceListSize];
+otInstance * mOtInstance = nullptr;
+Inet::InterfaceId mExternalNetIf;
+Inet::InterfaceId mThreadNetIf;
+
+// IntrusiveList requires an empty list at destruction time. NxpChipDnssdShutdown()
+// empties both lists, so static storage duration is safe here.
+IntrusiveList<mDnsQueryCtx> mResolveList;
+IntrusiveList<mDnsQueryCtx> mBrowseList;
+
+} // namespace
+
+static otMdnsService * mServiceList[kServiceListSize] = {};
 static uint32_t mServiceListFreeIndex;
-#endif
 
 CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {
-    struct netif * extNetif = (ConnectivityManagerImpl().GetExternalInterface()).GetPlatformInterface();
-    VerifyOrReturnError(extNetif != nullptr, CHIP_ERROR_INCORRECT_STATE,
-                        ChipLogError(DeviceLayer, "External interface not set, DNS-SD init failed"));
-    mNetifIndex = netif_get_index(extNetif);
+    mOtInstance = ThreadStackMgrImpl().OTInstance();
 
-    if (!mListIsInit)
+    mExternalNetIf = ConnectivityMgr().GetExternalInterface();
+    mThreadNetIf   = ConnectivityMgr().GetThreadInterface();
+
+    if (mExternalNetIf == Inet::InterfaceId::Null() || mThreadNetIf == Inet::InterfaceId::Null())
     {
-        mListIsInit = true;
-        LIST_Init(&mResolveList, 0);
-        LIST_Init(&mBrowseList, 0);
+        Inet::InterfaceIterator iter;
+        while (iter.HasCurrent())
+        {
+            Inet::InterfaceType ifType;
+            if (iter.IsUp() && iter.GetInterfaceType(ifType) == CHIP_NO_ERROR)
+            {
+                if (mExternalNetIf == Inet::InterfaceId::Null() &&
+                    (ifType == Inet::InterfaceType::Ethernet || ifType == Inet::InterfaceType::WiFi))
+                {
+                    mExternalNetIf = iter.GetInterfaceId();
+                }
+                else if (mThreadNetIf == Inet::InterfaceId::Null() && ifType == Inet::InterfaceType::Thread)
+                {
+                    mThreadNetIf = iter.GetInterfaceId();
+                }
+            }
+
+            if (mExternalNetIf != Inet::InterfaceId::Null() && mThreadNetIf != Inet::InterfaceId::Null())
+            {
+                break;
+            }
+            iter.Next();
+        }
     }
 
-    // The mDNS module is ready once the WIFI connectivity has been established
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    VerifyOrReturnError(mExternalNetIf != Inet::InterfaceId::Null(), CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(DeviceLayer, "External interface not set, DNS-SD init failed"));
+
+    if (mThreadNetIf == Inet::InterfaceId::Null())
+    {
+        ChipLogError(DeviceLayer, "Thread interface not set; SRP cache results will report a null interface");
+    }
+
+    mNetifIndex = mExternalNetIf.GetInterfaceIndex();
+
+    // The mDNS module is ready
+    if (otMdnsIsEnabled(mOtInstance))
     {
         initCallback(context, CHIP_NO_ERROR);
         return CHIP_NO_ERROR;
     }
     else
     {
-        return CHIP_ERROR_INCORRECT_STATE;
+        errorCallback(context, CHIP_ERROR_INCORRECT_STATE);
     }
+
+    return CHIP_ERROR_INCORRECT_STATE;
 }
 
 void NxpChipDnssdShutdown()
 {
-    if (mListIsInit)
+    while (!mBrowseList.Empty())
     {
-        // Stop all browse operations and clean the browse list
-        otInstance * thrInstancePtr  = ThreadStackMgrImpl().OTInstance();
-        mDnsQueryCtx * pQueryContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mBrowseList));
-
-        while (pQueryContext)
-        {
-            otMdnsStopBrowser(thrInstancePtr, &pQueryContext->mBrowseInfo);
-            LIST_RemoveElement(&pQueryContext->link);
-            Platform::Delete<mDnsQueryCtx>(pQueryContext);
-
-            pQueryContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mBrowseList));
-        }
-
-        // Stop all resolve operations and clean the resolve list
-        pQueryContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
-
-        while (pQueryContext)
-        {
-            otMdnsStopSrvResolver(thrInstancePtr, &pQueryContext->mSrvInfo);
-            LIST_RemoveElement(&pQueryContext->link);
-            Platform::Delete<mDnsQueryCtx>(pQueryContext);
-
-            pQueryContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
-        }
+        mDnsQueryCtx * pQueryContext = &(*mBrowseList.begin());
+        otMdnsStopBrowser(mOtInstance, &pQueryContext->mBrowseInfo);
+        mBrowseList.Remove(pQueryContext);
+        Platform::Delete<mDnsQueryCtx>(pQueryContext);
     }
+
+    // Stop all resolve operations and clean the resolve list
+    while (!mResolveList.Empty())
+    {
+        mDnsQueryCtx * pQueryContext = &(*mResolveList.begin());
+        HandleResolveCleanup(*pQueryContext, pQueryContext->mResolveStep, /* dispatchResolveError */ false);
+        mResolveList.Remove(pQueryContext);
+        Platform::Delete<mDnsQueryCtx>(pQueryContext);
+    }
+
+    mExternalNetIf = Inet::InterfaceId::Null();
+    mThreadNetIf   = Inet::InterfaceId::Null();
+    mNetifIndex    = 0;
 }
 
-#if USE_MDNS_NEXT_SERVICE_API
 CHIP_ERROR NxpChipDnssdRemoveServices()
 {
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
-    otMdnsIterator * iterator   = nullptr;
-    ChipError error             = CHIP_NO_ERROR;
-    otError otError             = OT_ERROR_NONE;
+    otMdnsIterator * iterator = nullptr;
+    ChipError error           = CHIP_NO_ERROR;
+    otError otErr             = OT_ERROR_NONE;
     otMdnsEntryState state;
 
-    const char * hostName = ConnectivityManagerImpl().GetHostName();
+    const char * hostName = otMdnsGetLocalHostName(mOtInstance);
 
-    iterator = otMdnsAllocateIterator(thrInstancePtr);
+    iterator = otMdnsAllocateIterator(mOtInstance);
     VerifyOrExit(iterator != nullptr, error = CHIP_ERROR_NO_MEMORY);
 
     mServiceListFreeIndex = 0;
@@ -247,8 +277,8 @@ CHIP_ERROR NxpChipDnssdRemoveServices()
             VerifyOrExit(mServiceList[mServiceListFreeIndex] != nullptr, error = CHIP_ERROR_NO_MEMORY);
         }
 
-        otError = otMdnsGetNextService(thrInstancePtr, iterator, mServiceList[mServiceListFreeIndex], &state);
-        if (otError == OT_ERROR_NOT_FOUND)
+        otErr = otMdnsGetNextService(mOtInstance, iterator, mServiceList[mServiceListFreeIndex], &state);
+        if (otErr == OT_ERROR_NOT_FOUND)
         {
             Platform::MemoryFree(mServiceList[mServiceListFreeIndex]);
             mServiceList[mServiceListFreeIndex] = nullptr;
@@ -268,39 +298,19 @@ CHIP_ERROR NxpChipDnssdRemoveServices()
 exit:
     if (iterator != nullptr)
     {
-        otMdnsFreeIterator(thrInstancePtr, iterator);
+        otMdnsFreeIterator(mOtInstance, iterator);
     }
     return error;
 }
-#else
-CHIP_ERROR NxpChipDnssdRemoveServices()
-{
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
-    otMdnsService otServiceData = { 0 };
-
-    otServiceData.mHostName = ConnectivityManagerImpl().GetHostName();
-
-    otServiceData.mServiceType = "_matter._tcp";
-    otMdnsUnregisterServiceType(thrInstancePtr, &otServiceData, OT_MDNS_SERVICE_MARK_FOR_UNREGISTER);
-    otServiceData.mServiceType = "_matterc._udp";
-    otMdnsUnregisterServiceType(thrInstancePtr, &otServiceData, OT_MDNS_SERVICE_MARK_FOR_UNREGISTER);
-
-    return CHIP_NO_ERROR;
-}
-#endif
 
 CHIP_ERROR NxpChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)
 {
     VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
     uint32_t txtBufferOffset    = 0;
     otError otErr               = OT_ERROR_NONE;
     otMdnsService otServiceData = { 0 };
-
-#if USE_MDNS_NEXT_SERVICE_API
-    bool bRegisterService = true;
-#endif
+    bool bRegisterService       = true;
 
     char serviceType[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + 1] = "";
     snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
@@ -310,7 +320,7 @@ CHIP_ERROR NxpChipDnssdPublishService(const DnssdService * service, DnssdPublish
     uint8_t txtBuffer[kMaxMdnsServiceTxtEntriesNumber + kTotalMdnsServiceTxtBufferSize] = { 0 };
 
     // Don't try to do anything until the mDNS server is started
-    VerifyOrReturnValue(otMdnsIsEnabled(thrInstancePtr), CHIP_NO_ERROR);
+    VerifyOrReturnValue(otMdnsIsEnabled(mOtInstance), CHIP_NO_ERROR);
 
     //  Create TXT Data as one string from multiple key entries
     for (uint32_t i = 0; i < service->mTextEntrySize; i++)
@@ -332,7 +342,6 @@ CHIP_ERROR NxpChipDnssdPublishService(const DnssdService * service, DnssdPublish
         }
     }
 
-#if USE_MDNS_NEXT_SERVICE_API
     for (uint32_t i = 0; i < mServiceListFreeIndex; i++)
     {
         if ((0 == strcmp(mServiceList[i]->mHostName, service->mHostName)) &&
@@ -359,7 +368,7 @@ CHIP_ERROR NxpChipDnssdPublishService(const DnssdService * service, DnssdPublish
             break;
         }
     }
-#endif
+
     if (bRegisterService)
     {
         if (strcmp(service->mHostName, "") != 0)
@@ -378,22 +387,19 @@ CHIP_ERROR NxpChipDnssdPublishService(const DnssdService * service, DnssdPublish
         otServiceData.mTxtData             = txtBuffer;
         otServiceData.mTxtDataLength       = txtBufferOffset;
 
-        otErr = otMdnsRegisterService(thrInstancePtr, &otServiceData, mRegisterServiceId++, NULL);
+        otErr = otMdnsRegisterService(mOtInstance, &otServiceData, mRegisterServiceId++, NULL);
     }
 
     return MapOpenThreadError(otErr);
 }
 
-#if USE_MDNS_NEXT_SERVICE_API
 CHIP_ERROR NxpChipDnssdFinalizeServiceUpdate()
 {
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
-
     for (uint32_t i = 0; i < mServiceListFreeIndex; i++)
     {
         if (mServiceList[i] != nullptr)
         {
-            otMdnsUnregisterService(thrInstancePtr, mServiceList[i]);
+            otMdnsUnregisterService(mOtInstance, mServiceList[i]);
             Platform::MemoryFree(mServiceList[i]);
             mServiceList[i] = nullptr;
         }
@@ -403,23 +409,6 @@ CHIP_ERROR NxpChipDnssdFinalizeServiceUpdate()
     return CHIP_NO_ERROR;
 }
 
-#else
-CHIP_ERROR NxpChipDnssdFinalizeServiceUpdate()
-{
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
-    otMdnsService otServiceData = { 0 };
-
-    otServiceData.mHostName = ConnectivityManagerImpl().GetHostName();
-
-    otServiceData.mServiceType = "_matter._tcp";
-    otMdnsUnregisterServiceType(thrInstancePtr, &otServiceData, OT_MDNS_SERVICE_UNREGISTER_MARKED_SERVICE);
-    otServiceData.mServiceType = "_matterc._udp";
-    otMdnsUnregisterServiceType(thrInstancePtr, &otServiceData, OT_MDNS_SERVICE_UNREGISTER_MARKED_SERVICE);
-
-    return CHIP_NO_ERROR;
-}
-#endif
-
 CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, Inet::IPAddressType addressType,
                               Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context,
                               intptr_t * browseIdentifier)
@@ -427,7 +416,6 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
     *browseIdentifier             = reinterpret_cast<intptr_t>(nullptr);
     CHIP_ERROR error              = CHIP_NO_ERROR;
     CHIP_ERROR srpBrowseError     = CHIP_NO_ERROR;
-    otInstance * thrInstancePtr   = ThreadStackMgrImpl().OTInstance();
     mDnsQueryCtx * pBrowseContext = nullptr;
     char serviceType[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + 1];
 
@@ -449,7 +437,7 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
 
     // First try to browse the service in the SRP cache
     // After browsing in the SRP cache we will continue with regular mDNS browse
-    srpBrowseError = BrowseBySrp(thrInstancePtr, pBrowseContext->mServiceType, pBrowseContext);
+    srpBrowseError = BrowseBySrp(mOtInstance, pBrowseContext->mServiceType, pBrowseContext);
 
     // Proceed to generate a mDNS query
     pBrowseContext->mBrowseInfo.mServiceType  = pBrowseContext->mServiceType;
@@ -457,9 +445,9 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
     pBrowseContext->mBrowseInfo.mInfraIfIndex = mNetifIndex;
     pBrowseContext->mBrowseInfo.mCallback     = OtBrowseCallback;
 
-    LIST_AddTail(&mBrowseList, (list_element_handle_t) pBrowseContext);
+    mBrowseList.PushBack(pBrowseContext);
 
-    error = MapOpenThreadError(otMdnsStartBrowser(thrInstancePtr, &pBrowseContext->mBrowseInfo));
+    error = MapOpenThreadError(otMdnsStartBrowser(mOtInstance, &pBrowseContext->mBrowseInfo));
 
     if (CHIP_NO_ERROR == error)
     {
@@ -467,15 +455,20 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
     }
     else
     {
-        LIST_RemoveElement(&pBrowseContext->link);
+        mBrowseList.Remove(pBrowseContext);
         if (srpBrowseError == CHIP_NO_ERROR)
         {
             // In this case, we need to send a final browse indication to signal the Matter App that there are no more
             // browse results coming but the result is no error since we have a match in the SRP cache.
-            error                 = CHIP_NO_ERROR;
-            pBrowseContext->error = CHIP_NO_ERROR;
-            TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchBrowseEmpty,
-                                                                             reinterpret_cast<intptr_t>(pBrowseContext));
+            error                  = CHIP_NO_ERROR;
+            pBrowseContext->mError = CHIP_NO_ERROR;
+            if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchBrowseEmpty, reinterpret_cast<intptr_t>(pBrowseContext)) !=
+                CHIP_NO_ERROR)
+            {
+                Platform::Delete<mDnsQueryCtx>(pBrowseContext);
+                pBrowseContext = nullptr;
+                error          = CHIP_ERROR_NO_MEMORY;
+            }
         }
         else
         {
@@ -489,16 +482,26 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
 CHIP_ERROR NxpChipDnssdStopBrowse(intptr_t browseIdentifier)
 {
     mDnsQueryCtx * pBrowseContext = reinterpret_cast<mDnsQueryCtx *>(browseIdentifier);
-    otInstance * thrInstancePtr   = ThreadStackMgrImpl().OTInstance();
     otError error                 = OT_ERROR_INVALID_ARGS;
 
     // The Matter stack can call this function even with a browseContext that has been
     // freed in DispatchBrowseEmpty. If the browseContext is successfully freed from the
     // browse list then we consider it valid and proceed to stop the mDNS browse operation.
-    if (kLIST_Ok == LIST_RemoveElement(&pBrowseContext->link))
+    bool found = false;
+    for (auto & ctx : mBrowseList)
     {
-        error                 = otMdnsStopBrowser(thrInstancePtr, &pBrowseContext->mBrowseInfo);
-        pBrowseContext->error = MapOpenThreadError(error);
+        if (&ctx == pBrowseContext)
+        {
+            found = true;
+            break;
+        }
+    }
+
+    if (found)
+    {
+        error                  = otMdnsStopBrowser(mOtInstance, &pBrowseContext->mBrowseInfo);
+        pBrowseContext->mError = MapOpenThreadError(error);
+        mBrowseList.Remove(pBrowseContext);
 
         // browse context will be freed in DispatchBrowseEmpty
         DispatchBrowseEmpty(reinterpret_cast<intptr_t>(pBrowseContext));
@@ -515,8 +518,6 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
     if (browseResult == nullptr || callback == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
-
     pResolveContext = reinterpret_cast<mDnsQueryCtx *>(GetResolveElement(browseResult->mName, kNameTypeInstance));
     if (pResolveContext != nullptr)
     {
@@ -531,7 +532,7 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
     snprintf(pResolveContext->mServiceType, sizeof(pResolveContext->mServiceType), "%s.%s", browseResult->mType,
              GetProtocolString(browseResult->mProtocol));
 
-    error = ResolveBySrp(thrInstancePtr, pResolveContext->mServiceType, pResolveContext, browseResult);
+    error = ResolveBySrp(mOtInstance, pResolveContext->mServiceType, pResolveContext, browseResult);
     // If the SRP cache returns not found, proceed to generate a MDNS query
     if (CHIP_ERROR_NOT_FOUND == error)
     {
@@ -544,14 +545,14 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
         pResolveContext->mSrvInfo.mServiceInstance = pResolveContext->mMdnsService.mName;
         pResolveContext->mSrvInfo.mServiceType     = pResolveContext->mServiceType;
 
-        LIST_AddTail(&mResolveList, (list_element_handle_t) pResolveContext);
+        mResolveList.PushBack(pResolveContext);
 
-        error = MapOpenThreadError(otMdnsStartSrvResolver(thrInstancePtr, &pResolveContext->mSrvInfo));
+        error = MapOpenThreadError(otMdnsStartSrvResolver(mOtInstance, &pResolveContext->mSrvInfo));
     }
 
     if (error != CHIP_NO_ERROR)
     {
-        LIST_RemoveElement(&pResolveContext->link);
+        mResolveList.Remove(pResolveContext);
         Platform::Delete<mDnsQueryCtx>(pResolveContext);
     }
 
@@ -564,9 +565,9 @@ void NxpChipDnssdResolveNoLongerNeeded(const char * instanceName)
     {
         if (strcmp(instanceName, pResolveContext->mMdnsService.mName) == 0)
         {
-            otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mSrvInfo);
+            HandleResolveCleanup(*pResolveContext, pResolveContext->mResolveStep, /* dispatchResolveError */ false);
 
-            LIST_RemoveElement(&pResolveContext->link);
+            mResolveList.Remove(pResolveContext);
             Platform::Delete<mDnsQueryCtx>(pResolveContext);
         }
     }
@@ -585,7 +586,7 @@ CHIP_ERROR BrowseBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQuer
             if ((false == otSrpServerServiceIsDeleted(service)) &&
                 (0 == strncmp(otSrpServerServiceGetServiceName(service), serviceName, strlen(serviceName))))
             {
-                mDnsQueryCtx * serviceContext = Platform::New<mDnsQueryCtx>(context->matterCtx, context->mDnsBrowseCallback);
+                mDnsQueryCtx * serviceContext = Platform::New<mDnsQueryCtx>(context->mMatterCtx, context->mDnsBrowseCallback);
                 if (serviceContext != nullptr)
                 {
                     if (CHIP_NO_ERROR ==
@@ -595,12 +596,14 @@ CHIP_ERROR BrowseBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQuer
                     {
                         // Set error to CHIP_NO_ERROR to signal that there was at least one service found in the cache
                         error = CHIP_NO_ERROR;
-                        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(
-                            DispatchBrowse, reinterpret_cast<intptr_t>(serviceContext));
+                        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchBrowse, reinterpret_cast<intptr_t>(serviceContext)) !=
+                            CHIP_NO_ERROR)
+                        {
+                            Platform::Delete<mDnsQueryCtx>(serviceContext);
+                        }
                     }
                     else
                     {
-                        Platform::Delete<mDnsQueryCtx>(serviceContext);
                     }
                 }
             }
@@ -629,8 +632,12 @@ CHIP_ERROR ResolveBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQue
                 {
                     if (context->mResolvedAddressCount > 0)
                     {
-                        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveSrp,
-                                                                                         reinterpret_cast<intptr_t>(context));
+                        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveSrp, reinterpret_cast<intptr_t>(context)) !=
+                            CHIP_NO_ERROR)
+                        {
+                            // Failed to shcedule work
+                            error = CHIP_ERROR_NO_MEMORY;
+                        }
                     }
                     else
                     {
@@ -664,6 +671,7 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
     uint8_t addrNum = 0;
     uint16_t txtDataLen;
     const otIp6Address * ip6AddrPtr = otSrpServerHostGetAddresses(host, &addrNum);
+    const char * dot;
 
     if (mdnsQueryReq != nullptr)
     {
@@ -675,7 +683,9 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
     {
         tmpName = otSrpServerServiceGetInstanceName(service);
         // Extract from the <instance>.<type>.<protocol>.<domain-name>. the <instance> part
-        substringSize = strchr(tmpName, '.') - tmpName;
+        dot = strchr(tmpName, '.');
+        VerifyOrReturnError(dot != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        substringSize = dot - tmpName;
         if (substringSize >= MATTER_ARRAY_SIZE(mdnsService.mName))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -683,8 +693,10 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
         Platform::CopyString(mdnsService.mName, substringSize + 1, tmpName);
 
         // Extract from the <instance>.<type>.<protocol>.<domain-name>. the <type> part.
-        tmpName       = tmpName + substringSize + 1;
-        substringSize = strchr(tmpName, '.') - tmpName;
+        tmpName = tmpName + substringSize + 1;
+        dot     = strchr(tmpName, '.');
+        VerifyOrReturnError(dot != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        substringSize = dot - tmpName;
         if (substringSize >= MATTER_ARRAY_SIZE(mdnsService.mType))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -692,8 +704,10 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
         Platform::CopyString(mdnsService.mType, substringSize + 1, tmpName);
 
         // Extract from the <instance>.<type>.<protocol>.<domain-name>. the <type> part.
-        tmpName       = tmpName + substringSize + 1;
-        substringSize = strchr(tmpName, '.') - tmpName;
+        tmpName = tmpName + substringSize + 1;
+        dot     = strchr(tmpName, '.');
+        VerifyOrReturnError(dot != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        substringSize = dot - tmpName;
         if (substringSize >= (chip::Dnssd::kDnssdProtocolTextMaxSize + 1))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -713,8 +727,10 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
     }
 
     // Extract from the <hostname>.<domain-name>. the <hostname> part.
-    tmpName       = otSrpServerHostGetFullName(host);
-    substringSize = strchr(tmpName, '.') - tmpName;
+    tmpName = otSrpServerHostGetFullName(host);
+    dot     = strchr(tmpName, '.');
+    VerifyOrReturnError(dot != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    substringSize = dot - tmpName;
     if (substringSize >= MATTER_ARRAY_SIZE(mdnsService.mHostName))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -723,7 +739,7 @@ CHIP_ERROR FromSrpCacheToMdnsData(const otSrpServerService * service, const otSr
     mdnsService.mPort = otSrpServerServiceGetPort(service);
 
     // All SRP cache hits come from the Thread Netif
-    mdnsService.mInterface = ConnectivityManagerImpl().GetThreadInterface();
+    mdnsService.mInterface = mThreadNetIf;
 
     mdnsService.mAddressType = Inet::IPAddressType::kIPv6;
 
@@ -775,9 +791,12 @@ static CHIP_ERROR FromServiceTypeToMdnsData(chip::Dnssd::DnssdService & mdnsServ
     char protocol[chip::Dnssd::kDnssdProtocolTextMaxSize + 1];
     const char * protocolSubstringStart;
     size_t substringSize;
+    const char * dot;
 
     // Extract from the <type>.<protocol> the <type> part.
-    substringSize = strchr(aServiceType, '.') - aServiceType;
+    dot = strchr(aServiceType, '.');
+    VerifyOrReturnError(dot != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    substringSize = dot - aServiceType;
     if (substringSize >= MATTER_ARRAY_SIZE(mdnsService.mType))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -815,7 +834,7 @@ static CHIP_ERROR FromServiceTypeToMdnsData(chip::Dnssd::DnssdService & mdnsServ
     }
 
     // All mDNS replies come from the External Netif
-    mdnsService.mInterface = ConnectivityManagerImpl().GetExternalInterface();
+    mdnsService.mInterface = mExternalNetIf;
 
     return CHIP_NO_ERROR;
 }
@@ -831,7 +850,7 @@ static void OtBrowseCallback(otInstance * aInstance, const otMdnsBrowseResult * 
     pBrowseContext = reinterpret_cast<mDnsQueryCtx *>(GetResolveElement(aResult->mServiceType, kNameTypeService));
     VerifyOrReturn(pBrowseContext != nullptr);
 
-    mDnsQueryCtx * tmpContext = Platform::New<mDnsQueryCtx>(pBrowseContext->matterCtx, pBrowseContext->mDnsBrowseCallback);
+    mDnsQueryCtx * tmpContext = Platform::New<mDnsQueryCtx>(pBrowseContext->mMatterCtx, pBrowseContext->mDnsBrowseCallback);
     VerifyOrReturn(tmpContext != nullptr);
 
     Platform::CopyString(tmpContext->mMdnsService.mName, sizeof(tmpContext->mMdnsService.mName), aResult->mServiceInstance);
@@ -839,7 +858,10 @@ static void OtBrowseCallback(otInstance * aInstance, const otMdnsBrowseResult * 
 
     if (CHIP_NO_ERROR == error)
     {
-        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchBrowse, reinterpret_cast<intptr_t>(tmpContext));
+        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchBrowse, reinterpret_cast<intptr_t>(tmpContext)) != CHIP_NO_ERROR)
+        {
+            Platform::Delete<mDnsQueryCtx>(tmpContext);
+        }
     }
     else
     {
@@ -858,8 +880,8 @@ static void OtServiceCallback(otInstance * aInstance, const otMdnsSrvResult * aR
     pResolveContext = GetResolveElement(aResult->mServiceInstance, kNameTypeInstance);
     VerifyOrReturn(pResolveContext != nullptr);
 
-    error                  = FromServiceTypeToMdnsData(pResolveContext->mMdnsService, aResult->mServiceType);
-    pResolveContext->error = error;
+    error                   = FromServiceTypeToMdnsData(pResolveContext->mMdnsService, aResult->mServiceType);
+    pResolveContext->mError = error;
 
     if (CHIP_NO_ERROR == error)
     {
@@ -875,7 +897,7 @@ static void OtServiceCallback(otInstance * aInstance, const otMdnsSrvResult * aR
     }
     else
     {
-        HandleResolveCleanup(*pResolveContext, kResolveStepSrv);
+        HandleResolveCleanup(*pResolveContext, kResolveStepSrv, /* dispatchResolveError*/ true);
     }
 }
 
@@ -913,8 +935,8 @@ static void OtTxtCallback(otInstance * aInstance, const otMdnsTxtResult * aResul
 
         if (alloc.AnyAllocFailed())
         {
-            bSendDispatch          = false;
-            pResolveContext->error = CHIP_ERROR_NO_MEMORY;
+            bSendDispatch           = false;
+            pResolveContext->mError = CHIP_ERROR_NO_MEMORY;
         }
         else
         {
@@ -934,7 +956,7 @@ static void OtTxtCallback(otInstance * aInstance, const otMdnsTxtResult * aResul
     }
     else
     {
-        HandleResolveCleanup(*pResolveContext, kResolveStepTxt);
+        HandleResolveCleanup(*pResolveContext, kResolveStepTxt, /* dispatchResolveError*/ true);
     }
 }
 
@@ -967,20 +989,25 @@ static void OtAddressCallback(otInstance * aInstance, const otMdnsAddressResult 
 
     VerifyOrReturn(pResolveContext->mResolvedAddressCount > 0);
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(pResolveContext));
+    if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(pResolveContext)) != CHIP_NO_ERROR)
+    {
+        (void) otMdnsStopIp6AddressResolver(mOtInstance, &pResolveContext->mAddrInfo);
+        pResolveContext->mError = CHIP_ERROR_NO_MEMORY;
+        DispatchResolveError(reinterpret_cast<intptr_t>(pResolveContext));
+    }
 }
 
 static void DispatchBrowseEmpty(intptr_t context)
 {
     auto * browseContext = reinterpret_cast<mDnsQueryCtx *>(context);
-    browseContext->mDnsBrowseCallback(browseContext->matterCtx, nullptr, 0, true, browseContext->error);
+    browseContext->mDnsBrowseCallback(browseContext->mMatterCtx, nullptr, 0, true, browseContext->mError);
     Platform::Delete<mDnsQueryCtx>(browseContext);
 }
 
 static void DispatchBrowse(intptr_t context)
 {
     auto * browseContext = reinterpret_cast<mDnsQueryCtx *>(context);
-    browseContext->mDnsBrowseCallback(browseContext->matterCtx, &browseContext->mMdnsService, 1, false, browseContext->error);
+    browseContext->mDnsBrowseCallback(browseContext->mMatterCtx, &browseContext->mMdnsService, 1, false, browseContext->mError);
     Platform::Delete<mDnsQueryCtx>(browseContext);
 }
 
@@ -992,19 +1019,26 @@ static void DispatchTxtResolve(intptr_t context)
     VerifyOrReturn(IsInResolveList(pResolveContext));
 
     // Stop SRV resolver before starting TXT one, ignore error as it will only happen if mMDS module is not initialized
-    (void) otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mSrvInfo);
+    (void) otMdnsStopSrvResolver(mOtInstance, &pResolveContext->mSrvInfo);
 
     pResolveContext->mTxtInfo.mServiceInstance = pResolveContext->mMdnsService.mName;
     pResolveContext->mTxtInfo.mServiceType     = pResolveContext->mServiceType;
     pResolveContext->mTxtInfo.mCallback        = OtTxtCallback;
     pResolveContext->mTxtInfo.mInfraIfIndex    = mNetifIndex;
 
-    error = otMdnsStartTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
+    error = otMdnsStartTxtResolver(mOtInstance, &pResolveContext->mTxtInfo);
     if (error != OT_ERROR_NONE)
     {
-        pResolveContext->error = MapOpenThreadError(error);
-        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                         reinterpret_cast<intptr_t>(pResolveContext));
+        pResolveContext->mError = MapOpenThreadError(error);
+        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(pResolveContext)) !=
+            CHIP_NO_ERROR)
+        {
+            DispatchResolveError(reinterpret_cast<intptr_t>(pResolveContext));
+        }
+    }
+    else
+    {
+        pResolveContext->mResolveStep = kResolveStepTxt;
     }
 }
 
@@ -1016,18 +1050,25 @@ static void DispatchAddressResolve(intptr_t context)
     VerifyOrReturn(IsInResolveList(pResolveContext));
 
     // Stop TXT resolver before starting address one, ignore error as it will only happen if mMDS module is not initialized
-    (void) otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
+    (void) otMdnsStopTxtResolver(mOtInstance, &pResolveContext->mTxtInfo);
 
     pResolveContext->mAddrInfo.mCallback     = OtAddressCallback;
     pResolveContext->mAddrInfo.mHostName     = pResolveContext->mMdnsService.mHostName;
     pResolveContext->mAddrInfo.mInfraIfIndex = mNetifIndex;
 
-    error = otMdnsStartIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
+    error = otMdnsStartIp6AddressResolver(mOtInstance, &pResolveContext->mAddrInfo);
     if (error != OT_ERROR_NONE)
     {
-        pResolveContext->error = MapOpenThreadError(error);
-        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                         reinterpret_cast<intptr_t>(pResolveContext));
+        pResolveContext->mError = MapOpenThreadError(error);
+        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(pResolveContext)) !=
+            CHIP_NO_ERROR)
+        {
+            DispatchResolveError(reinterpret_cast<intptr_t>(pResolveContext));
+        }
+    }
+    else
+    {
+        pResolveContext->mResolveStep = kResolveStepIpAddr;
     }
 }
 
@@ -1041,16 +1082,16 @@ static void DispatchResolve(intptr_t context)
 
     // Stop Address resolver, we have finished resolving the service. Ignore error as it will only happen if
     // mMDS module is not initialized
-    (void) otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
+    (void) otMdnsStopIp6AddressResolver(mOtInstance, &pResolveContext->mAddrInfo);
 
     // The context will be freed and the resolve operation is stopped. Matter will
     // try to stop it again on the mDnsResolveCallback but nothing will happen because the
     // element is no longer present in the list.
-    LIST_RemoveElement(&pResolveContext->link);
+    mResolveList.Remove(pResolveContext);
 
     Span<Inet::IPAddress> ipAddrs(pResolveContext->mResolvedAddresses, pResolveContext->mResolvedAddressCount);
 
-    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, &service, ipAddrs, pResolveContext->error);
+    pResolveContext->mDnsResolveCallback(pResolveContext->mMatterCtx, &service, ipAddrs, pResolveContext->mError);
     Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
@@ -1066,7 +1107,7 @@ static void DispatchResolveSrp(intptr_t context)
     // Address resolver was not started and the resolve context was not added to the resolve list
     // when the result came directly from SRP.
 
-    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, &service, ipAddrs, pResolveContext->error);
+    pResolveContext->mDnsResolveCallback(pResolveContext->mMatterCtx, &service, ipAddrs, pResolveContext->mError);
     Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
@@ -1081,87 +1122,72 @@ static void DispatchResolveError(intptr_t context)
     // The context will be freed and the resolve operation is stopped. Matter will
     // try to stop it again on the mDnsResolveCallback but nothing will happen because the
     // element is no longer present in the list.
-    LIST_RemoveElement(&pResolveContext->link);
+    mResolveList.Remove(pResolveContext);
 
-    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, nullptr, ipAddrs, pResolveContext->error);
+    pResolveContext->mDnsResolveCallback(pResolveContext->mMatterCtx, nullptr, ipAddrs, pResolveContext->mError);
     Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
-static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType)
+static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType, bool dispatchResolveError)
 {
     switch (stepType)
     {
     case kResolveStepSrv:
-        otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext.mSrvInfo);
+        otMdnsStopSrvResolver(mOtInstance, &resolveContext.mSrvInfo);
         break;
     case kResolveStepTxt:
-        otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext.mTxtInfo);
+        otMdnsStopTxtResolver(mOtInstance, &resolveContext.mTxtInfo);
         break;
     case kResolveStepIpAddr:
-        otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext.mAddrInfo);
+        otMdnsStopIp6AddressResolver(mOtInstance, &resolveContext.mAddrInfo);
         break;
     }
 
-    // In this case the resolve operation could not be completed successfully so we need to call
-    // DispatchResolveError to handle the Matter callback with an error case. No IP address is reported and
-    // the address resolve operation doesn’t need to be stopped again as was not started in the first place
-    // or it's already handled by HandleResolveCleanup.
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                     reinterpret_cast<intptr_t>(&resolveContext));
+    if (dispatchResolveError)
+    {
+        // In this case the resolve operation could not be completed successfully so we need to call
+        // DispatchResolveError to handle the Matter callback with an error case. No IP address is reported and
+        // the address resolve operation doesn’t need to be stopped again as was not started in the first place
+        // or it's already handled by HandleResolveCleanup.
+        if (DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(&resolveContext)) !=
+            CHIP_NO_ERROR)
+        {
+            DispatchResolveError(reinterpret_cast<intptr_t>(&resolveContext));
+        }
+    }
 }
 
 static mDnsQueryCtx * GetResolveElement(const char * aName, NameType aType)
 {
-    mDnsQueryCtx * pResolveContext = nullptr;
+    IntrusiveList<mDnsQueryCtx> & list = (aType == kNameTypeService) ? mBrowseList : mResolveList;
 
-    if (aType == kNameTypeService)
+    for (auto & ctx : list)
     {
-        pResolveContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mBrowseList));
-    }
-    else
-    {
-        pResolveContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
-    }
-
-    while (pResolveContext)
-    {
-        if (aType == kNameTypeInstance)
+        if (aType == kNameTypeInstance && strcmp(aName, ctx.mMdnsService.mName) == 0)
         {
-            if (strcmp(aName, pResolveContext->mMdnsService.mName) == 0)
-            {
-                break;
-            }
+            return &ctx;
         }
-        else if (aType == kNameTypeHost)
+        if (aType == kNameTypeHost && strcmp(aName, ctx.mMdnsService.mHostName) == 0)
         {
-            if (strcmp(aName, pResolveContext->mMdnsService.mHostName) == 0)
-            {
-                break;
-            }
+            return &ctx;
         }
-        else if (aType == kNameTypeService)
+        if (aType == kNameTypeService && strcmp(aName, ctx.mServiceType) == 0)
         {
-            if (strcmp(aName, pResolveContext->mServiceType) == 0)
-            {
-                break;
-            }
+            return &ctx;
         }
-        pResolveContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetNext(&pResolveContext->link));
     }
 
-    return pResolveContext;
+    return nullptr;
 }
 
 static bool IsInResolveList(const mDnsQueryCtx * pResolveContext)
 {
-    mDnsQueryCtx * pContextIterator = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
-    while (pContextIterator)
+    for (auto & ctx : mResolveList)
     {
-        if (pContextIterator == pResolveContext)
+        if (&ctx == pResolveContext)
         {
             return true;
         }
-        pContextIterator = reinterpret_cast<mDnsQueryCtx *>(LIST_GetNext(&pContextIterator->link));
     }
     return false;
 }


### PR DESCRIPTION
### Summary

Refactor the NXP Border Router DNS-SD implementation to remove direct dependencies on LwIP-specific APIs and types, improving portability across platforms and networking stacks.

Replace the previous LwIP-specific handling with the platform-agnostic Inet interface abstraction, so network interfaces are obtained through generic accessors rather than LwIP netif lookups.

Track outstanding browse and resolve operations using the SDK's IntrusiveList, removing custom list bookkeeping and reducing coupling to platform-specific data structures.

No functional change to DNS-SD behavior is intended; this is purely a portability and maintainability improvement.

### Testing

Tested on NXP border router FreeRTOS application.
Testing procedure was previously described in https://github.com/project-chip/connectedhomeip/pull/73438
This is a follow-up PR, implementing the changes and using new added accessors
