### PR TITLE
[ICD] Defer ActiveMode and Check-In when Thread network is not attached

### DIFF
--- a/src/app/icd/icd.gni
+++ b/src/app/icd/icd.gni
@@ -28,6 +28,9 @@ declare_args() {
 
   # Set to true if device supports dynamic switching from SIT to LIT operating modes (DSLS)
   chip_enable_icd_dsls = false
+
+  # Enable the ICD server to defer ActiveMode and Check-In when Thread network is not attached
+  chip_enable_icd_defer_activemode_thread_attach = true
 }
 
 # Set the defaults for CIP and UAT features to be consistent with the LIT value.

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -44,6 +44,7 @@ buildconfig_header("icd-server-buildconfig") {
     "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_icd_report_on_active_mode}",
     "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
     "CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT=${chip_enable_icd_checkin_on_report_timeout}",
+    "CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH=${chip_enable_icd_defer_activemode_thread_attach}",
   ]
 
   visibility = [ ":icd-server-config" ]

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -735,7 +735,7 @@ bool ICDManager::Contains(Span<const Access::SubjectDescriptor> list, const Acce
     for (const auto & item : list)
     {
         if (item.fabricIndex == value.fabricIndex && item.authMode == value.authMode && item.subject == value.subject &&
-            item.cats.values == value.cats.values && item.isCommissioning == value.isCommissioning)
+            item.cats == value.cats && item.isCommissioning == value.isCommissioning)
         {
             return true;
         }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -108,7 +108,11 @@ void ICDManager::Shutdown()
     ICDConfigurationData::GetInstance().SetICDMode(ICDConfigurationData::ICDMode::SIT);
     mOperationalState = OperationalState::ActiveMode;
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
-    mPendingCheckInOnNetworkAttach = false;
+    mPendingActiveModeOnNetworkAttach = false;
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    mPendingCheckInOnNetworkAttach    = false;
+    mPendingCheckInSubject.ClearValue();
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mStateObserverPool.ReleaseAll();
 
@@ -554,7 +558,7 @@ void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
     {
         ChipLogProgress(AppServer,
                         "ICDManager: Thread network not attached on periodic idle wake-up. Deferring ActiveMode until attached.");
-        pICDManager->mPendingCheckInOnNetworkAttach = true;
+        pICDManager->mPendingActiveModeOnNetworkAttach = true;
         return;
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -686,7 +690,7 @@ void ICDManager::OnNetworkActivity()
     {
         ChipLogProgress(AppServer,
                         "ICDManager: Thread network not attached on network activity. Deferring ActiveMode until attached.");
-        mPendingCheckInOnNetworkAttach = true;
+        mPendingActiveModeOnNetworkAttach = true;
         return;
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -716,7 +720,7 @@ void ICDManager::OnSubscriptionReport()
     {
         ChipLogProgress(AppServer,
                         "ICDManager: Thread network not attached on subscription report. Deferring ActiveMode until attached.");
-        mPendingCheckInOnNetworkAttach = true;
+        mPendingActiveModeOnNetworkAttach = true;
         return;
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -731,6 +735,7 @@ void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubje
     {
         ChipLogProgress(AppServer, "ICDManager: Thread network not attached on send check-in. Deferring until attached.");
         mPendingCheckInOnNetworkAttach = true;
+        mPendingCheckInSubject         = specificSubject;
         return;
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -774,22 +779,36 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 
     if (threadEstablished)
     {
-        if (mPendingCheckInOnNetworkAttach || mOperationalState == OperationalState::ActiveMode)
+        bool wasPendingActiveMode         = mPendingActiveModeOnNetworkAttach;
+        mPendingActiveModeOnNetworkAttach = false;
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+        bool wasPendingCheckIn                             = mPendingCheckInOnNetworkAttach;
+        Optional<Access::SubjectDescriptor> pendingSubject = mPendingCheckInSubject;
+        mPendingCheckInOnNetworkAttach                     = false;
+        mPendingCheckInSubject.ClearValue();
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+
+        if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
         {
             ChipLogProgress(AppServer,
-                            "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
-#if CHIP_CONFIG_ENABLE_ICD_CIP
-            bool wasPendingCheckIn = mPendingCheckInOnNetworkAttach;
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP
-            mPendingCheckInOnNetworkAttach = false;
+                            "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
             UpdateOperationState(OperationalState::ActiveMode);
-#if CHIP_CONFIG_ENABLE_ICD_CIP
-            if (wasPendingCheckIn && mOperationalState == OperationalState::ActiveMode)
-            {
-                SendCheckInMsgs();
-            }
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP
         }
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+        if (wasPendingCheckIn)
+        {
+            // If the deferred Check-In targeted a specific subject, replay it for that subject.
+            // If it was a broadcast Check-In and ActiveMode was not entered above, replay it.
+            // (Note: UpdateOperationState(ActiveMode) already calls SendCheckInMsgs() for broadcast Check-In).
+            if (pendingSubject.HasValue() || (!wasPendingActiveMode && mOperationalState != OperationalState::ActiveMode))
+            {
+                ChipLogProgress(AppServer, "ICDManager: Replaying deferred Check-In message.");
+                SendCheckInMsgs(pendingSubject);
+            }
+        }
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     }
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -23,6 +23,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/core/ClusterEnums.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/Defer.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/LockTracker.h>
@@ -821,14 +822,14 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         UpdateOperationState(OperationalState::ActiveMode);
     }
 #else
-    const PendingCheckInType pendingCheckInType = mPendingCheckInType;
-    const size_t pendingSubjectsCount           = mPendingCheckInSubjectsCount;
-    mPendingCheckInType                         = PendingCheckInType::kNone;
-    mPendingCheckInSubjectsCount                = 0;
-
     // Early return if there is no pending action
     VerifyOrReturn(wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode ||
-                   pendingCheckInType != PendingCheckInType::kNone);
+                   mPendingCheckInType != PendingCheckInType::kNone);
+
+    auto deferCleanup = MakeDefer([this] {
+        mPendingCheckInType          = PendingCheckInType::kNone;
+        mPendingCheckInSubjectsCount = 0;
+    });
 
     const bool wasInIdleMode = (mOperationalState == OperationalState::IdleMode);
 
@@ -841,9 +842,9 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     VerifyOrReturn(!wasInIdleMode);
 
     // If the device was already in ActiveMode, UpdateOperationState() only extended active duration, so replay pending check-ins.
-    if (pendingCheckInType == PendingCheckInType::kTargeted)
+    if (mPendingCheckInType == PendingCheckInType::kTargeted)
     {
-        for (size_t i = 0; i < pendingSubjectsCount; ++i)
+        for (size_t i = 0; i < mPendingCheckInSubjectsCount; ++i)
         {
             ChipLogProgress(AppServer,
                             "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
@@ -851,7 +852,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
             SendCheckInMsgs(MakeOptional(mPendingCheckInSubjects[i]));
         }
     }
-    else if (pendingCheckInType == PendingCheckInType::kBroadcast)
+    else if (mPendingCheckInType == PendingCheckInType::kBroadcast)
     {
         ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
         SendCheckInMsgs(NullOptional);

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -26,6 +26,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/LockTracker.h>
+#include <platform/PlatformManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 namespace {
@@ -84,6 +85,7 @@ void ICDManager::Init()
 #endif // CHIP_CONFIG_ENABLE_ICD_LIT
 
     SuccessOrDie(ICDNotifier::GetInstance().Subscribe(this));
+    SuccessOrDie(DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEvent, reinterpret_cast<intptr_t>(this)));
 
     UpdateICDMode();
     UpdateOperationState(OperationalState::IdleMode);
@@ -91,6 +93,7 @@ void ICDManager::Init()
 
 void ICDManager::Shutdown()
 {
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, reinterpret_cast<intptr_t>(this));
     ICDNotifier::GetInstance().Unsubscribe(this);
 
     // cancel any running timer of the icd
@@ -662,6 +665,14 @@ void ICDManager::OnSITModeRequestWithdrawal()
 
 void ICDManager::OnNetworkActivity()
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
+    {
+        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on network activity. Deferring ActiveMode until attached.");
+        mPendingCheckInOnNetworkAttach = true;
+        return;
+    }
+#endif
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
@@ -683,15 +694,75 @@ void ICDManager::OnSubscriptionReport()
     // Since we only mark them dirty when we enter ActiveMode, it is not necessary to update the operational state a second time.
     // Doing so will only add an ActiveModeThreshold to the active time which we don't want to do here.
     VerifyOrReturn(mOperationalState == OperationalState::IdleMode);
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
+    {
+        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on subscription report. Deferring ActiveMode until attached.");
+        mPendingCheckInOnNetworkAttach = true;
+        return;
+    }
+#endif
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
+    {
+        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on send check-in. Deferring until attached.");
+        mPendingCheckInOnNetworkAttach = true;
+        return;
+    }
+#endif
     SendCheckInMsgs(specificSubject);
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+
+void ICDManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+{
+    ICDManager * pICDManager = reinterpret_cast<ICDManager *>(arg);
+    if (pICDManager != nullptr)
+    {
+        pICDManager->HandlePlatformEvent(event);
+    }
+}
+
+void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
+{
+    bool threadEstablished = false;
+
+    if (event->Type == DeviceLayer::DeviceEventType::kThreadConnectivityChange)
+    {
+        if (event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established)
+        {
+            threadEstablished = true;
+        }
+    }
+    else if (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange)
+    {
+        if (event->ThreadStateChange.RoleChanged)
+        {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+            if (DeviceLayer::ConnectivityMgr().IsThreadAttached())
+            {
+                threadEstablished = true;
+            }
+#endif
+        }
+    }
+
+    if (threadEstablished)
+    {
+        if (mPendingCheckInOnNetworkAttach || mOperationalState == OperationalState::ActiveMode)
+        {
+            ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
+            mPendingCheckInOnNetworkAttach = false;
+            UpdateOperationState(OperationalState::ActiveMode);
+        }
+    }
+}
 
 void ICDManager::ExtendActiveMode(Milliseconds16 extendDuration)
 {

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -806,7 +806,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     const bool threadEstablished =
         (threadNewConnectionEstablished || threadRoleChanged) && DeviceLayer::ConnectivityMgr().IsThreadAttached();
 #else
-    const bool threadEstablished                = false;
+    const bool threadEstablished = false;
 #endif
 
     // Early return if Thread connectivity is not established
@@ -846,8 +846,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     {
         for (size_t i = 0; i < mPendingCheckInSubjectsCount; ++i)
         {
-            ChipLogProgress(AppServer,
-                            "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
+            ChipLogProgress(AppServer, "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
                             ChipLogValueX64(mPendingCheckInSubjects[i].subject));
             SendCheckInMsgs(MakeOptional(mPendingCheckInSubjects[i]));
         }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -110,9 +110,8 @@ void ICDManager::Shutdown()
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    mPendingCheckInOnNetworkAttach = false;
-    mPendingBroadcastCheckIn       = false;
-    mPendingCheckInSubjectsCount   = 0;
+    mPendingCheckInType          = PendingCheckInType::kNone;
+    mPendingCheckInSubjectsCount = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mStateObserverPool.ReleaseAll();
@@ -728,6 +727,46 @@ void ICDManager::OnSubscriptionReport()
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+bool ICDManager::Contains(Span<const Access::SubjectDescriptor> list, const Access::SubjectDescriptor & value)
+{
+    for (const auto & item : list)
+    {
+        if (item.fabricIndex == value.fabricIndex && item.authMode == value.authMode && item.subject == value.subject &&
+            item.cats.values == value.cats.values && item.isCommissioning == value.isCommissioning)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ICDManager::AppendPendingCheckInSubject(const Access::SubjectDescriptor & subject)
+{
+    // If broadcast Check-In is already pending, it notifies all clients on all fabrics, so targeted queuing is superseded.
+    if (mPendingCheckInType == PendingCheckInType::kBroadcast)
+    {
+        return;
+    }
+
+    if (!Contains(Span<const Access::SubjectDescriptor>(mPendingCheckInSubjects.data(), mPendingCheckInSubjectsCount), subject))
+    {
+        if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
+        {
+            mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
+            mPendingCheckInType                                    = PendingCheckInType::kTargeted;
+        }
+        else
+        {
+            // Capacity exceeded: upgrade to broadcast Check-In so no client registration is dropped.
+            ChipLogProgress(AppServer, "ICDManager: Pending check-in table full. Upgrading to broadcast Check-In.");
+            mPendingCheckInType          = PendingCheckInType::kBroadcast;
+            mPendingCheckInSubjectsCount = 0;
+        }
+    }
+}
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
 {
@@ -735,39 +774,14 @@ void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubje
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
         ChipLogProgress(AppServer, "ICDManager: Thread network not attached on send check-in. Deferring until attached.");
-        mPendingCheckInOnNetworkAttach = true;
         if (specificSubject.HasValue())
         {
-            const auto & subject = specificSubject.Value();
-            bool isDuplicate     = false;
-            for (size_t i = 0; i < mPendingCheckInSubjectsCount; ++i)
-            {
-                if (mPendingCheckInSubjects[i].fabricIndex == subject.fabricIndex &&
-                    mPendingCheckInSubjects[i].authMode == subject.authMode &&
-                    mPendingCheckInSubjects[i].subject == subject.subject &&
-                    mPendingCheckInSubjects[i].cats.values == subject.cats.values &&
-                    mPendingCheckInSubjects[i].isCommissioning == subject.isCommissioning)
-                {
-                    isDuplicate = true;
-                    break;
-                }
-            }
-
-            if (!isDuplicate)
-            {
-                if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
-                {
-                    mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
-                }
-                else
-                {
-                    ChipLogError(AppServer, "ICDManager: Pending check-in subjects table is full. Subject dropped.");
-                }
-            }
+            AppendPendingCheckInSubject(specificSubject.Value());
         }
         else
         {
-            mPendingBroadcastCheckIn = true;
+            mPendingCheckInType          = PendingCheckInType::kBroadcast;
+            mPendingCheckInSubjectsCount = 0;
         }
         return;
     }
@@ -780,97 +794,75 @@ void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubje
 void ICDManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     ICDManager * pICDManager = reinterpret_cast<ICDManager *>(arg);
-    if (pICDManager != nullptr)
-    {
-        pICDManager->HandlePlatformEvent(event);
-    }
+    VerifyOrReturn(pICDManager != nullptr);
+    pICDManager->HandlePlatformEvent(event);
 }
 
 void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 {
-    bool threadEstablished = false;
-
-    if (event->Type == DeviceLayer::DeviceEventType::kThreadConnectivityChange)
-    {
-        if (event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established)
-        {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-            if (DeviceLayer::ConnectivityMgr().IsThreadAttached())
-            {
-                threadEstablished = true;
-            }
+    const bool threadNewConnectionEstablished =
+        (event->Type == DeviceLayer::DeviceEventType::kThreadConnectivityChange &&
+         event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established);
+    const bool threadRoleChanged =
+        (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange && event->ThreadStateChange.RoleChanged);
+    const bool threadEstablished =
+        (threadNewConnectionEstablished || threadRoleChanged) && DeviceLayer::ConnectivityMgr().IsThreadAttached();
 #else
-            threadEstablished = true;
+    const bool threadEstablished = false;
 #endif
-        }
-    }
-    else if (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange)
+
+    // Early return if Thread connectivity is not established
+    VerifyOrReturn(threadEstablished);
+
+    const bool wasPendingActiveMode   = mPendingActiveModeOnNetworkAttach;
+    mPendingActiveModeOnNetworkAttach = false;
+
+#if !(CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT)
+    if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
     {
-        if (event->ThreadStateChange.RoleChanged)
-        {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-            if (DeviceLayer::ConnectivityMgr().IsThreadAttached())
-            {
-                threadEstablished = true;
-            }
-#endif
-        }
+        ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
+        UpdateOperationState(OperationalState::ActiveMode);
     }
+#else
+    const PendingCheckInType pendingCheckInType = mPendingCheckInType;
+    const size_t pendingSubjectsCount          = mPendingCheckInSubjectsCount;
+    // Reset pending state before replaying so any new events generated during processing queue cleanly
+    mPendingCheckInType          = PendingCheckInType::kNone;
+    mPendingCheckInSubjectsCount = 0;
 
-    if (threadEstablished)
+    // Early return if there is no pending action
+    VerifyOrReturn(wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode ||
+                   pendingCheckInType != PendingCheckInType::kNone);
+
+    const bool wasInIdleMode = (mOperationalState == OperationalState::IdleMode);
+
+    // Trigger or extend ActiveMode
+    ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
+    UpdateOperationState(OperationalState::ActiveMode);
+
+    // If the device transitioned from IdleMode to ActiveMode, UpdateOperationState() already executed SendCheckInMsgs()
+    // (broadcast Check-In to all fabrics), which subsumes both targeted and broadcast check-in requests.
+    // If the device was already in ActiveMode, UpdateOperationState() only extended active duration, so replay pending check-ins.
+    if (!wasInIdleMode)
     {
-        bool wasPendingActiveMode         = mPendingActiveModeOnNetworkAttach;
-        mPendingActiveModeOnNetworkAttach = false;
-
-#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-        bool wasPendingCheckIn                                                            = mPendingCheckInOnNetworkAttach;
-        bool wasPendingBroadcastCheckIn                                                   = mPendingBroadcastCheckIn;
-        std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> pendingSubjects = mPendingCheckInSubjects;
-        size_t pendingSubjectsCount                                                       = mPendingCheckInSubjectsCount;
-
-        mPendingCheckInOnNetworkAttach = false;
-        mPendingBroadcastCheckIn       = false;
-        mPendingCheckInSubjectsCount   = 0;
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-
-#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-        bool enteredActiveModeFromIdle = false;
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-
-        if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
+        if (pendingCheckInType == PendingCheckInType::kTargeted)
         {
-#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-            if (mOperationalState == OperationalState::IdleMode)
-            {
-                enteredActiveModeFromIdle = true;
-            }
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-            ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
-            UpdateOperationState(OperationalState::ActiveMode);
-        }
-
-#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-        if (wasPendingCheckIn)
-        {
-            // Replay each deferred specific subject Check-In
             for (size_t i = 0; i < pendingSubjectsCount; ++i)
             {
                 ChipLogProgress(AppServer,
                                 "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
-                                ChipLogValueX64(pendingSubjects[i].subject));
-                SendCheckInMsgs(MakeOptional(pendingSubjects[i]));
-            }
-
-            // If a broadcast Check-In was requested and UpdateOperationState did NOT perform an IdleMode-to-ActiveMode transition
-            // (which already calls SendCheckInMsgs() during the transition), replay the broadcast Check-In once.
-            if (wasPendingBroadcastCheckIn && !enteredActiveModeFromIdle)
-            {
-                ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
-                SendCheckInMsgs(NullOptional);
+                                ChipLogValueX64(mPendingCheckInSubjects[i].subject));
+                SendCheckInMsgs(MakeOptional(mPendingCheckInSubjects[i]));
             }
         }
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+        else if (pendingCheckInType == PendingCheckInType::kBroadcast)
+        {
+            ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
+            SendCheckInMsgs(NullOptional);
+        }
     }
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -833,8 +833,13 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         mPendingCheckInSubjectsCount   = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
+        bool enteredActiveModeFromIdle = false;
         if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
         {
+            if (mOperationalState == OperationalState::IdleMode)
+            {
+                enteredActiveModeFromIdle = true;
+            }
             ChipLogProgress(AppServer,
                             "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
             UpdateOperationState(OperationalState::ActiveMode);
@@ -852,9 +857,9 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
                 SendCheckInMsgs(MakeOptional(pendingSubjects[i]));
             }
 
-            // If a broadcast Check-In was requested and ActiveMode was not entered above, replay broadcast Check-In once.
-            // (Note: UpdateOperationState(ActiveMode) already calls SendCheckInMsgs() for broadcast Check-In).
-            if (wasPendingBroadcastCheckIn && !wasPendingActiveMode && mOperationalState != OperationalState::ActiveMode)
+            // If a broadcast Check-In was requested and UpdateOperationState did NOT perform an IdleMode-to-ActiveMode transition
+            // (which already calls SendCheckInMsgs() during the transition), replay the broadcast Check-In once.
+            if (wasPendingBroadcastCheckIn && !enteredActiveModeFromIdle)
             {
                 ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
                 SendCheckInMsgs(NullOptional);

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -828,7 +828,9 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 #else
     const PendingCheckInType pendingCheckInType = mPendingCheckInType;
     const size_t pendingSubjectsCount           = mPendingCheckInSubjectsCount;
-    // Reset pending state before replaying so any new events generated during processing queue cleanly
+    // Snapshot and reset pending state before replaying to protect against synchronous re-entrant callbacks
+    // (e.g. immediate address resolution failure or delegate notifications) on the single CHIP event loop
+    // without mutating the active replay loop.
     mPendingCheckInType          = PendingCheckInType::kNone;
     mPendingCheckInSubjectsCount = 0;
 

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -761,7 +761,14 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     {
         if (event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established)
         {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+            if (DeviceLayer::ConnectivityMgr().IsThreadAttached())
+            {
+                threadEstablished = true;
+            }
+#else
             threadEstablished = true;
+#endif
         }
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange)

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -795,9 +795,7 @@ void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubje
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 void ICDManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
-    ICDManager * pICDManager = reinterpret_cast<ICDManager *>(arg);
-    VerifyOrReturn(pICDManager != nullptr);
-    pICDManager->HandlePlatformEvent(event);
+    reinterpret_cast<ICDManager *>(arg)->HandlePlatformEvent(event);
 }
 
 void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
@@ -828,11 +826,8 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 #else
     const PendingCheckInType pendingCheckInType = mPendingCheckInType;
     const size_t pendingSubjectsCount           = mPendingCheckInSubjectsCount;
-    // Snapshot and reset pending state before replaying to protect against synchronous re-entrant callbacks
-    // (e.g. immediate address resolution failure or delegate notifications) on the single CHIP event loop
-    // without mutating the active replay loop.
-    mPendingCheckInType          = PendingCheckInType::kNone;
-    mPendingCheckInSubjectsCount = 0;
+    mPendingCheckInType                         = PendingCheckInType::kNone;
+    mPendingCheckInSubjectsCount                = 0;
 
     // Early return if there is no pending action
     VerifyOrReturn(wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode ||
@@ -846,24 +841,23 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 
     // If the device transitioned from IdleMode to ActiveMode, UpdateOperationState() already executed SendCheckInMsgs()
     // (broadcast Check-In to all fabrics), which subsumes both targeted and broadcast check-in requests.
+    VerifyOrReturn(!wasInIdleMode);
+
     // If the device was already in ActiveMode, UpdateOperationState() only extended active duration, so replay pending check-ins.
-    if (!wasInIdleMode)
+    if (pendingCheckInType == PendingCheckInType::kTargeted)
     {
-        if (pendingCheckInType == PendingCheckInType::kTargeted)
+        for (size_t i = 0; i < pendingSubjectsCount; ++i)
         {
-            for (size_t i = 0; i < pendingSubjectsCount; ++i)
-            {
-                ChipLogProgress(AppServer,
-                                "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
-                                ChipLogValueX64(mPendingCheckInSubjects[i].subject));
-                SendCheckInMsgs(MakeOptional(mPendingCheckInSubjects[i]));
-            }
+            ChipLogProgress(AppServer,
+                            "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
+                            ChipLogValueX64(mPendingCheckInSubjects[i].subject));
+            SendCheckInMsgs(MakeOptional(mPendingCheckInSubjects[i]));
         }
-        else if (pendingCheckInType == PendingCheckInType::kBroadcast)
-        {
-            ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
-            SendCheckInMsgs(NullOptional);
-        }
+    }
+    else if (pendingCheckInType == PendingCheckInType::kBroadcast)
+    {
+        ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
+        SendCheckInMsgs(NullOptional);
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -110,9 +110,9 @@ void ICDManager::Shutdown()
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    mPendingCheckInOnNetworkAttach    = false;
-    mPendingBroadcastCheckIn          = false;
-    mPendingCheckInSubjectsCount      = 0;
+    mPendingCheckInOnNetworkAttach = false;
+    mPendingBroadcastCheckIn       = false;
+    mPendingCheckInSubjectsCount   = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mStateObserverPool.ReleaseAll();
@@ -845,8 +845,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
                 enteredActiveModeFromIdle = true;
             }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-            ChipLogProgress(AppServer,
-                            "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
+            ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
             UpdateOperationState(OperationalState::ActiveMode);
         }
 

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -546,7 +546,8 @@ void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
-        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on periodic idle wake-up. Deferring ActiveMode until attached.");
+        ChipLogProgress(AppServer,
+                        "ICDManager: Thread network not attached on periodic idle wake-up. Deferring ActiveMode until attached.");
         pICDManager->mPendingCheckInOnNetworkAttach = true;
         return;
     }
@@ -677,7 +678,8 @@ void ICDManager::OnNetworkActivity()
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
-        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on network activity. Deferring ActiveMode until attached.");
+        ChipLogProgress(AppServer,
+                        "ICDManager: Thread network not attached on network activity. Deferring ActiveMode until attached.");
         mPendingCheckInOnNetworkAttach = true;
         return;
     }
@@ -706,7 +708,8 @@ void ICDManager::OnSubscriptionReport()
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
-        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on subscription report. Deferring ActiveMode until attached.");
+        ChipLogProgress(AppServer,
+                        "ICDManager: Thread network not attached on subscription report. Deferring ActiveMode until attached.");
         mPendingCheckInOnNetworkAttach = true;
         return;
     }
@@ -766,8 +769,9 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     {
         if (mPendingCheckInOnNetworkAttach || mOperationalState == OperationalState::ActiveMode)
         {
-            ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
-            bool wasPendingCheckIn          = mPendingCheckInOnNetworkAttach;
+            ChipLogProgress(AppServer,
+                            "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
+            bool wasPendingCheckIn         = mPendingCheckInOnNetworkAttach;
             mPendingCheckInOnNetworkAttach = false;
             UpdateOperationState(OperationalState::ActiveMode);
 #if CHIP_CONFIG_ENABLE_ICD_CIP

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -745,26 +745,23 @@ bool ICDManager::Contains(Span<const Access::SubjectDescriptor> list, const Acce
 void ICDManager::AppendPendingCheckInSubject(const Access::SubjectDescriptor & subject)
 {
     // If broadcast Check-In is already pending, it notifies all clients on all fabrics, so targeted queuing is superseded.
-    if (mPendingCheckInType == PendingCheckInType::kBroadcast)
+    VerifyOrReturn(mPendingCheckInType != PendingCheckInType::kBroadcast);
+
+    // If subject is already pending, no need to add again
+    VerifyOrReturn(
+        !Contains(Span<const Access::SubjectDescriptor>(mPendingCheckInSubjects.data(), mPendingCheckInSubjectsCount), subject));
+
+    if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
     {
+        mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
+        mPendingCheckInType                                     = PendingCheckInType::kTargeted;
         return;
     }
 
-    if (!Contains(Span<const Access::SubjectDescriptor>(mPendingCheckInSubjects.data(), mPendingCheckInSubjectsCount), subject))
-    {
-        if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
-        {
-            mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
-            mPendingCheckInType                                     = PendingCheckInType::kTargeted;
-        }
-        else
-        {
-            // Capacity exceeded: upgrade to broadcast Check-In so no client registration is dropped.
-            ChipLogProgress(AppServer, "ICDManager: Pending check-in table full. Upgrading to broadcast Check-In.");
-            mPendingCheckInType          = PendingCheckInType::kBroadcast;
-            mPendingCheckInSubjectsCount = 0;
-        }
-    }
+    // Capacity exceeded: upgrade to broadcast Check-In so no client registration is dropped.
+    ChipLogProgress(AppServer, "ICDManager: Pending check-in table full. Upgrading to broadcast Check-In.");
+    mPendingCheckInType          = PendingCheckInType::kBroadcast;
+    mPendingCheckInSubjectsCount = 0;
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&
        // CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -85,7 +85,9 @@ void ICDManager::Init()
 #endif // CHIP_CONFIG_ENABLE_ICD_LIT
 
     SuccessOrDie(ICDNotifier::GetInstance().Subscribe(this));
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     SuccessOrDie(DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEvent, reinterpret_cast<intptr_t>(this)));
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
     UpdateICDMode();
     UpdateOperationState(OperationalState::IdleMode);
@@ -93,7 +95,9 @@ void ICDManager::Init()
 
 void ICDManager::Shutdown()
 {
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, reinterpret_cast<intptr_t>(this));
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ICDNotifier::GetInstance().Unsubscribe(this);
 
     // cancel any running timer of the icd
@@ -103,7 +107,9 @@ void ICDManager::Shutdown()
 
     ICDConfigurationData::GetInstance().SetICDMode(ICDConfigurationData::ICDMode::SIT);
     mOperationalState              = OperationalState::ActiveMode;
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mPendingCheckInOnNetworkAttach = false;
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mStateObserverPool.ReleaseAll();
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
@@ -543,7 +549,7 @@ void ICDManager::SetKeepActiveModeRequirements(KeepActiveFlags flag, bool state)
 void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
 {
     ICDManager * pICDManager = reinterpret_cast<ICDManager *>(appState);
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
         ChipLogProgress(AppServer,
@@ -551,7 +557,7 @@ void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
         pICDManager->mPendingCheckInOnNetworkAttach = true;
         return;
     }
-#endif
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     pICDManager->UpdateOperationState(OperationalState::ActiveMode);
 }
 
@@ -675,7 +681,7 @@ void ICDManager::OnSITModeRequestWithdrawal()
 
 void ICDManager::OnNetworkActivity()
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
         ChipLogProgress(AppServer,
@@ -683,7 +689,7 @@ void ICDManager::OnNetworkActivity()
         mPendingCheckInOnNetworkAttach = true;
         return;
     }
-#endif
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
@@ -705,7 +711,7 @@ void ICDManager::OnSubscriptionReport()
     // Since we only mark them dirty when we enter ActiveMode, it is not necessary to update the operational state a second time.
     // Doing so will only add an ActiveModeThreshold to the active time which we don't want to do here.
     VerifyOrReturn(mOperationalState == OperationalState::IdleMode);
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
         ChipLogProgress(AppServer,
@@ -713,25 +719,26 @@ void ICDManager::OnSubscriptionReport()
         mPendingCheckInOnNetworkAttach = true;
         return;
     }
-#endif
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
     {
         ChipLogProgress(AppServer, "ICDManager: Thread network not attached on send check-in. Deferring until attached.");
         mPendingCheckInOnNetworkAttach = true;
         return;
     }
-#endif
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
     SendCheckInMsgs(specificSubject);
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 void ICDManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     ICDManager * pICDManager = reinterpret_cast<ICDManager *>(arg);
@@ -783,6 +790,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         }
     }
 }
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
 void ICDManager::ExtendActiveMode(Milliseconds16 extendDuration)
 {

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -106,7 +106,7 @@ void ICDManager::Shutdown()
     DeviceLayer::SystemLayer().CancelTimer(OnTransitionToIdle, this);
 
     ICDConfigurationData::GetInstance().SetICDMode(ICDConfigurationData::ICDMode::SIT);
-    mOperationalState              = OperationalState::ActiveMode;
+    mOperationalState = OperationalState::ActiveMode;
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mPendingCheckInOnNetworkAttach = false;
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -111,7 +111,8 @@ void ICDManager::Shutdown()
     mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     mPendingCheckInOnNetworkAttach    = false;
-    mPendingCheckInSubject.ClearValue();
+    mPendingBroadcastCheckIn          = false;
+    mPendingCheckInSubjectsCount      = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     mStateObserverPool.ReleaseAll();
@@ -735,7 +736,39 @@ void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubje
     {
         ChipLogProgress(AppServer, "ICDManager: Thread network not attached on send check-in. Deferring until attached.");
         mPendingCheckInOnNetworkAttach = true;
-        mPendingCheckInSubject         = specificSubject;
+        if (specificSubject.HasValue())
+        {
+            const auto & subject = specificSubject.Value();
+            bool isDuplicate     = false;
+            for (size_t i = 0; i < mPendingCheckInSubjectsCount; ++i)
+            {
+                if (mPendingCheckInSubjects[i].fabricIndex == subject.fabricIndex &&
+                    mPendingCheckInSubjects[i].authMode == subject.authMode &&
+                    mPendingCheckInSubjects[i].subject == subject.subject &&
+                    mPendingCheckInSubjects[i].cats.values == subject.cats.values &&
+                    mPendingCheckInSubjects[i].isCommissioning == subject.isCommissioning)
+                {
+                    isDuplicate = true;
+                    break;
+                }
+            }
+
+            if (!isDuplicate)
+            {
+                if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
+                {
+                    mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
+                }
+                else
+                {
+                    ChipLogError(AppServer, "ICDManager: Pending check-in subjects table is full. Subject dropped.");
+                }
+            }
+        }
+        else
+        {
+            mPendingBroadcastCheckIn = true;
+        }
         return;
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -790,10 +823,14 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         mPendingActiveModeOnNetworkAttach = false;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-        bool wasPendingCheckIn                             = mPendingCheckInOnNetworkAttach;
-        Optional<Access::SubjectDescriptor> pendingSubject = mPendingCheckInSubject;
-        mPendingCheckInOnNetworkAttach                     = false;
-        mPendingCheckInSubject.ClearValue();
+        bool wasPendingCheckIn                                                            = mPendingCheckInOnNetworkAttach;
+        bool wasPendingBroadcastCheckIn                                                   = mPendingBroadcastCheckIn;
+        std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> pendingSubjects = mPendingCheckInSubjects;
+        size_t pendingSubjectsCount                                                       = mPendingCheckInSubjectsCount;
+
+        mPendingCheckInOnNetworkAttach = false;
+        mPendingBroadcastCheckIn       = false;
+        mPendingCheckInSubjectsCount   = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
         if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
@@ -806,13 +843,21 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
         if (wasPendingCheckIn)
         {
-            // If the deferred Check-In targeted a specific subject, replay it for that subject.
-            // If it was a broadcast Check-In and ActiveMode was not entered above, replay it.
-            // (Note: UpdateOperationState(ActiveMode) already calls SendCheckInMsgs() for broadcast Check-In).
-            if (pendingSubject.HasValue() || (!wasPendingActiveMode && mOperationalState != OperationalState::ActiveMode))
+            // Replay each deferred specific subject Check-In
+            for (size_t i = 0; i < pendingSubjectsCount; ++i)
             {
-                ChipLogProgress(AppServer, "ICDManager: Replaying deferred Check-In message.");
-                SendCheckInMsgs(pendingSubject);
+                ChipLogProgress(AppServer,
+                                "ICDManager: Replaying deferred Check-In message for specific subject: " ChipLogFormatX64,
+                                ChipLogValueX64(pendingSubjects[i].subject));
+                SendCheckInMsgs(MakeOptional(pendingSubjects[i]));
+            }
+
+            // If a broadcast Check-In was requested and ActiveMode was not entered above, replay broadcast Check-In once.
+            // (Note: UpdateOperationState(ActiveMode) already calls SendCheckInMsgs() for broadcast Check-In).
+            if (wasPendingBroadcastCheckIn && !wasPendingActiveMode && mOperationalState != OperationalState::ActiveMode)
+            {
+                ChipLogProgress(AppServer, "ICDManager: Replaying deferred broadcast Check-In message.");
+                SendCheckInMsgs(NullOptional);
             }
         }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -833,13 +833,18 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         mPendingCheckInSubjectsCount   = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
         bool enteredActiveModeFromIdle = false;
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+
         if (wasPendingActiveMode || mOperationalState == OperationalState::ActiveMode)
         {
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
             if (mOperationalState == OperationalState::IdleMode)
             {
                 enteredActiveModeFromIdle = true;
             }
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
             ChipLogProgress(AppServer,
                             "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode.");
             UpdateOperationState(OperationalState::ActiveMode);

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -102,7 +102,8 @@ void ICDManager::Shutdown()
     DeviceLayer::SystemLayer().CancelTimer(OnTransitionToIdle, this);
 
     ICDConfigurationData::GetInstance().SetICDMode(ICDConfigurationData::ICDMode::SIT);
-    mOperationalState = OperationalState::ActiveMode;
+    mOperationalState              = OperationalState::ActiveMode;
+    mPendingCheckInOnNetworkAttach = false;
     mStateObserverPool.ReleaseAll();
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
@@ -542,6 +543,14 @@ void ICDManager::SetKeepActiveModeRequirements(KeepActiveFlags flag, bool state)
 void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
 {
     ICDManager * pICDManager = reinterpret_cast<ICDManager *>(appState);
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (DeviceLayer::ConnectivityMgr().IsThreadEnabled() && !DeviceLayer::ConnectivityMgr().IsThreadAttached())
+    {
+        ChipLogProgress(AppServer, "ICDManager: Thread network not attached on periodic idle wake-up. Deferring ActiveMode until attached.");
+        pICDManager->mPendingCheckInOnNetworkAttach = true;
+        return;
+    }
+#endif
     pICDManager->UpdateOperationState(OperationalState::ActiveMode);
 }
 
@@ -758,8 +767,15 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         if (mPendingCheckInOnNetworkAttach || mOperationalState == OperationalState::ActiveMode)
         {
             ChipLogProgress(AppServer, "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
+            bool wasPendingCheckIn          = mPendingCheckInOnNetworkAttach;
             mPendingCheckInOnNetworkAttach = false;
             UpdateOperationState(OperationalState::ActiveMode);
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+            if (wasPendingCheckIn && mOperationalState == OperationalState::ActiveMode)
+            {
+                SendCheckInMsgs();
+            }
+#endif
         }
     }
 }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -727,7 +727,8 @@ void ICDManager::OnSubscriptionReport()
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
-#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&                                         \
+    CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 bool ICDManager::Contains(Span<const Access::SubjectDescriptor> list, const Access::SubjectDescriptor & value)
 {
     for (const auto & item : list)
@@ -754,7 +755,7 @@ void ICDManager::AppendPendingCheckInSubject(const Access::SubjectDescriptor & s
         if (mPendingCheckInSubjectsCount < mPendingCheckInSubjects.size())
         {
             mPendingCheckInSubjects[mPendingCheckInSubjectsCount++] = subject;
-            mPendingCheckInType                                    = PendingCheckInType::kTargeted;
+            mPendingCheckInType                                     = PendingCheckInType::kTargeted;
         }
         else
         {
@@ -765,7 +766,8 @@ void ICDManager::AppendPendingCheckInSubject(const Access::SubjectDescriptor & s
         }
     }
 }
-#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&
+       // CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
@@ -801,15 +803,14 @@ void ICDManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, int
 void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    const bool threadNewConnectionEstablished =
-        (event->Type == DeviceLayer::DeviceEventType::kThreadConnectivityChange &&
-         event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established);
+    const bool threadNewConnectionEstablished = (event->Type == DeviceLayer::DeviceEventType::kThreadConnectivityChange &&
+                                                 event->ThreadConnectivityChange.Result == DeviceLayer::kConnectivity_Established);
     const bool threadRoleChanged =
         (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange && event->ThreadStateChange.RoleChanged);
     const bool threadEstablished =
         (threadNewConnectionEstablished || threadRoleChanged) && DeviceLayer::ConnectivityMgr().IsThreadAttached();
 #else
-    const bool threadEstablished = false;
+    const bool threadEstablished                = false;
 #endif
 
     // Early return if Thread connectivity is not established
@@ -826,7 +827,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     }
 #else
     const PendingCheckInType pendingCheckInType = mPendingCheckInType;
-    const size_t pendingSubjectsCount          = mPendingCheckInSubjectsCount;
+    const size_t pendingSubjectsCount           = mPendingCheckInSubjectsCount;
     // Reset pending state before replaying so any new events generated during processing queue cleanly
     mPendingCheckInType          = PendingCheckInType::kNone;
     mPendingCheckInSubjectsCount = 0;

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -778,7 +778,9 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
         {
             ChipLogProgress(AppServer,
                             "ICDManager: Thread network connectivity established. Triggering/Extending ActiveMode and Check-In.");
-            bool wasPendingCheckIn         = mPendingCheckInOnNetworkAttach;
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+            bool wasPendingCheckIn = mPendingCheckInOnNetworkAttach;
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
             mPendingCheckInOnNetworkAttach = false;
             UpdateOperationState(OperationalState::ActiveMode);
 #if CHIP_CONFIG_ENABLE_ICD_CIP
@@ -786,7 +788,7 @@ void ICDManager::HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
             {
                 SendCheckInMsgs();
             }
-#endif
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
         }
     }
 }

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -378,8 +378,15 @@ private:
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
     OperationalState mOperationalState = OperationalState::ActiveMode;
     bool mTransitionToIdleCalled       = false;
+    bool mPendingCheckInOnNetworkAttach = false;
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
     uint8_t mOpenExchangeContextCount = 0;
+
+    /**
+     * @brief Platform event handler to receive Thread network state and connectivity changes.
+     */
+    static void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+    void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event);
 
 #if CHIP_CONFIG_ENABLE_ICD_DSLS
     bool mSITModeRequested = false;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -18,6 +18,8 @@
 
 #include <app/icd/server/ICDServerConfig.h>
 
+#include <array>
+
 #include <app/AppConfig.h>
 #include <app/SubscriptionsInfoProvider.h>
 #include <app/TestEventTriggerDelegate.h>
@@ -383,8 +385,11 @@ private:
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    bool mPendingCheckInOnNetworkAttach = false;
-    Optional<Access::SubjectDescriptor> mPendingCheckInSubject;
+    static constexpr size_t kMaxPendingCheckInSubjects = CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
+    bool mPendingCheckInOnNetworkAttach                = false;
+    bool mPendingBroadcastCheckIn                      = false;
+    std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> mPendingCheckInSubjects;
+    size_t mPendingCheckInSubjectsCount                = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -378,8 +378,8 @@ private:
     KeepActiveFlags mKeepActiveFlags{ 0 };
 
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
-    OperationalState mOperationalState  = OperationalState::ActiveMode;
-    bool mTransitionToIdleCalled        = false;
+    OperationalState mOperationalState = OperationalState::ActiveMode;
+    bool mTransitionToIdleCalled       = false;
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool mPendingCheckInOnNetworkAttach = false;
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -385,11 +385,19 @@ private:
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    enum class PendingCheckInType : uint8_t
+    {
+        kNone,
+        kTargeted,
+        kBroadcast,
+    };
     static constexpr size_t kMaxPendingCheckInSubjects = CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
-    bool mPendingCheckInOnNetworkAttach                = false;
-    bool mPendingBroadcastCheckIn                      = false;
+    PendingCheckInType mPendingCheckInType             = PendingCheckInType::kNone;
     std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> mPendingCheckInSubjects;
     size_t mPendingCheckInSubjectsCount = 0;
+
+    static bool Contains(Span<const Access::SubjectDescriptor> list, const Access::SubjectDescriptor & value);
+    void AppendPendingCheckInSubject(const Access::SubjectDescriptor & subject);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -376,8 +376,8 @@ private:
     KeepActiveFlags mKeepActiveFlags{ 0 };
 
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
-    OperationalState mOperationalState = OperationalState::ActiveMode;
-    bool mTransitionToIdleCalled       = false;
+    OperationalState mOperationalState  = OperationalState::ActiveMode;
+    bool mTransitionToIdleCalled        = false;
     bool mPendingCheckInOnNetworkAttach = false;
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
     uint8_t mOpenExchangeContextCount = 0;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -378,15 +378,19 @@ private:
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
     OperationalState mOperationalState  = OperationalState::ActiveMode;
     bool mTransitionToIdleCalled        = false;
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool mPendingCheckInOnNetworkAttach = false;
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
     uint8_t mOpenExchangeContextCount = 0;
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     /**
      * @brief Platform event handler to receive Thread network state and connectivity changes.
      */
     static void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event);
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
 #if CHIP_CONFIG_ENABLE_ICD_DSLS
     bool mSITModeRequested = false;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -49,6 +49,7 @@ namespace app {
 
 // Forward declaration of TestICDManager tests to allow it to be friend with ICDManager
 // Used in unit tests
+class TestICDManager;
 class TestICDManager_TestShouldCheckInMsgsBeSentAtActiveModeFunction_Test;
 
 /**
@@ -269,6 +270,7 @@ public:
 
 private:
     // TODO : Once <gtest/gtest_prod.h> can be included, use FRIEND_TEST for the friend class.
+    friend class TestICDManager;
     friend class TestICDManager_TestShouldCheckInMsgsBeSentAtActiveModeFunction_Test;
 
     /**

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -105,6 +105,19 @@ public:
         ICDModeChange,
     };
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&                                         \
+    CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    enum class PendingCheckInType : uint8_t
+    {
+        kNone,
+        kTargeted,
+        kBroadcast,
+    };
+    static constexpr size_t kMaxPendingCheckInSubjects =
+        CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&
+       // CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+
     /**
      * @brief Verifier template function
      *        This type can be used to implement specific verifiers that can be used in the CheckInMessagesWouldBeSent function.
@@ -385,14 +398,7 @@ private:
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool mPendingActiveModeOnNetworkAttach = false;
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    enum class PendingCheckInType : uint8_t
-    {
-        kNone,
-        kTargeted,
-        kBroadcast,
-    };
-    static constexpr size_t kMaxPendingCheckInSubjects = CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
-    PendingCheckInType mPendingCheckInType             = PendingCheckInType::kNone;
+    PendingCheckInType mPendingCheckInType = PendingCheckInType::kNone;
     std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> mPendingCheckInSubjects;
     size_t mPendingCheckInSubjectsCount = 0;
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -381,7 +381,11 @@ private:
     OperationalState mOperationalState = OperationalState::ActiveMode;
     bool mTransitionToIdleCalled       = false;
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+    bool mPendingActiveModeOnNetworkAttach = false;
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     bool mPendingCheckInOnNetworkAttach = false;
+    Optional<Access::SubjectDescriptor> mPendingCheckInSubject;
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
     uint8_t mOpenExchangeContextCount = 0;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -113,8 +113,7 @@ public:
         kTargeted,
         kBroadcast,
     };
-    static constexpr size_t kMaxPendingCheckInSubjects =
-        CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
+    static constexpr size_t kMaxPendingCheckInSubjects = CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CHIP_CONFIG_ENABLE_ICD_CIP &&
        // CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -389,7 +389,7 @@ private:
     bool mPendingCheckInOnNetworkAttach                = false;
     bool mPendingBroadcastCheckIn                      = false;
     std::array<Access::SubjectDescriptor, kMaxPendingCheckInSubjects> mPendingCheckInSubjects;
-    size_t mPendingCheckInSubjectsCount                = 0;
+    size_t mPendingCheckInSubjectsCount = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1318,96 +1318,300 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 // }
 
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
-TEST_F(TestICDManager, TestDeferredActiveModeOnThreadAttach)
+
+/**
+ * ============================================================================
+ * Exhaustive Unit Test Suite Covering All 14 Execution Sequences & Corner Cases
+ * (Matter LIT ICD Stability & Thread Network Resilience Architecture)
+ * ============================================================================
+ */
+
+// ----------------------------------------------------------------------------
+// Group A: Event-Driven Triggers (Sequences 1 to 4)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario1_SensorEvent_ThreadAttached_CASEValid)
 {
-    // Ensure we start in IdleMode
+    // Pre-condition: Device in IdleMode deep sleep
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Simulate Thread Connectivity Established event
-    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    // Step 1: Sensor triggers network activity
+    ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 
-    // Case 1: Post event when no network activity/subscription report was deferred
-    // Background Thread attach events should NOT wake up the ICD to ActiveMode
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
-    AdvanceClockAndRunEventLoop(100_ms);
+    // Step 2 & 3: Transitions to ActiveMode for fast-polling and report delivery
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 4 & 5: ActiveModeDuration timer expires -> returns cleanly to IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
+TEST_F(TestICDManager, TestScenario2_SensorEvent_ThreadAttached_CASELost)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Case 2: Notify subscription report when Thread is not attached (or in test environment)
+    // Step 1: Sensor triggers network activity -> enters ActiveMode
+    ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 2 & 3: Stale CASE rejected by Hub -> triggers Check-In notification
+    ICDNotifier::GetInstance().NotifySendCheckIn();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 4: ActiveMode timer expires -> returns to IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
+TEST_F(TestICDManager, TestScenario3_SensorEvent_ThreadUnattached_Deferred)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: Sensor triggers subscription report while Thread is unattached
     ICDNotifier::GetInstance().NotifySubscriptionReport();
 
-    // Event should trigger deferred ActiveMode processing once Thread connectivity is established
+    // Step 3: Thread attaches -> PlatformMgr posts kConnectivity_Established
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // ActiveMode should now be triggered!
+    // Step 4: ActiveMode is triggered upon attach and Check-In is dispatched
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
-TEST_F(TestICDManager, TestActiveModeExtensionOnThreadReattach)
+TEST_F(TestICDManager, TestScenario4_SensorEvent_MACFailure_InstantDetachAndRecover)
 {
-    // Transition to ActiveMode via subscription report
+    // Step 1: Device enters ActiveMode on sensor trigger
     ICDNotifier::GetInstance().NotifySubscriptionReport();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
-    // Advance clock halfway through ActiveMode duration
+    // Step 2: Advance halfway through ActiveMode duration
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() / 2);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
-    // Simulate Thread re-attachment event arriving mid-exchange (e.g. after instant MAC failure & re-attach post Hub reboot)
+    // Step 3 & 4: MAC failure triggers instant detach and re-attach post Hub reboot
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // OperationalState should remain ActiveMode and active timer refreshed
+    // Step 5: ActiveMode is extended/refreshed upon Thread attach
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
-TEST_F(TestICDManager, TestDeferredCheckInWhenAlreadyInActiveMode)
+// ----------------------------------------------------------------------------
+// Group B: Periodic Idle Timer Triggers (Sequences 5 to 7)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario5_PeriodicIdleTimer_ThreadAttached_SubscriptionValid)
 {
-    // Transition to ActiveMode via KeepActiveFlag (e.g. user activity / commissioning)
-    ICDNotifier::GetInstance().NotifyActiveRequestNotification(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
+    // Pre-condition: Device in IdleMode with active subscriptions
+    mSubInfoProvider.SetHasActiveSubscription(true);
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: 1-Hour timer expires -> transitions to ActiveMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration() + 1_s);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
-    // Notify subscription report while Thread is unattached
-    ICDNotifier::GetInstance().NotifySubscriptionReport();
+    // Step 3 & 4: Active subscriptions valid -> Check-In suppressed, returns to IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
 
-    // Connectivity established event should process pending Check-In even though device is already in ActiveMode
+TEST_F(TestICDManager, TestScenario6_PeriodicIdleTimer_ThreadAttached_SubscriptionLost)
+{
+    // Pre-condition: Device in IdleMode with lost subscriptions
+    mSubInfoProvider.SetHasActiveSubscription(false);
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: 1-Hour timer expires -> transitions to ActiveMode and sends Check-In
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration() + 1_s);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 3: ActiveMode expires -> returns to IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
+TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: 1-Hour timer expires while unattached -> stays in IdleMode (deferral)
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 3 & 4: Thread attaches -> transitions to ActiveMode and sends Check-In
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
+// ----------------------------------------------------------------------------
+// Group C: Subscription Timeout Triggers (Sequences 8 to 9)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario8_SubscriptionTimeout_ThreadAttached)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: Subscription times out -> triggers NotifySendCheckIn with specific subject
+    Access::SubjectDescriptor subjectDescriptor;
+    subjectDescriptor.fabricIndex = kTestFabricIndex1;
+    subjectDescriptor.subject     = kClientNodeId11;
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subjectDescriptor));
+
+    AdvanceClockAndRunEventLoop(100_ms);
+}
+
+TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferred)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred
+    ICDNotifier::GetInstance().NotifySendCheckIn();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 3 & 4: Thread attaches -> transitions to ActiveMode and dispatches Check-In
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
+// ----------------------------------------------------------------------------
+// Group D: Thread Link Supervision & Hub Reboot (Sequences 10 to 11)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario10_SilentLinkHealing_BackgroundAttachNoWake)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: Background Thread attach occurs with NO pending events
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Step 3: Zero false wake-up: Device must remain in IdleMode to preserve battery
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
+TEST_F(TestICDManager, TestScenario11_ExtendedOutage_IdlePreservedUntilAttach)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1 & 2: Multiple periodic wake-ups fire during extended network outage
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 3: Hub comes back online at t=45m -> Thread attaches
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Step 4: Device wakes up and executes Check-In upon attach
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
+// ----------------------------------------------------------------------------
+// Group E: Advanced Corner Cases & Race Conditions (Sequences 12 to 14)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario12_DeviceAlreadyInActiveMode_WhenThreadAttaches)
+{
+    // Pre-condition: Device held in ActiveMode via KeepActiveFlag (commissioning window)
+    ICDNotifier::GetInstance().NotifyActiveRequestNotification(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 1: Subscription report queued while unattached
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+
+    // Step 2: Thread re-attaches before ActiveMode ends
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Step 3: Check-In dispatched while remaining in ActiveMode without dropping
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Cleanup
     ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
 }
 
-TEST_F(TestICDManager, TestDeferredActiveModeOnPeriodicIdleWakeUp)
+TEST_F(TestICDManager, TestScenario13_RapidNetworkFlapping_Resilience)
 {
-    // Ensure we start in IdleMode
+    // Pre-condition: Device in IdleMode deep sleep
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Advance clock past IdleModeDuration to trigger periodic OnIdleModeDone
-    // In test environment (where Thread is not attached), this should defer ActiveMode
-    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    // Queue a deferred event
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
 
-    // OperationalState should remain IdleMode due to Thread unattached deferral
-    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+    // Flap 1: Connect
+    DeviceLayer::ChipDeviceEvent connectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                               .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&connectEvent));
+    AdvanceClockAndRunEventLoop(10_ms);
 
-    // Simulate Thread Connectivity Established event
-    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    // Flap 2: Immediate Disconnect
+    DeviceLayer::ChipDeviceEvent disconnectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                                  .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Lost } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&disconnectEvent));
+    AdvanceClockAndRunEventLoop(10_ms);
+
+    // Flap 3: Re-connect
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&connectEvent));
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // ActiveMode should now be triggered upon Thread attach!
+    // Verifies clean state recovery without deadlocks
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
+
+TEST_F(TestICDManager, TestScenario14_DeviceShutdown_LifecycleReset)
+{
+    // Step 1: Queue a deferred event
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+
+    // Step 2: Shutdown device
+    mICDManager.Shutdown();
+
+    // Step 3: Verify all timers canceled and state cleanly reset
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 4: Re-initialize ICDManager
+    mICDManager.Init();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
 } // namespace app

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1385,5 +1385,28 @@ TEST_F(TestICDManager, TestDeferredCheckInWhenAlreadyInActiveMode)
     ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
 }
 
+TEST_F(TestICDManager, TestDeferredActiveModeOnPeriodicIdleWakeUp)
+{
+    // Ensure we start in IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Advance clock past IdleModeDuration to trigger periodic OnIdleModeDone
+    // In test environment (where Thread is not attached), this should defer ActiveMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+
+    // OperationalState should remain IdleMode due to Thread unattached deferral
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Simulate Thread Connectivity Established event
+    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // ActiveMode should now be triggered upon Thread attach!
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -240,7 +240,15 @@ public:
     bool IsPendingActiveModeOnNetworkAttach() const { return mICDManager.mPendingActiveModeOnNetworkAttach; }
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     bool IsPendingCheckInOnNetworkAttach() const { return mICDManager.mPendingCheckInOnNetworkAttach; }
-    Optional<Access::SubjectDescriptor> GetPendingCheckInSubject() const { return mICDManager.mPendingCheckInSubject; }
+    size_t GetPendingCheckInSubjectsCount() const { return mICDManager.mPendingCheckInSubjectsCount; }
+    Optional<Access::SubjectDescriptor> GetPendingCheckInSubject(size_t index = 0) const
+    {
+        if (index < mICDManager.mPendingCheckInSubjectsCount)
+        {
+            return MakeOptional(mICDManager.mPendingCheckInSubjects[index]);
+        }
+        return NullOptional;
+    }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event) { mICDManager.HandlePlatformEvent(event); }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
@@ -1562,6 +1570,53 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
 
     // Assert pending Check-In flag is consumed
     EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
+}
+
+TEST_F(TestICDManager, TestScenario9b_SubscriptionTimeout_MultipleSubjects_DeduplicationAndReplay)
+{
+    // Pre-condition: Device in IdleMode deep sleep
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 1: Thread network detached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 2: First subscription timeout for Subject 1
+    Access::SubjectDescriptor subject1;
+    subject1.fabricIndex = kTestFabricIndex1;
+    subject1.subject     = kClientNodeId11;
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subject1));
+
+    // Step 3: Duplicate subscription timeout for Subject 1 (should be deduplicated)
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subject1));
+
+    // Step 4: Second subscription timeout for Subject 2 (distinct fabric/subject)
+    Access::SubjectDescriptor subject2;
+    subject2.fabricIndex = kTestFabricIndex2;
+    subject2.subject     = kClientNodeId12;
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subject2));
+
+    // Assert real deferral: 2 distinct subjects retained, duplicate deduplicated
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_EQ(GetPendingCheckInSubjectsCount(), 2u);
+    EXPECT_TRUE(GetPendingCheckInSubject(0).HasValue());
+    EXPECT_EQ(GetPendingCheckInSubject(0).Value().fabricIndex, kTestFabricIndex1);
+    EXPECT_EQ(GetPendingCheckInSubject(0).Value().subject, kClientNodeId11);
+    EXPECT_TRUE(GetPendingCheckInSubject(1).HasValue());
+    EXPECT_EQ(GetPendingCheckInSubject(1).Value().fabricIndex, kTestFabricIndex2);
+    EXPECT_EQ(GetPendingCheckInSubject(1).Value().subject, kClientNodeId12);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 5: Thread attaches -> replays deferred Check-Ins for both distinct subjects
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    HandlePlatformEvent(&event);
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Assert all pending Check-In flags and subjects are consumed
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_EQ(GetPendingCheckInSubjectsCount(), 0u);
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -221,7 +221,14 @@ public:
     }
 
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
-    void SetPendingCheckInOnNetworkAttach(bool val) { mICDManager.mPendingCheckInOnNetworkAttach = val; }
+    void SetPendingActiveModeOnNetworkAttach(bool val) { mICDManager.mPendingActiveModeOnNetworkAttach = val; }
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    void SetPendingCheckInOnNetworkAttach(bool val, Optional<Access::SubjectDescriptor> subject = NullOptional)
+    {
+        mICDManager.mPendingCheckInOnNetworkAttach = val;
+        mICDManager.mPendingCheckInSubject         = subject;
+    }
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event) { mICDManager.HandlePlatformEvent(event); }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
@@ -1455,7 +1462,7 @@ TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: 1-Hour timer expires while unattached -> stays in IdleMode (deferral)
-    SetPendingCheckInOnNetworkAttach(true);
+    SetPendingActiveModeOnNetworkAttach(true);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3 & 4: Thread attaches -> transitions to ActiveMode and sends Check-In
@@ -1493,17 +1500,18 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred
-    SetPendingCheckInOnNetworkAttach(true);
+    // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred with specific subject preserved
+    Access::SubjectDescriptor subjectDescriptor;
+    subjectDescriptor.fabricIndex = kTestFabricIndex1;
+    subjectDescriptor.subject     = kClientNodeId11;
+    SetPendingCheckInOnNetworkAttach(true, MakeOptional(subjectDescriptor));
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 3 & 4: Thread attaches -> transitions to ActiveMode and dispatches Check-In
+    // Step 3 & 4: Thread attaches -> replaying deferred Check-In for specific subject
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
-
-    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
@@ -1534,7 +1542,7 @@ TEST_F(TestICDManager, TestScenario11_ExtendedOutage_IdlePreservedUntilAttach)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: Multiple periodic wake-ups fire during extended network outage
-    SetPendingCheckInOnNetworkAttach(true);
+    SetPendingActiveModeOnNetworkAttach(true);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3: Hub comes back online at t=45m -> Thread attaches
@@ -1647,7 +1655,7 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
 
     // Step 2: At bootup (kServerReady), TriggerCheckInMessages is called when Thread is detached
     // Setting pending flag simulates the unattached bootup deferral
-    SetPendingCheckInOnNetworkAttach(true);
+    SetPendingActiveModeOnNetworkAttach(true);
 
     // Step 3: Verify the device stays in low-power IdleMode (deep sleep) while Thread is attaching
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -220,6 +220,17 @@ public:
         LoopbackMessagingContext::TearDown();
     }
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+    void SetPendingCheckInOnNetworkAttach(bool val)
+    {
+        mICDManager.mPendingCheckInOnNetworkAttach = val;
+    }
+    void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
+    {
+        mICDManager.HandlePlatformEvent(event);
+    }
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+
     TestSessionKeystoreImpl mKeystore;
     ICDManager mICDManager;
     TestSubscriptionsInfoProvider mSubInfoProvider;
@@ -1357,9 +1368,11 @@ TEST_F(TestICDManager, TestScenario2_SensorEvent_ThreadAttached_CASELost)
     ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     // Step 2 & 3: Stale CASE rejected by Hub -> triggers Check-In notification
-    ICDNotifier::GetInstance().NotifySendCheckIn();
+    ICDNotifier::GetInstance().NotifySendCheckIn(NullOptional);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
     // Step 4: ActiveMode timer expires -> returns to IdleMode
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
@@ -1375,10 +1388,10 @@ TEST_F(TestICDManager, TestScenario3_SensorEvent_ThreadUnattached_Deferred)
     // Step 1 & 2: Sensor triggers subscription report while Thread is unattached
     ICDNotifier::GetInstance().NotifySubscriptionReport();
 
-    // Step 3: Thread attaches -> PlatformMgr posts kConnectivity_Established
+    // Step 3: Thread attaches -> HandlePlatformEvent receives kConnectivity_Established
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 4: ActiveMode is triggered upon attach and Check-In is dispatched
@@ -1398,7 +1411,7 @@ TEST_F(TestICDManager, TestScenario4_SensorEvent_MACFailure_InstantDetachAndReco
     // Step 3 & 4: MAC failure triggers instant detach and re-attach post Hub reboot
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 5: ActiveMode is extended/refreshed upon Thread attach
@@ -1448,13 +1461,13 @@ TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: 1-Hour timer expires while unattached -> stays in IdleMode (deferral)
-    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    SetPendingCheckInOnNetworkAttach(true);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3 & 4: Thread attaches -> transitions to ActiveMode and sends Check-In
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
@@ -1464,6 +1477,7 @@ TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred
 // Group C: Subscription Timeout Triggers (Sequences 8 to 9)
 // ----------------------------------------------------------------------------
 
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 TEST_F(TestICDManager, TestScenario8_SubscriptionTimeout_ThreadAttached)
 {
     // Pre-condition: Device in IdleMode deep sleep
@@ -1486,17 +1500,18 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred
-    ICDNotifier::GetInstance().NotifySendCheckIn();
+    ICDNotifier::GetInstance().NotifySendCheckIn(NullOptional);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3 & 4: Thread attaches -> transitions to ActiveMode and dispatches Check-In
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
 // ----------------------------------------------------------------------------
 // Group D: Thread Link Supervision & Hub Reboot (Sequences 10 to 11)
@@ -1511,7 +1526,7 @@ TEST_F(TestICDManager, TestScenario10_SilentLinkHealing_BackgroundAttachNoWake)
     // Step 1 & 2: Background Thread attach occurs with NO pending events
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 3: Zero false wake-up: Device must remain in IdleMode to preserve battery
@@ -1525,16 +1540,13 @@ TEST_F(TestICDManager, TestScenario11_ExtendedOutage_IdlePreservedUntilAttach)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: Multiple periodic wake-ups fire during extended network outage
-    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
-    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
-
-    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration());
+    SetPendingCheckInOnNetworkAttach(true);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3: Hub comes back online at t=45m -> Thread attaches
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 4: Device wakes up and executes Check-In upon attach
@@ -1557,7 +1569,7 @@ TEST_F(TestICDManager, TestScenario12_DeviceAlreadyInActiveMode_WhenThreadAttach
     // Step 2: Thread re-attaches before ActiveMode ends
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 3: Check-In dispatched while remaining in ActiveMode without dropping
@@ -1579,17 +1591,17 @@ TEST_F(TestICDManager, TestScenario13_RapidNetworkFlapping_Resilience)
     // Flap 1: Connect
     DeviceLayer::ChipDeviceEvent connectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                                .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&connectEvent));
+    HandlePlatformEvent(&connectEvent);
     AdvanceClockAndRunEventLoop(10_ms);
 
     // Flap 2: Immediate Disconnect
     DeviceLayer::ChipDeviceEvent disconnectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                                   .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Lost } };
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&disconnectEvent));
+    HandlePlatformEvent(&disconnectEvent);
     AdvanceClockAndRunEventLoop(10_ms);
 
     // Flap 3: Re-connect
-    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&connectEvent));
+    HandlePlatformEvent(&connectEvent);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Verifies clean state recovery without deadlocks

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1332,7 +1332,7 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 
 /**
  * ============================================================================
- * Exhaustive Unit Test Suite Covering All 14 Execution Sequences & Corner Cases
+ * Exhaustive Unit Test Suite Covering All 15 Execution Sequences & Corner Cases
  * (Matter LIT ICD Stability & Thread Network Resilience Architecture)
  * ============================================================================
  */
@@ -1621,6 +1621,38 @@ TEST_F(TestICDManager, TestScenario14_DeviceShutdown_LifecycleReset)
 
     // Step 4: Re-initialize ICDManager
     mICDManager.Init();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+}
+
+// ----------------------------------------------------------------------------
+// Group F: ICD Device Reboot & Power Cycle (Sequence 15)
+// ----------------------------------------------------------------------------
+
+TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
+{
+    // Step 1: Simulate cold boot / reboot initialization (Shutdown -> Init)
+    mICDManager.Shutdown();
+    mICDManager.Init();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 2: At bootup (kServerReady), TriggerCheckInMessages is called when Thread is detached
+    // Setting pending flag simulates the unattached bootup deferral
+    SetPendingCheckInOnNetworkAttach(true);
+
+    // Step 3: Verify the device stays in low-power IdleMode (deep sleep) while Thread is attaching
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 4: OpenThread finishes MLE attach in background -> kConnectivity_Established fires
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    HandlePlatformEvent(&event);
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Step 5: Verify device enters ActiveMode and flushes the deferred bootup Check-In
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Step 6: ActiveMode completes -> returns to IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }
 

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1867,7 +1867,8 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }
 
-#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CONFIG_BUILD_FOR_HOST_UNIT_TEST && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CONFIG_BUILD_FOR_HOST_UNIT_TEST &&
+       // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 } // namespace app
 } // namespace chip

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1494,7 +1494,7 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred
-    ICDNotifier::GetInstance().NotifySendCheckIn(NullOptional);
+    SetPendingCheckInOnNetworkAttach(true);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3 & 4: Thread attaches -> transitions to ActiveMode and dispatches Check-In
@@ -1614,6 +1614,14 @@ TEST_F(TestICDManager, TestScenario14_DeviceShutdown_LifecycleReset)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Step 4: Re-initialize ICDManager
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.SetPersistentStorageDelegate(&testStorage)
+        .SetFabricTable(&GetFabricTable())
+        .SetSymmetricKeyStore(&mKeystore)
+        .SetExchangeManager(&GetExchangeManager())
+        .SetSubscriptionsInfoProvider(&mSubInfoProvider)
+        .SetICDCheckInBackOffStrategy(&mStrategy);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
     mICDManager.Init();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }
@@ -1626,6 +1634,14 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
 {
     // Step 1: Simulate cold boot / reboot initialization (Shutdown -> Init)
     mICDManager.Shutdown();
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.SetPersistentStorageDelegate(&testStorage)
+        .SetFabricTable(&GetFabricTable())
+        .SetSymmetricKeyStore(&mKeystore)
+        .SetExchangeManager(&GetExchangeManager())
+        .SetSubscriptionsInfoProvider(&mSubInfoProvider)
+        .SetICDCheckInBackOffStrategy(&mStrategy);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
     mICDManager.Init();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1324,8 +1324,8 @@ TEST_F(TestICDManager, TestDeferredActiveModeOnThreadAttach)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Simulate Thread Connectivity Established event
-    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
 
     // Case 1: Post event when no network activity/subscription report was deferred
     // Background Thread attach events should NOT wake up the ICD to ActiveMode
@@ -1355,8 +1355,8 @@ TEST_F(TestICDManager, TestActiveModeExtensionOnThreadReattach)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Simulate Thread re-attachment event arriving mid-exchange (e.g. after instant MAC failure & re-attach post Hub reboot)
-    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 
@@ -1374,8 +1374,8 @@ TEST_F(TestICDManager, TestDeferredCheckInWhenAlreadyInActiveMode)
     ICDNotifier::GetInstance().NotifySubscriptionReport();
 
     // Connectivity established event should process pending Check-In even though device is already in ActiveMode
-    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 
@@ -1399,8 +1399,8 @@ TEST_F(TestICDManager, TestDeferredActiveModeOnPeriodicIdleWakeUp)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Simulate Thread Connectivity Established event
-    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
-                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
     AdvanceClockAndRunEventLoop(100_ms);
 

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1317,6 +1317,7 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 //     ICDConfigurationData::GetInstance().SetModeDurations(MakeOptional(oldActiveModeDuration), NullOptional);
 // }
 
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 TEST_F(TestICDManager, TestDeferredActiveModeOnThreadAttach)
 {
     // Ensure we start in IdleMode
@@ -1407,6 +1408,7 @@ TEST_F(TestICDManager, TestDeferredActiveModeOnPeriodicIdleWakeUp)
     // ActiveMode should now be triggered upon Thread attach!
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
 } // namespace app
 } // namespace chip

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -221,14 +221,8 @@ public:
     }
 
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
-    void SetPendingCheckInOnNetworkAttach(bool val)
-    {
-        mICDManager.mPendingCheckInOnNetworkAttach = val;
-    }
-    void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
-    {
-        mICDManager.HandlePlatformEvent(event);
-    }
+    void SetPendingCheckInOnNetworkAttach(bool val) { mICDManager.mPendingCheckInOnNetworkAttach = val; }
+    void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event) { mICDManager.HandlePlatformEvent(event); }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
 
     TestSessionKeystoreImpl mKeystore;
@@ -1595,7 +1589,7 @@ TEST_F(TestICDManager, TestScenario13_RapidNetworkFlapping_Resilience)
     AdvanceClockAndRunEventLoop(10_ms);
 
     // Flap 2: Immediate Disconnect
-    DeviceLayer::ChipDeviceEvent disconnectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+    DeviceLayer::ChipDeviceEvent disconnectEvent{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                                   .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Lost } };
     HandlePlatformEvent(&disconnectEvent);
     AdvanceClockAndRunEventLoop(10_ms);

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -242,8 +242,14 @@ public:
 #if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
     bool IsPendingActiveModeOnNetworkAttach() const { return mICDManager.mPendingActiveModeOnNetworkAttach; }
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    bool IsPendingCheckInOnNetworkAttach() const { return mICDManager.mPendingCheckInOnNetworkAttach; }
-    bool IsPendingBroadcastCheckInOnNetworkAttach() const { return mICDManager.mPendingBroadcastCheckIn; }
+    bool IsPendingCheckInOnNetworkAttach() const
+    {
+        return mICDManager.mPendingCheckInType != ICDManager::PendingCheckInType::kNone;
+    }
+    bool IsPendingBroadcastCheckInOnNetworkAttach() const
+    {
+        return mICDManager.mPendingCheckInType == ICDManager::PendingCheckInType::kBroadcast;
+    }
     size_t GetPendingCheckInSubjectsCount() const { return mICDManager.mPendingCheckInSubjectsCount; }
     Optional<Access::SubjectDescriptor> GetPendingCheckInSubject(size_t index = 0) const
     {
@@ -1866,6 +1872,49 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+TEST_F(TestICDManager, TestScenario16_PendingSubjectsOverflow_UpgradesToBroadcast)
+{
+    // Pre-condition: Device in IdleMode with Thread unattached
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 1: Enqueue distinct subjects up to capacity
+    for (size_t i = 0; i < ICDManager::kMaxPendingCheckInSubjects; ++i)
+    {
+        Access::SubjectDescriptor subject;
+        subject.fabricIndex = static_cast<FabricIndex>(1 + (i % 2));
+        subject.subject     = static_cast<NodeId>(0x1000 + i);
+        ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subject));
+    }
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_FALSE(IsPendingBroadcastCheckInOnNetworkAttach());
+    EXPECT_EQ(GetPendingCheckInSubjectsCount(), ICDManager::kMaxPendingCheckInSubjects);
+
+    // Step 2: Enqueue one more distinct subject beyond capacity -> triggers automatic upgrade to Broadcast Check-In
+    Access::SubjectDescriptor overflowSubject;
+    overflowSubject.fabricIndex = kTestFabricIndex1;
+    overflowSubject.subject     = 0x9999;
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(overflowSubject));
+
+    // Verify upgrade to broadcast so no registered clients are missed
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_TRUE(IsPendingBroadcastCheckInOnNetworkAttach());
+    EXPECT_EQ(GetPendingCheckInSubjectsCount(), 0u);
+
+    // Step 3: Thread attaches -> verifies broadcast Check-In is replayed cleanly
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
+    DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                        .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    HandlePlatformEvent(&event);
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_FALSE(IsPendingBroadcastCheckInOnNetworkAttach());
+}
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CONFIG_BUILD_FOR_HOST_UNIT_TEST &&
        // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1317,5 +1317,73 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 //     ICDConfigurationData::GetInstance().SetModeDurations(MakeOptional(oldActiveModeDuration), NullOptional);
 // }
 
+TEST_F(TestICDManager, TestDeferredActiveModeOnThreadAttach)
+{
+    // Ensure we start in IdleMode
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Simulate Thread Connectivity Established event
+    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+
+    // Case 1: Post event when no network activity/subscription report was deferred
+    // Background Thread attach events should NOT wake up the ICD to ActiveMode
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Case 2: Notify subscription report when Thread is not attached (or in test environment)
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+
+    // Event should trigger deferred ActiveMode processing once Thread connectivity is established
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // ActiveMode should now be triggered!
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
+TEST_F(TestICDManager, TestActiveModeExtensionOnThreadReattach)
+{
+    // Transition to ActiveMode via subscription report
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Advance clock halfway through ActiveMode duration
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() / 2);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Simulate Thread re-attachment event arriving mid-exchange (e.g. after instant MAC failure & re-attach post Hub reboot)
+    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // OperationalState should remain ActiveMode and active timer refreshed
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
+TEST_F(TestICDManager, TestDeferredCheckInWhenAlreadyInActiveMode)
+{
+    // Transition to ActiveMode via KeepActiveFlag (e.g. user activity / commissioning)
+    ICDNotifier::GetInstance().NotifyActiveRequestNotification(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Notify subscription report while Thread is unattached
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+
+    // Connectivity established event should process pending Check-In even though device is already in ActiveMode
+    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    EXPECT_EQ(CHIP_NO_ERROR, DeviceLayer::PlatformMgr().PostEvent(&event));
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+
+    // Cleanup
+    ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -240,6 +240,7 @@ public:
     bool IsPendingActiveModeOnNetworkAttach() const { return mICDManager.mPendingActiveModeOnNetworkAttach; }
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     bool IsPendingCheckInOnNetworkAttach() const { return mICDManager.mPendingCheckInOnNetworkAttach; }
+    bool IsPendingBroadcastCheckInOnNetworkAttach() const { return mICDManager.mPendingBroadcastCheckIn; }
     size_t GetPendingCheckInSubjectsCount() const { return mICDManager.mPendingCheckInSubjectsCount; }
     Optional<Access::SubjectDescriptor> GetPendingCheckInSubject(size_t index = 0) const
     {
@@ -1680,18 +1681,28 @@ TEST_F(TestICDManager, TestScenario12_DeviceAlreadyInActiveMode_WhenThreadAttach
     ICDNotifier::GetInstance().NotifyActiveRequestNotification(ICDListener::KeepActiveFlag::kCommissioningWindowOpen);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
-    // Step 1: Subscription report queued while unattached
+    // Step 1: Thread detaches while in ActiveMode
     SetThreadConnectivityState(true /* enabled */, false /* attached */);
-    ICDNotifier::GetInstance().NotifySubscriptionReport();
 
-    // Step 2: Thread re-attaches before ActiveMode ends
+    // Step 2: Broadcast Check-In requested while unattached
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    ICDNotifier::GetInstance().NotifySendCheckIn(NullOptional);
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_TRUE(IsPendingBroadcastCheckInOnNetworkAttach());
+#endif
+
+    // Step 3: Thread re-attaches while device is already in ActiveMode
     SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // Step 3: Check-In dispatched while remaining in ActiveMode without dropping
+    // Step 4: Pending broadcast Check-In is consumed and replayed while remaining in ActiveMode
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_FALSE(IsPendingBroadcastCheckInOnNetworkAttach());
+#endif
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Cleanup

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1354,7 +1354,7 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 //     ICDConfigurationData::GetInstance().SetModeDurations(MakeOptional(oldActiveModeDuration), NullOptional);
 // }
 
-#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CONFIG_BUILD_FOR_HOST_UNIT_TEST && CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 /**
  * ============================================================================
@@ -1867,7 +1867,7 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }
 
-#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+#endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH && CONFIG_BUILD_FOR_HOST_UNIT_TEST && CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 } // namespace app
 } // namespace chip

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -1678,6 +1678,54 @@ TEST_F(TestICDManager, TestScenario13_RapidNetworkFlapping_Resilience)
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
+TEST_F(TestICDManager, TestScenario13b_QueuedEstablishThenLoss_KeepsPendingWork)
+{
+    // Pre-condition: Device in IdleMode deep sleep with Thread unattached
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 1: Queue deferred ActiveMode and deferred Check-In while unattached
+    ICDNotifier::GetInstance().NotifySubscriptionReport();
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    Access::SubjectDescriptor subjectDescriptor;
+    subjectDescriptor.fabricIndex = kTestFabricIndex1;
+    subjectDescriptor.subject     = kClientNodeId11;
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subjectDescriptor));
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_TRUE(GetPendingCheckInSubject().HasValue());
+#endif
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 2: An "Established" event is dispatched, but current Thread state is unattached (race condition)
+    DeviceLayer::ChipDeviceEvent connectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
+                                               .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
+    HandlePlatformEvent(&connectEvent);
+    AdvanceClockAndRunEventLoop(10_ms);
+
+    // Step 3: Pending work MUST NOT be consumed and device MUST remain in IdleMode
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_TRUE(GetPendingCheckInSubject().HasValue());
+#endif
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
+    // Step 4: True network attachment occurs later (IsThreadAttached() == true)
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
+    HandlePlatformEvent(&connectEvent);
+    AdvanceClockAndRunEventLoop(100_ms);
+
+    // Step 5: Now pending work is consumed and device enters ActiveMode
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
+#endif
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
+}
+
 TEST_F(TestICDManager, TestScenario14_DeviceShutdown_LifecycleReset)
 {
     // Step 1: Queue a deferred event while unattached

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -223,15 +223,18 @@ public:
 
     void SetThreadConnectivityState(bool enabled, bool attached)
     {
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST && CHIP_DEVICE_CONFIG_ENABLE_THREAD
         DeviceLayer::ThreadStackMgrImpl().SetThreadEnabledForTest(enabled);
         DeviceLayer::ThreadStackMgrImpl().SetThreadAttachedForTest(attached);
+#else
+        (void) enabled;
+        (void) attached;
 #endif
     }
 
     void ResetThreadConnectivityState()
     {
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST && CHIP_DEVICE_CONFIG_ENABLE_THREAD
         DeviceLayer::ThreadStackMgrImpl().ResetThreadStateForTest();
 #endif
     }

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -216,18 +216,31 @@ public:
     // Performs teardown for each individual test in the test suite
     void TearDown() override
     {
+        ResetThreadConnectivityState();
         mICDManager.Shutdown();
         LoopbackMessagingContext::TearDown();
     }
 
-#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
-    void SetPendingActiveModeOnNetworkAttach(bool val) { mICDManager.mPendingActiveModeOnNetworkAttach = val; }
-#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    void SetPendingCheckInOnNetworkAttach(bool val, Optional<Access::SubjectDescriptor> subject = NullOptional)
+    void SetThreadConnectivityState(bool enabled, bool attached)
     {
-        mICDManager.mPendingCheckInOnNetworkAttach = val;
-        mICDManager.mPendingCheckInSubject         = subject;
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        DeviceLayer::ThreadStackMgrImpl().SetThreadEnabledForTest(enabled);
+        DeviceLayer::ThreadStackMgrImpl().SetThreadAttachedForTest(attached);
+#endif
     }
+
+    void ResetThreadConnectivityState()
+    {
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        DeviceLayer::ThreadStackMgrImpl().ResetThreadStateForTest();
+#endif
+    }
+
+#if CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
+    bool IsPendingActiveModeOnNetworkAttach() const { return mICDManager.mPendingActiveModeOnNetworkAttach; }
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
+    bool IsPendingCheckInOnNetworkAttach() const { return mICDManager.mPendingCheckInOnNetworkAttach; }
+    Optional<Access::SubjectDescriptor> GetPendingCheckInSubject() const { return mICDManager.mPendingCheckInSubject; }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
     void HandlePlatformEvent(const DeviceLayer::ChipDeviceEvent * event) { mICDManager.HandlePlatformEvent(event); }
 #endif // CHIP_CONFIG_ENABLE_ICD_DEFER_ACTIVEMODE_THREAD_ATTACH
@@ -1344,7 +1357,8 @@ TEST_F(TestICDManager, TestShortIdleModeBehaviorSITvsLIT)
 
 TEST_F(TestICDManager, TestScenario1_SensorEvent_ThreadAttached_CASEValid)
 {
-    // Pre-condition: Device in IdleMode deep sleep
+    // Pre-condition: Device in IdleMode deep sleep with Thread attached
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
@@ -1361,7 +1375,8 @@ TEST_F(TestICDManager, TestScenario1_SensorEvent_ThreadAttached_CASEValid)
 
 TEST_F(TestICDManager, TestScenario2_SensorEvent_ThreadAttached_CASELost)
 {
-    // Pre-condition: Device in IdleMode deep sleep
+    // Pre-condition: Device in IdleMode deep sleep with Thread attached
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
@@ -1386,22 +1401,32 @@ TEST_F(TestICDManager, TestScenario3_SensorEvent_ThreadUnattached_Deferred)
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 1 & 2: Sensor triggers subscription report while Thread is unattached
+    // Step 1: Thread detached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 2: Sensor triggers subscription report while Thread is unattached
     ICDNotifier::GetInstance().NotifySubscriptionReport();
 
+    // Assert real deferral: device remains in IdleMode and pending ActiveMode flag is asserted
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
+    EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
+
     // Step 3: Thread attaches -> HandlePlatformEvent receives kConnectivity_Established
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // Step 4: ActiveMode is triggered upon attach and Check-In is dispatched
+    // Step 4: ActiveMode is triggered upon attach and pending flag is consumed
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
 TEST_F(TestICDManager, TestScenario4_SensorEvent_MACFailure_InstantDetachAndRecover)
 {
     // Step 1: Device enters ActiveMode on sensor trigger
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     ICDNotifier::GetInstance().NotifySubscriptionReport();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
@@ -1426,6 +1451,7 @@ TEST_F(TestICDManager, TestScenario4_SensorEvent_MACFailure_InstantDetachAndReco
 TEST_F(TestICDManager, TestScenario5_PeriodicIdleTimer_ThreadAttached_SubscriptionValid)
 {
     // Pre-condition: Device in IdleMode with active subscriptions
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     mSubInfoProvider.SetHasActiveSubscription(true);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
@@ -1442,6 +1468,7 @@ TEST_F(TestICDManager, TestScenario5_PeriodicIdleTimer_ThreadAttached_Subscripti
 TEST_F(TestICDManager, TestScenario6_PeriodicIdleTimer_ThreadAttached_SubscriptionLost)
 {
     // Pre-condition: Device in IdleMode with lost subscriptions
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     mSubInfoProvider.SetHasActiveSubscription(false);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
@@ -1461,16 +1488,24 @@ TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 1 & 2: 1-Hour timer expires while unattached -> stays in IdleMode (deferral)
-    SetPendingActiveModeOnNetworkAttach(true);
+    // Step 1: Thread network detached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 2: 1-Hour timer expires while unattached -> timer advancement fires real OnIdleModeDone
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration() + 1_s);
+
+    // Assert real deferral: device remains in IdleMode and pending ActiveMode flag is asserted
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 3 & 4: Thread attaches -> transitions to ActiveMode and sends Check-In
+    // Step 3 & 4: Thread attaches -> transitions to ActiveMode and consumes pending flag
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
@@ -1481,7 +1516,8 @@ TEST_F(TestICDManager, TestScenario7_PeriodicIdleTimer_ThreadUnattached_Deferred
 #if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 TEST_F(TestICDManager, TestScenario8_SubscriptionTimeout_ThreadAttached)
 {
-    // Pre-condition: Device in IdleMode deep sleep
+    // Pre-condition: Device in IdleMode deep sleep with Thread attached
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
@@ -1492,6 +1528,7 @@ TEST_F(TestICDManager, TestScenario8_SubscriptionTimeout_ThreadAttached)
     ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subjectDescriptor));
 
     AdvanceClockAndRunEventLoop(100_ms);
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
 }
 
 TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferred)
@@ -1500,18 +1537,31 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 1 & 2: Subscription times out while unattached -> Check-In is deferred with specific subject preserved
+    // Step 1: Thread network detached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 2: Subscription times out while unattached -> triggers real NotifySendCheckIn with specific subject
     Access::SubjectDescriptor subjectDescriptor;
     subjectDescriptor.fabricIndex = kTestFabricIndex1;
     subjectDescriptor.subject     = kClientNodeId11;
-    SetPendingCheckInOnNetworkAttach(true, MakeOptional(subjectDescriptor));
+    ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(subjectDescriptor));
+
+    // Assert real deferral: pending check-in flag is asserted and subject is preserved
+    EXPECT_TRUE(IsPendingCheckInOnNetworkAttach());
+    EXPECT_TRUE(GetPendingCheckInSubject().HasValue());
+    EXPECT_EQ(GetPendingCheckInSubject().Value().fabricIndex, kTestFabricIndex1);
+    EXPECT_EQ(GetPendingCheckInSubject().Value().subject, kClientNodeId11);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3 & 4: Thread attaches -> replaying deferred Check-In for specific subject
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
+
+    // Assert pending Check-In flag is consumed
+    EXPECT_FALSE(IsPendingCheckInOnNetworkAttach());
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
@@ -1521,7 +1571,8 @@ TEST_F(TestICDManager, TestScenario9_SubscriptionTimeout_ThreadUnattached_Deferr
 
 TEST_F(TestICDManager, TestScenario10_SilentLinkHealing_BackgroundAttachNoWake)
 {
-    // Pre-condition: Device in IdleMode deep sleep
+    // Pre-condition: Device in IdleMode deep sleep with Thread attached
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
@@ -1541,17 +1592,26 @@ TEST_F(TestICDManager, TestScenario11_ExtendedOutage_IdlePreservedUntilAttach)
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 1 & 2: Multiple periodic wake-ups fire during extended network outage
-    SetPendingActiveModeOnNetworkAttach(true);
+    // Step 1: Extended network outage occurs
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
+
+    // Step 2: Multiple periodic wake-ups fire during outage -> all deferred via real triggers
+    AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration() + 1_s);
+    ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+
+    // Assert pending state
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
     // Step 3: Hub comes back online at t=45m -> Thread attaches
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Step 4: Device wakes up and executes Check-In upon attach
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
@@ -1566,9 +1626,11 @@ TEST_F(TestICDManager, TestScenario12_DeviceAlreadyInActiveMode_WhenThreadAttach
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Step 1: Subscription report queued while unattached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
     ICDNotifier::GetInstance().NotifySubscriptionReport();
 
     // Step 2: Thread re-attaches before ActiveMode ends
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
@@ -1587,38 +1649,47 @@ TEST_F(TestICDManager, TestScenario13_RapidNetworkFlapping_Resilience)
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Queue a deferred event
+    // Step 1: Queue a deferred event while unattached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
     ICDNotifier::GetInstance().NotifySubscriptionReport();
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
 
     // Flap 1: Connect
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent connectEvent{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                                .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&connectEvent);
     AdvanceClockAndRunEventLoop(10_ms);
 
     // Flap 2: Immediate Disconnect
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
     DeviceLayer::ChipDeviceEvent disconnectEvent{ .Type = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                                   .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Lost } };
     HandlePlatformEvent(&disconnectEvent);
     AdvanceClockAndRunEventLoop(10_ms);
 
     // Flap 3: Re-connect
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     HandlePlatformEvent(&connectEvent);
     AdvanceClockAndRunEventLoop(100_ms);
 
     // Verifies clean state recovery without deadlocks
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 }
 
 TEST_F(TestICDManager, TestScenario14_DeviceShutdown_LifecycleReset)
 {
-    // Step 1: Queue a deferred event
+    // Step 1: Queue a deferred event while unattached
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
     ICDNotifier::GetInstance().NotifySubscriptionReport();
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
 
     // Step 2: Shutdown device
     mICDManager.Shutdown();
 
-    // Step 3: Verify all timers canceled and state cleanly reset
+    // Step 3: Verify all timers canceled and deferred state cleanly reset
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
     // Step 4: Re-initialize ICDManager
@@ -1653,23 +1724,28 @@ TEST_F(TestICDManager, TestScenario15_DeviceReboot_ColdBoot_DeferredIfDetached)
     mICDManager.Init();
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 2: At bootup (kServerReady), TriggerCheckInMessages is called when Thread is detached
-    // Setting pending flag simulates the unattached bootup deferral
-    SetPendingActiveModeOnNetworkAttach(true);
+    // Step 2: Thread is unattached on cold boot
+    SetThreadConnectivityState(true /* enabled */, false /* attached */);
 
-    // Step 3: Verify the device stays in low-power IdleMode (deep sleep) while Thread is attaching
+    // Step 3: At bootup (kServerReady), TriggerCheckInMessages / network activity is triggered
+    ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+
+    // Step 4: Verify the device stays in low-power IdleMode (deep sleep) while Thread is attaching
+    EXPECT_TRUE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 
-    // Step 4: OpenThread finishes MLE attach in background -> kConnectivity_Established fires
+    // Step 5: OpenThread finishes MLE attach in background -> kConnectivity_Established fires
+    SetThreadConnectivityState(true /* enabled */, true /* attached */);
     DeviceLayer::ChipDeviceEvent event{ .Type                     = DeviceLayer::DeviceEventType::kThreadConnectivityChange,
                                         .ThreadConnectivityChange = { .Result = DeviceLayer::kConnectivity_Established } };
     HandlePlatformEvent(&event);
     AdvanceClockAndRunEventLoop(100_ms);
 
-    // Step 5: Verify device enters ActiveMode and flushes the deferred bootup Check-In
+    // Step 6: Verify device enters ActiveMode and flushes the deferred bootup Check-In
+    EXPECT_FALSE(IsPendingActiveModeOnNetworkAttach());
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::ActiveMode);
 
-    // Step 6: ActiveMode completes -> returns to IdleMode
+    // Step 7: ActiveMode completes -> returns to IdleMode
     AdvanceClockAndRunEventLoop(ICDConfigurationData::GetInstance().GetActiveModeDuration() + 1_ms32);
     EXPECT_EQ(mICDManager.GetOperaionalState(), ICDManager::OperationalState::IdleMode);
 }

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -317,9 +317,9 @@ void ThreadStackManagerImpl::_ErasePersistentInfo()
 bool ThreadStackManagerImpl::_IsThreadEnabled()
 {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    if (mThreadEnabledForTest.has_value())
+    if (mThreadEnabledForTest.HasValue())
     {
-        return mThreadEnabledForTest.value();
+        return mThreadEnabledForTest.Value();
     }
 #endif
     VerifyOrReturnError(mProxy, false);

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -316,6 +316,12 @@ void ThreadStackManagerImpl::_ErasePersistentInfo()
 
 bool ThreadStackManagerImpl::_IsThreadEnabled()
 {
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    if (mThreadEnabledForTest.has_value())
+    {
+        return mThreadEnabledForTest.value();
+    }
+#endif
     VerifyOrReturnError(mProxy, false);
 
     GAutoPtr<GError> err;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -22,10 +22,10 @@
 #else
 
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include <app/icd/server/ICDServerConfig.h>
+#include <lib/core/Optional.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/openthread/DBusOpenthread.h>
@@ -49,11 +49,11 @@ public:
     ThreadStackManagerImpl();
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    void SetThreadEnabledForTest(bool enabled) { mThreadEnabledForTest = enabled; }
+    void SetThreadEnabledForTest(bool enabled) { mThreadEnabledForTest.SetValue(enabled); }
     void SetThreadAttachedForTest(bool attached) { mAttached = attached; }
     void ResetThreadStateForTest()
     {
-        mThreadEnabledForTest.reset();
+        mThreadEnabledForTest.ClearValue();
         mAttached = false;
     }
 #endif
@@ -180,7 +180,7 @@ private:
 
     bool mAttached;
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    std::optional<bool> mThreadEnabledForTest;
+    chip::Optional<bool> mThreadEnabledForTest;
 #endif
     uint8_t mExtendedAddress[8];
 };

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -22,6 +22,7 @@
 #else
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <app/icd/server/ICDServerConfig.h>
@@ -46,6 +47,16 @@ class ThreadStackManagerImpl : public ThreadStackManager
 {
 public:
     ThreadStackManagerImpl();
+
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    void SetThreadEnabledForTest(bool enabled) { mThreadEnabledForTest = enabled; }
+    void SetThreadAttachedForTest(bool attached) { mAttached = attached; }
+    void ResetThreadStateForTest()
+    {
+        mThreadEnabledForTest.reset();
+        mAttached = false;
+    }
+#endif
 
     void
     SetNetworkStatusChangeCallback(NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
@@ -168,6 +179,9 @@ private:
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
     bool mAttached;
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    std::optional<bool> mThreadEnabledForTest;
+#endif
     uint8_t mExtendedAddress[8];
 };
 


### PR DESCRIPTION
### Summary

Long Idle Time (LIT) Intermittently Connected Devices (ICDs) operating over Thread (e.g., door/window contact sensors, motion sensors, temperature sensors, and smart locks) must maintain multi-year battery life while remaining responsive to state changes and network commands.

### The Solution
This PR implements an event-driven network deferral mechanism within `ICDManager` that keeps the ICD in low-power deep sleep (`IdleMode`) during Thread network outages and cleanly flushes pending transactions once Thread connectivity is re-established (`kConnectivity_Established`).
#### Core Architectural Changes:
* **Network Attachment Gating:** `OnIdleModeDone()` and `OnSendCheckIn()` verify `ConnectivityMgr().IsThreadAttached()`. If unattached, `ActiveMode` fast-polling and Check-In transmissions are deferred, immediately returning the MCU and radio to deep sleep.
* **Strongly Typed State Machine (`PendingCheckInType`):** Uses an enum (`kNone`, `kTargeted`, `kBroadcast`) where broadcast check-ins strictly supersede targeted check-ins, eliminating unrepresentable or conflicting states.
* **Zero-Heap & Zero-Stack Bounded Storage:** Bounded member array `mPendingCheckInSubjects` ($2\text{ clients/fabric} \times 5\text{ fabrics} = 10\text{ entries}$) with `Contains()` deduplication. Processed **in-place** to eliminate stack copies and protect $2\text{--}4\text{ KB}$ RTOS task stacks against stack overflow.
* **Automatic Broadcast Overflow Promotion:** If subscription timeouts exceed capacity ($N > 10$), state is automatically promoted to `kBroadcast`, guaranteeing zero dropped clients without dynamic allocations.
* **Subsumptive `IdleMode` $\to$ `ActiveMode` Transition (Zero Re-entrancy):** Waking from `IdleMode` to `ActiveMode` natively invokes `SendCheckInMsgs()` across all fabrics (evaluating active subscriptions to suppress valid clients and send Check-Ins to lost clients in one pass). In-place replay of queued subjects is strictly reserved for when the device was *already* awake in `ActiveMode`.
* **Queued Race Resilience:** Directly validates `IsThreadAttached()` upon dequeuing `kConnectivity_Established` to prevent stale queued events from consuming pending state if the link dropped before execution.
* **Lifecycle Reset:** `ICDManager::Shutdown()` cleanly clears all pending flags and queues across soft reboots.

### Related issues
N/A
### Testing
unit testing and local testing with multiple real devices across manufacturers
