### PR TITLE
Convert IterateX/Release call sites in the group clusters to the AutoRelease wrapper

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -21,6 +21,7 @@
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/GroupKeyManagement/ClusterId.h>
 #include <clusters/GroupKeyManagement/Metadata.h>
+#include <lib/support/AutoRelease.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -79,20 +80,13 @@ struct GroupTableCodec
         TLV::TLVType inner;
         ReturnErrorOnFailure(writer.StartContainer(TagEndpoints(), TLV::kTLVType_Array, inner));
         GroupDataProvider::GroupEndpoint mapping;
-        auto iter = mProvider->IterateEndpoints(mFabric, std::make_optional(mInfo.group_id));
-        if (nullptr != iter)
+        AutoRelease iter(mProvider->IterateEndpoints(mFabric, std::make_optional(mInfo.group_id)));
+        if (!iter.IsNull())
         {
-            CHIP_ERROR endpointEncodeErr = CHIP_NO_ERROR;
             while (iter->Next(mapping))
             {
-                endpointEncodeErr = writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id));
-                if (endpointEncodeErr != CHIP_NO_ERROR)
-                {
-                    break;
-                }
+                ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id)));
             }
-            iter->Release();
-            ReturnErrorOnFailure(endpointEncodeErr);
         }
         ReturnErrorOnFailure(writer.EndContainer(inner));
         // GroupName
@@ -144,13 +138,11 @@ struct KeySetReadAllIndicesResponse
 CHIP_ERROR ReadGroupKeyMap(FabricTable & fabricTable, GroupDataProvider & provider, AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([&fabricTable, &provider](const auto & encoder) -> CHIP_ERROR {
-        CHIP_ERROR encodeStatus = CHIP_NO_ERROR;
-
         for (auto & fabric : fabricTable)
         {
             auto fabric_index = fabric.GetFabricIndex();
-            auto iter         = provider.IterateGroupKeys(fabric_index);
-            VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
+            AutoRelease iter(provider.IterateGroupKeys(fabric_index));
+            VerifyOrReturnError(!iter.IsNull(), CHIP_ERROR_NO_MEMORY);
 
             GroupDataProvider::GroupKey mapping;
             while (iter->Next(mapping))
@@ -160,19 +152,10 @@ CHIP_ERROR ReadGroupKeyMap(FabricTable & fabricTable, GroupDataProvider & provid
                     .groupKeySetID = mapping.keyset_id,
                     .fabricIndex   = fabric_index,
                 };
-                encodeStatus = encoder.Encode(key);
-                if (encodeStatus != CHIP_NO_ERROR)
-                {
-                    break;
-                }
-            }
-            iter->Release();
-            if (encodeStatus != CHIP_NO_ERROR)
-            {
-                break;
+                ReturnErrorOnFailure(encoder.Encode(key));
             }
         }
-        return encodeStatus;
+        return CHIP_NO_ERROR;
     });
 }
 
@@ -216,11 +199,10 @@ CHIP_ERROR WriteGroupKeyMap(GroupDataProvider & provider, const ConcreteDataAttr
         VerifyOrReturnError(value.groupKeySetID != 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
         {
-            auto iter = provider.IterateGroupKeys(fabric_index);
-            VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
+            AutoRelease iter(provider.IterateGroupKeys(fabric_index));
+            VerifyOrReturnError(!iter.IsNull(), CHIP_ERROR_NO_MEMORY);
 
             current_count = iter->Count();
-            iter->Release();
         }
 
         ReturnErrorOnFailure(provider.SetGroupKeyAt(value.fabricIndex, current_count,
@@ -237,31 +219,20 @@ CHIP_ERROR WriteGroupKeyMap(GroupDataProvider & provider, const ConcreteDataAttr
 CHIP_ERROR ReadGroupTable(FabricTable & fabricTable, GroupDataProvider & provider, AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([&fabricTable, &provider](const auto & encoder) -> CHIP_ERROR {
-        CHIP_ERROR encodeStatus = CHIP_NO_ERROR;
-
         for (auto & fabric : fabricTable)
         {
             auto fabric_index = fabric.GetFabricIndex();
-            auto iter         = provider.IterateGroupInfo(fabric_index);
-            VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
+            AutoRelease iter(provider.IterateGroupInfo(fabric_index));
+            VerifyOrReturnError(!iter.IsNull(), CHIP_ERROR_NO_MEMORY);
 
             GroupDataProvider::GroupInfo info;
             while (iter->Next(info))
             {
-                encodeStatus = encoder.Encode(GroupTableCodec(&provider, fabric_index, info));
-                if (encodeStatus != CHIP_NO_ERROR)
-                {
-                    break;
-                }
-            }
-            iter->Release();
-            if (encodeStatus != CHIP_NO_ERROR)
-            {
-                break;
+                ReturnErrorOnFailure(encoder.Encode(GroupTableCodec(&provider, fabric_index, info)));
             }
         }
 
-        return encodeStatus;
+        return CHIP_NO_ERROR;
     });
 }
 
@@ -578,15 +549,14 @@ HandleKeySetReadAllIndices(CommandHandler * commandObj, const ConcreteCommandPat
                            Credentials::GroupDataProvider * provider, const FabricInfo * fabric)
 {
     FabricIndex fabricIndex = fabric->GetFabricIndex();
-    auto keysIt             = provider->IterateKeySets(fabricIndex);
-    if (nullptr == keysIt)
+    AutoRelease keysIt(provider->IterateKeySets(fabricIndex));
+    if (keysIt.IsNull())
     {
         commandObj->AddStatus(commandPath, Status::Failure, "Failed iteration of key set indices!");
         return std::nullopt;
     }
 
-    commandObj->AddResponse(commandPath, KeySetReadAllIndicesResponse(keysIt));
-    keysIt->Release();
+    commandObj->AddResponse(commandPath, KeySetReadAllIndicesResponse(&*keysIt));
     return std::nullopt;
 }
 } // namespace

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -1,3 +1,20 @@
+/**
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include "GroupcastCluster.h"
 #include <access/AccessControl.h>
 #include <app/EventManagement.h>

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -9,6 +9,7 @@
 #include <clusters/Groupcast/Metadata.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CodeUtils.h>
 
 using chip::Protocols::InteractionModel::Status;
@@ -298,29 +299,20 @@ CHIP_ERROR GroupcastCluster::ReadMembership(const chip::Access::SubjectDescripto
 
     CHIP_ERROR err = aEncoder.EncodeList([fabric_index, groups, this](const auto & encoder) -> CHIP_ERROR {
         EndpointList endpoints;
-        CHIP_ERROR status              = CHIP_NO_ERROR;
-        GroupInfoIterator * group_iter = groups->IterateGroupInfo(fabric_index);
-        VerifyOrReturnError(nullptr != group_iter, CHIP_ERROR_NO_MEMORY);
+        AutoRelease group_iter(groups->IterateGroupInfo(fabric_index));
+        VerifyOrReturnError(!group_iter.IsNull(), CHIP_ERROR_NO_MEMORY);
 
         GroupInfo info;
-        while (group_iter->Next(info) && (CHIP_NO_ERROR == status))
+        while (group_iter->Next(info))
         {
             // Group Key
             KeysetId keyset_id = kInvalidKeysetId;
             // Since keys are managed by the GroupKeyManagement cluster, groups may not have an associated keyset
-            status = groups->GetGroupKey(fabric_index, info.group_id, keyset_id).NoErrorIf(CHIP_ERROR_NOT_FOUND);
-            if (CHIP_NO_ERROR != status)
-            {
-                break;
-            }
+            ReturnErrorOnFailure(groups->GetGroupKey(fabric_index, info.group_id, keyset_id).NoErrorIf(CHIP_ERROR_NOT_FOUND));
 
             // Endpoints
-            EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
-            if (nullptr == end_iter)
-            {
-                status = CHIP_ERROR_NO_MEMORY;
-                break;
-            }
+            AutoRelease end_iter(groups->IterateEndpoints(fabric_index, info.group_id));
+            VerifyOrReturnError(!end_iter.IsNull(), CHIP_ERROR_NO_MEMORY);
 
             Groupcast::Structs::MembershipStruct::Type group;
             group.fabricIndex     = fabric_index;
@@ -338,18 +330,17 @@ CHIP_ERROR GroupcastCluster::ReadMembership(const chip::Access::SubjectDescripto
             size_t group_count = 0;
             size_t split_count = 0;
             GroupEndpoint mapping;
-            while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
+            while (end_iter->Next(mapping))
             {
                 group_count++;
                 endpoints.entries[split_count++] = mapping.endpoint_id;
                 if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
                 {
                     group.endpoints = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
-                    status          = encoder.Encode(group);
-                    split_count     = 0;
+                    ReturnErrorOnFailure(encoder.Encode(group));
+                    split_count = 0;
                 }
             }
-            end_iter->Release();
             if (group_count == 0)
             {
                 if (mFeatures.Has(Groupcast::Feature::kListener))
@@ -358,12 +349,11 @@ CHIP_ERROR GroupcastCluster::ReadMembership(const chip::Access::SubjectDescripto
                     group.endpoints = MakeOptional(DataModel::List<const chip::EndpointId>());
                 }
 
-                status = encoder.Encode(group);
+                ReturnErrorOnFailure(encoder.Encode(group));
             }
         }
-        group_iter->Release();
 
-        return status;
+        return CHIP_NO_ERROR;
     });
 
     return err;
@@ -472,11 +462,10 @@ Status GroupcastCluster::JoinGroup(const ConcreteCommandPath & path, const Group
         uint16_t total_count = 0;
         for (const FabricInfo & fabric : Fabrics())
         {
-            auto * iter = groups.IterateGroupInfo(fabric.GetFabricIndex());
-            if (iter != nullptr)
+            AutoRelease iter(groups.IterateGroupInfo(fabric.GetFabricIndex()));
+            if (!iter.IsNull())
             {
                 total_count += static_cast<uint16_t>(iter->Count());
-                iter->Release();
             }
         }
         VerifyOrReturnError(total_count < groups.getMaxMembershipCount(), Status::ResourceExhausted);
@@ -557,13 +546,9 @@ Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::Decod
     if (kUndefinedGroupId == data.groupID)
     {
         // Apply changes to all groups
-        GroupInfoIterator * iter = groups.IterateGroupInfo(fabricIndex);
-        VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
-        if (iter->Count() == 0)
-        {
-            iter->Release();
-            return Status::NotFound;
-        }
+        AutoRelease iter(groups.IterateGroupInfo(fabricIndex));
+        VerifyOrReturnError(!iter.IsNull(), Status::ResourceExhausted);
+        VerifyOrReturnError(iter->Count() != 0, Status::NotFound);
 
         GroupInfo info;
         while (iter->Next(info) && (Status::Success == err))
@@ -571,7 +556,6 @@ Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::Decod
             // For leave group, the leaveGroupResponse SHALL NOT contain the endpoints that were removed.
             err = RemoveGroup(info.group_id, data, nullptr /* endpoints */, subjectDescriptor);
         }
-        iter->Release();
     }
     else
     {
@@ -728,8 +712,8 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
         if (endpoints != nullptr)
         {
             // Get the endpoints list for the LeaveGroupResponse
-            EndpointIterator * epIter = groups.IterateEndpoints(fabricIndex, group_id);
-            VerifyOrReturnError(nullptr != epIter, Status::ResourceExhausted);
+            AutoRelease epIter(groups.IterateEndpoints(fabricIndex, group_id));
+            VerifyOrReturnError(!epIter.IsNull(), Status::ResourceExhausted);
 
             if (epIter->Count() <= kMaxCommandEndpoints)
             {
@@ -739,7 +723,6 @@ Status GroupcastCluster::RemoveGroup(GroupId group_id, const Groupcast::Commands
                     endpoints->entries[endpoints->count++] = ep.endpoint_id;
                 }
             }
-            epIter->Release();
         }
         // Remove whole group (with all endpoints)
         err = groups.RemoveGroupInfo(fabricIndex, group_id);
@@ -811,8 +794,8 @@ void GroupcastCluster::UpdateUsedMcastAddrCount()
     for (const FabricInfo & fabric : Fabrics())
     {
         // Count distinct group addresses
-        GroupInfoIterator * iter = Provider().IterateGroupInfo(fabric.GetFabricIndex());
-        VerifyOrReturn(nullptr != iter);
+        AutoRelease iter(Provider().IterateGroupInfo(fabric.GetFabricIndex()));
+        VerifyOrReturn(!iter.IsNull());
         GroupInfo group;
         while (iter->Next(group))
         {
@@ -825,7 +808,6 @@ void GroupcastCluster::UpdateUsedMcastAddrCount()
                 iana_address = 1;
             }
         }
-        iter->Release();
     }
     mIanaAddressUsed    = (iana_address > 0);
     mUsedMcastAddrCount = per_group_count + iana_address;

--- a/src/app/clusters/groups-server/GroupsCluster.cpp
+++ b/src/app/clusters/groups-server/GroupsCluster.cpp
@@ -24,6 +24,7 @@
 #include <clusters/Groups/Commands.h>
 #include <clusters/Groups/Metadata.h>
 #include <clusters/Groups/Structs.h>
+#include <lib/support/AutoRelease.h>
 #include <tracing/macros.h>
 
 using namespace chip::app::Clusters::Groups;
@@ -59,32 +60,13 @@ void NotifyGroupTableChanged(ServerClusterContext * context)
     context->provider.NotifyAttributeChanged(kGroupKeyGroupTableAttributePath, DataModel::AttributeChangeType::kReportable);
 }
 
-class AutoReleaseIterator
-{
-public:
-    AutoReleaseIterator(GroupDataProvider & provider, FabricIndex fabricIndex) : mIterator(provider.IterateGroupKeys(fabricIndex))
-    {}
-    ~AutoReleaseIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-    bool Valid() const { return mIterator != nullptr; }
-    GroupDataProvider::GroupKeyIterator * operator->() { return mIterator; }
-
-private:
-    GroupDataProvider::GroupKeyIterator * mIterator;
-};
-
 /**
  * @brief Checks if there are key set associated with the given GroupId
  */
 bool KeyExists(GroupDataProvider & provider, FabricIndex fabricIndex, GroupId groupId)
 {
-    AutoReleaseIterator it(provider, fabricIndex);
-    VerifyOrReturnValue(it.Valid(), false);
+    AutoRelease it(provider.IterateGroupKeys(fabricIndex));
+    VerifyOrReturnValue(!it.IsNull(), false);
 
     GroupDataProvider::GroupKey key;
     while (it->Next(key))
@@ -109,9 +91,7 @@ struct GroupMembershipResponse
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     GroupMembershipResponse(const Commands::GetGroupMembership::DecodableType & data, EndpointId endpoint,
-                            GroupDataProvider::EndpointIterator * iter) :
-        mCommandData(data),
-        mEndpoint(endpoint), mIterator(iter)
+                            GroupDataProvider::EndpointIterator * iter) : mCommandData(data), mEndpoint(endpoint), mIterator(iter)
     {}
 
     const Commands::GetGroupMembership::DecodableType & mCommandData;
@@ -287,11 +267,10 @@ GroupsCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVR
         GetGroupMembership::DecodableType request_data;
         ReturnErrorOnFailure(request_data.Decode(input_arguments, fabricIndex));
 
-        GroupDataProvider::EndpointIterator * iter = mGroupDataProvider.IterateEndpoints(fabricIndex);
-        VerifyOrReturnError(nullptr != iter, Status::Failure);
+        AutoRelease iter(mGroupDataProvider.IterateEndpoints(fabricIndex));
+        VerifyOrReturnError(!iter.IsNull(), Status::Failure);
 
-        handler->AddResponse(request.path, GroupMembershipResponse(request_data, mPath.mEndpointId, iter));
-        iter->Release();
+        handler->AddResponse(request.path, GroupMembershipResponse(request_data, mPath.mEndpointId, &*iter));
         return std::nullopt;
     }
     case RemoveGroup::Id: {
@@ -312,7 +291,7 @@ GroupsCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVR
                         err != CHIP_NO_ERROR)
                     {
                         ChipLogDetail(Zcl, "ERR: Failed to remove mapping (end:%d, group:0x%x), err:%" CHIP_ERROR_FORMAT,
-                                       mPath.mEndpointId, groupId, err.Format());
+                                      mPath.mEndpointId, groupId, err.Format());
                         return Status::NotFound;
                     }
 
@@ -339,10 +318,10 @@ GroupsCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVR
 
         if (mScenesIntegration != nullptr)
         {
-            GroupDataProvider::EndpointIterator * iter = mGroupDataProvider.IterateEndpoints(fabricIndex);
+            AutoRelease iter(mGroupDataProvider.IterateEndpoints(fabricIndex));
             GroupDataProvider::GroupEndpoint mapping;
 
-            VerifyOrReturnError(nullptr != iter, Status::Failure);
+            VerifyOrReturnError(!iter.IsNull(), Status::Failure);
             while (iter->Next(mapping))
             {
                 if (mPath.mEndpointId == mapping.endpoint_id)
@@ -350,7 +329,6 @@ GroupsCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVR
                     LogIfFailure(mScenesIntegration->GroupWillBeRemoved(fabricIndex, mapping.group_id));
                 }
             }
-            iter->Release();
             LogIfFailure(mScenesIntegration->GroupWillBeRemoved(fabricIndex, scenes::kGlobalSceneGroupId));
         }
 

--- a/src/app/clusters/groups-server/GroupsCluster.cpp
+++ b/src/app/clusters/groups-server/GroupsCluster.cpp
@@ -91,7 +91,9 @@ struct GroupMembershipResponse
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     GroupMembershipResponse(const Commands::GetGroupMembership::DecodableType & data, EndpointId endpoint,
-                            GroupDataProvider::EndpointIterator * iter) : mCommandData(data), mEndpoint(endpoint), mIterator(iter)
+                            GroupDataProvider::EndpointIterator * iter) :
+        mCommandData(data),
+        mEndpoint(endpoint), mIterator(iter)
     {}
 
     const Commands::GetGroupMembership::DecodableType & mCommandData;
@@ -291,7 +293,7 @@ GroupsCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVR
                         err != CHIP_NO_ERROR)
                     {
                         ChipLogDetail(Zcl, "ERR: Failed to remove mapping (end:%d, group:0x%x), err:%" CHIP_ERROR_FORMAT,
-                                      mPath.mEndpointId, groupId, err.Format());
+                                       mPath.mEndpointId, groupId, err.Format());
                         return Status::NotFound;
                     }
 

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -232,7 +232,7 @@ public:
          *
          *  @param[in] modified_group_id  ID of the modified group.
          */
-        virtual void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id) {};
+        virtual void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id){};
     };
 
     using GroupInfoIterator    = CommonIterator<GroupInfo>;

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -232,7 +232,7 @@ public:
          *
          *  @param[in] modified_group_id  ID of the modified group.
          */
-        virtual void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id){};
+        virtual void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id) {};
     };
 
     using GroupInfoIterator    = CommonIterator<GroupInfo>;
@@ -301,15 +301,17 @@ public:
     // Iterators
     /**
      *  Creates an iterator that may be used to obtain the list of groups associated with the given fabric.
-     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
+     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished;
+     *  the use of the AutoRelease wrapper (lib/support/AutoRelease.h) is recommended.
      *  Modifying the group table during the iteration is currently not supported, and may yield unexpected behaviour.
-     *  @retval An instance of EndpointIterator on success
+     *  @retval An instance of GroupInfoIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
     virtual GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) = 0;
     /**
      *  Creates an iterator that may be used to obtain the list of (group, endpoint) pairs associated with the given fabric.
-     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
+     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished;
+     *  the use of the AutoRelease wrapper (lib/support/AutoRelease.h) is recommended.
      *  Modifying the group table during the iteration is currently not supported, and may yield unexpected behaviour.
      *  If you wish to iterate only the endpoints of a particular group id you can provide the optional `group_id` to do so.
      *  @retval An instance of EndpointIterator on success
@@ -330,7 +332,8 @@ public:
 
     /**
      *  Creates an iterator that may be used to obtain the list of (group, keyset) pairs associated with the given fabric.
-     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
+     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished;
+     *  the use of the AutoRelease wrapper (lib/support/AutoRelease.h) is recommended.
      *  Modifying the keyset mappings during the iteration is currently not supported, and may yield unexpected behaviour.
      *  @retval An instance of GroupKeyIterator on success
      *  @retval nullptr if no iterator instances are available.
@@ -361,7 +364,8 @@ public:
 
     /**
      *  Creates an iterator that may be used to obtain the list of key sets associated with the given fabric.
-     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
+     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished;
+     *  the use of the AutoRelease wrapper (lib/support/AutoRelease.h) is recommended.
      *  Modifying the key sets table during the iteration is currently not supported, and may yield unexpected behaviour.
      *
      *  @retval An instance of KeySetIterator on success


### PR DESCRIPTION
### Summary
- The `CommonIterator` contract requires a manual `Release()` after every `Iterate*()` call
- The prevailing error-handling idiom is early-return macros (`ReturnErrorOnFailure`, `VerifyOrReturnError`); any such macro between the acquire and the `Release()` leaks the iterator.

- Replace the manual pattern with `AutoRelease` (`lib/support/AutoRelease.h`) at all group related clusters
- Removed file local `AutoReleaseIterator` wrapper in `GroupsCluster.cpp` in favor of the shared one.
- Reference `AutoRelease` from the `GroupDataProvider::Iterate*()` doc comments and fix the `IterateGroupInfo` retval typo (`EndpointIterator` -> `GroupInfoIterator`).

### Related issues
- Please see #73331 for more details 
- #73296 fixes one such leak

### Testing
- Existing unit tests cover all migrated paths, hence ran the unit tests locally and they'll also run in CI