### PR TITLE
[NXP] Align freertos factory reset process with Zephyr one

### DIFF
--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -813,4 +813,15 @@ config NETWORK_LAYER_BLE
 	help
 		Will be deprecated once application files replace CONFIG_NETWORK_LAYER_BLE with CONFIG_BT
 
+config CHIP_FACTORY_RESET_ERASE_SETTINGS
+	bool "Erase NVS/persistent storage on factory reset"
+	default n
+	help
+	  Erases non-volatile storage pages on factory reset instead of removing
+	  Matter-related settings only. Provides a more robust factory reset
+	  mechanism and restores original storage performance if any firmware
+	  issue has left it in an unexpected state. Set this option when the
+	  entire configuration is supposed to be cleared on a factory reset,
+	  including device-specific entries.
+
 endif # CHIP

--- a/config/nxp/chip-cmake-freertos/Kconfig.defaults
+++ b/config/nxp/chip-cmake-freertos/Kconfig.defaults
@@ -193,6 +193,9 @@ endif # CHIP_OTA_REQUESTOR
 config CHIP_CRYPTO_PSA_AEAD_SINGLE_PART
 	default y
 
+config CHIP_FACTORY_RESET_ERASE_SETTINGS
+	default y
+
 # Include defaults for SDK Kconfig
 rsource "../../../third_party/nxp/nxp_matter_support/cmake/Kconfig.defconfig"
 

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -86,11 +86,6 @@ endif # CHIP_FACTORY_DATA
 config CHIP_MALLOC_SYS_HEAP
 	default y if !ARCH_POSIX
 
-# See config/zephyr/Kconfig for full definition
-config CHIP_FACTORY_RESET_ERASE_SETTINGS
-	bool
-	default y
-
 config CHIP_OTA_REQUESTOR
 	bool
 	select BOOTLOADER_MCUBOOT
@@ -701,6 +696,9 @@ config CHIP_SE05X
 	select SE05X_LIB
 	select I2C
 	select PINCTRL
+
+config CHIP_FACTORY_RESET_ERASE_SETTINGS
+	default y
 
 endif # CHIP
 

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -100,16 +100,7 @@ config CHIP_CRYPTO_PSA
 	imply PSA_WANT_ALG_ECDSA
 
 config CHIP_FACTORY_RESET_ERASE_SETTINGS
-	bool "Erase NVS flash pages on factory reset"
 	depends on SETTINGS_NVS || SETTINGS_ZMS
-	help
-	  Erases non-volatile pages occupied by non-volatile storage when a factory reset
-	  is requested, instead of removing Matter-related settings only. Enabling
-	  this option provides a more robust factory reset mechanism and allows to
-	  regain the original storage performance if any firmware issue has brought
-	  it to an unexpected state. For this reason, set this option if the entire
-	  configuration is supposed to be cleared on a factory reset, including
-	  device-specific entries.
 
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -274,9 +274,34 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
-    CHIP_ERROR err;
-
+    CHIP_ERROR err = CHIP_NO_ERROR;
     ChipLogProgress(DeviceLayer, "Performing factory reset");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TEMPORARY_RETURN_IGNORED ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
+// Lock the Thread stack to avoid unwanted interaction with settings NVS during factory reset.
+#if defined(CONFIG_OPENTHREAD) || defined(CONFIG_NET_L2_OPENTHREAD)
+#ifndef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+    // erase thread file system if we don't want to do a full NVS erase
+    ThreadStackMgr().ErasePersistentInfo();
+#endif
+    ThreadStackMgr().LockThreadStack();
+#endif
+
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+    err = NXPConfig::FactoryResetEraseSettings();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "FactoryResetEraseSettings() failed: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+#else
+
+
+#if CONFIG_CHIP_PLAT_LOAD_REAL_FACTORY_DATA
+    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::FactoryDataPrvdImpl().FactoryReset();
+#endif
 
     err = NXPConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
@@ -284,16 +309,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    ThreadStackMgr().ErasePersistentInfo();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    ConnectivityMgr().ErasePersistentInfo();
+#endif // CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
 
-#if CONFIG_CHIP_PLAT_LOAD_REAL_FACTORY_DATA
-    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::FactoryDataPrvdImpl().FactoryReset();
-#endif
-
-    /* Schedule a reset in the next idle call */
-    PlatformMgrImpl().ScheduleResetInIdle();
+    PlatformMgrImpl().Reset();
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -298,7 +298,6 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     }
 #else
 
-
 #if CONFIG_CHIP_PLAT_LOAD_REAL_FACTORY_DATA
     TEMPORARY_RETURN_IGNORED chip::DeviceLayer::FactoryDataPrvdImpl().FactoryReset();
 #endif

--- a/src/platform/nxp/common/NXPConfig.h
+++ b/src/platform/nxp/common/NXPConfig.h
@@ -184,6 +184,9 @@ public:
     static CHIP_ERROR ClearConfigValue(Key key);
     static CHIP_ERROR ClearConfigValue(const char * keyString);
     static bool ConfigValueExists(Key key);
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+    static CHIP_ERROR FactoryResetEraseSettings(void);
+#endif
     static CHIP_ERROR FactoryResetConfig(void);
     static bool ValidConfigKey(Key key);
 

--- a/src/platform/nxp/common/NXPConfig.h
+++ b/src/platform/nxp/common/NXPConfig.h
@@ -74,11 +74,11 @@ class NXPConfig
 public:
     // Category ids used by the CHIP Device Layer
     static constexpr uint8_t kFileId_ChipFactory = CATEGORY_BASE;    /**< Category containing persistent config values set at
-                                                                      * manufacturing    time. Retained during factory reset. */
+                                                                      * manufacturing time. Cleared during factory reset. */
     static constexpr uint8_t kFileId_ChipConfig = CATEGORY_BASE + 1; /**< Catyegory containing dynamic config values set at runtime.
                                                                       *   Cleared during factory reset. */
     static constexpr uint8_t kFileId_ChipCounter = CATEGORY_BASE + 2; /**< Category containing dynamic counter values set at
-                                                                       * runtime. Retained during factory reset. */
+                                                                       * runtime. Cleared during factory reset. */
     static constexpr uint8_t kFileId_KVS = CATEGORY_BASE + 3;         /**< Category containing KVS set at runtime.
                                                                        *  Cleared during factory reset. */
     static constexpr uint8_t kFileId_App = CATEGORY_BASE + 4; /**< Category containing custom application values set at runtime.

--- a/src/platform/nxp/common/NXPConfigNVS.cpp
+++ b/src/platform/nxp/common/NXPConfigNVS.cpp
@@ -392,11 +392,19 @@ CHIP_ERROR NXPConfig::FactoryResetConfig(void)
 {
     DeleteSubtreeEntry entry_string{ /* success */ 0 };
     DeleteSubtreeEntry entry_int{ /* success */ 0 };
-    // Clear CHIP_DEVICE_STRING_SETTINGS_KEY/* keys
-    settings_load_subtree_direct(CHIP_DEVICE_STRING_SETTINGS_KEY, DeleteSubtreeCallback, &entry_string);
-    // Clear CHIP_DEVICE_INTEGER_SETTINGS_KEY/* keys
-    settings_load_subtree_direct(CHIP_DEVICE_INTEGER_SETTINGS_KEY, DeleteSubtreeCallback, &entry_int);
 
+    // Clear CHIP_DEVICE_STRING_SETTINGS_KEY/* keys
+    int err_string = settings_load_subtree_direct(CHIP_DEVICE_STRING_SETTINGS_KEY, DeleteSubtreeCallback, &entry_string);
+    // Clear CHIP_DEVICE_INTEGER_SETTINGS_KEY/* keys
+    int err_int = settings_load_subtree_direct(CHIP_DEVICE_INTEGER_SETTINGS_KEY, DeleteSubtreeCallback, &entry_int);
+
+    if (err_string != 0 || err_int != 0 || entry_string.result != 0 || entry_int.result != 0)
+    {
+        ChipLogError(DeviceLayer,
+                     "FactoryResetConfig failed: load_string=%d load_int=%d del_string=%d del_int=%d",
+                     err_string, err_int, entry_string.result, entry_int.result);
+        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nxp/common/NXPConfigNVS.cpp
+++ b/src/platform/nxp/common/NXPConfigNVS.cpp
@@ -28,6 +28,9 @@ extern "C" {
 
 /* Only for flash init, to be move to sdk framework */
 #include "nvs_port.h"
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+#include <zephyr/fs/nvs.h>
+#endif
 #if (CHIP_DEVICE_CONFIG_KVS_WEAR_STATS == 1)
 #include "fwk_nvs_stats.h"
 #endif /* CHIP_DEVICE_CONFIG_KVS_WEAR_STATS */
@@ -365,32 +368,35 @@ bool NXPConfig::ConfigValueExists(Key key)
     return err;
 }
 
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+CHIP_ERROR NXPConfig::FactoryResetEraseSettings(void)
+{
+    void * storage = nullptr;
+    int status     = settings_storage_get(&storage);
+
+    if (status == 0)
+    {
+        status = nvs_clear(static_cast<nvs_fs *>(storage));
+
+    }
+    if (status)
+    {
+        ChipLogError(DeviceLayer, "Factory reset failed: %d", status);
+        return CHIP_ERROR_INTERNAL;
+    }
+    return CHIP_NO_ERROR;
+}
+#endif
+
 CHIP_ERROR NXPConfig::FactoryResetConfig(void)
 {
-    DeleteSubtreeEntry entry{ /* success */ 0 };
+    DeleteSubtreeEntry entry_string{ /* success */ 0 };
+    DeleteSubtreeEntry entry_int{ /* success */ 0 };
     // Clear CHIP_DEVICE_STRING_SETTINGS_KEY/* keys
-    int result = settings_load_subtree_direct(CHIP_DEVICE_STRING_SETTINGS_KEY, DeleteSubtreeCallback, &entry);
+    settings_load_subtree_direct(CHIP_DEVICE_STRING_SETTINGS_KEY, DeleteSubtreeCallback, &entry_string);
+    // Clear CHIP_DEVICE_INTEGER_SETTINGS_KEY/* keys
+    settings_load_subtree_direct(CHIP_DEVICE_INTEGER_SETTINGS_KEY, DeleteSubtreeCallback, &entry_int);
 
-    if (result == 0)
-    {
-        result = entry.result;
-    }
-
-    char key_name[SETTINGS_MAX_NAME_LEN + 1];
-    for (Key key = kMinConfigKey_ChipConfig; key <= kMaxConfigKey_ChipConfig; key++)
-    {
-        sprintf(key_name, CHIP_DEVICE_INTEGER_SETTINGS_KEY "/%04x", key);
-        if (settings_delete(key_name) != 0)
-            return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    }
-
-    // Clear RebootCount, TotalOperationalHours, UpTime counters during factory reset
-    for (Key key = kMinConfigKey_ChipCounter; key <= (kMinConfigKey_ChipCounter + 3); key++)
-    {
-        sprintf(key_name, CHIP_DEVICE_INTEGER_SETTINGS_KEY "/%04x", key);
-        if (settings_delete(key_name) != 0)
-            return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nxp/common/NXPConfigNVS.cpp
+++ b/src/platform/nxp/common/NXPConfigNVS.cpp
@@ -377,7 +377,6 @@ CHIP_ERROR NXPConfig::FactoryResetEraseSettings(void)
     if (status == 0)
     {
         status = nvs_clear(static_cast<nvs_fs *>(storage));
-
     }
     if (status)
     {
@@ -400,9 +399,8 @@ CHIP_ERROR NXPConfig::FactoryResetConfig(void)
 
     if (err_string != 0 || err_int != 0 || entry_string.result != 0 || entry_int.result != 0)
     {
-        ChipLogError(DeviceLayer,
-                     "FactoryResetConfig failed: load_string=%d load_int=%d del_string=%d del_int=%d",
-                     err_string, err_int, entry_string.result, entry_int.result);
+        ChipLogError(DeviceLayer, "FactoryResetConfig failed: load_string=%d load_int=%d del_string=%d del_int=%d", err_string,
+                     err_int, entry_string.result, entry_int.result);
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
     return CHIP_NO_ERROR;


### PR DESCRIPTION
### Summary

The RW61x NXP platform supports both FreeRTOS and Zephyr RTOS. This PR aligns the FreeRTOS factory reset procedure with the existing Zephyr implementation.

As part of this change, the device reset is now performed synchronously instead of being deferred to the idle task. This ensures consistent behavior across both RTOS implementations and simplifies the factory reset flow.

### Testing

Validation was performed using the RW61x FreeRTOS Thermostat application:

1. Built and flashed the example application.
2. Commissioned the device to a Matter fabric.
3. Performed a factory reset.
4. Verified that all Matter-related keys and persistent data were removed from the file system.
5. Confirmed that the device could be successfully recommissioned after the factory reset.