### PR TITLE
[v1.5] Cap googleapis-common-protos below 1.75.1 to unblock the build venv

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -296,3 +296,8 @@ google-api-core==2.17.0
 # pydantic-core < 2.20 uses PyO3 0.21.x which does not support Python 3.13+
 # See: https://github.com/pydantic/pydantic/issues/11524
 pydantic-core>=2.20.0,<3.0.0; python_version >= "3.13"
+
+# googleapis-common-protos 1.75.1 raised its requirement from protobuf>=4.25.8
+# to protobuf>=6.33.5, which cannot be satisfied together with the protobuf
+# pinned above, so the pigweed build venv fails to resolve.
+googleapis-common-protos<1.75.1


### PR DESCRIPTION
#### Summary

`googleapis-common-protos` 1.75.1, published 2026-08-06, raised its protobuf requirement from `>=4.25.8` to `>=6.33.5`. It is an unpinned transitive dependency, so a fresh resolve picks it up and then conflicts with the `protobuf==5.28.3` pinned in `scripts/setup/constraints.txt`, leaving the pigweed build venv unresolvable:

```
pip._vendor.resolvelib.resolvers.ResolutionImpossible:
  SpecifierRequirement('protobuf~=5.28.2')
  SpecifierRequirement('protobuf<8.0.0,>=6.33.5')  parent=googleapis_common_protos-1.75.1
```

Every job that builds that venv fails, including the Chef variants, Bouffalo Lab, cc32xx, EFR32, Ameba and cc13xx_26xx. Builds only began failing several hours after the release, once the pip cache went cold, since a warm cache reused the previously resolved wheels.

`master` is unaffected: it removed the protobuf constraints in #43377 and delegates them to pigweed's `pw_protobuf_compiler`. That change is not on this branch, so the pin here still applies and the conflict is reachable only on the release branches.

This caps the dependency at 1.75.0, which requires `protobuf>=4.25.8` and is compatible with the pinned version. It follows the existing `# Manual edits:` convention in that file, alongside the `google-api-core` and `pydantic-core` caps.

`v1.4.2-branch` carries the same protobuf pin and is likely affected in the same way.

#### Testing

- Not built locally; CI on this PR exercises the affected jobs.
- Verified the file is actually consumed by the failing resolution: `.gn:30` sets `pw_build_PIP_CONSTRAINTS = [ "//scripts/setup/constraints.txt" ]`, which `BUILD.gn:87` passes to the pigweed venv, and the embedded configs (`config/esp32`, `config/ameba`, ...) point at the same file.
- Release metadata checked on PyPI: 1.75.0 requires `protobuf<8.0.0,>=4.25.8`; 1.75.1 requires `protobuf<8.0.0,>=6.33.5`.