### PR TITLE
Updated README.md for energy apps which activated in the wrong location.

### DIFF
--- a/examples/energy-gateway-app/linux/README.md
+++ b/examples/energy-gateway-app/linux/README.md
@@ -50,7 +50,7 @@ details.
                 $ cd connectedhomeip
                 $ ./scripts/checkout_submodules.py --platform linux --recursive
 
-                # Alternatively you can check out all submodules and resync with:
+                # Alternatively you can check out all submodules and re-sync with:
                 $ git submodule sync --recursive; git submodule update --init --recursive
 
 -   Activate your shell (do this every time you open the new terminal window)

--- a/examples/energy-gateway-app/linux/README.md
+++ b/examples/energy-gateway-app/linux/README.md
@@ -40,10 +40,10 @@ details.
 
                 $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
 
--   Clone the repo (this assumes you are checking the code out in home folder)
+-   Clone the repo (this assumes you are checking the code out in your home folder)
 
                 $ cd ~
-                $ git clone git@github.com:project-chip/connectedhomeip.git
+                $ git clone https://github.com/project-chip/connectedhomeip.git
 
 -   Ensure your repo is up to date with submodules fetched
 

--- a/examples/energy-gateway-app/linux/README.md
+++ b/examples/energy-gateway-app/linux/README.md
@@ -38,26 +38,37 @@ details.
 
 -   Install tool chain
 
-    ```bash
-    sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
-    ```
+                $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
 
--   Build the example application:
+-   Clone the repo (this assumes you are checking the code out in home folder)
 
-    ```bash
-    cd ~/connectedhomeip/examples/energy-gateway-app/linux
-    git submodule update --init
-    source third_party/connectedhomeip/scripts/activate.sh
-    gn gen out/debug
-    ninja -C out/debug
-    ```
+                $ cd ~
+                $ git clone git@github.com:project-chip/connectedhomeip.git
+
+-   Ensure your repo is up to date with submodules fetched
+
+                $ cd connectedhomeip
+                $ ./scripts/checkout_submodules.py --platform linux --recursive
+
+                # Alternatively you can check out all submodules and resync with:
+                $ git submodule sync --recursive; git submodule update --init --recursive
+
+
+-   Activate your shell (do this every time you open the new terminal window)
+
+                $ cd ~/connectedhomeip
+                $ source ./scripts/activate.sh
+
+-   Build the example application (in the activated shell - see above):
+
+                $ cd ~/connectedhomeip/examples/energy-gateway-app/linux
+                $ gn gen out/debug
+                $ ninja -C out/debug
 
 -   To delete generated executable, libraries and object files use:
 
-    ```bash
-    cd ~/connectedhomeip/examples/energy-gateway-app/linux
-    rm -rf out
-    ```
+                $ cd ~/connectedhomeip/examples/energy-gateway-app/linux
+                $ rm -rf out/
 
 ## Commandline arguments
 

--- a/examples/energy-gateway-app/linux/README.md
+++ b/examples/energy-gateway-app/linux/README.md
@@ -51,7 +51,7 @@ details.
                 $ ./scripts/checkout_submodules.py --platform linux --recursive
 
                 # Alternatively you can check out all submodules and re-sync with:
-                $ git submodule sync --recursive; git submodule update --init --recursive
+                $ git submodule sync --recursive && git submodule update --init --recursive
 
 -   Activate your shell (do this every time you open the new terminal window)
 

--- a/examples/energy-gateway-app/linux/README.md
+++ b/examples/energy-gateway-app/linux/README.md
@@ -53,7 +53,6 @@ details.
                 # Alternatively you can check out all submodules and resync with:
                 $ git submodule sync --recursive; git submodule update --init --recursive
 
-
 -   Activate your shell (do this every time you open the new terminal window)
 
                 $ cd ~/connectedhomeip

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -43,8 +43,8 @@ details.
                 $ cd connectedhomeip
                 $ ./scripts/checkout_submodules.py --platform linux --recursive
 
-                # Alternatively you can check out all submodules and resync with:
-                $ git submodule sync --recursive; git submodule update --init --recursive
+                # Alternatively you can check out all submodules and re-sync with:
+                $ git submodule sync --recursive && git submodule update --init --recursive
 
 -   Activate your shell (do this every time you open the new terminal window)
 
@@ -62,11 +62,6 @@ details.
                 $ cd ~/connectedhomeip/examples/evse-app/linux
                 $ rm -rf out/
 
--   Build the example with pigweed RPC
-
-                $ cd ~/connectedhomeip/examples/evse-app/linux
-                $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-                $ ninja -C out/debug
 
 ## Commandline arguments
 

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -33,10 +33,10 @@ details.
 
                 $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
 
--   Clone the repo (this assumes you are checking the code out in home folder)
+-   Clone the repo (this assumes you are checking the code out in your home folder)
 
                 $ cd ~
-                $ git clone git@github.com:project-chip/connectedhomeip.git
+                $ git clone https://github.com/project-chip/connectedhomeip.git
 
 -   Ensure your repo is up to date with submodules fetched
 

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -33,11 +33,28 @@ details.
 
                 $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
 
--   Build the example application:
+-   Clone the repo (this assumes you are checking the code out in home folder)
+
+                $ cd ~
+                $ git clone git@github.com:project-chip/connectedhomeip.git
+
+-   Ensure your repo is up to date with submodules fetched
+
+                $ cd connectedhomeip
+                $ ./scripts/checkout_submodules.py --platform linux --recursive
+
+                # Alternatively you can check out all submodules and resync with:
+                $ git submodule sync --recursive; git submodule update --init --recursive
+
+
+-   Activate your shell (do this every time you open the new terminal window)
+
+                $ cd ~/connectedhomeip
+                $ source ./scripts/activate.sh
+
+-   Build the example application (in the activated shell - see above):
 
                 $ cd ~/connectedhomeip/examples/evse-app/linux
-                $ git submodule update --init
-                $ source third_party/connectedhomeip/scripts/activate.sh
                 $ gn gen out/debug
                 $ ninja -C out/debug
 
@@ -49,8 +66,6 @@ details.
 -   Build the example with pigweed RPC
 
                 $ cd ~/connectedhomeip/examples/evse-app/linux
-                $ git submodule update --init
-                $ source third_party/connectedhomeip/scripts/activate.sh
                 $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
                 $ ninja -C out/debug
 

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -46,7 +46,6 @@ details.
                 # Alternatively you can check out all submodules and resync with:
                 $ git submodule sync --recursive; git submodule update --init --recursive
 
-
 -   Activate your shell (do this every time you open the new terminal window)
 
                 $ cd ~/connectedhomeip

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -33,7 +33,8 @@ details.
 
                 $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
 
--   Clone the repo (this assumes you are checking the code out in your home folder)
+-   Clone the repo (this assumes you are checking the code out in your home
+    folder)
 
                 $ cd ~
                 $ git clone https://github.com/project-chip/connectedhomeip.git

--- a/examples/evse-app/linux/README.md
+++ b/examples/evse-app/linux/README.md
@@ -62,7 +62,6 @@ details.
                 $ cd ~/connectedhomeip/examples/evse-app/linux
                 $ rm -rf out/
 
-
 ## Commandline arguments
 
 -   `--wifi`


### PR DESCRIPTION
### Summary

This PR aims to correct a convention in the READMEs used in the example folders. Currently they instruct users to cd to examples, then activate the shell there. This potentially creates a pigweed .environment in a different place. I believe most people activate in the top level and the cd into a different folder.

This impacts around 35 example files.

### Related issues

Picked up from slack thread.

### Testing

<!--
    Describe how you tested this change.

    Examples:
        - Added unit tests
        - Verified by YAML test: TC_ABC.yaml
        - Added Python test: TC_DEF.py
        - Manually tested (describe steps)

    Please replace this HTML comment with the actual testing details.
-->
