### PR TITLE
Update cloudbuild files to docker image 206

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,7 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -39,7 +39,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -54,7 +54,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -73,7 +73,7 @@ steps:
       waitFor:
           - CompileICD
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/examples.yaml
+++ b/integrations/cloudbuild/examples.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: AllDevices
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -43,7 +43,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: Camera
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -66,7 +66,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -144,7 +144,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:200"
+    - name: "ghcr.io/project-chip/chip-build-vscode:206"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
### Summary

EFR32 was updated to 206 since #73068 so we need a more recent version of the docker images (to allow us efr32 builds). Updated all of them.

### Testing

N/A - just a docker image update
Checked that image is valid: https://github.com/project-chip/connectedhomeip/pkgs/container/chip-build-vscode contains tag 206