### PR TITLE
[docker] Pull an existing parent image instead of rebuilding it

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -155,14 +155,23 @@ awk 'toupper($1) == "FROM" && $2 ~ /project-chip\// {
     sort -u | while read -r dep; do
     dep_dir=$(find "$IMAGES_ROOT" -maxdepth 2 -type d -name "$dep" | head -1)
     [[ -n $dep_dir ]] || die "cannot locate a directory for parent image '$dep' under $IMAGES_ROOT"
-    # Only build the parent if it is not already present. Without this, a
-    # build-all run rebuilds the base image once per dependent image, and any
-    # --no-cache is forwarded into each of those rebuilds.
-    # $VERSION is what the parent will be tagged with too: every image reads the
+    # Prefer a parent that already exists over building one. Locally that avoids
+    # rebuilding the base image once per dependent image during a build-all run;
+    # in CI, where each image builds on its own runner, it avoids rebuilding the
+    # base for every image in the matrix.
+    #
+    # Building is the fallback rather than the default, since the tag is missing
+    # exactly when a change has not been published yet, which is the case on a
+    # pull request that bumps a version file.
+    #
+    # $VERSION is what the parent would be tagged with too: every image reads the
     # same DOCKER_BUILD_VERSION when set, and the per-image version files match.
     if docker image inspect "$GHCR_ORG/$ORG/$dep:$VERSION" >/dev/null 2>&1; then
-        echo "$me: parent $GHCR_ORG/$ORG/$dep:$VERSION already present, not rebuilding"
+        echo "$me: parent $GHCR_ORG/$ORG/$dep:$VERSION already present"
+    elif docker pull "$GHCR_ORG/$ORG/$dep:$VERSION"; then
+        echo "$me: pulled parent $GHCR_ORG/$ORG/$dep:$VERSION"
     else
+        echo "$me: parent $GHCR_ORG/$ORG/$dep:$VERSION not published, building it"
         (cd "$dep_dir" && ./build.sh "${ORIG_ARGS[@]}")
     fi
 done


### PR DESCRIPTION
#### Summary

Makes the parent-image walk in `build.sh` pull an existing parent rather than
rebuild it.

##### Problem

The walk builds a parent whenever it is not already in the local daemon. That is
correct on a machine that has been building all along, but every CI job starts
on a fresh runner with an empty daemon, so each image in the matrix rebuilds the
base image before building itself.

##### Solution

Try `docker pull` first, and fall back to building only when it fails. The tag is
absent exactly when the change has not been published yet, which is the case on a
pull request that bumps a `version` file, so the fallback still covers what the
walk exists for.

Order is now: already local, else pull, else build.

#### Related issues

Follows #73474, which restored the walk. Part of #30750.

#### Testing

Exercised all three branches against a copy of `integrations/docker/`, using
`--skip-build` so only the walk runs:

-   **Parent absent locally, published.** Pulls it: `208: Pulling from
    project-chip/chip-build`, `Status: Downloaded newer image`, then
    `pulled parent ghcr.io/project-chip/chip-build:208`. No build.
-   **Parent already local.** Reports `already present`, no pull and no build.
-   **Parent absent and unpublished**, via `DOCKER_BUILD_VERSION=neverpublished-9999`.
    The pull fails with `manifest unknown` and it falls through to building,
    which is the version-bump case that must keep working.
