### PR TITLE
[Silabs] Add openthread.gn to all-device app

### DIFF
--- a/examples/all-devices-app/silabs/openthread.gn
+++ b/examples/all-devices-app/silabs/openthread.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+# The location of the build configuration file.
+buildconfig = "${build_root}/config/BUILDCONFIG.gn"
+
+# CHIP uses angle bracket includes.
+check_system_includes = true
+
+default_args = {
+  target_cpu = "arm"
+  target_os = "freertos"
+  chip_openthread_ftd = true
+  optimize_debug_level = "s"
+
+  import("//args.gni")
+}


### PR DESCRIPTION
### Summary

Without this file, building with `./scripts/examples/gn_silabs_example.sh ` would result in an error. Adding this file allows it to build with that script.

Copied the same one from the lighting app, but changed `import("//openthread.gni")` to `import("//args.gni")

### Related issues


### Testing

Runs on 4118A