### PR TITLE
chip-cert improvements for PDC identities

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -48,12 +48,15 @@ jobs:
               with:
                 platform: linux
 
-            - name: Build Standalone cert tool
+            - name: Build and test Standalone cert tool
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-cert \
-                        build" && rm -rf out
+                        build"
+                  CHIP_CERT=out/linux-x64-chip-cert/chip-cert \
+                      python3 src/tools/chip-cert/tests/test_chip_cert.py
+                  rm -rf out
             - name: Build minmdns example with platform dns
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -1604,6 +1604,7 @@ static CHIP_ERROR GenerateNetworkIdentity(const Crypto::P256Keypair & keypair, M
     P256ECDSASignatureSpan signatureSpan(signature.ConstBytes());
     ReturnErrorOnFailure(EncodeCompactIdentityCert(writer, AnonymousTag(), publicKeySpan, signatureSpan));
 
+    ReturnErrorOnFailure(writer.Finalize());
     outCompactCert.reduce_size(writer.GetLengthWritten());
     return CHIP_NO_ERROR;
 }

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -587,6 +587,19 @@ exit:
     return res;
 }
 
+CHIP_ERROR EncodeCompactIdentityCert(ChipCertificateData const & cert, MutableByteSpan & outCompactCert)
+{
+    TLVWriter writer;
+    writer.Init(outCompactCert);
+    TLVType containerType;
+    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag(), kTLVType_Structure, containerType));
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_EllipticCurvePublicKey), cert.mPublicKey));
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_ECDSASignature), cert.mSignature));
+    ReturnErrorOnFailure(writer.EndContainer(containerType));
+    outCompactCert.reduce_size(writer.GetLengthWritten());
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 bool ReadCert(const char * fileNameOrStr, std::unique_ptr<X509, void (*)(X509 *)> & cert)
@@ -799,6 +812,23 @@ bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
 
         VerifyOrReturnError(X509ToChipCert(cert, chipCert), false);
 
+        // Parse the CHIP certificate again to determine if it is a PDC Identity certificate,
+        // and if so re-encode it in compact format. This is a little clunky, but CHIPCert.h
+        // does not expose any APIs to do this directly, as this conversion is not needed
+        // in normal operation. Note that the certificate type is determined from the Subject
+        // DN field; it does not validate the remainder of PDC Identity requirements.
+        ChipCertificateData certData;
+        CertType certType;
+        if (DecodeChipCert(chipCert, certData) == CHIP_NO_ERROR && certData.mSubjectDN.GetCertType(certType) == CHIP_NO_ERROR &&
+            certType == CertType::kNetworkIdentity)
+        {
+            fprintf(stderr, "Subject DN identifies a PDC Identity, using compact TLV format\n");
+            uint8_t compactCertBuf[kMaxCHIPCompactNetworkIdentityLength];
+            MutableByteSpan compactCert(compactCertBuf);
+            ReturnValueOnFailure(EncodeCompactIdentityCert(certData, compactCert), false);
+            return WriteChipCert(fileName, compactCert, certFmt);
+        }
+
         return WriteChipCert(fileName, chipCert, certFmt);
     }
 
@@ -886,10 +916,11 @@ bool MakeCert(CertType certType, const ToolChipDN * subjectDN, X509 * caCert, EV
     }
 
     // Set the issuer name for the certificate. In the case of a self-signed cert, this will be
-    // the new cert's subject name.
+    // the new cert's subject name. Note that the subject DN is only applied to `newCert` further
+    // below, so for a self-signed cert it must be taken from `subjectDN` rather than from `caCert`.
     if (certConfig.IsIssuerPresent())
     {
-        if (certType == CertType::kRoot)
+        if (certType == CertType::kRoot || caCert == newCert)
         {
             res = subjectDN->SetCertIssuerDN(newCert);
             VerifyTrueOrExit(res);

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -596,6 +596,7 @@ CHIP_ERROR EncodeCompactIdentityCert(ChipCertificateData const & cert, MutableBy
     ReturnErrorOnFailure(writer.Put(ContextTag(kTag_EllipticCurvePublicKey), cert.mPublicKey));
     ReturnErrorOnFailure(writer.Put(ContextTag(kTag_ECDSASignature), cert.mSignature));
     ReturnErrorOnFailure(writer.EndContainer(containerType));
+    ReturnErrorOnFailure(writer.Finalize());
     outCompactCert.reduce_size(writer.GetLengthWritten());
     return CHIP_NO_ERROR;
 }

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -46,6 +46,7 @@ OptionDef gCmdOptionDefs[] =
 {
     { "cert",           kArgumentRequired,  'c' },
     { "trusted-cert",   kArgumentRequired,  't' },
+    { "pdc-identity",   kNoArgument,        'p' },
     { }
 };
 
@@ -59,6 +60,11 @@ const char * const gCmdOptionHelp =
     "\n"
     "       File or string containing a trusted CHIP certificate to be used during\n"
     "       validation. Usually, it is trust anchor root certificate (RCAC).\n"
+    "\n"
+    "  -p, --pdc-identity\n"
+    "\n"
+    "       Validate the certificate as a PDC Identity. No other certificates are\n"
+    "       involved, so the --cert and --trusted-cert options must not be used.\n"
     "\n"
     ;
 
@@ -74,7 +80,7 @@ HelpOptions gHelpOptions(
     CMD_NAME,
     "Usage: " CMD_NAME " [ <options...> ] <file/str>\n",
     CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
-    "Validate a chain of CHIP certificates.\n"
+    "Validate a chain of CHIP certificates, or a single Wi-Fi PDC Identity.\n"
     "\n"
     "ARGUMENTS\n"
     "\n"
@@ -103,6 +109,7 @@ const char * gTargetCertFileName         = nullptr;
 const char * gCACertFileNames[kMaxCerts] = { nullptr };
 bool gCACertIsTrusted[kMaxCerts]         = { false };
 size_t gNumCertFileNames                 = 0;
+bool gValidatePDCIdentity                = false;
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
 {
@@ -117,6 +124,9 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         }
         gCACertFileNames[gNumCertFileNames]   = arg;
         gCACertIsTrusted[gNumCertFileNames++] = (id == 't');
+        break;
+    case 'p':
+        gValidatePDCIdentity = true;
         break;
     default:
         PrintArgError("%s: Unhandled option: %s\n", progName, name);
@@ -140,25 +150,18 @@ bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
         return false;
     }
 
+    if (gValidatePDCIdentity && gNumCertFileNames > 0)
+    {
+        PrintArgError("%s: The --cert and --trusted-cert options cannot be used with --pdc-identity.\n", progName);
+        return false;
+    }
+
     gTargetCertFileName = argv[0];
 
     return true;
 }
 
-/**
- * Determine whether the certificate is a PDC Identity, and if so whether it is valid.
- *
- * PDC Identities cannot be validated via ChipCertificateSet: they carry neither a Subject
- * Key Id nor an Authority Key Id extension, both of which it requires. They are also
- * self-contained, so there is no chain to validate; instead the fixed set of values the
- * specification mandates is checked, along with the self-signature.
- *
- * @param outIsValid  Set to the result of validating the identity, but only if the
- *                    certificate is a PDC Identity, i.e. if this function returns true.
- *
- * @return true if the certificate is a PDC Identity, false if it is some other type.
- */
-bool CheckNetworkIdentity(const char * fileNameOrStr, bool * outIsValid)
+bool ValidatePDCIdentity(const char * fileNameOrStr)
 {
     std::unique_ptr<X509, void (*)(X509 *)> cert(nullptr, &X509_free);
     VerifyOrReturnValue(ReadCert(fileNameOrStr, cert), false);
@@ -167,20 +170,12 @@ bool CheckNetworkIdentity(const char * fileNameOrStr, bool * outIsValid)
     MutableByteSpan chipCert(chipCertBuf);
     VerifyOrReturnValue(X509ToChipCert(cert.get(), chipCert), false);
 
-    // The certificate type is determined from the Subject DN; the remaining requirements are
-    // what ValidateChipNetworkIdentity() then checks.
-    ChipCertificateData certData;
-    CertType certType;
-    VerifyOrReturnValue(DecodeChipCert(chipCert, certData) == CHIP_NO_ERROR, false);
-    VerifyOrReturnValue(certData.mSubjectDN.GetCertType(certType) == CHIP_NO_ERROR, false);
-    VerifyOrReturnValue(certType == CertType::kNetworkIdentity, false);
-
     CHIP_ERROR err = ValidateChipNetworkIdentity(chipCert);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed PDC Identity validation: %s\n", chip::ErrorStr(err));
+        return false;
     }
-    *outIsValid = (err == CHIP_NO_ERROR);
     return true;
 }
 
@@ -208,15 +203,9 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
     VerifyTrueOrExit(res);
 
-    // A PDC Identity is self-contained, so it is only validated when given on its own,
-    // without any additional certificates that would imply a chain to validate.
-    if (gNumCertFileNames == 0)
+    if (gValidatePDCIdentity)
     {
-        bool isValidIdentity;
-        if (CheckNetworkIdentity(gTargetCertFileName, &isValidIdentity))
-        {
-            ExitNow(res = isValidIdentity);
-        }
+        ExitNow(res = ValidatePDCIdentity(gTargetCertFileName));
     }
 
     err = certSet.Init(kMaxCerts);

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -145,6 +145,45 @@ bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
     return true;
 }
 
+/**
+ * Determine whether the certificate is a PDC Identity, and if so whether it is valid.
+ *
+ * PDC Identities cannot be validated via ChipCertificateSet: they carry neither a Subject
+ * Key Id nor an Authority Key Id extension, both of which it requires. They are also
+ * self-contained, so there is no chain to validate; instead the fixed set of values the
+ * specification mandates is checked, along with the self-signature.
+ *
+ * @param outIsValid  Set to the result of validating the identity, but only if the
+ *                    certificate is a PDC Identity, i.e. if this function returns true.
+ *
+ * @return true if the certificate is a PDC Identity, false if it is some other type.
+ */
+bool CheckNetworkIdentity(const char * fileNameOrStr, bool * outIsValid)
+{
+    std::unique_ptr<X509, void (*)(X509 *)> cert(nullptr, &X509_free);
+    VerifyOrReturnValue(ReadCert(fileNameOrStr, cert), false);
+
+    uint8_t chipCertBuf[kMaxCHIPCertLength];
+    MutableByteSpan chipCert(chipCertBuf);
+    VerifyOrReturnValue(X509ToChipCert(cert.get(), chipCert), false);
+
+    // The certificate type is determined from the Subject DN; the remaining requirements are
+    // what ValidateChipNetworkIdentity() then checks.
+    ChipCertificateData certData;
+    CertType certType;
+    VerifyOrReturnValue(DecodeChipCert(chipCert, certData) == CHIP_NO_ERROR, false);
+    VerifyOrReturnValue(certData.mSubjectDN.GetCertType(certType) == CHIP_NO_ERROR, false);
+    VerifyOrReturnValue(certType == CertType::kNetworkIdentity, false);
+
+    CHIP_ERROR err = ValidateChipNetworkIdentity(chipCert);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Failed PDC Identity validation: %s\n", chip::ErrorStr(err));
+    }
+    *outIsValid = (err == CHIP_NO_ERROR);
+    return true;
+}
+
 } // namespace
 
 bool Cmd_ValidateCert(int argc, char * argv[])
@@ -168,6 +207,17 @@ bool Cmd_ValidateCert(int argc, char * argv[])
 
     res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
     VerifyTrueOrExit(res);
+
+    // A PDC Identity is self-contained, so it is only validated when given on its own,
+    // without any additional certificates that would imply a chain to validate.
+    if (gNumCertFileNames == 0)
+    {
+        bool isValidIdentity;
+        if (CheckNetworkIdentity(gTargetCertFileName, &isValidIdentity))
+        {
+            ExitNow(res = isValidIdentity);
+        }
+    }
 
     err = certSet.Init(kMaxCerts);
     if (err != CHIP_NO_ERROR)

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -171,13 +171,15 @@ openssl verify -CAfile Chip-PAA-Cert.pem -untrusted Chip-PAI-Cert.pem Chip-DAC-C
 
 ## PDC Identity Usage Examples
 
-Example commands to generate a PDC identity (a constrained self-signed certificate):
+Example commands to generate a PDC identity (a constrained self-signed
+certificate):
 
 ```
 ./chip-cert gen-cert --type p --out-key identity-key.pem --out identity.pem --out-format x509-pem
 ```
 
-PDC Identities are usually transferred in (compact) TLV format. Convert to TLV (hex):
+PDC Identities are usually transferred in (compact) TLV format. Convert to TLV
+(hex):
 
 ```
 ./chip-cert convert-cert -x identity.pem identity.hex

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -42,7 +42,7 @@ This directory contains various command handler for the 'chip-cert' tool that:
 -   generate CHIP certificate
 -   convert CHIP certificate format
 -   convert CHIP private key format
--   validate CHIP certificate chain
+-   validate CHIP certificate chain or PDC identity
 -   resign CHIP certificate
 -   print CHIP certificate
 -   generate CHIP attestation certificates
@@ -167,6 +167,27 @@ attestation certificate chain that was just created:
 
 ```
 openssl verify -CAfile Chip-PAA-Cert.pem -untrusted Chip-PAI-Cert.pem Chip-DAC-Cert.pem
+```
+
+## PDC Identity Usage Examples
+
+Example commands to generate a PDC identity (a constrained self-signed certificate):
+
+```
+./chip-cert gen-cert --type p --out-key identity-key.pem --out identity.pem --out-format x509-pem
+```
+
+PDC Identities are usually transferred in (compact) TLV format. Convert to TLV (hex):
+
+```
+./chip-cert convert-cert -x identity.pem identity.hex
+```
+
+Either format validates as a self-signed identity:
+
+```
+./chip-cert validate-cert identity.pem && echo OK
+./chip-cert validate-cert identity.hex && echo OK
 ```
 
 ## Command Reference

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -516,9 +516,9 @@ HELP OPTIONS
 
 ```
 $ ./out/debug/standalone/chip-cert validate-cert -h
-Usage: chip-cert validate-cert [ <options...> ] <target-cert-file>
+Usage: chip-cert validate-cert [ <options...> ] <file/str>
 
-Validate a chain of CHIP certificates.
+Validate a chain of CHIP certificates, or a single Wi-Fi PDC Identity.
 
 ARGUMENTS
 
@@ -539,6 +539,11 @@ COMMAND OPTIONS
 
        File or string containing a trusted CHIP certificate to be used during
        validation. Usually, it is trust anchor root certificate (RCAC).
+
+  -p, --pdc-identity
+
+       Validate the certificate as a PDC Identity. No other certificates are
+       involved, so the --cert and --trusted-cert options must not be used.
 
 HELP OPTIONS
 

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -188,8 +188,8 @@ PDC Identities are usually transferred in (compact) TLV format. Convert to TLV
 Either format validates as a self-signed identity:
 
 ```
-./chip-cert validate-cert identity.pem && echo OK
-./chip-cert validate-cert identity.hex && echo OK
+./chip-cert validate-cert -p identity.pem && echo OK
+./chip-cert validate-cert -p identity.hex && echo OK
 ```
 
 ## Command Reference

--- a/src/tools/chip-cert/tests/test_chip_cert.py
+++ b/src/tools/chip-cert/tests/test_chip_cert.py
@@ -123,7 +123,7 @@ class ChipCertTest(unittest.TestCase):
 
 
 class PDCIdentityTest(ChipCertTest):
-    """Tests covering Wi-Fi PDC (Network Client) Identity certificates."""
+    """Tests covering PDC (Network / Client) Identity certificates."""
 
     def assert_is_pdc_identity(self, source):
         """Check the field values the specification mandates for a PDC Identity."""
@@ -137,7 +137,7 @@ class PDCIdentityTest(ChipCertTest):
         self.assertEqual(fields["Not After"], PDC_NOT_AFTER)
         self.assertEqual(fields["Is CA"], "false")
         # validate-cert checks the remaining requirements, including the self-signature.
-        self.run_chip_cert("validate-cert", source)
+        self.run_chip_cert("validate-cert", "--pdc-identity", source)
 
     def test_gen_cert_uses_compact_format(self):
         """gen-cert writes PDC Identities in the compact-pdc-identity format."""
@@ -205,7 +205,7 @@ class PDCIdentityTest(ChipCertTest):
         path = self.tmp_path / "tampered.chip"
         path.write_bytes(bytes(tampered))
 
-        self.run_chip_cert("validate-cert", path, expect_success=False)
+        self.run_chip_cert("validate-cert", "--pdc-identity", path, expect_success=False)
 
     def test_validate_cert_rejects_ca_cert_with_pdc_subject(self):
         """A CN=* CA certificate is recognised as an identity but fails the remaining checks.
@@ -215,7 +215,7 @@ class PDCIdentityTest(ChipCertTest):
         """
         source = self.generate_ca_cert_with_pdc_subject()
 
-        self.run_chip_cert("validate-cert", source, expect_success=False)
+        self.run_chip_cert("validate-cert", "--pdc-identity", source, expect_success=False)
 
 
 class OperationalCertTest(ChipCertTest):

--- a/src/tools/chip-cert/tests/test_chip_cert.py
+++ b/src/tools/chip-cert/tests/test_chip_cert.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the chip-cert tool.
+
+Certificates are generated, converted and validated using chip-cert itself,
+so these tests need nothing beyond the standard library.
+
+Set CHIP_CERT to the binary under test:
+
+    ninja -C out/default chip-cert
+    CHIP_CERT=out/default/chip-cert python3 src/tools/chip-cert/tests/test_chip_cert.py
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+CHIP_ROOT = next(filter(lambda p: (p / 'SPECIFICATION_VERSION').is_file(), Path(__file__).parents))
+OPERATIONAL_CERTS = CHIP_ROOT / "credentials/test/operational-certificates"
+
+# The compact-pdc-identity test vector from src/credentials/tests/CHIPCert_test_vectors.cpp
+# (sTestCert_PDCID01_ChipCompact). All fields other than the public key and signature are
+# implied by the specification, so a conforming encoder must reproduce these exact bytes.
+PDCID01_COMPACT = bytes.fromhex(
+    "153009410439ccd4ac7e5968bdf1b080111d92536494fc51624c70aa6d7308daedf3a15e3869"
+    "177b1bf3d09047ebf06be8dd17be23f2fb3d6390c6cf82802f62d05362c008300b40384c1bd0"
+    "8fe4caa0460791660d82145dfbfe97d314d15e000d75c073af5d7c7ecc1a01852126184ad9"
+    "ebec809b4c78fff381fe324baf881cc8249e169259bd5a18"
+)
+
+# Field values mandated for a PDC Identity by the specification, as print-cert renders them.
+PDC_DN = "[[ CommonName = * ]]"
+PDC_NOT_BEFORE = "0x00000001  ( 2000/01/01 00:00:01 )"
+PDC_NOT_AFTER = "0x00000000  ( 9999/12/31 23:59:59 )"
+
+# Reported by chip-cert whenever it takes the compact-pdc-identity encoding path.
+COMPACT_FORMAT_NOTICE = "using compact TLV format"
+
+
+class ChipCertTest(unittest.TestCase):
+    """Base class providing access to the chip-cert binary and a scratch directory."""
+
+    @classmethod
+    def setUpClass(cls):
+        from_env = os.environ.get("CHIP_CERT")
+        if not from_env:
+            raise AssertionError("CHIP_CERT is not set; point it at the chip-cert binary to test")
+        cls.chip_cert = Path(from_env)
+        if not cls.chip_cert.is_file():
+            raise AssertionError(f"chip-cert binary not found at {cls.chip_cert}")
+
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.tmp_path = Path(directory.name)
+
+    def run_chip_cert(self, *args, expect_success=True):
+        """Run chip-cert, assert whether it succeeded, and return the CompletedProcess."""
+        command = [str(self.chip_cert), *map(str, args)]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if expect_success:
+            self.assertEqual(result.returncode, 0, f"{' '.join(command)} failed:\n{result.stderr}")
+        else:
+            self.assertNotEqual(result.returncode, 0, f"{' '.join(command)} unexpectedly succeeded")
+        return result
+
+    def print_cert(self, source):
+        """Return the fields of a certificate as a dict, via the print-cert command.
+
+        Values spanning multiple lines (public key, signature) are not included, since
+        their continuation lines carry no field name.
+        """
+        output = self.run_chip_cert("print-cert", source).stdout
+        fields = {}
+        for line in output.splitlines():
+            name, separator, value = line.partition(":")
+            if separator and value.strip():
+                fields[name.strip()] = value.strip()
+        return fields
+
+    def convert(self, source, name, *options):
+        """Convert a certificate with convert-cert, returning (output path, result)."""
+        out = self.tmp_path / name
+        result = self.run_chip_cert("convert-cert", source, out, *options)
+        return out, result
+
+    def generate_identity(self, out_format, name="identity"):
+        """Generate a PDC Identity with gen-cert, returning the output path."""
+        out = self.tmp_path / name
+        self.run_chip_cert("gen-cert", "--type", "p", "--out", out,
+                           "--out-key", self.tmp_path / f"{name}-key.pem",
+                           "--out-format", out_format)
+        return out
+
+    def generate_ca_cert_with_pdc_subject(self):
+        """Generate a self-signed CA certificate whose subject is CN=*.
+
+        This is a valid certificate that is not a PDC Identity. chip-cert recognises
+        identities by their subject DN alone, so this exercises that heuristic's failure
+        mode. gen-cert normally refuses a subject DN that disagrees with the requested
+        certificate type, so error injection is needed to produce it.
+        """
+        out = self.tmp_path / "ca-with-pdc-subject.pem"
+        self.run_chip_cert("gen-cert", "--type", "r", "--subject-cn-u", "*",
+                           "--out", out, "--out-key", self.tmp_path / "ca-key.pem",
+                           "--out-format", "x509-pem", "--lifetime", "3650",
+                           "--ignore-error", "--error-type", "no-error")
+        return out
+
+
+class PDCIdentityTest(ChipCertTest):
+    """Tests covering Wi-Fi PDC (Network Client) Identity certificates."""
+
+    def assert_is_pdc_identity(self, source):
+        """Check the field values the specification mandates for a PDC Identity."""
+        fields = self.print_cert(source)
+        self.assertEqual(fields["Subject"], PDC_DN)
+        # The identity is self-signed, so the issuer must match the subject. Getting this
+        # wrong is not caught by the compact encoding, which always writes the canonical
+        # issuer, so it only shows up as a signature that fails to verify.
+        self.assertEqual(fields["Issuer"], PDC_DN)
+        self.assertEqual(fields["Not Before"], PDC_NOT_BEFORE)
+        self.assertEqual(fields["Not After"], PDC_NOT_AFTER)
+        self.assertEqual(fields["Is CA"], "false")
+        # validate-cert checks the remaining requirements, including the self-signature.
+        self.run_chip_cert("validate-cert", source)
+
+    def test_gen_cert_uses_compact_format(self):
+        """gen-cert writes PDC Identities in the compact-pdc-identity format."""
+        out = self.generate_identity("chip")
+        self.assertEqual(len(out.read_bytes()), len(PDCID01_COMPACT))
+
+    def test_gen_cert_produces_valid_identity(self):
+        """A generated PDC Identity must be well-formed and correctly self-signed.
+
+        Regression test: the self-signed issuer was previously taken from the not-yet-populated
+        subject of the certificate under construction, yielding an empty issuer and a signature
+        computed over a TBSCertificate that no verifier would accept.
+        """
+        self.assert_is_pdc_identity(self.generate_identity("chip"))
+
+    def test_gen_cert_x509_output_is_valid_identity(self):
+        """The same must hold for X.509 output, which has no compact encoding to mask a bad issuer."""
+        self.assert_is_pdc_identity(self.generate_identity("x509-pem"))
+
+    def test_convert_spec_vector_round_trip(self):
+        """compact -> X.509 -> compact must reproduce the spec test vector byte for byte."""
+        compact = self.tmp_path / "vector.chip"
+        compact.write_bytes(PDCID01_COMPACT)
+        self.assert_is_pdc_identity(compact)
+
+        pem_file, _ = self.convert(compact, "vector.pem", "--x509-pem")
+        self.assert_is_pdc_identity(pem_file)
+
+        round_tripped, _ = self.convert(pem_file, "vector-rt.chip", "--chip")
+        self.assertEqual(round_tripped.read_bytes(), PDCID01_COMPACT)
+
+    def test_convert_non_identity_is_unaffected(self):
+        """Certificates that are not PDC Identities must not be re-encoded as compact."""
+        out, result = self.convert(OPERATIONAL_CERTS / "Chip-Test-Root01-Cert.pem",
+                                   "root.chip", "--chip")
+
+        self.assertGreater(len(out.read_bytes()), len(PDCID01_COMPACT))
+        self.assertNotIn(COMPACT_FORMAT_NOTICE, result.stderr)
+
+    def test_convert_ca_cert_with_pdc_subject_is_rewritten(self):
+        """A CA certificate that merely happens to use CN=* is lossily rewritten as an identity.
+
+        Identities are recognised by their subject DN alone, so such a certificate takes the
+        compact path, which retains only the public key and signature. Basic constraints and
+        validity are replaced with the specification's values. chip-cert reports when it does
+        this, since the conversion is not reversible.
+        """
+        source = self.generate_ca_cert_with_pdc_subject()
+        self.assertEqual(self.print_cert(source)["Is CA"], "true")
+
+        compact, result = self.convert(source, "ca.chip", "--chip")
+
+        self.assertIn(COMPACT_FORMAT_NOTICE, result.stderr)
+        self.assertEqual(len(compact.read_bytes()), len(PDCID01_COMPACT))
+
+        # Confirm what the compact encoding discarded.
+        fields = self.print_cert(compact)
+        self.assertEqual(fields["Is CA"], "false")
+        self.assertEqual(fields["Not Before"], PDC_NOT_BEFORE)
+
+    def test_validate_cert_rejects_tampered_identity(self):
+        """A PDC Identity whose signature has been altered must be rejected."""
+        tampered = bytearray(PDCID01_COMPACT)
+        tampered[-5] ^= 0xFF
+        path = self.tmp_path / "tampered.chip"
+        path.write_bytes(bytes(tampered))
+
+        self.run_chip_cert("validate-cert", path, expect_success=False)
+
+    def test_validate_cert_rejects_ca_cert_with_pdc_subject(self):
+        """A CN=* CA certificate is recognised as an identity but fails the remaining checks.
+
+        This is the safety net for the subject-DN heuristic: such a certificate takes the
+        PDC validation path, where the full set of specification requirements rejects it.
+        """
+        source = self.generate_ca_cert_with_pdc_subject()
+
+        self.run_chip_cert("validate-cert", source, expect_success=False)
+
+
+class OperationalCertTest(ChipCertTest):
+    """Tests covering ordinary operational certificates."""
+
+    def generate_chain(self):
+        """Generate a self-signed root and a NOC issued by it, returning both paths."""
+        root = self.tmp_path / "root.pem"
+        root_key = self.tmp_path / "root-key.pem"
+        noc = self.tmp_path / "noc.pem"
+
+        self.run_chip_cert("gen-cert", "--type", "r", "--subject-chip-id", "CACACACA00000001",
+                           "--out", root, "--out-key", root_key,
+                           "--out-format", "x509-pem", "--lifetime", "3650")
+        self.run_chip_cert("gen-cert", "--type", "n", "--subject-chip-id", "DEDEDEDE00010001",
+                           "--subject-fab-id", "FAB000000000001D",
+                           "--ca-cert", root, "--ca-key", root_key,
+                           "--out", noc, "--out-key", self.tmp_path / "noc-key.pem",
+                           "--out-format", "x509-pem", "--lifetime", "3650")
+        return root, noc
+
+    def test_validate_cert_validates_chain(self):
+        """A NOC must validate against the root that issued it.
+
+        Also guards the PDC Identity handling in validate-cert, which must not disturb
+        ordinary chain validation.
+        """
+        root, noc = self.generate_chain()
+
+        self.run_chip_cert("validate-cert", "-t", root, noc)
+
+    def test_validate_cert_rejects_untrusted_chain(self):
+        """A NOC must not validate without the root that issued it."""
+        _, noc = self.generate_chain()
+
+        self.run_chip_cert("validate-cert", noc, expect_success=False)
+
+    def test_convert_between_chip_formats_is_stable(self):
+        """The CHIP TLV encoding must not depend on which container format carries it."""
+        source = OPERATIONAL_CERTS / "Chip-Test-Root01-Cert.pem"
+
+        raw, _ = self.convert(source, "root.chip", "--chip")
+        base64_form, _ = self.convert(source, "root.chip-b64", "--chip-b64")
+        hex_form, _ = self.convert(source, "root.chip-hex", "--chip-hex")
+
+        from_base64, _ = self.convert(base64_form, "from-b64.chip", "--chip")
+        from_hex, _ = self.convert(hex_form, "from-hex.chip", "--chip")
+
+        self.assertEqual(from_base64.read_bytes(), raw.read_bytes())
+        self.assertEqual(from_hex.read_bytes(), raw.read_bytes())
+
+    def test_convert_x509_round_trip_is_stable(self):
+        """Converting TLV to X.509 and back must reproduce the original TLV."""
+        source = OPERATIONAL_CERTS / "Chip-Test-Root01-Cert.pem"
+
+        raw, _ = self.convert(source, "root.chip", "--chip")
+        pem_file, _ = self.convert(raw, "root.pem", "--x509-pem")
+        round_tripped, _ = self.convert(pem_file, "root-rt.chip", "--chip")
+
+        self.assertEqual(round_tripped.read_bytes(), raw.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

- Fix invalid signatures on PDC identities generated by gen-cert. Note
  this issue was limited to chip-cert, which has its own logic for
  certificate generation separate from the core SDK.
- Add support for validating PDC identities to validate-cert.
- Use compact TLV format when converting PDC identities. Previously
  these would be written in the normal (non-compact) TLV format used by
  operational certs. The compact format is the canonical representation
  of PDC identities.
- Add an integration test that exercises a few key chip-cert operations
  and add it to the Linux Standalone CI workflow.

### Testing

Added new integration test script that drives the chip-cert tool.
