### PR TITLE
[dnssd] rename namespace for types under dnssd/wire

### DIFF
--- a/examples/minimal-mdns/PacketReporter.cpp
+++ b/examples/minimal-mdns/PacketReporter.cpp
@@ -27,33 +27,33 @@ namespace MdnsExample {
 
 namespace {
 
-const char * ToString(mdns::Minimal::QType qtype)
+const char * ToString(chip::Dnssd::QType qtype)
 {
     static char buff[32];
 
     switch (qtype)
     {
-    case mdns::Minimal::QType::A:
+    case chip::Dnssd::QType::A:
         return "A";
-    case mdns::Minimal::QType::NS:
+    case chip::Dnssd::QType::NS:
         return "NS";
-    case mdns::Minimal::QType::CNAME:
+    case chip::Dnssd::QType::CNAME:
         return "CNAME";
-    case mdns::Minimal::QType::SOA:
+    case chip::Dnssd::QType::SOA:
         return "SOA";
-    case mdns::Minimal::QType::WKS:
+    case chip::Dnssd::QType::WKS:
         return "WKS";
-    case mdns::Minimal::QType::PTR:
+    case chip::Dnssd::QType::PTR:
         return "PTR";
-    case mdns::Minimal::QType::MX:
+    case chip::Dnssd::QType::MX:
         return "MX";
-    case mdns::Minimal::QType::SRV:
+    case chip::Dnssd::QType::SRV:
         return "SRV";
-    case mdns::Minimal::QType::AAAA:
+    case chip::Dnssd::QType::AAAA:
         return "AAAA";
-    case mdns::Minimal::QType::ANY:
+    case chip::Dnssd::QType::ANY:
         return "ANY";
-    case mdns::Minimal::QType::TXT:
+    case chip::Dnssd::QType::TXT:
         return "TXT";
     default:
         sprintf(buff, "UNKNOWN (%d)!!", static_cast<int>(qtype));
@@ -61,15 +61,15 @@ const char * ToString(mdns::Minimal::QType qtype)
     }
 }
 
-const char * ToString(mdns::Minimal::QClass qclass)
+const char * ToString(chip::Dnssd::QClass qclass)
 {
     static char buff[32];
 
     switch (qclass)
     {
-    case mdns::Minimal::QClass::IN_UNICAST:
+    case chip::Dnssd::QClass::IN_UNICAST:
         return "IN(UNICAST)";
-    case mdns::Minimal::QClass::IN:
+    case chip::Dnssd::QClass::IN:
         return "IN";
     default:
         sprintf(buff, "UNKNOWN (%d)!!", static_cast<int>(qclass));
@@ -77,17 +77,17 @@ const char * ToString(mdns::Minimal::QClass qclass)
     }
 }
 
-const char * ToString(mdns::Minimal::ResourceType type)
+const char * ToString(chip::Dnssd::ResourceType type)
 {
     static char buff[32];
 
     switch (type)
     {
-    case mdns::Minimal::ResourceType::kAnswer:
+    case chip::Dnssd::ResourceType::kAnswer:
         return "ANSWER";
-    case mdns::Minimal::ResourceType::kAdditional:
+    case chip::Dnssd::ResourceType::kAdditional:
         return "ADDITIONAL";
-    case mdns::Minimal::ResourceType::kAuthority:
+    case chip::Dnssd::ResourceType::kAuthority:
         return "AUTHORITY";
     default:
         sprintf(buff, "UNKNOWN (%d)!!", static_cast<int>(type));
@@ -95,12 +95,12 @@ const char * ToString(mdns::Minimal::ResourceType type)
     }
 }
 
-class TxtReport : public mdns::Minimal::TxtRecordDelegate
+class TxtReport : public chip::Dnssd::TxtRecordDelegate
 {
 public:
     TxtReport(const char * prefix) : mPrefix(prefix) {}
 
-    void OnRecord(const mdns::Minimal::BytesRange & name, const mdns::Minimal::BytesRange & value) override
+    void OnRecord(const chip::Dnssd::BytesRange & name, const chip::Dnssd::BytesRange & value) override
     {
         std::string sname(reinterpret_cast<const char *>(name.Start()), name.Size());
         std::string svalue(reinterpret_cast<const char *>(value.Start()), value.Size());
@@ -112,7 +112,7 @@ private:
     const char * mPrefix;
 };
 
-void PrintQName(mdns::Minimal::SerializedQNameIterator it)
+void PrintQName(chip::Dnssd::SerializedQNameIterator it)
 {
     while (it.Next())
     {
@@ -127,36 +127,36 @@ void PrintQName(mdns::Minimal::SerializedQNameIterator it)
 
 } // namespace
 
-void PacketReporter::OnHeader(mdns::Minimal::ConstHeaderRef & header)
+void PacketReporter::OnHeader(chip::Dnssd::ConstHeaderRef & header)
 {
     printf("%s%s %d (%d, %d, %d, %d):\n", mPrefix, header.GetFlags().IsQuery() ? "QUERY" : "REPLY", header.GetMessageId(),
            header.GetQueryCount(), header.GetAnswerCount(), header.GetAuthorityCount(), header.GetAdditionalCount());
 }
 
-void PacketReporter::OnQuery(const mdns::Minimal::QueryData & data)
+void PacketReporter::OnQuery(const chip::Dnssd::QueryData & data)
 {
     printf("%s    QUERY %s/%s%s: ", mPrefix, ToString(data.GetType()), ToString(data.GetClass()),
            data.RequestedUnicastAnswer() ? " UNICAST" : "");
     PrintQName(data.GetName());
 }
 
-void PacketReporter::OnResource(mdns::Minimal::ResourceType type, const mdns::Minimal::ResourceData & data)
+void PacketReporter::OnResource(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceData & data)
 {
     printf("%s    %s %s/%s ttl %ld: ", mPrefix, ToString(type), ToString(data.GetType()), ToString(data.GetClass()),
            static_cast<long>(data.GetTtlSeconds()));
     PrintQName(data.GetName());
 
-    if (data.GetType() == mdns::Minimal::QType::TXT)
+    if (data.GetType() == chip::Dnssd::QType::TXT)
     {
         TxtReport txtReport(mPrefix);
-        if (!mdns::Minimal::ParseTxtRecord(data.GetData(), &txtReport))
+        if (!chip::Dnssd::ParseTxtRecord(data.GetData(), &txtReport))
         {
             printf("FAILED TO PARSE TXT RECORD\n");
         }
     }
-    else if (data.GetType() == mdns::Minimal::QType::SRV)
+    else if (data.GetType() == chip::Dnssd::QType::SRV)
     {
-        mdns::Minimal::SrvRecord srv;
+        chip::Dnssd::SrvRecord srv;
 
         if (!srv.Parse(data.GetData(), mPacketRange))
         {
@@ -168,11 +168,11 @@ void PacketReporter::OnResource(mdns::Minimal::ResourceType type, const mdns::Mi
             PrintQName(srv.GetName());
         }
     }
-    else if (data.GetType() == mdns::Minimal::QType::A)
+    else if (data.GetType() == chip::Dnssd::QType::A)
     {
         chip::Inet::IPAddress addr;
 
-        if (!mdns::Minimal::ParseARecord(data.GetData(), &addr))
+        if (!chip::Dnssd::ParseARecord(data.GetData(), &addr))
         {
             printf("FAILED TO PARSE A RECORD\n");
         }
@@ -182,11 +182,11 @@ void PacketReporter::OnResource(mdns::Minimal::ResourceType type, const mdns::Mi
             printf("%s      IP:  %s\n", mPrefix, addr.ToString(buff, sizeof(buff)));
         }
     }
-    else if (data.GetType() == mdns::Minimal::QType::AAAA)
+    else if (data.GetType() == chip::Dnssd::QType::AAAA)
     {
         chip::Inet::IPAddress addr;
 
-        if (!mdns::Minimal::ParseAAAARecord(data.GetData(), &addr))
+        if (!chip::Dnssd::ParseAAAARecord(data.GetData(), &addr))
         {
             printf("FAILED TO PARSE AAAA RECORD\n");
         }
@@ -196,10 +196,10 @@ void PacketReporter::OnResource(mdns::Minimal::ResourceType type, const mdns::Mi
             printf("%s      IP:  %s\n", mPrefix, addr.ToString(buff, sizeof(buff)));
         }
     }
-    else if (data.GetType() == mdns::Minimal::QType::PTR)
+    else if (data.GetType() == chip::Dnssd::QType::PTR)
     {
-        mdns::Minimal::SerializedQNameIterator name;
-        if (!mdns::Minimal::ParsePtrRecord(data.GetData(), mPacketRange, &name))
+        chip::Dnssd::SerializedQNameIterator name;
+        if (!chip::Dnssd::ParsePtrRecord(data.GetData(), mPacketRange, &name))
         {
             printf("FAILED TO PARSE AAAA RECORD\n");
         }

--- a/examples/minimal-mdns/PacketReporter.h
+++ b/examples/minimal-mdns/PacketReporter.h
@@ -21,18 +21,18 @@ namespace MdnsExample {
 
 /// Prints out the contents of a MDNS packet
 /// useful for visual debug of data
-class PacketReporter : public mdns::Minimal::ParserDelegate
+class PacketReporter : public chip::Dnssd::ParserDelegate
 {
 public:
-    PacketReporter(const char * prefix, const mdns::Minimal::BytesRange & packet) : mPrefix(prefix), mPacketRange(packet) {}
+    PacketReporter(const char * prefix, const chip::Dnssd::BytesRange & packet) : mPrefix(prefix), mPacketRange(packet) {}
 
-    void OnHeader(mdns::Minimal::ConstHeaderRef & header) override;
-    void OnQuery(const mdns::Minimal::QueryData & data) override;
-    void OnResource(mdns::Minimal::ResourceType type, const mdns::Minimal::ResourceData & data) override;
+    void OnHeader(chip::Dnssd::ConstHeaderRef & header) override;
+    void OnQuery(const chip::Dnssd::QueryData & data) override;
+    void OnResource(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceData & data) override;
 
 private:
     const char * mPrefix;
-    mdns::Minimal::BytesRange mPacketRange;
+    chip::Dnssd::BytesRange mPacketRange;
 };
 
 } // namespace MdnsExample

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -42,11 +42,11 @@ namespace {
 
 struct Options
 {
-    bool unicastAnswers       = true;
-    uint32_t runtimeMs        = 500;
-    uint16_t querySendPort    = 5353;
-    uint16_t listenPort       = 5388;
-    const char * query        = "_services._dns-sd._udp.local";
+    bool unicastAnswers     = true;
+    uint32_t runtimeMs      = 500;
+    uint16_t querySendPort  = 5353;
+    uint16_t listenPort     = 5388;
+    const char * query      = "_services._dns-sd._udp.local";
     chip::Dnssd::QType type = chip::Dnssd::QType::ANY;
 } gOptions;
 
@@ -270,7 +270,7 @@ void BroadcastPacket(mdns::Minimal::ServerBase * server)
     builder.Header().SetMessageId(kTestMessageId);
     builder.AddQuery(query
                          .MdnsQuery()                                  //
-                         .SetClass(chip::Dnssd::QClass::IN)          //
+                         .SetClass(chip::Dnssd::QClass::IN)            //
                          .SetType(gOptions.type)                       //
                          .SetAnswerViaUnicast(gOptions.unicastAnswers) //
     );

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -47,7 +47,7 @@ struct Options
     uint16_t querySendPort    = 5353;
     uint16_t listenPort       = 5388;
     const char * query        = "_services._dns-sd._udp.local";
-    mdns::Minimal::QType type = mdns::Minimal::QType::ANY;
+    chip::Dnssd::QType type = chip::Dnssd::QType::ANY;
 } gOptions;
 
 constexpr uint32_t kTestMessageId   = 0;
@@ -88,31 +88,31 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
     case kOptionType:
         if (strcasecmp(aValue, "ANY") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::ANY;
+            gOptions.type = chip::Dnssd::QType::ANY;
         }
         else if (strcasecmp(aValue, "A") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::A;
+            gOptions.type = chip::Dnssd::QType::A;
         }
         else if (strcasecmp(aValue, "AAAA") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::AAAA;
+            gOptions.type = chip::Dnssd::QType::AAAA;
         }
         else if (strcasecmp(aValue, "PTR") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::PTR;
+            gOptions.type = chip::Dnssd::QType::PTR;
         }
         else if (strcasecmp(aValue, "TXT") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::TXT;
+            gOptions.type = chip::Dnssd::QType::TXT;
         }
         else if (strcasecmp(aValue, "SRV") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::SRV;
+            gOptions.type = chip::Dnssd::QType::SRV;
         }
         else if (strcasecmp(aValue, "CNAME") == 0)
         {
-            gOptions.type = mdns::Minimal::QType::CNAME;
+            gOptions.type = chip::Dnssd::QType::CNAME;
         }
         else
         {
@@ -184,7 +184,7 @@ OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 class ReportDelegate : public mdns::Minimal::ServerDelegate
 {
 public:
-    void OnQuery(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -196,7 +196,7 @@ public:
         Report("QUERY: ", data);
     }
 
-    void OnResponse(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnResponse(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -209,10 +209,10 @@ public:
     }
 
 private:
-    void Report(const char * prefix, const mdns::Minimal::BytesRange & data)
+    void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!mdns::Minimal::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParsePacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }
@@ -242,18 +242,18 @@ public:
         }
     }
 
-    mdns::Minimal::Query MdnsQuery() const
+    chip::Dnssd::Query MdnsQuery() const
     {
-        mdns::Minimal::FullQName qName;
+        chip::Dnssd::FullQName qName;
 
         qName.nameCount = mParts.size();
         qName.names     = mParts.data();
 
-        return mdns::Minimal::Query(qName);
+        return chip::Dnssd::Query(qName);
     }
 
 private:
-    std::vector<mdns::Minimal::QNamePart> mParts;
+    std::vector<chip::Dnssd::QNamePart> mParts;
     std::vector<std::string> mStorage;
 };
 
@@ -270,7 +270,7 @@ void BroadcastPacket(mdns::Minimal::ServerBase * server)
     builder.Header().SetMessageId(kTestMessageId);
     builder.AddQuery(query
                          .MdnsQuery()                                  //
-                         .SetClass(mdns::Minimal::QClass::IN)          //
+                         .SetClass(chip::Dnssd::QClass::IN)          //
                          .SetType(gOptions.type)                       //
                          .SetAnswerViaUnicast(gOptions.unicastAnswers) //
     );

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -120,12 +120,12 @@ HelpOptions helpOptions("minimal-mdns-server", "Usage: minimal-mdns-server [opti
 
 OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 
-class ReplyDelegate : public mdns::Minimal::ServerDelegate, public mdns::Minimal::ParserDelegate
+class ReplyDelegate : public mdns::Minimal::ServerDelegate, public chip::Dnssd::ParserDelegate
 {
 public:
     ReplyDelegate(mdns::Minimal::ResponseSender * responder) : mResponder(responder) {}
 
-    void OnQuery(const mdns::Minimal::BytesRange & data, const Inet::IPPacketInfo * info) override
+    void OnQuery(const chip::Dnssd::BytesRange & data, const Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -137,14 +137,14 @@ public:
         Report("QUERY: ", data);
 
         mCurrentSource = info;
-        if (!mdns::Minimal::ParsePacket(data, this))
+        if (!chip::Dnssd::ParsePacket(data, this))
         {
             printf("Parsing failure may result in reply failure!\n");
         }
         mCurrentSource = nullptr;
     }
 
-    void OnResponse(const mdns::Minimal::BytesRange & data, const Inet::IPPacketInfo * info) override
+    void OnResponse(const chip::Dnssd::BytesRange & data, const Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -156,10 +156,10 @@ public:
     }
 
     // ParserDelegate
-    void OnHeader(mdns::Minimal::ConstHeaderRef & header) override { mMessageId = header.GetMessageId(); }
-    void OnResource(mdns::Minimal::ResourceType type, const mdns::Minimal::ResourceData & data) override {}
+    void OnHeader(chip::Dnssd::ConstHeaderRef & header) override { mMessageId = header.GetMessageId(); }
+    void OnResource(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceData & data) override {}
 
-    void OnQuery(const mdns::Minimal::QueryData & data) override
+    void OnQuery(const chip::Dnssd::QueryData & data) override
     {
         if (mResponder->Respond(mMessageId, data, mCurrentSource, mdns::Minimal::ResponseConfiguration()) != CHIP_NO_ERROR)
         {
@@ -168,10 +168,10 @@ public:
     }
 
 private:
-    void Report(const char * prefix, const mdns::Minimal::BytesRange & data)
+    void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!mdns::Minimal::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParsePacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }
@@ -224,30 +224,30 @@ int main(int argc, char ** args)
 
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
-    mdns::Minimal::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
+    chip::Dnssd::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
                                                         Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart tcpServerServiceName[] = { gOptions.instanceName, Dnssd::kOperationalServiceName,
+    chip::Dnssd::QNamePart tcpServerServiceName[] = { gOptions.instanceName, Dnssd::kOperationalServiceName,
                                                         Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart udpServiceName[]       = { Dnssd::kCommissionableServiceName, Dnssd::kCommissionProtocol,
+    chip::Dnssd::QNamePart udpServiceName[]       = { Dnssd::kCommissionableServiceName, Dnssd::kCommissionProtocol,
                                                         Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart udpServerServiceName[] = { gOptions.instanceName, Dnssd::kCommissionableServiceName,
+    chip::Dnssd::QNamePart udpServerServiceName[] = { gOptions.instanceName, Dnssd::kCommissionableServiceName,
                                                         Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 
     // several UDP versions for discriminators
-    mdns::Minimal::QNamePart udpDiscriminator1[] = { "S52", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
+    chip::Dnssd::QNamePart udpDiscriminator1[] = { "S52", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
                                                      Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart udpDiscriminator2[] = { "V123", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
+    chip::Dnssd::QNamePart udpDiscriminator2[] = { "V123", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
                                                      Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart udpDiscriminator3[] = { "L840", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
+    chip::Dnssd::QNamePart udpDiscriminator3[] = { "L840", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
                                                      Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 
-    mdns::Minimal::QNamePart serverName[] = { gOptions.instanceName, Dnssd::kLocalDomain };
+    chip::Dnssd::QNamePart serverName[] = { gOptions.instanceName, Dnssd::kLocalDomain };
 
     mdns::Minimal::IPv4Responder ipv4Responder(serverName);
     mdns::Minimal::IPv6Responder ipv6Responder(serverName);
-    mdns::Minimal::SrvResourceRecord srvRecord(tcpServerServiceName, serverName, CHIP_PORT);
-    mdns::Minimal::SrvResponder tcpSrvResponder(mdns::Minimal::SrvResourceRecord(tcpServerServiceName, serverName, CHIP_PORT));
-    mdns::Minimal::SrvResponder udpSrvResponder(mdns::Minimal::SrvResourceRecord(udpServerServiceName, serverName, CHIP_PORT));
+    chip::Dnssd::SrvResourceRecord srvRecord(tcpServerServiceName, serverName, CHIP_PORT);
+    mdns::Minimal::SrvResponder tcpSrvResponder(chip::Dnssd::SrvResourceRecord(tcpServerServiceName, serverName, CHIP_PORT));
+    mdns::Minimal::SrvResponder udpSrvResponder(chip::Dnssd::SrvResourceRecord(udpServerServiceName, serverName, CHIP_PORT));
     mdns::Minimal::PtrResponder ptrTcpResponder(tcpServiceName, tcpServerServiceName);
     mdns::Minimal::PtrResponder ptrUdpResponder(udpServiceName, udpServerServiceName);
     mdns::Minimal::PtrResponder ptrUdpDiscriminator1Responder(udpDiscriminator1, udpServerServiceName);
@@ -261,8 +261,8 @@ int main(int argc, char ** args)
         "PH=3",
         "OTH=Some text here...",
     };
-    mdns::Minimal::TxtResponder tcpTxtResponder(mdns::Minimal::TxtResourceRecord(tcpServerServiceName, txtEntries));
-    mdns::Minimal::TxtResponder udpTxtResponder(mdns::Minimal::TxtResourceRecord(udpServerServiceName, txtEntries));
+    mdns::Minimal::TxtResponder tcpTxtResponder(chip::Dnssd::TxtResourceRecord(tcpServerServiceName, txtEntries));
+    mdns::Minimal::TxtResponder udpTxtResponder(chip::Dnssd::TxtResourceRecord(udpServerServiceName, txtEntries));
 
     queryResponder.AddResponder(&ptrTcpResponder).SetReportInServiceListing(true).SetReportAdditional(tcpServerServiceName);
     queryResponder.AddResponder(&ptrUdpResponder).SetReportInServiceListing(true).SetReportAdditional(udpServerServiceName);

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -224,22 +224,21 @@ int main(int argc, char ** args)
 
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
-    chip::Dnssd::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
-                                                        Dnssd::kLocalDomain };
+    chip::Dnssd::QNamePart tcpServiceName[] = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart tcpServerServiceName[] = { gOptions.instanceName, Dnssd::kOperationalServiceName,
-                                                        Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
+                                                      Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart udpServiceName[]       = { Dnssd::kCommissionableServiceName, Dnssd::kCommissionProtocol,
-                                                        Dnssd::kLocalDomain };
+                                                      Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart udpServerServiceName[] = { gOptions.instanceName, Dnssd::kCommissionableServiceName,
-                                                        Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
+                                                      Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 
     // several UDP versions for discriminators
     chip::Dnssd::QNamePart udpDiscriminator1[] = { "S52", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
-                                                     Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
+                                                   Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart udpDiscriminator2[] = { "V123", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
-                                                     Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
+                                                   Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart udpDiscriminator3[] = { "L840", Dnssd::kSubtypeServiceNamePart, Dnssd::kCommissionableServiceName,
-                                                     Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
+                                                   Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 
     chip::Dnssd::QNamePart serverName[] = { gOptions.instanceName, Dnssd::kLocalDomain };
 

--- a/examples/minimal-mdns/tester.cpp
+++ b/examples/minimal-mdns/tester.cpp
@@ -136,7 +136,7 @@ OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 class ReportDelegate : public mdns::Minimal::ServerDelegate
 {
 public:
-    void OnQuery(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -148,7 +148,7 @@ public:
         Report("QUERY: ", data);
     }
 
-    void OnResponse(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnResponse(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         char addr[Inet::IPAddress::kMaxStringLength];
         info->SrcAddress.ToString(addr, sizeof(addr));
@@ -161,10 +161,10 @@ public:
     }
 
 private:
-    void Report(const char * prefix, const mdns::Minimal::BytesRange & data)
+    void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!mdns::Minimal::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParsePacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }
@@ -181,18 +181,18 @@ System::PacketBufferHandle BuildSrvTestPacket()
     constexpr uint16_t kSrvPort                          = 5540;
     constexpr const char * kNodeName                     = "ABCD1234ABCD1234";
     constexpr const char * kNodeFabricName               = "ABCD1234ABCD1234-0000000000000001";
-    constexpr mdns::Minimal::QNamePart kServiceName[]    = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
+    constexpr chip::Dnssd::QNamePart kServiceName[]    = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
                                                              Dnssd::kLocalDomain };
-    constexpr mdns::Minimal::QNamePart kServerFullName[] = { kNodeFabricName, Dnssd::kOperationalServiceName,
+    constexpr chip::Dnssd::QNamePart kServerFullName[] = { kNodeFabricName, Dnssd::kOperationalServiceName,
                                                              Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
-    constexpr mdns::Minimal::QNamePart kServerName[]     = { kNodeName, Dnssd::kLocalDomain };
+    constexpr chip::Dnssd::QNamePart kServerName[]     = { kNodeName, Dnssd::kLocalDomain };
 
-    mdns::Minimal::PtrResourceRecord ptrRecord(kServiceName, kServerFullName);
-    mdns::Minimal::SrvResourceRecord srvRecord(kServerFullName, kServerName, kSrvPort);
+    chip::Dnssd::PtrResourceRecord ptrRecord(kServiceName, kServerFullName);
+    chip::Dnssd::SrvResourceRecord srvRecord(kServerFullName, kServerName, kSrvPort);
     srvRecord.SetCacheFlush(true);
 
-    builder.AddRecord(mdns::Minimal::ResourceType::kAnswer, ptrRecord);
-    builder.AddRecord(mdns::Minimal::ResourceType::kAnswer, srvRecord);
+    builder.AddRecord(chip::Dnssd::ResourceType::kAnswer, ptrRecord);
+    builder.AddRecord(chip::Dnssd::ResourceType::kAnswer, srvRecord);
 
     if (!builder.Ok())
     {

--- a/examples/minimal-mdns/tester.cpp
+++ b/examples/minimal-mdns/tester.cpp
@@ -178,13 +178,13 @@ System::PacketBufferHandle BuildSrvTestPacket()
 
     mdns::Minimal::ResponseBuilder builder(std::move(packet));
 
-    constexpr uint16_t kSrvPort                          = 5540;
-    constexpr const char * kNodeName                     = "ABCD1234ABCD1234";
-    constexpr const char * kNodeFabricName               = "ABCD1234ABCD1234-0000000000000001";
+    constexpr uint16_t kSrvPort                        = 5540;
+    constexpr const char * kNodeName                   = "ABCD1234ABCD1234";
+    constexpr const char * kNodeFabricName             = "ABCD1234ABCD1234-0000000000000001";
     constexpr chip::Dnssd::QNamePart kServiceName[]    = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
-                                                             Dnssd::kLocalDomain };
+                                                           Dnssd::kLocalDomain };
     constexpr chip::Dnssd::QNamePart kServerFullName[] = { kNodeFabricName, Dnssd::kOperationalServiceName,
-                                                             Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
+                                                           Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
     constexpr chip::Dnssd::QNamePart kServerName[]     = { kNodeName, Dnssd::kLocalDomain };
 
     chip::Dnssd::PtrResourceRecord ptrRecord(kServiceName, kServerFullName);

--- a/src/app/server/ThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/ThreadRendezvousAnnouncement.cpp
@@ -123,17 +123,17 @@ CHIP_ERROR BuildThreadRendezvousAnnouncement(const Dnssd::CommissionAdvertisingP
         builder.Header().SetFlags(builder.Header().GetFlags().SetResponse().SetAuthoritative());
 
         static const char * matterc_udp_local[] = { "_matterc", "_udp", "local" };
-        mdns::Minimal::FullQName serviceName(matterc_udp_local);
+        chip::Dnssd::FullQName serviceName(matterc_udp_local);
 
         static const char * root[] = { "" };
-        mdns::Minimal::FullQName targetName(root);
-        mdns::Minimal::SrvResourceRecord srvRecord(serviceName, targetName, params.GetPort());
-        builder.AddRecord(mdns::Minimal::ResourceType::kAnswer, srvRecord);
+        chip::Dnssd::FullQName targetName(root);
+        chip::Dnssd::SrvResourceRecord srvRecord(serviceName, targetName, params.GetPort());
+        builder.AddRecord(chip::Dnssd::ResourceType::kAnswer, srvRecord);
 
         TxtStringsBuilder txtStringsBuilder;
         ReturnErrorOnFailure(txtStringsBuilder.Fill(params));
-        mdns::Minimal::TxtResourceRecord txtRecord(serviceName, txtStringsBuilder.GetEntries(), txtStringsBuilder.GetCount());
-        builder.AddRecord(mdns::Minimal::ResourceType::kAnswer, txtRecord);
+        chip::Dnssd::TxtResourceRecord txtRecord(serviceName, txtStringsBuilder.GetEntries(), txtStringsBuilder.GetCount());
+        builder.AddRecord(chip::Dnssd::ResourceType::kAnswer, txtRecord);
 
         outBuffer = builder.ReleasePacket();
     }

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -126,44 +126,44 @@ void ThreadMeshcopCommissionProxy::SetState(State state)
     mState = state;
 }
 
-void ThreadMeshcopCommissionProxy::OnHeader(mdns::Minimal::ConstHeaderRef & header)
+void ThreadMeshcopCommissionProxy::OnHeader(chip::Dnssd::ConstHeaderRef & header)
 {
     ChipLogDetail(Controller, "mDNS Response: ID=%u, Answers=%u, Additional=%u", header.GetMessageId(), header.GetAnswerCount(),
                   header.GetAdditionalCount());
 }
 
-void ThreadMeshcopCommissionProxy::OnQuery(const mdns::Minimal::QueryData & data)
+void ThreadMeshcopCommissionProxy::OnQuery(const chip::Dnssd::QueryData & data)
 {
     if (mState != State::kDiscovering)
     {
         ChipLogProgress(Controller, "Received mDNS query but proxy is not in discovery state");
     }
 
-    ChipLogDetail(Controller, "mDNS query: %s", mdns::Minimal::QNameString(data.GetName()).c_str());
+    ChipLogDetail(Controller, "mDNS query: %s", chip::Dnssd::QNameString(data.GetName()).c_str());
     mNodeData.Set<Dnssd::CommissionNodeData>();
 }
 
-void ThreadMeshcopCommissionProxy::OnResource(mdns::Minimal::ResourceType section, const mdns::Minimal::ResourceData & data)
+void ThreadMeshcopCommissionProxy::OnResource(chip::Dnssd::ResourceType section, const chip::Dnssd::ResourceData & data)
 {
     if (mState != State::kDiscovering)
     {
         return;
     }
 
-    auto name             = mdns::Minimal::QNameString(data.GetName());
+    auto name             = chip::Dnssd::QNameString(data.GetName());
     auto & commissionData = mNodeData.Get<Dnssd::CommissionNodeData>();
 
     commissionData.threadMeshcop = true;
 
     switch (data.GetType())
     {
-    case mdns::Minimal::QType::A:
-    case mdns::Minimal::QType::AAAA:
+    case chip::Dnssd::QType::A:
+    case chip::Dnssd::QType::AAAA:
         Platform::CopyString(commissionData.hostName, name.c_str());
         break;
 
-    case mdns::Minimal::QType::SRV: {
-        mdns::Minimal::SrvRecord srv;
+    case chip::Dnssd::QType::SRV: {
+        chip::Dnssd::SrvRecord srv;
         if (!srv.Parse(data.GetData(), mDnsPacket))
         {
             ChipLogError(Controller, "Failed to parse mDNS SRV record");
@@ -199,8 +199,8 @@ void ThreadMeshcopCommissionProxy::OnResource(mdns::Minimal::ResourceType sectio
         break;
     }
 
-    case mdns::Minimal::QType::TXT:
-        mdns::Minimal::ParseTxtRecord(data.GetData(), this);
+    case chip::Dnssd::QType::TXT:
+        chip::Dnssd::ParseTxtRecord(data.GetData(), this);
         break;
 
     default:
@@ -297,7 +297,7 @@ std::string ThreadMeshcopCommissionProxy::GetLastDiscoveryDiagnosticJson()
     return Json::writeString(writerBuilder, root);
 }
 
-void ThreadMeshcopCommissionProxy::OnRecord(const mdns::Minimal::BytesRange & name, const mdns::Minimal::BytesRange & value)
+void ThreadMeshcopCommissionProxy::OnRecord(const chip::Dnssd::BytesRange & name, const chip::Dnssd::BytesRange & value)
 {
     ByteSpan key(name.Start(), name.Size());
     ByteSpan val(value.Start(), value.Size());
@@ -316,9 +316,9 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
     }
 
     mNodeData.Set<Dnssd::CommissionNodeData>();
-    mDnsPacket = mdns::Minimal::BytesRange(payload.data(), payload.data() + payload.size());
+    mDnsPacket = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
 
-    if (!mdns::Minimal::ParsePacket(mDnsPacket, this))
+    if (!chip::Dnssd::ParsePacket(mDnsPacket, this))
     {
         ChipLogError(Controller, "Failed to parse joiner mDNS announcement");
         return;

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -47,8 +47,8 @@ namespace Controller {
  * to facilitate the transition into Matter's operational commissioning flow.
  */
 class ThreadMeshcopCommissionProxy : public ot::commissioner::CommissionerHandler,
-                                     public mdns::Minimal::ParserDelegate,
-                                     public mdns::Minimal::TxtRecordDelegate
+                                     public chip::Dnssd::ParserDelegate,
+                                     public chip::Dnssd::TxtRecordDelegate
 {
 public:
     enum class State
@@ -75,13 +75,13 @@ public:
     void OnJoinerMessage(const std::vector<uint8_t> & joinerIdBytes, uint16_t joinerPort,
                          const std::vector<uint8_t> & payload) override;
 
-    // mdns::Minimal::ParserDelegate
-    void OnHeader(mdns::Minimal::ConstHeaderRef & header) override;
-    void OnQuery(const mdns::Minimal::QueryData & data) override;
-    void OnResource(mdns::Minimal::ResourceType section, const mdns::Minimal::ResourceData & data) override;
+    // chip::Dnssd::ParserDelegate
+    void OnHeader(chip::Dnssd::ConstHeaderRef & header) override;
+    void OnQuery(const chip::Dnssd::QueryData & data) override;
+    void OnResource(chip::Dnssd::ResourceType section, const chip::Dnssd::ResourceData & data) override;
 
-    // mdns::Minimal::TxtRecordDelegate
-    void OnRecord(const mdns::Minimal::BytesRange & name, const mdns::Minimal::BytesRange & value) override;
+    // chip::Dnssd::TxtRecordDelegate
+    void OnRecord(const chip::Dnssd::BytesRange & name, const chip::Dnssd::BytesRange & value) override;
 
 private:
     // Internal Helper Methods
@@ -109,7 +109,7 @@ private:
 
     // Member Variables
     chip::Dnssd::DiscoveredNodeData mNodeData;
-    mdns::Minimal::BytesRange mDnsPacket;
+    chip::Dnssd::BytesRange mDnsPacket;
 
     int mProxyFd          = -1;
     uint16_t mServicePort = 0;

--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -72,7 +72,7 @@ bool ActiveResolveAttempts::HasBrowseFor(chip::Dnssd::DiscoveryType type) const
     return false;
 }
 
-void ActiveResolveAttempts::CompleteIpResolution(SerializedQNameIterator targetHostName)
+void ActiveResolveAttempts::CompleteIpResolution(chip::Dnssd::SerializedQNameIterator targetHostName)
 {
     for (auto & item : mRetryQueue)
     {
@@ -285,7 +285,7 @@ bool ActiveResolveAttempts::ShouldResolveIpAddress(PeerId peerId) const
     return false;
 }
 
-bool ActiveResolveAttempts::IsWaitingForIpResolutionFor(SerializedQNameIterator hostName) const
+bool ActiveResolveAttempts::IsWaitingForIpResolutionFor(chip::Dnssd::SerializedQNameIterator hostName) const
 {
     for (auto & entry : mRetryQueue)
     {

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -65,13 +65,13 @@ public:
 
         struct IpResolve
         {
-            HeapQName hostName;
-            IpResolve(HeapQName && host) : hostName(std::move(host)) {}
+            chip::Dnssd::HeapQName hostName;
+            IpResolve(chip::Dnssd::HeapQName && host) : hostName(std::move(host)) {}
         };
 
         ScheduledAttempt()
         {
-            static_assert(sizeof(Resolve) <= sizeof(Browse) || sizeof(Resolve) <= sizeof(HeapQName),
+            static_assert(sizeof(Resolve) <= sizeof(Browse) || sizeof(Resolve) <= sizeof(chip::Dnssd::HeapQName),
                           "Figure out where to put the Resolve counter so that Resolve is not making ScheduledAttempt bigger than "
                           "it has to be anyway to handle the other attempt types.");
         }
@@ -132,7 +132,7 @@ public:
             return false;
         }
 
-        bool MatchesIpResolve(SerializedQNameIterator hostName) const
+        bool MatchesIpResolve(chip::Dnssd::SerializedQNameIterator hostName) const
         {
             return resolveData.Is<IpResolve>() && (hostName == resolveData.Get<IpResolve>().hostName.Content());
         }
@@ -250,7 +250,7 @@ public:
 
     /// Mark a resolution as a success, removing it from the internal list
     void Complete(const chip::PeerId & peerId);
-    void CompleteIpResolution(SerializedQNameIterator targetHostName);
+    void CompleteIpResolution(chip::Dnssd::SerializedQNameIterator targetHostName);
 
     /// Mark all browse-type scheduled attemptes as a success, removing them
     /// from the internal list.
@@ -285,7 +285,7 @@ public:
 
     /// Check if any of the pending queries are for the given host name for
     /// IP resolution.
-    bool IsWaitingForIpResolutionFor(SerializedQNameIterator hostName) const;
+    bool IsWaitingForIpResolutionFor(chip::Dnssd::SerializedQNameIterator hostName) const;
 
     /// Determines if address resolution for the given peer ID is required
     ///

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -47,6 +47,7 @@ namespace {
 
 using chip::Platform::UniquePtr;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 #if CHIP_MINMDNS_HIGH_VERBOSITY
 const char * ToString(QClass qClass)

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdnsAllocator.h
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdnsAllocator.h
@@ -59,24 +59,24 @@ public:
     }
 
     template <typename... Args>
-    mdns::Minimal::FullQName AllocateQName(Args &&... names)
+    chip::Dnssd::FullQName AllocateQName(Args &&... names)
     {
-        void * storage = AllocateQNameSpace(mdns::Minimal::FlatAllocatedQName::RequiredStorageSize(std::forward<Args>(names)...));
+        void * storage = AllocateQNameSpace(chip::Dnssd::FlatAllocatedQName::RequiredStorageSize(std::forward<Args>(names)...));
         if (storage == nullptr)
         {
-            return mdns::Minimal::FullQName();
+            return chip::Dnssd::FullQName();
         }
-        return mdns::Minimal::FlatAllocatedQName::Build(storage, std::forward<Args>(names)...);
+        return chip::Dnssd::FlatAllocatedQName::Build(storage, std::forward<Args>(names)...);
     }
 
-    mdns::Minimal::FullQName AllocateQNameFromArray(char const * const * names, size_t num)
+    chip::Dnssd::FullQName AllocateQNameFromArray(char const * const * names, size_t num)
     {
-        void * storage = AllocateQNameSpace(mdns::Minimal::FlatAllocatedQName::RequiredStorageSizeFromArray(names, num));
+        void * storage = AllocateQNameSpace(chip::Dnssd::FlatAllocatedQName::RequiredStorageSizeFromArray(names, num));
         if (storage == nullptr)
         {
-            return mdns::Minimal::FullQName();
+            return chip::Dnssd::FullQName();
         }
-        return mdns::Minimal::FlatAllocatedQName::BuildFromArray(storage, names, num);
+        return chip::Dnssd::FlatAllocatedQName::BuildFromArray(storage, names, num);
     }
 
     /// Sets the query responder to a blank state and frees up any
@@ -106,8 +106,8 @@ public:
         }
     }
     mdns::Minimal::QueryResponder<kMaxRecords + 1> * GetQueryResponder() { return &mQueryResponder; }
-    const mdns::Minimal::RecordResponder * GetResponder(const mdns::Minimal::QType & qtype,
-                                                        const mdns::Minimal::FullQName & qname) const
+    const mdns::Minimal::RecordResponder * GetResponder(const chip::Dnssd::QType & qtype,
+                                                        const chip::Dnssd::FullQName & qname) const
     {
         for (auto & responder : mAllocatedResponders)
         {

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -28,7 +28,6 @@
 namespace chip {
 namespace Dnssd {
 
-using namespace mdns::Minimal;
 using namespace chip::Dnssd;
 using namespace mdns::Minimal::Logging;
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -29,11 +29,12 @@ namespace chip {
 namespace Dnssd {
 
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using namespace mdns::Minimal::Logging;
 
 namespace {
 
-ByteSpan GetSpan(const mdns::Minimal::BytesRange & range)
+ByteSpan GetSpan(const chip::Dnssd::BytesRange & range)
 {
     return ByteSpan(range.Start(), range.Size());
 }
@@ -42,11 +43,11 @@ ByteSpan GetSpan(const mdns::Minimal::BytesRange & range)
 ///
 /// Supported records are whatever `FillNodeDataFromTxt` supports.
 template <class DataType>
-class TxtParser : public mdns::Minimal::TxtRecordDelegate
+class TxtParser : public chip::Dnssd::TxtRecordDelegate
 {
 public:
     explicit TxtParser(DataType & data) : mData(data) {}
-    void OnRecord(const mdns::Minimal::BytesRange & name, const mdns::Minimal::BytesRange & value) override
+    void OnRecord(const chip::Dnssd::BytesRange & name, const chip::Dnssd::BytesRange & value) override
     {
         FillNodeDataFromTxt(GetSpan(name), GetSpan(value), mData);
     }
@@ -138,8 +139,8 @@ SerializedQNameIterator StoredServerName::Get() const
     return SerializedQNameIterator(BytesRange(mNameBuffer, mNameBuffer + sizeof(mNameBuffer)), mNameBuffer);
 }
 
-CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
-                                                  const mdns::Minimal::SrvRecord & srv)
+CHIP_ERROR IncrementalResolver::InitializeParsing(chip::Dnssd::SerializedQNameIterator name, const uint64_t ttl,
+                                                  const chip::Dnssd::SrvRecord & srv)
 {
     AutoInactiveResetter inactiveReset(*this);
 

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -117,8 +117,7 @@ public:
     /// Returns CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME for non-matter service names.
     ///
     /// If this function returns with error, the object will be in an inactive state.
-    CHIP_ERROR InitializeParsing(chip::Dnssd::SerializedQNameIterator name, const uint64_t ttl,
-                                 const chip::Dnssd::SrvRecord & srv);
+    CHIP_ERROR InitializeParsing(chip::Dnssd::SerializedQNameIterator name, const uint64_t ttl, const chip::Dnssd::SrvRecord & srv);
 
     /// Notify that a new record is being processed.
     /// Will handle filtering and processing of data to determine if the entry is relevant for
@@ -130,8 +129,7 @@ public:
     ///
     /// [data] represents the record received via [interface] and [packetRange] represents the range
     /// of valid bytes within the packet for the purpose of QName parsing
-    CHIP_ERROR OnRecord(Inet::InterfaceId interface, const chip::Dnssd::ResourceData & data,
-                        chip::Dnssd::BytesRange packetRange);
+    CHIP_ERROR OnRecord(Inet::InterfaceId interface, const chip::Dnssd::ResourceData & data, chip::Dnssd::BytesRange packetRange);
 
     /// Return what additional data is required until the object can be extracted
     ///

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -43,13 +43,13 @@ public:
     /// on insufficient storage space.
     ///
     /// If insufficient space, buffer will be cleared.
-    CHIP_ERROR Set(mdns::Minimal::SerializedQNameIterator value);
+    CHIP_ERROR Set(chip::Dnssd::SerializedQNameIterator value);
 
     /// Return the underlying value in this object.
     ///
     /// Value valid as long as this object is valid and underlying Set() is
     /// not called.
-    mdns::Minimal::SerializedQNameIterator Get() const;
+    chip::Dnssd::SerializedQNameIterator Get() const;
 
 private:
     // Try to have space for at least:
@@ -117,8 +117,8 @@ public:
     /// Returns CHIP_ERROR_UNSUPPORTED_DNSSD_SERVICE_NAME for non-matter service names.
     ///
     /// If this function returns with error, the object will be in an inactive state.
-    CHIP_ERROR InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
-                                 const mdns::Minimal::SrvRecord & srv);
+    CHIP_ERROR InitializeParsing(chip::Dnssd::SerializedQNameIterator name, const uint64_t ttl,
+                                 const chip::Dnssd::SrvRecord & srv);
 
     /// Notify that a new record is being processed.
     /// Will handle filtering and processing of data to determine if the entry is relevant for
@@ -130,8 +130,8 @@ public:
     ///
     /// [data] represents the record received via [interface] and [packetRange] represents the range
     /// of valid bytes within the packet for the purpose of QName parsing
-    CHIP_ERROR OnRecord(Inet::InterfaceId interface, const mdns::Minimal::ResourceData & data,
-                        mdns::Minimal::BytesRange packetRange);
+    CHIP_ERROR OnRecord(Inet::InterfaceId interface, const chip::Dnssd::ResourceData & data,
+                        chip::Dnssd::BytesRange packetRange);
 
     /// Return what additional data is required until the object can be extracted
     ///
@@ -143,13 +143,13 @@ public:
     ///
     /// VALIDITY: Data references internal storage of this object and is valid as long
     ///           as this object is valid and InitializeParsing is not called again.
-    mdns::Minimal::SerializedQNameIterator GetTargetHostName() const { return mTargetHostName.Get(); }
+    chip::Dnssd::SerializedQNameIterator GetTargetHostName() const { return mTargetHostName.Get(); }
 
     /// Fetch the record name set by `InitializeParsing`.
     ///
     /// VALIDITY: Data references internal storage of this object and is valid as long
     ///           as this object is valid and InitializeParsing is not called again.
-    mdns::Minimal::SerializedQNameIterator GetRecordName() const { return mRecordName.Get(); }
+    chip::Dnssd::SerializedQNameIterator GetRecordName() const { return mRecordName.Get(); }
 
     /// Take the current value of the object and clear it once returned.
     ///
@@ -178,7 +178,7 @@ private:
     /// Notify that a PTR record can be parsed.
     ///
     /// Input data MUST have GetType() == QType::TXT
-    CHIP_ERROR OnTxtRecord(const mdns::Minimal::ResourceData & data, mdns::Minimal::BytesRange packetRange);
+    CHIP_ERROR OnTxtRecord(const chip::Dnssd::ResourceData & data, chip::Dnssd::BytesRange packetRange);
 
     /// Notify that a new IP address has been found.
     ///

--- a/src/lib/dnssd/MinimalMdnsServer.cpp
+++ b/src/lib/dnssd/MinimalMdnsServer.cpp
@@ -39,6 +39,7 @@ namespace chip {
 namespace Dnssd {
 
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using chip::Platform::UniquePtr;
 
 GlobalMinimalMdnsServer::GlobalMinimalMdnsServer()

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -27,7 +27,7 @@ class MdnsPacketDelegate
 {
 public:
     virtual ~MdnsPacketDelegate() {}
-    virtual void OnMdnsPacketData(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
+    virtual void OnMdnsPacketData(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
 };
 
 /// A global mdns::Minimal::Server wrapper
@@ -61,7 +61,7 @@ public:
     void SetResponseDelegate(MdnsPacketDelegate * delegate) { mResponseDelegate = delegate; }
 
     // ServerDelegate implementation
-    void OnQuery(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         if (mQueryDelegate != nullptr)
         {
@@ -69,7 +69,7 @@ public:
         }
     }
 
-    void OnResponse(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnResponse(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         if (mResponseDelegate != nullptr)
         {

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -40,6 +40,7 @@ constexpr size_t kMdnsMaxPacketSize = 1024;
 constexpr uint16_t kMdnsPort        = 5353;
 
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 /// Handles processing of minmdns packet data.
 ///
@@ -314,14 +315,14 @@ private:
 
     CHIP_ERROR BrowseNodes(DiscoveryType type, DiscoveryFilter subtype);
     template <typename... Args>
-    mdns::Minimal::FullQName CheckAndAllocateQName(Args &&... parts)
+    chip::Dnssd::FullQName CheckAndAllocateQName(Args &&... parts)
     {
-        size_t requiredSize = mdns::Minimal::FlatAllocatedQName::RequiredStorageSize(parts...);
+        size_t requiredSize = chip::Dnssd::FlatAllocatedQName::RequiredStorageSize(parts...);
         if (requiredSize > kMaxQnameSize)
         {
-            return mdns::Minimal::FullQName();
+            return chip::Dnssd::FullQName();
         }
-        return mdns::Minimal::FlatAllocatedQName::Build(qnameStorage, parts...);
+        return chip::Dnssd::FlatAllocatedQName::Build(qnameStorage, parts...);
     }
     static constexpr int kMaxQnameSize = 100;
     char qnameStorage[kMaxQnameSize];
@@ -537,7 +538,7 @@ void MinMdnsResolver::Shutdown()
 CHIP_ERROR MinMdnsResolver::BuildQuery(QueryBuilder & builder, const ActiveResolveAttempts::ScheduledAttempt::Browse & data,
                                        bool firstSend)
 {
-    mdns::Minimal::FullQName qname;
+    chip::Dnssd::FullQName qname;
 
     switch (data.type)
     {
@@ -590,7 +591,7 @@ CHIP_ERROR MinMdnsResolver::BuildQuery(QueryBuilder & builder, const ActiveResol
 
     VerifyOrReturnError(qname.nameCount, CHIP_ERROR_NO_MEMORY);
 
-    mdns::Minimal::Query query(qname);
+    chip::Dnssd::Query query(qname);
     query
         .SetClass(QClass::IN)           //
         .SetType(QType::ANY)            //

--- a/src/lib/dnssd/minimal_mdns/Logging.cpp
+++ b/src/lib/dnssd/minimal_mdns/Logging.cpp
@@ -20,13 +20,15 @@
 
 namespace mdns {
 namespace Minimal {
+using namespace chip::Dnssd;
+
 namespace Logging {
 
 namespace {
 
 #if CHIP_PROGRESS_LOGGING
 
-const char * QueryTypeToString(mdns::Minimal::QType type)
+const char * QueryTypeToString(chip::Dnssd::QType type)
 {
     // NOTE: not all values are handled, only things that matter
     // and minmdns really cares about
@@ -55,7 +57,7 @@ const char * QueryTypeToString(mdns::Minimal::QType type)
 #endif // CHIP_PROGRESS_LOGGING
 } // namespace
 
-void LogSendingQuery(const mdns::Minimal::Query & query)
+void LogSendingQuery(const chip::Dnssd::Query & query)
 {
     QNameString name(query.GetName());
 
@@ -63,7 +65,7 @@ void LogSendingQuery(const mdns::Minimal::Query & query)
                     query.IsAnswerViaUnicast() ? "UNICAST" : "MULTICAST", name.c_str(), name.Fit() ? "" : "...");
 }
 
-void LogReceivedResource(const mdns::Minimal::ResourceData & data)
+void LogReceivedResource(const chip::Dnssd::ResourceData & data)
 {
     QNameString name(data.GetName());
 
@@ -71,7 +73,7 @@ void LogReceivedResource(const mdns::Minimal::ResourceData & data)
                     name.Fit() ? "" : "...");
 }
 
-void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const mdns::Minimal::SerializedQNameIterator & targetHost)
+void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const chip::Dnssd::SerializedQNameIterator & targetHost)
 {
     QNameString host(targetHost);
 
@@ -79,14 +81,14 @@ void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const mdns::Minim
                     ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()), host.c_str());
 }
 
-void LogFoundCommissionSrvRecord(const char * instance, const mdns::Minimal::SerializedQNameIterator & targetHost)
+void LogFoundCommissionSrvRecord(const char * instance, const chip::Dnssd::SerializedQNameIterator & targetHost)
 {
     QNameString host(targetHost);
 
     ChipLogProgress(Discovery, "MINMDNS:     Commission SRV for instance %s: %s", instance, host.c_str());
 }
 
-void LogFoundIPAddress(const mdns::Minimal::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr)
+void LogFoundIPAddress(const chip::Dnssd::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr)
 {
     QNameString host(targetHost);
     char ipBuff[chip::Inet::IPAddress::kMaxStringLength];

--- a/src/lib/dnssd/minimal_mdns/Logging.h
+++ b/src/lib/dnssd/minimal_mdns/Logging.h
@@ -31,19 +31,19 @@ namespace Logging {
 
 #if CHIP_MINMDNS_HIGH_VERBOSITY
 
-void LogSendingQuery(const mdns::Minimal::Query & query);
-void LogReceivedResource(const mdns::Minimal::ResourceData & data);
-void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const mdns::Minimal::SerializedQNameIterator & targetHost);
-void LogFoundCommissionSrvRecord(const char * instance, const mdns::Minimal::SerializedQNameIterator & targetHost);
-void LogFoundIPAddress(const mdns::Minimal::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr);
+void LogSendingQuery(const chip::Dnssd::Query & query);
+void LogReceivedResource(const chip::Dnssd::ResourceData & data);
+void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const chip::Dnssd::SerializedQNameIterator & targetHost);
+void LogFoundCommissionSrvRecord(const char * instance, const chip::Dnssd::SerializedQNameIterator & targetHost);
+void LogFoundIPAddress(const chip::Dnssd::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr);
 
 #else
 
-inline void LogSendingQuery(const mdns::Minimal::Query & query) {}
-inline void LogReceivedResource(const mdns::Minimal::ResourceData & data) {}
-inline void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const mdns::Minimal::SerializedQNameIterator & targetHost) {}
-inline void LogFoundCommissionSrvRecord(const char * instance, const mdns::Minimal::SerializedQNameIterator & targetHost) {}
-inline void LogFoundIPAddress(const mdns::Minimal::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr) {}
+inline void LogSendingQuery(const chip::Dnssd::Query & query) {}
+inline void LogReceivedResource(const chip::Dnssd::ResourceData & data) {}
+inline void LogFoundOperationalSrvRecord(const chip::PeerId & peerId, const chip::Dnssd::SerializedQNameIterator & targetHost) {}
+inline void LogFoundCommissionSrvRecord(const char * instance, const chip::Dnssd::SerializedQNameIterator & targetHost) {}
+inline void LogFoundIPAddress(const chip::Dnssd::SerializedQNameIterator & targetHost, const chip::Inet::IPAddress & addr) {}
 
 #endif
 

--- a/src/lib/dnssd/minimal_mdns/QueryBuilder.h
+++ b/src/lib/dnssd/minimal_mdns/QueryBuilder.h
@@ -34,11 +34,11 @@ public:
     QueryBuilder & Reset(chip::System::PacketBufferHandle && packet)
     {
         mPacket = std::move(packet);
-        mHeader = HeaderRef(mPacket->Start());
+        mHeader = chip::Dnssd::HeaderRef(mPacket->Start());
 
-        if (mPacket->AvailableDataLength() >= HeaderRef::kSizeBytes)
+        if (mPacket->AvailableDataLength() >= chip::Dnssd::HeaderRef::kSizeBytes)
         {
-            mPacket->SetDataLength(HeaderRef::kSizeBytes);
+            mPacket->SetDataLength(chip::Dnssd::HeaderRef::kSizeBytes);
             mHeader.Clear();
         }
         else
@@ -53,14 +53,14 @@ public:
     CHECK_RETURN_VALUE
     chip::System::PacketBufferHandle && ReleasePacket()
     {
-        mHeader       = HeaderRef(nullptr);
+        mHeader       = chip::Dnssd::HeaderRef(nullptr);
         mQueryBuildOk = false;
         return std::move(mPacket);
     }
 
-    HeaderRef & Header() { return mHeader; }
+    chip::Dnssd::HeaderRef & Header() { return mHeader; }
 
-    QueryBuilder & AddQuery(const Query & query)
+    QueryBuilder & AddQuery(const chip::Dnssd::Query & query)
     {
         if (!mQueryBuildOk)
         {
@@ -68,7 +68,7 @@ public:
         }
 
         chip::Encoding::BigEndian::BufferWriter out(mPacket->Start() + mPacket->DataLength(), mPacket->AvailableDataLength());
-        RecordWriter writer(&out);
+        chip::Dnssd::RecordWriter writer(&out);
 
         if (!query.Append(mHeader, writer))
         {
@@ -85,7 +85,7 @@ public:
 
 private:
     chip::System::PacketBufferHandle mPacket;
-    HeaderRef mHeader;
+    chip::Dnssd::HeaderRef mHeader;
     bool mQueryBuildOk = true;
 };
 

--- a/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
+++ b/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
@@ -29,9 +29,9 @@ namespace Minimal {
 class QueryReplyFilter : public ReplyFilter
 {
 public:
-    QueryReplyFilter(const QueryData & queryData) : mQueryData(queryData) {}
+    QueryReplyFilter(const chip::Dnssd::QueryData & queryData) : mQueryData(queryData) {}
 
-    bool Accept(QType qType, QClass qClass, FullQName qname) override
+    bool Accept(chip::Dnssd::QType qType, chip::Dnssd::QClass qClass, chip::Dnssd::FullQName qname) override
     {
         if (!AcceptableQueryType(qType))
         {
@@ -64,22 +64,22 @@ public:
     }
 
 private:
-    bool AcceptableQueryType(QType qType)
+    bool AcceptableQueryType(chip::Dnssd::QType qType)
     {
         if (mSendingAdditionalItems)
         {
             return true;
         }
 
-        return ((mQueryData.GetType() == QType::ANY) || (mQueryData.GetType() == qType));
+        return ((mQueryData.GetType() == chip::Dnssd::QType::ANY) || (mQueryData.GetType() == qType));
     }
 
-    bool AcceptableQueryClass(QClass qClass)
+    bool AcceptableQueryClass(chip::Dnssd::QClass qClass)
     {
-        return ((mQueryData.GetClass() == QClass::ANY) || (mQueryData.GetClass() == qClass));
+        return ((mQueryData.GetClass() == chip::Dnssd::QClass::ANY) || (mQueryData.GetClass() == qClass));
     }
 
-    bool AcceptablePath(FullQName qname)
+    bool AcceptablePath(chip::Dnssd::FullQName qname)
     {
         if (mIgnoreNameMatch || mQueryData.IsAnnounceBroadcast())
         {
@@ -89,7 +89,7 @@ private:
         return (mQueryData.GetName() == qname);
     }
 
-    const QueryData & mQueryData;
+    const chip::Dnssd::QueryData & mQueryData;
     bool mIgnoreNameMatch        = false;
     bool mSendingAdditionalItems = false;
 };

--- a/src/lib/dnssd/minimal_mdns/ResponseBuilder.h
+++ b/src/lib/dnssd/minimal_mdns/ResponseBuilder.h
@@ -40,11 +40,11 @@ public:
     ResponseBuilder & Reset(chip::System::PacketBufferHandle && packet)
     {
         mPacket = std::move(packet);
-        mHeader = HeaderRef(mPacket->Start());
+        mHeader = chip::Dnssd::HeaderRef(mPacket->Start());
 
-        if (mPacket->AvailableDataLength() >= HeaderRef::kSizeBytes)
+        if (mPacket->AvailableDataLength() >= chip::Dnssd::HeaderRef::kSizeBytes)
         {
-            mPacket->SetDataLength(HeaderRef::kSizeBytes);
+            mPacket->SetDataLength(chip::Dnssd::HeaderRef::kSizeBytes);
             mHeader.Clear();
             mBuildOk = true;
         }
@@ -67,7 +67,7 @@ public:
     CHECK_RETURN_VALUE
     chip::System::PacketBufferHandle ReleasePacket()
     {
-        mHeader  = HeaderRef(nullptr);
+        mHeader  = chip::Dnssd::HeaderRef(nullptr);
         mBuildOk = false;
         return std::move(mPacket);
     }
@@ -77,12 +77,12 @@ public:
         return (mHeader.GetAnswerCount() != 0) || (mHeader.GetAuthorityCount() != 0) || (mHeader.GetAdditionalCount() != 0);
     }
 
-    HeaderRef & Header() { return mHeader; }
+    chip::Dnssd::HeaderRef & Header() { return mHeader; }
 
     /// Attempts to add a record to the currentsystem packet buffer.
     /// On success, the packet buffer data length is updated.
     /// On failure, the packet buffer data length is NOT updated and header is unchanged.
-    ResponseBuilder & AddRecord(ResourceType type, const ResourceRecord & record)
+    ResponseBuilder & AddRecord(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceRecord & record)
     {
         if (!mBuildOk)
         {
@@ -102,7 +102,7 @@ public:
         return *this;
     }
 
-    ResponseBuilder & AddQuery(const QueryData & query)
+    ResponseBuilder & AddQuery(const chip::Dnssd::QueryData & query)
     {
         if (!mBuildOk)
         {
@@ -125,9 +125,9 @@ public:
 
 private:
     chip::System::PacketBufferHandle mPacket;
-    HeaderRef mHeader;
+    chip::Dnssd::HeaderRef mHeader;
     chip::Encoding::BigEndian::BufferWriter mEndianOutput;
-    RecordWriter mWriter;
+    chip::Dnssd::RecordWriter mWriter;
     bool mBuildOk = false;
 };
 

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -26,7 +26,6 @@ namespace mdns {
 namespace Minimal {
 using namespace chip::Dnssd;
 
-
 namespace {
 
 using namespace mdns::Minimal::Internal;

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -24,6 +24,8 @@
 
 namespace mdns {
 namespace Minimal {
+using namespace chip::Dnssd;
+
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.h
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.h
@@ -71,18 +71,18 @@ class ResponseSendingState
 public:
     ResponseSendingState() {}
 
-    void Reset(uint16_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * packet)
+    void Reset(uint16_t messageId, const chip::Dnssd::QueryData & query, const chip::Inet::IPPacketInfo * packet)
     {
         mMessageId    = messageId;
         mQuery        = &query;
         mSource       = packet;
         mSendError    = CHIP_NO_ERROR;
-        mResourceType = ResourceType::kAnswer;
+        mResourceType = chip::Dnssd::ResourceType::kAnswer;
         mSentItems.ClearAll();
     }
 
-    void SetResourceType(ResourceType resourceType) { mResourceType = resourceType; }
-    ResourceType GetResourceType() const { return mResourceType; }
+    void SetResourceType(chip::Dnssd::ResourceType resourceType) { mResourceType = resourceType; }
+    chip::Dnssd::ResourceType GetResourceType() const { return mResourceType; }
 
     CHIP_ERROR SetError(CHIP_ERROR chipError)
     {
@@ -93,7 +93,7 @@ public:
 
     uint16_t GetMessageId() const { return mMessageId; }
 
-    const QueryData * GetQuery() const { return mQuery; }
+    const chip::Dnssd::QueryData * GetQuery() const { return mQuery; }
 
     /// Check if the reply should be sent as a unicast reply
     bool SendUnicast() const;
@@ -111,10 +111,10 @@ public:
     void MarkWasSent(ResponseItemsSent item) { mSentItems.Set(item); }
 
 private:
-    const QueryData * mQuery                 = nullptr;               // query being replied to
-    const chip::Inet::IPPacketInfo * mSource = nullptr;               // Where to send the reply (if unicast)
-    uint16_t mMessageId                      = 0;                     // message id for the reply
-    ResourceType mResourceType               = ResourceType::kAnswer; // what is being sent right now
+    const chip::Dnssd::QueryData * mQuery    = nullptr;                            // query being replied to
+    const chip::Inet::IPPacketInfo * mSource = nullptr;                            // Where to send the reply (if unicast)
+    uint16_t mMessageId                      = 0;                                  // message id for the reply
+    chip::Dnssd::ResourceType mResourceType  = chip::Dnssd::ResourceType::kAnswer; // what is being sent right now
     CHIP_ERROR mSendError                    = CHIP_NO_ERROR;
     chip::BitFlags<ResponseItemsSent> mSentItems;
 };
@@ -135,11 +135,11 @@ public:
     bool HasQueryResponders() const;
 
     /// Send back the response to a particular query
-    CHIP_ERROR Respond(uint16_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * querySource,
+    CHIP_ERROR Respond(uint16_t messageId, const chip::Dnssd::QueryData & query, const chip::Inet::IPPacketInfo * querySource,
                        const ResponseConfiguration & configuration);
 
     // Implementation of ResponderDelegate
-    void AddResponse(const ResourceRecord & record) override;
+    void AddResponse(const chip::Dnssd::ResourceRecord & record) override;
     bool ShouldSend(const Responder &) const override;
     void ResponsesAdded(const Responder &) override;
 

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -25,6 +25,8 @@
 
 namespace mdns {
 namespace Minimal {
+using namespace chip::Dnssd;
+
 namespace {
 
 class ShutdownOnError
@@ -432,7 +434,7 @@ void ServerBase::OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::S
         return;
     }
 
-    mdns::Minimal::BytesRange data(buffer->Start(), buffer->Start() + buffer->DataLength());
+    chip::Dnssd::BytesRange data(buffer->Start(), buffer->Start() + buffer->DataLength());
     if (data.Size() < HeaderRef::kSizeBytes)
     {
         ChipLogError(Discovery, "Packet too small for mDNS data: %d bytes", static_cast<int>(data.Size()));

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -45,10 +45,10 @@ public:
     virtual ~ServerDelegate() {}
 
     // Callback of when a query is received
-    virtual void OnQuery(const BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
+    virtual void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
 
     // Callback of when a response is received
-    virtual void OnResponse(const BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
+    virtual void OnResponse(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) = 0;
 };
 
 // Defines an mDNS server that listens on one or more interfaces.

--- a/src/lib/dnssd/minimal_mdns/responders/IP.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.cpp
@@ -23,6 +23,8 @@
 
 namespace mdns {
 namespace Minimal {
+using namespace chip::Dnssd;
+
 
 using chip::Platform::UniquePtr;
 

--- a/src/lib/dnssd/minimal_mdns/responders/IP.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.cpp
@@ -25,7 +25,6 @@ namespace mdns {
 namespace Minimal {
 using namespace chip::Dnssd;
 
-
 using chip::Platform::UniquePtr;
 
 void IPv4Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,

--- a/src/lib/dnssd/minimal_mdns/responders/IP.h
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.h
@@ -25,7 +25,7 @@ namespace Minimal {
 class IPv4Responder : public RecordResponder
 {
 public:
-    IPv4Responder(const FullQName & qname) : RecordResponder(QType::A, qname) {}
+    IPv4Responder(const chip::Dnssd::FullQName & qname) : RecordResponder(chip::Dnssd::QType::A, qname) {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
                          const ResponseConfiguration & configuration) override;
@@ -34,7 +34,7 @@ public:
 class IPv6Responder : public RecordResponder
 {
 public:
-    IPv6Responder(const FullQName & qname) : RecordResponder(QType::AAAA, qname) {}
+    IPv6Responder(const chip::Dnssd::FullQName & qname) : RecordResponder(chip::Dnssd::QType::AAAA, qname) {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
                          const ResponseConfiguration & configuration) override;

--- a/src/lib/dnssd/minimal_mdns/responders/Ptr.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Ptr.h
@@ -26,7 +26,9 @@ namespace Minimal {
 class PtrResponder : public RecordResponder
 {
 public:
-    PtrResponder(const FullQName & qname, const FullQName & target) : RecordResponder(QType::PTR, qname), mTarget(target) {}
+    PtrResponder(const chip::Dnssd::FullQName & qname, const chip::Dnssd::FullQName & target) :
+        RecordResponder(chip::Dnssd::QType::PTR, qname), mTarget(target)
+    {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
                          const ResponseConfiguration & configuration) override
@@ -36,14 +38,14 @@ public:
             return;
         }
 
-        PtrResourceRecord record(GetQName(), mTarget);
+        chip::Dnssd::PtrResourceRecord record(GetQName(), mTarget);
         configuration.Adjust(record);
         delegate->AddResponse(record);
         delegate->ResponsesAdded(*this);
     }
 
 private:
-    const FullQName mTarget;
+    const chip::Dnssd::FullQName mTarget;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
@@ -24,6 +24,8 @@
 
 namespace mdns {
 namespace Minimal {
+using namespace chip::Dnssd;
+
 
 const QNamePart kDnsSdQueryPath[] = { "_services", "_dns-sd", "_udp", "local" };
 

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
@@ -26,7 +26,6 @@ namespace mdns {
 namespace Minimal {
 using namespace chip::Dnssd;
 
-
 const QNamePart kDnsSdQueryPath[] = { "_services", "_dns-sd", "_udp", "local" };
 
 QueryResponderBase::QueryResponderBase(Internal::QueryResponderInfo * infos, size_t infoSizes) :

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -42,7 +42,7 @@ struct QueryResponderInfo : public QueryResponderRecord
     bool reportNowAsAdditional; // report as additional data required
 
     bool alsoReportAdditionalQName = false; // report more data when this record is listed
-    FullQName additionalQName;              // if alsoReportAdditionalQName is set, send this extra data
+    chip::Dnssd::FullQName additionalQName; // if alsoReportAdditionalQName is set, send this extra data
 
     void Clear()
     {
@@ -78,7 +78,7 @@ public:
     /// This is useful to avoid chattyness by sending back referenced records
     /// (e.g. when sending a PTR record, send the corresponding SRV and when sending
     ///  SRV, send back the corresponding A/AAAA records).
-    QueryResponderSettings & SetReportAdditional(const FullQName & qname)
+    QueryResponderSettings & SetReportAdditional(const chip::Dnssd::FullQName & qname)
     {
         if (IsValid())
         {
@@ -266,7 +266,7 @@ public:
 
     /// Marks queries matching this qname as 'to be additionally reported'
     /// @return the number of items marked new as 'additional data'.
-    size_t MarkAdditional(const FullQName & qname);
+    size_t MarkAdditional(const chip::Dnssd::FullQName & qname);
 
     /// Flag any additional responses required for the given iterator
     void MarkAdditionalRepliesFor(QueryResponderIterator it);

--- a/src/lib/dnssd/minimal_mdns/responders/RecordResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/RecordResponder.h
@@ -26,7 +26,7 @@ namespace Minimal {
 class RecordResponder : public Responder
 {
 public:
-    RecordResponder(QType qType, const FullQName & qName) : Responder(qType, qName) {}
+    RecordResponder(chip::Dnssd::QType qType, const chip::Dnssd::FullQName & qName) : Responder(qType, qName) {}
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/ReplyFilter.h
+++ b/src/lib/dnssd/minimal_mdns/responders/ReplyFilter.h
@@ -30,7 +30,7 @@ public:
     virtual ~ReplyFilter() {}
 
     /// Returns true if specified answer should be sent back as a reply
-    virtual bool Accept(QType qType, QClass qClass, FullQName qname) = 0;
+    virtual bool Accept(chip::Dnssd::QType qType, chip::Dnssd::QClass qClass, chip::Dnssd::FullQName qname) = 0;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/Responder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Responder.h
@@ -48,7 +48,7 @@ public:
 
     /// Applies any adjustments to resource records before they are being serialized
     /// to some form of reply.
-    void Adjust(ResourceRecord & record) const
+    void Adjust(chip::Dnssd::ResourceRecord & record) const
     {
         VerifyOrReturn(mTtlSecondsOverride.has_value());
         record.SetTtl(*mTtlSecondsOverride);
@@ -65,15 +65,15 @@ class ResponderDelegate;
 class Responder
 {
 public:
-    Responder(QType qType, const FullQName & qName) : mQType(qType), mQName(qName) {}
+    Responder(chip::Dnssd::QType qType, const chip::Dnssd::FullQName & qName) : mQType(qType), mQName(qName) {}
     virtual ~Responder() {}
 
-    QClass GetQClass() const { return QClass::IN; }
-    QType GetQType() const { return mQType; }
+    chip::Dnssd::QClass GetQClass() const { return chip::Dnssd::QClass::IN; }
+    chip::Dnssd::QType GetQType() const { return mQType; }
 
     /// Full name as: "Instance"."Servicer"."Domain"
     /// Domain name is generally just 'local'
-    FullQName GetQName() const { return mQName; }
+    chip::Dnssd::FullQName GetQName() const { return mQName; }
 
     /// Report all responses maintained by this responder
     ///
@@ -82,8 +82,8 @@ public:
                                  const ResponseConfiguration & configuration) = 0;
 
 private:
-    const QType mQType;
-    const FullQName mQName;
+    const chip::Dnssd::QType mQType;
+    const chip::Dnssd::FullQName mQName;
 };
 
 class ResponderDelegate
@@ -92,7 +92,7 @@ public:
     virtual ~ResponderDelegate() {}
 
     /// Add the specified resource record to the response
-    virtual void AddResponse(const ResourceRecord & record) = 0;
+    virtual void AddResponse(const chip::Dnssd::ResourceRecord & record) = 0;
 
     /// Accept to add responses for the particular responder.
     ///

--- a/src/lib/dnssd/minimal_mdns/responders/Srv.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Srv.h
@@ -26,7 +26,9 @@ namespace Minimal {
 class SrvResponder : public RecordResponder
 {
 public:
-    SrvResponder(const SrvResourceRecord & record) : RecordResponder(QType::SRV, record.GetName()), mRecord(record) {}
+    SrvResponder(const chip::Dnssd::SrvResourceRecord & record) :
+        RecordResponder(chip::Dnssd::QType::SRV, record.GetName()), mRecord(record)
+    {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
                          const ResponseConfiguration & configuration) override
@@ -36,14 +38,14 @@ public:
             return;
         }
 
-        SrvResourceRecord record = mRecord;
+        chip::Dnssd::SrvResourceRecord record = mRecord;
         configuration.Adjust(record);
         delegate->AddResponse(record);
         delegate->ResponsesAdded(*this);
     }
 
 private:
-    const SrvResourceRecord mRecord;
+    const chip::Dnssd::SrvResourceRecord mRecord;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/Txt.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Txt.h
@@ -26,7 +26,9 @@ namespace Minimal {
 class TxtResponder : public RecordResponder
 {
 public:
-    TxtResponder(const TxtResourceRecord & record) : RecordResponder(QType::TXT, record.GetName()), mRecord(record) {}
+    TxtResponder(const chip::Dnssd::TxtResourceRecord & record) :
+        RecordResponder(chip::Dnssd::QType::TXT, record.GetName()), mRecord(record)
+    {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
                          const ResponseConfiguration & configuration) override
@@ -36,14 +38,14 @@ public:
             return;
         }
 
-        TxtResourceRecord record = mRecord;
+        chip::Dnssd::TxtResourceRecord record = mRecord;
         configuration.Adjust(record);
         delegate->AddResponse(record);
         delegate->ResponsesAdded(*this);
     }
 
 private:
-    const TxtResourceRecord mRecord;
+    const chip::Dnssd::TxtResourceRecord mRecord;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -29,6 +29,7 @@ namespace {
 using namespace chip;
 using namespace chip::Inet;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 constexpr uint16_t kMdnsPort = 5353;
 

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -30,6 +30,7 @@ using namespace chip;
 using namespace chip::Encoding;
 using namespace chip::Inet;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 constexpr uint16_t kMdnsPort = 5353;
 

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
@@ -27,6 +27,7 @@ namespace {
 
 using namespace chip;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 const QNamePart kDnsSdname[] = { "_services", "_dns-sd", "_udp", "local" };
 

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -38,15 +38,15 @@ namespace mdns {
 namespace Minimal {
 namespace test {
 
-inline constexpr QNamePart kIgnoreQNameParts[] = { "IGNORE", "THIS" };
+inline constexpr chip::Dnssd::QNamePart kIgnoreQNameParts[] = { "IGNORE", "THIS" };
 namespace {
-bool StringMatches(const BytesRange & br, const char * str)
+bool StringMatches(const chip::Dnssd::BytesRange & br, const char * str)
 {
     return br.Size() == strlen(str) && memcmp(str, br.Start(), br.Size()) == 0;
 }
 
 template <size_t N>
-void MakePrintableName(char (&location)[N], SerializedQNameIterator name)
+void MakePrintableName(char (&location)[N], chip::Dnssd::SerializedQNameIterator name)
 {
     auto buf = chip::Encoding::BigEndian::BufferWriter(reinterpret_cast<uint8_t *>(&location[0]), N);
     while (name.Next())
@@ -58,7 +58,7 @@ void MakePrintableName(char (&location)[N], SerializedQNameIterator name)
 }
 
 template <size_t N>
-void MakePrintableName(char (&location)[N], FullQName name)
+void MakePrintableName(char (&location)[N], chip::Dnssd::FullQName name)
 {
     auto buf = chip::Encoding::BigEndian::BufferWriter(reinterpret_cast<uint8_t *>(&location[0]), N);
     for (size_t i = 0; i < name.nameCount; ++i)
@@ -74,15 +74,15 @@ void MakePrintableName(char (&location)[N], FullQName name)
 class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, chip::ObjectPoolMem::kInline,
                                                ServerBase::EndpointInfoPoolType::Interface>,
                         public ServerBase,
-                        public ParserDelegate,
-                        public TxtRecordDelegate
+                        public chip::Dnssd::ParserDelegate,
+                        public chip::Dnssd::TxtRecordDelegate
 {
 public:
     CheckOnlyServer() : ServerBase(*static_cast<ServerBase::EndpointInfoPoolType *>(this)) { Reset(); }
     ~CheckOnlyServer() {}
 
     // Parser delegates
-    void OnHeader(ConstHeaderRef & header) override
+    void OnHeader(chip::Dnssd::ConstHeaderRef & header) override
     {
         EXPECT_TRUE(header.GetFlags().IsResponse());
         EXPECT_TRUE(header.GetFlags().IsValidMdns());
@@ -99,16 +99,16 @@ public:
         }
     }
 
-    void OnResource(ResourceType type, const ResourceData & data) override
+    void OnResource(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceData & data) override
     {
-        SerializedQNameIterator target;
+        chip::Dnssd::SerializedQNameIterator target;
         switch (data.GetType())
         {
-        case QType::PTR:
-            ParsePtrRecord(data.GetData(), mPacketData, &target);
+        case chip::Dnssd::QType::PTR:
+            chip::Dnssd::ParsePtrRecord(data.GetData(), mPacketData, &target);
             break;
-        case QType::SRV: {
-            SrvRecord srv;
+        case chip::Dnssd::QType::SRV: {
+            chip::Dnssd::SrvRecord srv;
             bool srvParseOk = srv.Parse(data.GetData(), mPacketData);
             EXPECT_TRUE(srvParseOk);
             if (!srvParseOk)
@@ -134,17 +134,18 @@ public:
                 (info.record->GetName() == kIgnoreQname || data.GetName() == info.record->GetName()) &&
                 (info.target == kIgnoreQname || target == info.target))
             {
-                if (data.GetType() == QType::TXT)
+                if (data.GetType() == chip::Dnssd::QType::TXT)
                 {
                     // First parse out the expected record to see what keys/values we have.
                     ClearTxtRecords();
-                    const TxtResourceRecord * expectedTxt = static_cast<const TxtResourceRecord *>(info.record);
+                    const chip::Dnssd::TxtResourceRecord * expectedTxt =
+                        static_cast<const chip::Dnssd::TxtResourceRecord *>(info.record);
                     for (size_t t = 0; t < expectedTxt->GetNumEntries(); ++t)
                     {
                         bool ok = AddExpectedTxtRecord(expectedTxt->GetEntries()[t]);
                         EXPECT_TRUE(ok);
                     }
-                    ParseTxtRecord(data.GetData(), this);
+                    chip::Dnssd::ParseTxtRecord(data.GetData(), this);
                     if (CheckTxtRecordMatches())
                     {
                         info.found       = true;
@@ -165,16 +166,16 @@ public:
         {
             char nameStr[64];
             char targetStr[64];
-            SerializedQNameIterator dataTarget;
-            SerializedQNameIterator it = data.GetName();
+            chip::Dnssd::SerializedQNameIterator dataTarget;
+            chip::Dnssd::SerializedQNameIterator it = data.GetName();
             MakePrintableName(nameStr, it);
             switch (data.GetType())
             {
-            case QType::PTR:
-                ParsePtrRecord(data.GetData(), data.GetData(), &dataTarget);
+            case chip::Dnssd::QType::PTR:
+                chip::Dnssd::ParsePtrRecord(data.GetData(), data.GetData(), &dataTarget);
                 break;
-            case QType::SRV: {
-                SrvRecord srv;
+            case chip::Dnssd::QType::SRV: {
+                chip::Dnssd::SrvRecord srv;
                 if (srv.Parse(data.GetData(), data.GetData()))
                 {
                     dataTarget = srv.GetName();
@@ -190,10 +191,10 @@ public:
         }
     }
 
-    void OnQuery(const QueryData & data) override {}
+    void OnQuery(const chip::Dnssd::QueryData & data) override {}
 
-    // TxtRecordDelegate
-    void OnRecord(const BytesRange & name, const BytesRange & value) override
+    // chip::Dnssd::TxtRecordDelegate
+    void OnRecord(const chip::Dnssd::BytesRange & name, const chip::Dnssd::BytesRange & value) override
     {
         for (size_t i = 0; i < mNumExpectedTxtRecords; ++i)
         {
@@ -226,8 +227,8 @@ public:
     DirectSend(chip::System::PacketBufferHandle && data, const chip::Inet::IPAddress & addr, uint16_t port,
                chip::Inet::InterfaceId interface) override
     {
-        mPacketData = BytesRange(data->Start(), data->Start() + data->TotalLength());
-        ParsePacket(mPacketData, this);
+        mPacketData = chip::Dnssd::BytesRange(data->Start(), data->Start() + data->TotalLength());
+        chip::Dnssd::ParsePacket(mPacketData, this);
         if (mHeaderFound)
         {
             TestGotAllExpectedPackets();
@@ -237,7 +238,7 @@ public:
     }
 
     // Functions used for controlling testing.
-    void AddExpectedRecord(PtrResourceRecord * ptr)
+    void AddExpectedRecord(chip::Dnssd::PtrResourceRecord * ptr)
     {
         RecordInfo * info = AddExpectedRecordBase(ptr);
         if (info == nullptr)
@@ -246,7 +247,7 @@ public:
         }
         info->target = ptr->GetPtr();
     }
-    void AddExpectedRecord(SrvResourceRecord * srv)
+    void AddExpectedRecord(chip::Dnssd::SrvResourceRecord * srv)
     {
         RecordInfo * info = AddExpectedRecordBase(srv);
         ASSERT_NE(info, nullptr);
@@ -256,7 +257,7 @@ public:
         }
         info->target = srv->GetServerName();
     }
-    void AddExpectedRecord(TxtResourceRecord * txt)
+    void AddExpectedRecord(chip::Dnssd::TxtResourceRecord * txt)
     {
         RecordInfo * info = AddExpectedRecordBase(txt);
         ASSERT_NE(info, nullptr);
@@ -285,9 +286,9 @@ private:
     static constexpr size_t kMaxExpectedRecords = 10;
     struct RecordInfo
     {
-        ResourceRecord * record;
+        chip::Dnssd::ResourceRecord * record;
         bool found = false;
-        FullQName target;
+        chip::Dnssd::FullQName target;
     };
     RecordInfo mExpectedRecordInfo[kMaxExpectedRecords];
     struct KV
@@ -307,13 +308,13 @@ private:
     };
     static constexpr size_t kMaxExpectedTxt = 13;
     KV mExpectedTxt[kMaxExpectedTxt];
-    size_t mNumExpectedTxtRecords = 0;
-    size_t mNumReceivedTxtRecords = 0;
-    bool mHeaderFound             = false;
-    bool mSendCalled              = false;
-    int mTotalRecords             = 0;
-    FullQName kIgnoreQname        = FullQName(kIgnoreQNameParts);
-    BytesRange mPacketData;
+    size_t mNumExpectedTxtRecords       = 0;
+    size_t mNumReceivedTxtRecords       = 0;
+    bool mHeaderFound                   = false;
+    bool mSendCalled                    = false;
+    int mTotalRecords                   = 0;
+    chip::Dnssd::FullQName kIgnoreQname = chip::Dnssd::FullQName(kIgnoreQNameParts);
+    chip::Dnssd::BytesRange mPacketData;
 
     int GetNumExpectedRecords() const
     {
@@ -375,7 +376,7 @@ private:
         return true;
     }
 
-    RecordInfo * AddExpectedRecordBase(ResourceRecord * record)
+    RecordInfo * AddExpectedRecordBase(chip::Dnssd::ResourceRecord * record)
     {
         for (auto & info : mExpectedRecordInfo)
         {

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsQNamePW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsQNamePW.cpp
@@ -56,7 +56,6 @@ namespace {
 
 using namespace chip;
 using namespace fuzztest;
-using namespace mdns::Minimal;
 using namespace chip::Dnssd;
 
 void EnsureInitialized()

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsQNamePW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsQNamePW.cpp
@@ -57,6 +57,7 @@ namespace {
 using namespace chip;
 using namespace fuzztest;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 void EnsureInitialized()
 {

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsRecordDataPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsRecordDataPW.cpp
@@ -59,6 +59,7 @@ namespace {
 using namespace chip;
 using namespace fuzztest;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 void EnsureInitialized()
 {

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsRecordDataPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzMdnsRecordDataPW.cpp
@@ -58,7 +58,6 @@ namespace {
 
 using namespace chip;
 using namespace fuzztest;
-using namespace mdns::Minimal;
 using namespace chip::Dnssd;
 
 void EnsureInitialized()

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
@@ -7,7 +7,6 @@
 namespace {
 
 using namespace chip;
-using namespace mdns::Minimal;
 using namespace chip::Dnssd;
 
 class FuzzDelegate : public ParserDelegate

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
@@ -8,11 +8,12 @@ namespace {
 
 using namespace chip;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 class FuzzDelegate : public ParserDelegate
 {
 public:
-    FuzzDelegate(const mdns::Minimal::BytesRange & packet) : mPacketRange(packet) {}
+    FuzzDelegate(const chip::Dnssd::BytesRange & packet) : mPacketRange(packet) {}
     virtual ~FuzzDelegate() {}
 
     void OnHeader(ConstHeaderRef & header) override {}
@@ -22,23 +23,23 @@ public:
         switch (data.GetType())
         {
         case QType::SRV: {
-            mdns::Minimal::SrvRecord srv;
+            chip::Dnssd::SrvRecord srv;
             (void) srv.Parse(data.GetData(), mPacketRange);
             break;
         }
         case QType::A: {
             chip::Inet::IPAddress addr;
-            (void) mdns::Minimal::ParseARecord(data.GetData(), &addr);
+            (void) chip::Dnssd::ParseARecord(data.GetData(), &addr);
             break;
         }
         case QType::AAAA: {
             chip::Inet::IPAddress addr;
-            (void) mdns::Minimal::ParseAAAARecord(data.GetData(), &addr);
+            (void) chip::Dnssd::ParseAAAARecord(data.GetData(), &addr);
             break;
         }
         case QType::PTR: {
-            mdns::Minimal::SerializedQNameIterator name;
-            (void) mdns::Minimal::ParsePtrRecord(data.GetData(), mPacketRange, &name);
+            chip::Dnssd::SerializedQNameIterator name;
+            (void) chip::Dnssd::ParsePtrRecord(data.GetData(), mPacketRange, &name);
             break;
         }
         default:
@@ -48,7 +49,7 @@ public:
     }
 
 private:
-    mdns::Minimal::BytesRange mPacketRange;
+    chip::Dnssd::BytesRange mPacketRange;
 };
 
 } // namespace
@@ -59,7 +60,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
     BytesRange packet(data, data + len);
     FuzzDelegate delegate(packet);
 
-    mdns::Minimal::ParsePacket(packet, &delegate);
+    chip::Dnssd::ParsePacket(packet, &delegate);
 
     return 0;
 }

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
@@ -13,11 +13,12 @@ using namespace fuzztest;
 
 using namespace chip;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 class FuzzDelegate : public ParserDelegate
 {
 public:
-    FuzzDelegate(const mdns::Minimal::BytesRange & packet) : mPacketRange(packet) {}
+    FuzzDelegate(const chip::Dnssd::BytesRange & packet) : mPacketRange(packet) {}
     virtual ~FuzzDelegate() {}
 
     void OnHeader(ConstHeaderRef & header) override {}
@@ -27,23 +28,23 @@ public:
         switch (data.GetType())
         {
         case QType::SRV: {
-            mdns::Minimal::SrvRecord srv;
+            chip::Dnssd::SrvRecord srv;
             (void) srv.Parse(data.GetData(), mPacketRange);
             break;
         }
         case QType::A: {
             chip::Inet::IPAddress addr;
-            (void) mdns::Minimal::ParseARecord(data.GetData(), &addr);
+            (void) chip::Dnssd::ParseARecord(data.GetData(), &addr);
             break;
         }
         case QType::AAAA: {
             chip::Inet::IPAddress addr;
-            (void) mdns::Minimal::ParseAAAARecord(data.GetData(), &addr);
+            (void) chip::Dnssd::ParseAAAARecord(data.GetData(), &addr);
             break;
         }
         case QType::PTR: {
-            mdns::Minimal::SerializedQNameIterator name;
-            (void) mdns::Minimal::ParsePtrRecord(data.GetData(), mPacketRange, &name);
+            chip::Dnssd::SerializedQNameIterator name;
+            (void) chip::Dnssd::ParsePtrRecord(data.GetData(), mPacketRange, &name);
             break;
         }
         default:
@@ -53,7 +54,7 @@ public:
     }
 
 private:
-    mdns::Minimal::BytesRange mPacketRange;
+    chip::Dnssd::BytesRange mPacketRange;
 };
 
 void PacketParserFuzz(const std::vector<std::uint8_t> & bytes)
@@ -61,7 +62,7 @@ void PacketParserFuzz(const std::vector<std::uint8_t> & bytes)
     BytesRange packet(bytes.data(), bytes.data() + bytes.size());
     FuzzDelegate delegate(packet);
 
-    mdns::Minimal::ParsePacket(packet, &delegate);
+    chip::Dnssd::ParsePacket(packet, &delegate);
 }
 
 FUZZ_TEST(MinimalmDNS, PacketParserFuzz).WithDomains(Arbitrary<std::vector<uint8_t>>());

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
@@ -12,7 +12,6 @@ namespace {
 using namespace fuzztest;
 
 using namespace chip;
-using namespace mdns::Minimal;
 using namespace chip::Dnssd;
 
 class FuzzDelegate : public ParserDelegate

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzQueryResponderPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzQueryResponderPW.cpp
@@ -77,6 +77,7 @@ namespace {
 using namespace chip;
 using namespace fuzztest;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 void EnsureInitialized()
 {

--- a/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
@@ -24,6 +24,7 @@ namespace {
 
 using namespace chip;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 const QNamePart kName1[] = { "some", "local" };
 const QNamePart kName2[] = { "something", "else" };

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -37,6 +37,7 @@ namespace {
 
 using namespace chip;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using namespace mdns::Minimal::test;
 
 struct CommonTestElements

--- a/src/lib/dnssd/tests/FuzzActiveResolveAttemptsPW.cpp
+++ b/src/lib/dnssd/tests/FuzzActiveResolveAttemptsPW.cpp
@@ -64,6 +64,7 @@ namespace {
 using namespace chip;
 using namespace fuzztest;
 using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 void EnsureInitialized()
 {

--- a/src/lib/dnssd/tests/FuzzMdnsResolverPW.cpp
+++ b/src/lib/dnssd/tests/FuzzMdnsResolverPW.cpp
@@ -73,7 +73,6 @@ namespace {
 
 using namespace chip;
 using namespace chip::Dnssd;
-using namespace mdns::Minimal;
 using namespace fuzztest;
 
 void EnsureInitialized()

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -34,7 +34,6 @@
 
 using namespace chip;
 using namespace chip::Dnssd;
-using namespace mdns::Minimal;
 
 namespace {
 

--- a/src/lib/dnssd/wire/BytesRange.h
+++ b/src/lib/dnssd/wire/BytesRange.h
@@ -22,8 +22,8 @@
 
 #include <lib/support/Span.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// Simple range of bytes with a start and an end
 class BytesRange
@@ -58,6 +58,6 @@ private:
     const uint8_t * mEnd   = nullptr;
 };
 
-} // namespace Minimal
+} // namespace Dnssd
 
-} // namespace mdns
+} // namespace chip

--- a/src/lib/dnssd/wire/Constants.h
+++ b/src/lib/dnssd/wire/Constants.h
@@ -19,8 +19,8 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 // Assigned by IANA: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 enum class QType : uint16_t
@@ -71,5 +71,5 @@ enum class ResourceType
     kAdditional,
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/DnsHeader.h
+++ b/src/lib/dnssd/wire/DnsHeader.h
@@ -18,8 +18,8 @@
 
 #include <lib/core/CHIPEncoding.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /**
  * Wrapper around a MDNS bit-packed flags in a DNS header as defined in
@@ -166,5 +166,5 @@ private:
     HeaderRef & SetRawFlags(uint16_t value) { return Set16At(kFlagsOffset, value); }
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/FlatAllocatedQName.h
+++ b/src/lib/dnssd/wire/FlatAllocatedQName.h
@@ -19,8 +19,8 @@
 
 #include "QName.h"
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// A void* implementation that stores QNames as
 ///   [ptr array] [name1] #0 [name2] #0 .... [namen] #0
@@ -115,5 +115,5 @@ inline FullQName BuildFromArray(void * storage, char const * const * parts, size
 
 } // namespace FlatAllocatedQName
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/HeapQName.h
+++ b/src/lib/dnssd/wire/HeapQName.h
@@ -24,8 +24,8 @@
 #include <lib/support/CHIPPlatformMemory.h>
 #include <lib/support/ScopedMemoryBuffer.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// Contructs a FullQName from a SerializedNameIterator
 ///
@@ -162,5 +162,5 @@ private:
     chip::Platform::ScopedMemoryBuffer<char *> mElementPointers;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/Parser.cpp
+++ b/src/lib/dnssd/wire/Parser.cpp
@@ -21,8 +21,8 @@
 
 #include <stdio.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 bool QueryData::Parse(const BytesRange & validData, const uint8_t ** start)
 {
@@ -215,5 +215,5 @@ bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate)
     return true;
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/Parser.h
+++ b/src/lib/dnssd/wire/Parser.h
@@ -22,8 +22,8 @@
 #include <lib/dnssd/wire/QName.h>
 #include <lib/dnssd/wire/RecordWriter.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class QueryData
 {
@@ -121,5 +121,5 @@ public:
 /// returns true if packet was successfully parsed, false otherwise
 bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate);
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/QName.cpp
+++ b/src/lib/dnssd/wire/QName.cpp
@@ -19,8 +19,8 @@
 
 #include "QName.h"
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 bool SerializedQNameIterator::Next()
 {
@@ -198,5 +198,5 @@ bool FullQName::operator==(const FullQName & other) const
     return true;
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/QName.h
+++ b/src/lib/dnssd/wire/QName.h
@@ -30,8 +30,8 @@
 #include <lib/dnssd/wire/BytesRange.h>
 #include <lib/dnssd/wire/DnsHeader.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// A QName part is a null-terminated string
 using QNamePart = const char *;
@@ -117,5 +117,5 @@ private:
     bool Next(bool followIndirectPointers);
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/QNameString.cpp
+++ b/src/lib/dnssd/wire/QNameString.cpp
@@ -16,10 +16,10 @@
  */
 #include <lib/dnssd/wire/QNameString.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
-QNameString::QNameString(const mdns::Minimal::FullQName & name)
+QNameString::QNameString(const chip::Dnssd::FullQName & name)
 {
     for (unsigned i = 0; i < name.nameCount; i++)
     {
@@ -31,7 +31,7 @@ QNameString::QNameString(const mdns::Minimal::FullQName & name)
     }
 }
 
-QNameString::QNameString(mdns::Minimal::SerializedQNameIterator name)
+QNameString::QNameString(chip::Dnssd::SerializedQNameIterator name)
 {
     bool first = true;
     while (name.Next())
@@ -52,5 +52,5 @@ QNameString::QNameString(mdns::Minimal::SerializedQNameIterator name)
     }
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/QNameString.h
+++ b/src/lib/dnssd/wire/QNameString.h
@@ -21,16 +21,16 @@
 
 #include <cstring>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 // Allows for a FullQName to be represented as a user-readable logging string
 class QNameString
 {
 public:
-    QNameString(const mdns::Minimal::FullQName & name);
+    QNameString(const chip::Dnssd::FullQName & name);
 
-    QNameString(mdns::Minimal::SerializedQNameIterator name);
+    QNameString(chip::Dnssd::SerializedQNameIterator name);
 
     inline const char * c_str() const { return mBuffer.c_str(); }
 
@@ -64,5 +64,5 @@ private:
     chip::StringBuilder<kMaxQNameLength> mBuffer;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/Query.h
+++ b/src/lib/dnssd/wire/Query.h
@@ -23,8 +23,8 @@
 #include <lib/dnssd/wire/QName.h>
 #include <lib/dnssd/wire/RecordWriter.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// Represents a MDNS Query: QName and flags
 class Query
@@ -87,6 +87,6 @@ private:
     bool mAnswerViaUnicast = true;
 };
 
-} // namespace Minimal
+} // namespace Dnssd
 
-} // namespace mdns
+} // namespace chip

--- a/src/lib/dnssd/wire/RecordData.cpp
+++ b/src/lib/dnssd/wire/RecordData.cpp
@@ -20,8 +20,8 @@
 #include <inet/arpa-inet-compatibility.h>
 #include <stdio.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 bool ParseTxtRecord(const BytesRange & data, TxtRecordDelegate * callback)
 {
@@ -152,5 +152,5 @@ bool ParsePtrRecord(const BytesRange & data, const BytesRange & packet, Serializ
     return true;
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/RecordData.h
+++ b/src/lib/dnssd/wire/RecordData.h
@@ -22,8 +22,8 @@
 #include <lib/dnssd/wire/BytesRange.h>
 #include <lib/dnssd/wire/QName.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class TxtRecordDelegate
 {
@@ -79,6 +79,6 @@ bool ParseAAAARecord(const BytesRange & data, chip::Inet::IPAddress * addr);
 /// https://tools.ietf.org/html/rfc1035 (included in base RFC)
 bool ParsePtrRecord(const BytesRange & data, const BytesRange & packet, SerializedQNameIterator * name);
 
-} // namespace Minimal
+} // namespace Dnssd
 
-} // namespace mdns
+} // namespace chip

--- a/src/lib/dnssd/wire/RecordWriter.cpp
+++ b/src/lib/dnssd/wire/RecordWriter.cpp
@@ -16,8 +16,8 @@
  */
 #include "RecordWriter.h"
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 SerializedQNameIterator RecordWriter::PreviousName(size_t index) const
 {
@@ -141,5 +141,5 @@ void RecordWriter::RememberWrittenQnameOffset(size_t offset)
     }
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/RecordWriter.h
+++ b/src/lib/dnssd/wire/RecordWriter.h
@@ -22,8 +22,8 @@
 
 #include <optional>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /**
  * Handles writing into mdns packets.
@@ -135,5 +135,5 @@ private:
     void RememberWrittenQnameOffset(size_t offset);
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/IP.cpp
+++ b/src/lib/dnssd/wire/records/IP.cpp
@@ -17,8 +17,8 @@
 
 #include "IP.h"
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 bool IPResourceRecord::WriteData(RecordWriter & out) const
 {
@@ -35,5 +35,5 @@ bool IPResourceRecord::WriteData(RecordWriter & out) const
     return out.Fit();
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/IP.h
+++ b/src/lib/dnssd/wire/records/IP.h
@@ -21,8 +21,8 @@
 
 #include <lib/dnssd/wire/records/ResourceRecord.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class IPResourceRecord : public ResourceRecord
 {
@@ -38,6 +38,6 @@ private:
     const chip::Inet::IPAddress mIPAddress;
 };
 
-} // namespace Minimal
+} // namespace Dnssd
 
-} // namespace mdns
+} // namespace chip

--- a/src/lib/dnssd/wire/records/Ptr.h
+++ b/src/lib/dnssd/wire/records/Ptr.h
@@ -19,8 +19,8 @@
 
 #include <lib/dnssd/wire/records/ResourceRecord.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class PtrResourceRecord : public ResourceRecord
 {
@@ -36,5 +36,5 @@ private:
     const FullQName mPtrName;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/ResourceRecord.cpp
+++ b/src/lib/dnssd/wire/records/ResourceRecord.cpp
@@ -17,8 +17,8 @@
 
 #include "ResourceRecord.h"
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 bool ResourceRecord::Append(HeaderRef & hdr, ResourceType asType, RecordWriter & out) const
 {
@@ -70,5 +70,5 @@ bool ResourceRecord::Append(HeaderRef & hdr, ResourceType asType, RecordWriter &
     return out.Fit();
 }
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/ResourceRecord.h
+++ b/src/lib/dnssd/wire/records/ResourceRecord.h
@@ -25,8 +25,8 @@
 
 #include <lib/support/BufferWriter.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 /// A generic Reply record that supports data serialization
 class ResourceRecord
@@ -87,5 +87,5 @@ private:
     QClass mClass = QClass::IN;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/Srv.h
+++ b/src/lib/dnssd/wire/records/Srv.h
@@ -19,8 +19,8 @@
 
 #include <lib/dnssd/wire/records/ResourceRecord.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class SrvResourceRecord : public ResourceRecord
 {
@@ -52,5 +52,5 @@ private:
     uint16_t mWeight   = 0;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/Txt.h
+++ b/src/lib/dnssd/wire/records/Txt.h
@@ -21,8 +21,8 @@
 
 #include <lib/dnssd/wire/records/ResourceRecord.h>
 
-namespace mdns {
-namespace Minimal {
+namespace chip {
+namespace Dnssd {
 
 class TxtResourceRecord : public ResourceRecord
 {
@@ -74,5 +74,5 @@ private:
     const size_t mEntryCount;
 };
 
-} // namespace Minimal
-} // namespace mdns
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/wire/records/tests/TestResourceRecord.cpp
+++ b/src/lib/dnssd/wire/records/tests/TestResourceRecord.cpp
@@ -25,7 +25,7 @@ namespace {
 
 using namespace chip;
 using namespace chip::Encoding::BigEndian;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 const QNamePart kNames[] = { "foo", "bar" };
 

--- a/src/lib/dnssd/wire/records/tests/TestResourceRecordIP.cpp
+++ b/src/lib/dnssd/wire/records/tests/TestResourceRecordIP.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Encoding::BigEndian;

--- a/src/lib/dnssd/wire/records/tests/TestResourceRecordPtr.cpp
+++ b/src/lib/dnssd/wire/records/tests/TestResourceRecordPtr.cpp
@@ -23,7 +23,7 @@
 namespace {
 
 using namespace chip;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using namespace chip::Encoding;
 
 TEST(TestResourceRecordPtr, TestPtrResourceRecord)

--- a/src/lib/dnssd/wire/records/tests/TestResourceRecordSrv.cpp
+++ b/src/lib/dnssd/wire/records/tests/TestResourceRecordSrv.cpp
@@ -24,7 +24,7 @@ namespace {
 
 using namespace chip;
 using namespace chip::Encoding;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 TEST(TestResourceRecordSrv, TestSrv)
 {

--- a/src/lib/dnssd/wire/records/tests/TestResourceRecordTxt.cpp
+++ b/src/lib/dnssd/wire/records/tests/TestResourceRecordTxt.cpp
@@ -24,7 +24,7 @@ namespace {
 
 using namespace chip;
 using namespace chip::Encoding;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 TEST(TestResourceRecordTxt, TestTxt)
 {

--- a/src/lib/dnssd/wire/tests/QNameStrings.h
+++ b/src/lib/dnssd/wire/tests/QNameStrings.h
@@ -68,16 +68,16 @@ public:
         }
     }
 
-    mdns::Minimal::SerializedQNameIterator Serialized() const
+    chip::Dnssd::SerializedQNameIterator Serialized() const
     {
-        return mdns::Minimal::SerializedQNameIterator(
-            mdns::Minimal::BytesRange(mSerializedQNameBuffer, mSerializedQNameBuffer + mSerializedBufferSize),
+        return chip::Dnssd::SerializedQNameIterator(
+            chip::Dnssd::BytesRange(mSerializedQNameBuffer, mSerializedQNameBuffer + mSerializedBufferSize),
             mSerializedQNameBuffer);
     }
 
-    mdns::Minimal::FullQName Full() const
+    chip::Dnssd::FullQName Full() const
     {
-        mdns::Minimal::FullQName result;
+        chip::Dnssd::FullQName result;
 
         result.names     = mStrings;
         result.nameCount = N;

--- a/src/lib/dnssd/wire/tests/TestFlatAllocatedQName.cpp
+++ b/src/lib/dnssd/wire/tests/TestFlatAllocatedQName.cpp
@@ -22,7 +22,7 @@
 
 namespace {
 
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 class AutoFreeBuffer
 {

--- a/src/lib/dnssd/wire/tests/TestHeapQName.cpp
+++ b/src/lib/dnssd/wire/tests/TestHeapQName.cpp
@@ -24,7 +24,7 @@
 
 namespace {
 
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 class TestHeapQName : public ::testing::Test
 {

--- a/src/lib/dnssd/wire/tests/TestParser.cpp
+++ b/src/lib/dnssd/wire/tests/TestParser.cpp
@@ -27,7 +27,7 @@
 namespace {
 
 using namespace chip;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 constexpr uint16_t kKeyRecordType = 25;
 

--- a/src/lib/dnssd/wire/tests/TestQName.cpp
+++ b/src/lib/dnssd/wire/tests/TestQName.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 /// Convenience method to have a  serialized QName:
 ///

--- a/src/lib/dnssd/wire/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/wire/tests/TestQNameString.cpp
@@ -26,7 +26,7 @@
 namespace {
 
 using namespace chip;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 class TestQNameString : public ::testing::Test
 {
@@ -45,7 +45,7 @@ TEST_F(TestQNameString, Construction)
         EXPECT_TRUE(heapQName.EndsWith(".test"));
         EXPECT_FALSE(heapQName.EndsWith("some"));
 
-        mdns::Minimal::SerializedQNameIterator SInvalid;
+        chip::Dnssd::SerializedQNameIterator SInvalid;
         QNameString heapQNameI(SInvalid);
         EXPECT_STREQ(heapQNameI.c_str(), "(!INVALID!)");
     }

--- a/src/lib/dnssd/wire/tests/TestRecordData.cpp
+++ b/src/lib/dnssd/wire/tests/TestRecordData.cpp
@@ -27,7 +27,7 @@
 namespace {
 
 using namespace chip;
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 
 TEST(TestRecordData, SrvRecordSimpleParsing)
 {

--- a/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-using namespace mdns::Minimal;
+using namespace chip::Dnssd;
 using namespace chip::Encoding::BigEndian;
 
 TEST(TestRecordWriter, BasicWriteTest)

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -208,7 +208,7 @@ TEST_F(TestDnssd, TestDnssdBrowse)
 
     mdns::Minimal::Server<10> server;
     chip::Dnssd::QNamePart serverName[] = { "resolve-tester", "_mock", chip::Dnssd::kCommissionProtocol,
-                                              chip::Dnssd::kLocalDomain };
+                                            chip::Dnssd::kLocalDomain };
     mdns::Minimal::ResponseSender responseSender(&server);
 
     mdns::Minimal::QueryResponder<16> queryResponder;
@@ -217,7 +217,7 @@ TEST_F(TestDnssd, TestDnssdBrowse)
     // Respond to PTR queries for _mock._udp.local
     chip::Dnssd::QNamePart serviceName[]       = { "_mock", chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
     chip::Dnssd::QNamePart serverServiceName[] = { "INSTANCE", chip::Dnssd::kCommissionableServiceName,
-                                                     chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
+                                                   chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
     mdns::Minimal::PtrResponder ptrUdpResponder(serviceName, serverServiceName);
     queryResponder.AddResponder(&ptrUdpResponder);
 

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -46,7 +46,7 @@ using chip::Dnssd::TextEntry;
 
 namespace {
 
-class TestDnssdResolveServerDelegate : public mdns::Minimal::ServerDelegate, public mdns::Minimal::ParserDelegate
+class TestDnssdResolveServerDelegate : public mdns::Minimal::ServerDelegate, public chip::Dnssd::ParserDelegate
 {
 public:
     TestDnssdResolveServerDelegate(mdns::Minimal::ResponseSender * responder) : mResponder(responder) {}
@@ -54,22 +54,22 @@ public:
 
     // Implementation of mdns::Minimal::ServerDelegate
 
-    void OnResponse(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override {}
-    void OnQuery(const mdns::Minimal::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
+    void OnResponse(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override {}
+    void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         mCurSrc = info;
-        mdns::Minimal::ParsePacket(data, this);
+        chip::Dnssd::ParsePacket(data, this);
         mCurSrc = nullptr;
     }
 
-    // Implementation of mdns::Minimal::ParserDelegate
+    // Implementation of chip::Dnssd::ParserDelegate
 
-    void OnHeader(mdns::Minimal::ConstHeaderRef & header) override { mMsgId = header.GetMessageId(); }
-    void OnQuery(const mdns::Minimal::QueryData & data) override
+    void OnHeader(chip::Dnssd::ConstHeaderRef & header) override { mMsgId = header.GetMessageId(); }
+    void OnQuery(const chip::Dnssd::QueryData & data) override
     {
         TEMPORARY_RETURN_IGNORED mResponder->Respond(mMsgId, data, mCurSrc, mRespConfig);
     }
-    void OnResource(mdns::Minimal::ResourceType type, const mdns::Minimal::ResourceData & data) override {}
+    void OnResource(chip::Dnssd::ResourceType type, const chip::Dnssd::ResourceData & data) override {}
 
 private:
     mdns::Minimal::ResponseSender * mResponder;
@@ -207,7 +207,7 @@ TEST_F(TestDnssd, TestDnssdBrowse)
     mdns::Minimal::SetDefaultAddressPolicy();
 
     mdns::Minimal::Server<10> server;
-    mdns::Minimal::QNamePart serverName[] = { "resolve-tester", "_mock", chip::Dnssd::kCommissionProtocol,
+    chip::Dnssd::QNamePart serverName[] = { "resolve-tester", "_mock", chip::Dnssd::kCommissionProtocol,
                                               chip::Dnssd::kLocalDomain };
     mdns::Minimal::ResponseSender responseSender(&server);
 
@@ -215,19 +215,19 @@ TEST_F(TestDnssd, TestDnssdBrowse)
     TEMPORARY_RETURN_IGNORED responseSender.AddQueryResponder(&queryResponder);
 
     // Respond to PTR queries for _mock._udp.local
-    mdns::Minimal::QNamePart serviceName[]       = { "_mock", chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
-    mdns::Minimal::QNamePart serverServiceName[] = { "INSTANCE", chip::Dnssd::kCommissionableServiceName,
+    chip::Dnssd::QNamePart serviceName[]       = { "_mock", chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
+    chip::Dnssd::QNamePart serverServiceName[] = { "INSTANCE", chip::Dnssd::kCommissionableServiceName,
                                                      chip::Dnssd::kCommissionProtocol, chip::Dnssd::kLocalDomain };
     mdns::Minimal::PtrResponder ptrUdpResponder(serviceName, serverServiceName);
     queryResponder.AddResponder(&ptrUdpResponder);
 
     // Respond to SRV queries for INSTANCE._matterc._udp.local
-    mdns::Minimal::SrvResponder srvResponder(mdns::Minimal::SrvResourceRecord(serverServiceName, serverName, CHIP_PORT));
+    mdns::Minimal::SrvResponder srvResponder(chip::Dnssd::SrvResourceRecord(serverServiceName, serverName, CHIP_PORT));
     queryResponder.AddResponder(&srvResponder);
 
     // Respond to TXT queries for INSTANCE._matterc._udp.local
     const char * txtEntries[] = { "key=val" };
-    mdns::Minimal::TxtResponder txtResponder(mdns::Minimal::TxtResourceRecord(serverServiceName, txtEntries));
+    mdns::Minimal::TxtResponder txtResponder(chip::Dnssd::TxtResourceRecord(serverServiceName, txtEntries));
     queryResponder.AddResponder(&txtResponder);
 
     // Respond to A queries


### PR DESCRIPTION
#### Summary

Rename DNS wire codec types under `src/lib/dnssd/wire` from namespace `mdns::Minimal` to `chip::Dnssd`.

##### Problem
- Wire types still lived in `mdns::Minimal` even after moving into `dnssd/wire`.

##### Solution
- Moved all `dnssd/wire` and `wire/records` declarations into `chip::Dnssd` namespace.
- Updated consumers (`minimal_mdns`, dnssd advertiser/resolver, platform tests, examples) to use the new namespace.
- Left mDNS-specific types in `mdns::Minimal`.

##### Caveats
- Rename-only; no behavior change.

#### Testing
- Built and ran:
  - `src/lib/dnssd/wire/tests:tests_run`
  - `src/lib/dnssd/wire/records/tests:tests_run`
  - `src/lib/dnssd/minimal_mdns/tests:tests_run`
  - `src/lib/dnssd/minimal_mdns/responders/tests:tests_run`
  - `src/lib/dnssd/tests:tests_run`