### PR TITLE
[linux][nuttx][webos] read the netlink message the loop is on

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -90,11 +90,11 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
              (NLMSG_OK(messageHeader, static_cast<uint32_t>(len))) && (messageHeader->nlmsg_type != NLMSG_DONE);
              messageHeader = NLMSG_NEXT(messageHeader, len))
         {
-            if (header->nlmsg_type == RTM_NEWADDR)
+            if (messageHeader->nlmsg_type == RTM_NEWADDR)
             {
-                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(header);
+                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(messageHeader);
                 struct rtattr * routeInfo         = IFA_RTA(addressMessage);
-                size_t rtl                        = IFA_PAYLOAD(header);
+                size_t rtl                        = IFA_PAYLOAD(messageHeader);
 
                 for (; rtl && RTA_OK(routeInfo, rtl); routeInfo = RTA_NEXT(routeInfo, rtl))
                 {

--- a/src/platform/NuttX/PlatformManagerImpl.cpp
+++ b/src/platform/NuttX/PlatformManagerImpl.cpp
@@ -89,11 +89,11 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
              (NLMSG_OK(messageHeader, static_cast<uint32_t>(len))) && (messageHeader->nlmsg_type != NLMSG_DONE);
              messageHeader = NLMSG_NEXT(messageHeader, len))
         {
-            if (header->nlmsg_type == RTM_NEWADDR)
+            if (messageHeader->nlmsg_type == RTM_NEWADDR)
             {
-                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(header);
+                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(messageHeader);
                 struct rtattr * routeInfo         = IFA_RTA(addressMessage);
-                size_t rtl                        = IFA_PAYLOAD(header);
+                size_t rtl                        = IFA_PAYLOAD(messageHeader);
 
                 for (; rtl && RTA_OK(routeInfo, rtl); routeInfo = RTA_NEXT(routeInfo, rtl))
                 {

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -90,11 +90,11 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
              (NLMSG_OK(messageHeader, static_cast<uint32_t>(len))) && (messageHeader->nlmsg_type != NLMSG_DONE);
              messageHeader = NLMSG_NEXT(messageHeader, len))
         {
-            if (header->nlmsg_type == RTM_NEWADDR)
+            if (messageHeader->nlmsg_type == RTM_NEWADDR)
             {
-                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(header);
+                struct ifaddrmsg * addressMessage = (struct ifaddrmsg *) NLMSG_DATA(messageHeader);
                 struct rtattr * routeInfo         = IFA_RTA(addressMessage);
-                size_t rtl                        = IFA_PAYLOAD(header);
+                size_t rtl                        = IFA_PAYLOAD(messageHeader);
 
                 for (; rtl && RTA_OK(routeInfo, rtl); routeInfo = RTA_NEXT(routeInfo, rtl))
                 {


### PR DESCRIPTION
#### Summary

The Linux, NuttX and webos IP-change listeners walk a batch of netlink messages with `NLMSG_NEXT` on `messageHeader`, but every read inside the loop uses `header`, which stays pointing at the first message in the buffer.

Today this is latent rather than active: the socket subscribes to `RTMGRP_IPV4_IFADDR` alone and rtnetlink delivers notifications one message per datagram, so the loop body only ever runs on the iteration where the two pointers are equal. The pointers diverge as soon as the socket joins a second group or reads a dump response, at which point a multi-message batch would report the first address twice and drop the rest.

Read `messageHeader`, which is what the loop is iterating, so the loop keeps working if what it subscribes to ever changes.

#### Testing

Correctness cleanup for a code path whose behaviour does not change under the current single-group subscription; verified by inspection against the rtnetlink delivery semantics and covered by existing CI builds of the three platforms.
