### PR TITLE
[NXP][examples] Move FreeRTOS specific CLI initialization to CLIFreeRTOS file

### DIFF
--- a/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIBase.cpp
@@ -25,12 +25,7 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
-
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
-
-extern "C" {
-#include "addons_cli.h"
-}
 #endif
 
 #define MATTER_CLI_LOG(message) (chip::Shell::streamer_printf(chip::Shell::streamer_get(), message))
@@ -89,12 +84,6 @@ void chip::NXP::App::AppCLIBase::RegisterDefaultCommands(void)
     /* Register common shell commands */
     cmd_misc_init();
     cmd_otcli_init();
-#if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
-    /* verify that otInstance is not null before initializing addons */
-    otInstance * instance = otInstanceGetSingle();
-    VerifyOrDie(instance != nullptr);
-    otAppCliAddonsInit(instance);
-#endif
 #if CHIP_SHELL_ENABLE_CMD_SERVER
     cmd_app_server_init();
 #endif /* CHIP_SHELL_ENABLE_CMD_SERVER */

--- a/examples/platform/nxp/common/matter_cli/source/AppCLIFreeRTOS.cpp
+++ b/examples/platform/nxp/common/matter_cli/source/AppCLIFreeRTOS.cpp
@@ -22,6 +22,13 @@
 #include <lib/shell/Engine.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
+#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
+extern "C" {
+#include "addons_cli.h"
+}
+#endif
+
 #define MATTER_CLI_TASK_SIZE ((configSTACK_DEPTH_TYPE) 2048 / sizeof(portSTACK_TYPE))
 
 TaskHandle_t AppMatterCliTaskHandle;
@@ -67,6 +74,13 @@ CHIP_ERROR chip::NXP::App::AppCLIFreeRTOS::Init(void)
         }
 
         RegisterDefaultCommands();
+
+#if (CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD)
+        /* verify that otInstance is not null before initializing addons */
+        otInstance * instance = otInstanceGetSingle();
+        VerifyOrDie(instance != nullptr);
+        otAppCliAddonsInit(instance);
+#endif
 
         if (xTaskCreate(&AppMatterCliTask, "AppMatterCli_task", MATTER_CLI_TASK_SIZE, NULL, 1, &AppMatterCliTaskHandle) != pdPASS)
         {


### PR DESCRIPTION
### Summary

Moving FreeRTOS specific CLI intialization function to corresponding FreeRTOS file.
This is done to let `AppCliBase.cpp` file be used by other platforms than FreeRTOS (e.g. Zephyr)


### Testing
No testing required. No functional change intended or added. Compiles with success on both FreeRTOS and Zephyr applications that have CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_ENABLE_OPENTHREAD enabled.
