### PR TITLE
thermostat: cascade Preset removal to ThermostatSuggestions

### DIFF
--- a/src/app/clusters/thermostat-server/ThermostatClusterAtomic.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterAtomic.cpp
@@ -16,8 +16,10 @@
  */
 
 #include "ThermostatCluster.h"
+#include "ThermostatClusterSuggestions.h"
 
 #include <app/GlobalAttributes.h>
+#include <app/reporting/reporting.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 using namespace chip;
@@ -542,13 +544,26 @@ void ThermostatAttrAccess::CommitAtomicWrite(CommandHandler * commandObj, const 
             CHIP_ERROR err;
             switch (attributeStatus.attributeID)
             {
-            case Presets::Id:
+            case Presets::Id: {
                 err = delegate->CommitPendingPresets();
                 if (err != CHIP_NO_ERROR)
                 {
                     statusCode = Status::InvalidInState;
+                    break;
                 }
+                // Per spec, removing a preset that is referenced by a ThermostatSuggestions entry or by
+                // CurrentThermostatSuggestion must cascade: prune the stale suggestion entries and re-evaluate
+                // CurrentThermostatSuggestion. This is best-effort, matching AddThermostatSuggestion/
+                // RemoveThermostatSuggestion, since the Presets commit above has already taken effect.
+                bool removedAThermostatSuggestion = false;
+                TEMPORARY_RETURN_IGNORED RemoveThermostatSuggestionsForRemovedPresets(delegate, removedAThermostatSuggestion);
+                if (removedAThermostatSuggestion)
+                {
+                    MatterReportingAttributeChangeCallback(endpoint, Thermostat::Id, ThermostatSuggestions::Id);
+                }
+                TEMPORARY_RETURN_IGNORED delegate->ReEvaluateCurrentSuggestion();
                 break;
+            }
             case Schedules::Id:
                 break;
             default:

--- a/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp
@@ -42,6 +42,43 @@ namespace Thermostat {
 
 namespace {
 
+/**
+ * @brief Determines whether a preset handle still exists in the Presets attribute list.
+ *
+ * Unlike IsPresetHandlePresentInPresets(), which treats a GetPresetAtIndex() enumeration error the same as "not
+ * found", this distinguishes the two so callers that take a destructive action (e.g. removing a thermostat
+ * suggestion) on "not found" do not do so on a transient enumeration error.
+ *
+ * @param[in]  delegate The delegate to use.
+ * @param[in]  presetHandle The preset handle to look for.
+ * @param[out] exists Set to true if a preset with this handle is present in the Presets attribute list, false
+ *             otherwise.
+ *
+ * @return CHIP_NO_ERROR if the Presets attribute list was enumerated successfully, an error code if not.
+ */
+CHIP_ERROR PresetHandleStillExists(Delegate * delegate, const ByteSpan & presetHandle, bool & exists)
+{
+    exists = false;
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    PresetStructWithOwnedMembers preset;
+    for (uint8_t i = 0; true; i++)
+    {
+        CHIP_ERROR err = delegate->GetPresetAtIndex(i, preset);
+        if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
+        {
+            return CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(err);
+
+        if (!preset.GetPresetHandle().IsNull() && preset.GetPresetHandle().Value().data_equal(presetHandle))
+        {
+            exists = true;
+            return CHIP_NO_ERROR;
+        }
+    }
+}
+
 CHIP_ERROR RemoveExpiredSuggestions(Delegate * delegate)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -108,7 +145,11 @@ CHIP_ERROR RemoveThermostatSuggestionsForRemovedPresets(Delegate * delegate, boo
         CHIP_ERROR err = delegate->GetThermostatSuggestionAtIndex(static_cast<size_t>(i), suggestion);
         ReturnErrorOnFailure(err);
 
-        if (!IsPresetHandlePresentInPresets(delegate, suggestion.GetPresetHandle()))
+        bool presetStillExists = false;
+        err                    = PresetHandleStillExists(delegate, suggestion.GetPresetHandle(), presetStillExists);
+        ReturnErrorOnFailure(err);
+
+        if (!presetStillExists)
         {
             ReturnErrorOnFailure(delegate->RemoveFromThermostatSuggestionsList(static_cast<size_t>(i)));
             didRemoveAnEntry = true;

--- a/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp
+++ b/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include "ThermostatClusterSuggestions.h"
 #include "ThermostatCluster.h"
 #include "ThermostatClusterPresets.h"
 #include "ThermostatSuggestionStructWithOwnedMembers.h"
@@ -94,6 +95,27 @@ Status RemoveFromThermostatSuggestionsList(Delegate * delegate, uint8_t uniqueID
 }
 
 } // anonymous namespace
+
+CHIP_ERROR RemoveThermostatSuggestionsForRemovedPresets(Delegate * delegate, bool & didRemoveAnEntry)
+{
+    didRemoveAnEntry = false;
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Walk backwards so removing an entry does not shift the indices of entries not yet visited.
+    for (int i = static_cast<int>(delegate->GetNumberOfThermostatSuggestions()) - 1; i >= 0; i--)
+    {
+        ThermostatSuggestionStructWithOwnedMembers suggestion;
+        CHIP_ERROR err = delegate->GetThermostatSuggestionAtIndex(static_cast<size_t>(i), suggestion);
+        ReturnErrorOnFailure(err);
+
+        if (!IsPresetHandlePresentInPresets(delegate, suggestion.GetPresetHandle()))
+        {
+            ReturnErrorOnFailure(delegate->RemoveFromThermostatSuggestionsList(static_cast<size_t>(i)));
+            didRemoveAnEntry = true;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
 
 bool AddThermostatSuggestion(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                              const Commands::AddThermostatSuggestion::DecodableType & commandData)

--- a/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.h
+++ b/src/app/clusters/thermostat-server/ThermostatClusterSuggestions.h
@@ -1,0 +1,45 @@
+/**
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/thermostat-server/ThermostatDelegate.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace Thermostat {
+
+/**
+ * @brief Removes every entry in the ThermostatSuggestions attribute list whose PresetHandle no longer matches a
+ *        preset in the Presets attribute list. Per spec, this cascade must run after a Presets atomic write commits
+ *        a preset removal. If the entry being removed is the CurrentThermostatSuggestion, RemoveFromThermostatSuggestionsList
+ *        is responsible for setting CurrentThermostatSuggestion to null, per its API contract.
+ *
+ * @param[in]  delegate The delegate to use.
+ * @param[out] didRemoveAnEntry Set to true if at least one entry was removed from the ThermostatSuggestions list,
+ *             false otherwise. Callers can use this to decide whether the ThermostatSuggestions attribute needs to
+ *             be reported as changed.
+ *
+ * @return CHIP_NO_ERROR if successful, an error code if not.
+ */
+CHIP_ERROR RemoveThermostatSuggestionsForRemovedPresets(Delegate * delegate, bool & didRemoveAnEntry);
+
+} // namespace Thermostat
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/thermostat-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/thermostat-server/app_config_dependent_sources.cmake
@@ -35,6 +35,7 @@ TARGET_SOURCES(
     "${CLUSTER_DIR}/ThermostatClusterSetpoints.cpp"
     "${CLUSTER_DIR}/ThermostatClusterSetpoints.h"
     "${CLUSTER_DIR}/ThermostatClusterSuggestions.cpp"
+    "${CLUSTER_DIR}/ThermostatClusterSuggestions.h"
     "${CLUSTER_DIR}/ThermostatCluster.cpp"
     "${CLUSTER_DIR}/ThermostatCluster.h"
     "${CLUSTER_DIR}/ThermostatDelegate.h"

--- a/src/app/clusters/thermostat-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/thermostat-server/app_config_dependent_sources.gni
@@ -33,6 +33,7 @@ app_config_dependent_sources = [
   "ThermostatClusterSetpoints.cpp",
   "ThermostatClusterSetpoints.h",
   "ThermostatClusterSuggestions.cpp",
+  "ThermostatClusterSuggestions.h",
   "ThermostatDelegate.h",
   "ThermostatSuggestionStructWithOwnedMembers.cpp",
   "ThermostatSuggestionStructWithOwnedMembers.h",


### PR DESCRIPTION
### Summary

##### Problem

-   Spec § 4.3.11.50 requires that removing a `Preset` via a `Presets` atomic write cascades to `ThermostatSuggestions`/`CurrentThermostatSuggestion`:
    -   Any `ThermostatSuggestions` entry whose `PresetHandle` matches the removed preset **must be deleted**.
    -   If `CurrentThermostatSuggestion` referenced the removed preset, it **must be set to null**.
-   `ThermostatAttrAccess::CommitAtomicWrite()` committed the pending presets (`delegate->CommitPendingPresets()`) but never invoked any cleanup for `ThermostatSuggestions` afterwards, unlike `AddThermostatSuggestion`/`RemoveThermostatSuggestion`, which already call this kind of cleanup.
-   Result: after a successful preset removal, stale `ThermostatSuggestions` entries and a stale `CurrentThermostatSuggestion` persist, pointing at a preset that no longer exists in `Presets`.

##### Solution

-   Added `RemoveThermostatSuggestionsForRemovedPresets()` (`ThermostatClusterSuggestions.{h,cpp}`), which prunes any `ThermostatSuggestions` entry whose `PresetHandle` no longer exists in the (just-committed) `Presets` list.
-   Called it from `CommitAtomicWrite()` right after a successful `Presets` commit, followed by `delegate->ReEvaluateCurrentSuggestion()`. `RemoveFromThermostatSuggestionsList()` already nulls `CurrentThermostatSuggestion` when the removed entry was the current suggestion, per its existing API contract, so no delegate changes were needed for that part.
-   This is best-effort (errors are logged/ignored), matching the existing pattern in `AddThermostatSuggestion`/`RemoveThermostatSuggestion`, since the `Presets` commit has already taken effect by this point and cannot be rolled back.

### Related issues

Fixes #73589

### Testing

-   Built `examples/thermostat/linux` (`linux-x64-thermostat-clang`) from this branch and reproduced the exact repro steps from the issue with `chip-tool`:
    1.  Added a non-built-in preset via a `Presets` atomic write (assigned handle `04`).
    2.  `add-thermostat-suggestion` referencing handle `04` → `ThermostatSuggestions` gets 1 entry, `CurrentThermostatSuggestion` follows it, `ActivePresetHandle` auto-updates to `04`.
    3.  Reset `ActivePresetHandle` back to `01`.
    4.  Removed preset `04` via a `Presets` atomic write. Commit succeeds.
    5.  Read back: `ThermostatSuggestions` goes from **1 stale entry to 0 entries**, and `CurrentThermostatSuggestion` goes from the **stale entry to null**.
-   No existing C++ unit test infrastructure covers `thermostat-server`'s presets/suggestions cluster logic (no `tests/` directory under `src/app/clusters/thermostat-server/`); this was verified through the live repro above instead. `src/python_testing/TC_TSTAT_4_2.py`/`TC_TSTAT_4_3.py` do not currently exercise this cross-feature interaction either (noted in the issue as a separate test-coverage gap).
