### PR TITLE
[TimeSynch] Do not emit TimeFailure on valid SetTrustedTimeSource

### DIFF
--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -170,10 +170,10 @@ void EmitMissingTrustedTimeSourceEvent(DataModel::EventsGenerator * eventsGenera
 TimeSynchronizationCluster::TimeSynchronizationCluster(EndpointId endpoint, const BitFlags<TimeSynchronization::Feature> features,
                                                        const OptionalAttributeSet & optionalAttributeSet,
                                                        const StartupConfiguration & config, Context context) :
-    DefaultServerCluster({ endpoint, TimeSynchronization::Id }), mFeatures(features), mOptionalAttributeSet(optionalAttributeSet),
-    mSupportsDNSResolve(config.supportsDNSResolve), mNTPServerAvailable(config.ntpServerAvailable),
-    mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource), mDelegate(config.delegate),
-    mTimeSyncContext(context),
+    DefaultServerCluster({ endpoint, TimeSynchronization::Id }),
+    mFeatures(features), mOptionalAttributeSet(optionalAttributeSet), mSupportsDNSResolve(config.supportsDNSResolve),
+    mNTPServerAvailable(config.ntpServerAvailable), mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource),
+    mDelegate(config.delegate), mTimeSyncContext(context),
 #if TIME_SYNC_ENABLE_TSC_FEATURE
     mOnDeviceConnectedCallback(OnDeviceConnectedWrapper, this),
     mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureWrapper, this),

--- a/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp
@@ -170,10 +170,10 @@ void EmitMissingTrustedTimeSourceEvent(DataModel::EventsGenerator * eventsGenera
 TimeSynchronizationCluster::TimeSynchronizationCluster(EndpointId endpoint, const BitFlags<TimeSynchronization::Feature> features,
                                                        const OptionalAttributeSet & optionalAttributeSet,
                                                        const StartupConfiguration & config, Context context) :
-    DefaultServerCluster({ endpoint, TimeSynchronization::Id }),
-    mFeatures(features), mOptionalAttributeSet(optionalAttributeSet), mSupportsDNSResolve(config.supportsDNSResolve),
-    mNTPServerAvailable(config.ntpServerAvailable), mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource),
-    mDelegate(config.delegate), mTimeSyncContext(context),
+    DefaultServerCluster({ endpoint, TimeSynchronization::Id }), mFeatures(features), mOptionalAttributeSet(optionalAttributeSet),
+    mSupportsDNSResolve(config.supportsDNSResolve), mNTPServerAvailable(config.ntpServerAvailable),
+    mTimeZoneDatabase(config.timeZoneDatabase), mTimeSource(config.timeSource), mDelegate(config.delegate),
+    mTimeSyncContext(context),
 #if TIME_SYNC_ENABLE_TSC_FEATURE
     mOnDeviceConnectedCallback(OnDeviceConnectedWrapper, this),
     mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureWrapper, this),
@@ -1146,8 +1146,6 @@ TimeSynchronizationCluster::HandleSetTrustedTimeSource(CommandHandler * commandO
         Structs::TrustedTimeSourceStruct::Type ts = { commandObj->GetAccessingFabricIndex(), timeSource.Value().nodeID,
                                                       timeSource.Value().endpoint };
         tts.SetNonNull(ts);
-        // TODO: schedule a utctime read from this time source and emit event only on failure to get time
-        EmitTimeFailureEvent(GetDelegate(), GetEventsGenerator());
     }
     else
     {

--- a/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
@@ -23,7 +23,9 @@
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/TimeSynchronization/Attributes.h>
+#include <clusters/TimeSynchronization/Commands.h>
 #include <clusters/TimeSynchronization/Enums.h>
+#include <clusters/TimeSynchronization/Events.h>
 #include <clusters/TimeSynchronization/Metadata.h>
 #include <clusters/TimeSynchronization/Structs.h>
 
@@ -36,6 +38,18 @@ using namespace chip::app::Clusters::TimeSynchronization;
 using namespace chip::app::Clusters::TimeSynchronization::Attributes;
 using namespace chip::Testing;
 
+// Test delegate that stubs UpdateTimeFromPlatformSource to prevent AttemptToGetTime() from
+// falling back to AttemptToGetTimeFromTrustedNode() on platforms where GetClock_RealTime() is
+// not implemented (e.g. Zephyr / nrf-native-sim). Falling back would attempt to establish a CASE
+// session via CASESessionManager, which is uninitialized in unit test fixtures and would segfault.
+struct TestTimeSyncDelegate : public TimeSynchronization::DefaultTimeSyncDelegate
+{
+    CHIP_ERROR UpdateTimeFromPlatformSource(chip::Callback::Callback<TimeSynchronization::OnTimeSyncCompletion> * callback) override
+    {
+        return CHIP_NO_ERROR;
+    }
+};
+
 struct TestTimeSynchronizationCluster : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
@@ -45,7 +59,7 @@ struct TestTimeSynchronizationCluster : public ::testing::Test
     TestTimeSynchronizationCluster() {}
 
     TestServerClusterContext testContext;
-    TimeSynchronization::DefaultTimeSyncDelegate delegate;
+    TestTimeSyncDelegate delegate;
     const TimeSynchronizationCluster::Context context = { .fabricTable            = testContext.GetFabricTable(),
                                                           .caseSessionManager     = testContext.GetCASESessionManager(),
                                                           .platformManager        = testContext.GetPlatformManager(),
@@ -346,4 +360,59 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
 
         timeSynchronization.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
+}
+
+TEST_F(TestTimeSynchronizationCluster, SetTrustedTimeSourceTest)
+{
+    const BitFlags<Feature> features{ Feature::kTimeSyncClient };
+    TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features, TimeSynchronizationCluster::OptionalAttributeSet(),
+                                                   TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate },
+                                                   context);
+    ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(timeSynchronization);
+
+    // 1. Invoke SetTrustedTimeSource with a valid (non-null) time source
+    Commands::SetTrustedTimeSource::Type request;
+    Structs::FabricScopedTrustedTimeSourceStruct::Type tts;
+    tts.nodeID   = 1234;
+    tts.endpoint = 0;
+    request.trustedTimeSource.SetNonNull(tts);
+
+    auto result = tester.Invoke(request);
+    EXPECT_TRUE(result.IsSuccess());
+
+    // Verify that NO event (specifically no TimeFailure event) is emitted on successful configuration
+    EXPECT_FALSE(testContext.EventsGenerator().GetNextEvent().has_value());
+
+    // Verify the attribute was updated
+    TrustedTimeSource::TypeInfo::DecodableType readBackTTS{};
+    ASSERT_EQ(tester.ReadAttribute(TrustedTimeSource::Id, readBackTTS), CHIP_NO_ERROR);
+    ASSERT_FALSE(readBackTTS.IsNull());
+    EXPECT_EQ(readBackTTS.Value().nodeID, 1234u);
+    EXPECT_EQ(readBackTTS.Value().endpoint, 0u);
+
+    // 2. Invoke SetTrustedTimeSource with null to clear the source
+    Commands::SetTrustedTimeSource::Type clearRequest;
+    clearRequest.trustedTimeSource.SetNull();
+
+    auto clearResult = tester.Invoke(clearRequest);
+    EXPECT_TRUE(clearResult.IsSuccess());
+
+    // Verify that MissingTrustedTimeSource event is emitted when set to null
+    auto eventInfo = testContext.EventsGenerator().GetNextEvent();
+    ASSERT_TRUE(eventInfo.has_value());
+    auto & event = *eventInfo; // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(event.eventOptions.mPath.mEventId, Events::MissingTrustedTimeSource::Id);
+    Events::MissingTrustedTimeSource::DecodableType missingEvent;
+    EXPECT_EQ(event.GetEventData(missingEvent), CHIP_NO_ERROR);
+
+    // Verify no further events
+    EXPECT_FALSE(testContext.EventsGenerator().GetNextEvent().has_value());
+
+    // Verify attribute is now null
+    ASSERT_EQ(tester.ReadAttribute(TrustedTimeSource::Id, readBackTTS), CHIP_NO_ERROR);
+    EXPECT_TRUE(readBackTTS.IsNull());
+
+    timeSynchronization.Shutdown(ClusterShutdownType::kClusterShutdown);
 }


### PR DESCRIPTION

### Summary

Removes the erroneous call to EmitTimeFailureEvent in HandleSetTrustedTimeSource when configuring a valid TrustedTimeSource. Also adds a unit test to verify that no failure event is emitted upon successfully setting a TrustedTimeSource and that MissingTrustedTimeSource is emitted when set to null.


### Testing

Added unit tests to validate sent events on SetTrustedTimeSource. 

