### PR TITLE
TC-DA-1.1 - Fix post-factory-reset PASE discovery with manual pairing codes

### DIFF
--- a/src/python_testing/TC_DA_1_1.py
+++ b/src/python_testing/TC_DA_1_1.py
@@ -135,6 +135,10 @@ class TC_DA_1_1(MatterBaseTest):
             product_id=product_id
         )
 
+        # Use the tester-provided setup code (QR or manual) verbatim when one exists,
+        # so PASE discovery filters exactly as that code dictates.
+        setup_code = setupPayloadInfo[0].setup_code or setup_params.qr_code
+
         # Setup
         root_node_id = 0
         self.discriminator = random.randint(0, 4095)
@@ -188,7 +192,7 @@ class TC_DA_1_1(MatterBaseTest):
         # TH2 opens a PASE session with the DUT
         self.step(4)
         pase_node_id = self.dut_node_id + 1
-        await th2.FindOrEstablishPASESession(setupCode=setup_params.qr_code, nodeId=pase_node_id)
+        await th2.FindOrEstablishPASESession(setupCode=setup_code, nodeId=pase_node_id)
 
         # *** STEP 5 ***
         # TH2 does a non-fabric-filtered read of the Fabrics attribute from the Node Operational Credentials cluster

--- a/src/python_testing/TC_DA_1_1.py
+++ b/src/python_testing/TC_DA_1_1.py
@@ -33,6 +33,30 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run2:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --qr-code MT:-24J0Q1212-10648G00
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+#   run3:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --manual-code 10054912339
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging
@@ -119,25 +143,25 @@ class TC_DA_1_1(MatterBaseTest):
         if not setupPayloadInfo:
             asserts.fail(f"Setup payload info is required for commissioning, found '{setupPayloadInfo}'")
 
-        # Vendor ID and Product ID are set to 0x0000, the pair the spec prescribes for
-        # commissioner-generated onboarding payloads not bound to a product identity.
-        vendor_id = 0
-        product_id = 0
-
-        # Build setup parameters for commissioning.
-        # - With no VID/PID claim in the QR, PASE discovery matches the DUT on long
-        #   discriminator and passcode alone instead of rejecting DUTs whose advertised
-        #   VID/PID differ from fabricated values.
-        setup_params = SetupParameters(
-            discriminator=setupPayloadInfo[0].filter_value,
-            passcode=setupPayloadInfo[0].passcode,
-            vendor_id=vendor_id,
-            product_id=product_id
-        )
-
         # Use the tester-provided setup code (QR or manual) verbatim when one exists,
         # so PASE discovery filters exactly as that code dictates.
-        setup_code = setupPayloadInfo[0].setup_code or setup_params.qr_code
+        setup_code = setupPayloadInfo[0].setup_code
+        if setup_code is None:
+            # No tester-supplied setup code, only a discriminator and passcode, so
+            # constructing a QR code from them.
+            #
+            # Vendor ID and Product ID are set to 0x0000, the pair the spec prescribes
+            # for commissioner-generated onboarding payloads not bound to a product
+            # identity. With no VID/PID claim in the QR, PASE discovery matches the DUT
+            # on long discriminator and passcode alone instead of rejecting DUTs whose
+            # advertised VID/PID differ from fabricated values.
+            setup_params = SetupParameters(
+                discriminator=setupPayloadInfo[0].filter_value,
+                passcode=setupPayloadInfo[0].passcode,
+                vendor_id=0,
+                product_id=0
+            )
+            setup_code = setup_params.qr_code
 
         # Setup
         root_node_id = 0


### PR DESCRIPTION
#### Summary
Fixes an issue where TC-DA-1.1 failed with "Discovery timed out" after factory reset when configured with a manual pairing code (the fabricated QR carried the short discriminator in the long discriminator field), by passing the tester-provided setup code verbatim to the PASE session and only fabricating a QR for the discriminator/passcode config style.

#### Included in this PR

- Use the tester-provided setup code (QR or manual) for the step 4 PASE session (`TC_DA_1_1.py`)
- Keep the fabricated QR as the fallback for the discriminator/passcode config style (`TC_DA_1_1.py`)

#### Testing

TC-DA-1.1
```
./scripts/tests/run_python_test.py --factory-reset \
    --app out/linux-x64-all-clusters/chip-all-clusters-app \
    --app-args "--discriminator 1234 --KVS kvs1" \
    --app-ready-pattern "APP STATUS: Starting event loop" \
    --script-args "--storage-path admin_storage.json \
      --commissioning-method on-network \
      --manual-code 10054912339 \
      --PICS src/app/tests/suites/certification/ci-pics-values" \
    --script src/python_testing/TC_DA_1_1.py
```

#### Related issues

Fixes #73370
