### PR TITLE
Dont set GCAST feature in GroupKeyManagement

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
@@ -647,10 +647,6 @@ DataModel::ActionReturnStatus GroupKeyManagementCluster::ReadAttribute(const Dat
         return encoder.Encode(kRevision);
     case Attributes::FeatureMap::Id: {
         BitFlags<GroupKeyManagement::Feature> features;
-        if (mContext.groupDataProvider.IsGroupcastEnabled())
-        {
-            features.Set(Clusters::GroupKeyManagement::Feature::kGroupcast);
-        }
         if (IsMCSPSupported())
         {
             features.Set(Clusters::GroupKeyManagement::Feature::kCacheAndSync);


### PR DESCRIPTION
### Summary

The GCAST feature is provisional and should not be set by default in the sdk

### Testing

- CI should still pass
