### PR TITLE
[NXP] Implement interface accessor helpers

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -693,12 +693,12 @@ void ConnectivityManagerImpl::UnlockThreadStack()
     ThreadStackMgrImpl().UnlockThreadStack();
 }
 
-Inet::InterfaceId ConnectivityManagerImpl::GetThreadInterface()
+Inet::InterfaceId ConnectivityManagerImpl::_GetThreadInterface()
 {
     return sInstance.mThreadNetIf;
 }
 
-Inet::InterfaceId ConnectivityManagerImpl::GetExternalInterface()
+Inet::InterfaceId ConnectivityManagerImpl::_GetExternalInterface()
 {
     return sInstance.mExternalNetIf;
 }

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -93,8 +93,8 @@ public:
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #if CHIP_ENABLE_OPENTHREAD
-    Inet::InterfaceId GetExternalInterface();
-    Inet::InterfaceId GetThreadInterface();
+    Inet::InterfaceId _GetExternalInterface();
+    Inet::InterfaceId _GetThreadInterface();
     const char * GetHostName() { return sInstance.mHostname; }
 #endif
 


### PR DESCRIPTION
### Summary

Make use of interface accessor helpers to set and return OpenThread and external interfaces when lwIP is used.

### Testing
Testing procedure was previously described in https://github.com/project-chip/connectedhomeip/pull/73438
This is a follow-up PR, implementing the changes and using new added accessors


