### PR TITLE
remove duplicate AutoReleaseIterator wrappers in label/localization clusters

### DIFF
--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -17,6 +17,7 @@
 #include <app/clusters/fixed-label-server/FixedLabelCluster.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/FixedLabel/Metadata.h>
+#include <lib/support/AutoRelease.h>
 
 namespace chip::app::Clusters {
 
@@ -24,32 +25,10 @@ using namespace FixedLabel::Attributes;
 
 namespace {
 
-class AutoReleaseIterator
-{
-public:
-    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider, EndpointId endpointId) :
-        mIterator(provider.IterateFixedLabel(endpointId))
-    {}
-    ~AutoReleaseIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-
-    bool IsValid() const { return mIterator != nullptr; }
-
-    DeviceLayer::DeviceInfoProvider::FixedLabelIterator * operator->() { return mIterator; }
-
-private:
-    DeviceLayer::DeviceInfoProvider::FixedLabelIterator * mIterator;
-};
-
 CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider & provider)
 {
-    AutoReleaseIterator it(provider, endpoint);
-    VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());
+    AutoRelease it(provider.IterateFixedLabel(endpoint));
+    VerifyOrReturnValue(!it.IsNull(), encoder.EncodeEmptyList());
 
     return encoder.EncodeList([&it](const auto & encod) -> CHIP_ERROR {
         FixedLabel::Structs::LabelStruct::Type fixedlabel;

--- a/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
@@ -21,6 +21,7 @@
 #include <app/persistence/String.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/LocalizationConfiguration/Metadata.h>
+#include <lib/support/AutoRelease.h>
 #include <platform/PlatformManager.h>
 
 using namespace chip;
@@ -30,35 +31,6 @@ using namespace chip::app::Clusters::LocalizationConfiguration;
 using namespace chip::app::Clusters::LocalizationConfiguration::Attributes;
 
 using Protocols::InteractionModel::Status;
-
-namespace {
-class AutoReleaseIterator
-{
-public:
-    using Iterator = DeviceLayer::DeviceInfoProvider::SupportedLocalesIterator;
-
-    explicit AutoReleaseIterator(DeviceLayer::DeviceInfoProvider * provider) :
-        mIterator(provider != nullptr ? provider->IterateSupportedLocales() : nullptr)
-    {}
-    ~AutoReleaseIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-
-    // Delete copy constructor and assignment
-    AutoReleaseIterator(const AutoReleaseIterator &)             = delete;
-    AutoReleaseIterator & operator=(const AutoReleaseIterator &) = delete;
-
-    bool IsValid() const { return mIterator != nullptr; }
-    bool Next(CharSpan & value) { return (mIterator == nullptr) ? false : mIterator->Next(value); }
-
-private:
-    Iterator * mIterator;
-};
-} // namespace
 
 namespace chip::app::Clusters {
 
@@ -182,13 +154,13 @@ CharSpan LocalizationConfigurationCluster::GetActiveLocale()
 
 CHIP_ERROR LocalizationConfigurationCluster::ReadSupportedLocales(AttributeValueEncoder & aEncoder)
 {
-    AutoReleaseIterator it(&mDeviceInfoProvider);
-    VerifyOrReturnValue(it.IsValid(), aEncoder.EncodeEmptyList());
+    AutoRelease it(mDeviceInfoProvider.IterateSupportedLocales());
+    VerifyOrReturnValue(!it.IsNull(), aEncoder.EncodeEmptyList());
 
     return aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
         CharSpan supportedLocale;
 
-        while (it.Next(supportedLocale))
+        while (it->Next(supportedLocale))
         {
             ReturnErrorOnFailure(encoder.Encode(supportedLocale));
         }
@@ -199,14 +171,11 @@ CHIP_ERROR LocalizationConfigurationCluster::ReadSupportedLocales(AttributeValue
 
 bool LocalizationConfigurationCluster::IsSupportedLocale(CharSpan newLangTag) const
 {
-    AutoReleaseIterator it(&mDeviceInfoProvider);
-    if (!it.IsValid())
-    {
-        return false;
-    }
+    AutoRelease it(mDeviceInfoProvider.IterateSupportedLocales());
+    VerifyOrReturnValue(!it.IsNull(), false);
 
     CharSpan outLocale;
-    while (it.Next(outLocale))
+    while (it->Next(outLocale))
     {
         if (outLocale.data_equal(newLangTag))
         {
@@ -219,14 +188,11 @@ bool LocalizationConfigurationCluster::IsSupportedLocale(CharSpan newLangTag) co
 
 bool LocalizationConfigurationCluster::GetDefaultLocale(MutableCharSpan & outLocale)
 {
-    AutoReleaseIterator it(&mDeviceInfoProvider);
-    if (!it.IsValid())
-    {
-        return false;
-    }
+    AutoRelease it(mDeviceInfoProvider.IterateSupportedLocales());
+    VerifyOrReturnValue(!it.IsNull(), false);
 
     CharSpan tempLocale;
-    bool found = it.Next(tempLocale);
+    bool found = it->Next(tempLocale);
     VerifyOrReturnValue(CopyCharSpanToMutableCharSpan(tempLocale, outLocale) == CHIP_NO_ERROR, false);
 
     return found;

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -22,6 +22,7 @@
 #include <app/data-model-provider/tests/WriteTesting.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
+#include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/LocalizationConfiguration/Enums.h>
@@ -61,8 +62,11 @@ public:
     UserLabelIterator * IterateUserLabel(EndpointId endpoint) override { return nullptr; }
     SupportedCalendarTypesIterator * IterateSupportedCalendarTypes() override { return nullptr; }
 
+    void SetSimulateIteratorAllocFailure(bool fail) { mSimulateIteratorAllocFailure = fail; }
+
     SupportedLocalesIterator * IterateSupportedLocales() override
     {
+        VerifyOrReturnValue(!mSimulateIteratorAllocFailure, nullptr);
         return chip::Platform::New<MockSupportedLocalesIterator>(mSupportedLocales);
     }
 
@@ -97,6 +101,7 @@ private:
     };
 
     std::vector<CharSpan> mSupportedLocales;
+    bool mSimulateIteratorAllocFailure = false;
 };
 
 class MockLocalizationConfigurationCluster : public LocalizationConfigurationCluster
@@ -193,6 +198,32 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAttributes)
                                             LocalizationConfiguration::Attributes::ActiveLocale::kMetadataEntry,
                                             LocalizationConfiguration::Attributes::SupportedLocales::kMetadataEntry,
                                         }));
+}
+
+TEST_F(TestLocalizationConfigurationCluster, IteratorAllocationFailure)
+{
+    // A null iterator (allocation failure) must be treated as "no supported locales"
+    // on every path, never dereferenced.
+    std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
+    mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
+    mDeviceInfoProvider->SetSimulateIteratorAllocFailure(true);
+
+    // Constructor can neither validate the initial locale nor find a default:
+    // ActiveLocale stays empty.
+    LocalizationConfigurationCluster cluster(*mDeviceInfoProvider, "en-US"_span);
+    EXPECT_TRUE(cluster.GetActiveLocale().empty());
+
+    // No locale can be validated, so any write is rejected.
+    DataModel::ActionReturnStatus status = cluster.SetActiveLocale("es-ES"_span);
+    EXPECT_EQ(status, Status::ConstraintError);
+
+    // Reading SupportedLocales encodes an empty list.
+    Testing::ClusterTester tester(cluster);
+    DataModel::DecodableList<CharSpan> locales;
+    ASSERT_EQ(tester.ReadAttribute(SupportedLocales::Id, locales), CHIP_NO_ERROR);
+    size_t count = 0;
+    ASSERT_EQ(locales.ComputeSize(&count), CHIP_NO_ERROR);
+    EXPECT_EQ(count, 0u);
 }
 
 TEST_F(TestLocalizationConfigurationCluster, WriteAttributeNotifiesSubscribers)

--- a/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
+++ b/src/app/clusters/localization-configuration-server/tests/TestLocalizationConfigurationCluster.cpp
@@ -202,8 +202,9 @@ TEST_F(TestLocalizationConfigurationCluster, TestReadAttributes)
 
 TEST_F(TestLocalizationConfigurationCluster, IteratorAllocationFailure)
 {
-    // A null iterator (allocation failure) must be treated as "no supported locales"
-    // on every path, never dereferenced.
+    // A null iterator (allocation failure) is currently indistinguishable from
+    // "no supported locales"; this test pins that behavior and verifies the
+    // iterator is never dereferenced.
     std::vector<CharSpan> supportedLocales = { "en-US"_span, "es-ES"_span };
     mDeviceInfoProvider->SetSupportedLocales(supportedLocales);
     mDeviceInfoProvider->SetSimulateIteratorAllocFailure(true);
@@ -213,7 +214,8 @@ TEST_F(TestLocalizationConfigurationCluster, IteratorAllocationFailure)
     LocalizationConfigurationCluster cluster(*mDeviceInfoProvider, "en-US"_span);
     EXPECT_TRUE(cluster.GetActiveLocale().empty());
 
-    // No locale can be validated, so any write is rejected.
+    // TODO(#73612): ConstraintError is the current behaviour, but the spec reserves
+    // it for a value not present in SupportedLocales. Should be ResourceExhausted.
     DataModel::ActionReturnStatus status = cluster.SetActiveLocale("es-ES"_span);
     EXPECT_EQ(status, Status::ConstraintError);
 

--- a/src/app/clusters/time-format-localization-server/TimeFormatLocalizationCluster.cpp
+++ b/src/app/clusters/time-format-localization-server/TimeFormatLocalizationCluster.cpp
@@ -19,6 +19,7 @@
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <clusters/TimeFormatLocalization/Metadata.h>
+#include <lib/support/AutoRelease.h>
 #include <tracing/macros.h>
 
 namespace chip {
@@ -26,40 +27,14 @@ namespace app {
 namespace Clusters {
 
 namespace {
-class AutoReleaseIterator
-{
-public:
-    using Iterator = DeviceLayer::DeviceInfoProvider::SupportedCalendarTypesIterator;
-
-    explicit AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider) : mIterator(provider.IterateSupportedCalendarTypes())
-    {}
-    ~AutoReleaseIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-
-    // Delete copy constructor and assignment
-    AutoReleaseIterator(const AutoReleaseIterator &)             = delete;
-    AutoReleaseIterator & operator=(const AutoReleaseIterator &) = delete;
-
-    bool IsValid() const { return mIterator != nullptr; }
-    bool Next(TimeFormatLocalization::CalendarTypeEnum & value) { return (mIterator == nullptr) ? false : mIterator->Next(value); }
-
-private:
-    Iterator * mIterator;
-};
-
 bool IsSupportedCalendarType(TimeFormatLocalization::CalendarTypeEnum reqCalendar, DeviceLayer::DeviceInfoProvider & provider,
                              TimeFormatLocalization::CalendarTypeEnum * aValidCalendar = nullptr)
 {
-    AutoReleaseIterator it(provider);
-    VerifyOrReturnValue(it.IsValid(), false);
+    AutoRelease it(provider.IterateSupportedCalendarTypes());
+    VerifyOrReturnValue(!it.IsNull(), false);
     TimeFormatLocalization::CalendarTypeEnum type;
 
-    while (it.Next(type))
+    while (it->Next(type))
     {
         // During the first loop, set some valid calendar value if requested
         if (aValidCalendar != nullptr)
@@ -78,13 +53,13 @@ bool IsSupportedCalendarType(TimeFormatLocalization::CalendarTypeEnum reqCalenda
 
 CHIP_ERROR GetSupportedCalendarTypes(AttributeValueEncoder & aEncoder, DeviceLayer::DeviceInfoProvider & provider)
 {
-    AutoReleaseIterator it(provider);
-    VerifyOrReturnValue(it.IsValid(), aEncoder.EncodeEmptyList());
+    AutoRelease it(provider.IterateSupportedCalendarTypes());
+    VerifyOrReturnValue(!it.IsNull(), aEncoder.EncodeEmptyList());
 
     return aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
         TimeFormatLocalization::CalendarTypeEnum type;
 
-        while (it.Next(type))
+        while (it->Next(type))
         {
             ReturnErrorOnFailure(encoder.Encode(type));
         }

--- a/src/app/clusters/user-label-server/UserLabelCluster.cpp
+++ b/src/app/clusters/user-label-server/UserLabelCluster.cpp
@@ -17,6 +17,7 @@
 #include <app/clusters/user-label-server/UserLabelCluster.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/UserLabel/Metadata.h>
+#include <lib/support/AutoRelease.h>
 
 #include <array>
 
@@ -27,32 +28,10 @@ using namespace UserLabel::Attributes;
 
 namespace {
 
-class AutoReleaseIterator
-{
-public:
-    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider, EndpointId endpointId) :
-        mIterator(provider.IterateUserLabel(endpointId))
-    {}
-    ~AutoReleaseIterator()
-    {
-        if (mIterator != nullptr)
-        {
-            mIterator->Release();
-        }
-    }
-
-    bool IsValid() const { return mIterator != nullptr; }
-
-    DeviceLayer::DeviceInfoProvider::UserLabelIterator * operator->() { return mIterator; }
-
-private:
-    DeviceLayer::DeviceInfoProvider::UserLabelIterator * mIterator;
-};
-
 CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider & provider)
 {
-    AutoReleaseIterator it(provider, endpoint);
-    VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());
+    AutoRelease it(provider.IterateUserLabel(endpoint));
+    VerifyOrReturnValue(!it.IsNull(), encoder.EncodeEmptyList());
 
     return encoder.EncodeList([&it](const auto & encod) -> CHIP_ERROR {
         UserLabel::Structs::LabelStruct::Type userlabel;


### PR DESCRIPTION
### Summary
remove four identically-named file-local AutoReleaseIterator
classes in the fixed-label, user-label, localization-configuration and
time-format-localization clusters and use AutoRelease

### Related issues
- Please see #73331 for more details
- Earlier PRs: #73296, #73546, #73556, #73568

### Testing
- Existing unit tests cover all migrated paths, hence ran the unit tests locally and they'll also run in CI
- New `IteratorAllocationFailure` test in `TestLocalizationConfigurationCluster.cpp`
exercises the null-iterator branches