### PR TITLE
Reassign tizen to https://github.com/dr-venkman/ in platform_maintainers.yaml

### DIFF
--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -119,8 +119,7 @@ stm32:
 # 
 # tizen:
 #   maintainers:
-#     - enkiusz
-#     - arkq
+#     - dr-venkman
 #   paths:
 #     - "src/platform/Tizen/**"
 #     - "examples/platform/tizen/**"

--- a/.github/platform_maintainers.yaml
+++ b/.github/platform_maintainers.yaml
@@ -104,6 +104,15 @@ stm32:
     - "config/stm32/**"
     - "third_party/st/**"
 
+tizen:
+  maintainers:
+    - dr-venkman
+  paths:
+    - "src/platform/Tizen/**"
+    - "examples/platform/tizen/**"
+    - "examples/**/tizen/**"
+    - "config/tizen/**"
+
 # --- Proposals / Opt-In Templates ---
 
 # nrfconnect:
@@ -117,14 +126,6 @@ stm32:
 #     - "examples/**/nrfconnect/**"
 #     - "config/nrfconnect/**"
 # 
-# tizen:
-#   maintainers:
-#     - dr-venkman
-#   paths:
-#     - "src/platform/Tizen/**"
-#     - "examples/platform/tizen/**"
-#     - "examples/**/tizen/**"
-#     - "config/tizen/**"
 # 
 # asr:
 #   maintainers:


### PR DESCRIPTION
### Summary

Missed one spot where me and @arkq were still refered as Tizen platform maintainers.

### Testing

Not applicable.