### PR TITLE
[minmdns] skip Thread interfaces in the libnl address policy too

### DIFF
--- a/src/lib/dnssd/minimal_mdns/AddressPolicy_LibNlImpl.cpp
+++ b/src/lib/dnssd/minimal_mdns/AddressPolicy_LibNlImpl.cpp
@@ -19,6 +19,8 @@
 #include <netlink/route/addr.h>
 #include <netlink/socket.h>
 
+#include <string.h>
+
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -244,6 +246,15 @@ bool AllListenIterator::IsCurrentLinkUsable()
     if ((flags & (IFF_BROADCAST | IFF_MULTICAST)) == 0)
     {
         // minmdns requires broadcast/multicast
+        return false;
+    }
+
+    // Skip IEEE 802.15.4 / Thread interfaces, matching AddressPolicy_DefaultImpl. Matching on the
+    // name is unsatisfying, but OpenThread's wpan0 is a tun device, so the link type does not
+    // identify it either.
+    const char * name = rtnl_link_get_name(CurrentLink());
+    if ((name != nullptr) && (strncmp(name, "wpan", 4) == 0))
+    {
         return false;
     }
 


### PR DESCRIPTION
#### Summary

#72559 stopped minimal-mDNS from sending into the Thread mesh by skipping `wpan*` interfaces, but only in `AddressPolicy_DefaultImpl`. The libnl policy (`chip_minmdns_default_policy = "libnl"`) filters on link flags alone and still hands wpan0 to the mDNS server. Apply the same rule there; matching on the name is not satisfying, but OpenThread presents wpan0 as a tun device, so the link type does not identify it either, and keeping the two policies in agreement matters more than the shape of the test.

#### Testing

Compiled against libnl-3. Untested at runtime: this policy is opt-in and not selected by any CI workflow or by my build; flagging that openly for reviewers with a libnl setup.
