### PR TITLE
[docker] Retry a failed image build before giving up

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -177,7 +177,28 @@ awk 'toupper($1) == "FROM" && $2 ~ /project-chip\// {
 done
 
 if [ "$SKIP_BUILD" = false ]; then
-    docker build "${BUILD_ARGS[@]}" --platform="$TARGET_PLATFORM_TYPE" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$GHCR_ORG/$ORG/$IMAGE:$VERSION" .
+    # These images fetch SDKs and toolchains from vendor servers while building,
+    # and those fetches fail intermittently: a truncated download or a 5xx from
+    # a vendor leaves the build red for a reason nothing here controls. Retry
+    # instead, so that a red build means the image is actually broken.
+    #
+    # A retry is cheap even when the failure is real, because the layers before
+    # the failing one are cached and the build resumes at that step.
+    #
+    # DOCKER_BUILD_ATTEMPTS=1 fails on the first attempt, which is usually what
+    # you want locally. DOCKER_BUILD_RETRY_DELAY is the backoff base in seconds:
+    # the wait before attempt N is N-1 times that, so the default 15 waits 15s
+    # then 30s.
+    attempts=${DOCKER_BUILD_ATTEMPTS:-3}
+    retry_delay=${DOCKER_BUILD_RETRY_DELAY:-15}
+    for attempt in $(seq 1 "$attempts"); do
+        if docker build "${BUILD_ARGS[@]}" --platform="$TARGET_PLATFORM_TYPE" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$GHCR_ORG/$ORG/$IMAGE:$VERSION" .; then
+            break
+        fi
+        [[ $attempt -lt $attempts ]] || die "docker build failed after $attempts attempts"
+        echo "$me: build failed on attempt $attempt of $attempts, retrying in $((attempt * retry_delay))s"
+        sleep $((attempt * retry_delay))
+    done
     docker image prune --force
 fi
 

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -191,7 +191,11 @@ if [ "$SKIP_BUILD" = false ]; then
     # then 30s.
     attempts=${DOCKER_BUILD_ATTEMPTS:-3}
     retry_delay=${DOCKER_BUILD_RETRY_DELAY:-15}
-    for attempt in $(seq 1 "$attempts"); do
+    # Reject bad values rather than looping zero times, which would skip the
+    # build entirely and still exit 0.
+    [[ $attempts =~ ^[1-9][0-9]*$ ]] || die "DOCKER_BUILD_ATTEMPTS must be a positive integer, got '$attempts'"
+    [[ $retry_delay =~ ^[0-9]+$ ]] || die "DOCKER_BUILD_RETRY_DELAY must be a non-negative integer, got '$retry_delay'"
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
         if docker build "${BUILD_ARGS[@]}" --platform="$TARGET_PLATFORM_TYPE" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$GHCR_ORG/$ORG/$IMAGE:$VERSION" .; then
             break
         fi


### PR DESCRIPTION
#### Summary

Retries a failed docker image build before treating it as a failure.

##### Problem

These images fetch SDKs and toolchains from vendor servers as part of the build,
and those fetches fail intermittently. Two recent examples, both on unmodified
Dockerfiles:

```
telink, telink-zephyr_3_3:  ChunkedEncodingError: Connection broken:
                            IncompleteRead(1080877 bytes read, 1548409 more expected)
silabs-zephyr:              HTTP error occurred: 521 Server Error
                            https://artifacts.silabs.net/.../objects/batch
```

Neither says anything about the image. Both leave the build red, and a build that
is red for reasons the repository does not control is how people learn to ignore
red.

##### Solution

Retry the build up to three times, waiting 15 then 30 seconds.

This is cheap because the layers before the failing step are cached, so a retry
resumes at that step rather than rebuilding. Measured on a build that fails at a
late step and can never succeed: 9s without retrying, 46s with, so 37s more, most
of it the sleep. Against builds that run from three to twenty-five minutes that
is noise.

`DOCKER_BUILD_ATTEMPTS` and `DOCKER_BUILD_RETRY_DELAY` adjust the count and the
backoff base; the wait before attempt N is N-1 times the base. Setting attempts
to 1 restores the previous behaviour, which is usually what you want locally.

##### Caveats

This converts the common case, a truncated transfer, into a pass. It does not
help with a sustained vendor outage; the silabs 521 above recurred over days. An
image that fails persistently still wants excluding with its error recorded, as
`-imx` was.

#### Related issues

Part of #30750.

#### Testing

Exercised against a Dockerfile that always fails, so every attempt is used:

-   Defaults: three attempts, waits reported as 15s then 30s, then
    `docker build failed after 3 attempts`. Elapsed 45s.
-   `DOCKER_BUILD_RETRY_DELAY=2`: waits 2s then 4s, elapsed 7s.
-   `DOCKER_BUILD_ATTEMPTS=4 DOCKER_BUILD_RETRY_DELAY=3`: waits 3s, 6s, 9s, then
    fails after 4 attempts. Elapsed 19s.
-   `DOCKER_BUILD_ATTEMPTS=1`: fails immediately with no retry and no sleep.

Cache behaviour checked with a Dockerfile whose first three layers succeed and
whose last always fails: the cached layers are not rebuilt on attempts 2 and 3.
