### PR TITLE
[AvAnalysis] Add Avanalysis events API and unit test

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -100,7 +100,7 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
 
     // Instantiate the AV Analysis Server
     mAVAnalysisServer.Create(mEndpoint, avAnalysisFeatures, appSupportedAmbientContexts, DataModel::MakeNullable(appMaxZones));
-    
+
     // The delegate must be set before registering the server
     mAVAnalysisServer.Cluster().SetDelegate(&mCameraDevice->GetAVAnalysisDelegate());
     err = CodegenDataModelProvider::Instance().Registry().Register(mAVAnalysisServer.Registration());

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -100,6 +100,8 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
 
     // Instantiate the AV Analysis Server
     mAVAnalysisServer.Create(mEndpoint, avAnalysisFeatures, appSupportedAmbientContexts, DataModel::MakeNullable(appMaxZones));
+    
+    // The delegate must be set before registering the server
     mAVAnalysisServer.Cluster().SetDelegate(&mCameraDevice->GetAVAnalysisDelegate());
     err = CodegenDataModelProvider::Instance().Registry().Register(mAVAnalysisServer.Registration());
     if (err != CHIP_NO_ERROR)

--- a/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
+++ b/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
@@ -61,7 +61,7 @@ public:
      * Delegate command assists
      */
 
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) override;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t> & aZoneIDs) override;
 
     virtual bool CanAddContextTriggers() override;
 

--- a/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
+++ b/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
@@ -61,7 +61,7 @@ public:
      * Delegate command assists
      */
 
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) override;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) override;
 
     virtual bool CanAddContextTriggers() override;
 

--- a/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
+++ b/examples/camera-app/linux/include/clusters/av-analysis/av-analysis-manager.h
@@ -61,7 +61,7 @@ public:
      * Delegate command assists
      */
 
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(DataModel::DecodableList<uint16_t> aZoneIDs) override;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) override;
 
     virtual bool CanAddContextTriggers() override;
 

--- a/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
@@ -67,7 +67,7 @@ Protocols::InteractionModel::Status AvAnalysisManager::RemoveAnalysisStream()
 /**
  * Delegate command assists
  */
-CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(DataModel::DecodableList<uint16_t> aZoneIDs)
+CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs)
 {
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
@@ -67,7 +67,7 @@ Protocols::InteractionModel::Status AvAnalysisManager::RemoveAnalysisStream()
 /**
  * Delegate command assists
  */
-CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs)
+CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(const std::vector<uint16_t> & aZoneIDs)
 {
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/av-analysis/av-analysis-manager.cpp
@@ -67,7 +67,7 @@ Protocols::InteractionModel::Status AvAnalysisManager::RemoveAnalysisStream()
 /**
  * Delegate command assists
  */
-CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs)
+CHIP_ERROR AvAnalysisManager::VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs)
 {
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
@@ -157,25 +157,29 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisCluster::InvokeCommand(co
 }
 
 // Context detection
-CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
-    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList)
 {
-    return mLogic.AnalysisSessionStart(aSessionId, aZoneList, aTriggeringContext);
+    return mLogic.AnalysisSessionStart(aSessionId, aZoneList, mContext);
 }
-    
+
+CHIP_ERROR AvAnalysisCluster::InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+{
+    return mLogic.InitialTriggeringContextDetected(aSessionId, aTriggeringContext, mContext);
+}
+
 CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
 {
-    return mLogic.NewContextDetected(aSessionId, aNewContext);
+    return mLogic.NewContextDetected(aSessionId, aNewContext, mContext);
 }
     
 CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
 {
-    return mLogic.ContextNoLongerDetected(aSessionId, aOldContext);
+    return mLogic.ContextNoLongerDetected(aSessionId, aOldContext, mContext);
 }
    
 CHIP_ERROR AvAnalysisCluster::AnalysisSessionEnd(uint16_t aSessionId)
 {
-    return mLogic.AnalysisSessionEnd(aSessionId);
+    return mLogic.AnalysisSessionEnd(aSessionId, mContext);
 }
 
 

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
@@ -163,20 +163,20 @@ CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataMo
 }
 
 CHIP_ERROR
-AvAnalysisCluster::InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                    const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext)
+AvAnalysisCluster::InitialTriggeringContextDetected(
+    uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aTriggeringContext)
 {
     return mLogic.InitialTriggeringContextDetected(aSessionId, aTriggeringContext, mContext);
 }
 
 CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId,
-                                                 const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext)
+                                                 const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aNewContext)
 {
     return mLogic.NewContextDetected(aSessionId, aNewContext, mContext);
 }
 
 CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId,
-                                                      const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext)
+                                                      const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aOldContext)
 {
     return mLogic.ContextNoLongerDetected(aSessionId, aOldContext, mContext);
 }

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
@@ -162,26 +162,29 @@ CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataMo
     return mLogic.AnalysisSessionStart(aSessionId, aZoneList, mContext);
 }
 
-CHIP_ERROR AvAnalysisCluster::InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+CHIP_ERROR
+AvAnalysisCluster::InitialTriggeringContextDetected(uint16_t aSessionId,
+                                                    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
 {
     return mLogic.InitialTriggeringContextDetected(aSessionId, aTriggeringContext, mContext);
 }
 
-CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
+CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId,
+                                                 std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
 {
     return mLogic.NewContextDetected(aSessionId, aNewContext, mContext);
 }
-    
-CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
+
+CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId,
+                                                      std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
 {
     return mLogic.ContextNoLongerDetected(aSessionId, aOldContext, mContext);
 }
-   
+
 CHIP_ERROR AvAnalysisCluster::AnalysisSessionEnd(uint16_t aSessionId)
 {
     return mLogic.AnalysisSessionEnd(aSessionId, mContext);
 }
-
 
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
@@ -156,6 +156,29 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisCluster::InvokeCommand(co
     return Status::UnsupportedCommand;
 }
 
+// Context detection
+CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
+    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+{
+    return mLogic.AnalysisSessionStart(aSessionId, aZoneList, aTriggeringContext);
+}
+    
+CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
+{
+    return mLogic.NewContextDetected(aSessionId, aNewContext);
+}
+    
+CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
+{
+    return mLogic.ContextNoLongerDetected(aSessionId, aOldContext);
+}
+   
+CHIP_ERROR AvAnalysisCluster::AnalysisSessionEnd(uint16_t aSessionId)
+{
+    return mLogic.AnalysisSessionEnd(aSessionId);
+}
+
+
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.cpp
@@ -164,19 +164,19 @@ CHIP_ERROR AvAnalysisCluster::AnalysisSessionStart(uint16_t & aSessionId, DataMo
 
 CHIP_ERROR
 AvAnalysisCluster::InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+                                                    const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext)
 {
     return mLogic.InitialTriggeringContextDetected(aSessionId, aTriggeringContext, mContext);
 }
 
 CHIP_ERROR AvAnalysisCluster::NewContextDetected(uint16_t aSessionId,
-                                                 std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
+                                                 const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext)
 {
     return mLogic.NewContextDetected(aSessionId, aNewContext, mContext);
 }
 
 CHIP_ERROR AvAnalysisCluster::ContextNoLongerDetected(uint16_t aSessionId,
-                                                      std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
+                                                      const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext)
 {
     return mLogic.ContextNoLongerDetected(aSessionId, aOldContext, mContext);
 }

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -136,6 +136,10 @@ public:
 
     void MarkAttributeDirty(AttributeId attributeId) { NotifyAttributeChanged(attributeId); }
 
+    /**
+     * Sets the app delegate on the cluster logic; and ensures that the delegate itself has a link to the server
+     * The app must set the delegate prior to registering the cluster instance.
+     */
     void SetDelegate(AvAnalysisDelegate * delegate)
     {
         mLogic.SetDelegate(delegate);

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -80,7 +80,7 @@ public:
     /**
      * @param  aZoneIDs  the set of ZoneIDs to be validated against what is defined in the Zone Management Cluster instance
      */
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(DataModel::DecodableList<uint16_t> aZoneIDs) = 0;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) = 0;
 
     /**
      * Allows the delegate to determine whether or not resources exist to add additional context triggers.
@@ -174,6 +174,16 @@ public:
 
     // Attribute mutators
     CHIP_ERROR SetMaxAnalysisStreamCount(uint8_t aMaxAnalysisStreamCount);
+    
+    // Context detection
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
+        std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+    
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
+    
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
+    
+    CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId);
 
 private:
     AvAnalysisServerLogic mLogic;

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -80,7 +80,7 @@ public:
     /**
      * @param  aZoneIDs  the set of ZoneIDs to be validated against what is defined in the Zone Management Cluster instance
      */
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) = 0;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) = 0;
 
     /**
      * Allows the delegate to determine whether or not resources exist to add additional context triggers.
@@ -181,46 +181,46 @@ public:
      * provide the session ID to be used over the lifetime of the session.  The server will generate the AnalysisSessionStart event.
      *
      * @param aSessionId the server will manage all session Ids
-     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not avaiable, or
+     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not available, or
      * all zones
      */
     CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList);
 
     /**
      * Invoked by the delegate to furnish details of the event that triggered the session. The server will generate a
-     * PerceivedContext event with the inital context
+     * PerceivedContext event with the initial context
      *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
      * @param aTriggeringContext the set (could be more than one) of contexts that triggered the session.
      *                           This will be validated against the set of known, enabled contexts by the server.
      */
     CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext);
 
     /**
      * Invoked by the delegate for all newly detected analysis contexts as part of the current session. The server will generate a
      * PerceivedContext event with the new context and the current contexts previously informed.
      *
-     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
-     * @param aTriggeringContext the set (could be more than one) of contexts that are newly detected for the session.
-     *                           This will be validated against the set of known, enabled contexts by the server.    *
+     * @param aSessionId  the sessionId for the current session, the method will fail if this is not known by the server
+     * @param aNewContext the set (could be more than one) of contexts that are newly detected for the session.
+     *                    This will be validated against the set of known, enabled contexts by the server.
      */
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext);
 
     /**
      * Invoked by the delegate when a previously detected context is no longer present (e.g. a detected package has been
-     * retrieved). The server will generate a PerceivedContext event with the expired contextand the current contexts previously
+     * retrieved). The server will generate a PerceivedContext event with the expired context and the current contexts previously
      * informed.
      *
-     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
-     * @param aTriggeringContext the set (could be more than one) of contexts that are no longer detected as part of the session.
-     *                           This will be validated against the set of known, active contexts that are part of the session by
-     * the server.    *      *
+     * @param aSessionId  the sessionId for the current session, the method will fail if this is not known by the server
+     * @param aOldContext the set (could be more than one) of contexts that are no longer detected as part of the session.
+     *                    This will be validated against the set of known, active contexts that are part of the session by
+     * the server.
      */
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext);
 
     /**
-     * Invoked by the delegate to indictae the conclusion of an analysis session that has been triggered. It is up to the
+     * Invoked by the delegate to indicate the conclusion of an analysis session that has been triggered. It is up to the
      * delegate to determine the criteria for determing that a session has concluded.
      *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -80,7 +80,7 @@ public:
     /**
      * @param  aZoneIDs  the set of ZoneIDs to be validated against what is defined in the Zone Management Cluster instance
      */
-    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) = 0;
+    virtual CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t> & aZoneIDs) = 0;
 
     /**
      * Allows the delegate to determine whether or not resources exist to add additional context triggers.
@@ -181,8 +181,8 @@ public:
      * provide the session ID to be used over the lifetime of the session.  The server will generate the AnalysisSessionStart event.
      *
      * @param aSessionId the server will manage all session Ids
-     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not available, or
-     * all zones
+     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not available,
+     * or all zones
      */
     CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList);
 
@@ -195,7 +195,7 @@ public:
      *                           This will be validated against the set of known, enabled contexts by the server.
      */
     CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext);
+                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aTriggeringContext);
 
     /**
      * Invoked by the delegate for all newly detected analysis contexts as part of the current session. The server will generate a
@@ -205,7 +205,7 @@ public:
      * @param aNewContext the set (could be more than one) of contexts that are newly detected for the session.
      *                    This will be validated against the set of known, enabled contexts by the server.
      */
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext);
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aNewContext);
 
     /**
      * Invoked by the delegate when a previously detected context is no longer present (e.g. a detected package has been
@@ -217,7 +217,8 @@ public:
      *                    This will be validated against the set of known, active contexts that are part of the session by
      * the server.
      */
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext);
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId,
+                                       const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aOldContext);
 
     /**
      * Invoked by the delegate to indicate the conclusion of an analysis session that has been triggered. It is up to the

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -174,51 +174,55 @@ public:
 
     // Attribute mutators
     CHIP_ERROR SetMaxAnalysisStreamCount(uint8_t aMaxAnalysisStreamCount);
-    
+
     // Context detection and event generation
     /**
-     * Invoked by the delegate when a new analysis session is initiated based on its own detection metrics. The server will 
+     * Invoked by the delegate when a new analysis session is initiated based on its own detection metrics. The server will
      * provide the session ID to be used over the lifetime of the session.  The server will generate the AnalysisSessionStart event.
-     * 
+     *
      * @param aSessionId the server will manage all session Ids
-     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not avaiable, or all zones
+     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not avaiable, or
+     * all zones
      */
     CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList);
-    
+
     /**
-     * Invoked by the delegate to furnish details of the event that triggered the session. The server will generate a PerceivedContext
-     * event with the inital context
-     * 
+     * Invoked by the delegate to furnish details of the event that triggered the session. The server will generate a
+     * PerceivedContext event with the inital context
+     *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
-     * @param aTriggeringContext the set (could be more than one) of contexts that triggered the session.  
+     * @param aTriggeringContext the set (could be more than one) of contexts that triggered the session.
      *                           This will be validated against the set of known, enabled contexts by the server.
      */
-    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
-    
+    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
+                                                std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+
     /**
-     * Invoked by the delegate for all newly detected analysis contexts as part of the current session. The server will generate a 
+     * Invoked by the delegate for all newly detected analysis contexts as part of the current session. The server will generate a
      * PerceivedContext event with the new context and the current contexts previously informed.
-     * 
+     *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
-     * @param aTriggeringContext the set (could be more than one) of contexts that are newly detected for the session.  
-     *                           This will be validated against the set of known, enabled contexts by the server.    * 
+     * @param aTriggeringContext the set (could be more than one) of contexts that are newly detected for the session.
+     *                           This will be validated against the set of known, enabled contexts by the server.    *
      */
     CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
-    
+
     /**
-     * Invoked by the delegate when a previously detected context is no longer present (e.g. a detected package has been 
-     * retrieved). The server will generate a PerceivedContext event with the expired contextand the current contexts previously informed.
-     * 
+     * Invoked by the delegate when a previously detected context is no longer present (e.g. a detected package has been
+     * retrieved). The server will generate a PerceivedContext event with the expired contextand the current contexts previously
+     * informed.
+     *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
-     * @param aTriggeringContext the set (could be more than one) of contexts that are no longer detected as part of the session.  
-     *                           This will be validated against the set of known, active contexts that are part of the session by the server.    *      * 
+     * @param aTriggeringContext the set (could be more than one) of contexts that are no longer detected as part of the session.
+     *                           This will be validated against the set of known, active contexts that are part of the session by
+     * the server.    *      *
      */
     CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
-    
-    /** 
-     * Invoked by the delegate to indictae the conclusion of an analysis session that has been triggered. It is up to the 
+
+    /**
+     * Invoked by the delegate to indictae the conclusion of an analysis session that has been triggered. It is up to the
      * delegate to determine the criteria for determing that a session has concluded.
-     * 
+     *
      * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
      */
     CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId);

--- a/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisCluster.h
@@ -175,14 +175,52 @@ public:
     // Attribute mutators
     CHIP_ERROR SetMaxAnalysisStreamCount(uint8_t aMaxAnalysisStreamCount);
     
-    // Context detection
-    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
-        std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+    // Context detection and event generation
+    /**
+     * Invoked by the delegate when a new analysis session is initiated based on its own detection metrics. The server will 
+     * provide the session ID to be used over the lifetime of the session.  The server will generate the AnalysisSessionStart event.
+     * 
+     * @param aSessionId the server will manage all session Ids
+     * @param aZoneList  the list of Zones that are relevant for the session, Null is used when this information is not avaiable, or all zones
+     */
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList);
     
+    /**
+     * Invoked by the delegate to furnish details of the event that triggered the session. The server will generate a PerceivedContext
+     * event with the inital context
+     * 
+     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
+     * @param aTriggeringContext the set (could be more than one) of contexts that triggered the session.  
+     *                           This will be validated against the set of known, enabled contexts by the server.
+     */
+    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+    
+    /**
+     * Invoked by the delegate for all newly detected analysis contexts as part of the current session. The server will generate a 
+     * PerceivedContext event with the new context and the current contexts previously informed.
+     * 
+     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
+     * @param aTriggeringContext the set (could be more than one) of contexts that are newly detected for the session.  
+     *                           This will be validated against the set of known, enabled contexts by the server.    * 
+     */
     CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
     
+    /**
+     * Invoked by the delegate when a previously detected context is no longer present (e.g. a detected package has been 
+     * retrieved). The server will generate a PerceivedContext event with the expired contextand the current contexts previously informed.
+     * 
+     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
+     * @param aTriggeringContext the set (could be more than one) of contexts that are no longer detected as part of the session.  
+     *                           This will be validated against the set of known, active contexts that are part of the session by the server.    *      * 
+     */
     CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
     
+    /** 
+     * Invoked by the delegate to indictae the conclusion of an analysis session that has been triggered. It is up to the 
+     * delegate to determine the criteria for determing that a session has concluded.
+     * 
+     * @param aSessionId         the sessionId for the current session, the method will fail if this is not known by the server
+     */
     CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId);
 
 private:

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -742,7 +742,7 @@ bool AvAnalysisServerLogic::ZoneIDListContains(const DataModel::DecodableList<ui
     return false;
 }
 
-CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList,
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, const DataModel::Nullable<std::vector<uint16_t>>& aZoneList,
                                                        ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -784,7 +784,7 @@ CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, Da
 }
 
 CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(
-    uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext, ServerClusterContext * aContext)
+    uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext, ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -821,7 +821,7 @@ CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(
 }
 
 CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId,
-                                                     std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
+                                                     const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext,
                                                      ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -862,7 +862,7 @@ CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId,
 }
 
 CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId,
-                                                          std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext,
+                                                          const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext,
                                                           ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -941,7 +941,7 @@ CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId, Server
     return CHIP_NO_ERROR;
 }
 
-bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(std::vector<AvAnalysis::Structs::TrackedContext::Type> aContext)
+bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aContext)
 {
     // Are the contexts part of our active set
     bool notFound = false;

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -297,6 +297,7 @@ CHIP_ERROR AvAnalysisServerLogic::LoadActiveAmbientContextTriggers()
             {
                 err = trigger.zoneIDs.Value().Value().ComputeSize(&size);
                 VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+                zoneIDs.reserve(size);
 
                 auto zone_iter = trigger.zoneIDs.Value().Value().begin();
 
@@ -428,6 +429,7 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisServerLogic::HandleLocalE
                 {
                     CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
                     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
+                    zoneIDs.reserve(size);
 
                     auto zone_iter = contextTrigger.zoneIDs.Value().Value().begin();
 
@@ -604,6 +606,7 @@ AvAnalysisServerLogic::HandleDisableContextTriggers(CommandHandler & handler, co
 
                     CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
                     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
+                    zoneIDs.reserve(size);
 
                     auto zone_iter = contextTrigger.zoneIDs.Value().Value().begin();
 

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -18,6 +18,7 @@
 
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterfaceRegistry.h>
+#include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/av-analysis-server/AvAnalysisCluster.h>
 #include <app/reporting/reporting.h>
@@ -28,13 +29,10 @@
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using namespace chip;
-using namespace chip::app;
-using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AvAnalysis;
 using namespace chip::app::Clusters::AvAnalysis::Structs;
 using namespace chip::app::Clusters::AvAnalysis::Attributes;
-using namespace Protocols::InteractionModel;
+using namespace chip::Protocols::InteractionModel;
 
 namespace chip {
 namespace app {
@@ -413,6 +411,11 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisServerLogic::HandleLocalE
                 return Status::InvalidCommand;
             }
 
+            // Get the ZoneIDs, if present, into a format that can be used, that is convert the DecodableList to a List
+            //
+            std::vector<uint16_t> zoneIDs;
+            size_t size;
+            
             if (hasZoneIDs)
             {
                 // Verify via the delegate that the provided list of ZoneIDs contains values present in ZoneManagement only
@@ -420,7 +423,16 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisServerLogic::HandleLocalE
                 //
                 if (!contextTrigger.zoneIDs.Value().IsNull())
                 {
-                    CHIP_ERROR err = mDelegate->VerifyZoneIDsAreValid(contextTrigger.zoneIDs.Value().Value());
+                    CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
+                    VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
+
+                    auto zone_iter = contextTrigger.zoneIDs.Value().Value().begin();
+
+                    while (zone_iter.Next())
+                    {
+                        zoneIDs.push_back(zone_iter.GetValue());
+                    }
+                    err = mDelegate->VerifyZoneIDsAreValid(zoneIDs);
                     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::NotFound);
                     hasNonNullZoneIDs = true;
                 }
@@ -438,24 +450,6 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisServerLogic::HandleLocalE
                                         return acs.GetContext().namespaceID == contextTrigger.context.namespaceID &&
                                             acs.GetContext().tag == contextTrigger.context.tag;
                                     });
-
-            // Get the ZoneIDs, if present, into a format that can be used, that is convert the DecodableList to a List
-            //
-            std::vector<uint16_t> zoneIDs;
-            size_t size;
-
-            if (hasNonNullZoneIDs)
-            {
-                CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
-                VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
-
-                auto zone_iter = contextTrigger.zoneIDs.Value().Value().begin();
-
-                while (zone_iter.Next())
-                {
-                    zoneIDs.push_back(zone_iter.GetValue());
-                }
-            }
 
             // Does an entry with this context already exist?
             //
@@ -602,7 +596,19 @@ AvAnalysisServerLogic::HandleDisableContextTriggers(CommandHandler & handler, co
                 //
                 if (!contextTrigger.zoneIDs.Value().IsNull())
                 {
-                    CHIP_ERROR err = mDelegate->VerifyZoneIDsAreValid(contextTrigger.zoneIDs.Value().Value());
+                    std::vector<uint16_t> zoneIDs;
+                    size_t size;
+                    
+                    CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
+                    VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
+
+                    auto zone_iter = contextTrigger.zoneIDs.Value().Value().begin();
+
+                    while (zone_iter.Next())
+                    {
+                        zoneIDs.push_back(zone_iter.GetValue());
+                    }
+                    err = mDelegate->VerifyZoneIDsAreValid(zoneIDs);
                     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::NotFound);
                 }
             }
@@ -734,6 +740,88 @@ bool AvAnalysisServerLogic::ZoneIDListContains(const DataModel::DecodableList<ui
         }
     }
     return false;
+}
+
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
+    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+{
+    // Validate the information received
+    // 1. are the zoneIDs known (if provided)
+    if (!aZoneList.IsNull()) 
+    {
+        ReturnErrorOnFailure(mDelegate->VerifyZoneIDsAreValid(aZoneList.Value()));
+    }
+    
+    // 2. are the contexts part of our active set
+    bool notFound = false;
+    for (const auto& contextTrigger : aTriggeringContext)
+    {
+        auto it = std::find_if(mActiveAmbientContextTriggers.begin(), mActiveAmbientContextTriggers.end(),
+            [&contextTrigger](AmbientContextStorage & acs) {
+                return acs.GetContext().namespaceID == contextTrigger.identifiedContext.namespaceID &&
+                    acs.GetContext().tag == contextTrigger.identifiedContext.tag;
+        });
+
+        if (it == mActiveAmbientContextTriggers.end())
+        {
+            notFound = true;
+            break;
+        }
+    }
+    
+    if (notFound)
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+            
+    // Get our current session ID, and increment for next use
+    aSessionId = mNextAnalysisSessionID++;
+    
+    // Capture our new active session information
+    AvAnalysis::ActiveAmbientContextSession newSession;
+    newSession.SetSessionId(aSessionId);
+    
+    // Create the Initial Event
+    Events::AnalysisSessionStart::Type startEvent;
+    EventNumber startEventNumber;
+
+    startEvent.sessionID = aSessionId;
+    startEvent.triggeredZones = DataModel::MakeNullable(DataModel::List<const uint16_t>(aZoneList.Value().data(), aZoneList.Value().size()));
+
+    CHIP_ERROR err = LogEvent(startEvent, mEndpointId, startEventNumber);
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(Zcl, "Unable to generate AnalysisSessionStart event");
+    }
+    
+    // Now create the first Perceived Context Event with the tiggering context
+    Events::PerceivedContext::Type perceivedEvent;
+    EventNumber perceivedEventNumber;
+
+    perceivedEvent.sessionID = aSessionId;
+    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aTriggeringContext.data(), aTriggeringContext.size()));
+
+    err = LogEvent(perceivedEvent, mEndpointId, perceivedEventNumber);
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(Zcl, "Unable to generate PerceivedContext event");
+    }
+    return CHIP_NO_ERROR;
+}
+    
+CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
+{
+    return CHIP_NO_ERROR;
+}
+    
+CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
+{
+    return CHIP_NO_ERROR;
+}
+   
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId)
+{
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Clusters

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -415,7 +415,7 @@ std::optional<DataModel::ActionReturnStatus> AvAnalysisServerLogic::HandleLocalE
             //
             std::vector<uint16_t> zoneIDs;
             size_t size;
-            
+
             if (hasZoneIDs)
             {
                 // Verify via the delegate that the provided list of ZoneIDs contains values present in ZoneManagement only
@@ -598,7 +598,7 @@ AvAnalysisServerLogic::HandleDisableContextTriggers(CommandHandler & handler, co
                 {
                     std::vector<uint16_t> zoneIDs;
                     size_t size;
-                    
+
                     CHIP_ERROR err = contextTrigger.zoneIDs.Value().Value().ComputeSize(&size);
                     VerifyOrReturnError(err == CHIP_NO_ERROR, Status::Failure);
 
@@ -743,193 +743,201 @@ bool AvAnalysisServerLogic::ZoneIDListContains(const DataModel::DecodableList<ui
 }
 
 CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList,
-    ServerClusterContext * aContext)
+                                                       ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // Validate the information received - are the zoneIDs known (if provided)
-    if (!aZoneList.IsNull()) 
+    if (!aZoneList.IsNull())
     {
         ReturnErrorOnFailure(mDelegate->VerifyZoneIDsAreValid(aZoneList.Value()));
     }
-              
+
     // Get our current session ID, and increment for next use
     aSessionId = mNextAnalysisSessionID++;
-    
+
     // Capture our new active session information
     AvAnalysis::ActiveAmbientContextSession newSession;
     newSession.SetSessionId(aSessionId);
     mActiveSessions.push_back(newSession);
-    
+
     // Create the Initial Event
     Events::AnalysisSessionStart::Type startEvent;
 
     startEvent.sessionID = aSessionId;
-    
+
     // The zones could be null, meaning that no zone information is available
     if (aZoneList.IsNull())
     {
         startEvent.triggeredZones = DataModel::NullNullable;
     }
-    else 
+    else
     {
-        startEvent.triggeredZones = DataModel::MakeNullable(DataModel::List<const uint16_t>(aZoneList.Value().data(), aZoneList.Value().size()));
+        startEvent.triggeredZones =
+            DataModel::MakeNullable(DataModel::List<const uint16_t>(aZoneList.Value().data(), aZoneList.Value().size()));
     }
 
     VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(startEvent, mEndpointId).has_value(),
-                        CHIP_ERROR_INTERNAL,
-                        ChipLogError(Zcl, "Unable to generate AnalysisSessionStart event"));
-    
+                        CHIP_ERROR_INTERNAL, ChipLogError(Zcl, "Unable to generate AnalysisSessionStart event"));
+
     return CHIP_NO_ERROR;
 }
-    
-CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext,
-    ServerClusterContext * aContext)
+
+CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(
+    uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext, ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // Make sure the provided session ID is one we know about
-    auto session_it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
-        return session.GetSessionId() == aSessionId;
-    });
+    auto session_it =
+        std::find_if(mActiveSessions.begin(), mActiveSessions.end(),
+                     [aSessionId](const ActiveAmbientContextSession & session) { return session.GetSessionId() == aSessionId; });
 
     // Check if the element was actually found
-    if (session_it == mActiveSessions.end()) 
+    if (session_it == mActiveSessions.end())
     {
         return CHIP_ERROR_NOT_FOUND;
     }
-    
-    // Are the contexts part of our active set  
+
+    // Are the contexts part of our active set
     if (!IsContextPartOfActiveContextTriggers(aTriggeringContext))
     {
         return CHIP_ERROR_NOT_FOUND;
     }
-    
+
     session_it->AddTrackedContext(aTriggeringContext);
 
     // Now create the first Perceived Context Event with the tiggering context
     Events::PerceivedContext::Type perceivedEvent;
 
-    perceivedEvent.sessionID = aSessionId;
-    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aTriggeringContext.data(), aTriggeringContext.size()));
+    perceivedEvent.sessionID             = aSessionId;
+    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(
+        DataModel::List<const Structs::TrackedContext::Type>(aTriggeringContext.data(), aTriggeringContext.size()));
 
     VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
-                        CHIP_ERROR_INTERNAL,
-                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+                        CHIP_ERROR_INTERNAL, ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
-    ServerClusterContext * aContext)
+CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId,
+                                                     std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
+                                                     ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // Make sure the provided session ID is one we know about
-    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
-        return session.GetSessionId() == aSessionId;
-    });
+    auto it =
+        std::find_if(mActiveSessions.begin(), mActiveSessions.end(),
+                     [aSessionId](const ActiveAmbientContextSession & session) { return session.GetSessionId() == aSessionId; });
 
     // Check if the element was actually found
-    if (it == mActiveSessions.end()) 
+    if (it == mActiveSessions.end())
     {
         return CHIP_ERROR_NOT_FOUND;
     }
- 
-    // Are the contexts part of our active set  
+
+    // Are the contexts part of our active set
     if (!IsContextPartOfActiveContextTriggers(aNewContext))
     {
         return CHIP_ERROR_NOT_FOUND;
     }
-    
+
     // Now create the Perceived Context Event with newly detected context
     Events::PerceivedContext::Type perceivedEvent;
 
     perceivedEvent.sessionID = aSessionId;
-    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aNewContext.data(), aNewContext.size()));
-    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
+    perceivedEvent.newIdentifiedContexts =
+        chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aNewContext.data(), aNewContext.size()));
+    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(
+        DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
 
     VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
-                        CHIP_ERROR_INTERNAL,
-                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
-                        
+                        CHIP_ERROR_INTERNAL, ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+
     // Add the new context triggers to our current set for the session
     it->AddTrackedContext(aNewContext);
-    
+
     return CHIP_NO_ERROR;
 }
-    
-CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext, 
-    ServerClusterContext * aContext)
+
+CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId,
+                                                          std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext,
+                                                          ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // Make sure the provided session ID is one we know about
-    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
-        return session.GetSessionId() == aSessionId;
-    });
+    auto it =
+        std::find_if(mActiveSessions.begin(), mActiveSessions.end(),
+                     [aSessionId](const ActiveAmbientContextSession & session) { return session.GetSessionId() == aSessionId; });
 
     // Check if the element was actually found
-    if (it == mActiveSessions.end()) {
+    if (it == mActiveSessions.end())
+    {
         return CHIP_ERROR_NOT_FOUND;
     }
-    
-    for (const auto& context : aOldContext)
-    {   
-        // Make sure the context actually exists in the session 
-        auto context_it = std::find_if(it->GetTrackedContexts().begin(), it->GetTrackedContexts().end(), [context](const Structs::TrackedContext::Type& mContext) {
-            return ((context.identifiedContext.namespaceID == mContext.identifiedContext.namespaceID) &&
-                    (context.identifiedContext.tag == mContext.identifiedContext.tag));
-        });
+
+    for (const auto & context : aOldContext)
+    {
+        // Make sure the context actually exists in the session
+        auto context_it =
+            std::find_if(it->GetTrackedContexts().begin(), it->GetTrackedContexts().end(),
+                         [context](const Structs::TrackedContext::Type & mContext) {
+                             return ((context.identifiedContext.namespaceID == mContext.identifiedContext.namespaceID) &&
+                                     (context.identifiedContext.tag == mContext.identifiedContext.tag));
+                         });
 
         // Check if the element was actually found
-        if (context_it == it->GetTrackedContexts().end()) {
+        if (context_it == it->GetTrackedContexts().end())
+        {
             return CHIP_ERROR_NOT_FOUND;
         }
-    }   
-    
+    }
+
     // Remove the old context triggers from our current set for the session
     it->RemoveTrackedContext(aOldContext);
-    
+
     // Now create the Perceived Context Event with newly removed context
     Events::PerceivedContext::Type perceivedEvent;
 
-    perceivedEvent.sessionID = aSessionId;
-    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
-    perceivedEvent.expiredContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aOldContext.data(), aOldContext.size()));
+    perceivedEvent.sessionID                 = aSessionId;
+    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(
+        DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
+    perceivedEvent.expiredContexts =
+        chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aOldContext.data(), aOldContext.size()));
 
     VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
-                        CHIP_ERROR_INTERNAL,
-                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
-    
+                        CHIP_ERROR_INTERNAL, ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+
     return CHIP_NO_ERROR;
 }
-   
+
 CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // Make sure the provided session ID is one we know about
-    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
-        return session.GetSessionId() == aSessionId;
-    });
+    auto it =
+        std::find_if(mActiveSessions.begin(), mActiveSessions.end(),
+                     [aSessionId](const ActiveAmbientContextSession & session) { return session.GetSessionId() == aSessionId; });
 
     // Check if the element was actually found
-    if (it == mActiveSessions.end()) {
+    if (it == mActiveSessions.end())
+    {
         return CHIP_ERROR_NOT_FOUND;
     }
-    
+
     // Now create the End Session Event
     Events::AnalysisSessionEnd::Type endSessionEvent;
     endSessionEvent.sessionID = aSessionId;
 
     VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(endSessionEvent, mEndpointId).has_value(),
-                        CHIP_ERROR_INTERNAL,
-                        ChipLogError(Zcl, "Unable to generate EndSession event"));
+                        CHIP_ERROR_INTERNAL, ChipLogError(Zcl, "Unable to generate EndSession event"));
 
     // Remove the session from our active contexts
     it = mActiveSessions.erase(it);
-    
+
     return CHIP_NO_ERROR;
 }
 
@@ -937,13 +945,13 @@ bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(std::vector<AvA
 {
     // Are the contexts part of our active set
     bool notFound = false;
-    for (const auto& contextTrigger : aContext)
+    for (const auto & contextTrigger : aContext)
     {
         auto trigger_it = std::find_if(mActiveAmbientContextTriggers.begin(), mActiveAmbientContextTriggers.end(),
-            [&contextTrigger](AmbientContextStorage & acs) {
-                return acs.GetContext().namespaceID == contextTrigger.identifiedContext.namespaceID &&
-                    acs.GetContext().tag == contextTrigger.identifiedContext.tag;
-        });
+                                       [&contextTrigger](AmbientContextStorage & acs) {
+                                           return acs.GetContext().namespaceID == contextTrigger.identifiedContext.namespaceID &&
+                                               acs.GetContext().tag == contextTrigger.identifiedContext.tag;
+                                       });
 
         if (trigger_it == mActiveAmbientContextTriggers.end())
         {
@@ -951,7 +959,7 @@ bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(std::vector<AvA
             break;
         }
     }
-    
+
     if (notFound)
     {
         return false;

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -742,27 +742,210 @@ bool AvAnalysisServerLogic::ZoneIDListContains(const DataModel::DecodableList<ui
     return false;
 }
 
-CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
-    std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext)
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList,
+    ServerClusterContext * aContext)
 {
-    // Validate the information received
-    // 1. are the zoneIDs known (if provided)
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Validate the information received - are the zoneIDs known (if provided)
     if (!aZoneList.IsNull()) 
     {
         ReturnErrorOnFailure(mDelegate->VerifyZoneIDsAreValid(aZoneList.Value()));
     }
+              
+    // Get our current session ID, and increment for next use
+    aSessionId = mNextAnalysisSessionID++;
     
-    // 2. are the contexts part of our active set
-    bool notFound = false;
-    for (const auto& contextTrigger : aTriggeringContext)
+    // Capture our new active session information
+    AvAnalysis::ActiveAmbientContextSession newSession;
+    newSession.SetSessionId(aSessionId);
+    mActiveSessions.push_back(newSession);
+    
+    // Create the Initial Event
+    Events::AnalysisSessionStart::Type startEvent;
+
+    startEvent.sessionID = aSessionId;
+    
+    // The zones could be null, meaning that no zone information is available
+    if (aZoneList.IsNull())
     {
-        auto it = std::find_if(mActiveAmbientContextTriggers.begin(), mActiveAmbientContextTriggers.end(),
+        startEvent.triggeredZones = DataModel::NullNullable;
+    }
+    else 
+    {
+        startEvent.triggeredZones = DataModel::MakeNullable(DataModel::List<const uint16_t>(aZoneList.Value().data(), aZoneList.Value().size()));
+    }
+
+    VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(startEvent, mEndpointId).has_value(),
+                        CHIP_ERROR_INTERNAL,
+                        ChipLogError(Zcl, "Unable to generate AnalysisSessionStart event"));
+    
+    return CHIP_NO_ERROR;
+}
+    
+CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext,
+    ServerClusterContext * aContext)
+{
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Make sure the provided session ID is one we know about
+    auto session_it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
+        return session.GetSessionId() == aSessionId;
+    });
+
+    // Check if the element was actually found
+    if (session_it == mActiveSessions.end()) 
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    
+    // Are the contexts part of our active set  
+    if (!IsContextPartOfActiveContextTriggers(aTriggeringContext))
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    
+    session_it->AddTrackedContext(aTriggeringContext);
+
+    // Now create the first Perceived Context Event with the tiggering context
+    Events::PerceivedContext::Type perceivedEvent;
+
+    perceivedEvent.sessionID = aSessionId;
+    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aTriggeringContext.data(), aTriggeringContext.size()));
+
+    VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
+                        CHIP_ERROR_INTERNAL,
+                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
+    ServerClusterContext * aContext)
+{
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Make sure the provided session ID is one we know about
+    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
+        return session.GetSessionId() == aSessionId;
+    });
+
+    // Check if the element was actually found
+    if (it == mActiveSessions.end()) 
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+ 
+    // Are the contexts part of our active set  
+    if (!IsContextPartOfActiveContextTriggers(aNewContext))
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    
+    // Now create the Perceived Context Event with newly detected context
+    Events::PerceivedContext::Type perceivedEvent;
+
+    perceivedEvent.sessionID = aSessionId;
+    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aNewContext.data(), aNewContext.size()));
+    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
+
+    VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
+                        CHIP_ERROR_INTERNAL,
+                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+                        
+    // Add the new context triggers to our current set for the session
+    it->AddTrackedContext(aNewContext);
+    
+    return CHIP_NO_ERROR;
+}
+    
+CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext, 
+    ServerClusterContext * aContext)
+{
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Make sure the provided session ID is one we know about
+    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
+        return session.GetSessionId() == aSessionId;
+    });
+
+    // Check if the element was actually found
+    if (it == mActiveSessions.end()) {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    
+    for (const auto& context : aOldContext)
+    {   
+        // Make sure the context actually exists in the session 
+        auto context_it = std::find_if(it->GetTrackedContexts().begin(), it->GetTrackedContexts().end(), [context](const Structs::TrackedContext::Type& mContext) {
+            return ((context.identifiedContext.namespaceID == mContext.identifiedContext.namespaceID) &&
+                    (context.identifiedContext.tag == mContext.identifiedContext.tag));
+        });
+
+        // Check if the element was actually found
+        if (context_it == it->GetTrackedContexts().end()) {
+            return CHIP_ERROR_NOT_FOUND;
+        }
+    }   
+    
+    // Remove the old context triggers from our current set for the session
+    it->RemoveTrackedContext(aOldContext);
+    
+    // Now create the Perceived Context Event with newly removed context
+    Events::PerceivedContext::Type perceivedEvent;
+
+    perceivedEvent.sessionID = aSessionId;
+    perceivedEvent.currentIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(it->GetTrackedContexts().data(), it->GetTrackedContexts().size()));
+    perceivedEvent.expiredContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aOldContext.data(), aOldContext.size()));
+
+    VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(perceivedEvent, mEndpointId).has_value(),
+                        CHIP_ERROR_INTERNAL,
+                        ChipLogError(Zcl, "Unable to generate PerceivedContext event"));
+    
+    return CHIP_NO_ERROR;
+}
+   
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext)
+{
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Make sure the provided session ID is one we know about
+    auto it = std::find_if(mActiveSessions.begin(), mActiveSessions.end(), [aSessionId](const ActiveAmbientContextSession& session) {
+        return session.GetSessionId() == aSessionId;
+    });
+
+    // Check if the element was actually found
+    if (it == mActiveSessions.end()) {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    
+    // Now create the End Session Event
+    Events::AnalysisSessionEnd::Type endSessionEvent;
+    endSessionEvent.sessionID = aSessionId;
+
+    VerifyOrReturnError(aContext->interactionContext.eventsGenerator.GenerateEvent(endSessionEvent, mEndpointId).has_value(),
+                        CHIP_ERROR_INTERNAL,
+                        ChipLogError(Zcl, "Unable to generate EndSession event"));
+
+    // Remove the session from our active contexts
+    it = mActiveSessions.erase(it);
+    
+    return CHIP_NO_ERROR;
+}
+
+bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(std::vector<AvAnalysis::Structs::TrackedContext::Type> aContext)
+{
+    // Are the contexts part of our active set
+    bool notFound = false;
+    for (const auto& contextTrigger : aContext)
+    {
+        auto trigger_it = std::find_if(mActiveAmbientContextTriggers.begin(), mActiveAmbientContextTriggers.end(),
             [&contextTrigger](AmbientContextStorage & acs) {
                 return acs.GetContext().namespaceID == contextTrigger.identifiedContext.namespaceID &&
                     acs.GetContext().tag == contextTrigger.identifiedContext.tag;
         });
 
-        if (it == mActiveAmbientContextTriggers.end())
+        if (trigger_it == mActiveAmbientContextTriggers.end())
         {
             notFound = true;
             break;
@@ -771,57 +954,9 @@ CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, Da
     
     if (notFound)
     {
-        return CHIP_ERROR_NOT_FOUND;
+        return false;
     }
-            
-    // Get our current session ID, and increment for next use
-    aSessionId = mNextAnalysisSessionID++;
-    
-    // Capture our new active session information
-    AvAnalysis::ActiveAmbientContextSession newSession;
-    newSession.SetSessionId(aSessionId);
-    
-    // Create the Initial Event
-    Events::AnalysisSessionStart::Type startEvent;
-    EventNumber startEventNumber;
-
-    startEvent.sessionID = aSessionId;
-    startEvent.triggeredZones = DataModel::MakeNullable(DataModel::List<const uint16_t>(aZoneList.Value().data(), aZoneList.Value().size()));
-
-    CHIP_ERROR err = LogEvent(startEvent, mEndpointId, startEventNumber);
-    if (CHIP_NO_ERROR != err)
-    {
-        ChipLogError(Zcl, "Unable to generate AnalysisSessionStart event");
-    }
-    
-    // Now create the first Perceived Context Event with the tiggering context
-    Events::PerceivedContext::Type perceivedEvent;
-    EventNumber perceivedEventNumber;
-
-    perceivedEvent.sessionID = aSessionId;
-    perceivedEvent.newIdentifiedContexts = chip::MakeOptional(DataModel::List<const Structs::TrackedContext::Type>(aTriggeringContext.data(), aTriggeringContext.size()));
-
-    err = LogEvent(perceivedEvent, mEndpointId, perceivedEventNumber);
-    if (CHIP_NO_ERROR != err)
-    {
-        ChipLogError(Zcl, "Unable to generate PerceivedContext event");
-    }
-    return CHIP_NO_ERROR;
-}
-    
-CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext)
-{
-    return CHIP_NO_ERROR;
-}
-    
-CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext)
-{
-    return CHIP_NO_ERROR;
-}
-   
-CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId)
-{
-    return CHIP_NO_ERROR;
+    return true;
 }
 
 } // namespace Clusters

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -954,7 +954,6 @@ bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(
     const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aContext)
 {
     // Are the contexts part of our active set
-    bool notFound = false;
     for (const auto & contextTrigger : aContext)
     {
         auto trigger_it = std::find_if(mActiveAmbientContextTriggers.begin(), mActiveAmbientContextTriggers.end(),
@@ -965,15 +964,10 @@ bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(
 
         if (trigger_it == mActiveAmbientContextTriggers.end())
         {
-            notFound = true;
-            break;
+            return false;
         }
     }
 
-    if (notFound)
-    {
-        return false;
-    }
     return true;
 }
 

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -50,6 +50,7 @@ AvAnalysisServerLogic::~AvAnalysisServerLogic() {}
 
 CHIP_ERROR AvAnalysisServerLogic::Startup(AttributePersistenceProvider & aAttributePersistenceProvider)
 {
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mAttributePersistenceProvider = &aAttributePersistenceProvider;
 
     // Make sure mandated Features are set, one and only one of Local or Remote has to be set
@@ -65,6 +66,8 @@ CHIP_ERROR AvAnalysisServerLogic::Startup(AttributePersistenceProvider & aAttrib
                         ChipLogError(Zcl, "AvAnalysis: If Per Zone Sensitivity is set, Zones must be present, and vice versa"));
 
     LoadPersistentAttributes();
+
+    ChipLogProgress(Zcl, "AvAnalysis Cluster: Startup completed ");
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.cpp
@@ -742,7 +742,8 @@ bool AvAnalysisServerLogic::ZoneIDListContains(const DataModel::DecodableList<ui
     return false;
 }
 
-CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, const DataModel::Nullable<std::vector<uint16_t>>& aZoneList,
+CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId,
+                                                       const DataModel::Nullable<std::vector<uint16_t>> & aZoneList,
                                                        ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -784,7 +785,8 @@ CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionStart(uint16_t & aSessionId, co
 }
 
 CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(
-    uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext, ServerClusterContext * aContext)
+    uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aTriggeringContext,
+    ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -821,7 +823,7 @@ CHIP_ERROR AvAnalysisServerLogic::InitialTriggeringContextDetected(
 }
 
 CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId,
-                                                     const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext,
+                                                     const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aNewContext,
                                                      ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -861,9 +863,10 @@ CHIP_ERROR AvAnalysisServerLogic::NewContextDetected(uint16_t aSessionId,
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId,
-                                                          const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext,
-                                                          ServerClusterContext * aContext)
+CHIP_ERROR
+AvAnalysisServerLogic::ContextNoLongerDetected(uint16_t aSessionId,
+                                               const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aOldContext,
+                                               ServerClusterContext * aContext)
 {
     VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -941,7 +944,8 @@ CHIP_ERROR AvAnalysisServerLogic::AnalysisSessionEnd(uint16_t aSessionId, Server
     return CHIP_NO_ERROR;
 }
 
-bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aContext)
+bool AvAnalysisServerLogic::IsContextPartOfActiveContextTriggers(
+    const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aContext)
 {
     // Are the contexts part of our active set
     bool notFound = false;

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
@@ -128,16 +128,21 @@ public:
     std::optional<DataModel::ActionReturnStatus>
     HandleRemoveAnalysisStream(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                                const AvAnalysis::Commands::RemoveAnalysisStream::DecodableType & commandData);
-                               
+
     // Active context tracking and events
-    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, ServerClusterContext * aContext);
-        
-    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext, ServerClusterContext * aContext);
-    
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext, ServerClusterContext * aContext);
-    
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext, ServerClusterContext * aContext);
-    
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList,
+                                    ServerClusterContext * aContext);
+
+    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
+                                                std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext,
+                                                ServerClusterContext * aContext);
+
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
+                                  ServerClusterContext * aContext);
+
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext,
+                                       ServerClusterContext * aContext);
+
     CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext);
 
 private:

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
@@ -130,17 +130,17 @@ public:
                                const AvAnalysis::Commands::RemoveAnalysisStream::DecodableType & commandData);
 
     // Active context tracking and events
-    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList,
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, const DataModel::Nullable<std::vector<uint16_t>>& aZoneList,
                                     ServerClusterContext * aContext);
 
     CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext,
+                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext,
                                                 ServerClusterContext * aContext);
 
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext,
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext,
                                   ServerClusterContext * aContext);
 
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext,
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext,
                                        ServerClusterContext * aContext);
 
     CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext);
@@ -172,7 +172,7 @@ private:
      * Command and event handler helper methods
      */
     bool ZoneIDListContains(const DataModel::DecodableList<uint16_t> list, uint16_t value);
-    bool IsContextPartOfActiveContextTriggers(std::vector<AvAnalysis::Structs::TrackedContext::Type> aContext);
+    bool IsContextPartOfActiveContextTriggers(const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aContext);
 
     /**
      * Helper functions to handle persistent data and the KVS.

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
@@ -26,6 +26,7 @@
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/persistence/AttributePersistenceProvider.h>
+#include <app/server-cluster/DefaultServerCluster.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -129,14 +130,15 @@ public:
                                const AvAnalysis::Commands::RemoveAnalysisStream::DecodableType & commandData);
                                
     // Active context tracking and events
-    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
-        std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, ServerClusterContext * aContext);
+        
+    CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext, ServerClusterContext * aContext);
     
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext, ServerClusterContext * aContext);
     
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext, ServerClusterContext * aContext);
     
-    CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId);
+    CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext);
 
 private:
     AvAnalysisDelegate * mDelegate                               = nullptr;
@@ -162,9 +164,10 @@ private:
                                       const AvAnalysis::Commands::EnableContextTriggers::DecodableType & commandData);
 
     /*
-     * Command handler helper methods
+     * Command and event handler helper methods
      */
     bool ZoneIDListContains(const DataModel::DecodableList<uint16_t> list, uint16_t value);
+    bool IsContextPartOfActiveContextTriggers(std::vector<AvAnalysis::Structs::TrackedContext::Type> aContext);
 
     /**
      * Helper functions to handle persistent data and the KVS.

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
@@ -130,17 +130,18 @@ public:
                                const AvAnalysis::Commands::RemoveAnalysisStream::DecodableType & commandData);
 
     // Active context tracking and events
-    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, const DataModel::Nullable<std::vector<uint16_t>>& aZoneList,
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, const DataModel::Nullable<std::vector<uint16_t>> & aZoneList,
                                     ServerClusterContext * aContext);
 
     CHIP_ERROR InitialTriggeringContextDetected(uint16_t aSessionId,
-                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aTriggeringContext,
+                                                const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aTriggeringContext,
                                                 ServerClusterContext * aContext);
 
-    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aNewContext,
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aNewContext,
                                   ServerClusterContext * aContext);
 
-    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aOldContext,
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId,
+                                       const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aOldContext,
                                        ServerClusterContext * aContext);
 
     CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId, ServerClusterContext * aContext);
@@ -172,7 +173,7 @@ private:
      * Command and event handler helper methods
      */
     bool ZoneIDListContains(const DataModel::DecodableList<uint16_t> list, uint16_t value);
-    bool IsContextPartOfActiveContextTriggers(const std::vector<AvAnalysis::Structs::TrackedContext::Type>& aContext);
+    bool IsContextPartOfActiveContextTriggers(const std::vector<AvAnalysis::Structs::TrackedContext::Type> & aContext);
 
     /**
      * Helper functions to handle persistent data and the KVS.

--- a/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisLogic.h
@@ -127,10 +127,22 @@ public:
     std::optional<DataModel::ActionReturnStatus>
     HandleRemoveAnalysisStream(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                                const AvAnalysis::Commands::RemoveAnalysisStream::DecodableType & commandData);
+                               
+    // Active context tracking and events
+    CHIP_ERROR AnalysisSessionStart(uint16_t & aSessionId, DataModel::Nullable<std::vector<uint16_t>> aZoneList, 
+        std::vector<AvAnalysis::Structs::TrackedContext::Type> aTriggeringContext);
+    
+    CHIP_ERROR NewContextDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aNewContext);
+    
+    CHIP_ERROR ContextNoLongerDetected(uint16_t aSessionId, std::vector<AvAnalysis::Structs::TrackedContext::Type> aOldContext);
+    
+    CHIP_ERROR AnalysisSessionEnd(uint16_t aSessionId);
 
 private:
     AvAnalysisDelegate * mDelegate                               = nullptr;
     AttributePersistenceProvider * mAttributePersistenceProvider = nullptr;
+    uint16_t mNextAnalysisSessionID                              = 0;
+    std::vector<AvAnalysis::ActiveAmbientContextSession> mActiveSessions;
 
     MarkDirtyCallback mMarkDirtyCallback;
 

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -20,6 +20,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <vector>
+#include <unordered_set>
 
 namespace chip {
 namespace app {
@@ -133,12 +134,37 @@ struct ActiveAmbientContextSession
 {
 private:
     uint16_t mSessionId;
+    std::vector<Structs::TrackedContext::Type> mTrackedContexts;
     
 public:
     virtual ~ActiveAmbientContextSession() = default;
     ActiveAmbientContextSession() {}
-    
+        
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
+    uint16_t GetSessionId() const { return mSessionId; }
+    
+    void AddTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
+    {
+        // Update the current set of tracked contexts with those newly provided
+        //
+        mTrackedContexts.insert(mTrackedContexts.end(), aTrackedContext.begin(), aTrackedContext.end());        
+    }
+    
+    void RemoveTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
+    {
+        // Remove the provided contexts from our current set     
+        std::erase_if(mTrackedContexts, [&](const Structs::TrackedContext::Type& context1) {
+            for (const auto& context2 : aTrackedContext) {
+                if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID && 
+                    context1.identifiedContext.tag == context2.identifiedContext.tag) {
+                    return true; // Match found, remove it
+                }
+            }
+            return false;
+        });
+    }
+    
+    const std::vector<Structs::TrackedContext::Type>& GetTrackedContexts() const { return mTrackedContexts; }
 };
 
 } // namespace AvAnalysis

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -18,10 +18,10 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <algorithm>
-#include <vector>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <unordered_set>
+#include <vector>
 
 namespace chip {
 namespace app {
@@ -154,18 +154,20 @@ public:
     void RemoveTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
     {
         // Remove the provided contexts from our current set
-        mTrackedContexts.erase(
-            std::remove_if(mTrackedContexts.begin(), mTrackedContexts.end(),
-                [&](const Structs::TrackedContext::Type & context1) {
-                    for (const auto & context2 : aTrackedContext) {
-                        if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID &&
-                            context1.identifiedContext.tag == context2.identifiedContext.tag) {
-                            return true; // Match found, remove it
-                        }
-                    }
-                    return false;
-                }),
-            mTrackedContexts.end());
+        mTrackedContexts.erase(std::remove_if(mTrackedContexts.begin(), mTrackedContexts.end(),
+                                              [&](const Structs::TrackedContext::Type & context1) {
+                                                  for (const auto & context2 : aTrackedContext)
+                                                  {
+                                                      if (context1.identifiedContext.namespaceID ==
+                                                              context2.identifiedContext.namespaceID &&
+                                                          context1.identifiedContext.tag == context2.identifiedContext.tag)
+                                                      {
+                                                          return true; // Match found, remove it
+                                                      }
+                                                  }
+                                                  return false;
+                                              }),
+                               mTrackedContexts.end());
     }
 
     const std::vector<Structs::TrackedContext::Type> & GetTrackedContexts() const { return mTrackedContexts; }

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -144,14 +144,14 @@ public:
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
     uint16_t GetSessionId() const { return mSessionId; }
 
-    void AddTrackedContext(const std::vector<Structs::TrackedContext::Type>& aTrackedContext)
+    void AddTrackedContext(const std::vector<Structs::TrackedContext::Type> & aTrackedContext)
     {
         // Update the current set of tracked contexts with those newly provided
         //
         mTrackedContexts.insert(mTrackedContexts.end(), aTrackedContext.begin(), aTrackedContext.end());
     }
 
-    void RemoveTrackedContext(const std::vector<Structs::TrackedContext::Type>& aTrackedContext)
+    void RemoveTrackedContext(const std::vector<Structs::TrackedContext::Type> & aTrackedContext)
     {
         // Remove the provided contexts from our current set
         mTrackedContexts.erase(std::remove_if(mTrackedContexts.begin(), mTrackedContexts.end(),

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <algorithm>
 #include <vector>
 #include <unordered_set>
 
@@ -152,16 +153,19 @@ public:
     
     void RemoveTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
     {
-        // Remove the provided contexts from our current set     
-        std::erase_if(mTrackedContexts, [&](const Structs::TrackedContext::Type& context1) {
-            for (const auto& context2 : aTrackedContext) {
-                if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID && 
-                    context1.identifiedContext.tag == context2.identifiedContext.tag) {
-                    return true; // Match found, remove it
-                }
-            }
-            return false;
-        });
+        // Remove the provided contexts from our current set
+        mTrackedContexts.erase(
+            std::remove_if(mTrackedContexts.begin(), mTrackedContexts.end(),
+                [&](const Structs::TrackedContext::Type & context1) {
+                    for (const auto & context2 : aTrackedContext) {
+                        if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID &&
+                            context1.identifiedContext.tag == context2.identifiedContext.tag) {
+                            return true; // Match found, remove it
+                        }
+                    }
+                    return false;
+                }),
+            mTrackedContexts.end());
     }
     
     const std::vector<Structs::TrackedContext::Type>& GetTrackedContexts() const { return mTrackedContexts; }

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -134,12 +134,12 @@ public:
 struct ActiveAmbientContextSession
 {
 private:
-    uint16_t mSessionId;
+    uint16_t mSessionId = 0;
     std::vector<Structs::TrackedContext::Type> mTrackedContexts;
 
 public:
     virtual ~ActiveAmbientContextSession() = default;
-    ActiveAmbientContextSession() {}
+    ActiveAmbientContextSession() = default;
 
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
     uint16_t GetSessionId() const { return mSessionId; }

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -139,7 +139,7 @@ private:
 
 public:
     virtual ~ActiveAmbientContextSession() = default;
-    ActiveAmbientContextSession() = default;
+    ActiveAmbientContextSession()          = default;
 
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
     uint16_t GetSessionId() const { return mSessionId; }

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -129,6 +129,18 @@ public:
     void SetZoneIDs(chip::Optional<DataModel::Nullable<std::vector<uint16_t>>> aZoneIDs) { mZoneIDs = aZoneIDs; }
 };
 
+struct ActiveAmbientContextSession 
+{
+private:
+    uint16_t mSessionId;
+    
+public:
+    virtual ~ActiveAmbientContextSession() = default;
+    ActiveAmbientContextSession() {}
+    
+    void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
+};
+
 } // namespace AvAnalysis
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -144,14 +144,14 @@ public:
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
     uint16_t GetSessionId() const { return mSessionId; }
 
-    void AddTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
+    void AddTrackedContext(const std::vector<Structs::TrackedContext::Type>& aTrackedContext)
     {
         // Update the current set of tracked contexts with those newly provided
         //
         mTrackedContexts.insert(mTrackedContexts.end(), aTrackedContext.begin(), aTrackedContext.end());
     }
 
-    void RemoveTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
+    void RemoveTrackedContext(const std::vector<Structs::TrackedContext::Type>& aTrackedContext)
     {
         // Remove the provided contexts from our current set
         mTrackedContexts.erase(std::remove_if(mTrackedContexts.begin(), mTrackedContexts.end(),

--- a/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
+++ b/src/app/clusters/av-analysis-server/AvAnalysisStorage.h
@@ -19,8 +19,8 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 namespace chip {
 namespace app {
@@ -130,41 +130,43 @@ public:
     void SetZoneIDs(chip::Optional<DataModel::Nullable<std::vector<uint16_t>>> aZoneIDs) { mZoneIDs = aZoneIDs; }
 };
 
-struct ActiveAmbientContextSession 
+struct ActiveAmbientContextSession
 {
 private:
     uint16_t mSessionId;
     std::vector<Structs::TrackedContext::Type> mTrackedContexts;
-    
+
 public:
     virtual ~ActiveAmbientContextSession() = default;
     ActiveAmbientContextSession() {}
-        
+
     void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
     uint16_t GetSessionId() const { return mSessionId; }
-    
+
     void AddTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
     {
         // Update the current set of tracked contexts with those newly provided
         //
-        mTrackedContexts.insert(mTrackedContexts.end(), aTrackedContext.begin(), aTrackedContext.end());        
+        mTrackedContexts.insert(mTrackedContexts.end(), aTrackedContext.begin(), aTrackedContext.end());
     }
-    
+
     void RemoveTrackedContext(std::vector<Structs::TrackedContext::Type> aTrackedContext)
     {
-        // Remove the provided contexts from our current set     
-        std::erase_if(mTrackedContexts, [&](const Structs::TrackedContext::Type& context1) {
-            for (const auto& context2 : aTrackedContext) {
-                if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID && 
-                    context1.identifiedContext.tag == context2.identifiedContext.tag) {
+        // Remove the provided contexts from our current set
+        std::erase_if(mTrackedContexts, [&](const Structs::TrackedContext::Type & context1) {
+            for (const auto & context2 : aTrackedContext)
+            {
+                if (context1.identifiedContext.namespaceID == context2.identifiedContext.namespaceID &&
+                    context1.identifiedContext.tag == context2.identifiedContext.tag)
+                {
                     return true; // Match found, remove it
                 }
             }
             return false;
         });
     }
-    
-    const std::vector<Structs::TrackedContext::Type>& GetTrackedContexts() const { return mTrackedContexts; }
+
+    const std::vector<Structs::TrackedContext::Type> & GetTrackedContexts() const { return mTrackedContexts; }
 };
 
 } // namespace AvAnalysis

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -72,18 +72,18 @@ const std::vector<app::Clusters::Descriptor::Structs::SemanticTagStruct::Type> t
 // Define the test tracked contexts for the event framework
 const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> testTrackedContext = {
     { .identifiedContextID = 0,
-      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x49), .tag = static_cast<uint8_t>(0x0B)},
+      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x49), .tag = static_cast<uint8_t>(0x0B) },
       .startTime           = 0,
       .endTime             = DataModel::NullNullable }
 };
 
 const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> testAdditionalTrackedContext = {
     { .identifiedContextID = 0,
-      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x4B), .tag = static_cast<uint8_t>(0x09)},
+      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x4B), .tag = static_cast<uint8_t>(0x09) },
       .startTime           = 0,
       .endTime             = DataModel::NullNullable }
 };
-    
+
 const std::vector<uint16_t> testZoneIDList = { static_cast<uint16_t>(0x01), static_cast<uint16_t>(0x02),
                                                static_cast<uint16_t>(0x03), static_cast<uint16_t>(0x04) };
 
@@ -865,12 +865,13 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     {
         FAIL();
     }
-    
+
     // 1. Session Start Event
     uint16_t mSessionId;
 
-    ASSERT_EQ(mServer.GetLogic().AnalysisSessionStart(mSessionId, DataModel::NullNullable, &mClusterTester.GetServerClusterContext()),
-              CHIP_NO_ERROR);
+    ASSERT_EQ(
+        mServer.GetLogic().AnalysisSessionStart(mSessionId, DataModel::NullNullable, &mClusterTester.GetServerClusterContext()),
+        CHIP_NO_ERROR);
     auto analysisStartEvent = mClusterTester.GetNextGeneratedEvent();
     if (!analysisStartEvent.has_value())
     {
@@ -885,37 +886,40 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
         FAIL() << "Expected Zones to be Null";
         return;
     }
-    
+
     // 2a. Initial Perceived Context Event - Invalid Session ID
     uint16_t invalidSessionID = 99;
-    ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(invalidSessionID, testTrackedContext, &mClusterTester.GetServerClusterContext()),
+    ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(invalidSessionID, testTrackedContext,
+                                                                  &mClusterTester.GetServerClusterContext()),
               CHIP_ERROR_NOT_FOUND);
-              
+
     // 2b. Initial Perceived Context Event
-     ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(mSessionId, testTrackedContext, &mClusterTester.GetServerClusterContext()),
-              CHIP_NO_ERROR);   
+    ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(mSessionId, testTrackedContext,
+                                                                  &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);
     auto perceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
     if (!perceivedContextEvent.has_value())
     {
         FAIL() << "Expected perceivedContextEvent to have a value";
         return;
     }
-    
+
     Events::PerceivedContext::DecodableType perceivedContextData;
     ASSERT_EQ(perceivedContextEvent->GetEventData(perceivedContextData), CHIP_NO_ERROR);
     ASSERT_EQ(perceivedContextData.sessionID, 0);
-    
+
     // Verify that the event contains only a new identified context, and that it has one value.
     ASSERT_TRUE(perceivedContextData.newIdentifiedContexts.HasValue());
     ASSERT_FALSE(perceivedContextData.currentIdentifiedContexts.HasValue());
     ASSERT_FALSE(perceivedContextData.expiredContexts.HasValue());
 
     // Starting with element count, should be one
-    size_t count;                                                                                                                                                                       
-    CHIP_ERROR err = perceivedContextData.newIdentifiedContexts.Value().ComputeSize(&count);                                                                                                                                 
-    if (err != CHIP_NO_ERROR) {       
-        FAIL() << "Error in computing the size of the elements in a PerceivedContext Event";                                                                                                                                                                                                                                            
-    }  
+    size_t count;
+    CHIP_ERROR err = perceivedContextData.newIdentifiedContexts.Value().ComputeSize(&count);
+    if (err != CHIP_NO_ERROR)
+    {
+        FAIL() << "Error in computing the size of the elements in a PerceivedContext Event";
+    }
     ASSERT_EQ(count, static_cast<size_t>(1));
 
     // Ensure the identifiedContext matches the test context
@@ -929,31 +933,33 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     }
 
     // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value
-    bool are_equal =
-        std::equal(testTrackedContext.begin(), testTrackedContext.end(), initialEventContexts.begin(), initialEventContexts.end(),
-                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
-                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    bool are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), initialEventContexts.begin(),
+                                initialEventContexts.end(), [](const auto & tc1, const auto & tc2) {
+                                    return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                        tc1.identifiedContext.tag == tc2.identifiedContext.tag;
+                                });
     ASSERT_TRUE(are_equal);
-    
-    // 3. Updated context 
-    ASSERT_EQ(mServer.GetLogic().NewContextDetected(mSessionId, testAdditionalTrackedContext, &mClusterTester.GetServerClusterContext()),
-              CHIP_NO_ERROR);   
+
+    // 3. Updated context
+    ASSERT_EQ(
+        mServer.GetLogic().NewContextDetected(mSessionId, testAdditionalTrackedContext, &mClusterTester.GetServerClusterContext()),
+        CHIP_NO_ERROR);
     auto secondPerceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
     if (!secondPerceivedContextEvent.has_value())
     {
         FAIL() << "Expected perceivedContextEvent to have a value";
         return;
     }
-    
+
     Events::PerceivedContext::DecodableType secondPerceivedContextData;
     ASSERT_EQ(secondPerceivedContextEvent->GetEventData(secondPerceivedContextData), CHIP_NO_ERROR);
-    ASSERT_EQ(secondPerceivedContextData.sessionID, 0);    
-    
+    ASSERT_EQ(secondPerceivedContextData.sessionID, 0);
+
     // Verify that the event contains a new and current identified context only
     ASSERT_TRUE(secondPerceivedContextData.newIdentifiedContexts.HasValue());
     ASSERT_TRUE(secondPerceivedContextData.currentIdentifiedContexts.HasValue());
     ASSERT_FALSE(secondPerceivedContextData.expiredContexts.HasValue());
-    
+
     // Ensure the new and current identifiedContexts matches the test contexts
     // Create vectors of the values for the new values and the current values then compare
     std::vector<Structs::TrackedContext::Type> currentEventContexts;
@@ -962,48 +968,50 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     {
         currentEventContexts.push_back(aCurrentContextIterator.GetValue());
     }
-    
+
     std::vector<Structs::TrackedContext::Type> newEventContexts;
     auto aNewContextIterator = secondPerceivedContextData.newIdentifiedContexts.Value().begin();
     while (aNewContextIterator.Next())
     {
         newEventContexts.push_back(aNewContextIterator.GetValue());
     }
-    
+
     // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value for the two
     // event fields
-    are_equal =
-        std::equal(testTrackedContext.begin(), testTrackedContext.end(), currentEventContexts.begin(), currentEventContexts.end(),
-                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
-                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), currentEventContexts.begin(),
+                           currentEventContexts.end(), [](const auto & tc1, const auto & tc2) {
+                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                   tc1.identifiedContext.tag == tc2.identifiedContext.tag;
+                           });
     ASSERT_TRUE(are_equal);
-    
-    are_equal =
-        std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), newEventContexts.begin(), newEventContexts.end(),
-                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
-                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+
+    are_equal = std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), newEventContexts.begin(),
+                           newEventContexts.end(), [](const auto & tc1, const auto & tc2) {
+                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                   tc1.identifiedContext.tag == tc2.identifiedContext.tag;
+                           });
     ASSERT_TRUE(are_equal);
-        
+
     // 4. Deleted Context
     ASSERT_EQ(mServer.GetLogic().ContextNoLongerDetected(mSessionId, testTrackedContext, &mClusterTester.GetServerClusterContext()),
-              CHIP_NO_ERROR);   
-              
+              CHIP_NO_ERROR);
+
     auto thirdPerceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
     if (!thirdPerceivedContextEvent.has_value())
     {
         FAIL() << "Expected perceivedContextEvent to have a value";
         return;
     }
-    
+
     Events::PerceivedContext::DecodableType thirdPerceivedContextData;
     ASSERT_EQ(thirdPerceivedContextEvent->GetEventData(thirdPerceivedContextData), CHIP_NO_ERROR);
-    ASSERT_EQ(thirdPerceivedContextData.sessionID, 0);    
-    
+    ASSERT_EQ(thirdPerceivedContextData.sessionID, 0);
+
     // Verify that the event contains a current and expired identified context only
     ASSERT_FALSE(thirdPerceivedContextData.newIdentifiedContexts.HasValue());
     ASSERT_TRUE(thirdPerceivedContextData.currentIdentifiedContexts.HasValue());
     ASSERT_TRUE(thirdPerceivedContextData.expiredContexts.HasValue());
-    
+
     // Ensure the expired and current identifiedContexts matches the test contexts
     // Create vectors of the values for the new values and the current values then compare
     currentEventContexts.clear();
@@ -1012,42 +1020,43 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     {
         currentEventContexts.push_back(aCurrentContextIterator.GetValue());
     }
-    
+
     std::vector<Structs::TrackedContext::Type> expiredEventContexts;
     auto aExpiredContextIterator = thirdPerceivedContextData.expiredContexts.Value().begin();
     while (aExpiredContextIterator.Next())
     {
         expiredEventContexts.push_back(aExpiredContextIterator.GetValue());
-    }    
+    }
 
     // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value for the two
     // event fields
-    are_equal =
-        std::equal(testTrackedContext.begin(), testTrackedContext.end(), expiredEventContexts.begin(), expiredEventContexts.end(),
-                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
-                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), expiredEventContexts.begin(),
+                           expiredEventContexts.end(), [](const auto & tc1, const auto & tc2) {
+                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                   tc1.identifiedContext.tag == tc2.identifiedContext.tag;
+                           });
     ASSERT_TRUE(are_equal);
-    
-    are_equal =
-        std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), currentEventContexts.begin(), currentEventContexts.end(),
-                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
-                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+
+    are_equal = std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), currentEventContexts.begin(),
+                           currentEventContexts.end(), [](const auto & tc1, const auto & tc2) {
+                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                   tc1.identifiedContext.tag == tc2.identifiedContext.tag;
+                           });
     ASSERT_TRUE(are_equal);
-    
+
     // 5. End Session
-    ASSERT_EQ(mServer.GetLogic().AnalysisSessionEnd(mSessionId, &mClusterTester.GetServerClusterContext()),
-              CHIP_NO_ERROR);   
-              
+    ASSERT_EQ(mServer.GetLogic().AnalysisSessionEnd(mSessionId, &mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
+
     auto endSessionEvent = mClusterTester.GetNextGeneratedEvent();
     if (!endSessionEvent.has_value())
     {
         FAIL() << "Expected endSessionEvent to have a value";
         return;
     }
-    
+
     Events::AnalysisSessionEnd::DecodableType endSessionData;
     ASSERT_EQ(endSessionEvent->GetEventData(endSessionData), CHIP_NO_ERROR);
-    ASSERT_EQ(endSessionData.sessionID, 0);        
+    ASSERT_EQ(endSessionData.sessionID, 0);
 }
 
 } // namespace

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -109,7 +109,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t> & aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -1062,12 +1062,11 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     Events::AnalysisSessionEnd::DecodableType endSessionData;
     ASSERT_EQ(endSessionEvent->GetEventData(endSessionData), CHIP_NO_ERROR);
     ASSERT_EQ(endSessionData.sessionID, mSessionId);
-    
+
     // 6. Verify that the session is no longer available, a new context should fail with the no longer valid session id
     ASSERT_EQ(
         mServer.GetLogic().NewContextDetected(mSessionId, testAdditionalTrackedContext, &mClusterTester.GetServerClusterContext()),
         CHIP_ERROR_NOT_FOUND);
-
 }
 
 } // namespace

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -78,7 +78,7 @@ const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> test
 };
 
 const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> testAdditionalTrackedContext = {
-    { .identifiedContextID = 0,
+    { .identifiedContextID = 1,
       .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x4B), .tag = static_cast<uint8_t>(0x09) },
       .startTime           = 0,
       .endTime             = DataModel::NullNullable }
@@ -109,7 +109,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -880,7 +880,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     }
     Events::AnalysisSessionStart::DecodableType startData;
     ASSERT_EQ(analysisStartEvent->GetEventData(startData), CHIP_NO_ERROR);
-    ASSERT_EQ(startData.sessionID, 0);
+    ASSERT_EQ(startData.sessionID, mSessionId);
     if (!startData.triggeredZones.IsNull())
     {
         FAIL() << "Expected Zones to be Null";
@@ -906,7 +906,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
 
     Events::PerceivedContext::DecodableType perceivedContextData;
     ASSERT_EQ(perceivedContextEvent->GetEventData(perceivedContextData), CHIP_NO_ERROR);
-    ASSERT_EQ(perceivedContextData.sessionID, 0);
+    ASSERT_EQ(perceivedContextData.sessionID, mSessionId);
 
     // Verify that the event contains only a new identified context, and that it has one value.
     ASSERT_TRUE(perceivedContextData.newIdentifiedContexts.HasValue());
@@ -935,7 +935,8 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value
     bool are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), initialEventContexts.begin(),
                                 initialEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                                    return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                                    return tc1.identifiedContextID == tc2.identifiedContextID &&
+                                        tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                         tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                                 });
     ASSERT_TRUE(are_equal);
@@ -953,7 +954,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
 
     Events::PerceivedContext::DecodableType secondPerceivedContextData;
     ASSERT_EQ(secondPerceivedContextEvent->GetEventData(secondPerceivedContextData), CHIP_NO_ERROR);
-    ASSERT_EQ(secondPerceivedContextData.sessionID, 0);
+    ASSERT_EQ(secondPerceivedContextData.sessionID, mSessionId);
 
     // Verify that the event contains a new and current identified context only
     ASSERT_TRUE(secondPerceivedContextData.newIdentifiedContexts.HasValue());
@@ -980,14 +981,16 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     // event fields
     are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), currentEventContexts.begin(),
                            currentEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                               return tc1.identifiedContextID == tc2.identifiedContextID &&
+                                   tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                    tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                            });
     ASSERT_TRUE(are_equal);
 
     are_equal = std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), newEventContexts.begin(),
                            newEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                               return tc1.identifiedContextID == tc2.identifiedContextID &&
+                                   tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                    tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                            });
     ASSERT_TRUE(are_equal);
@@ -1005,7 +1008,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
 
     Events::PerceivedContext::DecodableType thirdPerceivedContextData;
     ASSERT_EQ(thirdPerceivedContextEvent->GetEventData(thirdPerceivedContextData), CHIP_NO_ERROR);
-    ASSERT_EQ(thirdPerceivedContextData.sessionID, 0);
+    ASSERT_EQ(thirdPerceivedContextData.sessionID, mSessionId);
 
     // Verify that the event contains a current and expired identified context only
     ASSERT_FALSE(thirdPerceivedContextData.newIdentifiedContexts.HasValue());
@@ -1032,14 +1035,16 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     // event fields
     are_equal = std::equal(testTrackedContext.begin(), testTrackedContext.end(), expiredEventContexts.begin(),
                            expiredEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                               return tc1.identifiedContextID == tc2.identifiedContextID &&
+                                   tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                    tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                            });
     ASSERT_TRUE(are_equal);
 
     are_equal = std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), currentEventContexts.begin(),
                            currentEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                               return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
+                               return tc1.identifiedContextID == tc2.identifiedContextID && 
+                                   tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                    tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                            });
     ASSERT_TRUE(are_equal);
@@ -1056,7 +1061,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
 
     Events::AnalysisSessionEnd::DecodableType endSessionData;
     ASSERT_EQ(endSessionEvent->GetEventData(endSessionData), CHIP_NO_ERROR);
-    ASSERT_EQ(endSessionData.sessionID, 0);
+    ASSERT_EQ(endSessionData.sessionID, mSessionId);
 }
 
 } // namespace

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -69,6 +69,21 @@ const std::vector<app::Clusters::Descriptor::Structs::SemanticTagStruct::Type> t
       .label       = MakeOptional(chip::app::DataModel::Nullable<chip::CharSpan>("Sound.Snoring"_span)) }
 };
 
+// Define the test tracked contexts for the event framework
+const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> testTrackedContext = {
+    { .identifiedContextID = 0,
+      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x49), .tag = static_cast<uint8_t>(0x0B)},
+      .startTime           = 0,
+      .endTime             = DataModel::NullNullable }
+};
+
+const std::vector<app::Clusters::AvAnalysis::Structs::TrackedContext::Type> testAdditionalTrackedContext = {
+    { .identifiedContextID = 0,
+      .identifiedContext   = { .namespaceID = static_cast<uint8_t>(0x4B), .tag = static_cast<uint8_t>(0x09)},
+      .startTime           = 0,
+      .endTime             = DataModel::NullNullable }
+};
+    
 const std::vector<uint16_t> testZoneIDList = { static_cast<uint16_t>(0x01), static_cast<uint16_t>(0x02),
                                                static_cast<uint16_t>(0x03), static_cast<uint16_t>(0x04) };
 
@@ -94,7 +109,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(DataModel::DecodableList<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 
@@ -839,6 +854,200 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteDisableContextTriggersCommandTestRemov
     }
 
     ASSERT_EQ(testZoneIDRemainingList, zoneIDs);
+}
+
+TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
+{
+    Testing::MockCommandHandler commandHandler;
+    commandHandler.SetFabricIndex(1);
+
+    if (!EnableAllTestContexts())
+    {
+        FAIL();
+    }
+    
+    // 1. Session Start Event
+    uint16_t mSessionId;
+
+    ASSERT_EQ(mServer.GetLogic().AnalysisSessionStart(mSessionId, DataModel::NullNullable, &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);
+    auto analysisStartEvent = mClusterTester.GetNextGeneratedEvent();
+    if (!analysisStartEvent.has_value())
+    {
+        FAIL() << "Expected analysisStartEvent to have a value";
+        return;
+    }
+    Events::AnalysisSessionStart::DecodableType startData;
+    ASSERT_EQ(analysisStartEvent->GetEventData(startData), CHIP_NO_ERROR);
+    ASSERT_EQ(startData.sessionID, 0);
+    if (!startData.triggeredZones.IsNull())
+    {
+        FAIL() << "Expected Zones to be Null";
+        return;
+    }
+    
+    // 2a. Initial Perceived Context Event - Invalid Session ID
+    uint16_t invalidSessionID = 99;
+    ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(invalidSessionID, testTrackedContext, &mClusterTester.GetServerClusterContext()),
+              CHIP_ERROR_NOT_FOUND);
+              
+    // 2b. Initial Perceived Context Event
+     ASSERT_EQ(mServer.GetLogic().InitialTriggeringContextDetected(mSessionId, testTrackedContext, &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);   
+    auto perceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
+    if (!perceivedContextEvent.has_value())
+    {
+        FAIL() << "Expected perceivedContextEvent to have a value";
+        return;
+    }
+    
+    Events::PerceivedContext::DecodableType perceivedContextData;
+    ASSERT_EQ(perceivedContextEvent->GetEventData(perceivedContextData), CHIP_NO_ERROR);
+    ASSERT_EQ(perceivedContextData.sessionID, 0);
+    
+    // Verify that the event contains only a new identified context, and that it has one value.
+    ASSERT_TRUE(perceivedContextData.newIdentifiedContexts.HasValue());
+    ASSERT_FALSE(perceivedContextData.currentIdentifiedContexts.HasValue());
+    ASSERT_FALSE(perceivedContextData.expiredContexts.HasValue());
+
+    // Starting with element count, should be one
+    size_t count;                                                                                                                                                                       
+    CHIP_ERROR err = perceivedContextData.newIdentifiedContexts.Value().ComputeSize(&count);                                                                                                                                 
+    if (err != CHIP_NO_ERROR) {       
+        FAIL() << "Error in computing the size of the elements in a PerceivedContext Event";                                                                                                                                                                                                                                            
+    }  
+    ASSERT_EQ(count, static_cast<size_t>(1));
+
+    // Ensure the identifiedContext matches the test context
+    // Verify that the entries in the DecodableList match the entries used in construction of the instance by
+    // creating a vector of the values then comparing the two vectors
+    std::vector<Structs::TrackedContext::Type> initialEventContexts;
+    auto aInitialContextIterator = perceivedContextData.newIdentifiedContexts.Value().begin();
+    while (aInitialContextIterator.Next())
+    {
+        initialEventContexts.push_back(aInitialContextIterator.GetValue());
+    }
+
+    // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value
+    bool are_equal =
+        std::equal(testTrackedContext.begin(), testTrackedContext.end(), initialEventContexts.begin(), initialEventContexts.end(),
+                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
+                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    ASSERT_TRUE(are_equal);
+    
+    // 3. Updated context 
+    ASSERT_EQ(mServer.GetLogic().NewContextDetected(mSessionId, testAdditionalTrackedContext, &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);   
+    auto secondPerceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
+    if (!secondPerceivedContextEvent.has_value())
+    {
+        FAIL() << "Expected perceivedContextEvent to have a value";
+        return;
+    }
+    
+    Events::PerceivedContext::DecodableType secondPerceivedContextData;
+    ASSERT_EQ(secondPerceivedContextEvent->GetEventData(secondPerceivedContextData), CHIP_NO_ERROR);
+    ASSERT_EQ(secondPerceivedContextData.sessionID, 0);    
+    
+    // Verify that the event contains a new and current identified context only
+    ASSERT_TRUE(secondPerceivedContextData.newIdentifiedContexts.HasValue());
+    ASSERT_TRUE(secondPerceivedContextData.currentIdentifiedContexts.HasValue());
+    ASSERT_FALSE(secondPerceivedContextData.expiredContexts.HasValue());
+    
+    // Ensure the new and current identifiedContexts matches the test contexts
+    // Create vectors of the values for the new values and the current values then compare
+    std::vector<Structs::TrackedContext::Type> currentEventContexts;
+    auto aCurrentContextIterator = secondPerceivedContextData.currentIdentifiedContexts.Value().begin();
+    while (aCurrentContextIterator.Next())
+    {
+        currentEventContexts.push_back(aCurrentContextIterator.GetValue());
+    }
+    
+    std::vector<Structs::TrackedContext::Type> newEventContexts;
+    auto aNewContextIterator = secondPerceivedContextData.newIdentifiedContexts.Value().begin();
+    while (aNewContextIterator.Next())
+    {
+        newEventContexts.push_back(aNewContextIterator.GetValue());
+    }
+    
+    // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value for the two
+    // event fields
+    are_equal =
+        std::equal(testTrackedContext.begin(), testTrackedContext.end(), currentEventContexts.begin(), currentEventContexts.end(),
+                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
+                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    ASSERT_TRUE(are_equal);
+    
+    are_equal =
+        std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), newEventContexts.begin(), newEventContexts.end(),
+                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
+                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    ASSERT_TRUE(are_equal);
+        
+    // 4. Deleted Context
+    ASSERT_EQ(mServer.GetLogic().ContextNoLongerDetected(mSessionId, testTrackedContext, &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);   
+              
+    auto thirdPerceivedContextEvent = mClusterTester.GetNextGeneratedEvent();
+    if (!thirdPerceivedContextEvent.has_value())
+    {
+        FAIL() << "Expected perceivedContextEvent to have a value";
+        return;
+    }
+    
+    Events::PerceivedContext::DecodableType thirdPerceivedContextData;
+    ASSERT_EQ(thirdPerceivedContextEvent->GetEventData(thirdPerceivedContextData), CHIP_NO_ERROR);
+    ASSERT_EQ(thirdPerceivedContextData.sessionID, 0);    
+    
+    // Verify that the event contains a current and expired identified context only
+    ASSERT_FALSE(thirdPerceivedContextData.newIdentifiedContexts.HasValue());
+    ASSERT_TRUE(thirdPerceivedContextData.currentIdentifiedContexts.HasValue());
+    ASSERT_TRUE(thirdPerceivedContextData.expiredContexts.HasValue());
+    
+    // Ensure the expired and current identifiedContexts matches the test contexts
+    // Create vectors of the values for the new values and the current values then compare
+    currentEventContexts.clear();
+    aCurrentContextIterator = thirdPerceivedContextData.currentIdentifiedContexts.Value().begin();
+    while (aCurrentContextIterator.Next())
+    {
+        currentEventContexts.push_back(aCurrentContextIterator.GetValue());
+    }
+    
+    std::vector<Structs::TrackedContext::Type> expiredEventContexts;
+    auto aExpiredContextIterator = thirdPerceivedContextData.expiredContexts.Value().begin();
+    while (aExpiredContextIterator.Next())
+    {
+        expiredEventContexts.push_back(aExpiredContextIterator.GetValue());
+    }    
+
+    // No == exists for the Struct, and creating one fails due to the Struct structure, check value by value for the two
+    // event fields
+    are_equal =
+        std::equal(testTrackedContext.begin(), testTrackedContext.end(), expiredEventContexts.begin(), expiredEventContexts.end(),
+                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
+                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    ASSERT_TRUE(are_equal);
+    
+    are_equal =
+        std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), currentEventContexts.begin(), currentEventContexts.end(),
+                   [](const auto & tc1, const auto & tc2) { return tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID && 
+                                                            tc1.identifiedContext.tag == tc2.identifiedContext.tag; });
+    ASSERT_TRUE(are_equal);
+    
+    // 5. End Session
+    ASSERT_EQ(mServer.GetLogic().AnalysisSessionEnd(mSessionId, &mClusterTester.GetServerClusterContext()),
+              CHIP_NO_ERROR);   
+              
+    auto endSessionEvent = mClusterTester.GetNextGeneratedEvent();
+    if (!endSessionEvent.has_value())
+    {
+        FAIL() << "Expected endSessionEvent to have a value";
+        return;
+    }
+    
+    Events::AnalysisSessionEnd::DecodableType endSessionData;
+    ASSERT_EQ(endSessionEvent->GetEventData(endSessionData), CHIP_NO_ERROR);
+    ASSERT_EQ(endSessionData.sessionID, 0);        
 }
 
 } // namespace

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -1062,6 +1062,12 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
     Events::AnalysisSessionEnd::DecodableType endSessionData;
     ASSERT_EQ(endSessionEvent->GetEventData(endSessionData), CHIP_NO_ERROR);
     ASSERT_EQ(endSessionData.sessionID, mSessionId);
+    
+    // 6. Verify that the session is no longer available, a new context should fail with the no longer valid session id
+    ASSERT_EQ(
+        mServer.GetLogic().NewContextDetected(mSessionId, testAdditionalTrackedContext, &mClusterTester.GetServerClusterContext()),
+        CHIP_ERROR_NOT_FOUND);
+
 }
 
 } // namespace

--- a/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestLocalAvAnalysisCluster.cpp
@@ -1043,7 +1043,7 @@ TEST_F(TestLocalAvAnalysisCluster, ExecuteEventGenerationSequence)
 
     are_equal = std::equal(testAdditionalTrackedContext.begin(), testAdditionalTrackedContext.end(), currentEventContexts.begin(),
                            currentEventContexts.end(), [](const auto & tc1, const auto & tc2) {
-                               return tc1.identifiedContextID == tc2.identifiedContextID && 
+                               return tc1.identifiedContextID == tc2.identifiedContextID &&
                                    tc1.identifiedContext.namespaceID == tc2.identifiedContext.namespaceID &&
                                    tc1.identifiedContext.tag == tc2.identifiedContext.tag;
                            });

--- a/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
@@ -75,7 +75,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t> & aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 

--- a/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
@@ -75,7 +75,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(DataModel::DecodableList<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 

--- a/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
+++ b/src/app/clusters/av-analysis-server/tests/TestRemoteAvAnalysisCluster.cpp
@@ -75,7 +75,7 @@ public:
 
     Protocols::InteractionModel::Status RemoveAnalysisStream() { return Status::Success; }
 
-    CHIP_ERROR VerifyZoneIDsAreValid(std::vector<uint16_t> aZoneIDs) { return CHIP_NO_ERROR; }
+    CHIP_ERROR VerifyZoneIDsAreValid(const std::vector<uint16_t>& aZoneIDs) { return CHIP_NO_ERROR; }
 
     bool CanAddContextTriggers() { return true; }
 


### PR DESCRIPTION
### Summary

Adds APIs for the delegate to invoke for all parts of the expected event flow on analysis context detection.  

### Related issues

None

### Testing

Create new unit test covering all APIs.  Execute unit test. 