### PR TITLE
[Scenes] Backwards Compatibility TC_CC_10_1

### DIFF
--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -79,53 +79,97 @@ class TC_CC_10_1(MatterBaseTest):
     def steps_TC_CC_10_1(self) -> list[TestStep]:
         return [
             TestStep("0", "Commissioning, already done", is_commissioning=True),
-            TestStep("0a", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT using a key that is pre-installed on the TH. GroupKeySet fields are as follows: GroupKeySetID: 0x01a1, GroupKeySecurityPolicy: TrustFirst (0), EpochKey0: a0a1a2a3a4a5a6a7a8a9aaabacadaeaf, EpochStartTime0: 1110000"),
-            TestStep("0b", "If the Groupcast cluster is enabled on the root node, skip this step. Otherwise, TH binds GroupIds 0x0001 with GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on GroupKeyManagement cluster."),
-            TestStep("0c", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH reads the Groupcast membership attribute on the DUT."),
-            TestStep("0d", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command with GroupID field as 0 to DUT. Otherwise, TH sends a RemoveAllGroups command to DUT."),
-            TestStep("1a", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command with GroupID 1, Endpoints set with the EndpointId, where ColorControl cluster is enabled, and KeySetID 0x01a1 to DUT. Otherwise, TH sends AddGroup command to DUT, with the GroupID field set to 1."),
+            TestStep("0a", "TH sends KeySetWrite command in the GroupKeyManagement cluster to DUT using a key that is pre-installed "
+                     "on the TH. GroupKeySet fields are as follows: GroupKeySetID: 0x01a1, GroupKeySecurityPolicy: TrustFirst (0), "
+                     "EpochKey0: a0a1a2a3a4a5a6a7a8a9aaabacadaeaf, EpochStartTime0: 1110000"),
+            TestStep("0b", "If the Groupcast cluster is enabled on the root node, skip this step. Otherwise, TH binds GroupIds "
+                     "0x0001 with GroupKeySetID 0x01a1 in the GroupKeyMap attribute list on GroupKeyManagement cluster."),
+            TestStep("0c", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH reads the Groupcast membership "
+                     "attribute on the DUT."),
+            TestStep("0d", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast LeaveGroup command "
+                     "with GroupID field as 0 to DUT. Otherwise, TH sends a RemoveAllGroups command to DUT."),
+            TestStep("1a", "If the Groupcast cluster is enabled on the RootNode endpoint, the TH sends Groupcast JoinGroup command "
+                     "with GroupID 1, Endpoints set with the EndpointId, where ColorControl cluster is enabled, and KeySetID 0x01a1 "
+                     "to DUT. Otherwise, TH sends AddGroup command to DUT, with the GroupID field set to 1."),
             TestStep("1b", "TH sends a _RemoveAllScenes_ command to DUT with the _GroupID_ field set to _G~1~_."),
             TestStep("1c", "TH sends a _GetSceneMembership_ command to DUT with the _GroupID_ field set to _G~1~_."),
             TestStep("1d", "TH reads ColorTempPhysicalMinMireds attribute from DUT."),
             TestStep("1e", "TH reads ColorTempPhysicalMaxMireds attribute from DUT."),
-            TestStep("2a", "TH sends _MoveToHueAndSaturation command_ to DUT with _Hue_=200, _Saturation_=50 and _TransitionTime_=0 (immediately)."),
+            TestStep("2a", "TH sends _MoveToHueAndSaturation command_ to DUT with _Hue_=200, _Saturation_=50 and _TransitionTime_=0 "
+                     "(immediately)."),
             TestStep("2b", "TH reads _CurrentHue and CurrentSaturation attributes_ from DUT."),
-            TestStep("2c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("2d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("3a", "TH sends _MoveToColor command_ to DUT, with: ColorX = 32768/0x8000 (x=0.5) (purple), ColorY = 19660/0x4CCC (y=0.3), TransitionTime = 0 (immediate)"),
+            TestStep("2c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("2d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("3a", "TH sends _MoveToColor command_ to DUT, with: ColorX = 32768/0x8000 (x=0.5) (purple), ColorY = "
+                     "19660/0x4CCC (y=0.3), TransitionTime = 0 (immediate)"),
             TestStep("3b", "TH reads _CurrentX and CurrentY attributes_ from DUT."),
-            TestStep("3c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("3d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("4a", "TH sends _MoveToColorTemperature command_ to DUT with _ColorTemperatureMireds_=(_ColorTempPhysicalMinMireds_ + _ColorTempPhysicalMaxMireds_)/2"),
+            TestStep("3c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("3d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("4a", "TH sends _MoveToColorTemperature command_ to DUT with _ColorTemperatureMireds_="
+                     "(_ColorTempPhysicalMinMireds_ + _ColorTempPhysicalMaxMireds_)/2"),
             TestStep("4b", "TH reads _ColorTemperatureMireds attribute_ from DUT."),
-            TestStep("4c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("4d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("5a", "TH sends _EnhancedMoveToHueAndSaturation command_ to DUT with _EnhancedHue_=20000, _Saturation_=50 and _TransitionTime_=0 (immediately)."),
+            TestStep("4c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("4d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("5a", "TH sends _EnhancedMoveToHueAndSaturation command_ to DUT with _EnhancedHue_=20000, _Saturation_=50 and "
+                     "_TransitionTime_=0 (immediately)."),
             TestStep("5b", "TH reads _EnhancedCurrentHue and CurrentSaturation attributes_ from DUT."),
-            TestStep("5c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
-            TestStep("5d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
+            TestStep("5c", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("5d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
+                     "set to 0x01."),
+            TestStep("6", "If the ClusterRevision is < 2, then skip the tests 7b and 7e. Otherwise, skip the tests 7a and 7d."),
             TestStep(
-                "6a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0xE0 }, { AttributeID: 0x4001, ValueUnsigned8: 0xE0 }, { AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
-            TestStep("6b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02 and the _TransitionTime_ omitted."),
-            TestStep("6c", "TH reads the _CurrentHue attribute_ and _CurrentSaturation attribute_ from DUT."),
+                "7a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02,"
+                " the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300,"
+                "AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x00 }, { AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
             TestStep(
-                "7a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x01 }, { AttributeID: 0x0003, ValueUnsigned16: 16334 },{ AttributeID: 0x0004, ValueUnsigned16: 13067 }]}]'"),
-            TestStep("7b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03 and the _TransitionTime_ omitted."),
-            TestStep("7c", "TH reads _CurrentX and CurrentY attributes_ from DUT."),
+                "7b", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02,"
+                " the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300,"
+                "AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x00 }, { AttributeID: 0x0000, ValueUnsigned8: 0xE0 }, "
+                "{ AttributeID: 0x0001, ValueUnsigned8: 0xE0 }]}]'"),
+            TestStep("7c", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set "
+                     "to 0x02 and the _TransitionTime_ omitted."),
+            TestStep("7d", "TH reads the _CurrentSaturation attribute_ from DUT."),
+            TestStep("7e", "TH reads the _CurrentHue attribute_ and _CurrentSaturation attribute_ from DUT."),
             TestStep(
-                "8a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x04, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x02 }, { AttributeID: 0x0007, ValueUnsigned16: 250 }]}]'"),
-            TestStep("8b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x04 and the _TransitionTime_ omitted."),
-            TestStep("8c", "TH reads _ColorTemperatureMireds attribute_ from DUT."),
+                "8a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03"
+                ", the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, "
+                "AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x01 }, { AttributeID: 0x0003, ValueUnsigned16: 16334 },"
+                "{ AttributeID: 0x0004, ValueUnsigned16: 13067 }]}]'"),
+            TestStep("8b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x03"
+                     " and the _TransitionTime_ omitted."),
+            TestStep("8c", "TH reads _CurrentX and CurrentY attributes_ from DUT."),
             TestStep(
-                "9a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x05, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x03 }, { AttributeID: 0x4000, ValueUnsigned16: 12000 }, { AttributeID: 0x0001, ValueUnsigned16: 70 }]}]'"),
-            TestStep("9b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x05 and the _TransitionTime_ omitted."),
-            TestStep("9c", "TH reads _EnhancedCurrentHue and CurrentSaturation attributes_ from DUT."),
+                "9a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x04,"
+                " the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, "
+                "AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x02 }, { AttributeID: 0x0007, ValueUnsigned16: 250 }]}]'"),
+            TestStep("9b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x04"
+                     " and the _TransitionTime_ omitted."),
+            TestStep("9c", "TH reads _ColorTemperatureMireds attribute_ from DUT."),
             TestStep(
-                "10a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x06, the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, AttributeValueList: [{ AttributeID: 0x4002, ValueUnsigned8: 1 }, { AttributeID: 0x4003, ValueUnsigned8: 1 }, { AttributeID: 0x4004, ValueUnsigned16: 5 }]}]'"),
-            TestStep("10b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x06 and the _TransitionTime_ omitted."),
-            TestStep("10c", "TH read _ColorLoopActive attribute_ from DUT."),
-            TestStep("10d", "TH read _ColorLoopDirection attribute_ from DUT."),
-            TestStep("10e", "TH read _ColorLoopTime attribute_ from DUT."),
+                "10a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x05"
+                ", the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, "
+                "AttributeValueList: [{ AttributeID: 0x4001, ValueUnsigned8: 0x03 }, { AttributeID: 0x4000, ValueUnsigned16: 12000 }"
+                ", { AttributeID: 0x0001, ValueUnsigned16: 70 }]}]'"),
+            TestStep("10b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set"
+                     " to 0x05 and the _TransitionTime_ omitted."),
+            TestStep("10c", "TH reads _EnhancedCurrentHue and CurrentSaturation attributes_ from DUT."),
+            TestStep(
+                "11a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x06"
+                ", the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300, "
+                "AttributeValueList: [{ AttributeID: 0x4002, ValueUnsigned8: 1 }, { AttributeID: 0x4003, ValueUnsigned8: 1 }, "
+                "{ AttributeID: 0x4004, ValueUnsigned16: 5 }]}]'"),
+            TestStep("11b", "TH sends a _RecallScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set"
+                     " to 0x06 and the _TransitionTime_ omitted."),
+            TestStep("11c", "TH read _ColorLoopActive attribute_ from DUT."),
+            TestStep("11d", "TH read _ColorLoopDirection attribute_ from DUT."),
+            TestStep("11e", "TH read _ColorLoopTime attribute_ from DUT."),
         ]
 
     @async_test_body
@@ -362,9 +406,38 @@ class TC_CC_10_1(MatterBaseTest):
                     if AV.attributeID == 0x4000:
                         asserts.assert_less_equal(AV.valueUnsigned16, 21800, "View Scene failed on EnhancedHue above limit")
                         asserts.assert_greater_equal(AV.valueUnsigned16, 18200, "View Scene failed on EnhancedHue below limit")
+        self.step("6")
+        clusterRevision = await self.read_single_attribute_check_success(
+            cluster=cluster, attribute=cluster.Attributes.ClusterRevision, dev_ctrl=self.TH1, endpoint=self.matter_test_config.endpoint)
 
-        self.step("6a")
-        if self.pics_guard(self.check_pics("CC.S.F00")):
+        self.step("7a")
+        if clusterRevision < 2 and self.pics_guard(self.check_pics("CC.S.F00")):
+            result = await self.TH1.SendCommand(
+                self.dut_node_id, self.matter_test_config.endpoint,
+                Clusters.ScenesManagement.Commands.AddScene(
+                    self.kGroup1,
+                    0x02,
+                    0,
+                    "Sat Scene",
+                    [
+                        self._prepare_cc_extension_field_set(
+                            [
+                                Clusters.ScenesManagement.Structs.AttributeValuePairStruct(attributeID=0x4001, valueUnsigned8=0x00),
+                                Clusters.ScenesManagement.Structs.AttributeValuePairStruct(attributeID=0x0001, valueUnsigned8=0xE0)
+                            ]
+                        )
+                    ]
+
+                )
+            )
+            asserts.assert_equal(result.status, Status.Success, "Add Scene failed on status")
+            asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
+            asserts.assert_equal(result.sceneID, 0x02, "Add Scene failed on sceneID")
+        else:
+            self.mark_current_step_skipped()
+
+        self.step("7b")
+        if clusterRevision >= 2 and self.pics_guard(self.check_pics("CC.S.F00")):
             result = await self.TH1.SendCommand(
                 self.dut_node_id, self.matter_test_config.endpoint,
                 Clusters.ScenesManagement.Commands.AddScene(
@@ -387,15 +460,25 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_equal(result.status, Status.Success, "Add Scene failed on status")
             asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
             asserts.assert_equal(result.sceneID, 0x02, "Add Scene failed on sceneID")
-
-        self.step("6b")
+        else:
+            self.mark_current_step_skipped()
+        self.step("7c")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x02))
-        self.step("6c")
-        if self.pics_guard(self.check_pics("CC.S.F00")):
-            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8), (attributes.CurrentHue, 0xD8, 0xE8)])
 
-        self.step("7a")
+        self.step("7d")
+        if clusterRevision < 2 and self.pics_guard(self.check_pics("CC.S.F00")):
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8)])
+        else:
+            self.mark_current_step_skipped()
+
+        self.step("7e")
+        if clusterRevision >= 2 and self.pics_guard(self.check_pics("CC.S.F00")):
+            await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentSaturation, 0xD8, 0xE8), (attributes.CurrentHue, 0xD8, 0xE8)])
+        else:
+            self.mark_current_step_skipped()
+
+        self.step("8a")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             result = await self.TH1.SendCommand(
                 self.dut_node_id, self.matter_test_config.endpoint,
@@ -422,14 +505,14 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
             asserts.assert_equal(result.sceneID, 0x03, "Add Scene failed on sceneID")
 
-        self.step("7b")
+        self.step("8b")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x03))
-        self.step("7c")
+        self.step("8c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.poll_until_attributes_in_range(cluster, [(attributes.CurrentX, 14000, 18000), (attributes.CurrentY, 11000, 15000)])
 
-        self.step("8a")
+        self.step("9a")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             result = await self.TH1.SendCommand(
                 self.dut_node_id, self.matter_test_config.endpoint,
@@ -453,14 +536,14 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
             asserts.assert_equal(result.sceneID, 0x04, "Add Scene failed on sceneID")
 
-        self.step("8b")
+        self.step("9b")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x04))
-        self.step("8c")
+        self.step("9c")
         if self.pics_guard(self.check_pics("CC.S.F04")):
             await self.poll_until_attributes_in_range(cluster, [(attributes.ColorTemperatureMireds, ColorTempPhysicalMinMiredsValue, ColorTempPhysicalMaxMiredsValue)])
 
-        self.step("9a")
+        self.step("10a")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             result = await self.TH1.SendCommand(
                 self.dut_node_id, self.matter_test_config.endpoint,
@@ -486,14 +569,14 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
             asserts.assert_equal(result.sceneID, 0x05, "Add Scene failed on sceneID")
 
-        self.step("9b")
+        self.step("10b")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x05))
-        self.step("9c")
+        self.step("10c")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.poll_until_attributes_in_range(cluster, [(attributes.EnhancedCurrentHue, 10200, 13800), (attributes.CurrentSaturation, 62, 78)])
 
-        self.step("10a")
+        self.step("11a")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             result = await self.TH1.SendCommand(
                 self.dut_node_id, self.matter_test_config.endpoint,
@@ -518,19 +601,19 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_equal(result.groupID, self.kGroup1, "Add Scene failed on groupID")
             asserts.assert_equal(result.sceneID, 0x06, "Add Scene failed on sceneID")
 
-        self.step("10b")
+        self.step("11b")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, Clusters.ScenesManagement.Commands.RecallScene(self.kGroup1, 0x06))
-        self.step("10c")
+        self.step("11c")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             await self.poll_until_attributes_in_range(cluster, [(attributes.ColorLoopActive, 1, 1)])
 
-        self.step("10d")
+        self.step("11d")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             ColorLoopDirection = await self.read_single_attribute_check_success(cluster, attributes.ColorLoopDirection)
             asserts.assert_equal(ColorLoopDirection, 1, "ColorLoopDirection is not 1")
 
-        self.step("10e")
+        self.step("11e")
         if self.pics_guard(self.check_pics("CC.S.F02")):
             ColorLoopTime = await self.read_single_attribute_check_success(cluster, attributes.ColorLoopTime)
             asserts.assert_equal(ColorLoopTime, 5, "ColorLoopTime is not 5")

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -123,7 +123,7 @@ class TC_CC_10_1(MatterBaseTest):
                      "set to 0x01."),
             TestStep("5d", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field "
                      "set to 0x01."),
-            TestStep("6", "If the ClusterRevision is < 2, then skip the tests 7b and 7e. Otherwise, skip the tests 7a and 7d."),
+            TestStep("6", "If the ScenesManagement ClusterRevision is < 2, then skip the tests 7b and 7e. Otherwise, skip the tests 7a and 7d."),
             TestStep(
                 "7a", "TH sends a _AddScene_ command to DUT with the _GroupID_ field set to _G~1~_, the _SceneID_ field set to 0x02,"
                 " the TransitionTime field set to 0 and the ExtensionFieldSetStructs set to: '[{ ClusterID: 0x0300,"
@@ -408,7 +408,7 @@ class TC_CC_10_1(MatterBaseTest):
                         asserts.assert_greater_equal(AV.valueUnsigned16, 18200, "View Scene failed on EnhancedHue below limit")
         self.step("6")
         clusterRevision = await self.read_single_attribute_check_success(
-            cluster=cluster, attribute=cluster.Attributes.ClusterRevision, dev_ctrl=self.TH1, endpoint=self.matter_test_config.endpoint)
+            cluster=Clusters.Objects.ScenesManagement, attribute=Clusters.ScenesManagement.Attributes.ClusterRevision, dev_ctrl=self.TH1, endpoint=self.matter_test_config.endpoint)
 
         self.step("7a")
         if clusterRevision < 2 and self.pics_guard(self.check_pics("CC.S.F00")):


### PR DESCRIPTION
### Summary

When making CurrentHue Sceneable check as part of TC_CC_10_1, we ended up making the test breaking backwards compatibility.

This PR adds a path for backwards compatibility test for TC_CC_10_1 for rev < 2 by branching on the Scenes cluster revision

### Related issues

na

### Testing
Ran TC_CC_10_1 locally.