### PR TITLE
[platform] let a product keep the setup passcode out of the log

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -670,10 +670,12 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
 
     ConfigurationMgr().LogDeviceConfig();
 
+#if CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
     {
         ChipLogProgress(NotSpecified, "==== Onboarding payload for Standard Commissioning Flow ====");
         PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
     }
+#endif // CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
 
 #if defined(PW_RPC_ENABLED)
     rpc::Init(LinuxDeviceOptions::GetInstance().rpcServerPort);
@@ -1028,7 +1030,9 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     // noise.
     ConfigurationMgr().LogDeviceConfig();
 
+#if CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
+#endif // CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 #if CHIP_LINUX_APP_START_COMMISSIONER_AT_BOOT

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1298,6 +1298,22 @@ static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE
 #define CHIP_DEVICE_CONFIG_DEFAULT_TELEMETRY_INTERVAL_MS 90000
 #endif
 
+/**
+ * @def CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
+ *
+ * @brief
+ *   Log the setup passcode and the onboarding codes derived from it.
+ *
+ *  @note
+ *    Convenient during development, where the log is the only place to read the
+ *    code from. A product that has another way to present it — a label, a
+ *    display, an administration interface — should set this to 0, so that the
+ *    passcode does not end up in a system log that outlives commissioning.
+ */
+#ifndef CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
+#define CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD 1
+#endif
+
 // -------------------- Test Setup (PASE) Configuration --------------------
 
 /**

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -768,6 +768,7 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
 
     CommissionableDataProvider * cdp = GetCommissionableDataProvider();
 
+#if CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
     {
         uint32_t setupPasscode;
         if ((cdp == nullptr) || (cdp->GetSetupPasscode(setupPasscode) != CHIP_NO_ERROR))
@@ -776,6 +777,7 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
         }
         ChipLogProgress(DeviceLayer, "  Setup Pin Code (0 for UNKNOWN/ERROR): %" PRIu32 "", setupPasscode);
     }
+#endif // CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD
 
     {
         uint16_t setupDiscriminator;


### PR DESCRIPTION
#### Problem

Every standalone Linux example logs the setup passcode twice at startup: once as "Setup Pin Code" from `LogDeviceConfig()`, and again inside the manual pairing code and QR payload from `PrintOnboardingCodes()`. That is the right default for a development board, where the log is the only place to read the code from. It is the wrong default for a product that has a display, a label or an administration interface, and whose system log outlives commissioning by years.

#### Change overview

Add `CHIP_DEVICE_CONFIG_LOG_ONBOARDING_PAYLOAD`, on by default, and guard both log sites with it. Nothing changes for any existing build.

#### Testing

Built `matter-network-manager-app` with the default configuration; the payload is logged exactly as before. Inversely verified with `=0` it's omitted.
