### PR TITLE
[Silabs] Migrate SiWx ICD broadcast filter off deprecated WiSeConnect API

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #include "sl_wifi_callback_framework.h"
 #include "sl_wifi_constants.h"
 #include "sl_wifi_types.h"
+#include "sl_utility.h"
 #if SL_MBEDTLS_USE_TINYCRYPT
 #include "sl_si91x_constants.h"
 #include "sl_si91x_trng.h"
@@ -98,8 +99,9 @@ constexpr osThreadAttr_t kWlanTaskAttr = { .name       = "wlan_rsi",
                                            .priority   = osPriorityAboveNormal7 };
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-constexpr uint32_t kTimeToFullBeaconReception = 5000; // 5 seconds
-#endif                                                // CHIP_CONFIG_ENABLE_ICD_SERVER
+constexpr uint32_t kTimeToFullBeaconReception     = 5000; // 5 seconds
+constexpr char kMatterMdnsIpv6McastAddress[]      = "ff02::fb";
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 wfx_wifi_scan_ext_t temp_reset;
 
@@ -802,6 +804,9 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
+    // Power save configuration is already set, nothing to do
+    VerifyOrReturnValue(mCurrentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
+
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: %" PRIu32, error));
@@ -814,20 +819,59 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
     VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile_v2 failed: 0x%" PRIx32, status));
 
+    mCurrentPowerSaveConfiguration = configuration;
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WifiInterfaceImpl::ConfigureBroadcastFilter(bool enableBroadcastFilter)
 {
-    sl_status_t status = SL_STATUS_OK;
+    // Skip the underlying call if the filter is already in the requested state.
+    VerifyOrReturnValue(mBroadcastFilterEnabled != enableBroadcastFilter, CHIP_NO_ERROR);
 
-    uint16_t beaconDropThreshold = (enableBroadcastFilter) ? kTimeToFullBeaconReception : 0;
-    uint8_t filterBcastInTim     = (enableBroadcastFilter) ? 1 : 0;
-
-    status = sl_wifi_filter_broadcast(beaconDropThreshold, filterBcastInTim, 1 /* valid till next update*/);
+    sl_status_t status = sl_wifi_allowlist_mcast_remove_all();
     VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_remove_all failed: 0x%" PRIx32,
+                                     static_cast<uint32_t>(status)));
 
+    if (!enableBroadcastFilter)
+    {
+        // Filter disabled: allowlist Matter mDNS (ff02::fb) so only that multicast is received.
+        // Use sl_inet_pton6 so the address is in the endianness expected by the NWP.
+        sl_ip_address_t mdnsIpv6McastAddress                  = {};
+        uint8_t parsedAddress[SL_IPV6_ADDRESS_LENGTH]         = {};
+        const int parseStatus = sl_inet_pton6(kMatterMdnsIpv6McastAddress,
+                                              kMatterMdnsIpv6McastAddress + sizeof(kMatterMdnsIpv6McastAddress) - 1,
+                                              parsedAddress,
+                                              reinterpret_cast<unsigned int *>(mdnsIpv6McastAddress.ip.v6.value));
+        VerifyOrReturnError(parseStatus == 1, CHIP_ERROR_INTERNAL,
+                            ChipLogError(DeviceLayer, "Failed to parse Matter mDNS IPv6 multicast address"));
+        mdnsIpv6McastAddress.type = SL_IPV6;
+
+        sl_ip_address_handle_t allowlistHandle = UINT8_MAX;
+        status                                 = sl_wifi_allowlist_mcast_add_ip(&mdnsIpv6McastAddress, &allowlistHandle);
+        VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+                            ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_add_ip failed: 0x%" PRIx32,
+                                         static_cast<uint32_t>(status)));
+    }
+
+    // Multicast filtering stays enabled in both modes; the allowlist controls what passes.
+    sl_wifi_groupcast_filter_config_t groupcastFilterConfig = {};
+    groupcastFilterConfig.enable_bcast_filter               = enableBroadcastFilter ? 1 : 0;
+    groupcastFilterConfig.enable_mcast_filter               = 1;
+    groupcastFilterConfig.filter_mode                       = 0; // default
+
+    status = sl_wifi_set_groupcast_filter_config(&groupcastFilterConfig);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "sl_wifi_set_groupcast_filter_config failed: 0x%" PRIx32,
+                                     static_cast<uint32_t>(status)));
+
+    uint16_t beaconDropThreshold = enableBroadcastFilter ? kTimeToFullBeaconReception : 0;
+    status                       = sl_wifi_set_beacon_drop_threshold(SL_WIFI_CLIENT_INTERFACE, beaconDropThreshold);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "sl_wifi_set_beacon_drop_threshold failed: 0x%" PRIx32,
+                                     static_cast<uint32_t>(status)));
+
+    mBroadcastFilterEnabled = enableBroadcastFilter;
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -39,11 +39,11 @@ extern "C" {
 #include "sl_si91x_driver.h"
 #include "sl_si91x_host_interface.h"
 #include "sl_si91x_types.h"
+#include "sl_utility.h"
 #include "sl_wifi.h"
 #include "sl_wifi_callback_framework.h"
 #include "sl_wifi_constants.h"
 #include "sl_wifi_types.h"
-#include "sl_utility.h"
 #if SL_MBEDTLS_USE_TINYCRYPT
 #include "sl_si91x_constants.h"
 #include "sl_si91x_trng.h"
@@ -99,8 +99,8 @@ constexpr osThreadAttr_t kWlanTaskAttr = { .name       = "wlan_rsi",
                                            .priority   = osPriorityAboveNormal7 };
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-constexpr uint32_t kTimeToFullBeaconReception     = 5000; // 5 seconds
-constexpr char kMatterMdnsIpv6McastAddress[]      = "ff02::fb";
+constexpr uint32_t kTimeToFullBeaconReception = 5000; // 5 seconds
+constexpr char kMatterMdnsIpv6McastAddress[]  = "ff02::fb";
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 wfx_wifi_scan_ext_t temp_reset;
@@ -829,29 +829,28 @@ CHIP_ERROR WifiInterfaceImpl::ConfigureBroadcastFilter(bool enableBroadcastFilte
     VerifyOrReturnValue(mBroadcastFilterEnabled != enableBroadcastFilter, CHIP_NO_ERROR);
 
     sl_status_t status = sl_wifi_allowlist_mcast_remove_all();
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_remove_all failed: 0x%" PRIx32,
-                                     static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+        ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_remove_all failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     if (!enableBroadcastFilter)
     {
         // Filter disabled: allowlist Matter mDNS (ff02::fb) so only that multicast is received.
         // Use sl_inet_pton6 so the address is in the endianness expected by the NWP.
-        sl_ip_address_t mdnsIpv6McastAddress                  = {};
-        uint8_t parsedAddress[SL_IPV6_ADDRESS_LENGTH]         = {};
-        const int parseStatus = sl_inet_pton6(kMatterMdnsIpv6McastAddress,
-                                              kMatterMdnsIpv6McastAddress + sizeof(kMatterMdnsIpv6McastAddress) - 1,
-                                              parsedAddress,
-                                              reinterpret_cast<unsigned int *>(mdnsIpv6McastAddress.ip.v6.value));
+        sl_ip_address_t mdnsIpv6McastAddress          = {};
+        uint8_t parsedAddress[SL_IPV6_ADDRESS_LENGTH] = {};
+        const int parseStatus =
+            sl_inet_pton6(kMatterMdnsIpv6McastAddress, kMatterMdnsIpv6McastAddress + sizeof(kMatterMdnsIpv6McastAddress) - 1,
+                          parsedAddress, reinterpret_cast<unsigned int *>(mdnsIpv6McastAddress.ip.v6.value));
         VerifyOrReturnError(parseStatus == 1, CHIP_ERROR_INTERNAL,
                             ChipLogError(DeviceLayer, "Failed to parse Matter mDNS IPv6 multicast address"));
         mdnsIpv6McastAddress.type = SL_IPV6;
 
         sl_ip_address_handle_t allowlistHandle = UINT8_MAX;
         status                                 = sl_wifi_allowlist_mcast_add_ip(&mdnsIpv6McastAddress, &allowlistHandle);
-        VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                            ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_add_ip failed: 0x%" PRIx32,
-                                         static_cast<uint32_t>(status)));
+        VerifyOrReturnError(
+            status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+            ChipLogError(DeviceLayer, "sl_wifi_allowlist_mcast_add_ip failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
     }
 
     // Multicast filtering stays enabled in both modes; the allowlist controls what passes.
@@ -861,15 +860,15 @@ CHIP_ERROR WifiInterfaceImpl::ConfigureBroadcastFilter(bool enableBroadcastFilte
     groupcastFilterConfig.filter_mode                       = 0; // default
 
     status = sl_wifi_set_groupcast_filter_config(&groupcastFilterConfig);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_groupcast_filter_config failed: 0x%" PRIx32,
-                                     static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+        ChipLogError(DeviceLayer, "sl_wifi_set_groupcast_filter_config failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     uint16_t beaconDropThreshold = enableBroadcastFilter ? kTimeToFullBeaconReception : 0;
     status                       = sl_wifi_set_beacon_drop_threshold(SL_WIFI_CLIENT_INTERFACE, beaconDropThreshold);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "sl_wifi_set_beacon_drop_threshold failed: 0x%" PRIx32,
-                                     static_cast<uint32_t>(status)));
+    VerifyOrReturnError(
+        status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+        ChipLogError(DeviceLayer, "sl_wifi_set_beacon_drop_threshold failed: 0x%" PRIx32, static_cast<uint32_t>(status)));
 
     mBroadcastFilterEnabled = enableBroadcastFilter;
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -66,6 +66,12 @@ public:
      *                                                         or if it is a non-supported configuration
      */
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    protected:
+    // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be
+    // explicitly configured
+    PowerSaveConfiguration mCurrentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
+    bool mBroadcastFilterEnabled                          = false;
 };
 
 } // namespace Silabs

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -67,7 +67,7 @@ public:
      */
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
 
-    protected:
+protected:
     // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be
     // explicitly configured
     PowerSaveConfiguration mCurrentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -122,6 +122,7 @@ CHIP_ERROR WifiSleepManager::ConfigureDTIMBasedSleep()
 {
     VerifyOrDieWithMsg(mPowerSaveInterface != nullptr, DeviceLayer, "PowerSaveInterface is not initialized");
 
+    // Filter disabled: Matter mDNS (ff02::fb) remains allowlisted.
     ReturnLogErrorOnFailure(mPowerSaveInterface->ConfigureBroadcastFilter(false));
 
     // Allowing the device to go to sleep must be the last actions to avoid configuration failures.


### PR DESCRIPTION
### Summary
Migrates SiWx ICD broadcast/multicast filtering to WiSeConnect 4.1 APIs and skips redundant power-save/filter reconfiguration.

#### Problem
- `sl_wifi_filter_broadcast` is deprecated in WiSeConnect 4.1 and is scheduled for removal.
- ICD paths repeatedly re-applied the same power-save and broadcast-filter configuration, causing unnecessary NWP commands.
- Without an mDNS allowlist, enabling multicast filtering blocks Matter operational discovery traffic (`ff02::fb`).

#### Solution
- Replaced `sl_wifi_filter_broadcast` with:
  - `sl_wifi_set_groupcast_filter_config`
  - `sl_wifi_set_beacon_drop_threshold`
  - `sl_wifi_allowlist_mcast_add_ip` / `sl_wifi_allowlist_mcast_remove_all`
- Filter behavior:
  - **Disabled**: multicast filtering on with Matter mDNS (`ff02::fb`) allowlisted
  - **Enabled**: allowlist cleared so all multicast is blocked
- Skip `ConfigurePowerSave` / `ConfigureBroadcastFilter` when the requested state already matches the cached state.
- Parse `ff02::fb` via `sl_inet_pton6` so the address uses NWP-expected endianness.

### Related issues
NA

### Testing
- Built Silabs lock-app (SiWx) with the updated filter path.
- Commissioning, commands and subscription validation