### PR TITLE
Make mve-sve branch backport to 1.7 as well. Remove 1.5 backport from "supported"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -50,6 +50,7 @@ pull_request_rules:
           - merged
           - base=master
           - or:
+                - label="request-backport-latest-mve-sve"
                 - label="request-backport-latest"
                 - label="request-backport-supported"
       actions:
@@ -96,18 +97,6 @@ pull_request_rules:
                   - v1.6-branch
               labels:
                   - backport-v1.6-branch
-
-    - name: Backport to v1.5-branch
-      conditions:
-          - merged
-          - base=master
-          - label="request-backport-supported"
-      actions:
-          backport:
-              branches:
-                  - v1.5-branch
-              labels:
-                  - backport-v1.5-branch
 
     - name: Backport to v1.4.2-branch
       conditions:


### PR DESCRIPTION
### Summary

If a cherrypick is important enough from mve/sve, it should be included in 1.7 as well (i.e. latest).

Trim down backport surface for "latest": now that we have 1.6 released, we do not backport by default to 1.5.1.

### Testing

N/A: trivial change