### PR TITLE
[dnssd] Add ULD DNS UPDATE writer and record types

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -162,6 +162,7 @@ if (chip_build_tests) {
       "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
       "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
       "${chip_root}/src/lib/dnssd/tests",
+      "${chip_root}/src/lib/dnssd/uld/tests",
       "${chip_root}/src/lib/format/tests",
       "${chip_root}/src/lib/support/verhoeff/tests",
       "${chip_root}/src/messaging/tests",

--- a/src/lib/dnssd/uld/BUILD.gn
+++ b/src/lib/dnssd/uld/BUILD.gn
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+source_set("uld") {
+  sources = [
+    "Constants.h",
+    "DeleteRecord.h",
+    "KeyRecord.cpp",
+    "KeyRecord.h",
+    "OptRecord.h",
+    "Sig0Record.h",
+    "UpdateBuilder.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/dnssd/wire",
+    "${chip_root}/src/lib/dnssd/wire/records",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/lib/dnssd/uld/Constants.h
+++ b/src/lib/dnssd/uld/Constants.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+// DNS Update opcode (RFC 2136).
+inline constexpr uint8_t kOpcodeUpdate = 5;
+
+// DNSKEY RR / SIG algorithm ECDSA P-256 with SHA-256 (RFC 6605).
+inline constexpr uint8_t kKeyAlgorithmEcdsaP256 = 13;
+
+// Raw P-256 public key size in KEY RDATA (X || Y, no 0x04 prefix).
+inline constexpr size_t kP256RawPublicKeySize = 64;
+
+// Raw P-256 ECDSA signature size in SIG(0) RDATA (r || s).
+inline constexpr size_t kP256RawSignatureSize = 64;
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/Constants.h
+++ b/src/lib/dnssd/uld/Constants.h
@@ -23,9 +23,6 @@ namespace chip {
 namespace Dnssd {
 namespace Uld {
 
-// DNS Update opcode (RFC 2136).
-inline constexpr uint8_t kOpcodeUpdate = 5;
-
 // DNSKEY RR / SIG algorithm ECDSA P-256 with SHA-256 (RFC 6605).
 inline constexpr uint8_t kKeyAlgorithmEcdsaP256 = 13;
 

--- a/src/lib/dnssd/uld/DeleteRecord.h
+++ b/src/lib/dnssd/uld/DeleteRecord.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/dnssd/wire/records/ResourceRecord.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * @brief  Delete all RRsets (RFC 2136 §2.5.2: CLASS=ANY, TTL=0, empty RDATA).
+ */
+class DeleteAllRrsetsRecord : public ResourceRecord
+{
+public:
+    DeleteAllRrsetsRecord(const FullQName & name, QType type) : ResourceRecord(type, name)
+    {
+        SetClass(QClass::ANY);
+        SetTtl(0);
+    }
+
+protected:
+    bool WriteData(RecordWriter & out) const override { return out.Fit(); }
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/DeleteRecord.h
+++ b/src/lib/dnssd/uld/DeleteRecord.h
@@ -23,12 +23,14 @@ namespace Dnssd {
 namespace Uld {
 
 /**
- * @brief  Delete all RRsets (RFC 2136 §2.5.2: CLASS=ANY, TTL=0, empty RDATA).
+ * @brief Delete an RRset (RFC 2136 §2.5.2: CLASS=ANY, TTL=0, empty RDATA).
+ *
+ * When @p type is QType::ANY this delete all RRsets from a name.
  */
-class DeleteAllRrsetsRecord : public ResourceRecord
+class DeleteRrsetRecord : public ResourceRecord
 {
 public:
-    DeleteAllRrsetsRecord(const FullQName & name, QType type) : ResourceRecord(type, name)
+    DeleteRrsetRecord(const FullQName & name, QType type) : ResourceRecord(type, name)
     {
         SetClass(QClass::ANY);
         SetTtl(0);

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/dnssd/uld/KeyRecord.h>
+
+#include <cstring>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+bool KeyResourceRecord::WriteData(RecordWriter & out) const
+{
+    if (mPublicKey.size() != kP256RawPublicKeySize)
+    {
+        return false;
+    }
+
+    out.Put16(kKeyFlags).Put8(kKeyProtocolDnssec).Put8(kKeyAlgorithmEcdsaP256);
+    out.Writer().Put(mPublicKey.data(), mPublicKey.size());
+    return out.Fit();
+}
+
+bool KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey)
+{
+    constexpr uint8_t kUncompressedPointPrefix = 0x04;
+    constexpr size_t kUncompressedPointSize    = kP256RawPublicKeySize + 1;
+
+    if ((uncompressedPoint.size() != kUncompressedPointSize) || (uncompressedPoint[0] != kUncompressedPointPrefix) ||
+        (outRawKey.size() < kP256RawPublicKeySize))
+    {
+        return false;
+    }
+
+    memcpy(outRawKey.data(), uncompressedPoint.data() + 1, kP256RawPublicKeySize);
+    outRawKey.reduce_size(kP256RawPublicKeySize);
+    return true;
+}
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -15,9 +15,9 @@
  *    limitations under the License.
  */
 
-#include <lib/dnssd/uld/KeyRecord.h>
-
 #include <cstring>
+#include <lib/dnssd/uld/KeyRecord.h>
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 namespace Dnssd {
@@ -35,20 +35,16 @@ bool KeyResourceRecord::WriteData(RecordWriter & out) const
     return out.Fit();
 }
 
-bool KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey)
+CHIP_ERROR KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey)
 {
     constexpr uint8_t kUncompressedPointPrefix = 0x04;
     constexpr size_t kUncompressedPointSize    = kP256RawPublicKeySize + 1;
 
-    if ((uncompressedPoint.size() != kUncompressedPointSize) || (uncompressedPoint[0] != kUncompressedPointPrefix) ||
-        (outRawKey.size() < kP256RawPublicKeySize))
-    {
-        return false;
-    }
+    VerifyOrReturnError(uncompressedPoint.size() == kUncompressedPointSize, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(uncompressedPoint[0] == kUncompressedPointPrefix, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(outRawKey.size() >= kP256RawPublicKeySize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    memcpy(outRawKey.data(), uncompressedPoint.data() + 1, kP256RawPublicKeySize);
-    outRawKey.reduce_size(kP256RawPublicKeySize);
-    return true;
+    return CopySpanToMutableSpan(uncompressedPoint.SubSpan(1), outRawKey);
 }
 
 } // namespace Uld

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <cstring>
 #include <lib/dnssd/uld/KeyRecord.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/dnssd/uld/Constants.h>
+#include <lib/dnssd/wire/records/ResourceRecord.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * @brief DNS KEY resource record (RFC 2535 / RFC 6605).
+ *
+ * RDATA: flags(2) | protocol(1) | algorithm(1) | public_key(64).
+ * @p publicKey is the 64-byte raw X||Y material (no 0x04 prefix).
+ */
+class KeyResourceRecord : public ResourceRecord
+{
+public:
+    // DNSKEY RR flags for SRP / ULD requesters (RFC 9665): must be all zeroes.
+    static constexpr uint16_t kKeyFlags = 0x0000;
+
+    // DNSKEY RR protocol value for DNSSEC (RFC 4034).
+    static constexpr uint8_t kKeyProtocolDnssec = 3;
+
+    KeyResourceRecord(const FullQName & name, ByteSpan publicKey) : ResourceRecord(QType::KEY, name), mPublicKey(publicKey) {}
+
+    ByteSpan GetPublicKey() const { return mPublicKey; }
+
+    /**
+     * @brief Copies X||Y from an uncompressed P-256 point (65 bytes, leading 0x04).
+     * @return false if @p uncompressedPoint is not a valid uncompressed point or
+     *         @p outRawKey is smaller than #kP256RawPublicKeySize.
+     */
+    static bool ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey);
+
+protected:
+    bool WriteData(RecordWriter & out) const override;
+
+private:
+    ByteSpan mPublicKey;
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -44,9 +44,10 @@ public:
     ByteSpan GetPublicKey() const { return mPublicKey; }
 
     /**
-     * @brief Copies X||Y from an uncompressed P-256 point (65 bytes, leading 0x04).
-     * @return false if @p uncompressedPoint is not a valid uncompressed point or
-     *         @p outRawKey is smaller than #kP256RawPublicKeySize.
+     * @brief Copies X||Y after checking uncompressed-point length (65) and 0x04 prefix.
+     * Does not validate coordinates or curve membership.
+     * @return false if length/prefix checks fail or @p outRawKey is smaller than
+     *         #kP256RawPublicKeySize.
      */
     static bool ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey);
 

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <lib/core/CHIPError.h>
 #include <lib/dnssd/uld/Constants.h>
 #include <lib/dnssd/wire/records/ResourceRecord.h>
 #include <lib/support/Span.h>
@@ -46,10 +47,11 @@ public:
     /**
      * @brief Copies X||Y after checking uncompressed-point length (65) and 0x04 prefix.
      * Does not validate coordinates or curve membership.
-     * @return false if length/prefix checks fail or @p outRawKey is smaller than
-     *         #kP256RawPublicKeySize.
+     * @return CHIP_NO_ERROR on success; CHIP_ERROR_INVALID_ARGUMENT if length/prefix
+     *         checks fail; CHIP_ERROR_BUFFER_TOO_SMALL if @p outRawKey is smaller than
+     *         kP256RawPublicKeySize.
      */
-    static bool ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey);
+    static CHIP_ERROR ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey);
 
 protected:
     bool WriteData(RecordWriter & out) const override;

--- a/src/lib/dnssd/uld/OptRecord.h
+++ b/src/lib/dnssd/uld/OptRecord.h
@@ -34,14 +34,14 @@ public:
     // EDNS(0) Update Lease option code (RFC 9665/9664).
     static constexpr uint16_t kEdnsOptionUpdateLease = 2;
 
-    // EDNS(0) TTL DNSSEC OK flag bit.
-    static constexpr uint32_t kEdnsTtlDnssecOk = 0x00008000;
+    // EDNS(0) TTL default value.
+    static constexpr uint32_t kEdnsTtlDefault = 0x00000000;
 
     OptLeaseRecord(uint16_t udpPayloadSize, uint32_t leaseSeconds, uint32_t keyLeaseSeconds) :
         ResourceRecord(QType::OPT, FullQName()), mLeaseSeconds(leaseSeconds), mKeyLeaseSeconds(keyLeaseSeconds)
     {
         SetClass(static_cast<QClass>(udpPayloadSize));
-        SetTtl(kEdnsTtlDnssecOk);
+        SetTtl(kEdnsTtlDefault);
     }
 
     uint32_t GetLeaseSeconds() const { return mLeaseSeconds; }

--- a/src/lib/dnssd/uld/OptRecord.h
+++ b/src/lib/dnssd/uld/OptRecord.h
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/dnssd/wire/records/ResourceRecord.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * @brief EDNS(0) OPT record with an Update Lease option (RFC 6891 / RFC 9665).
+ *
+ * CLASS holds the UDP payload size. TTL holds EDNS flags (DNSSEC OK).
+ * RDATA is option_code=2, length=8, lease, key_lease.
+ */
+class OptLeaseRecord : public ResourceRecord
+{
+public:
+    // EDNS(0) Update Lease option code (RFC 9665/9664).
+    static constexpr uint16_t kEdnsOptionUpdateLease = 2;
+
+    // EDNS(0) TTL DNSSEC OK flag bit.
+    static constexpr uint32_t kEdnsTtlDnssecOk = 0x00008000;
+
+    OptLeaseRecord(uint16_t udpPayloadSize, uint32_t leaseSeconds, uint32_t keyLeaseSeconds) :
+        ResourceRecord(QType::OPT, FullQName()), mLeaseSeconds(leaseSeconds), mKeyLeaseSeconds(keyLeaseSeconds)
+    {
+        SetClass(static_cast<QClass>(udpPayloadSize));
+        SetTtl(kEdnsTtlDnssecOk);
+    }
+
+    uint32_t GetLeaseSeconds() const { return mLeaseSeconds; }
+    uint32_t GetKeyLeaseSeconds() const { return mKeyLeaseSeconds; }
+
+protected:
+    bool WriteData(RecordWriter & out) const override
+    {
+        return out.Put16(kEdnsOptionUpdateLease).Put16(8).Put32(mLeaseSeconds).Put32(mKeyLeaseSeconds).Fit();
+    }
+
+private:
+    uint32_t mLeaseSeconds;
+    uint32_t mKeyLeaseSeconds;
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/Sig0Record.h
+++ b/src/lib/dnssd/uld/Sig0Record.h
@@ -63,7 +63,8 @@ protected:
             .Put32(mInception)
             .Put16(mKeyTag);
 
-        out.WriteQName(mSignerName);
+        // RFC 3597 §4: names embedded in SIG RDATA must not be compressed.
+        out.WriteQNameUncompressed(mSignerName);
         out.Writer().Put(mSignature.data(), mSignature.size());
         return out.Fit();
     }

--- a/src/lib/dnssd/uld/Sig0Record.h
+++ b/src/lib/dnssd/uld/Sig0Record.h
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/dnssd/uld/Constants.h>
+#include <lib/dnssd/wire/records/ResourceRecord.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * @brief SIG(0) resource record wire encoding (RFC 2931).
+ *
+ * Owner name is root; CLASS=ANY; TTL=0.
+ * RDATA: type_covered | algorithm | labels | original_ttl | expiration |
+ * inception | key_tag | signer_name | signature(64).
+ * Does not generate or verify the signature.
+ */
+class Sig0ResourceRecord : public ResourceRecord
+{
+public:
+    Sig0ResourceRecord(const FullQName & signerName, ByteSpan signature, uint16_t keyTag = 0, uint32_t inception = 0,
+                       uint32_t expiration = 0) :
+        ResourceRecord(QType::SIG, FullQName()),
+        mSignerName(signerName), mSignature(signature), mKeyTag(keyTag), mInception(inception), mExpiration(expiration)
+    {
+        SetClass(QClass::ANY);
+        SetTtl(0);
+    }
+
+    FullQName GetSignerName() const { return mSignerName; }
+    ByteSpan GetSignature() const { return mSignature; }
+
+protected:
+    bool WriteData(RecordWriter & out) const override
+    {
+        if (mSignature.size() != kP256RawSignatureSize)
+        {
+            return false;
+        }
+
+        out.Put16(0) // type covered
+            .Put8(kKeyAlgorithmEcdsaP256)
+            .Put8(0)  // labels
+            .Put32(0) // original TTL
+            .Put32(mExpiration)
+            .Put32(mInception)
+            .Put16(mKeyTag);
+
+        out.WriteQName(mSignerName);
+        out.Writer().Put(mSignature.data(), mSignature.size());
+        return out.Fit();
+    }
+
+private:
+    FullQName mSignerName;
+    ByteSpan mSignature;
+    uint16_t mKeyTag;
+    uint32_t mInception;
+    uint32_t mExpiration;
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/UpdateBuilder.h
+++ b/src/lib/dnssd/uld/UpdateBuilder.h
@@ -19,7 +19,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <lib/dnssd/uld/Constants.h>
 #include <lib/dnssd/wire/DnsHeader.h>
 #include <lib/dnssd/wire/QName.h>
 #include <lib/dnssd/wire/Query.h>
@@ -90,7 +89,7 @@ public:
 
         mHeader.Clear();
         mHeader.SetMessageId(messageId);
-        mHeader.SetAllFlags(BitPackedFlags(0).SetQuery().SetOpcode(kOpcodeUpdate));
+        mHeader.SetAllFlags(BitPackedFlags(0).SetQuery().SetOpcode(Opcode::kUpdate));
 
         mOutput = Encoding::BigEndian::BufferWriter(mBuffer, mSize);
         mOutput.Skip(HeaderRef::kSizeBytes);

--- a/src/lib/dnssd/uld/UpdateBuilder.h
+++ b/src/lib/dnssd/uld/UpdateBuilder.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <lib/core/CHIPError.h>
 #include <lib/dnssd/wire/DnsHeader.h>
 #include <lib/dnssd/wire/QName.h>
 #include <lib/dnssd/wire/Query.h>
@@ -43,50 +44,27 @@ namespace Uld {
  * - Authority (nscount) -> Update
  * - Additional (arcount) -> Additional
  *
- * @note : All Add* methods can be chained. On failure they set a sticky "error state";
- *         When in a failed state, all Add* calls are no-ops.
- *         The assembly state can be checked by calling Ok().
- *         Reset()/Begin() clear the error state and allows for a new assembly.
+ * Add* methods have documented ordering preconditions. Not respecting them will result in VerifyOrDie failures.
+ * Buffer overflow is sticky and makes subsequent Add* calls no-ops.
+ * Call GetPacket() to obtain the encoded message or report CHIP_ERROR_BUFFER_TOO_SMALL.
  */
 class UpdateBuilder
 {
 public:
-    UpdateBuilder() : mHeader(nullptr), mOutput(nullptr, 0), mWriter(&mOutput) {}
-
-    UpdateBuilder(uint8_t * buffer, size_t size) : mHeader(nullptr), mOutput(nullptr, 0), mWriter(&mOutput) { Reset(buffer, size); }
-
-    /**
-     * @brief Binds the builder to @p buffer and clears the DNS header.
-     */
-    UpdateBuilder & Reset(uint8_t * buffer, size_t size)
-    {
-        mBuffer  = buffer;
-        mSize    = size;
-        mHeader  = HeaderRef(nullptr);
-        mBuildOk = false;
-
-        if ((buffer != nullptr) && (size >= HeaderRef::kSizeBytes))
-        {
-            mHeader = HeaderRef(buffer);
-            mHeader.Clear();
-            mOutput = Encoding::BigEndian::BufferWriter(buffer, size);
-            mOutput.Skip(HeaderRef::kSizeBytes);
-            mWriter.Reset();
-            mBuildOk = true;
-        }
-
-        return *this;
-    }
+    UpdateBuilder(uint8_t * buffer, size_t size) :
+        mHeader(nullptr), mOutput(nullptr, 0), mWriter(&mOutput), mBuffer(buffer), mSize(size)
+    {}
 
     /**
      * @brief Starts a new UPDATE query with the given message id.
      */
-    UpdateBuilder & Begin(uint16_t messageId)
+    void Begin(uint16_t messageId)
     {
-        // Allow restarting after a previous build failure as long as a valid buffer is bound.
-        VerifyOrReturnValue((mBuffer != nullptr) && (mSize >= HeaderRef::kSizeBytes), *this);
-        mBuildOk = true;
+        mBuildStarted = true;
+        mBuildOk      = (mBuffer != nullptr) && (mSize >= HeaderRef::kSizeBytes);
+        VerifyOrReturn(mBuildOk);
 
+        mHeader = HeaderRef(mBuffer);
         mHeader.Clear();
         mHeader.SetMessageId(messageId);
         mHeader.SetAllFlags(BitPackedFlags(0).SetQuery().SetOpcode(Opcode::kUpdate));
@@ -94,68 +72,88 @@ public:
         mOutput = Encoding::BigEndian::BufferWriter(mBuffer, mSize);
         mOutput.Skip(HeaderRef::kSizeBytes);
         mWriter.Reset();
-        return *this;
     }
 
     /**
-     * @brief Appends the ZONE question (SOA / IN). Must be written before records.
+     * @brief Appends the ZONE question (SOA / IN).
+     *
+     * Shall be called exactly once, before any records are added.
      */
-    UpdateBuilder & AddZone(FullQName zoneName)
+    void AddZone(FullQName zoneName)
     {
-        VerifyOrReturnValue(mBuildOk, *this);
+        VerifyOrDie(mBuildStarted);
+        VerifyOrReturn(mBuildOk);
+        VerifyOrDie((mHeader.GetQueryCount() == 0) && (mHeader.GetAnswerCount() == 0) && (mHeader.GetAuthorityCount() == 0) &&
+                    (mHeader.GetAdditionalCount() == 0));
 
         Query zone(zoneName);
         zone.SetType(QType::SOA).SetClass(QClass::IN).SetAnswerViaUnicast(false);
 
-        if (!zone.Append(mHeader, mWriter))
-        {
-            mBuildOk = false;
-        }
-        return *this;
+        mBuildOk = zone.Append(mHeader, mWriter);
     }
 
-    /** @brief Appends a prerequisite record (answer section). */
-    UpdateBuilder & AddPrerequisite(const ResourceRecord & record) { return AddRecord(ResourceType::kAnswer, record); }
+    /**
+     * @brief Appends a prerequisite record (answer section).
+     *
+     * Shall be called after AddZone() and before AddUpdate() or AddAdditional().
+     */
+    void AddPrerequisite(const ResourceRecord & record) { AddRecord(ResourceType::kAnswer, record); }
 
-    /** @brief Appends an update record (authority section). */
-    UpdateBuilder & AddUpdate(const ResourceRecord & record) { return AddRecord(ResourceType::kAuthority, record); }
+    /**
+     * @brief Appends an update record (authority section).
+     *
+     * Shall be called after AddZone() and before AddAdditional().
+     */
+    void AddUpdate(const ResourceRecord & record) { AddRecord(ResourceType::kAuthority, record); }
 
-    /** @brief Appends an additional record (additional section). */
-    UpdateBuilder & AddAdditional(const ResourceRecord & record) { return AddRecord(ResourceType::kAdditional, record); }
+    /**
+     * @brief Appends an additional record (additional section).
+     *
+     * Shall be called after AddZone().
+     */
+    void AddAdditional(const ResourceRecord & record) { AddRecord(ResourceType::kAdditional, record); }
 
-    HeaderRef & Header() { return mHeader; }
-
-    bool Ok() const { return mBuildOk; }
-
-    /** @brief Total bytes written (header + body). */
-    size_t PacketSize() const { return mOutput.Needed(); }
-
-    /** @brief View of the encoded packet; empty if the builder is not Ok. */
-    ByteSpan Packet() const
+    HeaderRef & Header()
     {
-        VerifyOrReturnValue(mBuildOk && (mBuffer != nullptr), ByteSpan());
-        return ByteSpan(mBuffer, mOutput.Needed());
+        VerifyOrDie(mBuildStarted && mBuildOk);
+        return mHeader;
+    }
+
+    /** @brief Returns the encoded message built so far. */
+    CHIP_ERROR GetPacket(ByteSpan & out) const
+    {
+        VerifyOrReturnError(mBuildOk, CHIP_ERROR_BUFFER_TOO_SMALL);
+        out = ByteSpan(mBuffer, mOutput.Needed());
+        return CHIP_NO_ERROR;
     }
 
 private:
-    UpdateBuilder & AddRecord(ResourceType type, const ResourceRecord & record)
+    void AddRecord(ResourceType type, const ResourceRecord & record)
     {
-        VerifyOrReturnValue(mBuildOk, *this);
+        VerifyOrDie(mBuildStarted);
+        VerifyOrReturn(mBuildOk);
+        VerifyOrDie(mHeader.GetQueryCount() == 1);
 
-        if (!record.Append(mHeader, type, mWriter))
+        if (type == ResourceType::kAnswer)
         {
-            mBuildOk = false;
+            VerifyOrDie((mHeader.GetAuthorityCount() == 0) && (mHeader.GetAdditionalCount() == 0));
         }
-        return *this;
+        else if (type == ResourceType::kAuthority)
+        {
+            VerifyOrDie(mHeader.GetAdditionalCount() == 0);
+        }
+
+        mBuildOk = record.Append(mHeader, type, mWriter);
     }
 
     HeaderRef mHeader;
     Encoding::BigEndian::BufferWriter mOutput;
     RecordWriter mWriter;
 
-    uint8_t * mBuffer = nullptr;
-    size_t mSize      = 0;
-    bool mBuildOk     = false;
+    uint8_t * mBuffer  = nullptr;
+    size_t mSize       = 0;
+    bool mBuildOk      = false;
+    bool mBuildStarted = false;
 };
 
 } // namespace Uld

--- a/src/lib/dnssd/uld/UpdateBuilder.h
+++ b/src/lib/dnssd/uld/UpdateBuilder.h
@@ -84,7 +84,9 @@ public:
      */
     UpdateBuilder & Begin(uint16_t messageId)
     {
-        VerifyOrReturnValue(mBuildOk, *this);
+        // Allow restarting after a previous build failure as long as a valid buffer is bound.
+        VerifyOrReturnValue((mBuffer != nullptr) && (mSize >= HeaderRef::kSizeBytes), *this);
+        mBuildOk = true;
 
         mHeader.Clear();
         mHeader.SetMessageId(messageId);
@@ -132,8 +134,7 @@ public:
     /** @brief View of the encoded packet; empty if the builder is not Ok. */
     ByteSpan Packet() const
     {
-        VerifyOrReturnError(mBuildOk && (mBuffer != nullptr), ByteSpan());
-
+        VerifyOrReturnValue(mBuildOk && (mBuffer != nullptr), ByteSpan());
         return ByteSpan(mBuffer, mOutput.Needed());
     }
 

--- a/src/lib/dnssd/uld/UpdateBuilder.h
+++ b/src/lib/dnssd/uld/UpdateBuilder.h
@@ -1,0 +1,163 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <lib/dnssd/uld/Constants.h>
+#include <lib/dnssd/wire/DnsHeader.h>
+#include <lib/dnssd/wire/QName.h>
+#include <lib/dnssd/wire/Query.h>
+#include <lib/dnssd/wire/RecordWriter.h>
+#include <lib/dnssd/wire/records/ResourceRecord.h>
+#include <lib/support/BufferWriter.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * @brief Assembles a DNS UPDATE message (RFC 2136) for ULD registration.
+ *
+ * Owns the header and section orders, and appends ResourceRecord / Query objects via RecordWriter.
+ *
+ * Section mapping:
+ * - Query (qdcount) -> ZONE
+ * - Answer (ancount) -> Prerequisite
+ * - Authority (nscount) -> Update
+ * - Additional (arcount) -> Additional
+ *
+ * @note : All Add* methods can be chained. On failure they set a sticky "error state";
+ *         When in a failed state, all Add* calls are no-ops.
+ *         The assembly state can be checked by calling Ok().
+ *         Reset()/Begin() clear the error state and allows for a new assembly.
+ */
+class UpdateBuilder
+{
+public:
+    UpdateBuilder() : mHeader(nullptr), mOutput(nullptr, 0), mWriter(&mOutput) {}
+
+    UpdateBuilder(uint8_t * buffer, size_t size) : mHeader(nullptr), mOutput(nullptr, 0), mWriter(&mOutput) { Reset(buffer, size); }
+
+    /**
+     * @brief Binds the builder to @p buffer and clears the DNS header.
+     */
+    UpdateBuilder & Reset(uint8_t * buffer, size_t size)
+    {
+        mBuffer  = buffer;
+        mSize    = size;
+        mHeader  = HeaderRef(nullptr);
+        mBuildOk = false;
+
+        if ((buffer != nullptr) && (size >= HeaderRef::kSizeBytes))
+        {
+            mHeader = HeaderRef(buffer);
+            mHeader.Clear();
+            mOutput = Encoding::BigEndian::BufferWriter(buffer, size);
+            mOutput.Skip(HeaderRef::kSizeBytes);
+            mWriter.Reset();
+            mBuildOk = true;
+        }
+
+        return *this;
+    }
+
+    /**
+     * @brief Starts a new UPDATE query with the given message id.
+     */
+    UpdateBuilder & Begin(uint16_t messageId)
+    {
+        VerifyOrReturnValue(mBuildOk, *this);
+
+        mHeader.Clear();
+        mHeader.SetMessageId(messageId);
+        mHeader.SetAllFlags(BitPackedFlags(0).SetQuery().SetOpcode(kOpcodeUpdate));
+
+        mOutput = Encoding::BigEndian::BufferWriter(mBuffer, mSize);
+        mOutput.Skip(HeaderRef::kSizeBytes);
+        mWriter.Reset();
+        return *this;
+    }
+
+    /**
+     * @brief Appends the ZONE question (SOA / IN). Must be written before records.
+     */
+    UpdateBuilder & AddZone(FullQName zoneName)
+    {
+        VerifyOrReturnValue(mBuildOk, *this);
+
+        Query zone(zoneName);
+        zone.SetType(QType::SOA).SetClass(QClass::IN).SetAnswerViaUnicast(false);
+
+        if (!zone.Append(mHeader, mWriter))
+        {
+            mBuildOk = false;
+        }
+        return *this;
+    }
+
+    /** @brief Appends a prerequisite record (answer section). */
+    UpdateBuilder & AddPrerequisite(const ResourceRecord & record) { return AddRecord(ResourceType::kAnswer, record); }
+
+    /** @brief Appends an update record (authority section). */
+    UpdateBuilder & AddUpdate(const ResourceRecord & record) { return AddRecord(ResourceType::kAuthority, record); }
+
+    /** @brief Appends an additional record (additional section). */
+    UpdateBuilder & AddAdditional(const ResourceRecord & record) { return AddRecord(ResourceType::kAdditional, record); }
+
+    HeaderRef & Header() { return mHeader; }
+
+    bool Ok() const { return mBuildOk; }
+
+    /** @brief Total bytes written (header + body). */
+    size_t PacketSize() const { return mOutput.Needed(); }
+
+    /** @brief View of the encoded packet; empty if the builder is not Ok. */
+    ByteSpan Packet() const
+    {
+        VerifyOrReturnError(mBuildOk && (mBuffer != nullptr), ByteSpan());
+
+        return ByteSpan(mBuffer, mOutput.Needed());
+    }
+
+private:
+    UpdateBuilder & AddRecord(ResourceType type, const ResourceRecord & record)
+    {
+        VerifyOrReturnValue(mBuildOk, *this);
+
+        if (!record.Append(mHeader, type, mWriter))
+        {
+            mBuildOk = false;
+        }
+        return *this;
+    }
+
+    HeaderRef mHeader;
+    Encoding::BigEndian::BufferWriter mOutput;
+    RecordWriter mWriter;
+
+    uint8_t * mBuffer = nullptr;
+    size_t mSize      = 0;
+    bool mBuildOk     = false;
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/tests/BUILD.gn
+++ b/src/lib/dnssd/uld/tests/BUILD.gn
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libDnssdUldTests"
+
+  test_sources = [
+    "TestDeleteRecord.cpp",
+    "TestKeyRecord.cpp",
+    "TestOptRecord.cpp",
+    "TestSig0Record.cpp",
+    "TestUpdateBuilder.cpp",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
+    "${chip_root}/src/lib/dnssd/uld",
+    "${chip_root}/src/lib/dnssd/wire/records",
+  ]
+}

--- a/src/lib/dnssd/uld/tests/TestDeleteRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestDeleteRecord.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/DeleteRecord.h>
+#include <lib/dnssd/wire/records/IP.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Encoding::BigEndian;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+const QNamePart kNames[] = { "host", "local" };
+
+TEST(TestDeleteRecord, DeleteAllRrsetsWritesEmptyRdata)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    DeleteAllRrsetsRecord record(kNames, QType::ANY);
+
+    const uint8_t expectedOutput[] = {
+        4, 'h', 'o', 's', 't',      //
+        5, 'l', 'o', 'c', 'a', 'l', //
+        0,                          //
+        0, 255,                     // QType ANY
+        0, 255,                     // QClass ANY
+        0, 0,   0,   0,             // TTL 0
+        0, 0,                       // RDLENGTH 0
+    };
+
+    EXPECT_TRUE(record.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAuthorityCount(), 1);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+TEST(TestDeleteRecord, DeleteSpecificUsesClassNoneWithMatchingRdata)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    Inet::IPAddress addr;
+    ASSERT_TRUE(Inet::IPAddress::FromString("fd00::1", addr));
+
+    IPResourceRecord record(kNames, addr);
+    record.SetClass(QClass::NONE).SetTtl(0);
+
+    EXPECT_TRUE(record.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAuthorityCount(), 1);
+
+    // TYPE AAAA, CLASS NONE, TTL 0, RDLENGTH 16 + 16 address bytes after the name.
+    // Validate class / ttl / rdlength fields rather than the full address encoding.
+    const size_t nameBytes = 1 + 4 + 1 + 5 + 1; // host.local.
+    EXPECT_EQ(dataBuffer[nameBytes], 0);        // type hi
+    EXPECT_EQ(dataBuffer[nameBytes + 1], static_cast<uint8_t>(QType::AAAA));
+    EXPECT_EQ(dataBuffer[nameBytes + 2], 0); // class hi
+    EXPECT_EQ(dataBuffer[nameBytes + 3], static_cast<uint8_t>(QClass::NONE));
+    EXPECT_EQ(dataBuffer[nameBytes + 4], 0); // ttl
+    EXPECT_EQ(dataBuffer[nameBytes + 5], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 6], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 7], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 8], 0); // rdlength hi
+    EXPECT_EQ(dataBuffer[nameBytes + 9], 16);
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestDeleteRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestDeleteRecord.cpp
@@ -32,7 +32,7 @@ using namespace chip::Dnssd::Uld;
 
 const QNamePart kNames[] = { "host", "local" };
 
-TEST(TestDeleteRecord, DeleteAllRrsetsWritesEmptyRdata)
+TEST(TestDeleteRecord, DeleteRrsetWritesEmptyRdata)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -43,7 +43,7 @@ TEST(TestDeleteRecord, DeleteAllRrsetsWritesEmptyRdata)
     BufferWriter output(dataBuffer, sizeof(dataBuffer));
     RecordWriter writer(&output);
 
-    DeleteAllRrsetsRecord record(kNames, QType::ANY);
+    DeleteRrsetRecord record(kNames, QType::ANY);
 
     const uint8_t expectedOutput[] = {
         4, 'h', 'o', 's', 't',      //

--- a/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
@@ -102,13 +102,17 @@ TEST(TestKeyRecord, ExtractRawP256PublicKeyStripsPrefix)
     }
 
     MutableByteSpan out(raw);
-    EXPECT_TRUE(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out));
+    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_NO_ERROR);
     EXPECT_EQ(out.size(), kP256RawPublicKeySize);
     EXPECT_EQ(memcmp(raw, point + 1, kP256RawPublicKeySize), 0);
 
     point[0] = 0x02; // compressed — reject
     out      = MutableByteSpan(raw);
-    EXPECT_FALSE(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out));
+    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_ERROR_INVALID_ARGUMENT);
+
+    point[0] = 0x04;
+    out      = MutableByteSpan(raw, kP256RawPublicKeySize - 1);
+    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_ERROR_BUFFER_TOO_SMALL);
 }
 
 } // namespace

--- a/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
@@ -1,0 +1,114 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/KeyRecord.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Encoding::BigEndian;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+const QNamePart kNames[] = { "host", "local" };
+
+TEST(TestKeyRecord, WritesFlagsProtocolAlgorithmAndRawKey)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[256];
+    uint8_t rawKey[kP256RawPublicKeySize];
+
+    for (size_t i = 0; i < sizeof(rawKey); i++)
+    {
+        rawKey[i] = static_cast<uint8_t>(i);
+    }
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    KeyResourceRecord record(kNames, ByteSpan(rawKey));
+    record.SetTtl(120);
+
+    EXPECT_TRUE(record.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAuthorityCount(), 1);
+
+    const size_t nameBytes = 1 + 4 + 1 + 5 + 1;
+    // type KEY
+    EXPECT_EQ(dataBuffer[nameBytes], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 1], static_cast<uint8_t>(QType::KEY));
+    // class IN
+    EXPECT_EQ(dataBuffer[nameBytes + 2], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 3], static_cast<uint8_t>(QClass::IN));
+    // rdlength = 4 + 64
+    EXPECT_EQ(dataBuffer[nameBytes + 8], 0);
+    EXPECT_EQ(dataBuffer[nameBytes + 9], 68);
+
+    const uint8_t * rdata = dataBuffer + nameBytes + 10;
+    EXPECT_EQ(rdata[0], 0x00);
+    EXPECT_EQ(rdata[1], 0x00);
+    EXPECT_EQ(rdata[2], KeyResourceRecord::kKeyProtocolDnssec);
+    EXPECT_EQ(rdata[3], kKeyAlgorithmEcdsaP256);
+    EXPECT_EQ(memcmp(rdata + 4, rawKey, sizeof(rawKey)), 0);
+}
+
+TEST(TestKeyRecord, RejectsWrongKeyLength)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+    uint8_t shortKey[16] = {};
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    KeyResourceRecord record(kNames, ByteSpan(shortKey));
+    EXPECT_FALSE(record.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+}
+
+TEST(TestKeyRecord, ExtractRawP256PublicKeyStripsPrefix)
+{
+    uint8_t point[kP256RawPublicKeySize + 1];
+    uint8_t raw[kP256RawPublicKeySize];
+
+    point[0] = 0x04;
+    for (size_t i = 0; i < kP256RawPublicKeySize; i++)
+    {
+        point[i + 1] = static_cast<uint8_t>(0xA0 + i);
+    }
+
+    MutableByteSpan out(raw);
+    EXPECT_TRUE(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out));
+    EXPECT_EQ(out.size(), kP256RawPublicKeySize);
+    EXPECT_EQ(memcmp(raw, point + 1, kP256RawPublicKeySize), 0);
+
+    point[0] = 0x02; // compressed — reject
+    out      = MutableByteSpan(raw);
+    EXPECT_FALSE(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out));
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestOptRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestOptRecord.cpp
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/OptRecord.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Encoding::BigEndian;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+TEST(TestOptRecord, WritesRootNameLeaseOptionAndDnssecOk)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    OptLeaseRecord record(/*udpPayloadSize=*/1232, /*leaseSeconds=*/0x11111111, /*keyLeaseSeconds=*/0x22222222);
+
+    const uint8_t expectedOutput[] = {
+        0,                      // root name
+        0,    41,               // TYPE OPT
+        0x04, 0xD0,             // CLASS = UDP payload 1232
+        0x00, 0x00, 0x80, 0x00, // TTL = DNSSEC OK
+        0,    12,               // RDLENGTH = 12
+        0,    2,                // option code Update Lease
+        0,    8,                // option length
+        0x11, 0x11, 0x11, 0x11, // lease
+        0x22, 0x22, 0x22, 0x22, // key lease
+    };
+
+    EXPECT_TRUE(record.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAdditionalCount(), 1);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestOptRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestOptRecord.cpp
@@ -29,7 +29,7 @@ using namespace chip::Encoding::BigEndian;
 using namespace chip::Dnssd;
 using namespace chip::Dnssd::Uld;
 
-TEST(TestOptRecord, WritesRootNameLeaseOptionAndDnssecOk)
+TEST(TestOptRecord, WritesRootNameLeaseOption)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -46,7 +46,7 @@ TEST(TestOptRecord, WritesRootNameLeaseOptionAndDnssecOk)
         0,                      // root name
         0,    41,               // TYPE OPT
         0x04, 0xD0,             // CLASS = UDP payload 1232
-        0x00, 0x00, 0x80, 0x00, // TTL = DNSSEC OK
+        0x00, 0x00, 0x00, 0x00, // TTL = default
         0,    12,               // RDLENGTH = 12
         0,    2,                // option code Update Lease
         0,    8,                // option length

--- a/src/lib/dnssd/uld/tests/TestSig0Record.cpp
+++ b/src/lib/dnssd/uld/tests/TestSig0Record.cpp
@@ -1,0 +1,114 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/Sig0Record.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Encoding::BigEndian;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+const QNamePart kSigner[] = { "host", "local" };
+
+TEST(TestSig0Record, WritesWireLayoutWithZeroSignature)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[256];
+    uint8_t signature[kP256RawSignatureSize] = {};
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    Sig0ResourceRecord record(kSigner, ByteSpan(signature), /*keyTag=*/0xABCD, /*inception=*/0x01020304,
+                              /*expiration=*/0x05060708);
+
+    EXPECT_TRUE(record.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAdditionalCount(), 1);
+
+    // NAME = root
+    EXPECT_EQ(dataBuffer[0], 0);
+    // TYPE SIG
+    EXPECT_EQ(dataBuffer[1], 0);
+    EXPECT_EQ(dataBuffer[2], static_cast<uint8_t>(QType::SIG));
+    // CLASS ANY
+    EXPECT_EQ(dataBuffer[3], 0);
+    EXPECT_EQ(dataBuffer[4], static_cast<uint8_t>(QClass::ANY));
+    // TTL 0
+    EXPECT_EQ(dataBuffer[5], 0);
+    EXPECT_EQ(dataBuffer[6], 0);
+    EXPECT_EQ(dataBuffer[7], 0);
+    EXPECT_EQ(dataBuffer[8], 0);
+
+    const uint8_t * rdata = dataBuffer + 11;
+    EXPECT_EQ(rdata[0], 0); // type covered
+    EXPECT_EQ(rdata[1], 0);
+    EXPECT_EQ(rdata[2], kKeyAlgorithmEcdsaP256);
+    EXPECT_EQ(rdata[3], 0); // labels
+
+    // expiration
+    EXPECT_EQ(rdata[8], 0x05);
+    EXPECT_EQ(rdata[9], 0x06);
+    EXPECT_EQ(rdata[10], 0x07);
+    EXPECT_EQ(rdata[11], 0x08);
+    // inception
+    EXPECT_EQ(rdata[12], 0x01);
+    EXPECT_EQ(rdata[13], 0x02);
+    EXPECT_EQ(rdata[14], 0x03);
+    EXPECT_EQ(rdata[15], 0x04);
+    // key tag
+    EXPECT_EQ(rdata[16], 0xAB);
+    EXPECT_EQ(rdata[17], 0xCD);
+
+    // signer name host.local.
+    EXPECT_EQ(rdata[18], 4);
+    EXPECT_EQ(memcmp(rdata + 19, "host", 4), 0);
+    EXPECT_EQ(rdata[23], 5);
+    EXPECT_EQ(memcmp(rdata + 24, "local", 5), 0);
+    EXPECT_EQ(rdata[29], 0);
+
+    // 64-byte zero signature follows
+    EXPECT_EQ(memcmp(rdata + 30, signature, sizeof(signature)), 0);
+}
+
+TEST(TestSig0Record, RejectsWrongSignatureLength)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+    uint8_t shortSig[8] = {};
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    Sig0ResourceRecord record(kSigner, ByteSpan(shortSig));
+    EXPECT_FALSE(record.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
@@ -1,0 +1,123 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/DeleteRecord.h>
+#include <lib/dnssd/uld/KeyRecord.h>
+#include <lib/dnssd/uld/OptRecord.h>
+#include <lib/dnssd/uld/Sig0Record.h>
+#include <lib/dnssd/uld/UpdateBuilder.h>
+#include <lib/dnssd/wire/records/Ptr.h>
+#include <lib/dnssd/wire/records/Srv.h>
+
+#include <cstring>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+const QNamePart kZone[]     = { "default", "service", "arpa" };
+const QNamePart kService[]  = { "foo", "_matterc", "_udp", "local" };
+const QNamePart kInstance[] = { "inst", "_matterc", "_udp", "local" };
+const QNamePart kHost[]     = { "host", "local" };
+
+TEST(TestUpdateBuilder, BeginSetsOpcodeUpdate)
+{
+    uint8_t buffer[256];
+    UpdateBuilder builder(buffer, sizeof(buffer));
+
+    EXPECT_TRUE(builder.Ok());
+    builder.Begin(0x1234);
+
+    EXPECT_TRUE(builder.Ok());
+    EXPECT_EQ(builder.Header().GetMessageId(), 0x1234);
+    EXPECT_TRUE(builder.Header().GetFlags().IsQuery());
+    EXPECT_EQ(builder.Header().GetFlags().GetOpcode(), kOpcodeUpdate);
+    EXPECT_EQ(builder.PacketSize(), HeaderRef::kSizeBytes);
+}
+
+TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
+{
+    uint8_t buffer[512];
+    uint8_t rawKey[kP256RawPublicKeySize];
+    uint8_t signature[kP256RawSignatureSize] = {};
+
+    for (size_t i = 0; i < sizeof(rawKey); i++)
+    {
+        rawKey[i] = static_cast<uint8_t>(i + 1);
+    }
+
+    UpdateBuilder builder(buffer, sizeof(buffer));
+    builder.Begin(0xABCD);
+
+    DeleteAllRrsetsRecord delAny(kHost, QType::ANY);
+    PtrResourceRecord ptr(kService, kInstance);
+    SrvResourceRecord srv(kInstance, kHost, 5540);
+    KeyResourceRecord key(kHost, ByteSpan(rawKey));
+    OptLeaseRecord opt(/*udpPayloadSize=*/1232, /*leaseSeconds=*/7200, /*keyLeaseSeconds=*/86400);
+    Sig0ResourceRecord sig(kHost, ByteSpan(signature));
+
+    builder.AddZone(kZone).AddUpdate(delAny).AddUpdate(ptr).AddUpdate(srv).AddUpdate(key).AddAdditional(opt).AddAdditional(sig);
+
+    EXPECT_TRUE(builder.Ok());
+    EXPECT_EQ(builder.Header().GetQueryCount(), 1);      // ZONE
+    EXPECT_EQ(builder.Header().GetAnswerCount(), 0);     // Prerequisite
+    EXPECT_EQ(builder.Header().GetAuthorityCount(), 4);  // Update
+    EXPECT_EQ(builder.Header().GetAdditionalCount(), 2); // OPT + SIG
+
+    // Header flags: opcode UPDATE at offset 2.
+    EXPECT_EQ(buffer[2], 0x28); // QR=0, OPCODE=5
+    EXPECT_EQ(buffer[3], 0x00);
+}
+
+TEST(TestUpdateBuilder, RejectsUpdateBeforeZone)
+{
+    uint8_t buffer[256];
+    UpdateBuilder builder(buffer, sizeof(buffer));
+    builder.Begin(1);
+
+    // Query::Append requires no records yet; adding an update first is fine at the
+    // ResourceRecord layer, but AddZone after records must fail.
+    DeleteAllRrsetsRecord delAny(kHost, QType::TXT);
+    builder.AddUpdate(delAny);
+    EXPECT_TRUE(builder.Ok());
+
+    builder.AddZone(kZone);
+    EXPECT_FALSE(builder.Ok());
+}
+
+TEST(TestUpdateBuilder, SectionOrderAnswerBeforeAuthority)
+{
+    uint8_t buffer[256];
+    UpdateBuilder builder(buffer, sizeof(buffer));
+    builder.Begin(1).AddZone(kZone);
+
+    DeleteAllRrsetsRecord delAny(kHost, QType::TXT);
+    builder.AddUpdate(delAny);
+    EXPECT_TRUE(builder.Ok());
+
+    // Prerequisite (answer) after update (authority) is rejected by ResourceRecord::Append.
+    DeleteAllRrsetsRecord prereq(kHost, QType::TXT);
+    builder.AddPrerequisite(prereq);
+    EXPECT_FALSE(builder.Ok());
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
@@ -44,14 +44,15 @@ TEST(TestUpdateBuilder, BeginSetsOpcodeUpdate)
     uint8_t buffer[256];
     UpdateBuilder builder(buffer, sizeof(buffer));
 
-    EXPECT_TRUE(builder.Ok());
     builder.Begin(0x1234);
 
-    EXPECT_TRUE(builder.Ok());
     EXPECT_EQ(builder.Header().GetMessageId(), 0x1234);
     EXPECT_TRUE(builder.Header().GetFlags().IsQuery());
     EXPECT_EQ(builder.Header().GetFlags().GetOpcode(), Opcode::kUpdate);
-    EXPECT_EQ(builder.PacketSize(), HeaderRef::kSizeBytes);
+
+    ByteSpan packet;
+    EXPECT_EQ(builder.GetPacket(packet), CHIP_NO_ERROR);
+    EXPECT_EQ(packet.size(), HeaderRef::kSizeBytes);
 }
 
 TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
@@ -75,9 +76,14 @@ TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
     OptLeaseRecord opt(/*udpPayloadSize=*/1232, /*leaseSeconds=*/7200, /*keyLeaseSeconds=*/86400);
     Sig0ResourceRecord sig(kHost, ByteSpan(signature));
 
-    builder.AddZone(kZone).AddUpdate(delAny).AddUpdate(ptr).AddUpdate(srv).AddUpdate(key).AddAdditional(opt).AddAdditional(sig);
+    builder.AddZone(kZone);
+    builder.AddUpdate(delAny);
+    builder.AddUpdate(ptr);
+    builder.AddUpdate(srv);
+    builder.AddUpdate(key);
+    builder.AddAdditional(opt);
+    builder.AddAdditional(sig);
 
-    EXPECT_TRUE(builder.Ok());
     EXPECT_EQ(builder.Header().GetQueryCount(), 1);      // ZONE
     EXPECT_EQ(builder.Header().GetAnswerCount(), 0);     // Prerequisite
     EXPECT_EQ(builder.Header().GetAuthorityCount(), 4);  // Update
@@ -86,38 +92,47 @@ TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
     // Header flags: opcode UPDATE at offset 2.
     EXPECT_EQ(buffer[2], 0x28); // QR=0, OPCODE=5
     EXPECT_EQ(buffer[3], 0x00);
+
+    ByteSpan packet;
+    EXPECT_EQ(builder.GetPacket(packet), CHIP_NO_ERROR);
+    EXPECT_GT(packet.size(), HeaderRef::kSizeBytes);
+
+    ByteSpan samePacket;
+    EXPECT_EQ(builder.GetPacket(samePacket), CHIP_NO_ERROR);
+    EXPECT_EQ(samePacket.data(), packet.data());
+    EXPECT_EQ(samePacket.size(), packet.size());
 }
 
-TEST(TestUpdateBuilder, RejectsUpdateBeforeZone)
+TEST(TestUpdateBuilder, ReportsBufferTooSmall)
 {
-    uint8_t buffer[256];
+    uint8_t buffer[HeaderRef::kSizeBytes];
     UpdateBuilder builder(buffer, sizeof(buffer));
     builder.Begin(1);
 
-    // Query::Append requires no records yet; adding an update first is fine at the
-    // ResourceRecord layer, but AddZone after records must fail.
-    DeleteRrsetRecord delAny(kHost, QType::TXT);
-    builder.AddUpdate(delAny);
-    EXPECT_TRUE(builder.Ok());
-
     builder.AddZone(kZone);
-    EXPECT_FALSE(builder.Ok());
+
+    ByteSpan packet;
+    EXPECT_EQ(builder.GetPacket(packet), CHIP_ERROR_BUFFER_TOO_SMALL);
 }
 
-TEST(TestUpdateBuilder, SectionOrderAnswerBeforeAuthority)
+TEST(TestUpdateBuilder, BeginClearsBufferOverflow)
 {
-    uint8_t buffer[256];
+    uint8_t buffer[64];
     UpdateBuilder builder(buffer, sizeof(buffer));
-    builder.Begin(1).AddZone(kZone);
+    builder.Begin(1);
+    builder.AddZone(kZone);
 
-    DeleteRrsetRecord delAny(kHost, QType::TXT);
-    builder.AddUpdate(delAny);
-    EXPECT_TRUE(builder.Ok());
+    DeleteRrsetRecord record(kHost, QType::TXT);
+    builder.AddUpdate(record);
+    builder.AddUpdate(record);
 
-    // Prerequisite (answer) after update (authority) is rejected by ResourceRecord::Append.
-    DeleteRrsetRecord prereq(kHost, QType::TXT);
-    builder.AddPrerequisite(prereq);
-    EXPECT_FALSE(builder.Ok());
+    ByteSpan packet;
+    EXPECT_EQ(builder.GetPacket(packet), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    builder.Begin(2);
+    EXPECT_EQ(builder.GetPacket(packet), CHIP_NO_ERROR);
+    EXPECT_EQ(packet.size(), HeaderRef::kSizeBytes);
+    EXPECT_EQ(builder.Header().GetMessageId(), 2);
 }
 
 } // namespace

--- a/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
@@ -50,7 +50,7 @@ TEST(TestUpdateBuilder, BeginSetsOpcodeUpdate)
     EXPECT_TRUE(builder.Ok());
     EXPECT_EQ(builder.Header().GetMessageId(), 0x1234);
     EXPECT_TRUE(builder.Header().GetFlags().IsQuery());
-    EXPECT_EQ(builder.Header().GetFlags().GetOpcode(), kOpcodeUpdate);
+    EXPECT_EQ(builder.Header().GetFlags().GetOpcode(), Opcode::kUpdate);
     EXPECT_EQ(builder.PacketSize(), HeaderRef::kSizeBytes);
 }
 
@@ -68,7 +68,7 @@ TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
     UpdateBuilder builder(buffer, sizeof(buffer));
     builder.Begin(0xABCD);
 
-    DeleteAllRrsetsRecord delAny(kHost, QType::ANY);
+    DeleteRrsetRecord delAny(kHost, QType::ANY);
     PtrResourceRecord ptr(kService, kInstance);
     SrvResourceRecord srv(kInstance, kHost, 5540);
     KeyResourceRecord key(kHost, ByteSpan(rawKey));
@@ -96,7 +96,7 @@ TEST(TestUpdateBuilder, RejectsUpdateBeforeZone)
 
     // Query::Append requires no records yet; adding an update first is fine at the
     // ResourceRecord layer, but AddZone after records must fail.
-    DeleteAllRrsetsRecord delAny(kHost, QType::TXT);
+    DeleteRrsetRecord delAny(kHost, QType::TXT);
     builder.AddUpdate(delAny);
     EXPECT_TRUE(builder.Ok());
 
@@ -110,12 +110,12 @@ TEST(TestUpdateBuilder, SectionOrderAnswerBeforeAuthority)
     UpdateBuilder builder(buffer, sizeof(buffer));
     builder.Begin(1).AddZone(kZone);
 
-    DeleteAllRrsetsRecord delAny(kHost, QType::TXT);
+    DeleteRrsetRecord delAny(kHost, QType::TXT);
     builder.AddUpdate(delAny);
     EXPECT_TRUE(builder.Ok());
 
     // Prerequisite (answer) after update (authority) is rejected by ResourceRecord::Append.
-    DeleteAllRrsetsRecord prereq(kHost, QType::TXT);
+    DeleteRrsetRecord prereq(kHost, QType::TXT);
     builder.AddPrerequisite(prereq);
     EXPECT_FALSE(builder.Ok());
 }

--- a/src/lib/dnssd/wire/BUILD.gn
+++ b/src/lib/dnssd/wire/BUILD.gn
@@ -25,6 +25,7 @@ static_library("wire") {
     "QName.h",
     "QNameString.cpp",
     "QNameString.h",
+    "Query.h",
     "RecordWriter.cpp",
     "RecordWriter.h",
   ]

--- a/src/lib/dnssd/wire/Constants.h
+++ b/src/lib/dnssd/wire/Constants.h
@@ -70,6 +70,13 @@ enum class QClass : uint16_t
     IN_FLUSH   = IN | kQClassResponseFlushBit,
 };
 
+// DNS header OPCODE field
+enum class Opcode : uint8_t
+{
+    kQuery  = 0,
+    kUpdate = 5,
+};
+
 enum class ResourceType
 {
     kAnswer,

--- a/src/lib/dnssd/wire/Constants.h
+++ b/src/lib/dnssd/wire/Constants.h
@@ -37,10 +37,16 @@ enum class QType : uint16_t
     MX        = 15,
     TXT       = 16,
     ISDN      = 20,
-    AAAA      = 28,
-    SRV       = 33,
-    DNAM      = 39,
-    ANY       = 255,
+    // RFC 2535 / RFC 2931 — used by SIG(0) for DNS Update authentication.
+    SIG = 24,
+    // RFC 2535 / RFC 3445 — public key used by SRP / ULD.
+    KEY  = 25,
+    AAAA = 28,
+    SRV  = 33,
+    DNAM = 39,
+    // RFC 6891 — EDNS(0) OPT pseudo-RR.
+    OPT = 41,
+    ANY = 255,
 };
 
 /// Flag encoded in QCLASS requesting unicast answers

--- a/src/lib/dnssd/wire/DnsHeader.h
+++ b/src/lib/dnssd/wire/DnsHeader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <lib/core/CHIPEncoding.h>
+#include <lib/dnssd/wire/Constants.h>
 
 namespace chip {
 namespace Dnssd {
@@ -59,21 +60,16 @@ public:
     bool IsTruncated() const { return (mValue & kTruncationMask) != 0; }
     BitPackedFlags & SetTruncated(bool value) { return value ? SetMask(kTruncationMask) : ClearMask(kTruncationMask); }
 
-    uint8_t GetOpcode() const { return static_cast<uint8_t>((mValue & kOpcodeMask) >> kOpcodeShift); }
-    BitPackedFlags & SetOpcode(uint8_t opcode)
+    Opcode GetOpcode() const { return static_cast<Opcode>((mValue & kOpcodeMask) >> kOpcodeShift); }
+    BitPackedFlags & SetOpcode(Opcode opcode)
     {
         ClearMask(kOpcodeMask);
         mValue = static_cast<uint16_t>(mValue | ((static_cast<uint16_t>(opcode) & 0x0F) << kOpcodeShift));
         return *this;
     }
 
-    uint8_t GetResponseCode() const { return static_cast<uint8_t>(mValue & kReturnCodeMask); }
-    BitPackedFlags & SetResponseCode(uint8_t code)
-    {
-        ClearMask(kReturnCodeMask);
-        mValue = static_cast<uint16_t>(mValue | (static_cast<uint16_t>(code) & kReturnCodeMask));
-        return *this;
-    }
+    /// Lower 4 bits of the DNS header RCODE
+    uint8_t GetResponseCodeBits() const { return static_cast<uint8_t>(mValue & kResponseCodeMask); }
 
     /// Full 16-bit flags value, including OPCODE and RCODE.
     /// Prefer this over RawValue() for DNS Update (RFC 2136) and other non-mDNS messages.
@@ -83,7 +79,7 @@ public:
     /// RFC 6762
     // TODO: DNS Update carries an OpCode (5) and often non-zero return code. We will need to change this for ULD/SRP support.
     // (RFC 2136)
-    bool IsValidMdns() const { return (mValue & (kOpcodeMask | kReturnCodeMask)) == 0; }
+    bool IsValidMdns() const { return (mValue & (kOpcodeMask | kResponseCodeMask)) == 0; }
 
 private:
     uint16_t mValue = 0;
@@ -102,10 +98,10 @@ private:
 
     static constexpr uint16_t kAuthoritativeMask = 0x0400;
     static constexpr uint16_t kIsResponseMask    = 0x8000;
-    static constexpr uint16_t kOpcodeMask        = 0x7800;
     static constexpr uint16_t kOpcodeShift       = 11;
+    static constexpr uint16_t kOpcodeMask        = 0x0F << kOpcodeShift;
     static constexpr uint16_t kTruncationMask    = 0x0200;
-    static constexpr uint16_t kReturnCodeMask    = 0x000F;
+    static constexpr uint16_t kResponseCodeMask  = 0x000F;
 
     // Bits preserved by RawValue()/SetFlags for mDNS (RFC 6762: OPCODE/RCODE must be 0).
     static constexpr uint16_t kMdnsNonIgnoredMask = kIsResponseMask | kAuthoritativeMask | kTruncationMask;

--- a/src/lib/dnssd/wire/DnsHeader.h
+++ b/src/lib/dnssd/wire/DnsHeader.h
@@ -100,16 +100,15 @@ private:
         return *this;
     }
 
-    // Mask to limit values to what RFC 6762 consideres useful
-    // 1111 1110 0000 0000 = FE0F
-    // TODO(cecille): need to better document this value. Why is the comment different than the value?
-    static constexpr uint16_t kMdnsNonIgnoredMask = 0x8E08;
-    static constexpr uint16_t kAuthoritativeMask  = 0x0400;
-    static constexpr uint16_t kIsResponseMask     = 0x8000;
-    static constexpr uint16_t kOpcodeMask         = 0x7800;
-    static constexpr uint16_t kOpcodeShift        = 11;
-    static constexpr uint16_t kTruncationMask     = 0x0200;
-    static constexpr uint16_t kReturnCodeMask     = 0x000F;
+    static constexpr uint16_t kAuthoritativeMask = 0x0400;
+    static constexpr uint16_t kIsResponseMask    = 0x8000;
+    static constexpr uint16_t kOpcodeMask        = 0x7800;
+    static constexpr uint16_t kOpcodeShift       = 11;
+    static constexpr uint16_t kTruncationMask    = 0x0200;
+    static constexpr uint16_t kReturnCodeMask    = 0x000F;
+
+    // Bits preserved by RawValue()/SetFlags for mDNS (RFC 6762: OPCODE/RCODE must be 0).
+    static constexpr uint16_t kMdnsNonIgnoredMask = kIsResponseMask | kAuthoritativeMask | kTruncationMask;
 };
 
 /**
@@ -168,7 +167,7 @@ public:
 
     HeaderRef & SetMessageId(uint16_t value) { return Set16At(kMessageIdOffset, value); }
 
-    /// Writes mDNS-relevant flag bits only (OPCODE/RCODE cleared via RawValue()).
+    /// Writes QR/AA/TC only; OPCODE and RCODE are forced to 0 (RFC 6762).
     HeaderRef & SetFlags(BitPackedFlags flags) { return Set16At(kFlagsOffset, flags.RawValue()); }
 
     /// Writes the full flags word, including OPCODE and RCODE. Use for DNS Update.

--- a/src/lib/dnssd/wire/DnsHeader.h
+++ b/src/lib/dnssd/wire/DnsHeader.h
@@ -59,6 +59,26 @@ public:
     bool IsTruncated() const { return (mValue & kTruncationMask) != 0; }
     BitPackedFlags & SetTruncated(bool value) { return value ? SetMask(kTruncationMask) : ClearMask(kTruncationMask); }
 
+    uint8_t GetOpcode() const { return static_cast<uint8_t>((mValue & kOpcodeMask) >> kOpcodeShift); }
+    BitPackedFlags & SetOpcode(uint8_t opcode)
+    {
+        ClearMask(kOpcodeMask);
+        mValue = static_cast<uint16_t>(mValue | ((static_cast<uint16_t>(opcode) & 0x0F) << kOpcodeShift));
+        return *this;
+    }
+
+    uint8_t GetResponseCode() const { return static_cast<uint8_t>(mValue & kReturnCodeMask); }
+    BitPackedFlags & SetResponseCode(uint8_t code)
+    {
+        ClearMask(kReturnCodeMask);
+        mValue = static_cast<uint16_t>(mValue | (static_cast<uint16_t>(code) & kReturnCodeMask));
+        return *this;
+    }
+
+    /// Full 16-bit flags value, including OPCODE and RCODE.
+    /// Prefer this over RawValue() for DNS Update (RFC 2136) and other non-mDNS messages.
+    uint16_t FullValue() const { return mValue; }
+
     /// Validates that the message does not need to be ignored according to
     /// RFC 6762
     // TODO: DNS Update carries an OpCode (5) and often non-zero return code. We will need to change this for ULD/SRP support.
@@ -87,6 +107,7 @@ private:
     static constexpr uint16_t kAuthoritativeMask  = 0x0400;
     static constexpr uint16_t kIsResponseMask     = 0x8000;
     static constexpr uint16_t kOpcodeMask         = 0x7800;
+    static constexpr uint16_t kOpcodeShift        = 11;
     static constexpr uint16_t kTruncationMask     = 0x0200;
     static constexpr uint16_t kReturnCodeMask     = 0x000F;
 };
@@ -146,7 +167,13 @@ public:
     }
 
     HeaderRef & SetMessageId(uint16_t value) { return Set16At(kMessageIdOffset, value); }
+
+    /// Writes mDNS-relevant flag bits only (OPCODE/RCODE cleared via RawValue()).
     HeaderRef & SetFlags(BitPackedFlags flags) { return Set16At(kFlagsOffset, flags.RawValue()); }
+
+    /// Writes the full flags word, including OPCODE and RCODE. Use for DNS Update.
+    HeaderRef & SetAllFlags(BitPackedFlags flags) { return Set16At(kFlagsOffset, flags.FullValue()); }
+
     HeaderRef & SetQueryCount(uint16_t value) { return Set16At(kQueryCountOffset, value); }
     HeaderRef & SetAnswerCount(uint16_t value) { return Set16At(kAnswerCountOffset, value); }
     HeaderRef & SetAuthorityCount(uint16_t value) { return Set16At(kAuthorityCountOffset, value); }

--- a/src/lib/dnssd/wire/RecordWriter.cpp
+++ b/src/lib/dnssd/wire/RecordWriter.cpp
@@ -77,6 +77,17 @@ RecordWriter & RecordWriter::WriteQName(const FullQName & qname)
     return *this;
 }
 
+RecordWriter & RecordWriter::WriteQNameUncompressed(const FullQName & qname)
+{
+    for (size_t i = 0; i < qname.nameCount; i++)
+    {
+        mOutput->Put8(static_cast<uint8_t>(strlen(qname.names[i])));
+        mOutput->Put(qname.names[i]);
+    }
+    mOutput->Put8(0);
+    return *this;
+}
+
 RecordWriter & RecordWriter::WriteQName(const SerializedQNameIterator & qname)
 {
     size_t qNameWriteStart = mOutput->WritePos();

--- a/src/lib/dnssd/wire/RecordWriter.h
+++ b/src/lib/dnssd/wire/RecordWriter.h
@@ -46,13 +46,16 @@ public:
 
     chip::Encoding::BigEndian::BufferWriter & Writer() { return *mOutput; }
 
-    /// Writes  the given qname into the underlying buffer, applying
+    /// Writes the given qname into the underlying buffer, applying
     /// compression if possible
     RecordWriter & WriteQName(const FullQName & qname);
 
-    /// Writes  the given qname into the underlying buffer, applying
+    /// Writes the given qname into the underlying buffer, applying
     /// compression if possible
     RecordWriter & WriteQName(const SerializedQNameIterator & qname);
+
+    /// Writes the given qname without DNS name compression.
+    RecordWriter & WriteQNameUncompressed(const FullQName & qname);
 
     inline RecordWriter & Put8(uint8_t value)
     {

--- a/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/wire/tests/TestRecordWriter.cpp
@@ -163,4 +163,32 @@ TEST(TestRecordWriter, TonsOfReferences)
     EXPECT_EQ(output.Needed(), 423u);
 }
 
+TEST(TestRecordWriter, UncompressedAvoidsPointers)
+{
+    const QNamePart kName1[] = { "some", "name" };
+    const QNamePart kName2[] = { "other", "name" };
+
+    uint8_t dataBuffer[128];
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    writer.WriteQName(FullQName(kName1));
+    writer.WriteQNameUncompressed(FullQName(kName2));
+
+    // clang-format off
+    const uint8_t expectedOutput[] = {
+        4, 's', 'o', 'm', 'e',      // QNAME part: some
+        4, 'n', 'a', 'm', 'e',      // QNAME part: name
+        0,                          // QNAME ends
+        5, 'o', 't', 'h', 'e', 'r', // QNAME part: other
+        4, 'n', 'a', 'm', 'e',      // QNAME part: name (not compressed)
+        0,                          // QNAME ends
+    };
+    // clang-format on
+
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

Adds a ULD (Unicast Local Discovery) DNS UPDATE message writer on top of
`dnssd/wire`, enabling encoding of SRP-style registration packets without yet
implementing signing or a full client.

##### Problem
- Matter DNS-SD on infrastructure (ULD / SRP) needs to send DNS UPDATE messages
  (RFC 2136) with KEY, OPT (Update Lease), SIG(0), and delete RRs.
- `dnssd/wire` already provides shared RR/query encoding for mDNS, but:
  - Lacked QTypes (`KEY` / `SIG` / `OPT`) and header OPCODE/RCODE helpers needed
    for DNS Update.
  - Had no ULD-specific UPDATE assembler or RR types for registration.

##### Solution
- Extended `dnssd/wire` with `QType::KEY` / `SIG` / `OPT`, opcode/rcode accessors
  on `BitPackedFlags`, and `HeaderRef::SetAllFlags()` so UPDATE messages can
  carry OPCODE 5 without mDNS flag masking.
- Added `chip::Dnssd::Uld` under `src/lib/dnssd/uld/`:
  - `UpdateBuilder` — fluent ZONE / Prerequisite / Update / Additional assembler
  - Record writers: KEY (P-256), OPT Update Lease, SIG(0) wire layout, and
    delete-all-RRsets.
- Specific RR deletes reuse existing records with `SetClass(NONE)` / `SetTtl(0)`.

##### Caveats
- SIG(0) encodes the wire layout only; signature generation/verification to be done in a later PR

#### Testing
- Added unit tests in `src/lib/dnssd/uld/tests/` for
  `TestDeleteRecord`, `TestKeyRecord`, `TestOptRecord`, `TestSig0Record`, and
  `TestUpdateBuilder`.
- Built and ran those targets on `out/darwin-arm64-tests-clang`.