### PR TITLE
[dnssd] Reject zero-length and empty inputs in the service naming builders

### DIFF
--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -89,6 +89,8 @@ CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerId * peerId)
 CHIP_ERROR MakeHostName(char * buffer, size_t bufferLen, const chip::ByteSpan & macOrEui64)
 {
     VerifyOrReturnError(bufferLen >= macOrEui64.size() * 2 + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
+    // An empty input would otherwise leave the destination untouched and still report success.
+    VerifyOrReturnError(!macOrEui64.empty(), CHIP_ERROR_INVALID_ARGUMENT);
 
     int idx = 0;
     for (size_t i = 0; i < macOrEui64.size(); ++i)
@@ -100,6 +102,10 @@ CHIP_ERROR MakeHostName(char * buffer, size_t bufferLen, const chip::ByteSpan & 
 
 CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter subtype)
 {
+    // Checked up front: the kNone case below writes a terminator unconditionally, and the
+    // final size comparison subtracts one from bufferLen.
+    VerifyOrReturnError(bufferLen > 0, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     int requiredSize;
     switch (subtype.type)
     {
@@ -153,11 +159,15 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         buffer[0]    = '\0';
         break;
     }
-    return (static_cast<size_t>(requiredSize) <= (bufferLen - 1)) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
+    return (static_cast<size_t>(requiredSize) < bufferLen) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }
 
 CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter nameDesc, DiscoveryType type)
 {
+    // Checked up front: the subtype branch below relies on the buffer being terminated by
+    // MakeServiceSubtype, and the final size comparison subtracts one from bufferLen.
+    VerifyOrReturnError(bufferLen > 0, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     int requiredSize;
     if (nameDesc.type == DiscoveryFilterType::kNone)
     {
@@ -203,7 +213,7 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
         }
     }
 
-    return (static_cast<size_t>(requiredSize) <= (bufferLen - 1)) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
+    return (static_cast<size_t>(requiredSize) < bufferLen) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -102,8 +102,7 @@ CHIP_ERROR MakeHostName(char * buffer, size_t bufferLen, const chip::ByteSpan & 
 
 CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter subtype)
 {
-    // Checked up front: the kNone case below writes a terminator unconditionally, and the
-    // final size comparison subtracts one from bufferLen.
+    // Checked up front: the kNone case below writes a terminator without consulting bufferLen.
     VerifyOrReturnError(bufferLen > 0, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     int requiredSize;
@@ -165,23 +164,27 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
 CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter nameDesc, DiscoveryType type)
 {
     // Checked up front: the subtype branch below relies on the buffer being terminated by
-    // MakeServiceSubtype, and the final size comparison subtracts one from bufferLen.
+    // MakeServiceSubtype.
     VerifyOrReturnError(bufferLen > 0, CHIP_ERROR_BUFFER_TOO_SMALL);
 
+    // Space available at the offset the service type is written to. The subtype branch writes
+    // past a subtype already in the buffer, so this is not always the whole destination, and
+    // requiredSize below is measured against it rather than against bufferLen.
+    size_t availableLen = bufferLen;
     int requiredSize;
     if (nameDesc.type == DiscoveryFilterType::kNone)
     {
         if (type == DiscoveryType::kCommissionableNode)
         {
-            requiredSize = snprintf(buffer, bufferLen, kCommissionableServiceName);
+            requiredSize = snprintf(buffer, availableLen, kCommissionableServiceName);
         }
         else if (type == DiscoveryType::kCommissionerNode)
         {
-            requiredSize = snprintf(buffer, bufferLen, kCommissionerServiceName);
+            requiredSize = snprintf(buffer, availableLen, kCommissionerServiceName);
         }
         else if (type == DiscoveryType::kOperational)
         {
-            requiredSize = snprintf(buffer, bufferLen, kOperationalServiceName);
+            requiredSize = snprintf(buffer, availableLen, kOperationalServiceName);
         }
         else
         {
@@ -192,20 +195,19 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
     {
         ReturnErrorOnFailure(MakeServiceSubtype(buffer, bufferLen, nameDesc));
         size_t subtypeLen = strlen(buffer);
+        availableLen      = bufferLen - subtypeLen;
         if (type == DiscoveryType::kCommissionableNode)
         {
-            requiredSize = snprintf(buffer + subtypeLen, bufferLen - subtypeLen, ".%s.%s", kSubtypeServiceNamePart,
-                                    kCommissionableServiceName);
+            requiredSize =
+                snprintf(buffer + subtypeLen, availableLen, ".%s.%s", kSubtypeServiceNamePart, kCommissionableServiceName);
         }
         else if (type == DiscoveryType::kCommissionerNode)
         {
-            requiredSize =
-                snprintf(buffer + subtypeLen, bufferLen - subtypeLen, ".%s.%s", kSubtypeServiceNamePart, kCommissionerServiceName);
+            requiredSize = snprintf(buffer + subtypeLen, availableLen, ".%s.%s", kSubtypeServiceNamePart, kCommissionerServiceName);
         }
         else if (type == DiscoveryType::kOperational)
         {
-            requiredSize =
-                snprintf(buffer + subtypeLen, bufferLen - subtypeLen, ".%s.%s", kSubtypeServiceNamePart, kOperationalServiceName);
+            requiredSize = snprintf(buffer + subtypeLen, availableLen, ".%s.%s", kSubtypeServiceNamePart, kOperationalServiceName);
         }
         else
         {
@@ -213,7 +215,7 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
         }
     }
 
-    return (static_cast<size_t>(requiredSize) < bufferLen) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
+    return (static_cast<size_t>(requiredSize) < availableLen) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -180,7 +180,9 @@ TEST_F(TestDnssdPlatform, TestStub)
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    OperationalAdvertisingParameters params;
+    // A MAC is required to build the host name, so set one here: this case is about the
+    // platform's reaction to an unexpected start, not about the advertising parameters.
+    OperationalAdvertisingParameters params = OperationalAdvertisingParameters().SetMac(ByteSpan(kMac));
     EXPECT_EQ(mdnsPlatform.Advertise(params), CHIP_ERROR_UNEXPECTED_EVENT);
 }
 

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -255,4 +255,41 @@ TEST(TestServiceNaming, TestMakeServiceTypeName)
     EXPECT_EQ(MakeServiceTypeName(buffer, 18, filter, DiscoveryType::kCommissionableNode), CHIP_NO_ERROR);
     EXPECT_STREQ(buffer, "_CM._sub._matterc");
 }
+
+TEST(TestServiceNaming, TestMakeHostNameEmptyInput)
+{
+    char buffer[64];
+
+    memset(buffer, 'x', sizeof(buffer));
+    // An empty mac/eui64 has no valid host name representation; the call must not report success
+    // while leaving the destination untouched.
+    EXPECT_EQ(MakeHostName(buffer, sizeof(buffer), ByteSpan()), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const uint8_t mac[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 };
+    EXPECT_EQ(MakeHostName(buffer, sizeof(buffer), ByteSpan(mac)), CHIP_NO_ERROR);
+    EXPECT_STREQ(buffer, "001122334455");
+}
+
+TEST(TestServiceNaming, TestZeroLengthDestination)
+{
+    char buffer[64];
+    DiscoveryFilter filter;
+
+    // bufferLen == 0 leaves no room even for a terminator, so every builder must reject it
+    // rather than underflow the (bufferLen - 1) comparison and report success.
+    filter.type = DiscoveryFilterType::kNone;
+    EXPECT_EQ(MakeServiceSubtype(buffer, 0, filter), CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(MakeServiceTypeName(buffer, 0, filter, DiscoveryType::kCommissionableNode), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    filter.type = DiscoveryFilterType::kCommissioningMode;
+    EXPECT_EQ(MakeServiceSubtype(buffer, 0, filter), CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(MakeServiceTypeName(buffer, 0, filter, DiscoveryType::kCommissionableNode), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    filter.type = DiscoveryFilterType::kLongDiscriminator;
+    filter.code = 0xFFF;
+    EXPECT_EQ(MakeServiceSubtype(buffer, 0, filter), CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(MakeServiceTypeName(buffer, 0, filter, DiscoveryType::kCommissionableNode), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    EXPECT_EQ(MakeHostName(buffer, 0, ByteSpan()), CHIP_ERROR_BUFFER_TOO_SMALL);
+}
 } // namespace

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -270,6 +270,25 @@ TEST(TestServiceNaming, TestMakeHostNameEmptyInput)
     EXPECT_STREQ(buffer, "001122334455");
 }
 
+TEST(TestServiceNaming, TestMakeServiceTypeNameSubtypeCapacity)
+{
+    char buffer[64];
+    DiscoveryFilter filter;
+    filter.type = DiscoveryFilterType::kCommissioningMode;
+
+    // "_CM" (3) + "._sub._matterc" (14) + terminator = 18. The suffix on its own fits in fewer
+    // bytes than the whole name does, so the final check has to account for the subtype already
+    // in the buffer rather than comparing the suffix length against the full destination size.
+    constexpr size_t kRequired = 18;
+    for (size_t tooSmall = 1; tooSmall < kRequired; tooSmall++)
+    {
+        EXPECT_EQ(MakeServiceTypeName(buffer, tooSmall, filter, DiscoveryType::kCommissionableNode), CHIP_ERROR_NO_MEMORY);
+    }
+
+    EXPECT_EQ(MakeServiceTypeName(buffer, kRequired, filter, DiscoveryType::kCommissionableNode), CHIP_NO_ERROR);
+    EXPECT_STREQ(buffer, "_CM._sub._matterc");
+}
+
 TEST(TestServiceNaming, TestZeroLengthDestination)
 {
     char buffer[64];


### PR DESCRIPTION
#### Summary

Three service naming builders return `CHIP_NO_ERROR` for inputs they cannot serve, reporting success for a result that is missing, truncated, or non-conforming. None is reachable from current callers.

##### Problem

- `MakeHostName` with an empty `macOrEui64`: the length guard degenerates to `bufferLen >= 1`, the hex loop runs zero times, and nothing is written — not even the terminator. At both call sites in `Advertiser_ImplMinimalMdns.cpp` the destination still holds the instance name from the preceding line, so the advertiser would publish that as its host name. The specification requires a link-layer-derived twelve- or sixteen-character hexadecimal string, which an instance name is not.
- `MakeServiceTypeName` measures the wrong thing: in the subtype branch `requiredSize` is the length of the `".<sub>.<service>"` suffix written past the subtype, but it is compared against the whole `bufferLen`. `_CM._sub._matterc` needs 18 bytes, yet any `bufferLen` from 15 up returned success with a truncated name. What prevents that today is the sizing of the destinations, not the check.
- `MakeServiceSubtype` and `MakeServiceTypeName` both computed `bufferLen - 1` on a `size_t`, so `bufferLen == 0` wrapped to `SIZE_MAX` and every result compared as fitting. `MakeServiceSubtype`'s `kNone` case also writes a terminator before any length check.

##### Solution

- `MakeHostName` rejects an empty span with `CHIP_ERROR_INVALID_ARGUMENT`.
- `MakeServiceTypeName` tracks the space available at the offset it writes to and measures `requiredSize` against that.
- Both builders check `bufferLen > 0` up front, ahead of the `kNone` write, and compare without subtracting.

#### Testing

- Added `TestMakeHostNameEmptyInput`, `TestMakeServiceTypeNameSubtypeCapacity` and `TestZeroLengthDestination` to `src/lib/dnssd/tests/TestServiceNaming.cpp`. The capacity test walks every destination size up to the exact fit, and fails at 15, 16 and 17 before the change.
- Each test fails before its corresponding change and passes after. `TestServiceNaming` and the other DNS-SD suites pass under `out/linux-x64-tests-asan-clang`.
