### PR TITLE
[Silabs] Remove Wi-Fi ICD high-performance request during commissioning

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -183,28 +183,16 @@ BaseApplicationDelegate BaseApplication::sAppDelegate = BaseApplicationDelegate(
 void BaseApplicationDelegate::OnCommissioningSessionStarted()
 {
     isComissioningStarted = true;
-
-#if defined(SL_WIFI) && SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
-#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 void BaseApplicationDelegate::OnCommissioningSessionStopped()
 {
     isComissioningStarted = false;
-
-#if defined(SL_WIFI) && SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 void BaseApplicationDelegate::OnCommissioningSessionEstablishmentError(CHIP_ERROR err)
 {
     isComissioningStarted = false;
-
-#if defined(SL_WIFI) && SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 void BaseApplicationDelegate::OnCommissioningWindowClosed()

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -72,10 +72,6 @@ CHIP_ERROR WifiSleepManager::HandlePowerEvent(PowerEvent event)
     {
     case PowerEvent::kCommissioningComplete:
         ChipLogProgress(AppServer, "WifiSleepManager: Handling Commissioning Complete Event");
-        mIsCommissioningInProgress = false;
-
-        // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-        TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
         break;
 
     case PowerEvent::kConnectivityChange:
@@ -101,13 +97,6 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
     if (mHighPerformanceRequestCounter > 0)
     {
         return ConfigureHighPerformance();
-    }
-
-    if (mIsCommissioningInProgress)
-    {
-        // During commissioning, don't let the device go to sleep
-        // This is needed to interrupt the sleep and retry joining the network
-        return CHIP_NO_ERROR;
     }
 
     if (!mWifiStateProvider->IsWifiProvisioned())

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -59,30 +59,6 @@ public:
      */
     CHIP_ERROR Init(PowerSaveInterface * platformInterface, WifiStateProvider * wifiStateProvider);
 
-    inline void HandleCommissioningSessionStarted()
-    {
-        bool wasCommissioningInProgress = mIsCommissioningInProgress;
-        mIsCommissioningInProgress      = true;
-
-        if (!wasCommissioningInProgress)
-        {
-            // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-            TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition();
-        }
-    }
-
-    inline void HandleCommissioningSessionStopped()
-    {
-        bool wasCommissioningInProgress = mIsCommissioningInProgress;
-        mIsCommissioningInProgress      = false;
-
-        if (wasCommissioningInProgress)
-        {
-            // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-            TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
-        }
-    }
-
     /**
      * @brief Public API to request the Wi-Fi chip to transition to High Performance.
      *        Function increases the HighPerformance request counter to prevent the chip from going to sleep
@@ -131,8 +107,8 @@ public:
      *
      *        State machine logic:
      *        1. If there are high performance requests, configure high performance mode.
-     *        2. If commissioning is in progress, configure DTIM based sleep.
-     *        3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
+     *        2. If the device is unprovisioned, configure deep sleep.
+     *        3. Otherwise, configure DTIM based sleep.
      *
      * @param event PowerEvent triggering the Verify and transition to low power mode processing
      *
@@ -199,7 +175,6 @@ private:
 
     PowerSaveInterface * mPowerSaveInterface = nullptr;
     WifiStateProvider * mWifiStateProvider   = nullptr;
-    bool mIsCommissioningInProgress          = false;
     uint8_t mHighPerformanceRequestCounter   = 0;
 };
 

--- a/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
@@ -163,29 +163,6 @@ TEST_F(TestWifiSleepManager, TestRemovePerformanceRequestSubMinimum)
     EXPECT_FALSE(mMock.WasConfigurePowerSaveCalled());
 }
 
-// This tests will need to be updated once the High performance req is removed from the WifiSleepManager
-TEST_F(TestWifiSleepManager, TestCommissioningInProgressAndStopped)
-{
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
-    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kHighPerformance);
-    EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
-
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
-    EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
-}
-
-TEST_F(TestWifiSleepManager, TestCommissioningInProgressAndCompleted)
-{
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
-    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kHighPerformance);
-    EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
-
-    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
-    EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
-}
-
 TEST_F(TestWifiSleepManager, TestVerifyOrTransitionStandardOperation)
 {
     mMock.SetIsWifiProvisioned(true);


### PR DESCRIPTION
### Summary
Removes the temporary Wi-Fi ICD high-performance lock that was held for the duration of a commissioning session.

- With the improve in stability removing this condition so that the device doesn't go the high power mode during commissioning
- Removed `HandleCommissioningSessionStarted` and `HandleCommissioningSessionStopped`.
- Removed `mIsCommissioningInProgress` and the commissioning-in-progress early return from the sleep-state machine.
- Stopped calling those APIs from `BaseApplicationDelegate` commissioning callbacks.
- Removed the paired high-performance request cleanup from the commissioning-complete power event.
- Deleted the unit tests that only covered the removed APIs.

### Related issues
NA

### Testing
Tested commissioning 100 times with the 917SoC with my home AP and it was all good