### PR TITLE
controller: ignore incomplete/partial mDNS annoucement in ThreadMeshcopCommissionProxy

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -496,6 +496,17 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 
     if (!Dnssd::ServiceAdvertiser::Instance().IsInitialized())
     {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
+        // OpenThread DNS-SD initialization cannot complete before an unprovisioned
+        // device joins a Thread network. Start MeshCoP rendezvous so the device can
+        // be commissioned and DNS-SD initialization can complete afterwards.
+        if (mode != Dnssd::CommissioningMode::kDisabled && !DeviceLayer::ThreadStackMgr().IsThreadProvisioned())
+        {
+            SuccessOrLog(AdvertiseCommissionableNode(mode), Discovery, "Failed to advertise commissionable node");
+            return;
+        }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
+
         // Somehow Init can succeed without being initialized...
         // Issue #13844
         ChipLogError(Discovery, "Advertiser not initialized");

--- a/src/app/server/ThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/ThreadRendezvousAnnouncement.cpp
@@ -125,8 +125,7 @@ CHIP_ERROR BuildThreadRendezvousAnnouncement(const Dnssd::CommissionAdvertisingP
         static const char * matterc_udp_local[] = { "_matterc", "_udp", "local" };
         chip::Dnssd::FullQName serviceName(matterc_udp_local);
 
-        static const char * root[] = { "" };
-        chip::Dnssd::FullQName targetName(root);
+        chip::Dnssd::FullQName targetName;
         chip::Dnssd::SrvResourceRecord srvRecord(serviceName, targetName, params.GetPort());
         builder.AddRecord(chip::Dnssd::ResourceType::kAnswer, srvRecord);
 

--- a/src/app/server/tests/BUILD.gn
+++ b/src/app/server/tests/BUILD.gn
@@ -32,6 +32,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/server:joint_fabric",
     "${chip_root}/src/app/server:thread_rendezvous_announcement",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/dnssd/wire:reader",
     "${chip_root}/src/lib/support:testing",
   ]
 }

--- a/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
@@ -21,6 +21,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/dnssd/wire/Parser.h>
 #include <lib/dnssd/wire/RecordData.h>
+#include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 
 #include <optional>
@@ -30,6 +31,9 @@ using namespace chip::app;
 
 class TestThreadRendezvousAnnouncement : public ::testing::Test
 {
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 };
 
 namespace {

--- a/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
@@ -19,6 +19,8 @@
 
 #include <app/server/ThreadRendezvousAnnouncement.h>
 #include <lib/core/CHIPError.h>
+#include <lib/dnssd/wire/Parser.h>
+#include <lib/dnssd/wire/RecordData.h>
 #include <lib/support/CodeUtils.h>
 
 #include <optional>
@@ -29,6 +31,45 @@ using namespace chip::app;
 class TestThreadRendezvousAnnouncement : public ::testing::Test
 {
 };
+
+namespace {
+
+class AnnouncementParser : public Dnssd::ParserDelegate
+{
+public:
+    explicit AnnouncementParser(const Dnssd::BytesRange & packet) : mPacket(packet) {}
+
+    void OnHeader(Dnssd::ConstHeaderRef &) override {}
+    void OnQuery(const Dnssd::QueryData &) override {}
+
+    void OnResource(Dnssd::ResourceType, const Dnssd::ResourceData & data) override
+    {
+        mResourceCount++;
+        if (data.GetType() != Dnssd::QType::SRV)
+        {
+            return;
+        }
+
+        Dnssd::SrvRecord srv;
+        mSrvParsed = srv.Parse(data.GetData(), mPacket);
+        if (mSrvParsed)
+        {
+            mSrvPort = srv.GetPort();
+        }
+    }
+
+    size_t GetResourceCount() const { return mResourceCount; }
+    bool SrvParsed() const { return mSrvParsed; }
+    uint16_t GetSrvPort() const { return mSrvPort; }
+
+private:
+    Dnssd::BytesRange mPacket;
+    size_t mResourceCount = 0;
+    bool mSrvParsed       = false;
+    uint16_t mSrvPort     = 0;
+};
+
+} // namespace
 
 TEST_F(TestThreadRendezvousAnnouncement, TxtStringsBuilder)
 {
@@ -81,8 +122,6 @@ TEST_F(TestThreadRendezvousAnnouncement, TxtStringsBuilderOverflow)
     EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
-
 TEST_F(TestThreadRendezvousAnnouncement, BuildThreadRendezvousAnnouncement)
 {
     Dnssd::CommissionAdvertisingParameters params;
@@ -91,8 +130,13 @@ TEST_F(TestThreadRendezvousAnnouncement, BuildThreadRendezvousAnnouncement)
 
     System::PacketBufferHandle buffer;
     CHIP_ERROR err = BuildThreadRendezvousAnnouncement(params, buffer);
-    EXPECT_EQ(err, CHIP_NO_ERROR);
-    EXPECT_FALSE(buffer.IsNull());
-}
+    ASSERT_EQ(err, CHIP_NO_ERROR);
+    ASSERT_FALSE(buffer.IsNull());
 
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
+    Dnssd::BytesRange packet(buffer->Start(), buffer->Start() + buffer->DataLength());
+    AnnouncementParser parser(packet);
+    ASSERT_TRUE(Dnssd::ParsePacket(packet, &parser));
+    EXPECT_EQ(parser.GetResourceCount(), 2u);
+    EXPECT_TRUE(parser.SrvParsed());
+    EXPECT_EQ(parser.GetSrvPort(), 5540u);
+}

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -368,10 +368,10 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
 
     if (!mExpectedDiscriminator.MatchesLongDiscriminator(static_cast<uint16_t>(discoveredDiscriminator)))
     {
-        uint16_t expectedDiscriminator = mExpectedDiscriminator.IsShortDiscriminator() ? mExpectedDiscriminator.GetShortValue()
-                                                                                       : mExpectedDiscriminator.GetLongValue();
         ChipLogProgress(Controller, "Discriminator mismatch (Expected %s %u, Got long %u). Ignoring announcement.",
-                        mExpectedDiscriminator.IsShortDiscriminator() ? "short" : "long", expectedDiscriminator,
+                        mExpectedDiscriminator.IsShortDiscriminator() ? "short" : "long",
+                        mExpectedDiscriminator.IsShortDiscriminator() ? mExpectedDiscriminator.GetShortValue()
+                                                                      : mExpectedDiscriminator.GetLongValue(),
                         discoveredDiscriminator);
         return;
     }

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -68,6 +68,27 @@ std::vector<uint8_t> DiscoveryCodeToVector(Thread::DiscoveryCode code)
     return std::vector<uint8_t>(bytes, bytes + sizeof(bytes));
 }
 
+bool IsValidLongDiscriminatorTxtValue(ByteSpan value)
+{
+    if (value.empty() || value.size() > 4 || (value.size() > 1 && value[0] == '0'))
+    {
+        return false;
+    }
+
+    uint16_t discriminator = 0;
+    for (uint8_t digit : value)
+    {
+        if (digit < '0' || digit > '9')
+        {
+            return false;
+        }
+
+        discriminator = static_cast<uint16_t>(discriminator * 10 + digit - '0');
+    }
+
+    return discriminator < (1u << SetupDiscriminator::kLongBits);
+}
+
 } // namespace
 
 namespace chip {
@@ -308,7 +329,7 @@ void ThreadMeshcopCommissionProxy::OnRecord(const chip::Dnssd::BytesRange & name
 
     if (name.Size() == 1 && (name.Start()[0] == 'D' || name.Start()[0] == 'd'))
     {
-        mCurrentTxtRecordHasDiscriminator = true;
+        mCurrentTxtRecordHasDiscriminator = IsValidLongDiscriminatorTxtValue(val);
     }
 }
 
@@ -347,8 +368,11 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
 
     if (!mExpectedDiscriminator.MatchesLongDiscriminator(static_cast<uint16_t>(discoveredDiscriminator)))
     {
-        ChipLogProgress(Controller, "Discriminator mismatch (Expected %u, Got %u). Ignoring announcement.",
-                        mExpectedDiscriminator.GetLongValue(), discoveredDiscriminator);
+        uint16_t expectedDiscriminator = mExpectedDiscriminator.IsShortDiscriminator() ? mExpectedDiscriminator.GetShortValue()
+                                                                                       : mExpectedDiscriminator.GetLongValue();
+        ChipLogProgress(Controller, "Discriminator mismatch (Expected %s %u, Got long %u). Ignoring announcement.",
+                        mExpectedDiscriminator.IsShortDiscriminator() ? "short" : "long", expectedDiscriminator,
+                        discoveredDiscriminator);
         return;
     }
 

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -340,7 +340,8 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
         return;
     }
 
-    if (mProxyFd == -1) {
+    if (mProxyFd == -1)
+    {
         if (CreateProxySocket(commissionData) != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Failed to setup proxy socket: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -197,7 +197,11 @@ void ThreadMeshcopCommissionProxy::OnResource(chip::Dnssd::ResourceType section,
             break;
         }
 
-        chip::Dnssd::ParseTxtRecord(data.GetData(), this);
+        mCurrentTxtRecordHasDiscriminator = false;
+        if (chip::Dnssd::ParseTxtRecord(data.GetData(), this) && mCurrentTxtRecordHasDiscriminator)
+        {
+            mCurrentPacketHasDiscriminator = true;
+        }
         break;
     }
 
@@ -301,6 +305,11 @@ void ThreadMeshcopCommissionProxy::OnRecord(const chip::Dnssd::BytesRange & name
     ByteSpan val(value.Start(), value.Size());
 
     Dnssd::FillNodeDataFromTxt(key, val, mNodeData.Get<Dnssd::CommissionNodeData>());
+
+    if (name.Size() == 1 && (name.Start()[0] == 'D' || name.Start()[0] == 'd'))
+    {
+        mCurrentTxtRecordHasDiscriminator = true;
+    }
 }
 
 void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t> & joinerIdBytes, uint16_t joinerPort,
@@ -314,10 +323,12 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
     }
 
     mNodeData.Set<Dnssd::CommissionNodeData>();
-    mServicePort               = 0;
-    mCurrentPacketIsResponse   = false;
-    mCurrentPacketHasMatterSrv = false;
-    mDnsPacket                 = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
+    mServicePort                      = 0;
+    mCurrentPacketIsResponse          = false;
+    mCurrentPacketHasMatterSrv        = false;
+    mCurrentPacketHasDiscriminator    = false;
+    mCurrentTxtRecordHasDiscriminator = false;
+    mDnsPacket                        = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
 
     if (!chip::Dnssd::ParsePacket(mDnsPacket, this))
     {
@@ -325,7 +336,7 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
         return;
     }
 
-    if (!mCurrentPacketIsResponse || !mCurrentPacketHasMatterSrv || mServicePort == 0)
+    if (!mCurrentPacketIsResponse || !mCurrentPacketHasMatterSrv || !mCurrentPacketHasDiscriminator || mServicePort == 0)
     {
         ChipLogDetail(Controller, "Ignoring incomplete joiner mDNS announcement");
         return;

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -340,9 +340,11 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
         return;
     }
 
+    auto & commissionData = mNodeData.Get<Dnssd::CommissionNodeData>();
     if (mProxyFd == -1)
     {
-        if (CreateProxySocket(commissionData) != CHIP_NO_ERROR)
+        CHIP_ERROR err = CreateProxySocket(commissionData);
+        if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Failed to setup proxy socket: %" CHIP_ERROR_FORMAT, err.Format());
             SetState(State::kAborted);

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -128,6 +128,7 @@ void ThreadMeshcopCommissionProxy::SetState(State state)
 
 void ThreadMeshcopCommissionProxy::OnHeader(chip::Dnssd::ConstHeaderRef & header)
 {
+    mCurrentPacketIsResponse = header.GetFlags().IsResponse();
     ChipLogDetail(Controller, "mDNS Response: ID=%u, Answers=%u, Additional=%u", header.GetMessageId(), header.GetAnswerCount(),
                   header.GetAdditionalCount());
 }
@@ -140,12 +141,11 @@ void ThreadMeshcopCommissionProxy::OnQuery(const chip::Dnssd::QueryData & data)
     }
 
     ChipLogDetail(Controller, "mDNS query: %s", chip::Dnssd::QNameString(data.GetName()).c_str());
-    mNodeData.Set<Dnssd::CommissionNodeData>();
 }
 
 void ThreadMeshcopCommissionProxy::OnResource(chip::Dnssd::ResourceType section, const chip::Dnssd::ResourceData & data)
 {
-    if (mState != State::kDiscovering)
+    if (mState != State::kDiscovering || !mCurrentPacketIsResponse)
     {
         return;
     }
@@ -185,23 +185,20 @@ void ThreadMeshcopCommissionProxy::OnResource(chip::Dnssd::ResourceType section,
         }
         Platform::CopyString(commissionData.instanceName, fullName.c_str());
 
-        mServicePort = srv.GetPort();
-
-        if (mProxyFd == -1)
-        {
-            CHIP_ERROR err = CreateProxySocket(commissionData);
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Controller, "Failed to setup proxy socket: %" CHIP_ERROR_FORMAT, err.Format());
-                SetState(State::kAborted);
-            }
-        }
+        mServicePort               = srv.GetPort();
+        mCurrentPacketHasMatterSrv = true;
         break;
     }
 
-    case chip::Dnssd::QType::TXT:
+    case chip::Dnssd::QType::TXT: {
+        if (!name.EndsWith(kMatterCServiceSuffix))
+        {
+            break;
+        }
+
         chip::Dnssd::ParseTxtRecord(data.GetData(), this);
         break;
+    }
 
     default:
         break;
@@ -316,11 +313,20 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
     }
 
     mNodeData.Set<Dnssd::CommissionNodeData>();
-    mDnsPacket = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
+    mServicePort               = 0;
+    mCurrentPacketIsResponse   = false;
+    mCurrentPacketHasMatterSrv = false;
+    mDnsPacket                 = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
 
     if (!chip::Dnssd::ParsePacket(mDnsPacket, this))
     {
         ChipLogError(Controller, "Failed to parse joiner mDNS announcement");
+        return;
+    }
+
+    if (!mCurrentPacketIsResponse || !mCurrentPacketHasMatterSrv || mServicePort == 0)
+    {
+        ChipLogDetail(Controller, "Ignoring incomplete joiner mDNS announcement");
         return;
     }
 
@@ -332,6 +338,15 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
         ChipLogProgress(Controller, "Discriminator mismatch (Expected %u, Got %u). Ignoring announcement.",
                         mExpectedDiscriminator.GetLongValue(), discoveredDiscriminator);
         return;
+    }
+
+    if (mProxyFd == -1) {
+        if (CreateProxySocket(commissionData) != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "Failed to setup proxy socket: %" CHIP_ERROR_FORMAT, err.Format());
+            SetState(State::kAborted);
+            return;
+        }
     }
 
     mDiscoveredNodePromise.set_value(mNodeData);

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -129,7 +129,8 @@ void ThreadMeshcopCommissionProxy::SetState(State state)
 void ThreadMeshcopCommissionProxy::OnHeader(chip::Dnssd::ConstHeaderRef & header)
 {
     mCurrentPacketIsResponse = header.GetFlags().IsResponse();
-    ChipLogDetail(Controller, "mDNS Response: ID=%u, Answers=%u, Additional=%u", header.GetMessageId(), header.GetAnswerCount(),
+    ChipLogDetail(Controller, "mDNS packet: type=%s, ID=%u, Answers=%u, Additional=%u",
+                  mCurrentPacketIsResponse ? "response" : "query", header.GetMessageId(), header.GetAnswerCount(),
                   header.GetAdditionalCount());
 }
 

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -118,6 +118,9 @@ private:
 
     uint64_t mJoinerId = 0;
 
+    bool mCurrentPacketIsResponse   = false;
+    bool mCurrentPacketHasMatterSrv = false;
+
     std::recursive_mutex mMutex;
     bool mPromiseFulfilled = false;
     std::promise<Dnssd::DiscoveredNodeData> mDiscoveredNodePromise;

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -118,8 +118,10 @@ private:
 
     uint64_t mJoinerId = 0;
 
-    bool mCurrentPacketIsResponse   = false;
-    bool mCurrentPacketHasMatterSrv = false;
+    bool mCurrentPacketIsResponse          = false;
+    bool mCurrentPacketHasMatterSrv        = false;
+    bool mCurrentPacketHasDiscriminator    = false;
+    bool mCurrentTxtRecordHasDiscriminator = false;
 
     std::recursive_mutex mMutex;
     bool mPromiseFulfilled = false;

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -59,12 +59,6 @@ chip_test_suite("tests") {
     ]
   }
 
-  if (chip_device_platform == "linux" && chip_crypto != "mbedtls" &&
-      chip_crypto != "psa" && chip_support_thread_meshcop &&
-      current_cpu == host_cpu && current_os == host_os) {
-    test_sources += [ "TestThreadMeshcopCommissionProxy.cpp" ]
-  }
-
   test_sources += [ "TestCommissioningDelegate.cpp" ]
 
   cflags = [ "-Wconversion" ]
@@ -86,4 +80,11 @@ chip_test_suite("tests") {
     "${chip_root}/src/messaging/tests:helpers",
     "${chip_root}/src/transport/raw/tests:helpers",
   ]
+
+  if (chip_device_platform == "linux" && chip_crypto != "mbedtls" &&
+      chip_crypto != "psa" && chip_support_thread_meshcop &&
+      current_cpu == host_cpu && current_os == host_os) {
+    test_sources += [ "TestThreadMeshcopCommissionProxy.cpp" ]
+    public_deps += [ "${chip_root}/third_party/jsoncpp" ]
+  }
 }

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("${chip_root}/src/controller/flags.gni")
+import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/lib/lib.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
@@ -56,6 +57,12 @@ chip_test_suite("tests") {
       "TestICDManagementResponses.cpp",
       "TestParseICDInfo.cpp",
     ]
+  }
+
+  if (chip_device_platform == "linux" && chip_crypto != "mbedtls" &&
+      chip_crypto != "psa" && chip_support_thread_meshcop &&
+      current_cpu == host_cpu && current_os == host_os) {
+    test_sources += [ "TestThreadMeshcopCommissionProxy.cpp" ]
   }
 
   test_sources += [ "TestCommissioningDelegate.cpp" ]

--- a/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
@@ -47,6 +47,16 @@ constexpr uint8_t kMalformedMattercSrvResponse[] = {
     0x00, 0x00, 0x00, 0x78, 0x00, 0x01, 0x00,                               // TTL, invalid one-byte SRV data
 };
 
+constexpr uint8_t kMattercSrvOnlyResponse[] = {
+    0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // DNS response header
+    0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
+    0x04, '_',  'u',  'd',  'p',                                            // _udp
+    0x05, 'l',  'o',  'c',  'a',  'l',                                      // local
+    0x00, 0x00, 0x21, 0x00, 0x01,                                           // SRV, IN
+    0x00, 0x00, 0x00, 0x78, 0x00, 0x07,                                     // TTL, data length
+    0x00, 0x00, 0x00, 0x00, 0x15, 0xa4, 0x00,                               // priority, weight, port, root target
+};
+
 constexpr uint8_t kCompleteMattercResponse[] = {
     0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, // DNS response header
     0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
@@ -96,6 +106,17 @@ TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterMalformedSrv
     ThreadMeshcopCommissionProxy proxy;
 
     SendJoinerPacket(proxy, kMalformedMattercSrvResponse);
+    EXPECT_FALSE(LastDiscoveryIsValid(proxy));
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterSrvOnlyResponse)
+{
+    ThreadMeshcopCommissionProxy proxy;
+
+    SendJoinerPacket(proxy, kMattercSrvOnlyResponse);
     EXPECT_FALSE(LastDiscoveryIsValid(proxy));
 
     SendJoinerPacket(proxy, kCompleteMattercResponse);

--- a/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
@@ -1,0 +1,109 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <controller/ThreadMeshcopCommissionProxy.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace chip {
+namespace Controller {
+namespace {
+
+constexpr uint8_t kJoinerId[] = { 0x1a, 0x6f, 0x7e, 0xf3, 0x12, 0x66, 0xa6, 0x30 };
+
+constexpr uint8_t kMattercSrvQuery[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // DNS header
+    0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
+    0x04, '_',  'u',  'd',  'p',                                            // _udp
+    0x05, 'l',  'o',  'c',  'a',  'l',                                      // local
+    0x00, 0x00, 0x21, 0x00, 0x01,                                           // SRV, IN
+};
+
+constexpr uint8_t kMalformedMattercSrvResponse[] = {
+    0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // DNS response header
+    0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
+    0x04, '_',  'u',  'd',  'p',                                            // _udp
+    0x05, 'l',  'o',  'c',  'a',  'l',                                      // local
+    0x00, 0x00, 0x21, 0x00, 0x01,                                           // SRV, IN
+    0x00, 0x00, 0x00, 0x78, 0x00, 0x01, 0x00,                               // TTL, invalid one-byte SRV data
+};
+
+constexpr uint8_t kCompleteMattercResponse[] = {
+    0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, // DNS response header
+    0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
+    0x04, '_',  'u',  'd',  'p',                                            // _udp
+    0x05, 'l',  'o',  'c',  'a',  'l',                                      // local
+    0x00, 0x00, 0x21, 0x00, 0x01,                                           // SRV, IN
+    0x00, 0x00, 0x00, 0x78, 0x00, 0x07,                                     // TTL, data length
+    0x00, 0x00, 0x00, 0x00, 0x15, 0xa4, 0x00,                               // priority, weight, port, root target
+    0x08, '_',  'm',  'a',  't',  't',  'e',  'r',  'c',                    // _matterc
+    0x04, '_',  'u',  'd',  'p',                                            // _udp
+    0x05, 'l',  'o',  'c',  'a',  'l',                                      // local
+    0x00, 0x00, 0x10, 0x00, 0x01,                                           // TXT, IN
+    0x00, 0x00, 0x00, 0x78, 0x00, 0x04, 0x03, 'D',  '=',  '0',              // TTL and D=0 TXT entry
+};
+
+template <size_t N>
+void SendJoinerPacket(ThreadMeshcopCommissionProxy & proxy, const uint8_t (&packet)[N])
+{
+    proxy.OnJoinerMessage(std::vector<uint8_t>(std::begin(kJoinerId), std::end(kJoinerId)), 49154,
+                          std::vector<uint8_t>(std::begin(packet), std::end(packet)));
+}
+
+bool LastDiscoveryIsValid(ThreadMeshcopCommissionProxy & proxy)
+{
+    return proxy.GetLastDiscoveryDiagnosticJson().find("\"valid\" : true") != std::string::npos;
+}
+
+TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterSrvQuery)
+{
+    ThreadMeshcopCommissionProxy proxy;
+
+    SendJoinerPacket(proxy, kMattercSrvQuery);
+    EXPECT_FALSE(LastDiscoveryIsValid(proxy));
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterMalformedSrv)
+{
+    ThreadMeshcopCommissionProxy proxy;
+
+    SendJoinerPacket(proxy, kMalformedMattercSrvResponse);
+    EXPECT_FALSE(LastDiscoveryIsValid(proxy));
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+TEST(TestThreadMeshcopCommissionProxy, AcceptsCompleteResponse)
+{
+    ThreadMeshcopCommissionProxy proxy;
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+} // namespace
+} // namespace Controller
+} // namespace chip

--- a/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace chip {
@@ -72,8 +73,24 @@ constexpr uint8_t kCompleteMattercResponse[] = {
     0x00, 0x00, 0x00, 0x78, 0x00, 0x04, 0x03, 'D',  '=',  '0',              // TTL and D=0 TXT entry
 };
 
-template <size_t N>
-void SendJoinerPacket(ThreadMeshcopCommissionProxy & proxy, const uint8_t (&packet)[N])
+std::vector<uint8_t> MakeMattercResponseWithDiscriminator(std::string_view discriminator)
+{
+    constexpr size_t kEncodedDiscriminatorTxtRecordSize = 6;
+    std::vector<uint8_t> response(std::begin(kCompleteMattercResponse),
+                                  std::end(kCompleteMattercResponse) - kEncodedDiscriminatorTxtRecordSize);
+    const size_t txtEntrySize = 2 + discriminator.size(); // "D=" and its value
+
+    response.push_back(0);
+    response.push_back(static_cast<uint8_t>(txtEntrySize + 1));
+    response.push_back(static_cast<uint8_t>(txtEntrySize));
+    response.push_back('D');
+    response.push_back('=');
+    response.insert(response.end(), discriminator.begin(), discriminator.end());
+    return response;
+}
+
+template <typename Packet>
+void SendJoinerPacket(ThreadMeshcopCommissionProxy & proxy, const Packet & packet)
 {
     proxy.OnJoinerMessage(std::vector<uint8_t>(std::begin(kJoinerId), std::end(kJoinerId)), 49154,
                           std::vector<uint8_t>(std::begin(packet), std::end(packet)));
@@ -121,6 +138,37 @@ TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterSrvOnlyRespo
 
     SendJoinerPacket(proxy, kCompleteMattercResponse);
     EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+TEST(TestThreadMeshcopCommissionProxy, WaitsForValidDiscriminatorAfterMalformedValues)
+{
+    constexpr std::string_view kMalformedDiscriminators[] = { "", "abc", "0123", "70000" };
+    ThreadMeshcopCommissionProxy proxy;
+
+    for (std::string_view discriminator : kMalformedDiscriminators)
+    {
+        SendJoinerPacket(proxy, MakeMattercResponseWithDiscriminator(discriminator));
+        EXPECT_FALSE(LastDiscoveryIsValid(proxy));
+    }
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
+TEST(TestThreadMeshcopCommissionProxy, IgnoresMismatchWithShortDiscriminator)
+{
+    ThreadMeshcopCommissionProxy proxy;
+    SetupDiscriminator expectedDiscriminator;
+    expectedDiscriminator.SetShortValue(1);
+    ByteSpan invalidPskc;
+    Transport::PeerAddress peerAddress;
+    Dnssd::DiscoveredNodeData nodeData;
+
+    EXPECT_EQ(proxy.Discover(invalidPskc, peerAddress, Thread::DiscoveryCode(), expectedDiscriminator, nodeData, 0),
+              CHIP_ERROR_INVALID_ARGUMENT);
+
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_FALSE(LastDiscoveryIsValid(proxy));
 }
 
 TEST(TestThreadMeshcopCommissionProxy, AcceptsCompleteResponse)

--- a/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
@@ -17,10 +17,11 @@
 
 #include <controller/ThreadMeshcopCommissionProxy.h>
 
+#include <json/json.h>
 #include <pw_unit_test/framework.h>
 
 #include <cstdint>
-#include <string>
+#include <sstream>
 #include <vector>
 
 namespace chip {
@@ -70,7 +71,13 @@ void SendJoinerPacket(ThreadMeshcopCommissionProxy & proxy, const uint8_t (&pack
 
 bool LastDiscoveryIsValid(ThreadMeshcopCommissionProxy & proxy)
 {
-    return proxy.GetLastDiscoveryDiagnosticJson().find("\"valid\" : true") != std::string::npos;
+    Json::Value root;
+    std::string errors;
+    std::istringstream diagnostic(proxy.GetLastDiscoveryDiagnosticJson());
+    bool parsed = Json::parseFromStream(Json::CharReaderBuilder(), diagnostic, &root, &errors);
+
+    EXPECT_TRUE(parsed);
+    return parsed && root["valid"].asBool();
 }
 
 TEST(TestThreadMeshcopCommissionProxy, WaitsForCompleteResponseAfterSrvQuery)


### PR DESCRIPTION
### Summary

Ignore incomplete/partial mDNS annoucement in ThreadMeshcopCommissionProxy

### Related issues

Fixes #73597

### Testing

Added src/controller/tests/TestThreadMeshcopCommissionProxy.cpp