### PR TITLE
[python] Widen WriteAttributes interaction timeout to uint32_t

### DIFF
--- a/src/controller/python/matter/clusters/attribute.cpp
+++ b/src/controller/python/matter/clusters/attribute.cpp
@@ -409,9 +409,10 @@ PyChipError pychip_WriteClient_WriteAttributes(void * appContext, DeviceProxy * 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // The FFI from Python to C when calling a variadic function has issues when the regular, non-variadic, function
-    // arguments are unit16_t. As a result we pass these arguments as size_t and cast them to the expected uint16_t.
+    // arguments are narrow integer types. As a result we pass these arguments as size_t and cast them to their
+    // expected width: uint32_t for the interaction timeout, uint16_t for the others.
     uint16_t timedWriteTimeoutMs  = static_cast<uint16_t>(timedWriteTimeoutMsSizeT);
-    uint16_t interactionTimeoutMs = static_cast<uint16_t>(interactionTimeoutMsSizeT);
+    uint32_t interactionTimeoutMs = static_cast<uint32_t>(interactionTimeoutMsSizeT);
     uint16_t busyWaitMs           = static_cast<uint16_t>(busyWaitMsSizeT);
 
     std::unique_ptr<WriteClientCallback> callback = std::make_unique<WriteClientCallback>(appContext);
@@ -449,7 +450,7 @@ PyChipError pychip_WriteClient_TestOnlyWriteAttributesWithMismatchedTimedRequest
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     uint16_t timedWriteTimeoutMs  = static_cast<uint16_t>(timedWriteTimeoutMsSizeT);
-    uint16_t interactionTimeoutMs = static_cast<uint16_t>(interactionTimeoutMsSizeT);
+    uint32_t interactionTimeoutMs = static_cast<uint32_t>(interactionTimeoutMsSizeT);
     uint16_t busyWaitMs           = static_cast<uint16_t>(busyWaitMsSizeT);
 
     std::unique_ptr<WriteClientCallback> callback = std::make_unique<WriteClientCallback>(appContext);


### PR DESCRIPTION
#### Summary

Widen the interaction timeout in the Python `WriteClient` bindings from `uint16_t` to `uint32_t`, matching the invoke-path bindings updated in #73359.

##### Problem

- `pychip_WriteClient_WriteAttributes` (and its TestOnly sibling) receive the interaction timeout across the FFI boundary as `size_t`, then cast it to `uint16_t` before passing it to `SendWriteRequest` as a `System::Clock::Milliseconds32`.
- Any interaction timeout above 65535 ms is silently truncated (and wraps): 70000 ms becomes 4464 ms, and multiples of 65536 ms collapse to 0, i.e. the default timeout.

##### Solution

- Cast the interaction timeout to `uint32_t`, matching the `Milliseconds32` width of the sink and the invoke-path bindings (`pychip_CommandSender_*`), which #73359 already moved to a 32-bit interaction timeout.
- `timedWriteTimeoutMs` and `busyWaitMs` remain `uint16_t`: the timed-request timeout is a `uint16` protocol field consumed as `Optional<uint16_t>`, and `busyWaitMs` is a local `usleep` budget where 16 bits is ample.

#### Related issues

Applies to the write path the same fix #73359 made on the invoke path.

#### Testing

N/A. No in-tree caller passes a write interaction timeout above 65535 ms, so there is no behavior change to assert against; this is a type-consistency fix mirroring the invoke path. The Python side already marshals the value as `c_size_t`, so no binding-registration change is needed.
