### PR TITLE
[NXP] Gate Zephyr OpenThread config on CONFIG_OPENTHREAD instead of CONFIG_NET_L2_OPENTHREAD

### DIFF
--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -54,11 +54,11 @@ config MAX_EVENT_QUEUE_SIZE
 	default 64
 
 config CHIP_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
-	default 800 if NET_L2_OPENTHREAD
+	default 800 if OPENTHREAD
 	default 2000
 
 config CHIP_MRP_LOCAL_IDLE_RETRY_INTERVAL
-	default 800 if NET_L2_OPENTHREAD
+	default 800 if OPENTHREAD
 	default 2000
 
 config CHIP_INET_ENABLE_TCP_ENDPOINT
@@ -128,7 +128,7 @@ config LOG_RUNTIME_DEFAULT_LEVEL
 endif # LOG_MODE_DEFERRED
 
 config LOG_BUFFER_SIZE
-	default 6144 if NET_L2_OPENTHREAD
+	default 6144 if OPENTHREAD
 
 choice MATTER_LOG_LEVEL_CHOICE
 	default MATTER_LOG_LEVEL_DBG
@@ -177,7 +177,7 @@ config POSIX_MAX_FDS
 # Application stack size
 config MAIN_STACK_SIZE
 	default 16384 if CHIP_SE05X  # Increase is due to the additional middle-ware APDU buffers and Zephyr
-	default 6144 if NET_L2_OPENTHREAD
+	default 6144 if OPENTHREAD
 	default 3072
 	  
 # AEAD ITS transform module encryption key provider
@@ -253,7 +253,7 @@ config NET_BUF_TX_COUNT
 config NET_BUF_DATA_SIZE
 	default 256
 
-if NET_L2_OPENTHREAD
+if OPENTHREAD
 
 config HDLC_RCP_IF
 	default y if SOC_FAMILY_NXP_RW
@@ -350,7 +350,7 @@ config OPENTHREAD_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
 config CHIP_USE_OT_ENDPOINT
 	default y
 
-endif # NET_L2_OPENTHREAD
+endif # OPENTHREAD
 
 # Bluetooth Low Energy configs
 
@@ -404,7 +404,7 @@ config BT_BUF_ACL_TX_SIZE
 	default 251
 
 config BT_RX_STACK_SIZE
-	default 2560 if NET_L2_OPENTHREAD
+	default 2560 if OPENTHREAD
 	default 2048 if NO_OPTIMIZATIONS && DEBUG
 	default 1700
 
@@ -583,7 +583,7 @@ config CHIP_MALLOC_SYS_HEAP_SIZE
 	default 28672 # 28 kB
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 3072 if NET_L2_OPENTHREAD
+	default 3072 if OPENTHREAD
 	default 2048 if CHIP_WIFI
 
 choice LIBC_IMPLEMENTATION

--- a/config/nxp/chip-module/Kconfig.features
+++ b/config/nxp/chip-module/Kconfig.features
@@ -21,7 +21,7 @@ if CHIP
 
 # See config/common/cmake/Kconfig for full definition
 config CHIP_WIFI
-	default y if !NET_L2_OPENTHREAD
+	default y if !OPENTHREAD
 	select WIFI
 	select WIFI_NXP
 	select WIFI_NM_WPA_SUPPLICANT

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -54,7 +54,7 @@
 #include "binding-handler.h"
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 #include <inet/EndPointStateOpenThread.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/OpenThread/GenericNetworkCommissioningThreadDriver.h>
@@ -141,7 +141,7 @@ using namespace ::chip::app::Clusters;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 app::Clusters::NetworkCommissioning::InstanceAndDriver<DeviceLayer::NetworkCommissioning::GenericThreadDriver>
     sThreadNetworkDriver(CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID /*endpointId*/);
 #endif
@@ -178,7 +178,7 @@ app::RegisteredServerCluster<app::Clusters::IdentifyCluster>
                          .WithDelegate(&sIdentifyDelegate));
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 void LockOpenThreadTask(void)
 {
     chip::NXP::App::GetAppTask().AppMatter_DisallowDeviceToSleep();
@@ -230,7 +230,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     // Init ZCL Data Model and start server
     chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
     nativeParams.lockCb                = LockOpenThreadTask;
@@ -325,7 +325,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     err = AppMatter_Register();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error during APP features registration"));
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     err = ThreadStackMgr().InitThreadStack();
     if (err != CHIP_NO_ERROR)
     {
@@ -419,7 +419,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
         goto exit;
     }
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     // Start OpenThread task
     err = ThreadStackMgrImpl().StartThreadTask();
     if (err != CHIP_NO_ERROR)

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -54,7 +54,7 @@
 #include "binding-handler.h"
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 #include <inet/EndPointStateOpenThread.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/OpenThread/GenericNetworkCommissioningThreadDriver.h>
@@ -174,7 +174,7 @@ static LastFabricRemovedDelegate sLastFabricRemovedDelegate;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 app::Clusters::NetworkCommissioning::InstanceAndDriver<DeviceLayer::NetworkCommissioning::GenericThreadDriver>
     sThreadNetworkDriver(CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID /*endpointId*/);
 #endif
@@ -207,7 +207,7 @@ app::RegisteredServerCluster<app::Clusters::IdentifyCluster>
                          .WithDelegate(&sIdentifyDelegate));
 #endif
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
 void LockOpenThreadTask(void)
 {
     chip::NXP::App::GetAppTask().AppMatter_DisallowDeviceToSleep();
@@ -259,7 +259,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     // Init ZCL Data Model and start server
     chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
     nativeParams.lockCb                = LockOpenThreadTask;
@@ -357,7 +357,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     err = AppMatter_Register();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error during APP features registration"));
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     err = ThreadStackMgr().InitThreadStack();
     if (err != CHIP_NO_ERROR)
     {
@@ -451,7 +451,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
         goto exit;
     }
 
-#if CONFIG_NET_L2_OPENTHREAD
+#if CONFIG_OPENTHREAD
     // Start OpenThread task
     err = ThreadStackMgrImpl().StartThreadTask();
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
### Summary

NXP Zephyr platform and example config currently key OpenThread behavior on
`CONFIG_NET_L2_OPENTHREAD`. That symbol is only set when the Zephyr OpenThread
L2 network layer is used. NXP targets can run OpenThread without the net L2 layer, in
which case `NET_L2_OPENTHREAD` is not set and the Thread paths are wrongly
compiled out.

This PR replaces the `NET_L2_OPENTHREAD` conditions with `OPENTHREAD`, so the
Thread configuration and code paths are selected whenever OpenThread is enabled,
independent of the L2 layer.

### Changes

- `config/nxp/chip-module/Kconfig.defaults`: use `OPENTHREAD` (instead of
  `NET_L2_OPENTHREAD`) for the OpenThread-dependent defaults.
- `config/nxp/chip-module/Kconfig.features`: `CHIP_WIFI` defaults on only when
  OpenThread is not enabled (`!OPENTHREAD`).
- `examples/platform/nxp/common/app_task/source/AppTaskBase.cpp`: guard the
  Thread includes, network-commissioning driver, OpenThread endpoint init, and
  Thread stack start/init on `CONFIG_OPENTHREAD`.

### Impact

- Targets using OpenThread with the L2 layer: no change (`OPENTHREAD` is set in
  both cases).
- Targets using OpenThread without the net L2 layer: Thread
  config and code paths are now correctly enabled.
- No effect on non-Thread (Wi-Fi/Ethernet) builds.

### Testing

Testing for this PR is covered by the CI workflow.
