### PR TITLE
[dnssd] Use the two-argument erase when pruning browse results

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -803,14 +803,12 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         ChipLogProgress(DeviceLayer, "Avahi browse: remove");
         if (strcmp("local", domain) == 0)
         {
-            // don't attempt to erase if vector has been cleared
-            if (context->mServices.size())
-            {
-                context->mServices.erase(std::remove_if(
-                    context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
-                        return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
-                    }));
-            }
+            context->mServices.erase(std::remove_if(context->mServices.begin(), context->mServices.end(),
+                                                    [name, type](const DnssdService & service) {
+                                                        return strcmp(name, service.mName) == 0 &&
+                                                            type == GetFullType(service.mType, service.mProtocol);
+                                                    }),
+                                     context->mServices.end());
 
             if (context->mReceivedAllCached)
             {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -145,11 +145,13 @@ void OnBrowseRemove(chip::Dnssd::BrowseContext * context, const char * type, con
 {
     ChipLogDetail(DeviceLayer, "DNSsd %s: name: %s, type: %s, interfaceId: %u", __func__, StringOrNullMarker(name),
                   StringOrNullMarker(type), interfaceId);
-    context->mServices.erase(std::remove_if(
-        context->mServices.begin(), context->mServices.end(), [name, type, interfaceId](const chip::Dnssd::DnssdService & service) {
-            return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol) &&
-                interfaceId == service.mInterface.GetPlatformInterface();
-        }));
+    context->mServices.erase(std::remove_if(context->mServices.begin(), context->mServices.end(),
+                                            [name, type, interfaceId](const chip::Dnssd::DnssdService & service) {
+                                                return strcmp(name, service.mName) == 0 &&
+                                                    type == GetFullType(service.mType, service.mProtocol) &&
+                                                    interfaceId == service.mInterface.GetPlatformInterface();
+                                            }),
+                             context->mServices.end());
 }
 
 void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -761,14 +761,12 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         ChipLogProgress(DeviceLayer, "Avahi browse: remove");
         if (strcmp("local", domain) == 0)
         {
-            // don't attempt to erase if vector has been cleared
-            if (context->mServices.size())
-            {
-                context->mServices.erase(std::remove_if(
-                    context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
-                        return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
-                    }));
-            }
+            context->mServices.erase(std::remove_if(context->mServices.begin(), context->mServices.end(),
+                                                    [name, type](const DnssdService & service) {
+                                                        return strcmp(name, service.mName) == 0 &&
+                                                            type == GetFullType(service.mType, service.mProtocol);
+                                                    }),
+                                     context->mServices.end());
 
             if (context->mReceivedAllCached)
             {


### PR DESCRIPTION
#### Summary

The DNS-SD browse-remove handlers use the erase-remove idiom with the single-argument `vector::erase`, which is a different overload than the idiom requires.

##### Problem

`std::remove_if` returns the new logical end and does not shrink the container. Passing only that iterator to `erase` selects `erase(iterator)` — erase the single element at this position — rather than `erase(first, last)`:

- **No entry matches**: `remove_if` returns `end()`, so the call is `erase(end())` on a past-the-end iterator, which is undefined behaviour. On libstdc++ it decrements the size and destroys the last live element, so an unrelated cached service is silently dropped. A checked STL build (`-D_GLIBCXX_DEBUG`) aborts with `attempt to erase from container with a past-the-end iterator`.
- **Entries do match**: only one element is erased instead of the whole moved-from range, so services that were withdrawn stay in the cache.

The preceding `if (context->mServices.size())` check guards the wrong condition: the failing case is a predicate that matches nothing, not an empty container.

##### Solution

Pass the end iterator as well, which is the form the Darwin backend already uses in `src/platform/Darwin/dnssd/DnssdContexts.cpp`. The `size()` check is no longer needed — `erase(end(), end())` on an empty vector is a well-defined no-op.

Applied to the Linux, Tizen and webos backends.

#### Testing

These handlers are backend callbacks (avahi, Tizen dnssd) and the files have no unit-test scaffolding, so there is no host test to add.

- Reproduced the before/after behaviour with a standalone program of the same shape (GCC 13, libstdc++, ASan, `-O0`/`-O1`/`-O2`). Removing a name that is not cached: `[AAA BBB CCC]` → `[AAA BBB]` before, unchanged after. Removing a name that is cached twice: `[AAA BBB AAA AAA]` → `[BBB AAA AAA]` before, `[BBB]` after. Under `-D_GLIBCXX_DEBUG` the first case aborts before the change and passes after.
- Compile-checked the Linux backend with `gn gen out/dnssd-platform-check --args='is_clang=true chip_mdns="platform"'`. Tizen and webos were not built locally.
