### PR TITLE
bound FileDesLength to kMaxFileDesignatorLen in TransferInit::Parse

### DIFF
--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -136,6 +136,10 @@ CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
 
     ReturnErrorOnFailure(bufReader.Read16(&FileDesLength).StatusCode());
 
+    // The file designator is capped at kMaxFileDesignatorLen by the protocol. Reject anything larger before it
+    // is used to compute the metadata start index below, where it is narrowed to a uint16_t.
+    VerifyOrReturnError(FileDesLength <= kMaxFileDesignatorLen, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
     VerifyOrReturnError(bufReader.HasAtLeast(FileDesLength), CHIP_ERROR_MESSAGE_INCOMPLETE);
     FileDesignator = &bufStart[bufReader.OctetsRead()];
 

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -73,6 +73,38 @@ TEST_F(TestBdxMessages, TestTransferInitMessage)
     TestHelperWrittenAndParsedMatch<TransferInit>(testMsg);
 }
 
+TEST_F(TestBdxMessages, TestTransferInitOversizedFileDesignator)
+{
+    // A FileDesLength larger than kMaxFileDesignatorLen must be rejected while parsing, before it feeds the
+    // metadata start index computation. A designator of exactly kMaxFileDesignatorLen bytes still round-trips.
+    uint8_t designator[kMaxFileDesignatorLen + 1] = { 0 };
+
+    TransferInit testMsg;
+    testMsg.TransferCtlOptions.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
+    testMsg.Version        = 1;
+    testMsg.MaxBlockSize   = 256;
+    testMsg.FileDesLength  = kMaxFileDesignatorLen + 1;
+    testMsg.FileDesignator = designator;
+
+    size_t msgSize = testMsg.MessageSize();
+    Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(msgSize));
+    ASSERT_FALSE(bbuf.IsNull());
+    testMsg.WriteToBuffer(bbuf);
+    EXPECT_TRUE(bbuf.Fit());
+
+    System::PacketBufferHandle msgBuf = bbuf.Finalize();
+    ASSERT_FALSE(msgBuf.IsNull());
+    System::PacketBufferHandle rcvBuf = System::PacketBufferHandle::NewWithData(msgBuf->Start(), msgSize);
+    ASSERT_FALSE(rcvBuf.IsNull());
+
+    TransferInit parsed;
+    EXPECT_NE(parsed.Parse(std::move(rcvBuf)), CHIP_NO_ERROR);
+
+    // A designator sized exactly at the maximum is still accepted.
+    testMsg.FileDesLength = kMaxFileDesignatorLen;
+    TestHelperWrittenAndParsedMatch<TransferInit>(testMsg);
+}
+
 TEST_F(TestBdxMessages, TestSendAcceptMessage)
 {
     SendAccept testMsg;


### PR DESCRIPTION
### Summary

`TransferInit::Parse` reads the 16-bit `FileDesLength` off the wire and never checks it against `kMaxFileDesignatorLen`, so it flows into the metadata start index computation where the offset is narrowed to `uint16_t`, while the sibling accept and block parsers keep a `size_t` remaining count and never narrow. The field's own consumer in `BdxOTASender` already re-checks that same bound, so the cap belongs at the parse boundary next to the existing length checks. Bound `FileDesLength` right after the read so an over-max designator is rejected before it reaches the narrowing.

### Related issues

None.

### Testing

Added a `TestBdxMessages` regression that crafts a `TransferInit` whose `FileDesLength` exceeds `kMaxFileDesignatorLen` and expects `Parse` to reject it, plus a boundary case at exactly `kMaxFileDesignatorLen` that still round-trips. It fails before the change (the oversized designator parses as `CHIP_NO_ERROR`) and passes after. The full `src/protocols/bdx/tests` suite is green on `darwin-arm64-tests-clang`.
