### PR TITLE
Convert IterateX/Release calls in the core with AutoRelease wrapper

### DIFF
--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -28,6 +28,7 @@
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/TLVData.h>
 #include <lib/core/TLVUtilities.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/TypeTraits.h>
 #include <messaging/ExchangeContext.h>
@@ -478,7 +479,6 @@ Status CommandHandlerImpl::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
 
     Credentials::GroupDataProvider::GroupEndpoint mapping;
     Credentials::GroupDataProvider * groupDataProvider = Credentials::GetGroupDataProvider();
-    Credentials::GroupDataProvider::EndpointIterator * iterator;
 
     err = aCommandElement.GetPath(&commandPath);
     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::InvalidAction);
@@ -510,8 +510,8 @@ Status CommandHandlerImpl::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
     // always have an accessing fabric, by definition.
 
     // Find which endpoints can process the command, and dispatch to them.
-    iterator = groupDataProvider->IterateEndpoints(fabric);
-    VerifyOrReturnError(iterator != nullptr, Status::Failure);
+    AutoRelease iterator(groupDataProvider->IterateEndpoints(fabric));
+    VerifyOrReturnError(!iterator.IsNull(), Status::Failure);
 
     while (iterator->Next(mapping))
     {
@@ -564,7 +564,6 @@ Status CommandHandlerImpl::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
             continue;
         }
     }
-    iterator->Release();
     return Status::Success;
 }
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -35,6 +35,7 @@
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>
 #include <lib/support/logging/TextOnlyLogging.h>
@@ -46,33 +47,6 @@
 
 namespace chip {
 namespace app {
-
-namespace {
-
-using Protocols::InteractionModel::Status;
-
-/// Wraps a EndpointIterator and ensures that `::Release()` is called
-/// for the iterator (assuming it is non-null)
-class AutoReleaseGroupEndpointIterator
-{
-public:
-    explicit AutoReleaseGroupEndpointIterator(Credentials::GroupDataProvider::EndpointIterator * iterator) : mIterator(iterator) {}
-    ~AutoReleaseGroupEndpointIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-
-    bool IsNull() const { return mIterator == nullptr; }
-    bool Next(Credentials::GroupDataProvider::GroupEndpoint & item) { return mIterator->Next(item); }
-
-private:
-    Credentials::GroupDataProvider::EndpointIterator * mIterator;
-};
-
-} // namespace
 
 using namespace Protocols::InteractionModel;
 using Status = Protocols::InteractionModel::Status;
@@ -306,7 +280,6 @@ CHIP_ERROR WriteHandler::DeliverFinalListWriteEndForGroupWrite(bool writeWasSucc
 
     Credentials::GroupDataProvider::GroupEndpoint mapping;
     Credentials::GroupDataProvider * groupDataProvider = Credentials::GetGroupDataProvider();
-    Credentials::GroupDataProvider::EndpointIterator * iterator;
 
     GroupId groupId         = mExchangeCtx->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
     FabricIndex fabricIndex = GetAccessingFabricIndex();
@@ -314,8 +287,8 @@ CHIP_ERROR WriteHandler::DeliverFinalListWriteEndForGroupWrite(bool writeWasSucc
     auto processingConcreteAttributePath = mProcessingAttributePath.Value();
     mProcessingAttributePath.ClearValue();
 
-    iterator = groupDataProvider->IterateEndpoints(fabricIndex);
-    VerifyOrReturnError(iterator != nullptr, CHIP_ERROR_NO_MEMORY);
+    AutoRelease iterator(groupDataProvider->IterateEndpoints(fabricIndex));
+    VerifyOrReturnError(!iterator.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     while (iterator->Next(mapping))
     {
@@ -332,7 +305,6 @@ CHIP_ERROR WriteHandler::DeliverFinalListWriteEndForGroupWrite(bool writeWasSucc
             DeliverListWriteEnd(processingConcreteAttributePath, writeWasSuccessful);
         }
     }
-    iterator->Release();
     return CHIP_NO_ERROR;
 }
 namespace {
@@ -499,7 +471,7 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
                       "Received group attribute write for Group=%u Cluster=" ChipLogFormatMEI " attribute=" ChipLogFormatMEI,
                       groupId, ChipLogValueMEI(dataAttributePath.mClusterId), ChipLogValueMEI(dataAttributePath.mAttributeId));
 
-        AutoReleaseGroupEndpointIterator iterator(Credentials::GetGroupDataProvider()->IterateEndpoints(fabric));
+        AutoRelease iterator(Credentials::GetGroupDataProvider()->IterateEndpoints(fabric));
         VerifyOrExit(!iterator.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
         bool shouldReportListWriteEnd = ShouldReportListWriteEnd(
@@ -509,7 +481,7 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
         std::optional<bool> isListAttribute = std::nullopt;
 
         Credentials::GroupDataProvider::GroupEndpoint mapping;
-        while (iterator.Next(mapping))
+        while (iterator->Next(mapping))
         {
             if (groupId != mapping.group_id)
             {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -37,6 +37,7 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/ServiceNaming.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/PersistedCounter.h>
@@ -684,9 +685,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         [&](uint16_t port) -> CHIP_ERROR {
             // Attempt to initialize UDC transport with the selected port
             return mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                           .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                           .SetListenPort(port)
-                                                           .SetNativeParams(initParams.endpointNativeParams)
+                                              .SetAddressType(Inet::IPAddressType::kIPv6)
+                                              .SetListenPort(port)
+                                              .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                           Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -704,12 +705,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                                   .SetListenPort(mCdcListenPort)
                                                   .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
-                                                  ,
-                                              Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                  .SetAddressType(Inet::IPAddressType::kIPv4)
-                                                  .SetListenPort(mCdcListenPort)
+                                     ,
+                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                     .SetAddressType(Inet::IPAddressType::kIPv4)
+                                     .SetListenPort(mCdcListenPort)
 #endif // INET_CONFIG_ENABLE_IPV4
-                 );
+    );
 #endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 
@@ -808,8 +809,8 @@ void Server::RejoinExistingMulticastGroups()
     {
         Credentials::GroupDataProvider::GroupInfo groupInfo;
 
-        auto * iterator = mGroupsProvider->IterateGroupInfo(fabric.GetFabricIndex());
-        if (iterator)
+        AutoRelease iterator(mGroupsProvider->IterateGroupInfo(fabric.GetFabricIndex()));
+        if (!iterator.IsNull())
         {
             // GroupDataProvider was able to allocate rescources for an iterator
             while (iterator->Next(groupInfo))
@@ -833,14 +834,11 @@ void Server::RejoinExistingMulticastGroups()
 
                     // We assume the failure is caused by a network issue or a lack of rescources; neither of which will be solved
                     // before the next join. Exit the loop to save rescources.
-                    iterator->Release();
                     return;
                 }
                 if (use_iana_addr)
                     groupcast_joined = true;
             }
-
-            iterator->Release();
         }
     }
 }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -685,9 +685,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         [&](uint16_t port) -> CHIP_ERROR {
             // Attempt to initialize UDC transport with the selected port
             return mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                              .SetAddressType(Inet::IPAddressType::kIPv6)
-                                              .SetListenPort(port)
-                                              .SetNativeParams(initParams.endpointNativeParams)
+                                                           .SetAddressType(Inet::IPAddressType::kIPv6)
+                                                           .SetListenPort(port)
+                                                           .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                           Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -705,12 +705,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                                   .SetListenPort(mCdcListenPort)
                                                   .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
-                                     ,
-                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                     .SetAddressType(Inet::IPAddressType::kIPv4)
-                                     .SetListenPort(mCdcListenPort)
+                                                  ,
+                                              Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                  .SetAddressType(Inet::IPAddressType::kIPv4)
+                                                  .SetListenPort(mCdcListenPort)
 #endif // INET_CONFIG_ENABLE_IPV4
-    );
+                 );
 #endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 


### PR DESCRIPTION
### Summary

Replace manual Iterate*()/Release() calls in WriteHandler, CommandHandlerImpl and Server::RejoinExistingMulticastGroups with AutoRelease, so early returns cannot leak pooled iterators (#73331).

remove WriteHandler's file-local AutoReleaseGroupEndpointIterator wrapper.

### Related issues
- Please see #73331 for more details
- Earlier PRs: #73296, #73546

### Testing
- existing unit tests cover all migrated paths, hence ran the unit tests locally and they'll also run in CI