### PR TITLE
[docker] Do not re-push an image the registry already serves

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -75,6 +75,13 @@ die() {
     exit 1
 }
 
+# Digest the registry currently serves for a tag, empty if it serves none.
+# Always succeeds: an unknown tag is an answer, not an error, and the callers
+# run under set -e where a non-zero status would abort the script.
+remote_digest() {
+    docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$1" 2>/dev/null || true
+}
+
 set -ex
 
 [[ -n $VERSION ]] || die "version cannot be empty"
@@ -220,9 +227,37 @@ if [ "$SQUASH" = true ]; then
 fi
 
 if [ "$PUSH" = true ]; then
-    docker push "$GHCR_ORG"/"$ORG"/"$IMAGE":"$VERSION"
+    IMAGE_REF="$GHCR_ORG/$ORG/$IMAGE"
+
+    # Only push what the registry does not already serve.
+    #
+    # Ask the registry rather than inferring it from the build being skipped. A
+    # runner with a persistent image cache can hold an image from an earlier run
+    # whose push failed, so "we did not build it" does not mean "it is
+    # published", and treating the two as equivalent would stop publishing
+    # silently while the job stayed green.
+    #
+    # An unknown tag, or no buildx, leaves the digest empty and the push goes
+    # ahead, so a failure to answer errs towards publishing.
+    VERSION_DIGEST=""
+    if [ "$BUILT" = false ]; then
+        VERSION_DIGEST=$(remote_digest "$IMAGE_REF:$VERSION")
+    fi
+
+    if [ -n "$VERSION_DIGEST" ]; then
+        echo "$me: $IMAGE_REF:$VERSION already published, not pushing"
+    else
+        docker push "$IMAGE_REF:$VERSION"
+    fi
+
     if [ "$LATEST" = true ]; then
-        docker push "$GHCR_ORG"/"$ORG"/"$IMAGE":latest
+        # latest moves, so compare digests rather than just existence: the
+        # version tag can be published while latest still points at an older one.
+        if [ -n "$VERSION_DIGEST" ] && [ "$(remote_digest "$IMAGE_REF:latest")" = "$VERSION_DIGEST" ]; then
+            echo "$me: $IMAGE_REF:latest already points at $VERSION, not pushing"
+        else
+            docker push "$IMAGE_REF:latest"
+        fi
     fi
 fi
 

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -244,7 +244,7 @@ if [ "$PUSH" = true ]; then
         VERSION_DIGEST=$(remote_digest "$IMAGE_REF:$VERSION")
     fi
 
-    if [ -n "$VERSION_DIGEST" ]; then
+    if [ "$VERSION_DIGEST" != "" ]; then
         echo "$me: $IMAGE_REF:$VERSION already published, not pushing"
     else
         docker push "$IMAGE_REF:$VERSION"
@@ -253,7 +253,7 @@ if [ "$PUSH" = true ]; then
     if [ "$LATEST" = true ]; then
         # latest moves, so compare digests rather than just existence: the
         # version tag can be published while latest still points at an older one.
-        if [ -n "$VERSION_DIGEST" ] && [ "$(remote_digest "$IMAGE_REF:latest")" = "$VERSION_DIGEST" ]; then
+        if [ "$VERSION_DIGEST" != "" ] && [ "$(remote_digest "$IMAGE_REF:latest")" = "$VERSION_DIGEST" ]; then
             echo "$me: $IMAGE_REF:latest already points at $VERSION, not pushing"
         else
             docker push "$IMAGE_REF:latest"


### PR DESCRIPTION
#### Summary

##### Problem

The publish step pushes the version tag on every run, including runs that built
nothing because the image already existed.

-   #73537 made an image that already exists at its version skip the build, and
    set a `BUILT` flag, but the flag is never read and the push stayed
    unconditional.
-   On a runner whose image cache persists, that means every merge touching
    `integrations/docker/**` re-pushes an unchanged image, uploading nothing.

The obvious gate, "push only what we built", is wrong and would be worse than
leaving it alone:

```
run 1   version bumped   build succeeds   push fails       -> red, correct
run 2   image still in the runner cache   build skipped
        push skipped because nothing was built             -> GREEN, and the
                                                              version never
                                                              publishes
```

That converts a loud failure into a silent one.

There is also a second, sharper consequence, now observed on master rather than
hypothesised. A runner's local image cache is not necessarily what the registry
holds, so re-pushing a version tag can overwrite a published image with a
different one:

```
chip-build:208 before   sha256:235f02a4...   built 2026-08-05, by hand
chip-build:208 after    sha256:a4336a4d...   built 2026-08-12, in CI
```

Both are linux/amd64 with 8 layers, so nothing was lost, but `208` no longer
identifies the image it identified this morning. The push that did it reported
`already present, not rebuilding` first: the job pushed a cached image it had
not built and had not pulled. Runners still holding the old `208` and anything
pulling now disagree about what that version is.

##### Solution

-   Decide from the registry, not from whether a build happened.
-   `latest` is compared by digest rather than existence, since the version tag
    can be published while `latest` still points at an older one.
-   An unknown tag, or no `buildx`, leaves the answer empty and the push goes
    ahead, so failing to reach the registry errs towards publishing rather than
    towards silence.

##### Caveats

-   Adds up to two registry metadata lookups per image on runs that build
    nothing. They are manifest reads, not layer transfers.
-   Independent of the `permission_denied: write_package` failures, which were a
    per-package GHCR access-list problem and have now been resolved for
    `chip-build`.


#### Testing

Drove the four registry states against a fake `docker` on `PATH`:

| state | version push | latest push |
|---|---|---|
| version published, `latest` same digest | skipped | skipped |
| version published, `latest` points elsewhere | skipped | pushed |
| version not published | pushed | pushed |
| built this run | pushed | pushed |
| `buildx` unavailable | pushed | pushed |

The same cases run against `master` fail exactly the first two and pass the
rest, so the behaviour is unchanged wherever there is genuinely something to
publish.


