### PR TITLE
[BooleanStateCluster] Make FeatureMap configurable

### DIFF
--- a/src/app/clusters/boolean-state-server/BooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/BooleanStateCluster.cpp
@@ -38,7 +38,7 @@ DataModel::ActionReturnStatus BooleanStateCluster::ReadAttribute(const DataModel
     case ClusterRevision::Id:
         return encoder.Encode(BooleanState::kRevision);
     case FeatureMap::Id:
-        return encoder.Encode(BooleanState::Feature::kChangeEvent);
+        return encoder.Encode(mFeatureMap);
     default:
         return Protocols::InteractionModel::Status::UnsupportedAttribute;
     }
@@ -54,6 +54,7 @@ CHIP_ERROR BooleanStateCluster::Attributes(const ConcreteClusterPath & path,
 std::optional<EventNumber> BooleanStateCluster::SetStateValue(bool stateValue)
 {
     VerifyOrReturnValue(SetAttributeValue(mStateValue, stateValue, StateValue::Id), std::nullopt);
+    VerifyOrReturnValue(mFeatureMap.Has(BooleanState::Feature::kChangeEvent), std::nullopt);
     VerifyOrReturnValue(mContext != nullptr, std::nullopt);
     BooleanState::Events::StateChange::Type event{ stateValue };
     return mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);

--- a/src/app/clusters/boolean-state-server/BooleanStateCluster.h
+++ b/src/app/clusters/boolean-state-server/BooleanStateCluster.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <clusters/BooleanState/Enums.h>
 #include <platform/DeviceInfoProvider.h>
 
 namespace chip::app::Clusters {
@@ -31,8 +32,11 @@ public:
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
+    void SetFeatureMap(BitFlags<BooleanState::Feature> featureMap) { mFeatureMap = featureMap; }
+    BitFlags<BooleanState::Feature> GetFeatureMap() const { return mFeatureMap; }
+
     // Set a boolean value.
-    // If the boolean value was actually modified, an event will be generated.
+    // If the boolean value was actually modified and the CHGEVENT feature is enabled, an event will be generated.
     // On success, the return value is an optional containing the EventNumber of the event that was generated.
     // On error, the return value is nullopt.
     std::optional<EventNumber> SetStateValue(bool stateValue);
@@ -40,6 +44,7 @@ public:
     bool GetStateValue() const { return mStateValue; }
 
 protected:
+    BitFlags<BooleanState::Feature> mFeatureMap = BooleanState::Feature::kChangeEvent;
     bool mStateValue;
 };
 


### PR DESCRIPTION
### Summary

Allow applications to override the BooleanState feature map instead of always reporting kChangeEvent.
Add SetFeatureMap()/GetFeatureMap() and encode the stored value in ReadAttribute. Gate StateChange event generation on the kChangeEvent feature bit.

Default behavior is unchanged.

### Testing

Using existing tests, and locally using chiptool
