### PR TITLE
[v1.4.2] fix(tv-casting-app): Optimise proguard rules to reduce sdk s…

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1176,6 +1176,7 @@ ProductID
 ProductLabel
 ProductName
 ProductURL
+proguard
 proto
 protobuf
 protos

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -8,6 +8,7 @@
 21
 22
 AAAA
+AAB
 aarch
 abcdef
 abfb

--- a/examples/tv-casting-app/APK_SIZE_ANALYSIS.md
+++ b/examples/tv-casting-app/APK_SIZE_ANALYSIS.md
@@ -18,17 +18,17 @@ Casting App on Android (arm64-v8a).
 
 ### What drives the reduction
 
-| Optimization                           | Mechanism                                                                                                | Impact                                                                                                    |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Slim cluster-objects override          | Compile ~29 casting clusters instead of ~200+ via `chip_data_model_overrides_dir`                        | Major `.so` reduction                                                                                     |
-| Slim TLV decoder overrides             | Compile TLV decoders for 18 casting clusters only via `chip_data_model_overrides_dir`                    | Removes link-time deps on ~200+ clusters while keeping `ChipClusters.java` read/subscribe APIs functional |
-| Remove legacy chip-tool sources        | Exclude ~20 source files + tracing/JSON deps                                                             | Further `.so` reduction                                                                                   |
-| Static libc++ with dead-code stripping | `−static-libstdc++` + `--gc-sections` + LTO                                                              | Eliminates separate 8.9 MB `libc++_shared.so`; only referenced symbols survive                            |
-| Compiler / linker flags                | `-Os`, `-g0`, `-flto=thin`, `--icf=safe`, `-fvisibility=hidden`                                          | ~10–20 % further `.so` reduction                                                                          |
-| R8 Java shrinking                      | `minifyEnabled true` in Gradle debug build                                                               | Reduces DEX size (Java / Kotlin)                                                                          |
-| Cluster server exclusion (phase 3)     | Compile only 13 cluster server dirs via `chip_data_model_overrides_dir` + `cluster-servers-override.gni` | ~1.1 MB `.o` savings                                                                                      |
-| Slim Accessors.cpp (phase 3)           | Compile accessors for 29 clusters only via `chip_data_model_overrides_dir` + `Accessors-override.cpp`    | ~826 KB `.o` savings                                                                                      |
-| jsoncpp/jsontlv removal (phase 3)      | Not feasible — `AndroidCallbacks.cpp` and `AndroidInteractionClient.cpp` use jsontlv at runtime          | ~350 KB (not achievable)                                                                                  |
+| Optimization                           | Mechanism                                                                                                | Impact                                                                                                      |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Slim cluster-objects override          | Compile ~29 casting clusters instead of ~200+ via `chip_data_model_overrides_dir`                        | Major `.so` reduction                                                                                       |
+| Slim TLV decoder overrides             | Compile TLV decoders for 19 casting clusters only via `chip_data_model_overrides_dir`                    | Removes link-time deps on ~200+ clusters while keeping `ChipClusters.java` read/subscribe APIs functional   |
+| Remove legacy chip-tool sources        | Exclude ~20 source files + tracing/JSON deps                                                             | Further `.so` reduction                                                                                     |
+| Static libc++ with dead-code stripping | `−static-libstdc++` + `--gc-sections` + LTO                                                              | Eliminates separate 8.9 MB `libc++_shared.so`; only referenced symbols survive                              |
+| Compiler / linker flags                | `-Os`, `-g0`, `-flto=thin`, `--icf=safe`, `-fvisibility=hidden`                                          | ~10–20 % further `.so` reduction                                                                            |
+| R8 Java shrinking                      | `minifyEnabled true` + cluster-scoped proguard keeps for the 19 slim-decoder clusters                    | Prunes ~6,500 unused classes from `CHIPInteractionModel.jar`; chip.\* method count reduced from 29K to 2.5K |
+| Cluster server exclusion (phase 3)     | Compile only 13 cluster server dirs via `chip_data_model_overrides_dir` + `cluster-servers-override.gni` | ~1.1 MB `.o` savings                                                                                        |
+| Slim Accessors.cpp (phase 3)           | Compile accessors for 29 clusters only via `chip_data_model_overrides_dir` + `Accessors-override.cpp`    | ~826 KB `.o` savings                                                                                        |
+| jsoncpp/jsontlv removal (phase 3)      | Not feasible — `AndroidCallbacks.cpp` and `AndroidInteractionClient.cpp` use jsontlv at runtime          | ~350 KB (not achievable)                                                                                    |
 
 ---
 
@@ -166,9 +166,9 @@ overhead is removed.
 | Compressed in APK (ZIP deflate, single ABI)            | ~2–3 MB        |
 
 The `CHIPInteractionModel.jar` (7.3 MB) is the largest Java component, but it
-contains classes for all ~200+ clusters. When the host app applies R8 shrinking,
-only the classes actually referenced by the casting API survive, reducing its
-contribution to well under 1 MB.
+contains classes for all ~200+ clusters. The proguard rules keep only the 19
+clusters present in the slim TLV decoder overrides; R8 prunes the rest, reducing
+`CHIPInteractionModel.jar`'s contribution to well under 1 MB.
 
 For a production app shipping a single ABI (arm64-v8a), the casting SDK adds an
 estimated **2–3 MB compressed** to the APK — down from **27.9 MB** of native
@@ -176,7 +176,41 @@ libraries in the default non-optimized build.
 
 ---
 
-## 4. Build Instructions
+## 4. Casting SDK Size Impact (Measured)
+
+Measured on the size-optimized build (`optimize_apk_size=true`, arm64-v8a) using
+the following methodology:
+
+1. Build an AAB: `./gradlew bundleRelease`
+2. Convert to APK set:
+   `bundletool build-apks --bundle=app-release.aab --output=app.apks`
+3. Measure download size: `bundletool get-size total --apks=app.apks`
+4. Inspect DEX, resources, and native breakdown in Android Studio APK Analyzer
+
+Three scenarios were measured to isolate the SDK contribution and the proguard
+impact:
+
+| Scenario                                          | Download size | DEX    | Resources | Native | Method count     |
+| ------------------------------------------------- | ------------- | ------ | --------- | ------ | ---------------- |
+| Without libs — app only (baseline)                | 1 MB          | 637 KB | 357 KB    | 0      | 8K               |
+| With libs — broad `chip.devicecontroller.**` keep | 2.77–2.85 MB  | 1.5 MB | 371 KB    | 1 MB   | 38K (chip: 29K)  |
+| With libs — cluster-scoped keeps (this change)    | 2.1 MB        | 757 KB | 357 KB    | 1 MB   | 11K (chip: 2.5K) |
+
+### Key findings
+
+-   _*chip.* method count: 29K → 2.5K_\* — 91% reduction from scoping proguard
+    keeps to the 19 casting clusters in the slim TLV decoders.
+-   **DEX: 1.5 MB → 757 KB** — ~750 KB reduction; R8 pruned ~6,500 unused
+    cluster classes from `CHIPInteractionModel.jar`.
+-   **Download size: 2.77–2.85 MB → 2.1 MB** — ~700 KB reduction from proguard
+    alone, on top of the native `.so` optimizations already applied.
+
+The net SDK contribution (download size minus the app-only baseline) is **~1.1
+MB** with cluster-scoped keeps, down from **~1.77–1.85 MB** with the broad keep.
+
+---
+
+## 5. Build Instructions
 
 ### Prerequisites
 
@@ -290,7 +324,7 @@ Android build.
 
 ---
 
-## 5. Property Tests
+## 6. Property Tests
 
 The `examples/tv-casting-app/tests/` directory contains property-based tests
 (Python, using `hypothesis` + `pytest`) that guard the slim decoder files and
@@ -330,7 +364,7 @@ and phase 3 optimizations._ _Validates: Requirements 2.1, 2.2, 2.3, 2.4_
 
 ---
 
-## 6. Phase 2 Optimizations (~2.8 MB → ~2.6 MB)
+## 7. Phase 2 Optimizations (~2.8 MB → ~2.6 MB)
 
 Phase 1 reduced `libTvCastingApp.so` from 19 MB to 2.8 MB. Phase 2 targets an
 additional ~200 KB reduction by trimming non-essential infrastructure from the
@@ -419,7 +453,7 @@ unit-test hooks, RTTI, and ICD removal._
 
 ---
 
-## 7. Phase 3 Optimizations (~2.6 MB → ~2.3 MB estimated)
+## 8. Phase 3 Optimizations (~2.6 MB → ~2.3 MB estimated)
 
 Phase 2 reduced `libTvCastingApp.so` from 2.8 MB to 2.6 MB. Phase 3 targets an
 additional ~2.3 MB of `.o` file bloat identified through binary analysis of the

--- a/examples/tv-casting-app/android/App/app/proguard-rules.pro
+++ b/examples/tv-casting-app/android/App/app/proguard-rules.pro
@@ -28,32 +28,157 @@
 # App server — CHIP application server Java bindings
 -keep class chip.appserver.** { *; }
 
-# Interaction model — cluster/command/attribute Java bindings
--keep class chip.clusterinfo.** { *; }
+# ============================================================================
+# 3. chip.devicecontroller — CHIPInteractionModel.jar
+#
+# Kept at the individual-class level rather than chip.devicecontroller.**
+# because CHIPInteractionModel.jar contains ~6,700 classes — the majority
+# being ChipClusters, ChipStructs, and ChipEventStructs inner classes
+# generated for all ~200 Matter clusters.
+#
+# Two sources of truth determine what to keep:
+#   1. FindClass/GetLocalClassRef calls in the android_chip_im_jni source set
+#      (src/controller/java/BUILD.gn) — drives the non-cluster class list below.
+#   2. The 19 casting clusters in the slim TLV decoder overrides
+#      (tv-casting-common/CHIPAttributeTLVValueDecoder-override.cpp and
+#       tv-casting-common/CHIPEventTLVValueDecoder-override.cpp) — drives the
+#      cluster class list.
+# Only classes present in CHIPInteractionModel.jar in the actual build need
+# keep rules; others are unreachable by R8 regardless.
+# ============================================================================
 
-# Device controller — used by the interaction model layer
--keep class chip.devicecontroller.** { *; }
+# Non-cluster classes — referenced by android_chip_im_jni and present in CHIPInteractionModel.jar
+-keep class chip.devicecontroller.ChipDeviceControllerException { *; }
+-keep class chip.devicecontroller.ChipClusterException { *; }
+-keep class chip.devicecontroller.StatusException { *; }
+-keep class chip.devicecontroller.ChipInteractionClient { *; }
+-keep class chip.devicecontroller.ChipICDClient { *; }
+-keep class chip.devicecontroller.ICDClientInfo { *; }
+-keep class chip.devicecontroller.ChipTLVType { *; }
+-keep class chip.devicecontroller.ChipTLVType$* { *; }
+-keep class chip.devicecontroller.ChipTLVValueDecoder { *; }
+-keep class chip.devicecontroller.ReportCallback { *; }
+-keep class chip.devicecontroller.ReportCallbackJni { *; }
+-keep class chip.devicecontroller.InvokeCallback { *; }
+-keep class chip.devicecontroller.InvokeCallbackJni { *; }
+-keep class chip.devicecontroller.WriteAttributesCallback { *; }
+-keep class chip.devicecontroller.WriteAttributesCallbackJni { *; }
+-keep class chip.devicecontroller.SubscriptionEstablishedCallback { *; }
+-keep class chip.devicecontroller.ResubscriptionAttemptCallback { *; }
+-keep class chip.devicecontroller.ExtendableInvokeCallback { *; }
+-keep class chip.devicecontroller.ExtendableInvokeCallbackJni { *; }
+-keep class chip.devicecontroller.GetConnectedDeviceCallbackJni { *; }
 
-# Setup payload (QR code / manual pairing code parsing)
--keep class chip.setuppayload.** { *; }
+# model.* — parameter types in ChipInteractionClient native method signatures
+-keep class chip.devicecontroller.model.** { *; }
 
-# TLV codec — used by interaction model serialization
--keep class chip.tlv.** { *; }
+# Base cluster classes — superclasses of all ChipClusters inner classes
+-keep class chip.devicecontroller.ChipClusters { *; }
+-keep class chip.devicecontroller.ChipClusters$BaseChipCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$BaseAttributeCallback { *; }
+-keep class chip.devicecontroller.ChipClusters$BaseClusterCallback { *; }
+
+# ChipClusters inner classes — clusters referenced by the casting app 
+# and/or the slim TLV decoder overrides compiled into libTvCastingApp.so.
+# Decoder source of truth: CHIPAttributeTLVValueDecoder-override.cpp and
+# CHIPEventTLVValueDecoder-override.cpp in tv-casting-common/.
+-keep class chip.devicecontroller.ChipClusters$AccountLoginCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$AccountLoginCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ApplicationBasicCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ApplicationBasicCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ApplicationLauncherCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ApplicationLauncherCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$AudioOutputCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$AudioOutputCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$BindingCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$BindingCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ChannelCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ChannelCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentAppObserverCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentAppObserverCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentControlCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentControlCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentLauncherCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$ContentLauncherCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$DescriptorCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$DescriptorCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$KeypadInputCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$KeypadInputCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$LevelControlCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$LevelControlCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$LowPowerCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$LowPowerCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$MediaInputCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$MediaInputCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$MediaPlaybackCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$MediaPlaybackCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$MessagesCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$MessagesCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$OnOffCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$OnOffCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$TargetNavigatorCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$TargetNavigatorCluster$* { *; }
+-keep class chip.devicecontroller.ChipClusters$WakeOnLanCluster { *; }
+-keep class chip.devicecontroller.ChipClusters$WakeOnLanCluster$* { *; }
+
+# ChipStructs — only the 19 clusters in the slim attribute TLV decoder.
+# These FindClass calls are inside switch-case branches and only execute when
+# that cluster's attribute response arrives; all other cluster structs are pruned.
+-keep class chip.devicecontroller.ChipStructs$AccountLoginCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ApplicationBasicCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ApplicationLauncherCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$AudioOutputCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$BindingCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ChannelCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ContentAppObserverCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ContentControlCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$ContentLauncherCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$DescriptorCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$KeypadInputCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$LevelControlCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$LowPowerCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$MediaInputCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$MediaPlaybackCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$MessagesCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$OnOffCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$TargetNavigatorCluster* { *; }
+-keep class chip.devicecontroller.ChipStructs$WakeOnLanCluster* { *; }
+
+# ChipEventStructs — only the 19 clusters in the slim event TLV decoder.
+-keep class chip.devicecontroller.ChipEventStructs$AccountLoginCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ApplicationBasicCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ApplicationLauncherCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$AudioOutputCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$BindingCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ChannelCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ContentAppObserverCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ContentControlCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$ContentLauncherCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$DescriptorCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$KeypadInputCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$LevelControlCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$LowPowerCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$MediaInputCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$MediaPlaybackCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$MessagesCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$OnOffCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$TargetNavigatorCluster* { *; }
+-keep class chip.devicecontroller.ChipEventStructs$WakeOnLanCluster* { *; }
 
 # ============================================================================
-# 3. Keep native method declarations so the JNI linkage works
+# 4. Keep native method declarations so the JNI linkage works
 # ============================================================================
 -keepclasseswithmembernames class * {
     native <methods>;
 }
 
 # ============================================================================
-# 4. Keep the Android Application subclass (entry point)
+# 5. Keep the Android Application subclass (entry point)
 # ============================================================================
 -keep class com.matter.casting.ChipTvCastingApplication { *; }
 
 # ============================================================================
-# 5. Standard Android keep rules
+# 6. Standard Android keep rules
 # ============================================================================
 
 # Keep Parcelable implementations
@@ -68,7 +193,7 @@
 }
 
 # ============================================================================
-# 6. Suppress warnings for annotations not present at runtime
+# 7. Suppress warnings for annotations not present at runtime
 # ============================================================================
 
 # javax.annotation.* annotations (Nonnull, Nullable) are compile-time only


### PR DESCRIPTION
Backport of [73490](https://github.com/project-chip/connectedhomeip/pull/73490) to v1.4.2-branch.

Cherry-pick (git cherry-pick -x) of commit https://github.com/project-chip/connectedhomeip/commit/5124bd5650aed7419be2532cd11096e7ad3c471f (the squash-merge of https://github.com/project-chip/connectedhomeip/pull/73490 on master).

### Original description 

CHIPInteractionModel.jar contains ~6,700 classes — the majority being
ChipClusters, ChipStructs, and ChipEventStructs inner classes generated
for all ~200 Matter clusters. The proguard rule -keep class chip.devicecontroller.** { *; }
prevented R8 from pruning any of them, even though the optimized build's slim
TLV decoder overrides (CHIPAttributeTLVValueDecoder-override.cpp,
CHIPEventTLVValueDecoder-override.cpp in tv-casting-common/) only contain
switch-case branches for 19 casting clusters. R8 cannot trace JNI FindClass
calls that are inside switch-case branches never executed at runtime, so the
unused ~180 clusters' classes were preserved unnecessarily.

Fix: Replace the broad chip.devicecontroller.** wildcard with individual
keeps scoped to exactly the 19 clusters present in the slim TLV decoder
overrides. R8 now prunes all remaining cluster classes, including
ClusterInfoMapping/ClusterReadMapping/ClusterWriteMapping (~1,047
generated classes) which are not referenced by the casting app.

Result: chip.* method count 29K → 2.5K; DEX 1.5 MB → 757 KB; download size
2.77–2.85 MB → 2.1 MB (measured via bundletool on arm64-v8a).

Also updates APK_SIZE_ANALYSIS.md with the measured size data and methodology.

### Backport notes
Replaced MediaFileManagement with Messages in proguard keep rules to match the v1.4.2-branch slim TLV decoders which still reference the Messages cluster.
Details:
The master PR (#73490) scopes proguard keeps to MediaFileManagement cluster, which is present in master's slim TLV decoder overrides (CHIPAttributeTLVValueDecoder-override.cpp, CHIPEventTLVValueDecoder-override.cpp). On v1.4.2-branch, these same decoder files still reference the Messages cluster instead. The proguard keep rules have been updated accordingly — MediaFileManagement replaced with Messages in all three keep blocks (ChipClusters, ChipStructs, ChipEventStructs) — so the rules stay aligned with the actual clusters present in the v1.4.2-branch .so at runtime.

### Testing
Build, CI, Android - Size measurement, commissioning.