### PR TITLE
Guard loading of bash completions on the framework being loaded

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -195,8 +195,10 @@ else
     _install_additional_pip_requirements "none" "$@"
 fi
 
-# Load bash completion helper if running bash
-if [ -n "$BASH" ]; then
+# Load bash completion helper if running bash and the bash-completion package
+# (providing _init_completion etc.) is already loaded, since our completion
+# functions won't work correctly without it.
+if [ -n "$BASH" ] && declare -F _init_completion >/dev/null 2>&1; then
     . "$_CHIP_ROOT/scripts/helpers/bash-completion.sh"
 fi
 


### PR DESCRIPTION
### Summary

If the base bash-completion framework is not loaded (as tested by
checking for the existence of the _init_completion function), the smart
completion functions will fail at the point where they are invoked.

### Testing

Tested manually on my mac. I am no longer getting "bash: _init_completion:
command not found" errors when trying to tab-complete arguments of a
chip-cert command.
