### PR TITLE
[NXP] Report full MeshCoP service instance name for TBR management cluster

### DIFF
--- a/examples/platform/nxp/common/app_task/include/AppTaskBase.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskBase.h
@@ -209,6 +209,15 @@ private:
     static constexpr EndpointId kThreadBRMgmtEndpoint = 2;
     bool mTbrmClusterEnabled                          = false;
 #endif
+
+protected:
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+    // Each platform provides the border agent base service name, which differs by OpenThread integration.
+    virtual chip::CharSpan GetBorderRouterName() = 0;
+
+    // Builds the full MeshCoP service instance name (base name + extended address hex) that OpenThread advertises.
+    chip::CharSpan BuildBorderRouterName(const char * baseName);
+#endif
 };
 
 /**

--- a/examples/platform/nxp/common/app_task/include/AppTaskFreeRTOS.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskFreeRTOS.h
@@ -86,6 +86,10 @@ public:
      */
     TickType_t ticksToWait;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+    chip::CharSpan GetBorderRouterName() override;
+#endif
+
 private:
     void DispatchEvent(const AppEvent & event);
 };

--- a/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
@@ -69,6 +69,10 @@ public:
      */
     virtual void PreInitMatterServerInstance(void) override;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+    chip::CharSpan GetBorderRouterName() override;
+#endif
+
 private:
     void DispatchEvent(const AppEvent & event);
 };

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -2,7 +2,7 @@
  *
  *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2021 Google LLC.
- *    Copyright 2024 NXP
+ *    Copyright 2024, 2026 NXP
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,6 +104,11 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_TBR
 #include "platform/OpenThread/GenericThreadBorderRouterDelegate.h"
 #include <app/clusters/thread-border-router-management-server/thread-border-router-management-server.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/StringBuilder.h>
+#include <openthread/dns.h>
+#include <openthread/link.h>
+#include <platform/ThreadStackManager.h>
 #endif
 
 #ifndef CONFIG_THREAD_DEVICE_TYPE
@@ -156,10 +161,6 @@ app::Clusters::NetworkCommissioning::Instance
 
 #if CONFIG_CHIP_CRYPTO_PSA
 chip::Crypto::PSAOperationalKeystore sPSAOperationalKeystore{};
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_TBR
-extern const char sBaseServiceInstanceName[];
 #endif
 
 #ifdef CONFIG_CHIP_REGISTER_SIMPLE_TEST_EVENT_TRIGGER_DELEGATE
@@ -562,6 +563,38 @@ void chip::NXP::App::AppTaskBase::PrintCurrentVersion()
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_TBR
+chip::CharSpan chip::NXP::App::AppTaskBase::BuildBorderRouterName(const char * baseName)
+{
+    // OpenThread does not expose the constructed MeshCoP service instance name, so rebuild it here as
+    // base name + extended address hex to match what the border agent advertises.
+
+    static chip::StringBuilder<OT_DNS_MAX_LABEL_SIZE + 1> sBorderAgentName;
+
+    sBorderAgentName.Reset();
+    sBorderAgentName.Add(baseName);
+
+    const otExtAddress * extAddr = otLinkGetExtendedAddress(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
+    if (extAddr != nullptr)
+    {
+        char hex[OT_EXT_ADDRESS_SIZE * 2 + 1];
+        if (chip::Encoding::BytesToLowercaseHexString(extAddr->m8, OT_EXT_ADDRESS_SIZE, hex, sizeof(hex)) == CHIP_NO_ERROR)
+        {
+            sBorderAgentName.Add(hex);
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get Thread extended address; reporting base border router name only");
+    }
+
+    if (!sBorderAgentName.Fit())
+    {
+        ChipLogError(DeviceLayer, "Border router name truncated to fit the MeshCoP service instance name buffer");
+    }
+
+    return chip::CharSpan::fromCharString(sBorderAgentName.c_str());
+}
+
 void chip::NXP::App::AppTaskBase::EnableTbrManagementCluster()
 {
     if (mTbrmClusterEnabled == false)
@@ -574,7 +607,7 @@ void chip::NXP::App::AppTaskBase::EnableTbrManagementCluster()
                                                                                   Server::GetInstance().GetFailSafeContext());
 
         // Initialize TBR name
-        CharSpan brName(sBaseServiceInstanceName, strlen(sBaseServiceInstanceName));
+        CharSpan brName = GetBorderRouterName();
         sThreadBRDelegate.SetThreadBorderRouterName(brName);
         // Initialize TBR cluster
         TEMPORARY_RETURN_IGNORED sThreadBRMgmtInstance.Init();

--- a/examples/platform/nxp/common/app_task/source/AppTaskFreeRTOS.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskFreeRTOS.cpp
@@ -85,6 +85,11 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::app::Clusters;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+// Defined in the ot-nxp submodule (border_agent.c), which is a C source file.
+extern "C" const char sBaseServiceInstanceName[];
+#endif // CHIP_DEVICE_CONFIG_ENABLE_TBR
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 chip::DeviceLayer::NetworkCommissioning::WiFiDriver * chip::NXP::App::AppTaskFreeRTOS::GetWifiDriverInstance()
@@ -231,3 +236,10 @@ void chip::NXP::App::AppTaskFreeRTOS::DispatchEvent(const AppEvent & event)
         ChipLogProgress(DeviceLayer, "Event received with no handler. Dropping event.");
     }
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+chip::CharSpan chip::NXP::App::AppTaskFreeRTOS::GetBorderRouterName()
+{
+    return BuildBorderRouterName(sBaseServiceInstanceName);
+}
+#endif

--- a/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
@@ -53,6 +53,11 @@
 #endif // CONFIG_SOC_FAMILY_NXP_RW
 #endif // CONFIG_CHIP_CRYPTO_PSA
 
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+// Defined in the Zephyr border router implementation (border_agent.c), which is a C source file.
+extern "C" const char otbr_base_service_instance_name[];
+#endif // CHIP_DEVICE_CONFIG_ENABLE_TBR
+
 #include "AppFactoryData.h"
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
@@ -146,3 +151,10 @@ void chip::NXP::App::AppTaskZephyr::DispatchEvent(const AppEvent & event)
         LOG_INF("Event received with no handler. Dropping event.");
     }
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+chip::CharSpan chip::NXP::App::AppTaskZephyr::GetBorderRouterName()
+{
+    return BuildBorderRouterName(otbr_base_service_instance_name);
+}
+#endif


### PR DESCRIPTION
### Summary

Add a GetBorderRouterName() virtual method to AppTaskBase and implement it for both the FreeRTOS and Zephyr app tasks. The implementation reconstructs the full name by appending the Thread extended address (as lowercase hex, no separators) to the base service name, matching what OpenThread advertises.

### Testing
Read TBRM cluster name using chip-tool and saw that name is the same with the advertised MeshCoP service.
