### PR TITLE
[Silabs] Fix refrigerator app build

### DIFF
--- a/examples/refrigerator-app/silabs/src/AppTask.cpp
+++ b/examples/refrigerator-app/silabs/src/AppTask.cpp
@@ -372,7 +372,7 @@ void AppTask::CabinetModeClusterInit(chip::EndpointId endpointId)
     VerifyOrDie(gCabinetModeInstance->Init() == CHIP_NO_ERROR);
 }
 
-void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback(chip::EndpointId endpointId)
+void MatterRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback(chip::EndpointId endpointId)
 {
     AppInstance().CabinetModeClusterInit(endpointId);
 }


### PR DESCRIPTION
### Summary
https://github.com/project-chip/connectedhomeip/pull/73444 cherry-picked refactor work from matter_sdk based on 1.6 branch

on master branch, https://github.com/project-chip/connectedhomeip/pull/72058 renamed `emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback` -> `MatterRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback` causing build failures in the sync PR (undefined reference to the newly named function)

rename to `MatterRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback` to fix build and be up to date with latest master. 

no implication on exposed API/project upgrades (internal helper function)

### Related issues
n/a

### Testing
build refrigerator app locally
