### PR TITLE
replace AutoReleaseSubscriptionInfoIterator with AutoRelease

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -46,6 +46,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Global.h>
 #include <lib/core/TLVUtilities.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/FibonacciUtils.h>
@@ -166,25 +167,6 @@ bool IsAccessibleAttributeEntry(const ConcreteAttributePath & path, const Access
 }
 
 } // namespace
-
-class AutoReleaseSubscriptionInfoIterator
-{
-public:
-    AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) : mIterator(iterator){};
-    ~AutoReleaseSubscriptionInfoIterator()
-    {
-        if (mIterator)
-        {
-            mIterator->Release();
-        }
-    }
-
-    explicit operator bool() const { return mIterator != nullptr; }
-    SubscriptionResumptionStorage::SubscriptionInfoIterator * operator->() const { return mIterator; }
-
-private:
-    SubscriptionResumptionStorage::SubscriptionInfoIterator * mIterator;
-};
 
 using Protocols::InteractionModel::Status;
 
@@ -2200,8 +2182,8 @@ void InteractionModelEngine::ResumeSubscriptionsTimerCallback(System::Layer * ap
     bool resumedSubscriptions                  = false;
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
-    AutoReleaseSubscriptionInfoIterator iterator(imEngine->mpSubscriptionResumptionStorage->IterateSubscriptions());
-    VerifyOrReturn(iterator, ChipLogError(InteractionModel, "Failed to allocate subscription resumption iterator"));
+    AutoRelease iterator(imEngine->mpSubscriptionResumptionStorage->IterateSubscriptions());
+    VerifyOrReturn(!iterator.IsNull(), ChipLogError(InteractionModel, "Failed to allocate subscription resumption iterator"));
     while (iterator->Next(subscriptionInfo))
     {
         // If subscription happens between reboot and this timer callback, it's already live and should skip resumption


### PR DESCRIPTION
### Summary
remove file-local wrapper in InteractionModelEngine and use AutoRelease.

### Related issues
- Please see #73331 for more details
- Earlier PRs: #73296, #73546, #73556, #73568, #73603

### Testing
- Existing unit tests cover the migrated path, hence ran the unit tests locally and they'll also run in CI