### PR TITLE
check first block size before copying platform OTA header

### DIFF
--- a/src/platform/Beken/OTAImageProcessorImpl.cpp
+++ b/src/platform/Beken/OTAImageProcessorImpl.cpp
@@ -206,6 +206,15 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     if (!imageProcessor->readHeader) // First block received, process header
     {
+        // the header copy below reads sizeof(ota_data_struct_t) bytes from the block, so reject a
+        // first block that is too small before it reads past the end of the allocation
+        if (block.size() < sizeof(ota_data_struct_t))
+        {
+            ChipLogError(SoftwareUpdate, "First block smaller than OTA image header");
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+            return;
+        }
+
         ota_data_struct_t * tempBuf = (ota_data_struct_t *) chip::Platform::MemoryAlloc(sizeof(ota_data_struct_t));
 
         if (NULL == tempBuf)

--- a/src/platform/stm32/stm32wba/OTAImageProcessorImpl.cpp
+++ b/src/platform/stm32/stm32wba/OTAImageProcessorImpl.cpp
@@ -415,6 +415,15 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         // first block received, get STM_Header
         uint8_t STMHeader[STM_HEADER_SIZE];
 
+        // the header copy below and the length math that follows assume the block holds a full
+        // STM header; a shorter first block would read past mBlock and underflow the size subtraction
+        if (imageProcessor->mBlock.size() < STM_HEADER_SIZE)
+        {
+            ChipLogError(SoftwareUpdate, "First block smaller than STM header");
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_DECODE_FAILED);
+            return;
+        }
+
         memcpy(STMHeader, reinterpret_cast<std::uint8_t *>(imageProcessor->mBlock.data()), sizeof(STMHeader));
 
         memset(tempBUF, TEMPBUF_PADDING, TEMPBUF_SIZE);


### PR DESCRIPTION
### Summary

The STM32 (stm32wba) and Beken OTA image processors read a fixed-size vendor header out of the first received block inside `HandleProcessBlock` without checking the block actually holds that many bytes. `SetBlock` sizes the `mBlock` heap allocation to exactly the block length, and `ProcessHeader` strips the Matter OTA header first, so the remainder of the first block can be a handful of bytes or empty. On STM32 the `memcpy(STMHeader, mBlock.data(), STM_HEADER_SIZE)` then reads up to 8 bytes past the allocation, and the follow-up `mBlock.size() - STM_HEADER_SIZE` subtraction underflows and feeds a very large length into the flash write path. On Beken the `memcpy(&pOtaTgtHdr, block.data(), sizeof(ota_data_struct_t))` reads past the block the same way. The block comes from BDX image data whose framing the provider controls.

Both are fixed by rejecting a first block smaller than the header before the copy, which is the shape the ti cc13xx and bouffalolab processors already use.

### Related issues

None.

### Testing

These files only build under their vendor toolchains, so there is no host test target to add. Verified by tracing the untrusted path (BDX block into `ProcessBlock`, `SetBlock`, then `HandleProcessBlock`) and confirming the header copy and, on STM32, the size subtraction run before any lower-bound check. The added guard matches the size-checked first-block handling in `src/platform/ti/cc13xx_26xx/cc13x4_26x4/OTAImageProcessorImpl.cpp` and `src/platform/bouffalolab/common/OTAImageProcessorImpl.cpp`.