### PR TITLE
test: derive TC_DESC_2_1 namespace whitelist dynamically from bundled spec XML

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -1126,6 +1126,11 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
         REFRIGERATOR_NAMESPACE_ID = 0x41
         ROOM_AIRCONDITIONER_NAMESPACE_ID = 0x42
         SWITCHES_NAMESPACE_ID = 0x43
+        CLOSURE_NAMESPACE_ID = 0x44
+        CLOSURE_PANEL_NAMESPACE_ID = 0x45
+        CLOSURE_COVERING_NAMESPACE_ID = 0x46
+        CLOSURE_WINDOW_NAMESPACE_ID = 0x47
+        CLOSURE_CABINET_NAMESPACE_ID = 0x48
 
         END_POINT_UNIQUE_ID_LENGTH_BYTES = 32
 
@@ -1297,7 +1302,12 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
                                                       COMMON_RELATIVE_POSITION_ID,
                                                       REFRIGERATOR_NAMESPACE_ID,
                                                       ROOM_AIRCONDITIONER_NAMESPACE_ID,
-                                                      SWITCHES_NAMESPACE_ID]:
+                                                      SWITCHES_NAMESPACE_ID,
+                                                      CLOSURE_NAMESPACE_ID,
+                                                      CLOSURE_PANEL_NAMESPACE_ID,
+                                                      CLOSURE_COVERING_NAMESPACE_ID,
+                                                      CLOSURE_WINDOW_NAMESPACE_ID,
+                                                      CLOSURE_CABINET_NAMESPACE_ID]:
                         self.fail_current_test("Non manufacturer specific tag is not a tag from namespace defined in spec")
                 else:
 

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -1109,28 +1109,10 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
         ROOT_NODE_DEVICE_TYPE = 0x0016
         SECONDARY_NETWORK_INTERFACE_DEVICE_TYPE = 0x0019
 
-        COMMON_AREA_NAMESPACE_ID = 0x10
-        COMMON_CLOSURE_NAMESPACE_NAMESPACE_ID = 0x01
-        COMMON_COMPASS_DIRECTION_NAMESPACE_ID = 0x02
-        COMMON_COMPASS_LOCATION_NAMESPACE_ID = 0x03
-        COMMON_DIRECTION_NAMESPACE_ID = 0x04
-        COMMON_LANDMARK_NAMESPACE_ID = 0x11
-        COMMON_LEVEL_NAMESPACE_ID = 0x05
-        COMMON_LOCATION_NAMESPACE_ID = 0x06
-        COMMON_NUMBERNAME_SPACE_ID = 0x07
-        COMMON_POSITION_NAMESPACE_ID = 0x08
-        COMMON_RELATIVE_POSITION_ID = 0x12
-        ELECTRICAL_MEASUREMENT_NAMESPACE_ID = 0x0A
-        LAUNDRY_NAMESPACE_ID = 0x0E
-        POWER_SOURCE_NAMESPACE_ID = 0x0F
-        REFRIGERATOR_NAMESPACE_ID = 0x41
-        ROOM_AIRCONDITIONER_NAMESPACE_ID = 0x42
-        SWITCHES_NAMESPACE_ID = 0x43
-        CLOSURE_NAMESPACE_ID = 0x44
-        CLOSURE_PANEL_NAMESPACE_ID = 0x45
-        CLOSURE_COVERING_NAMESPACE_ID = 0x46
-        CLOSURE_WINDOW_NAMESPACE_ID = 0x47
-        CLOSURE_CABINET_NAMESPACE_ID = 0x48
+        # Namespace IDs accepted for non-manufacturer-specific TagList entries are derived from the
+        # bundled data model's namespaces/*.xml files (self.xml_namespaces), rather than a hand-coded
+        # whitelist, so newly-added namespaces (e.g. the Matter 1.6 Closure family) are picked up
+        # automatically without needing this test to be updated for every spec revision.
 
         END_POINT_UNIQUE_ID_LENGTH_BYTES = 32
 
@@ -1286,28 +1268,7 @@ class TC_DeviceBasicComposition(BasicCompositionTests):
                 self.print_step(5.2, f"verifying namespaceID value falls under defined namespaces for endpoint: {endpoint_id}")
 
                 if isinstance(tag_struct.mfgCode, Nullable):
-                    if tag_struct.namespaceID not in [COMMON_CLOSURE_NAMESPACE_NAMESPACE_ID,
-                                                      COMMON_COMPASS_DIRECTION_NAMESPACE_ID,
-                                                      COMMON_COMPASS_LOCATION_NAMESPACE_ID,
-                                                      COMMON_DIRECTION_NAMESPACE_ID,
-                                                      COMMON_LEVEL_NAMESPACE_ID,
-                                                      COMMON_LOCATION_NAMESPACE_ID,
-                                                      COMMON_NUMBERNAME_SPACE_ID,
-                                                      COMMON_POSITION_NAMESPACE_ID,
-                                                      ELECTRICAL_MEASUREMENT_NAMESPACE_ID,
-                                                      LAUNDRY_NAMESPACE_ID,
-                                                      POWER_SOURCE_NAMESPACE_ID,
-                                                      COMMON_AREA_NAMESPACE_ID,
-                                                      COMMON_LANDMARK_NAMESPACE_ID,
-                                                      COMMON_RELATIVE_POSITION_ID,
-                                                      REFRIGERATOR_NAMESPACE_ID,
-                                                      ROOM_AIRCONDITIONER_NAMESPACE_ID,
-                                                      SWITCHES_NAMESPACE_ID,
-                                                      CLOSURE_NAMESPACE_ID,
-                                                      CLOSURE_PANEL_NAMESPACE_ID,
-                                                      CLOSURE_COVERING_NAMESPACE_ID,
-                                                      CLOSURE_WINDOW_NAMESPACE_ID,
-                                                      CLOSURE_CABINET_NAMESPACE_ID]:
+                    if tag_struct.namespaceID not in self.xml_namespaces:
                         self.fail_current_test("Non manufacturer specific tag is not a tag from namespace defined in spec")
                 else:
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -39,8 +39,8 @@ from matter.testing.conformance import ConformanceException
 from matter.testing.matter_test_config import MatterTestConfig
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.problem_notices import ProblemNotice
-from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlCluster, XmlDeviceType, build_xml_clusters,
-                                         build_xml_device_types, dm_from_spec_version)
+from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlCluster, XmlDeviceType, XmlNamespace, build_xml_clusters,
+                                         build_xml_device_types, build_xml_namespaces, dm_from_spec_version)
 from matter.tlv import uint
 
 LOGGER = logging.getLogger(__name__)
@@ -153,6 +153,7 @@ class BasicCompositionTests(MatterBaseTest):
     endpoints_tlv: dict[int, Any]  # Wildcard read result (raw TLV)
     xml_clusters: dict[uint, XmlCluster]
     xml_device_types: dict[int, XmlDeviceType]
+    xml_namespaces: dict[int, XmlNamespace]
 
     def dump_wildcard(self, dump_device_composition_path: str | None) -> tuple[str, str]:
         """ Dumps a json and a txt file of the attribute wildcard for this device if the dump_device_composition_path is supplied.
@@ -278,4 +279,6 @@ class BasicCompositionTests(MatterBaseTest):
         LOGGER.info("----------------------------------------------------------------------------------")
         self.xml_clusters, self.problems = build_xml_clusters(dm, errata_path=errata_path)
         self.xml_device_types, problems = build_xml_device_types(dm)
+        self.problems.extend(problems)
+        self.xml_namespaces, problems = build_xml_namespaces(dm)
         self.problems.extend(problems)


### PR DESCRIPTION
#### Summary

##### Problem

- `test_TC_DESC_2_1` validates that every non-manufacturer-specific `TagList`
  entry's `namespaceID` falls under a namespace defined by the spec, using a
  hand-coded whitelist of accepted namespace ID constants.
- That whitelist stopped at `0x43` (Switches) and had not been updated for
  Matter 1.6: it was missing the entire Closure namespace family, even though
  all five are already defined in this repo's own bundled data model
  (`data_model/1.6/namespaces/Namespace-Closure*.xml`):
  - `0x44` Closure, `0x45` Closure Panel, `0x46` Closure Covering,
    `0x47` Closure Window, `0x48` Closure Cabinet
- Root cause: the whitelist is a manually maintained list of constants that is
  never automatically kept in sync with the namespace XML files bundled in
  `data_model/`, so any DUT legitimately using a namespace added by a newer
  spec revision fails this test purely because the whitelist hasn't caught up.

##### Solution

- Replaced the hand-coded whitelist with a dynamic lookup against
  `self.xml_namespaces`, a `dict[int, XmlNamespace]` built from the bundled
  `data_model/<version>/namespaces/*.xml` files via the existing
  `build_xml_namespaces()` helper in `spec_parsing.py` (already used by
  `device_conformance_tests.py` and the device-graph tool).
- Wired `xml_namespaces` into `BasicCompositionTests.build_spec_xmls()`
  alongside the existing `xml_clusters`/`xml_device_types` loading.
- The check in `test_TC_DESC_2_1` is now simply
  `tag_struct.namespaceID not in self.xml_namespaces`, so any namespace
  already defined in the bundled data model for the DUT's spec version is
  accepted automatically — no more manually maintained list of namespace ID
  constants, and no test update needed for future spec revisions that add
  namespaces.

#### Related issues

Fixes #73479

#### Testing

- Manually tested against a real DUT (a Matterbridge bridge exposing a
  Venetian Blind `Closure` (device type 0x0230) endpoint with `Lift`/`Tilt`
  `Closure Panel` (device type 0x0231) children, tagged with the
  `0x44`/`0x45` namespaces): `TC_DeviceBasicComposition.py` passes 9/9
  (0 failed) against this DUT, including `test_TC_DESC_2_1`.
- `self.xml_namespaces` reuses `build_xml_namespaces()`, which already has
  dedicated coverage in `src/python_testing/test_testing/TestSpecParsingNamespace.py`
  (including assertions that the Closure namespace family is present from
  1.5 onward).
