### PR TITLE
Add missing test step skips if DPTZ is not supported on the DUT

### DIFF
--- a/src/python_testing/TC_AVSUM_2_9.py
+++ b/src/python_testing/TC_AVSUM_2_9.py
@@ -254,6 +254,10 @@ class TC_AVSUM_2_9(MatterBaseTest, AVSUMTestBase):
             # Read DPTZStreams and verify that the stream and viewport are present
             if not await self.dptzstreamentryvalid(endpoint, videoStreamID, viewport):
                 asserts.assert_fail("No matching stream id and viewport found in DPTZStreams for the allocated video stream")
+        else:
+            self.skip_step(19)
+            self.skip_step(20)
+            self.skip_step(21)
 
         self.step(22)
         # Reboot DUT


### PR DESCRIPTION
### Summary

AVSUM 2.9 didn't skip steps 19-21 if the DUT doesn't support DPTZ. Resulting in a test script failure.

### Related issues

Fixes #73435 

### Testing

Rebuild the camera app, run test script, ensure success with DPTZ
Instrument the camera-app so DPTZ is not a supported feature, manually re-run AVSUM 2.9, ensure no errors. 
