### PR TITLE
Implement JCM cross-signing and AddICAC installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,10 @@ Alternatively, you can activate the environment in your shell:
     -   Compile and run can be separated (e.g. if running under some memory
         debugger or needing to set other options):
 
-      ```bash
-      scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
-      ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
-      ```
+    ```bash
+    scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
+    ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
+    ```
 
 ### Building Common Apps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,10 @@ Alternatively, you can activate the environment in your shell:
     -   Compile and run can be separated (e.g. if running under some memory
         debugger or needing to set other options):
 
-              ```bash
-              scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
-              ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
-              ```
+      ```bash
+      scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
+      ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
+      ```
 
 ### Building Common Apps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,80 +5,80 @@ Matter SDK codebase.
 
 ## General Principles
 
-- **When in Rome**: Match the prevailing style of the code being modified. See
-  [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md).
-- **Atomicity**: Make small, incremental changes. Do not mix refactoring with
-  feature implementation.
-- **No Filler Names**: Avoid names like "support", "common", "helpers", "util",
-  "core". Use concrete names.
-- **Error Handling**: Use `CHIP_ERROR` as the standard return type for fallible
-  operations. Prefer `VerifyOrReturnError` and `ReturnErrorOnFailure` macros for
-  concise error checking and propagation.
-- Ensure resources are cleaned up appropriately, especially on early returns.
-  Generally prefer RAII patterns for cleanup.
-- **Logging**: Use the `ChipLog*` macros (e.g., `ChipLogProgress`,
-  `ChipLogError`, `ChipLogDetail`) for logging. Ensure logs are appropriately
-  categorized by module (e.g., `AppServer`, `InteractionModel`).
+-   **When in Rome**: Match the prevailing style of the code being modified. See
+    [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md).
+-   **Atomicity**: Make small, incremental changes. Do not mix refactoring with
+    feature implementation.
+-   **No Filler Names**: Avoid names like "support", "common", "helpers",
+    "util", "core". Use concrete names.
+-   **Error Handling**: Use `CHIP_ERROR` as the standard return type for
+    fallible operations. Prefer `VerifyOrReturnError` and `ReturnErrorOnFailure`
+    macros for concise error checking and propagation.
+-   Ensure resources are cleaned up appropriately, especially on early returns.
+    Generally prefer RAII patterns for cleanup.
+-   **Logging**: Use the `ChipLog*` macros (e.g., `ChipLogProgress`,
+    `ChipLogError`, `ChipLogDetail`) for logging. Ensure logs are appropriately
+    categorized by module (e.g., `AppServer`, `InteractionModel`).
 
 ## Ignored Directories
 
 When searching for files or code patterns, ignore the following directories
 unless explicitly asked to look there:
 
-- `third_party/` (contains external dependencies)
-- `out/` (contains build artifacts)
+-   `third_party/` (contains external dependencies)
+-   `out/` (contains build artifacts)
 
 ## Code Review Instructions
 
-- Do not comment on content for XML files or .matter content for clusters.
-- The SDK implements an in-progress Matter specification that may be in flux and
-  may not be available to all contributors. Assume the Matter specification is
-  unknown and out of scope _unless_ you have explicit access to the latest
-  version (e.g., via a specialized tool or skill).
-- Avoid "pat on the back" style comments that just restate what the code is
-  doing. Focus on suggesting concrete code improvements.
-- Be concise. Do not over-explain code.
-- Look for common typos and suggest fixes.
-- Do not comment on whitespace or formatting (auto-formatters handle this).
-- Review changes for embedded development:
-    - Minimize use of heap allocation.
-    - Optimize for resource usage (RAM/Flash).
-    - Be cautious with complex templates that could lead to code bloat.
+-   Do not comment on content for XML files or .matter content for clusters.
+-   The SDK implements an in-progress Matter specification that may be in flux
+    and may not be available to all contributors. Assume the Matter
+    specification is unknown and out of scope _unless_ you have explicit access
+    to the latest version (e.g., via a specialized tool or skill).
+-   Avoid "pat on the back" style comments that just restate what the code is
+    doing. Focus on suggesting concrete code improvements.
+-   Be concise. Do not over-explain code.
+-   Look for common typos and suggest fixes.
+-   Do not comment on whitespace or formatting (auto-formatters handle this).
+-   Review changes for embedded development:
+    -   Minimize use of heap allocation.
+    -   Optimize for resource usage (RAM/Flash).
+    -   Be cautious with complex templates that could lead to code bloat.
 
 ## API preferences
 
-- Prefer using `chip::Span` from `src/lib/support/Span.h` to pointer + size
-  groups. Pass `Span` by value rather than const reference (treat it as a
-  `string_view`)
-- Use `"foo"_span` (i.e. `operator _span`) for const char spans instead of
-  `fromCharString`.
-- Prefer `std::optional` to `chip::Optional`
-- Prefer `StringBuilder` from `src/lib/support/StringBuilder.h` to using
-  `snprintf` for string formatting.
+-   Prefer using `chip::Span` from `src/lib/support/Span.h` to pointer + size
+    groups. Pass `Span` by value rather than const reference (treat it as a
+    `string_view`)
+-   Use `"foo"_span` (i.e. `operator _span`) for const char spans instead of
+    `fromCharString`.
+-   Prefer `std::optional` to `chip::Optional`
+-   Prefer `StringBuilder` from `src/lib/support/StringBuilder.h` to using
+    `snprintf` for string formatting.
 
 ## Coding Style (Highlights)
 
 Refer to [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md)
 for full details.
 
-- **C++**: C++17 standard.
-    - Use fixed-width integer types from `<cstdint>` for POD integer types
-    - Avoid top-level `using namespace` in headers.
-    - Use anonymous namespaces for file-internal classes/objects.
-    - Avoid heap allocation and auto-resizing containers in core SDK.
-- **Python**: Python 3.11 standard.
-    - Use type hints on public APIs.
-    - Include docstrings for public APIs.
-- _Always_ include `{}` bracketing for control flows, even if using one liners
-  (e.g. for `if`, `while`, `for` and such)
+-   **C++**: C++17 standard.
+    -   Use fixed-width integer types from `<cstdint>` for POD integer types
+    -   Avoid top-level `using namespace` in headers.
+    -   Use anonymous namespaces for file-internal classes/objects.
+    -   Avoid heap allocation and auto-resizing containers in core SDK.
+-   **Python**: Python 3.11 standard.
+    -   Use type hints on public APIs.
+    -   Include docstrings for public APIs.
+-   _Always_ include `{}` bracketing for control flows, even if using one liners
+    (e.g. for `if`, `while`, `for` and such)
 
 ## Testing
 
-- Unit tests are required for all changes unless unit testing is impossible
-  (e.g., platform-specific code).
-- Tests in `src/python_testing` and `src/app/tests/suites` which verify expected
-  failures should clearly indicate why the failure is expected. Include a
-  summary of the relevant specification requirements if possible.
+-   Unit tests are required for all changes unless unit testing is impossible
+    (e.g., platform-specific code).
+-   Tests in `src/python_testing` and `src/app/tests/suites` which verify
+    expected failures should clearly indicate why the failure is expected.
+    Include a summary of the relevant specification requirements if possible.
 
 ## Architectural Constraints
 
@@ -87,19 +87,19 @@ for full details.
 Code-driven clusters are implementations in `src/app/clusters` that use
 `DefaultServerCluster` as a base class. When developing them:
 
-- `ReadAttribute`, `WriteAttribute`, and `InvokeCommand` are by API contract
-  only called for existent paths. Do not add path validity checks — they
-  increase code size and are redundant as long as `Attributes` or
-  `AcceptedCommands` are correct.
-- Ember APIs and generated ZAP accessors must not be used outside the
-  `CodegenIntegration` layer. `CodegenIntegration.h/cpp` is the documented
-  bridge between generated configuration and code-driven cluster logic. Avoid
-  types like `EmberAfStatus` or functions like `emberAfContainsServer`,
-  `emberAfReadAttribute`, or `emberAfWriteAttribute` in core cluster code.
-- When adding files: codegen-specific files belong in
-  `app_config_dependent_sources.cmake/gni`; all others belong in `BUILD.gn`.
-  Ensure every file (especially headers) is listed in one of these — there
-  should be no unreferenced files.
+-   `ReadAttribute`, `WriteAttribute`, and `InvokeCommand` are by API contract
+    only called for existent paths. Do not add path validity checks — they
+    increase code size and are redundant as long as `Attributes` or
+    `AcceptedCommands` are correct.
+-   Ember APIs and generated ZAP accessors must not be used outside the
+    `CodegenIntegration` layer. `CodegenIntegration.h/cpp` is the documented
+    bridge between generated configuration and code-driven cluster logic. Avoid
+    types like `EmberAfStatus` or functions like `emberAfContainsServer`,
+    `emberAfReadAttribute`, or `emberAfWriteAttribute` in core cluster code.
+-   When adding files: codegen-specific files belong in
+    `app_config_dependent_sources.cmake/gni`; all others belong in `BUILD.gn`.
+    Ensure every file (especially headers) is listed in one of these — there
+    should be no unreferenced files.
 
 ### Example Applications (Documentation Discovery)
 
@@ -123,39 +123,40 @@ Alternatively, you can activate the environment in your shell:
 
 ### Build and Test
 
-- **List available targets**:
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py targets"`
-- **Generate Ninja files**:
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet gen"`
-- **Build and run all tests**:
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build"`
-- **Run a specific test**:
-  `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang --quiet path/to/test:test_name.run"`
-    - Explicit example:
-      `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster.run"`
-    - Compile and run can be separated (e.g. if running under some memory
-      debugger or needing to set other options):
+-   **List available targets**:
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py targets"`
+-   **Generate Ninja files**:
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet gen"`
+-   **Build and run all tests**:
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build"`
+-   **Run a specific test**:
+    `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang --quiet path/to/test:test_name.run"`
 
-            ```bash
-            scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
-            ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
-            ```
+    -   Explicit example:
+        `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster.run"`
+    -   Compile and run can be separated (e.g. if running under some memory
+        debugger or needing to set other options):
+
+              ```bash
+              scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
+              ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
+              ```
 
 ### Building Common Apps
 
-- **chip-tool** (Interactive commissioning tool):
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-chip-tool-clang --quiet build"`
-- **all-clusters-app** (Feature-rich device simulator):
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang --quiet build"`
-- **all-devices-app** (Alternative feature-rich simulator):
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-clang --quiet build"`
+-   **chip-tool** (Interactive commissioning tool):
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-chip-tool-clang --quiet build"`
+-   **all-clusters-app** (Feature-rich device simulator):
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang --quiet build"`
+-   **all-devices-app** (Alternative feature-rich simulator):
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-clang --quiet build"`
 
 ### Building Joint Fabric Apps
 
-- **jf-admin-app** (Joint Fabric Administrator):
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"`
-- **jf-control-app** (Joint Fabric Controller):
-  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"`
+-   **jf-admin-app** (Joint Fabric Administrator):
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"`
+-   **jf-control-app** (Joint Fabric Controller):
+    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"`
 
 ### Running Python Integration Tests
 
@@ -220,7 +221,7 @@ See also `/home/robert/matter/AGENTS.md` for workspace-level setup instructions.
 
 ## Development Resources
 
-- [docs/guides/writing_clusters.md](docs/guides/writing_clusters.md)
-- [docs/guides/migrating_ember_cluster_to_code_driven.md](docs/guides/migrating_ember_cluster_to_code_driven.md)
-- [docs/testing/unit_testing.md](docs/testing/unit_testing.md)
-- [docs/testing/integration_tests.md](docs/testing/integration_tests.md)
+-   [docs/guides/writing_clusters.md](docs/guides/writing_clusters.md)
+-   [docs/guides/migrating_ember_cluster_to_code_driven.md](docs/guides/migrating_ember_cluster_to_code_driven.md)
+-   [docs/testing/unit_testing.md](docs/testing/unit_testing.md)
+-   [docs/testing/integration_tests.md](docs/testing/integration_tests.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,80 +5,80 @@ Matter SDK codebase.
 
 ## General Principles
 
--   **When in Rome**: Match the prevailing style of the code being modified. See
-    [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md).
--   **Atomicity**: Make small, incremental changes. Do not mix refactoring with
-    feature implementation.
--   **No Filler Names**: Avoid names like "support", "common", "helpers",
-    "util", "core". Use concrete names.
--   **Error Handling**: Use `CHIP_ERROR` as the standard return type for
-    fallible operations. Prefer `VerifyOrReturnError` and `ReturnErrorOnFailure`
-    macros for concise error checking and propagation.
--   Ensure resources are cleaned up appropriately, especially on early returns.
-    Generally prefer RAII patterns for cleanup.
--   **Logging**: Use the `ChipLog*` macros (e.g., `ChipLogProgress`,
-    `ChipLogError`, `ChipLogDetail`) for logging. Ensure logs are appropriately
-    categorized by module (e.g., `AppServer`, `InteractionModel`).
+- **When in Rome**: Match the prevailing style of the code being modified. See
+  [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md).
+- **Atomicity**: Make small, incremental changes. Do not mix refactoring with
+  feature implementation.
+- **No Filler Names**: Avoid names like "support", "common", "helpers", "util",
+  "core". Use concrete names.
+- **Error Handling**: Use `CHIP_ERROR` as the standard return type for fallible
+  operations. Prefer `VerifyOrReturnError` and `ReturnErrorOnFailure` macros for
+  concise error checking and propagation.
+- Ensure resources are cleaned up appropriately, especially on early returns.
+  Generally prefer RAII patterns for cleanup.
+- **Logging**: Use the `ChipLog*` macros (e.g., `ChipLogProgress`,
+  `ChipLogError`, `ChipLogDetail`) for logging. Ensure logs are appropriately
+  categorized by module (e.g., `AppServer`, `InteractionModel`).
 
 ## Ignored Directories
 
 When searching for files or code patterns, ignore the following directories
 unless explicitly asked to look there:
 
--   `third_party/` (contains external dependencies)
--   `out/` (contains build artifacts)
+- `third_party/` (contains external dependencies)
+- `out/` (contains build artifacts)
 
 ## Code Review Instructions
 
--   Do not comment on content for XML files or .matter content for clusters.
--   The SDK implements an in-progress Matter specification that may be in flux
-    and may not be available to all contributors. Assume the Matter
-    specification is unknown and out of scope _unless_ you have explicit access
-    to the latest version (e.g., via a specialized tool or skill).
--   Avoid "pat on the back" style comments that just restate what the code is
-    doing. Focus on suggesting concrete code improvements.
--   Be concise. Do not over-explain code.
--   Look for common typos and suggest fixes.
--   Do not comment on whitespace or formatting (auto-formatters handle this).
--   Review changes for embedded development:
-    -   Minimize use of heap allocation.
-    -   Optimize for resource usage (RAM/Flash).
-    -   Be cautious with complex templates that could lead to code bloat.
+- Do not comment on content for XML files or .matter content for clusters.
+- The SDK implements an in-progress Matter specification that may be in flux and
+  may not be available to all contributors. Assume the Matter specification is
+  unknown and out of scope _unless_ you have explicit access to the latest
+  version (e.g., via a specialized tool or skill).
+- Avoid "pat on the back" style comments that just restate what the code is
+  doing. Focus on suggesting concrete code improvements.
+- Be concise. Do not over-explain code.
+- Look for common typos and suggest fixes.
+- Do not comment on whitespace or formatting (auto-formatters handle this).
+- Review changes for embedded development:
+    - Minimize use of heap allocation.
+    - Optimize for resource usage (RAM/Flash).
+    - Be cautious with complex templates that could lead to code bloat.
 
 ## API preferences
 
--   Prefer using `chip::Span` from `src/lib/support/Span.h` to pointer + size
-    groups. Pass `Span` by value rather than const reference (treat it as a
-    `string_view`)
--   Use `"foo"_span` (i.e. `operator _span`) for const char spans instead of
-    `fromCharString`.
--   Prefer `std::optional` to `chip::Optional`
--   Prefer `StringBuilder` from `src/lib/support/StringBuilder.h` to using
-    `snprintf` for string formatting.
+- Prefer using `chip::Span` from `src/lib/support/Span.h` to pointer + size
+  groups. Pass `Span` by value rather than const reference (treat it as a
+  `string_view`)
+- Use `"foo"_span` (i.e. `operator _span`) for const char spans instead of
+  `fromCharString`.
+- Prefer `std::optional` to `chip::Optional`
+- Prefer `StringBuilder` from `src/lib/support/StringBuilder.h` to using
+  `snprintf` for string formatting.
 
 ## Coding Style (Highlights)
 
 Refer to [docs/style/CODING_STYLE_GUIDE.md](docs/style/CODING_STYLE_GUIDE.md)
 for full details.
 
--   **C++**: C++17 standard.
-    -   Use fixed-width integer types from `<cstdint>` for POD integer types
-    -   Avoid top-level `using namespace` in headers.
-    -   Use anonymous namespaces for file-internal classes/objects.
-    -   Avoid heap allocation and auto-resizing containers in core SDK.
--   **Python**: Python 3.11 standard.
-    -   Use type hints on public APIs.
-    -   Include docstrings for public APIs.
--   _Always_ include `{}` bracketing for control flows, even if using one liners
-    (e.g. for `if`, `while`, `for` and such)
+- **C++**: C++17 standard.
+    - Use fixed-width integer types from `<cstdint>` for POD integer types
+    - Avoid top-level `using namespace` in headers.
+    - Use anonymous namespaces for file-internal classes/objects.
+    - Avoid heap allocation and auto-resizing containers in core SDK.
+- **Python**: Python 3.11 standard.
+    - Use type hints on public APIs.
+    - Include docstrings for public APIs.
+- _Always_ include `{}` bracketing for control flows, even if using one liners
+  (e.g. for `if`, `while`, `for` and such)
 
 ## Testing
 
--   Unit tests are required for all changes unless unit testing is impossible
-    (e.g., platform-specific code).
--   Tests in `src/python_testing` and `src/app/tests/suites` which verify
-    expected failures should clearly indicate why the failure is expected.
-    Include a summary of the relevant specification requirements if possible.
+- Unit tests are required for all changes unless unit testing is impossible
+  (e.g., platform-specific code).
+- Tests in `src/python_testing` and `src/app/tests/suites` which verify expected
+  failures should clearly indicate why the failure is expected. Include a
+  summary of the relevant specification requirements if possible.
 
 ## Architectural Constraints
 
@@ -87,19 +87,19 @@ for full details.
 Code-driven clusters are implementations in `src/app/clusters` that use
 `DefaultServerCluster` as a base class. When developing them:
 
--   `ReadAttribute`, `WriteAttribute`, and `InvokeCommand` are by API contract
-    only called for existent paths. Do not add path validity checks — they
-    increase code size and are redundant as long as `Attributes` or
-    `AcceptedCommands` are correct.
--   Ember APIs and generated ZAP accessors must not be used outside the
-    `CodegenIntegration` layer. `CodegenIntegration.h/cpp` is the documented
-    bridge between generated configuration and code-driven cluster logic. Avoid
-    types like `EmberAfStatus` or functions like `emberAfContainsServer`,
-    `emberAfReadAttribute`, or `emberAfWriteAttribute` in core cluster code.
--   When adding files: codegen-specific files belong in
-    `app_config_dependent_sources.cmake/gni`; all others belong in `BUILD.gn`.
-    Ensure every file (especially headers) is listed in one of these — there
-    should be no unreferenced files.
+- `ReadAttribute`, `WriteAttribute`, and `InvokeCommand` are by API contract
+  only called for existent paths. Do not add path validity checks — they
+  increase code size and are redundant as long as `Attributes` or
+  `AcceptedCommands` are correct.
+- Ember APIs and generated ZAP accessors must not be used outside the
+  `CodegenIntegration` layer. `CodegenIntegration.h/cpp` is the documented
+  bridge between generated configuration and code-driven cluster logic. Avoid
+  types like `EmberAfStatus` or functions like `emberAfContainsServer`,
+  `emberAfReadAttribute`, or `emberAfWriteAttribute` in core cluster code.
+- When adding files: codegen-specific files belong in
+  `app_config_dependent_sources.cmake/gni`; all others belong in `BUILD.gn`.
+  Ensure every file (especially headers) is listed in one of these — there
+  should be no unreferenced files.
 
 ### Example Applications (Documentation Discovery)
 
@@ -123,19 +123,18 @@ Alternatively, you can activate the environment in your shell:
 
 ### Build and Test
 
--   **List available targets**:
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py targets"`
--   **Generate Ninja files**:
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet gen"`
--   **Build and run all tests**:
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build"`
--   **Run a specific test**:
-    `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang --quiet path/to/test:test_name.run"`
-
-    -   Explicit example:
-        `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster.run"`
-    -   Compile and run can be separated (e.g. if running under some memory
-        debugger or needing to set other options):
+- **List available targets**:
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py targets"`
+- **Generate Ninja files**:
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet gen"`
+- **Build and run all tests**:
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build"`
+- **Run a specific test**:
+  `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang --quiet path/to/test:test_name.run"`
+    - Explicit example:
+      `scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster.run"`
+    - Compile and run can be separated (e.g. if running under some memory
+      debugger or needing to set other options):
 
             ```bash
             scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
@@ -144,16 +143,84 @@ Alternatively, you can activate the environment in your shell:
 
 ### Building Common Apps
 
--   **chip-tool** (Interactive commissioning tool):
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-chip-tool-clang --quiet build"`
--   **all-clusters-app** (Feature-rich device simulator):
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang --quiet build"`
--   **all-devices-app** (Alternative feature-rich simulator):
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-clang --quiet build"`
+- **chip-tool** (Interactive commissioning tool):
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-chip-tool-clang --quiet build"`
+- **all-clusters-app** (Feature-rich device simulator):
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang --quiet build"`
+- **all-devices-app** (Alternative feature-rich simulator):
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-clang --quiet build"`
+
+### Building Joint Fabric Apps
+
+- **jf-admin-app** (Joint Fabric Administrator):
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"`
+- **jf-control-app** (Joint Fabric Controller):
+  `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"`
+
+### Running Python Integration Tests
+
+Python tests in `src/python_testing/` require a separate venv and built example
+apps. Build the venv (re-run whenever Python bindings change):
+
+```bash
+./scripts/build_python.sh -i out/venv --enable_ipv4 true
+source out/venv/bin/activate
+```
+
+Run tests using the `local.py` harness, mapping CI binary variables to local
+build outputs with `--override-binary-path`:
+
+```bash
+source out/venv/bin/activate
+./scripts/tests/local.py python-tests \
+  --test-filter "TC_JFADMIN*" \
+  --override-binary-path JF_ADMIN_APP     out/linux-x64-jf-admin-app-clang/jfa-app \
+  --override-binary-path JF_CONTROL_APP   out/linux-x64-jf-control-app-clang/jfc-app \
+  --override-binary-path ALL_CLUSTERS_APP out/linux-x64-all-clusters-clang/chip-all-clusters-app
+```
+
+## Pre-commit Test Policy
+
+Before committing or pushing, run the tests that match the scope of changes.
+Rebuild any affected example apps before running Python tests against them.
+
+| Changed area                                            | Tests to run                                                                                  |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `src/app/clusters/joint-fabric-administrator-server/**` | C++ unit tests: `joint-fabric-administrator-server/tests:tests` **and** Python: `TC_JFADMIN*` |
+| `examples/jf-admin-app/**`                              | Rebuild `linux-x64-jf-admin-app-clang`; Python: `TC_JFADMIN*`                                 |
+| `examples/jf-control-app/**`                            | Rebuild `linux-x64-jf-control-app-clang`; Python: `TC_JFADMIN*`, `TC_JFDS*`                   |
+| `examples/common/pigweed/rpc_services/JointFabric.h`    | Rebuild jf-admin-app and jf-control-app; Python: `TC_JFADMIN*`                                |
+| `src/app/server/JointFabricAdministrator.h`             | C++ unit tests: `joint-fabric-administrator-server/tests:tests` **and** Python: `TC_JFADMIN*` |
+| `src/credentials/**`                                    | `ninja -C out/linux-x64-tests-clang src/credentials/tests:tests`                              |
+| `src/app/clusters/<cluster-name>/**`                    | C++ unit tests for that cluster; Python `TC_<CLUSTER>*` if they exist                         |
+| General SDK changes                                     | `./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build`              |
+
+### Minimum checklist for Joint Fabric changes
+
+```bash
+# 1. Rebuild affected apps
+scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"
+scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"
+
+# 2. C++ unit tests
+scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang \
+  src/app/clusters/joint-fabric-administrator-server/tests:TestAddICACInstallation.run \
+  src/app/clusters/joint-fabric-administrator-server/tests:TestJCMCommissionee.run"
+
+# 3. Python integration tests
+source out/venv/bin/activate
+./scripts/tests/local.py python-tests \
+  --test-filter "TC_JFADMIN*" \
+  --override-binary-path JF_ADMIN_APP     out/linux-x64-jf-admin-app-clang/jfa-app \
+  --override-binary-path JF_CONTROL_APP   out/linux-x64-jf-control-app-clang/jfc-app \
+  --override-binary-path ALL_CLUSTERS_APP out/linux-x64-all-clusters-clang/chip-all-clusters-app
+```
+
+See also `/home/robert/matter/AGENTS.md` for workspace-level setup instructions.
 
 ## Development Resources
 
--   [docs/guides/writing_clusters.md](docs/guides/writing_clusters.md)
--   [docs/guides/migrating_ember_cluster_to_code_driven.md](docs/guides/migrating_ember_cluster_to_code_driven.md)
--   [docs/testing/unit_testing.md](docs/testing/unit_testing.md)
--   [docs/testing/integration_tests.md](docs/testing/integration_tests.md)
+- [docs/guides/writing_clusters.md](docs/guides/writing_clusters.md)
+- [docs/guides/migrating_ember_cluster_to_code_driven.md](docs/guides/migrating_ember_cluster_to_code_driven.md)
+- [docs/testing/unit_testing.md](docs/testing/unit_testing.md)
+- [docs/testing/integration_tests.md](docs/testing/integration_tests.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,10 @@ Alternatively, you can activate the environment in your shell:
     -   Compile and run can be separated (e.g. if running under some memory
         debugger or needing to set other options):
 
-    ```bash
-    scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
-    ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
-    ```
+            ```bash
+            scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster"`
+            ./out/linux-x64-tests-clang/tests/TestOccupancySensingCluster
+            ```
 
 ### Building Common Apps
 
@@ -150,74 +150,6 @@ Alternatively, you can activate the environment in your shell:
     `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-clang --quiet build"`
 -   **all-devices-app** (Alternative feature-rich simulator):
     `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-clang --quiet build"`
-
-### Building Joint Fabric Apps
-
--   **jf-admin-app** (Joint Fabric Administrator):
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"`
--   **jf-control-app** (Joint Fabric Controller):
-    `scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"`
-
-### Running Python Integration Tests
-
-Python tests in `src/python_testing/` require a separate venv and built example
-apps. Build the venv (re-run whenever Python bindings change):
-
-```bash
-./scripts/build_python.sh -i out/venv --enable_ipv4 true
-source out/venv/bin/activate
-```
-
-Run tests using the `local.py` harness, mapping CI binary variables to local
-build outputs with `--override-binary-path`:
-
-```bash
-source out/venv/bin/activate
-./scripts/tests/local.py python-tests \
-  --test-filter "TC_JFADMIN*" \
-  --override-binary-path JF_ADMIN_APP     out/linux-x64-jf-admin-app-clang/jfa-app \
-  --override-binary-path JF_CONTROL_APP   out/linux-x64-jf-control-app-clang/jfc-app \
-  --override-binary-path ALL_CLUSTERS_APP out/linux-x64-all-clusters-clang/chip-all-clusters-app
-```
-
-## Pre-commit Test Policy
-
-Before committing or pushing, run the tests that match the scope of changes.
-Rebuild any affected example apps before running Python tests against them.
-
-| Changed area                                            | Tests to run                                                                                  |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `src/app/clusters/joint-fabric-administrator-server/**` | C++ unit tests: `joint-fabric-administrator-server/tests:tests` **and** Python: `TC_JFADMIN*` |
-| `examples/jf-admin-app/**`                              | Rebuild `linux-x64-jf-admin-app-clang`; Python: `TC_JFADMIN*`                                 |
-| `examples/jf-control-app/**`                            | Rebuild `linux-x64-jf-control-app-clang`; Python: `TC_JFADMIN*`, `TC_JFDS*`                   |
-| `examples/common/pigweed/rpc_services/JointFabric.h`    | Rebuild jf-admin-app and jf-control-app; Python: `TC_JFADMIN*`                                |
-| `src/app/server/JointFabricAdministrator.h`             | C++ unit tests: `joint-fabric-administrator-server/tests:tests` **and** Python: `TC_JFADMIN*` |
-| `src/credentials/**`                                    | `ninja -C out/linux-x64-tests-clang src/credentials/tests:tests`                              |
-| `src/app/clusters/<cluster-name>/**`                    | C++ unit tests for that cluster; Python `TC_<CLUSTER>*` if they exist                         |
-| General SDK changes                                     | `./scripts/build/build_examples.py --target linux-x64-tests-clang --quiet build`              |
-
-### Minimum checklist for Joint Fabric changes
-
-```bash
-# 1. Rebuild affected apps
-scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-admin-app-clang --quiet build"
-scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-jf-control-app-clang --quiet build"
-
-# 2. C++ unit tests
-scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang \
-  src/app/clusters/joint-fabric-administrator-server/tests:TestAddICACInstallation.run \
-  src/app/clusters/joint-fabric-administrator-server/tests:TestJCMCommissionee.run"
-
-# 3. Python integration tests
-source out/venv/bin/activate
-./scripts/tests/local.py python-tests \
-  --test-filter "TC_JFADMIN*" \
-  --override-binary-path JF_ADMIN_APP     out/linux-x64-jf-admin-app-clang/jfa-app \
-  --override-binary-path JF_CONTROL_APP   out/linux-x64-jf-control-app-clang/jfc-app \
-  --override-binary-path ALL_CLUSTERS_APP out/linux-x64-all-clusters-clang/chip-all-clusters-app
-```
-
-See also `/home/robert/matter/AGENTS.md` for workspace-level setup instructions.
 
 ## Development Resources
 

--- a/docs/guides/joint_fabric_guide.md
+++ b/docs/guides/joint_fabric_guide.md
@@ -1,13 +1,13 @@
 # Joint Fabric Guide
 
--   [Joint Fabric Guide](#joint-fabric-guide)
-    -   [Joint Fabric Example Applications](#joint-fabric-example-applications)
-        -   [Building the Example Application](#building-the-example-application)
-    -   [Bootstrap Joint Fabric Demo on Linux](#bootstrap-joint-fabric-demo-on-linux)
-        -   [Initialize Ecosystem A (Vendor ID = 0xFFF1)](#initialize-ecosystem-a-vendor-id--0xfff1)
-        -   [Initialize Ecosystem B (Vendor ID = 0xFFF2)](#initialize-ecosystem-b-vendor-id--0xfff2)
-    -   [Manually Testing JCM (Joint Commissioning Method)](#manually-testing-jcm-joint-commissioning-method)
-    -   [Unit Testing Joint Fabric](#unit-testing-joint-fabric)
+- [Joint Fabric Guide](#joint-fabric-guide)
+    - [Joint Fabric Example Applications](#joint-fabric-example-applications)
+        - [Building the Example Application](#building-the-example-application)
+    - [Bootstrap Joint Fabric Demo on Linux](#bootstrap-joint-fabric-demo-on-linux)
+        - [Initialize Ecosystem A (Vendor ID = 0xFFF1)](#initialize-ecosystem-a-vendor-id--0xfff1)
+        - [Initialize Ecosystem B (Vendor ID = 0xFFF2)](#initialize-ecosystem-b-vendor-id--0xfff2)
+    - [Manually Testing JCM (Joint Commissioning Method)](#manually-testing-jcm-joint-commissioning-method)
+    - [Unit Testing Joint Fabric](#unit-testing-joint-fabric)
 
 ## Joint Fabric Example Applications
 
@@ -41,11 +41,11 @@ jf-admin-app that finalizes the commissioning.
 
 ### Building the Example Application
 
--   Building the Joint Fabric Control Application
+- Building the Joint Fabric Control Application
 
     [jf-control-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/jf-control-app/README.md)
 
--   Building the Joint Fabric Admin Application
+- Building the Joint Fabric Admin Application
 
     [jf-admin-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/jf-admin-app/linux/README.md)
 
@@ -59,7 +59,7 @@ $ rm -rf /tmp/chip_*
 
 ### Initialize Ecosystem A (Vendor ID = 0xFFF1)
 
--   Start jf-admin-app
+- Start jf-admin-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-admin-app/linux/out/debug
@@ -67,7 +67,7 @@ $ rm -rf jfa_a_kvs && touch jfa_a_kvs
 $ ./jfa-app --capabilities 0x4 --passcode 11022033 --discriminator 3840  --secured-device-port 5533 --rpc-server-port 33033 --KVS jfa_a_kvs
 ```
 
--   Start jf-control-app
+- Start jf-control-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-control-app/out/debug
@@ -75,7 +75,7 @@ $ rm -rf jfc_a_storage_directory && mkdir jfc_a_storage_directory
 $ ./jfc-app --rpc-server-port 33033 --storage-directory jfc_a_storage_directory --commissioner-vendor-id 0xFFF1
 ```
 
--   Commission jf-admin-app
+- Commission jf-admin-app
 
 ```
 >>> pairing onnetwork-long 1 11022033 3840 --anchor true
@@ -124,8 +124,8 @@ Subject: 1.3.6.1.4.1.37244.1.3 = 0000000000000003, OU = jf-anchor-icac
 ...
 ```
 
--   Start the
-    [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
+- Start the
+  [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
 
 ```
 $ cd ~/connectedhomeip/examples/lighting-app/linux/out/debug
@@ -133,7 +133,7 @@ $ rm -rf light_a_kvs && touch light_a_kvs
 $ ./chip-lighting-app --capabilities 0x4 --passcode 11022044 --KVS light_a_kvs
 ```
 
--   Commission lighting-app
+- Commission lighting-app
 
 ```
 >>> pairing onnetwork 2 11022044 --regular 1
@@ -157,7 +157,7 @@ should be found.
 
 ### Initialize Ecosystem B (Vendor ID = 0xFFF2)
 
--   Start jf-admin-app
+- Start jf-admin-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-admin-app/linux/out/debug
@@ -165,7 +165,7 @@ $ rm -rf jfa_b_kvs && touch jfa_b_kvs
 $ ./jfa-app --capabilities 0x4 --passcode 11022055 --discriminator 3841 --secured-device-port 5555 --rpc-server-port 33055 --KVS jfa_b_kvs
 ```
 
--   Start jf-control-app
+- Start jf-control-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-control-app/out/debug
@@ -173,7 +173,7 @@ $ rm -rf jfc_b_storage_directory && mkdir jfc_b_storage_directory
 $ ./jfc-app --rpc-server-port 33055 --storage-directory jfc_b_storage_directory --commissioner-vendor-id 0xFFF2
 ```
 
--   Commission jf-admin-app
+- Commission jf-admin-app
 
 ```
 >>> pairing onnetwork-long 11 11022055 3841 --anchor true
@@ -223,8 +223,8 @@ Subject: 1.3.6.1.4.1.37244.1.3 = 0000000000000003, OU = jf-anchor-icac
 ...
 ```
 
--   Start the
-    [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
+- Start the
+  [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
 
 ```
 $ cd ~/connectedhomeip/examples/lighting-app/linux/out/debug
@@ -232,7 +232,7 @@ $ rm -rf light_b_kvs && touch light_b_kvs
 $ ./chip-lighting-app --capabilities 0x4 --passcode 11022066 --KVS light_b_kvs
 ```
 
--   Commission lighting-app
+- Commission lighting-app
 
 ```
 >>> pairing onnetwork 22 11022066 --regular 1
@@ -258,9 +258,34 @@ should be found.
 
 Execute all the initialization steps for Ecosystem A and Ecosystem B above.
 
+### JCM Flow Overview
+
+When the JCM commissioning step (`--jcm true`) is triggered, the following
+sequence is executed automatically by the Ecosystem A jf-admin-app after the
+standard commissioning finalizes ownership transfer:
+
+1. **AnnounceJointFabricAdministrator** — jf-admin-app sends itself to the
+   commissionee (the Ecosystem B jf-admin-app) as an administrator
+2. **ICACCSRRequest** — jf-admin-app requests an ICAC CSR from the commissionee;
+   the commissionee returns the CSR signed by its `TrustedIcacPublicKeyB`
+   keypair
+3. **Cross-signing** — jf-admin-app asks the Ecosystem A jf-control-app (via the
+   `CROSS_SIGNED_ICAC` RPC transaction) to cross-sign the commissionee's ICAC
+   CSR under the Ecosystem A anchor root CA, embedding the anchor fabric ID in
+   the Subject DN
+4. **AddICAC** — jf-admin-app installs the cross-signed ICAC on the commissionee
+   via the `AddICAC` cluster command; the commissionee validates the certificate
+   chain and stores it
+5. **CommissioningComplete** — jf-admin-app finalizes commissioning
+
+The cross-signed ICAC enables the commissionee to later receive NOCs valid on
+the Ecosystem A anchor fabric, establishing the joint fabric relationship.
+
+### Running the JCM Test
+
 On the Ecosystem B Joint Fabric Controller application
 
--   Open Joint Commissioning Window on JF Admin App of Ecosystem B
+- Open Joint Commissioning Window on JF Admin App of Ecosystem B
 
 ```
 >>> pairing open-joint-commissioning-window 11 1 400 1000 1261
@@ -278,6 +303,16 @@ On the Ecosystem A Joint Fabric Controller application
 
 ```
 pairing code 10 [manual pairing code] --jcm true
+```
+
+After successful JCM commissioning, check for the following logs on Ecosystem
+A's jf-admin-app to confirm the cross-signing flow completed:
+
+```
+OnSendICACSRRequestResponse: validated ICAC CSR
+CrossSignICAC: requesting cross-signed ICAC for anchor fabric ...
+OnAddICACResponse: ICAC installed successfully, proceeding to CommissioningComplete
+Joint Commissioning Method (nodeId=...) success
 ```
 
 ## Unit Testing Joint Fabric

--- a/docs/guides/joint_fabric_guide.md
+++ b/docs/guides/joint_fabric_guide.md
@@ -1,13 +1,13 @@
 # Joint Fabric Guide
 
-- [Joint Fabric Guide](#joint-fabric-guide)
-    - [Joint Fabric Example Applications](#joint-fabric-example-applications)
-        - [Building the Example Application](#building-the-example-application)
-    - [Bootstrap Joint Fabric Demo on Linux](#bootstrap-joint-fabric-demo-on-linux)
-        - [Initialize Ecosystem A (Vendor ID = 0xFFF1)](#initialize-ecosystem-a-vendor-id--0xfff1)
-        - [Initialize Ecosystem B (Vendor ID = 0xFFF2)](#initialize-ecosystem-b-vendor-id--0xfff2)
-    - [Manually Testing JCM (Joint Commissioning Method)](#manually-testing-jcm-joint-commissioning-method)
-    - [Unit Testing Joint Fabric](#unit-testing-joint-fabric)
+-   [Joint Fabric Guide](#joint-fabric-guide)
+    -   [Joint Fabric Example Applications](#joint-fabric-example-applications)
+        -   [Building the Example Application](#building-the-example-application)
+    -   [Bootstrap Joint Fabric Demo on Linux](#bootstrap-joint-fabric-demo-on-linux)
+        -   [Initialize Ecosystem A (Vendor ID = 0xFFF1)](#initialize-ecosystem-a-vendor-id--0xfff1)
+        -   [Initialize Ecosystem B (Vendor ID = 0xFFF2)](#initialize-ecosystem-b-vendor-id--0xfff2)
+    -   [Manually Testing JCM (Joint Commissioning Method)](#manually-testing-jcm-joint-commissioning-method)
+    -   [Unit Testing Joint Fabric](#unit-testing-joint-fabric)
 
 ## Joint Fabric Example Applications
 
@@ -41,11 +41,11 @@ jf-admin-app that finalizes the commissioning.
 
 ### Building the Example Application
 
-- Building the Joint Fabric Control Application
+-   Building the Joint Fabric Control Application
 
     [jf-control-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/jf-control-app/README.md)
 
-- Building the Joint Fabric Admin Application
+-   Building the Joint Fabric Admin Application
 
     [jf-admin-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/jf-admin-app/linux/README.md)
 
@@ -59,7 +59,7 @@ $ rm -rf /tmp/chip_*
 
 ### Initialize Ecosystem A (Vendor ID = 0xFFF1)
 
-- Start jf-admin-app
+-   Start jf-admin-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-admin-app/linux/out/debug
@@ -67,7 +67,7 @@ $ rm -rf jfa_a_kvs && touch jfa_a_kvs
 $ ./jfa-app --capabilities 0x4 --passcode 11022033 --discriminator 3840  --secured-device-port 5533 --rpc-server-port 33033 --KVS jfa_a_kvs
 ```
 
-- Start jf-control-app
+-   Start jf-control-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-control-app/out/debug
@@ -75,7 +75,7 @@ $ rm -rf jfc_a_storage_directory && mkdir jfc_a_storage_directory
 $ ./jfc-app --rpc-server-port 33033 --storage-directory jfc_a_storage_directory --commissioner-vendor-id 0xFFF1
 ```
 
-- Commission jf-admin-app
+-   Commission jf-admin-app
 
 ```
 >>> pairing onnetwork-long 1 11022033 3840 --anchor true
@@ -124,8 +124,8 @@ Subject: 1.3.6.1.4.1.37244.1.3 = 0000000000000003, OU = jf-anchor-icac
 ...
 ```
 
-- Start the
-  [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
+-   Start the
+    [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
 
 ```
 $ cd ~/connectedhomeip/examples/lighting-app/linux/out/debug
@@ -133,7 +133,7 @@ $ rm -rf light_a_kvs && touch light_a_kvs
 $ ./chip-lighting-app --capabilities 0x4 --passcode 11022044 --KVS light_a_kvs
 ```
 
-- Commission lighting-app
+-   Commission lighting-app
 
 ```
 >>> pairing onnetwork 2 11022044 --regular 1
@@ -157,7 +157,7 @@ should be found.
 
 ### Initialize Ecosystem B (Vendor ID = 0xFFF2)
 
-- Start jf-admin-app
+-   Start jf-admin-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-admin-app/linux/out/debug
@@ -165,7 +165,7 @@ $ rm -rf jfa_b_kvs && touch jfa_b_kvs
 $ ./jfa-app --capabilities 0x4 --passcode 11022055 --discriminator 3841 --secured-device-port 5555 --rpc-server-port 33055 --KVS jfa_b_kvs
 ```
 
-- Start jf-control-app
+-   Start jf-control-app
 
 ```
 $ cd ~/connectedhomeip/examples/jf-control-app/out/debug
@@ -173,7 +173,7 @@ $ rm -rf jfc_b_storage_directory && mkdir jfc_b_storage_directory
 $ ./jfc-app --rpc-server-port 33055 --storage-directory jfc_b_storage_directory --commissioner-vendor-id 0xFFF2
 ```
 
-- Commission jf-admin-app
+-   Commission jf-admin-app
 
 ```
 >>> pairing onnetwork-long 11 11022055 3841 --anchor true
@@ -223,8 +223,8 @@ Subject: 1.3.6.1.4.1.37244.1.3 = 0000000000000003, OU = jf-anchor-icac
 ...
 ```
 
-- Start the
-  [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
+-   Start the
+    [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/linux/README.md)
 
 ```
 $ cd ~/connectedhomeip/examples/lighting-app/linux/out/debug
@@ -232,7 +232,7 @@ $ rm -rf light_b_kvs && touch light_b_kvs
 $ ./chip-lighting-app --capabilities 0x4 --passcode 11022066 --KVS light_b_kvs
 ```
 
-- Commission lighting-app
+-   Commission lighting-app
 
 ```
 >>> pairing onnetwork 22 11022066 --regular 1
@@ -285,7 +285,7 @@ the Ecosystem A anchor fabric, establishing the joint fabric relationship.
 
 On the Ecosystem B Joint Fabric Controller application
 
-- Open Joint Commissioning Window on JF Admin App of Ecosystem B
+-   Open Joint Commissioning Window on JF Admin App of Ecosystem B
 
 ```
 >>> pairing open-joint-commissioning-window 11 1 400 1000 1261

--- a/examples/common/pigweed/rpc_services/JointFabric.h
+++ b/examples/common/pigweed/rpc_services/JointFabric.h
@@ -18,6 +18,7 @@ public:
 
     /* JFARpc overrides */
     CHIP_ERROR GetICACCSRForJF(chip::MutableByteSpan & icacCSR);
+    CHIP_ERROR GetCrossSignedICAC(chip::FabricId anchorFabricId, chip::ByteSpan icacCSR, chip::MutableByteSpan & crossSignedICAC);
     void CloseStreams();
 
 private:

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -562,8 +562,7 @@ CHIP_ERROR JFAManager::SendAddICAC()
     return cluster.InvokeCommand(request, this, OnAddICACResponse, OnAddICACFailure);
 }
 
-void JFAManager::OnAddICACResponse(void * context,
-                                   const Commands::ICACResponse::DecodableType & response)
+void JFAManager::OnAddICACResponse(void * context, const Commands::ICACResponse::DecodableType & response)
 {
     JFAManager * jfaManagerCore = static_cast<JFAManager *>(context);
     VerifyOrDie(jfaManagerCore != nullptr);
@@ -575,8 +574,7 @@ void JFAManager::OnAddICACResponse(void * context,
 
     if (response.statusCode != app::Clusters::JointFabricAdministrator::ICACResponseStatusEnum::kOk)
     {
-        ChipLogError(JointFabric, "OnAddICACResponse: AddICAC command failed with status %u",
-                     to_underlying(response.statusCode));
+        ChipLogError(JointFabric, "OnAddICACResponse: AddICAC command failed with status %u", to_underlying(response.statusCode));
         jfaManagerCore->ReleaseSession();
         return;
     }

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -29,12 +29,14 @@
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
 #include <controller/CHIPCluster.h>
+#include <credentials/CHIPCert.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::Controller;
+using namespace chip::Credentials;
 using namespace chip::Crypto;
 using namespace chip::app::Clusters::JointFabricAdministrator;
 
@@ -318,6 +320,7 @@ void JFAManager::OnConnected(void * context, Messaging::ExchangeManager & exchan
         break;
     }
     case kJCMCommissioning: {
+        jfaManager->mJCMStage = kJCMStageAnnounce;
         TEMPORARY_RETURN_IGNORED jfaManager->AnnounceJointFabricAdministrator();
         break;
     }
@@ -335,6 +338,7 @@ void JFAManager::OnConnectionFailure(void * context, const ScopedNodeId & peerId
     ChipLogError(JointFabric, "Failed to establish connection to 0x" ChipLogFormatX64 " on fabric index %d",
                  ChipLogValueX64(peerId.GetNodeId()), peerId.GetFabricIndex());
 
+    jfaManager->mJCMStage = kJCMStageIdle;
     jfaManager->ReleaseSession();
 }
 
@@ -362,6 +366,7 @@ void JFAManager::OnAnnounceJointFabricAdministratorResponse(void * context, cons
 
     ChipLogProgress(JointFabric, "OnAnnounceJointFabricAdministratorResponse");
 
+    jfaManagerCore->mJCMStage = kJCMStageICACCSRRequest;
     /* TODO: https://github.com/project-chip/connectedhomeip/issues/38202 */
     TEMPORARY_RETURN_IGNORED jfaManagerCore->SendICACSRRequest();
 }
@@ -398,13 +403,103 @@ void JFAManager::OnSendICACSRRequestResponse(void * context, const Commands::ICA
 
     ChipLogProgress(JointFabric, "OnSendICACSRRequestResponse");
 
-    if (icaccsr.icaccsr.HasValue() &&
-        (CHIP_NO_ERROR ==
-         VerifyCertificateSigningRequest(icaccsr.icaccsr.Value().data(), icaccsr.icaccsr.Value().size(), pubKey)) &&
-        jfaManagerCore->peerAdminICACPubKey.Matches(pubKey))
+    if (!icaccsr.icaccsr.HasValue())
     {
-        ChipLogProgress(JointFabric, "OnSendICACSRRequestResponse: validated ICAC CSR");
-        TEMPORARY_RETURN_IGNORED jfaManagerCore->SendCommissioningComplete();
+        ChipLogError(JointFabric, "OnSendICACSRRequestResponse: missing ICAC CSR in response");
+        jfaManagerCore->ReleaseSession();
+        return;
+    }
+
+    ByteSpan csrSpan = icaccsr.icaccsr.Value();
+
+    if (CHIP_NO_ERROR != VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), pubKey))
+    {
+        ChipLogError(JointFabric, "OnSendICACSRRequestResponse: ICAC CSR signature verification failed");
+        jfaManagerCore->ReleaseSession();
+        return;
+    }
+
+    if (!jfaManagerCore->peerAdminICACPubKey.Matches(pubKey))
+    {
+        ChipLogError(JointFabric, "OnSendICACSRRequestResponse: ICAC CSR public key does not match TrustedIcacPublicKeyB");
+        jfaManagerCore->ReleaseSession();
+        return;
+    }
+
+    ChipLogProgress(JointFabric, "OnSendICACSRRequestResponse: validated ICAC CSR");
+
+    // Save the CSR for cross-signing
+    VerifyOrDie(csrSpan.size() <= sizeof(jfaManagerCore->mPendingICACSRBuf));
+    memcpy(jfaManagerCore->mPendingICACSRBuf, csrSpan.data(), csrSpan.size());
+    jfaManagerCore->mPendingICACSRLen = csrSpan.size();
+
+    // Cross-sign the CSR under the anchor root CA
+    CHIP_ERROR err = jfaManagerCore->CrossSignICAC();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(JointFabric, "OnSendICACSRRequestResponse: CrossSignICAC failed: %" CHIP_ERROR_FORMAT, err.Format());
+        jfaManagerCore->mPendingICACSRLen = 0;
+        jfaManagerCore->ReleaseSession();
+        return;
+    }
+
+    // Validate that the cross-signed ICAC chains to the anchor root before installing
+    {
+        constexpr uint8_t kMaxCertsInChain = 2;
+        uint8_t rcacBuf[Credentials::kMaxCHIPCertLength];
+        MutableByteSpan rcacSpan{ rcacBuf };
+        Credentials::ChipCertificateSet certificates;
+        Credentials::ValidationContext validContext;
+
+        if (mServer->GetFabricTable().FetchRootCert(jfaManagerCore->jfFabricIndex, rcacSpan) != CHIP_NO_ERROR)
+        {
+            ChipLogError(JointFabric, "OnSendICACSRRequestResponse: failed to fetch anchor root cert");
+            jfaManagerCore->mCrossSignedICACLen = 0;
+            jfaManagerCore->mPendingICACSRLen   = 0;
+            jfaManagerCore->ReleaseSession();
+            return;
+        }
+
+        if (certificates.Init(kMaxCertsInChain) != CHIP_NO_ERROR ||
+            certificates.LoadCert(rcacSpan, BitFlags<Credentials::CertDecodeFlags>(Credentials::CertDecodeFlags::kIsTrustAnchor)) !=
+                CHIP_NO_ERROR ||
+            certificates.LoadCert(ByteSpan(jfaManagerCore->mCrossSignedICACBuf, jfaManagerCore->mCrossSignedICACLen),
+                                  BitFlags<Credentials::CertDecodeFlags>(Credentials::CertDecodeFlags::kGenerateTBSHash)) !=
+                CHIP_NO_ERROR)
+        {
+            ChipLogError(JointFabric, "OnSendICACSRRequestResponse: failed to load certificates for chain validation");
+            jfaManagerCore->mCrossSignedICACLen = 0;
+            jfaManagerCore->mPendingICACSRLen   = 0;
+            jfaManagerCore->ReleaseSession();
+            return;
+        }
+
+        validContext.Reset();
+        validContext.mRequiredKeyUsages.Set(Credentials::KeyUsageFlags::kKeyCertSign);
+        validContext.mRequiredCertType = Credentials::CertType::kICA;
+
+        if (certificates.ValidateCert(certificates.GetLastCert(), validContext) != CHIP_NO_ERROR)
+        {
+            ChipLogError(JointFabric, "OnSendICACSRRequestResponse: cross-signed ICAC chain validation failed");
+            jfaManagerCore->mCrossSignedICACLen = 0;
+            jfaManagerCore->mPendingICACSRLen   = 0;
+            jfaManagerCore->ReleaseSession();
+            return;
+        }
+    }
+
+    ChipLogProgress(JointFabric, "OnSendICACSRRequestResponse: cross-signed ICAC validated, invoking AddICAC");
+
+    jfaManagerCore->mJCMStage = kJCMStageAddICAC;
+
+    // Proceed with installing the cross-signed ICAC on the commissionee
+    err = jfaManagerCore->SendAddICAC();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(JointFabric, "OnSendICACSRRequestResponse: SendAddICAC failed: %" CHIP_ERROR_FORMAT, err.Format());
+        jfaManagerCore->mCrossSignedICACLen = 0;
+        jfaManagerCore->mPendingICACSRLen   = 0;
+        jfaManagerCore->ReleaseSession();
     }
 }
 
@@ -415,6 +510,92 @@ void JFAManager::OnSendICACSRRequestFailure(void * context, CHIP_ERROR error)
     jfaManagerCore->ReleaseSession();
 
     ChipLogError(JointFabric, "OnSendICACSRRequestFailure: %s\n", chip::ErrorStr(error));
+}
+
+CHIP_ERROR JFAManager::CrossSignICAC()
+{
+    JFARpc * jfaRpc = GetJFARpc();
+    VerifyOrReturnError(jfaRpc != nullptr, CHIP_ERROR_UNINITIALIZED);
+    VerifyOrReturnError(mPendingICACSRLen > 0, CHIP_ERROR_INCORRECT_STATE);
+
+    // Retrieve the anchor fabric ID from the fabric table
+    const FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(jfFabricIndex);
+    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    FabricId anchorFabricId = fabricInfo->GetFabricId();
+
+    ByteSpan csrSpan(mPendingICACSRBuf, mPendingICACSRLen);
+    MutableByteSpan crossSignedICAC(mCrossSignedICACBuf, sizeof(mCrossSignedICACBuf));
+
+    mJCMStage = kJCMStageCrossSign;
+    ChipLogProgress(JointFabric, "CrossSignICAC: requesting cross-signed ICAC for anchor fabric 0x" ChipLogFormatX64,
+                    ChipLogValueX64(anchorFabricId));
+
+    CHIP_ERROR err = jfaRpc->GetCrossSignedICAC(anchorFabricId, csrSpan, crossSignedICAC);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(JointFabric, "CrossSignICAC: GetCrossSignedICAC failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+
+    mCrossSignedICACLen = crossSignedICAC.size();
+    ChipLogProgress(JointFabric, "CrossSignICAC: received cross-signed ICAC (%u bytes)",
+                    static_cast<unsigned>(mCrossSignedICACLen));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR JFAManager::SendAddICAC()
+{
+    Commands::AddICAC::Type request;
+
+    if (!mExchangeMgr)
+    {
+        return CHIP_ERROR_UNINITIALIZED;
+    }
+
+    VerifyOrReturnError(mCrossSignedICACLen > 0, CHIP_ERROR_INCORRECT_STATE);
+
+    request.ICACValue = ByteSpan(mCrossSignedICACBuf, mCrossSignedICACLen);
+
+    ChipLogProgress(JointFabric, "SendAddICAC: invoke cluster command with %u byte ICAC",
+                    static_cast<unsigned>(mCrossSignedICACLen));
+    Controller::ClusterBase cluster(*mExchangeMgr, mSessionHolder.Get().Value(), peerAdminJFAdminClusterEndpointId);
+    return cluster.InvokeCommand(request, this, OnAddICACResponse, OnAddICACFailure);
+}
+
+void JFAManager::OnAddICACResponse(void * context,
+                                   const Commands::ICACResponse::DecodableType & response)
+{
+    JFAManager * jfaManagerCore = static_cast<JFAManager *>(context);
+    VerifyOrDie(jfaManagerCore != nullptr);
+
+    ChipLogProgress(JointFabric, "OnAddICACResponse: statusCode=%u", to_underlying(response.statusCode));
+
+    jfaManagerCore->mCrossSignedICACLen = 0;
+    jfaManagerCore->mPendingICACSRLen   = 0;
+
+    if (response.statusCode != app::Clusters::JointFabricAdministrator::ICACResponseStatusEnum::kOk)
+    {
+        ChipLogError(JointFabric, "OnAddICACResponse: AddICAC command failed with status %u",
+                     to_underlying(response.statusCode));
+        jfaManagerCore->ReleaseSession();
+        return;
+    }
+
+    ChipLogProgress(JointFabric, "OnAddICACResponse: ICAC installed successfully, proceeding to CommissioningComplete");
+    jfaManagerCore->mJCMStage = kJCMStageCommissionComplete;
+    TEMPORARY_RETURN_IGNORED jfaManagerCore->SendCommissioningComplete();
+}
+
+void JFAManager::OnAddICACFailure(void * context, CHIP_ERROR error)
+{
+    JFAManager * jfaManagerCore = static_cast<JFAManager *>(context);
+    VerifyOrDie(jfaManagerCore != nullptr);
+
+    jfaManagerCore->mCrossSignedICACLen = 0;
+    jfaManagerCore->mPendingICACSRLen   = 0;
+    jfaManagerCore->ReleaseSession();
+
+    ChipLogError(JointFabric, "OnAddICACFailure: %s\n", chip::ErrorStr(error));
 }
 
 CHIP_ERROR JFAManager::SendCommissioningComplete()
@@ -441,8 +622,8 @@ void JFAManager::OnCommissioningCompleteResponse(
 
     if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
     {
-        ChipLogProgress(JointFabric, "Commssioning Failed (nodeId=%ld, isJCM = %d), Code=%u", jfaManager->mNodeId,
-                        jfaManager->mOnConnectedAction == kJCMCommissioning, to_underlying(data.errorCode));
+        ChipLogError(JointFabric, "Commissioning Failed (nodeId=%ld, isJCM = %d), Code=%u", jfaManager->mNodeId,
+                     jfaManager->mOnConnectedAction == kJCMCommissioning, to_underlying(data.errorCode));
     }
     else
     {
@@ -459,6 +640,7 @@ void JFAManager::OnCommissioningCompleteResponse(
         }
     }
 
+    jfaManager->mJCMStage = kJCMStageIdle;
     jfaManager->ReleaseSession();
 }
 
@@ -481,4 +663,16 @@ CHIP_ERROR JFAManager::GetIcacCsr(MutableByteSpan & icacCsr)
     }
 
     return CHIP_ERROR_UNINITIALIZED;
+}
+
+CHIP_ERROR JFAManager::StoreCrossSignedICAC(const ByteSpan & crossSignedICAC)
+{
+    VerifyOrReturnError(crossSignedICAC.size() <= sizeof(mICACBuffer), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    memcpy(mICACBuffer, crossSignedICAC.data(), crossSignedICAC.size());
+    mICACBufferLen = crossSignedICAC.size();
+
+    ChipLogProgress(JointFabric, "StoreCrossSignedICAC: stored cross-signed ICAC (%u bytes)",
+                    static_cast<unsigned>(mICACBufferLen));
+    return CHIP_NO_ERROR;
 }

--- a/examples/jf-admin-app/linux/include/JFAManager.h
+++ b/examples/jf-admin-app/linux/include/JFAManager.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/support/ScopedMemoryBuffer.h>
 
 #include "JFARpc.h"
 
@@ -47,6 +48,7 @@ public:
 
     /* app::JointFabricAdministrator::Delegate */
     CHIP_ERROR GetIcacCsr(MutableByteSpan & icacCsr) override;
+    CHIP_ERROR StoreCrossSignedICAC(const ByteSpan & crossSignedICAC) override;
 
     CHIP_ERROR GetJointFabricMode(uint8_t & jointFabricMode);
 
@@ -60,6 +62,17 @@ private:
     {
         kStandardCommissioningComplete = 0,
         kJCMCommissioning              = 1,
+    };
+
+    // JCM flow stage, used to prevent out-of-order invocations
+    enum JCMStage
+    {
+        kJCMStageIdle              = 0, ///< No JCM flow active
+        kJCMStageAnnounce          = 1, ///< Sent AnnounceJointFabricAdministrator
+        kJCMStageICACCSRRequest    = 2, ///< Sent ICACCSRRequest, waiting for response
+        kJCMStageCrossSign         = 3, ///< Cross-signing ICAC CSR via RPC
+        kJCMStageAddICAC           = 4, ///< Sent AddICAC, waiting for response
+        kJCMStageCommissionComplete = 5, ///< Sent CommissioningComplete
     };
 
     friend JFAManager & JFAMgr(void);
@@ -77,6 +90,7 @@ private:
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;
     NodeId mNodeId                               = kUndefinedNodeId;
     OnConnectedAction mOnConnectedAction         = kStandardCommissioningComplete;
+    JCMStage mJCMStage                           = kJCMStageIdle;
     FabricId jfFabricIndex                       = kUndefinedFabricId;
     EndpointId peerAdminJFAdminClusterEndpointId = kInvalidEndpointId;
     Crypto::P256PublicKey peerAdminICACPubKey;
@@ -84,10 +98,31 @@ private:
     size_t mICACBufferLen         = 0;
     bool mCommissionerInitialized = false;
 
+    // JCM state: pending CSR bytes received from commissionee, cleared after cross-signing
+    uint8_t mPendingICACSRBuf[Crypto::kMIN_CSR_Buffer_Size];
+    size_t mPendingICACSRLen = 0;
+
+    // JCM state: cross-signed ICAC to be installed via AddICAC, cleared after installation
+    uint8_t mCrossSignedICACBuf[Credentials::kMaxDERCertLength];
+    size_t mCrossSignedICACLen = 0;
+
     void ConnectToNode(ScopedNodeId scopedNodeId, OnConnectedAction onConnectedAction);
     CHIP_ERROR SendCommissioningComplete();
     CHIP_ERROR AnnounceJointFabricAdministrator();
     CHIP_ERROR SendICACSRRequest();
+
+    /**
+     * Cross-sign the pending ICAC CSR under the anchor root CA via the JFC RPC,
+     * storing the resulting cross-signed ICAC in mCrossSignedICACBuf.
+     * The CSR to sign must have been saved in mPendingICACSRBuf beforehand.
+     */
+    CHIP_ERROR CrossSignICAC();
+
+    /**
+     * Invoke the AddICAC cluster command on the commissionee with the cross-signed
+     * ICAC stored in mCrossSignedICACBuf.
+     */
+    CHIP_ERROR SendAddICAC();
 
     static void OnCommissioningCompleteResponse(
         void * context, const app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data);
@@ -98,6 +133,10 @@ private:
     OnSendICACSRRequestResponse(void * context,
                                 const app::Clusters::JointFabricAdministrator::Commands::ICACCSRResponse::DecodableType & icaccsr);
     static void OnSendICACSRRequestFailure(void * context, CHIP_ERROR error);
+    static void
+    OnAddICACResponse(void * context,
+                      const app::Clusters::JointFabricAdministrator::Commands::ICACResponse::DecodableType & response);
+    static void OnAddICACFailure(void * context, CHIP_ERROR error);
 
     void ReleaseSession();
 };

--- a/examples/jf-admin-app/linux/include/JFAManager.h
+++ b/examples/jf-admin-app/linux/include/JFAManager.h
@@ -67,11 +67,11 @@ private:
     // JCM flow stage, used to prevent out-of-order invocations
     enum JCMStage
     {
-        kJCMStageIdle              = 0, ///< No JCM flow active
-        kJCMStageAnnounce          = 1, ///< Sent AnnounceJointFabricAdministrator
-        kJCMStageICACCSRRequest    = 2, ///< Sent ICACCSRRequest, waiting for response
-        kJCMStageCrossSign         = 3, ///< Cross-signing ICAC CSR via RPC
-        kJCMStageAddICAC           = 4, ///< Sent AddICAC, waiting for response
+        kJCMStageIdle               = 0, ///< No JCM flow active
+        kJCMStageAnnounce           = 1, ///< Sent AnnounceJointFabricAdministrator
+        kJCMStageICACCSRRequest     = 2, ///< Sent ICACCSRRequest, waiting for response
+        kJCMStageCrossSign          = 3, ///< Cross-signing ICAC CSR via RPC
+        kJCMStageAddICAC            = 4, ///< Sent AddICAC, waiting for response
         kJCMStageCommissionComplete = 5, ///< Sent CommissioningComplete
     };
 
@@ -133,9 +133,8 @@ private:
     OnSendICACSRRequestResponse(void * context,
                                 const app::Clusters::JointFabricAdministrator::Commands::ICACCSRResponse::DecodableType & icaccsr);
     static void OnSendICACSRRequestFailure(void * context, CHIP_ERROR error);
-    static void
-    OnAddICACResponse(void * context,
-                      const app::Clusters::JointFabricAdministrator::Commands::ICACResponse::DecodableType & response);
+    static void OnAddICACResponse(void * context,
+                                  const app::Clusters::JointFabricAdministrator::Commands::ICACResponse::DecodableType & response);
     static void OnAddICACFailure(void * context, CHIP_ERROR error);
 
     void ReleaseSession();

--- a/examples/jf-admin-app/linux/include/JFARpc.h
+++ b/examples/jf-admin-app/linux/include/JFARpc.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 
 namespace chip {
 
@@ -27,7 +28,19 @@ class JFARpc
 public:
     virtual ~JFARpc() {}
     virtual CHIP_ERROR GetICACCSRForJF(MutableByteSpan & icacCSR) = 0;
-    virtual void CloseStreams()                                   = 0;
+
+    /**
+     * Request the JFC to cross-sign the commissionee's ICAC CSR under the
+     * anchor root CA and return the resulting cross-signed ICAC.
+     *
+     * @param anchorFabricId  The FabricId of the anchor fabric, embedded as
+     *                        matter-fabric-id in the cross-signed ICAC Subject DN.
+     * @param icacCSR         The raw ICAC CSR bytes received from the commissionee.
+     * @param crossSignedICAC Output buffer for the cross-signed ICAC (DER/TLV encoded).
+     */
+    virtual CHIP_ERROR GetCrossSignedICAC(FabricId anchorFabricId, ByteSpan icacCSR, MutableByteSpan & crossSignedICAC) = 0;
+
+    virtual void CloseStreams() = 0;
 };
 
 } // namespace chip

--- a/examples/jf-admin-app/linux/rpc/RpcServer.cpp
+++ b/examples/jf-admin-app/linux/rpc/RpcServer.cpp
@@ -2,9 +2,11 @@
 
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <credentials/CHIPCert.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
+using namespace chip::Credentials;
 
 namespace joint_fabric_service {
 
@@ -12,8 +14,16 @@ constexpr uint32_t kRpcTimeoutMs = 1000;
 std::condition_variable responseCv;
 bool responseReceived = false;
 
+// Buffer for ICAC_CSR transaction responses
 uint8_t icacCSRBuf[Crypto::kMIN_CSR_Buffer_Size] = { 0 };
 MutableByteSpan icacCSRSpan{ icacCSRBuf };
+
+// Buffer for CROSS_SIGNED_ICAC transaction responses
+uint8_t crossSignedICACBuf[Credentials::kMaxDERCertLength] = { 0 };
+MutableByteSpan crossSignedICACSpan{ crossSignedICACBuf };
+
+// Track which transaction type the last response belongs to
+TransactionType lastResponseTransactionType = TransactionType::TransactionType_ICAC_CSR;
 
 ::pw::Status JointFabric::TransferOwnership(const ::OwnershipContext & request, ::pw_protobuf_Empty & response)
 {
@@ -49,12 +59,26 @@ void JointFabric::GetStream(const ::pw_protobuf_Empty & request, ServerWriter<::
     return;
 }
 
-::pw::Status JointFabric::ResponseStream(const ::Response & ICACCSRBytes, ::pw_protobuf_Empty & response)
+::pw::Status JointFabric::ResponseStream(const ::Response & responseBytes, ::pw_protobuf_Empty & response)
 {
-    ChipLogProgress(JointFabric, "RPC ReplyWithICACCSR");
+    ChipLogProgress(JointFabric, "RPC ResponseStream: transaction_type=%d", responseBytes.transaction_type);
 
-    TEMPORARY_RETURN_IGNORED CopySpanToMutableSpan(ByteSpan(ICACCSRBytes.response_bytes.bytes, ICACCSRBytes.response_bytes.size),
-                                                   icacCSRSpan);
+    lastResponseTransactionType = responseBytes.transaction_type;
+
+    switch (responseBytes.transaction_type)
+    {
+    case TransactionType::TransactionType_ICAC_CSR:
+        TEMPORARY_RETURN_IGNORED CopySpanToMutableSpan(
+            ByteSpan(responseBytes.response_bytes.bytes, responseBytes.response_bytes.size), icacCSRSpan);
+        break;
+    case TransactionType::TransactionType_CROSS_SIGNED_ICAC:
+        TEMPORARY_RETURN_IGNORED CopySpanToMutableSpan(
+            ByteSpan(responseBytes.response_bytes.bytes, responseBytes.response_bytes.size), crossSignedICACSpan);
+        break;
+    default:
+        ChipLogError(JointFabric, "ResponseStream: unknown transaction type %d", responseBytes.transaction_type);
+        return pw::Status::InvalidArgument();
+    }
 
     responseReceived = true;
     responseCv.notify_one();
@@ -69,8 +93,10 @@ CHIP_ERROR JointFabric::GetICACCSRForJF(MutableByteSpan & icacCSR)
     ::pw::Status status;
 
     // JFA requests an ICAC CSR from JFC
-    RequestOptions requestOptions{ TransactionType::TransactionType_ICAC_CSR };
-    status = rpcGetStream.Write(requestOptions);
+    RequestOptions requestOptions;
+    requestOptions.transaction_type = TransactionType::TransactionType_ICAC_CSR;
+    requestOptions.anchor_fabric_id = 0;
+    status                          = rpcGetStream.Write(requestOptions);
 
     if (pw::OkStatus() != status)
     {
@@ -87,6 +113,52 @@ CHIP_ERROR JointFabric::GetICACCSRForJF(MutableByteSpan & icacCSR)
         return CHIP_NO_ERROR;
     }
 
+    return CHIP_ERROR_TIMEOUT;
+}
+
+CHIP_ERROR JointFabric::GetCrossSignedICAC(FabricId anchorFabricId, ByteSpan icacCSR, MutableByteSpan & crossSignedICAC)
+{
+    std::mutex responseMutex;
+    std::unique_lock<std::mutex> lock(responseMutex);
+    ::pw::Status status;
+
+    // Reset the cross-signed ICAC buffer and copy the CSR into the request context
+    // The proto RequestOptions carries anchor_fabric_id; the CSR itself is already known
+    // to JFC from the earlier ICAC_CSR exchange (it generated the key pair for it).
+    // We pass anchor_fabric_id so JFC can embed the correct matter-fabric-id in the ICAC Subject.
+    crossSignedICACSpan = MutableByteSpan(crossSignedICACBuf, sizeof(crossSignedICACBuf));
+
+    RequestOptions requestOptions;
+    requestOptions.transaction_type = TransactionType::TransactionType_CROSS_SIGNED_ICAC;
+    requestOptions.anchor_fabric_id = anchorFabricId;
+    status                          = rpcGetStream.Write(requestOptions);
+
+    if (pw::OkStatus() != status)
+    {
+        ChipLogError(JointFabric, "GetCrossSignedICAC: writing CROSS_SIGNED_ICAC request to GetStream failed");
+        return CHIP_ERROR_SHUT_DOWN;
+    }
+
+    // Wait for the cross-signed ICAC from JFC
+    if (responseCv.wait_for(lock, std::chrono::milliseconds(kRpcTimeoutMs), [] { return responseReceived; }))
+    {
+        if (lastResponseTransactionType != TransactionType::TransactionType_CROSS_SIGNED_ICAC)
+        {
+            ChipLogError(JointFabric, "GetCrossSignedICAC: unexpected response transaction type %d",
+                         lastResponseTransactionType);
+            responseReceived = false;
+            return CHIP_ERROR_WRONG_ORDER;
+        }
+
+        ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(crossSignedICACSpan.data(), crossSignedICACSpan.size()), crossSignedICAC));
+        responseReceived = false;
+
+        ChipLogProgress(JointFabric, "GetCrossSignedICAC: received cross-signed ICAC (%u bytes)",
+                        static_cast<unsigned>(crossSignedICAC.size()));
+        return CHIP_NO_ERROR;
+    }
+
+    ChipLogError(JointFabric, "GetCrossSignedICAC: timed out waiting for cross-signed ICAC");
     return CHIP_ERROR_TIMEOUT;
 }
 

--- a/examples/jf-admin-app/linux/rpc/RpcServer.cpp
+++ b/examples/jf-admin-app/linux/rpc/RpcServer.cpp
@@ -144,13 +144,13 @@ CHIP_ERROR JointFabric::GetCrossSignedICAC(FabricId anchorFabricId, ByteSpan ica
     {
         if (lastResponseTransactionType != TransactionType::TransactionType_CROSS_SIGNED_ICAC)
         {
-            ChipLogError(JointFabric, "GetCrossSignedICAC: unexpected response transaction type %d",
-                         lastResponseTransactionType);
+            ChipLogError(JointFabric, "GetCrossSignedICAC: unexpected response transaction type %d", lastResponseTransactionType);
             responseReceived = false;
             return CHIP_ERROR_WRONG_ORDER;
         }
 
-        ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(crossSignedICACSpan.data(), crossSignedICACSpan.size()), crossSignedICAC));
+        ReturnErrorOnFailure(
+            CopySpanToMutableSpan(ByteSpan(crossSignedICACSpan.data(), crossSignedICACSpan.size()), crossSignedICAC));
         responseReceived = false;
 
         ChipLogProgress(JointFabric, "GetCrossSignedICAC: received cross-signed ICAC (%u bytes)",

--- a/examples/jf-control-app/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/jf-control-app/commands/example/ExampleCredentialIssuerCommands.h
@@ -62,6 +62,11 @@ public:
 
     CHIP_ERROR GenerateIcacCsr(chip::MutableByteSpan & generatedIcacCsr) { return mOpCredsIssuer.ObtainICACSR(generatedIcacCsr); }
 
+    CHIP_ERROR SignICAC(chip::ByteSpan icaCsr, chip::FabricId anchorFabricId, chip::MutableByteSpan & icac)
+    {
+        return mOpCredsIssuer.SignICAC(icaCsr, anchorFabricId, icac);
+    }
+
     CHIP_ERROR AddAdditionalCDVerifyingCerts(const std::vector<std::vector<uint8_t>> & additionalCdCerts) override
     {
         VerifyOrReturnError(mDacVerifier != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/examples/jf-control-app/commands/pairing/PairingCommand.cpp
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.cpp
@@ -628,14 +628,37 @@ static void GenerateReplyWork(intptr_t arg)
         {
             ChipLogError(JointFabric, "GenerateIcacCsr failed");
         }
+        rsp.transaction_type = TransactionType::TransactionType_ICAC_CSR;
+        break;
+    }
+    case TransactionType::TransactionType_CROSS_SIGNED_ICAC: {
+        // JFC obtains the CSR for its anchor intermediate issuer keypair
+        // (same keypair used in the ICAC_CSR step) and cross-signs it under
+        // the anchor root CA with the anchor fabric ID embedded in the Subject DN.
+        uint8_t csrBuf[kMaxDERCertLength];
+        MutableByteSpan csrSpan(csrBuf, sizeof(csrBuf));
+        err = (static_cast<ExampleCredentialIssuerCommands *>(pkiProviderCredentialIssuer))->GenerateIcacCsr(csrSpan);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(JointFabric, "CROSS_SIGNED_ICAC: GenerateIcacCsr failed: %" CHIP_ERROR_FORMAT, err.Format());
+            break;
+        }
+        err = (static_cast<ExampleCredentialIssuerCommands *>(pkiProviderCredentialIssuer))
+                  ->SignICAC(csrSpan, request->mAnchorFabricId, generatedCertificate);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(JointFabric, "CROSS_SIGNED_ICAC: SignICAC failed: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+        rsp.transaction_type = TransactionType::TransactionType_CROSS_SIGNED_ICAC;
         break;
     }
     default: {
+        ChipLogError(JointFabric, "GenerateReplyWork: unsupported transaction type %d", request->mTransactionType);
         err = CHIP_ERROR_INVALID_ARGUMENT;
         break;
     }
     }
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(JointFabric, "GenerateReplyWork: invalid request"));
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(JointFabric, "GenerateReplyWork: operation failed, not sending response"));
 
     memcpy(rsp.response_bytes.bytes, generatedCertificate.data(), generatedCertificate.size());
     rsp.response_bytes.size = (short unsigned int) generatedCertificate.size();

--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -379,11 +379,41 @@ void JointFabricAdministratorGlobalInstance::HandleAddICAC(HandlerContext & ctx,
 
     VerifyOrExit(VerifyAddICACDNEncodingRules(commandData) == CHIP_NO_ERROR, status.Emplace(ICACResponseStatusEnum::kInvalidICAC));
 
+    // Certificate chain validated successfully — install the cross-signed ICAC
+    {
+        auto & jointFabricAdministrator = Server::GetInstance().GetJointFabricAdministrator();
+        auto * delegate                 = jointFabricAdministrator.GetDelegate();
+        if (delegate != nullptr)
+        {
+            CHIP_ERROR installErr = delegate->StoreCrossSignedICAC(commandData.ICACValue);
+            if (installErr != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "JointFabricAdministrator: StoreCrossSignedICAC failed: %" CHIP_ERROR_FORMAT,
+                             installErr.Format());
+                status.Emplace(ICACResponseStatusEnum::kInvalidICAC);
+                goto exit;
+            }
+            ChipLogProgress(Zcl, "JointFabricAdministrator: cross-signed ICAC installed successfully (%u bytes)",
+                            static_cast<unsigned>(commandData.ICACValue.size()));
+        }
+        else
+        {
+            ChipLogDetail(Zcl, "JointFabricAdministrator: no delegate registered, skipping ICAC storage");
+        }
+    }
+
 exit:
     if (status.HasValue())
     {
         Commands::ICACResponse::Type response;
         response.statusCode = status.Value();
+        ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+        return;
+    }
+    if (nonDefaultStatus == Status::Success)
+    {
+        Commands::ICACResponse::Type response;
+        response.statusCode = ICACResponseStatusEnum::kOk;
         ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
         return;
     }

--- a/src/app/clusters/joint-fabric-administrator-server/tests/BUILD.gn
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/BUILD.gn
@@ -22,10 +22,14 @@ chip_test_suite("tests") {
 
   sources = [ "../JCMCommissionee.cpp" ]
 
-  test_sources = [ "TestJCMCommissionee.cpp" ]
+  test_sources = [
+    "TestAddICACInstallation.cpp",
+    "TestJCMCommissionee.cpp",
+  ]
 
   public_deps = [
     "${chip_root}/src/app/server",
+    "${chip_root}/src/app/server:joint_fabric",
     "${chip_root}/src/app/tests:helpers",
     "${chip_root}/src/credentials/jcm",
     "${chip_root}/src/credentials/tests:cert_test_vectors",

--- a/src/app/clusters/joint-fabric-administrator-server/tests/TestAddICACInstallation.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/TestAddICACInstallation.cpp
@@ -1,0 +1,177 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Tests for the JointFabricAdministrator cluster's AddICAC certificate
+ * installation path, specifically the StoreCrossSignedICAC delegate interface.
+ */
+
+#include <app/server/JointFabricAdministrator.h>
+#include <credentials/CHIPCert.h>
+#include <credentials/tests/CHIPCert_test_vectors.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <pw_unit_test/framework.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::Credentials;
+using namespace chip::TestCerts;
+
+namespace {
+
+/**
+ * A test delegate that captures the cross-signed ICAC passed to StoreCrossSignedICAC.
+ */
+class TestJFADelegate : public JointFabricAdministrator::Delegate
+{
+public:
+    CHIP_ERROR GetIcacCsr(MutableByteSpan & icacCsr) override { return CHIP_NO_ERROR; }
+
+    CHIP_ERROR StoreCrossSignedICAC(const ByteSpan & crossSignedICAC) override
+    {
+        mStoreCallCount++;
+        mStoredICACLen = crossSignedICAC.size();
+        if (crossSignedICAC.size() <= sizeof(mStoredICACBuf))
+        {
+            memcpy(mStoredICACBuf, crossSignedICAC.data(), crossSignedICAC.size());
+        }
+        return mReturnError;
+    }
+
+    uint8_t mStoredICACBuf[Credentials::kMaxDERCertLength] = { 0 };
+    size_t mStoredICACLen                                   = 0;
+    int mStoreCallCount                                     = 0;
+    CHIP_ERROR mReturnError                                 = CHIP_NO_ERROR;
+};
+
+/**
+ * A test delegate that fails on StoreCrossSignedICAC.
+ */
+class FailingJFADelegate : public JointFabricAdministrator::Delegate
+{
+public:
+    CHIP_ERROR GetIcacCsr(MutableByteSpan & icacCsr) override { return CHIP_NO_ERROR; }
+
+    CHIP_ERROR StoreCrossSignedICAC(const ByteSpan & crossSignedICAC) override { return CHIP_ERROR_PERSISTED_STORAGE_FAILED; }
+};
+
+} // namespace
+
+class TestAddICACInstallation : public ::testing::Test
+{
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+/**
+ * Verify that the default JointFabricAdministrator::Delegate::StoreCrossSignedICAC
+ * returns CHIP_NO_ERROR (no-op base implementation).
+ */
+TEST_F(TestAddICACInstallation, DefaultDelegateStoreCrossSignedICACIsNoop)
+{
+    JointFabricAdministrator::Delegate delegate;
+    ByteSpan testICACSpan(sTestCert_ICA01_Chip);
+    EXPECT_EQ(delegate.StoreCrossSignedICAC(testICACSpan), CHIP_NO_ERROR);
+}
+
+/**
+ * Verify that a custom delegate receives the cross-signed ICAC bytes correctly.
+ */
+TEST_F(TestAddICACInstallation, DelegateStoreCrossSignedICACReceivesCorrectBytes)
+{
+    TestJFADelegate delegate;
+    ByteSpan testICACSpan(sTestCert_ICA01_Chip);
+
+    EXPECT_EQ(delegate.StoreCrossSignedICAC(testICACSpan), CHIP_NO_ERROR);
+    EXPECT_EQ(delegate.mStoreCallCount, 1);
+    EXPECT_EQ(delegate.mStoredICACLen, testICACSpan.size());
+    EXPECT_EQ(memcmp(delegate.mStoredICACBuf, testICACSpan.data(), testICACSpan.size()), 0);
+}
+
+/**
+ * Verify that StoreCrossSignedICAC is only called once per AddICAC invocation.
+ */
+TEST_F(TestAddICACInstallation, DelegateStoreCrossSignedICACCalledOnce)
+{
+    TestJFADelegate delegate;
+    ByteSpan testICACSpan(sTestCert_ICA01_Chip);
+
+    // First call succeeds
+    EXPECT_EQ(delegate.StoreCrossSignedICAC(testICACSpan), CHIP_NO_ERROR);
+    EXPECT_EQ(delegate.mStoreCallCount, 1);
+
+    // If called again (e.g., retry scenario), the count increases
+    EXPECT_EQ(delegate.StoreCrossSignedICAC(testICACSpan), CHIP_NO_ERROR);
+    EXPECT_EQ(delegate.mStoreCallCount, 2);
+}
+
+/**
+ * Verify that an error returned from StoreCrossSignedICAC is propagated.
+ * This mirrors the expected behavior in HandleAddICAC when installation fails.
+ */
+TEST_F(TestAddICACInstallation, DelegateStoreCrossSignedICACFailurePropagates)
+{
+    TestJFADelegate delegate;
+    delegate.mReturnError = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+
+    ByteSpan testICACSpan(sTestCert_ICA01_Chip);
+    CHIP_ERROR err = delegate.StoreCrossSignedICAC(testICACSpan);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+}
+
+/**
+ * Verify that an empty ICAC span can be passed without crashing.
+ * Expected behavior: CHIP_NO_ERROR (or implementation-specific error), no crash.
+ */
+TEST_F(TestAddICACInstallation, DelegateStoreCrossSignedICACWithEmptySpan)
+{
+    TestJFADelegate delegate;
+    ByteSpan emptySpan;
+
+    CHIP_ERROR err = delegate.StoreCrossSignedICAC(emptySpan);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(delegate.mStoredICACLen, 0u);
+}
+
+/**
+ * Verify that a second ICA certificate (ICA02) can also be stored correctly.
+ * Expected behavior: tests backward-compatibility with different cert sizes.
+ */
+TEST_F(TestAddICACInstallation, DelegateStoreCrossSignedICACWithICA02)
+{
+    TestJFADelegate delegate;
+    ByteSpan testICACSpan(sTestCert_ICA02_Chip);
+
+    EXPECT_EQ(delegate.StoreCrossSignedICAC(testICACSpan), CHIP_NO_ERROR);
+    EXPECT_EQ(delegate.mStoredICACLen, testICACSpan.size());
+    EXPECT_EQ(memcmp(delegate.mStoredICACBuf, testICACSpan.data(), testICACSpan.size()), 0);
+}
+
+/**
+ * Verify that the JointFabricAdministrator singleton can have a delegate set
+ * and retrieved correctly.
+ */
+TEST_F(TestAddICACInstallation, JointFabricAdministratorSetGetDelegate)
+{
+    TestJFADelegate delegate;
+    auto & jfa = JointFabricAdministrator::GetInstance();
+
+    EXPECT_EQ(jfa.SetDelegate(&delegate), CHIP_NO_ERROR);
+    EXPECT_EQ(jfa.GetDelegate(), &delegate);
+}

--- a/src/app/clusters/joint-fabric-administrator-server/tests/TestAddICACInstallation.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/tests/TestAddICACInstallation.cpp
@@ -54,9 +54,9 @@ public:
     }
 
     uint8_t mStoredICACBuf[Credentials::kMaxDERCertLength] = { 0 };
-    size_t mStoredICACLen                                   = 0;
-    int mStoreCallCount                                     = 0;
-    CHIP_ERROR mReturnError                                 = CHIP_NO_ERROR;
+    size_t mStoredICACLen                                  = 0;
+    int mStoreCallCount                                    = 0;
+    CHIP_ERROR mReturnError                                = CHIP_NO_ERROR;
 };
 
 /**

--- a/src/app/server/JointFabricAdministrator.h
+++ b/src/app/server/JointFabricAdministrator.h
@@ -22,6 +22,7 @@
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/NodeId.h>
+#include <lib/support/Span.h>
 
 #include <optional>
 
@@ -38,6 +39,16 @@ public:
         virtual ~Delegate() {}
 
         virtual CHIP_ERROR GetIcacCsr(MutableByteSpan & icacCsr) { return CHIP_NO_ERROR; }
+
+        /**
+         * Store the cross-signed ICAC certificate received via the AddICAC command.
+         * This certificate was cross-signed by the anchor root CA and can be used
+         * to issue NOCs on the joint fabric.
+         *
+         * @param crossSignedICAC  The DER/TLV-encoded cross-signed ICAC certificate.
+         * @return CHIP_NO_ERROR on success, or an error if storage fails.
+         */
+        virtual CHIP_ERROR StoreCrossSignedICAC(const ByteSpan & crossSignedICAC) { return CHIP_NO_ERROR; }
     };
 
     static JointFabricAdministrator & GetInstance()


### PR DESCRIPTION
Completes the Joint Commissioning Method (JCM) flow in jf-admin-app by adding the missing cross-signing step and AddICAC command invocation:

JFAManager (jf-admin-app/linux):
- Add CrossSignICAC() method: requests a cross-signed ICAC from the JFC via the new CROSS_SIGNED_ICAC RPC transaction type, then validates the returned cert chains to the anchor root CA before proceeding
- Add SendAddICAC() method: invokes the AddICAC cluster command on the commissionee with the cross-signed ICAC
- Add OnAddICACResponse()/OnAddICACFailure() callbacks: route to CommissioningComplete only on kOk, abort on errors
- Update OnSendICACSRRequestResponse() to save the CSR and call CrossSignICAC() + SendAddICAC() instead of going directly to CommissioningComplete
- Add JCMStage enum for explicit stage tracking (Idle → Announce → ICACCSRRequest → CrossSign → AddICAC → CommissionComplete)
- Add StoreCrossSignedICAC() delegate override to persist the installed cert
- Add mPendingICACSRBuf/mCrossSignedICACBuf members for JCM state

RPC (JointFabric.h + RpcServer.cpp):
- Extend JFARpc interface with GetCrossSignedICAC(anchorFabricId, csr, out)
- Add CROSS_SIGNED_ICAC handling to GetICACCSRForJF caller and ResponseStream; route responses to appropriate buffer based on transaction_type
- Update RequestOptions construction to set both transaction_type and anchor_fabric_id fields explicitly

JFC side (PairingCommand.cpp + ExampleCredentialIssuerCommands.h):
- Add CROSS_SIGNED_ICAC case in GenerateReplyWork: calls GenerateIcacCsr then SignICAC(csrSpan, anchorFabricId, icac) and sets rsp.transaction_type
- Add SignICAC() forwarding method to ExampleCredentialIssuerCommands

HandleAddICAC (joint-fabric-administrator-server.cpp):
- After all validation passes, call delegate->StoreCrossSignedICAC()
- On success respond with ICACResponse::kOk instead of generic Success
- On installation failure respond with kInvalidICAC

JointFabricAdministrator::Delegate (JointFabricAdministrator.h):
- Add StoreCrossSignedICAC() virtual method (default: no-op, CHIP_NO_ERROR)

Testing:
- Add TestAddICACInstallation.cpp with six unit tests covering the StoreCrossSignedICAC delegate interface (default no-op, correct bytes, failure propagation, empty span, multiple cert types, singleton access)
- Update tests/BUILD.gn with new test file and joint_fabric dep

Documentation:
- Add JCM Flow Overview section to joint_fabric_guide.md describing all five steps and expected log output for verification
