### PR TITLE
[docker] Read the digest from imagetools output instead of --format

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -79,7 +79,12 @@ die() {
 # Always succeeds: an unknown tag is an answer, not an error, and the callers
 # run under set -e where a non-zero status would abort the script.
 remote_digest() {
-    docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$1" 2>/dev/null || true
+    # Parse the Digest line rather than asking for it with --format: older
+    # buildx ignores the flag and prints the whole human readable record, which
+    # still compares as non-empty and so silently defeats any comparison
+    # between two of these. The unformatted output has carried a "Digest:" line
+    # across versions.
+    docker buildx imagetools inspect "$1" 2>/dev/null | awk '$1 == "Digest:" { print $2; exit }'
 }
 
 set -ex


### PR DESCRIPTION
#### Summary

##### Problem

`remote_digest`, added in #73575, asks for the digest with
`--format '{{.Manifest.Digest}}'`. The buildx present on the CI runners ignores
the flag and prints the whole human readable record instead, so the variable
holds this rather than a digest:

```
Name:      ghcr.io/project-chip/chip-build:208
MediaType: application/vnd.oci.image.manifest.v1+json
Digest:    sha256:a4336a4d...
```

-   Skipping the **version** tag still works, since the test is only for
    non-empty, and that is the case that matters: it is what stops a published
    version being overwritten.
-   Comparing two of these records never matches, because each names its own
    tag, so **latest is pushed on every run** even when it already points at the
    version being published.

Observed on master in run 31824905889, where the version push was correctly
skipped and `latest` was pushed immediately afterwards to the digest it already
had.

##### Solution

-   Read the `Digest:` line from the unformatted output, which has carried
    across buildx versions, so the comparison works whatever is installed.

#### Testing

Same five registry states as #73575, driven against a fake `docker`. The fake
previously returned a bare digest, which is what hid this; it now emits the full
record as real buildx does. With that correction the `master` code fails
`already-published-latest-same` (pushes `latest` when it should not) and passes
with this change, 5/5.
