### PR TITLE
Fix casting player use after free crash

### DIFF
--- a/examples/tv-casting-app/android/App/app/build.gradle
+++ b/examples/tv-casting-app/android/App/app/build.gradle
@@ -95,7 +95,9 @@ dependencies {
         implementation fileTree(dir: "libs", include: ["*.jar"], exclude: ["TvCastingApp.jar"])
         compileOnly files("libs/TvCastingApp.jar")
     } else {
-        implementation fileTree(dir: "libs", include: ["*.jar","*.so"])
+        implementation fileTree(dir: "libs", include: ["*.so"])
+        implementation fileTree(dir: "libs", include: ["*.jar"], exclude: ["TvCastingApp.jar"])
+        compileOnly files("libs/TvCastingApp.jar")
     }
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -159,6 +159,10 @@ public class MatterCastingPlayer implements CastingPlayer {
   void setNativeCastingPlayer(long nativePtr) {
     try {
       // Register cleanup before assigning so _cppCastingPlayer stays 0 if registration fails.
+      // SAFETY: The cleanup action does not zero _cppCastingPlayer after freeing the native handle.
+      // This is safe because phantom-reference cleanup can only fire when this object is no longer
+      // strongly reachable. Any JNI method executing on this object holds a strong reference via
+      // its receiver, so the cleanup and a concurrent JNI read of _cppCastingPlayer cannot race.
       MatterCleaner.getInstance().register(this, () -> nativeReleaseCastingPlayer(nativePtr));
       this._cppCastingPlayer = nativePtr;
     } catch (RuntimeException e) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -337,7 +337,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   /*
    * @brief Get the Current ConnectionState of a CastingPlayer from the native layer.
    *
-   * @returns A String representation of the CastingPlayer's current connection state.
+   * @return A String representation of the CastingPlayer's current connection state.
    *          Possible return values are
    *            - "NOT_CONNECTED"
    *            - "CONNECTING"

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -327,7 +327,6 @@ public class MatterCastingPlayer implements CastingPlayer {
 
   /**
    * @brief Get CastingPlayer's current ConnectionState.
-   *
    * @return Current ConnectionState, or NOT_CONNECTED if the native player is no longer valid.
    */
   @Override
@@ -335,7 +334,10 @@ public class MatterCastingPlayer implements CastingPlayer {
     try {
       return ConnectionState.valueOf(getConnectionStateNative());
     } catch (IllegalArgumentException | NullPointerException e) {
-      Log.w(TAG, "getConnectionState(): native returned invalid state, defaulting to NOT_CONNECTED: " + e.getMessage());
+      Log.w(
+          TAG,
+          "getConnectionState(): native returned invalid state, defaulting to NOT_CONNECTED: "
+              + e.getMessage());
       return ConnectionState.NOT_CONNECTED;
     }
   }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -19,6 +19,7 @@ package com.matter.casting.core;
 import android.util.Log;
 import com.matter.casting.support.ConnectionCallbacks;
 import com.matter.casting.support.IdentificationDeclarationOptions;
+import com.matter.casting.support.MatterCleaner;
 import com.matter.casting.support.MatterError;
 import java.net.InetAddress;
 import java.util.List;
@@ -144,6 +145,23 @@ public class MatterCastingPlayer implements CastingPlayer {
 
   @Override
   public native List<Endpoint> getEndpoints();
+
+  /**
+   * Sets the native pointer backing this casting player and registers a cleanup action to free it
+   * when this object becomes phantom-reachable.
+   *
+   * <p>Called by JNI immediately after the Java object is constructed. The cleanup action captures
+   * {@code nativePtr} as a primitive to avoid retaining a reference to {@code this}, which would
+   * prevent GC from ever collecting this object.
+   *
+   * @param nativePtr pointer to the native heap allocation backing this casting player
+   */
+  void setNativeCastingPlayer(long nativePtr) {
+    this._cppCastingPlayer = nativePtr;
+    MatterCleaner.getInstance().register(this, () -> nativeReleaseCastingPlayer(nativePtr));
+  }
+
+  private static native void nativeReleaseCastingPlayer(long nativePtr);
 
   @Override
   public String toString() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -303,24 +303,28 @@ public class MatterCastingPlayer implements CastingPlayer {
 
   /**
    * @brief Get CastingPlayer's current ConnectionState.
-   * @throws IllegalArgumentException or NullPointerException when native layer returns invalid
-   *     state.
-   * @return Current ConnectionState.
+   *
+   * @return Current ConnectionState, or NOT_CONNECTED if the native player is no longer valid.
    */
   @Override
   public ConnectionState getConnectionState() {
-    return ConnectionState.valueOf(getConnectionStateNative());
+    try {
+      return ConnectionState.valueOf(getConnectionStateNative());
+    } catch (IllegalArgumentException | NullPointerException e) {
+      Log.w(TAG, "getConnectionState(): native returned invalid state, defaulting to NOT_CONNECTED: " + e.getMessage());
+      return ConnectionState.NOT_CONNECTED;
+    }
   }
 
   /*
    * @brief Get the Current ConnectionState of a CastingPlayer from the native layer.
    *
-   * @returns A String representation of the CastingPlayer's current connectation.
+   * @returns A String representation of the CastingPlayer's current connection state.
    *          Possible return values are
    *            - "NOT_CONNECTED"
    *            - "CONNECTING"
    *            - "CONNECTED"
-   *            - Error message or NULL on error
+   *            - NULL on error
    */
   @Override
   public native String getConnectionStateNative();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -157,8 +157,14 @@ public class MatterCastingPlayer implements CastingPlayer {
    * @param nativePtr pointer to the native heap allocation backing this casting player
    */
   void setNativeCastingPlayer(long nativePtr) {
-    this._cppCastingPlayer = nativePtr;
-    MatterCleaner.getInstance().register(this, () -> nativeReleaseCastingPlayer(nativePtr));
+    try {
+      // Register cleanup before assigning so _cppCastingPlayer stays 0 if registration fails.
+      MatterCleaner.getInstance().register(this, () -> nativeReleaseCastingPlayer(nativePtr));
+      this._cppCastingPlayer = nativePtr;
+    } catch (RuntimeException e) {
+      this._cppCastingPlayer = 0;
+      throw e;
+    }
   }
 
   private static native void nativeReleaseCastingPlayer(long nativePtr);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -19,6 +19,7 @@ package com.matter.casting.support;
 
 import android.os.Build;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 import java.lang.ref.Cleaner;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
@@ -80,6 +81,7 @@ public final class MatterCleaner {
    * referent is collected. Without this, the phantom reference itself could be collected before its
    * referent and never enqueued.
    */
+  @VisibleForTesting
   static final class LegacyCleanerHolder {
     static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
     static final Set<CleanupRef> LIVE_REFS = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -48,8 +48,8 @@ public final class MatterCleaner {
   /**
    * Registers a cleanup action to run when {@code obj} becomes phantom-reachable.
    *
-   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as
-   * this would prevent the object from ever becoming phantom-reachable.
+   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as this
+   * would prevent the object from ever becoming phantom-reachable.
    *
    * @param obj the object whose reachability triggers the action
    * @param action the cleanup action; must not capture {@code obj}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -1,0 +1,75 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import android.os.Build;
+import android.util.Log;
+import androidx.annotation.RequiresApi;
+import java.lang.ref.Cleaner;
+
+/**
+ * Manages native resource cleanup for Matter Java objects that wrap native pointers.
+ *
+ * <p>Any Matter Java object holding a native resource can register a cleanup action via {@link
+ * #register(Object, Runnable)}. The action runs when the Java object becomes phantom-reachable,
+ * freeing the associated native memory without requiring explicit {@code close()} calls from
+ * callers.
+ *
+ * <p>On API 33 and above, delegates to {@link java.lang.ref.Cleaner}. Support for earlier API
+ * levels via {@code PhantomReference} is not yet implemented.
+ */
+public final class MatterCleaner {
+
+  private static final String TAG = MatterCleaner.class.getSimpleName();
+
+  private static final MatterCleaner INSTANCE = new MatterCleaner();
+
+  private MatterCleaner() {}
+
+  public static MatterCleaner getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Registers a cleanup action to run when {@code obj} becomes phantom-reachable.
+   *
+   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as
+   * this would prevent the object from ever becoming phantom-reachable.
+   *
+   * @param obj the object whose reachability triggers the action
+   * @param action the cleanup action; must not capture {@code obj}
+   */
+  public void register(Object obj, Runnable action) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      CleanerHolder.CLEANER.register(obj, action);
+    } else {
+      // TODO: Implement PhantomReference-based cleanup for API < 33.
+      // On API 26-32, native handle memory is reclaimed at process exit.
+      Log.d(TAG, "register(): native resource cleanup not available below API 33");
+    }
+  }
+
+  /**
+   * Holder initialized on first access, which only occurs on API 33+. This prevents
+   * NoClassDefFoundError on earlier API levels.
+   */
+  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+  private static final class CleanerHolder {
+    static final Cleaner CLEANER = Cleaner.create();
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -50,8 +50,8 @@ public final class MatterCleaner {
   /**
    * Registers a cleanup action to run when {@code obj} becomes phantom-reachable.
    *
-   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as
-   * this would prevent the object from ever becoming phantom-reachable.
+   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as this
+   * would prevent the object from ever becoming phantom-reachable.
    *
    * @param obj the object whose reachability triggers the action
    * @param action the cleanup action; must not capture {@code obj}
@@ -82,8 +82,7 @@ public final class MatterCleaner {
    */
   static final class LegacyCleanerHolder {
     static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
-    static final Set<CleanupRef> LIVE_REFS =
-        Collections.newSetFromMap(new ConcurrentHashMap<>());
+    static final Set<CleanupRef> LIVE_REFS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     static final class CleanupRef extends PhantomReference<Object> {
       final Runnable action;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2024 Project CHIP Authors
+ *   Copyright (c) 2026 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java
@@ -18,9 +18,13 @@
 package com.matter.casting.support;
 
 import android.os.Build;
-import android.util.Log;
 import androidx.annotation.RequiresApi;
 import java.lang.ref.Cleaner;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages native resource cleanup for Matter Java objects that wrap native pointers.
@@ -30,12 +34,10 @@ import java.lang.ref.Cleaner;
  * freeing the associated native memory without requiring explicit {@code close()} calls from
  * callers.
  *
- * <p>On API 33 and above, delegates to {@link java.lang.ref.Cleaner}. Support for earlier API
- * levels via {@code PhantomReference} is not yet implemented.
+ * <p>On API 33 and above, delegates to {@link java.lang.ref.Cleaner}. On API 26–32, uses a {@link
+ * PhantomReference} and {@link ReferenceQueue} with a dedicated daemon thread.
  */
 public final class MatterCleaner {
-
-  private static final String TAG = MatterCleaner.class.getSimpleName();
 
   private static final MatterCleaner INSTANCE = new MatterCleaner();
 
@@ -48,8 +50,8 @@ public final class MatterCleaner {
   /**
    * Registers a cleanup action to run when {@code obj} becomes phantom-reachable.
    *
-   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as this
-   * would prevent the object from ever becoming phantom-reachable.
+   * <p>The {@code action} must not hold a reference to {@code obj}, directly or indirectly, as
+   * this would prevent the object from ever becoming phantom-reachable.
    *
    * @param obj the object whose reachability triggers the action
    * @param action the cleanup action; must not capture {@code obj}
@@ -58,9 +60,7 @@ public final class MatterCleaner {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       CleanerHolder.CLEANER.register(obj, action);
     } else {
-      // TODO: Implement PhantomReference-based cleanup for API < 33.
-      // On API 26-32, native handle memory is reclaimed at process exit.
-      Log.d(TAG, "register(): native resource cleanup not available below API 33");
+      LegacyCleanerHolder.LIVE_REFS.add(new LegacyCleanerHolder.CleanupRef(obj, action));
     }
   }
 
@@ -71,5 +71,48 @@ public final class MatterCleaner {
   @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   private static final class CleanerHolder {
     static final Cleaner CLEANER = Cleaner.create();
+  }
+
+  /**
+   * Holder initialized on first access, which only occurs on API 26–32.
+   *
+   * <p>A strong reference to each {@link CleanupRef} is kept in {@link #LIVE_REFS} until the
+   * referent is collected. Without this, the phantom reference itself could be collected before its
+   * referent and never enqueued.
+   */
+  static final class LegacyCleanerHolder {
+    static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+    static final Set<CleanupRef> LIVE_REFS =
+        Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    static final class CleanupRef extends PhantomReference<Object> {
+      final Runnable action;
+
+      CleanupRef(Object referent, Runnable action) {
+        super(referent, QUEUE);
+        this.action = action;
+      }
+    }
+
+    static {
+      Thread t =
+          new Thread(
+              () -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                  try {
+                    CleanupRef ref = (CleanupRef) QUEUE.remove();
+                    LIVE_REFS.remove(ref);
+                    ref.action.run();
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  } catch (Throwable ignored) {
+                    // Matches Cleaner convention: exceptions from cleanup actions are ignored.
+                  }
+                }
+              },
+              "MatterCleaner");
+      t.setDaemon(true);
+      t.start();
+    }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -282,10 +282,12 @@ JNI_METHOD(jstring, getConnectionStateNative)
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::getConnectionState()");
 
     memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
-    jstring result                              = nullptr;
-    LogErrorOnFailure(
-        JniReferences::GetInstance().CharToStringUTF("Cast Player is nullptr"_span, reinterpret_cast<jobject &>(result)));
-    VerifyOrReturnValue(castingPlayer != nullptr, result);
+    if (castingPlayer == nullptr)
+    {
+        ChipLogError(AppServer, "MatterCastingPlayer-JNI::getConnectionStateNative() castingPlayer == nullptr, returning NOT_CONNECTED");
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("NOT_CONNECTED"_span, jstr_obj));
+        return static_cast<jstring>(jstr_obj);
+    }
 
     matter::casting::core::ConnectionState state = castingPlayer->GetConnectionState();
     switch (state)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -292,7 +292,8 @@ JNI_METHOD(jstring, getConnectionStateNative)
     memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     if (castingPlayer == nullptr)
     {
-        ChipLogError(AppServer, "MatterCastingPlayer-JNI::getConnectionStateNative() castingPlayer == nullptr, returning NOT_CONNECTED");
+        ChipLogError(AppServer,
+                     "MatterCastingPlayer-JNI::getConnectionStateNative() castingPlayer == nullptr, returning NOT_CONNECTED");
         LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("NOT_CONNECTED"_span, jstr_obj));
         return static_cast<jstring>(jstr_obj);
     }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -50,7 +50,7 @@ JNI_METHOD(jobject, sendUDC)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() called");
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
 
     // Find the ConnectionCallbacks class, get the field IDs of the connection callbacks and extract the callback objects.
@@ -134,7 +134,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() called with a timeout of: %d seconds",
                     static_cast<int>(commissioningWindowTimeoutSec));
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
 
     // Find the ConnectionCallbacks class, get the field IDs of the connection callbacks and extract the callback objects.
@@ -222,7 +222,7 @@ JNI_METHOD(jobject, continueConnectingNative)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::continueConnecting()");
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
 
     return support::convertMatterErrorFromCppToJava(castingPlayer->ContinueConnecting());
@@ -234,7 +234,7 @@ JNI_METHOD(jobject, stopConnecting)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::stopConnecting()");
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
 
     return support::convertMatterErrorFromCppToJava(castingPlayer->StopConnecting());
@@ -246,7 +246,7 @@ JNI_METHOD(void, disconnect)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::disconnect()");
 
-    core::CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<core::CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturn(castingPlayer != nullptr,
                    ChipLogError(AppServer, "MatterCastingPlayer-JNI::disconnect() castingPlayer == nullptr"));
 
@@ -259,7 +259,7 @@ JNI_METHOD(void, removeFabric)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::removeFabric()");
 
-    core::CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<core::CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturn(castingPlayer != nullptr,
                    ChipLogError(AppServer, "MatterCastingPlayer-JNI::removeFabric() castingPlayer == nullptr"));
 
@@ -281,8 +281,8 @@ JNI_METHOD(jstring, getConnectionStateNative)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::getConnectionState()");
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
-    jstring result                = nullptr;
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    jstring result                              = nullptr;
     LogErrorOnFailure(
         JniReferences::GetInstance().CharToStringUTF("Cast Player is nullptr"_span, reinterpret_cast<jobject &>(result)));
     VerifyOrReturnValue(castingPlayer != nullptr, result);
@@ -313,7 +313,7 @@ JNI_METHOD(jobject, getEndpoints)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::getEndpoints() called");
 
-    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    memory::Strong<CastingPlayer> castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, nullptr,
                         ChipLogError(AppServer, "MatterCastingPlayer-JNI::getEndpoints() castingPlayer == nullptr"));
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -266,6 +266,14 @@ JNI_METHOD(void, removeFabric)
     castingPlayer->RemoveFabric();
 }
 
+JNI_METHOD(void, nativeReleaseCastingPlayer)
+(JNIEnv * env, jclass clazz, jlong ptr)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::nativeReleaseCastingPlayer()");
+    delete reinterpret_cast<support::CastingPlayerHandle *>(ptr);
+}
+
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -277,7 +277,6 @@ JNI_METHOD(void, nativeReleaseCastingPlayer)
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {
-    char error_str[50];
     jobject jstr_obj = nullptr;
 
     if (NULL == env)
@@ -311,8 +310,9 @@ JNI_METHOD(jstring, getConnectionStateNative)
         LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("CONNECTED"_span, jstr_obj));
         break;
     default:
-        snprintf(error_str, sizeof(error_str), "Unsupported Connection State: %d", state);
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(error_str), jstr_obj));
+        ChipLogError(AppServer, "MatterCastingPlayer-JNI::getConnectionStateNative() unexpected state: %d, returning NOT_CONNECTED",
+                     state);
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF("NOT_CONNECTED"_span, jstr_obj));
         break;
     }
     return static_cast<jstring>(jstr_obj);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -269,7 +269,6 @@ JNI_METHOD(void, removeFabric)
 JNI_METHOD(void, nativeReleaseCastingPlayer)
 (JNIEnv * env, jclass clazz, jlong ptr)
 {
-    chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::nativeReleaseCastingPlayer()");
     delete reinterpret_cast<support::CastingPlayerHandle *>(ptr);
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -231,11 +231,11 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
         env->ExceptionClear();
         return jMatterCastingPlayer;
     }
-    
-    jmethodID setNativeCastingPlayerId =
-        env->GetMethodID(matterCastingPlayerJavaClass, "setNativeCastingPlayer", "(J)V");
-    VerifyOrReturnValue(setNativeCastingPlayerId != nullptr, nullptr,
-                        ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not get setNativeCastingPlayer method ID"));
+
+    jmethodID setNativeCastingPlayerId = env->GetMethodID(matterCastingPlayerJavaClass, "setNativeCastingPlayer", "(J)V");
+    VerifyOrReturnValue(
+        setNativeCastingPlayerId != nullptr, nullptr,
+        ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not get setNativeCastingPlayer method ID"));
 
     // Store a heap-allocated handle containing a weak_ptr so the Java long field never
     // holds a dangling raw pointer if the C++ CastingPlayer is destroyed.

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -231,11 +231,18 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
         env->ExceptionClear();
         return jMatterCastingPlayer;
     }
+    
+    jmethodID setNativeCastingPlayerId =
+        env->GetMethodID(matterCastingPlayerJavaClass, "setNativeCastingPlayer", "(J)V");
+    VerifyOrReturnValue(setNativeCastingPlayerId != nullptr, nullptr,
+                        ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not get setNativeCastingPlayer method ID"));
+
     // Store a heap-allocated handle containing a weak_ptr so the Java long field never
     // holds a dangling raw pointer if the C++ CastingPlayer is destroyed.
-    auto * handle = new CastingPlayerHandle{ player };
-    jfieldID longFieldId = env->GetFieldID(matterCastingPlayerJavaClass, "_cppCastingPlayer", "J");
-    env->SetLongField(jMatterCastingPlayer, longFieldId, reinterpret_cast<jlong>(handle));
+    auto handle = std::unique_ptr<CastingPlayerHandle>(new CastingPlayerHandle{ player });
+    env->CallVoidMethod(jMatterCastingPlayer, setNativeCastingPlayerId, reinterpret_cast<jlong>(handle.get()));
+    handle.release();
+
     return jMatterCastingPlayer;
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -241,6 +241,12 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
     // holds a dangling raw pointer if the C++ CastingPlayer is destroyed.
     auto handle = std::unique_ptr<CastingPlayerHandle>(new CastingPlayerHandle{ player });
     env->CallVoidMethod(jMatterCastingPlayer, setNativeCastingPlayerId, reinterpret_cast<jlong>(handle.get()));
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() setNativeCastingPlayer threw");
+        env->ExceptionClear();
+        return jMatterCastingPlayer; // unique_ptr destructor frees the handle
+    }
     handle.release();
 
     return jMatterCastingPlayer;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -231,13 +231,15 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
         env->ExceptionClear();
         return jMatterCastingPlayer;
     }
-    // Set the value of the _cppCastingPlayer field in the Java object to the C++ CastingPlayer pointer.
+    // Store a heap-allocated handle containing a weak_ptr so the Java long field never
+    // holds a dangling raw pointer if the C++ CastingPlayer is destroyed.
+    auto * handle = new CastingPlayerHandle{ player };
     jfieldID longFieldId = env->GetFieldID(matterCastingPlayerJavaClass, "_cppCastingPlayer", "J");
-    env->SetLongField(jMatterCastingPlayer, longFieldId, reinterpret_cast<jlong>(player.get()));
+    env->SetLongField(jMatterCastingPlayer, longFieldId, reinterpret_cast<jlong>(handle));
     return jMatterCastingPlayer;
 }
 
-core::CastingPlayer * convertCastingPlayerFromJavaToCpp(jobject jCastingPlayerObject)
+matter::casting::memory::Strong<core::CastingPlayer> convertCastingPlayerFromJavaToCpp(jobject jCastingPlayerObject)
 {
     ChipLogProgress(AppServer, "convertCastingPlayerFromJavaToCpp() called");
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
@@ -254,8 +256,13 @@ core::CastingPlayer * convertCastingPlayerFromJavaToCpp(jobject jCastingPlayerOb
     jfieldID _cppCastingPlayerFieldId = env->GetFieldID(castingPlayerClass, "_cppCastingPlayer", "J");
     VerifyOrReturnValue(_cppCastingPlayerFieldId != nullptr, nullptr,
                         ChipLogError(AppServer, "convertCastingPlayerFromJavaToCpp _cppCastingPlayerFieldId == nullptr"));
-    jlong _cppCastingPlayerValue = env->GetLongField(jCastingPlayerObject, _cppCastingPlayerFieldId);
-    return reinterpret_cast<core::CastingPlayer *>(_cppCastingPlayerValue);
+    auto * handle = reinterpret_cast<CastingPlayerHandle *>(env->GetLongField(jCastingPlayerObject, _cppCastingPlayerFieldId));
+    VerifyOrReturnValue(handle != nullptr, nullptr,
+                        ChipLogError(AppServer, "convertCastingPlayerFromJavaToCpp() handle == nullptr"));
+    auto player = handle->player.lock();
+    VerifyOrReturnValue(player != nullptr, nullptr,
+                        ChipLogError(AppServer, "convertCastingPlayerFromJavaToCpp() CastingPlayer no longer exists"));
+    return player;
 }
 
 jobject convertClusterFromCppToJava(matter::casting::memory::Strong<core::BaseCluster> cluster, const char * className)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -239,6 +239,10 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Store a heap-allocated handle containing a weak_ptr so the Java long field never
     // holds a dangling raw pointer if the C++ CastingPlayer is destroyed.
+    // Note: Each call allocates a new CastingPlayerHandle. During discovery, repeated callbacks
+    // for the same player create short-lived wrappers collected by GC after stopDiscovery().
+    // A CastingPlayer* -> Java GlobalRef cache would avoid this but requires explicit
+    // eviction on player removal; not warranted at home-network scale.
     auto handle = std::unique_ptr<CastingPlayerHandle>(new CastingPlayerHandle{ player });
     env->CallVoidMethod(jMatterCastingPlayer, setNativeCastingPlayerId, reinterpret_cast<jlong>(handle.get()));
     if (env->ExceptionCheck())

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.h
@@ -32,6 +32,11 @@ namespace matter {
 namespace casting {
 namespace support {
 
+struct CastingPlayerHandle
+{
+    matter::casting::memory::Weak<core::CastingPlayer> player;
+};
+
 jobject convertLongFromCppToJava(jlong value);
 
 jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr);
@@ -55,7 +60,7 @@ core::Endpoint * convertEndpointFromJavaToCpp(jobject jEndpointObject);
  */
 jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::CastingPlayer> player);
 
-core::CastingPlayer * convertCastingPlayerFromJavaToCpp(jobject jCastingPlayerObject);
+matter::casting::memory::Strong<core::CastingPlayer> convertCastingPlayerFromJavaToCpp(jobject jCastingPlayerObject);
 
 /**
  * @brief Converts a native Cluster into a MatterCluster jobject

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
@@ -91,7 +91,7 @@ public class MatterCastingPlayerGetConnectionStateTest {
 
   // ---------------------------------------------------------------------------
   // Invalid states — native returns a string that is not a valid enum constant.
-  // All of these caused a fatal IllegalArgumentException before the fix.
+  // getConnectionState() must not throw exception but return NOT_CONNECTED
   // ---------------------------------------------------------------------------
 
   @Test
@@ -120,7 +120,7 @@ public class MatterCastingPlayerGetConnectionStateTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Null — native returns null, causing NullPointerException in valueOf(null).
+  // Null — native returns null, getConnectionState() must not throw exception but return NOT_CONNECTED
   // ---------------------------------------------------------------------------
 
   @Test

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
@@ -120,7 +120,8 @@ public class MatterCastingPlayerGetConnectionStateTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Null — native returns null, getConnectionState() must not throw exception but return NOT_CONNECTED
+  // Null — native returns null, getConnectionState() must not throw exception but return
+  // NOT_CONNECTED
   // ---------------------------------------------------------------------------
 
   @Test
@@ -144,9 +145,9 @@ public class MatterCastingPlayerGetConnectionStateTest {
       "GARBAGE",
       "0",
       "-1",
-      "not_connected",       // wrong case
-      " NOT_CONNECTED ",     // extra whitespace
-      "NOT_CONNECTED\n",     // trailing newline
+      "not_connected", // wrong case
+      " NOT_CONNECTED ", // extra whitespace
+      "NOT_CONNECTED\n", // trailing newline
     };
 
     for (String input : inputs) {

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/MatterCastingPlayerGetConnectionStateTest.java
@@ -1,0 +1,166 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.matter.casting.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Unit tests for {@link MatterCastingPlayer#getConnectionState()}.
+ *
+ * <p>Verifies that getConnectionState() always returns a valid {@link
+ * CastingPlayer.ConnectionState} and never throws, including when the native layer returns an
+ * invalid or null string.
+ *
+ * <p>Robolectric is used to stub Android APIs (e.g. {@code android.util.Log}) without requiring a
+ * device.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MatterCastingPlayerGetConnectionStateTest {
+
+  /**
+   * Test subclass that overrides {@code getConnectionStateNative()} to return a controlled string
+   * without loading the native library.
+   */
+  private static class FakeMatterCastingPlayer extends MatterCastingPlayer {
+
+    private final String nativeStateString;
+
+    FakeMatterCastingPlayer(String nativeStateString) {
+      super(
+          /* connected= */ false,
+          /* deviceId= */ "test-device-id",
+          /* hostName= */ "test-host",
+          /* deviceName= */ "test-device",
+          /* instanceName= */ "test-instance",
+          /* ipAddresses= */ null,
+          /* port= */ 0,
+          /* productId= */ 0,
+          /* vendorId= */ 0,
+          /* deviceType= */ 0L,
+          /* supportsCommissionerGeneratedPasscode= */ false);
+      this.nativeStateString = nativeStateString;
+    }
+
+    @Override
+    public String getConnectionStateNative() {
+      return nativeStateString;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Valid states — native returns a well-formed string
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void getConnectionState_whenNativeReturnsNotConnected_returnsNotConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("NOT_CONNECTED");
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  @Test
+  public void getConnectionState_whenNativeReturnsConnecting_returnsConnecting() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("CONNECTING");
+    assertEquals(CastingPlayer.ConnectionState.CONNECTING, player.getConnectionState());
+  }
+
+  @Test
+  public void getConnectionState_whenNativeReturnsConnected_returnsConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("CONNECTED");
+    assertEquals(CastingPlayer.ConnectionState.CONNECTED, player.getConnectionState());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Invalid states — native returns a string that is not a valid enum constant.
+  // All of these caused a fatal IllegalArgumentException before the fix.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void getConnectionState_whenNativeReturnsNullptrErrorString_returnsNotConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("Cast Player is nullptr");
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  @Test
+  public void getConnectionState_whenNativeReturnsUnsupportedStateString_returnsNotConnected() {
+    FakeMatterCastingPlayer player =
+        new FakeMatterCastingPlayer("Unsupported Connection State: 99");
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  @Test
+  public void getConnectionState_whenNativeReturnsArbitraryString_returnsNotConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("GARBAGE");
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  @Test
+  public void getConnectionState_whenNativeReturnsEmptyString_returnsNotConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer("");
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Null — native returns null, causing NullPointerException in valueOf(null).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void getConnectionState_whenNativeReturnsNull_returnsNotConnected() {
+    FakeMatterCastingPlayer player = new FakeMatterCastingPlayer(null);
+    assertEquals(CastingPlayer.ConnectionState.NOT_CONNECTED, player.getConnectionState());
+  }
+
+  // ---------------------------------------------------------------------------
+  // No-throw guarantee — getConnectionState() must never propagate an exception
+  // regardless of what the native layer returns.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void getConnectionState_neverThrowsForAnyNativeString() {
+    String[] inputs = {
+      null,
+      "",
+      "Cast Player is nullptr",
+      "Unsupported Connection State: 99",
+      "GARBAGE",
+      "0",
+      "-1",
+      "not_connected",       // wrong case
+      " NOT_CONNECTED ",     // extra whitespace
+      "NOT_CONNECTED\n",     // trailing newline
+    };
+
+    for (String input : inputs) {
+      FakeMatterCastingPlayer player = new FakeMatterCastingPlayer(input);
+      try {
+        CastingPlayer.ConnectionState state = player.getConnectionState();
+        assertNotNull("getConnectionState() must not return null for input: " + input, state);
+        assertEquals(
+            "getConnectionState() must return NOT_CONNECTED for invalid input: " + input,
+            CastingPlayer.ConnectionState.NOT_CONNECTED,
+            state);
+      } catch (Exception e) {
+        fail("getConnectionState() must not throw for input: " + input + ", but threw: " + e);
+      }
+    }
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Unit tests for {@link MatterCleaner}.
+ *
+ * <p>The legacy path (API 26–32) is tested by manually enqueuing phantom references via {@link
+ * java.lang.ref.PhantomReference#enqueue()}, simulating GC-driven cleanup without relying on the
+ * garbage collector.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class MatterCleanerTest {
+
+  @Before
+  public void setUp() {
+    MatterCleaner.LegacyCleanerHolder.LIVE_REFS.clear();
+  }
+
+  @Test
+  public void register_addsToLiveRefs() {
+    MatterCleaner.getInstance().register(new Object(), () -> {});
+    assertEquals(1, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
+  }
+
+  @Test
+  public void register_actionCalledWhenRefEnqueued() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    MatterCleaner.getInstance().register(new Object(), latch::countDown);
+
+    enqueueFirst();
+
+    assertTrue("action was not called within timeout", latch.await(2, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void register_liveRefsEmptiedAfterCleanup() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    MatterCleaner.getInstance().register(new Object(), latch::countDown);
+    assertEquals(1, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
+
+    enqueueFirst();
+
+    assertTrue("action was not called within timeout", latch.await(2, TimeUnit.SECONDS));
+    assertEquals(0, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
+  }
+
+  @Test
+  public void register_cleanupThreadSurvivesThrowingAction() throws Exception {
+    CountDownLatch firstProcessed = new CountDownLatch(1);
+    MatterCleaner.getInstance()
+        .register(
+            new Object(),
+            () -> {
+              firstProcessed.countDown();
+              throw new RuntimeException("test exception");
+            });
+    enqueueFirst();
+    assertTrue("first action was not processed within timeout", firstProcessed.await(2, TimeUnit.SECONDS));
+
+    // Thread must still be alive — a second action should fire normally.
+    CountDownLatch secondProcessed = new CountDownLatch(1);
+    MatterCleaner.getInstance().register(new Object(), secondProcessed::countDown);
+    enqueueFirst();
+    assertTrue("second action was not called within timeout", secondProcessed.await(2, TimeUnit.SECONDS));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static void enqueueFirst() {
+    MatterCleaner.LegacyCleanerHolder.LIVE_REFS.iterator().next().enqueue();
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
@@ -83,13 +83,15 @@ public class MatterCleanerTest {
               throw new RuntimeException("test exception");
             });
     enqueueFirst();
-    assertTrue("first action was not processed within timeout", firstProcessed.await(2, TimeUnit.SECONDS));
+    assertTrue(
+        "first action was not processed within timeout", firstProcessed.await(2, TimeUnit.SECONDS));
 
     // Thread must still be alive — a second action should fire normally.
     CountDownLatch secondProcessed = new CountDownLatch(1);
     MatterCleaner.getInstance().register(new Object(), secondProcessed::countDown);
     enqueueFirst();
-    assertTrue("second action was not called within timeout", secondProcessed.await(2, TimeUnit.SECONDS));
+    assertTrue(
+        "second action was not called within timeout", secondProcessed.await(2, TimeUnit.SECONDS));
   }
 
   // ---------------------------------------------------------------------------

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/support/MatterCleanerTest.java
@@ -46,16 +46,20 @@ public class MatterCleanerTest {
 
   @Test
   public void register_addsToLiveRefs() {
-    MatterCleaner.getInstance().register(new Object(), () -> {});
+    Object obj = new Object();
+    MatterCleaner.getInstance().register(obj, () -> {});
     assertEquals(1, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
+    assertNotNull(obj);
   }
 
   @Test
   public void register_actionCalledWhenRefEnqueued() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
-    MatterCleaner.getInstance().register(new Object(), latch::countDown);
+    Object obj = new Object();
+    MatterCleaner.getInstance().register(obj, latch::countDown);
 
     enqueueFirst();
+    assertNotNull(obj);
 
     assertTrue("action was not called within timeout", latch.await(2, TimeUnit.SECONDS));
   }
@@ -63,10 +67,12 @@ public class MatterCleanerTest {
   @Test
   public void register_liveRefsEmptiedAfterCleanup() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
-    MatterCleaner.getInstance().register(new Object(), latch::countDown);
+    Object obj = new Object();
+    MatterCleaner.getInstance().register(obj, latch::countDown);
     assertEquals(1, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
 
     enqueueFirst();
+    assertNotNull(obj);
 
     assertTrue("action was not called within timeout", latch.await(2, TimeUnit.SECONDS));
     assertEquals(0, MatterCleaner.LegacyCleanerHolder.LIVE_REFS.size());
@@ -75,21 +81,25 @@ public class MatterCleanerTest {
   @Test
   public void register_cleanupThreadSurvivesThrowingAction() throws Exception {
     CountDownLatch firstProcessed = new CountDownLatch(1);
+    Object obj1 = new Object();
     MatterCleaner.getInstance()
         .register(
-            new Object(),
+            obj1,
             () -> {
               firstProcessed.countDown();
               throw new RuntimeException("test exception");
             });
     enqueueFirst();
+    assertNotNull(obj1);
     assertTrue(
         "first action was not processed within timeout", firstProcessed.await(2, TimeUnit.SECONDS));
 
     // Thread must still be alive — a second action should fire normally.
     CountDownLatch secondProcessed = new CountDownLatch(1);
-    MatterCleaner.getInstance().register(new Object(), secondProcessed::countDown);
+    Object obj2 = new Object();
+    MatterCleaner.getInstance().register(obj2, secondProcessed::countDown);
     enqueueFirst();
+    assertNotNull(obj2);
     assertTrue(
         "second action was not called within timeout", secondProcessed.await(2, TimeUnit.SECONDS));
   }

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -133,6 +133,7 @@ android_library("java") {
     "App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java",
     "App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java",
     "App/app/src/main/jni/com/matter/casting/support/MatterCallback.java",
+    "App/app/src/main/jni/com/matter/casting/support/MatterCleaner.java",
     "App/app/src/main/jni/com/matter/casting/support/MatterError.java",
     "App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java",
   ]


### PR DESCRIPTION
### Summary

This PR fixes two crashes in the Android tv-casting JNI layer that occur when a MatterCastingPlayer Java object is used after its underlying C++ CastingPlayer instance has been destroyed.

#### Root cause

While discovery is running, mCastingPlayers holds Strong<CastingPlayer> references keeping all discovered C++ objects alive. When stopDiscovery() is called, mCastingPlayers is cleared and references are moved to mCastingPlayersInternal. From this point the C++ objects are kept alive only by mCastingPlayersInternal. When VerifyOrEstablishConnection() is subsequently called on one player, ClearDisconnectedCastingPlayersInternal() removes all NOT_CONNECTED players from mCastingPlayersInternal, destroying their C++ objects. Any other discovered player that was not being commissioned is silently destroyed at this point.

The JNI layer stored a raw CastingPlayer* in the MatterCastingPlayer._cppCastingPlayer Java long field — a raw pointer to an object whose lifecycle is owned by a different layer. With the C++ object destroyed, subsequent JNI calls on those players dereference the now-dangling pointer. With fix 1 in place, convertCastingPlayerFromJavaToCpp() returns nullptr safely rather than crashing, but getConnectionStateNative() then returns the diagnostic string "Cast Player is nullptr" instead of a valid connection state name, causing ConnectionState.valueOf() to throw IllegalArgumentException.

#### Fix 1 — Native crash (use-after-free)

Replace the raw pointer stored in _cppCastingPlayer with a heap-allocated CastingPlayerHandle containing a Weak<CastingPlayer>. convertCastingPlayerFromJavaToCpp() locks the weak pointer on each call, returning nullptr safely if the C++ object has been destroyed, instead of dereferencing a dangling pointer.

#### Fix 2 — Java crash (IllegalArgumentException)

Return "NOT_CONNECTED" from getConnectionStateNative() when the casting player is gone. Add a defensive try-catch in getConnectionState() as a safeguard against any unexpected native string.

### Related issues

N/A

### Testing

#### Repro steps using the sample app (DiscoveryExampleFragment)

Note: To reproduce with the sample app, comment out the stopDiscovery() call in onPause() and the startDiscovery() call in onResume() in DiscoveryExampleFragment.

Prerequisites: two Matter-supported FireTV devices on the network.

1. Launch the sample app and tap Start Discovery — both FireTVs appear in the list
2. Tap Stop Discovery
3. Long-press FireTV 1 and complete commissioning, then disconnect
4. Long-press FireTV 2 — without the fix, the app crashes with a native use-after-free or IllegalArgumentException

Full native crash log: https://drive.google.com/file/d/1g-sw1LUfTOLAOpXPG7XOVOSijdzYDYBO/view?usp=share_link
Full IllegalArgumentException log: https://drive.google.com/file/d/1XvvA5PvU5VnYjeBgLGLE7siOXd9deInw/view?usp=sharing

Why stopping discovery before commissioning is a valid scenario:
Apps stopping discovery on WiFi loss and then establishing a connection with more than one previously discovered device will encounter this bug. The crash is a consequence of the JNI layer holding a raw pointer to an object whose lifecycle it does not own.

#### Automated tests

Added MatterCastingPlayerGetConnectionStateTest — local JVM unit tests verifying that getConnectionState() never throws and always returns a valid ConnectionState regardless of what the native layer returns, including null and invalid strings.

#### Manual verification

Executed the repro steps above on two FireTV devices. Both crashes are resolved. getConnectionState() returns NOT_CONNECTED when called on a stale player.